### PR TITLE
A behavior's partition evidence holds only the lines it is owed a row at

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -124,7 +124,14 @@ class AMeasureIsIntroducedInOnePlaceTest {
             // be built from, and unknown where a composition takes what a stage nobody could work
             // out takes. Two states and one place that chooses between them — the cases at each
             // position are that position's own answer and never this one's.
-            Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#at(Ljava/util/List;)Lsouther/compiler/query/Measure;", 1)));
+            Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#at(Ljava/util/List;)Lsouther/compiler/query/Measure;", 1),
+            // And the one place a measure's answer is carried over to a value read off what it
+            // found. All five arms, because carrying them over is the whole of what it does: what a
+            // behavior is owed a row for is read off the lines its positions met, and the two are
+            // one measurement. This is the only entry here that decides nothing — a projection that
+            // chose between the arms could call a reading that did not run out complete over
+            // whatever it happened to produce, which is what every other entry exists to stop.
+            Map.entry("souther.compiler.query.Measure#readAs(Ljava/util/function/Function;)Lsouther/compiler/query/Measure;", 5)));
 
     @Test
     void nothingButTheIntroductionRuleMakesACaseOfAMeasure() throws Exception {

--- a/souther-bench/src/test/java/souther/bench/WhoseARowIsIsDecidedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhoseARowIsIsDecidedInOnePlaceTest.java
@@ -1,0 +1,116 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Whose it is to write a row at a point is decided once, and read by two accounts and nobody else.
+ *
+ * <p>A border owes a row at up to four points, and two of them can be owed to the declarations that
+ * drew the line rather than to the body carrying the type. Everything that measures a behavior,
+ * counts what it covers, raises a finding about it or offers it a row has to know which of the two
+ * it is holding — and while every one of them asked for itself, the one that forgot weighed a
+ * behavior's row against another behavior having no rows and held a build undetermined about a line
+ * the module's own account had settled.
+ *
+ * <p>So the question is asked where the point is made, and what comes out of it is one of two arms.
+ * This holds the two halves of that: the classifier is called from one place, and the arms are read
+ * only by the two accounts made from them. A third reader is a consumer deciding again.
+ */
+class WhoseARowIsIsDecidedInOnePlaceTest {
+
+    private static final String ATTRIBUTION = "souther.compiler.partition.PointAttribution";
+
+    /**
+     * Every way the classifier or one of its arms is reached from outside, one at a time.
+     *
+     * <p>Two rules in one answer, because one list of what is reached holds both. The classifier is
+     * called where the point is made and nowhere else: everything that settled a point has arrived
+     * there, so asked earlier the answer would be about whichever contributor had arrived, and asked
+     * later it would be asked by whoever wanted it. And an arm is named by the two accounts and by
+     * nothing else, because naming one is deciding whose a row is — which the classifier already
+     * did.
+     *
+     * <p>Which member of which arm, reached which way, and by whom. Folded to the methods that touch
+     * an arm somehow, this rule is passed by writing {@code new TheDeclarations(...)} inside a method
+     * that is already allowed to hold {@code TheDeclarations::and} — the set of names does not move,
+     * and what the name of this rule says did not happen would have happened.
+     *
+     * <p>So the answer is spelled per member and per way of reaching it, and the whole of it is
+     * compared: a reach nobody has written down is a reach nobody has thought about, whichever kind
+     * it is.
+     */
+    @Test
+    void everyWayAnArmIsReachedFromOutside() {
+        assertEquals(new java.util.TreeMap<>(Map.of(
+                        // Merging the owners of two readings of one point, which is the declarations'
+                        // account folding what it was given. A reference rather than a call because
+                        // it is handed to `Map.merge`.
+                        ATTRIBUTION + "$TheDeclarations#and REFERS",
+                        List.of("souther.compiler.query.BorderObligationPointAssessment#across"),
+                        // Which of this module's declarations owe the point, which is the arm
+                        // answering about itself rather than anybody deciding which arm it is.
+                        ATTRIBUTION + "$TheDeclarations#ownersIn CALLS",
+                        List.of("souther.compiler.query.Adequacy$DeclaredBorders#compute",
+                                "souther.compiler.query.BorderObligationPointAssessment#across"),
+                        // And the two accounts, each naming both arms because each answers for the
+                        // whole question: a producer that named one of them would be a point whose
+                        // arm neither account holds.
+                        ATTRIBUTION + "$TheDeclarations#case NAMES", ACCOUNTS,
+                        ATTRIBUTION + "$TheReading#case NAMES", ACCOUNTS,
+                        // Two points of one line are compared as values, which is what a reading
+                        // holds ({@code OwedPoint}).
+                        ATTRIBUTION + "#equals CALLS",
+                        List.of("souther.compiler.partition.OwedPoint#equals"),
+                        // And the classifier itself, which the rule above is about.
+                        ATTRIBUTION + "#of CALLS",
+                        List.of("souther.compiler.partition.Border#owes"))),
+                reachesFromOutside());
+    }
+
+    /** The two accounts made from what the classifier answered. */
+    private static final List<String> ACCOUNTS = List.of(
+            "souther.compiler.query.BorderObligationPointAssessment#across",
+            "souther.compiler.query.OwedBoundaryPoint#across");
+
+    /**
+     * Every reach to the classifier or one of its arms from outside it, by what is reached and how.
+     *
+     * <p>Sites inside {@link souther.compiler.partition.PointAttribution} are left out: what an arm
+     * does with itself — holding its own field, comparing itself, making itself in its own static
+     * initialiser — is the value being a value, and a rule about who may reach it from elsewhere is
+     * not about that.
+     */
+    private static java.util.SortedMap<String, List<String>> reachesFromOutside() {
+        java.util.SortedMap<String, java.util.SortedSet<String>> found = new java.util.TreeMap<>();
+        try {
+            for (Compiled.Site site : Compiled.sites()) {
+                if (!site.owner().startsWith(ATTRIBUTION) || site.from().startsWith(ATTRIBUTION)) {
+                    continue;
+                }
+                found.computeIfAbsent(site.owner() + "#" + site.member() + " " + site.how(),
+                                _ -> new java.util.TreeSet<>())
+                        .add(site.from() + "#" + written(site.method()));
+            }
+        } catch (IOException e) {
+            throw new AssertionError("the compiled classes were not readable", e);
+        }
+        java.util.SortedMap<String, List<String>> out = new java.util.TreeMap<>();
+        found.forEach((what, where) -> out.put(what, List.copyOf(where)));
+        return out;
+    }
+
+    /** The method as somebody wrote it: a lambda is named for the one that holds it. */
+    private static String written(String method) {
+        if (!method.startsWith("lambda$")) {
+            return method;
+        }
+        String rest = method.substring("lambda$".length());
+        return rest.substring(0, rest.lastIndexOf('$'));
+    }
+}

--- a/souther-cli/src/test/java/souther/cli/ABuildCanBeHeldToReliableDomainCoverageTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABuildCanBeHeldToReliableDomainCoverageTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.ItemAssessment;
-import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
 
@@ -100,19 +99,19 @@ class ABuildCanBeHeldToReliableDomainCoverageTest {
      */
     @Test
     void aVerdictRestsOnTheEvidenceItsCriterionAsksFor() {
-        PartitionEvidence measured = AReportOfOneBorder.partition(
-                AReportOfOneBorder.measured(
+        souther.compiler.query.Measurement<java.util.List<
+                souther.compiler.query.BorderAssessment>> lines = AReportOfOneBorder.measured(
                         AReportOfOneBorder.assessed(AReportOfOneBorder.aBorderABodyDrew(),
                                 role -> role.againstTheLine()
                                         ? AReportOfOneBorder.settled(
                                                 new ItemAssessment.Coverage.Hit())
-                                        : AReportOfOneBorder.undecided())));
+                                        : AReportOfOneBorder.undecided()));
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
-                AReportOfOneBorder.verdictOf(measured, Adequacy.AdequacyBar.SIMPLIFIED_DOMAIN),
+                AReportOfOneBorder.verdictOf(lines, Adequacy.AdequacyBar.SIMPLIFIED_DOMAIN),
                 "the points it asks for came to an answer");
         assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,
-                AReportOfOneBorder.verdictOf(measured, Adequacy.AdequacyBar.RELIABLE_DOMAIN),
+                AReportOfOneBorder.verdictOf(lines, Adequacy.AdequacyBar.RELIABLE_DOMAIN),
                 "two of the points it asks for did not");
     }
 

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -188,7 +188,7 @@ final class AReportOfOneBorder {
                         WeakeningSet.of(new Weakening.ModelReadingIncomplete(
                                 new souther.compiler.partition.ClosureGap.RulesNotReached(
                                         new souther.compiler.partition.AxisId("b", "t"))))),
-                border,
+                souther.compiler.query.OwedBoundaryPoint.accountOf(border),
                 PartitionEvidence.PairSpace.NONE,
                 List.of(), List.of(), List.of(), List.of(), List.of(),
                 List.of());
@@ -208,18 +208,28 @@ final class AReportOfOneBorder {
                                 new souther.compiler.partition.AxisId("b", "m")))));
     }
 
-    /** What one behavior's partition makes of the whole report, held to {@code held}. */
-    static AdequacyReport.AdequacyStatus verdictOf(PartitionEvidence partition,
+    /**
+     * What one behavior's lines make of the whole report, held to {@code held}.
+     *
+     * <p>The lines and nothing else, because the account is read off them: handed both, a fixture
+     * could put a verdict in front of an account made from other lines than the ones beside it, and
+     * what came back would be about neither.
+     */
+    static AdequacyReport.AdequacyStatus verdictOf(Measurement<List<BorderAssessment>> lines,
                                                    Adequacy.AdequacyBar held) {
+        PartitionEvidence partition = partition(lines);
         AdequacyReport.BehaviorReport behavior = new AdequacyReport.BehaviorReport(
                 "weigh", souther.compiler.check.BehaviorImplementation.IMPLEMENTED,
                 new souther.compiler.query.BehaviorEvidence(
-                        Adequacy.RowReading.NONE, null, partition, null),
+                        Adequacy.RowReading.NONE, null, partition, lines, null),
                 souther.compiler.query.ClaimAnnotations.NONE, List.of());
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test",
                 held, WeakeningSet.none(),
                 List.of(new AdequacyReport.ModuleReport("example.wide",
-                        new SourceId("wide.sou"), List.of(behavior), List.of(), List.of())))
+                        new SourceId("wide.sou"), List.of(behavior), List.of(),
+                        // Nothing this module's declarations are owed, and nothing that finding
+                        // them went without: the fixture is about one behavior's own lines.
+                        new Adequacy.DeclaredBoundaries(List.of(), java.util.Map.of()))))
                 .adequacy();
     }
 }

--- a/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -537,10 +537,10 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
                 AReportOfOneBorder.aBorderAtTheEdgeOfItsDomain(), AReportOfOneBorder::hit);
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
-                verdictOf(partition(AReportOfOneBorder.measured(met))),
+                verdictOf(AReportOfOneBorder.measured(met)),
                 "a border measure made in full");
         assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,
-                verdictOf(partition(AReportOfOneBorder.shortOfSomething(met))),
+                verdictOf(AReportOfOneBorder.shortOfSomething(met)),
                 "a border measure that was not made in full");
     }
 
@@ -561,14 +561,14 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
     void aPartitionReadingThatDidNotRunOutHoldsTheClassesBarOpen() {
         BorderAssessment met = AReportOfOneBorder.assessed(
                 AReportOfOneBorder.aBorderAtTheEdgeOfItsDomain(), AReportOfOneBorder::hit);
-        PartitionEvidence readingStopped = partition(AReportOfOneBorder.measured(met));
+        souther.compiler.query.Measurement<List<BorderAssessment>> lines =
+                AReportOfOneBorder.measured(met);
 
         assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,
-                AReportOfOneBorder.verdictOf(readingStopped, Adequacy.AdequacyBar.CLASSES),
+                AReportOfOneBorder.verdictOf(lines, Adequacy.AdequacyBar.CLASSES),
                 "the classes this could not derive are classes nobody has covered");
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
-                AReportOfOneBorder.verdictOf(readingStopped,
-                        Adequacy.AdequacyBar.RELIABLE_DOMAIN),
+                AReportOfOneBorder.verdictOf(lines, Adequacy.AdequacyBar.RELIABLE_DOMAIN),
                 "and a bar that asks nothing of the classes reads only the lines");
     }
 
@@ -578,8 +578,9 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
         return AReportOfOneBorder.partition(border);
     }
 
-    private static AdequacyReport.AdequacyStatus verdictOf(PartitionEvidence partition) {
-        return AReportOfOneBorder.verdictOf(partition, Adequacy.AdequacyBar.SIMPLIFIED_DOMAIN);
+    private static AdequacyReport.AdequacyStatus verdictOf(
+            souther.compiler.query.Measurement<List<BorderAssessment>> lines) {
+        return AReportOfOneBorder.verdictOf(lines, Adequacy.AdequacyBar.SIMPLIFIED_DOMAIN);
     }
 
     /** Two covered stages and the composition of them, which carries rows of its own. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -89,21 +89,27 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, PointA
      * <p>Made here, from the answer that settled both halves at once. Everything that accounts for
      * rows asks this rather than building a point out of the parts it happened to know — which is
      * how a debt came to carry the reading it was met at.
+     *
+     * <p>Whose account each point falls in is read here as well, and here only. Everything that
+     * settled the point has arrived by this line: its own rule, and whatever stops the region
+     * beside it. A caller handed the contributors would be deciding it again, and a caller that
+     * forgot to decide would measure a body against a line no row written for it is owed.
      */
     public java.util.List<OwedPoint> owes(PointRole role) {
         BorderObligationId line = obligation();
         // The line's own rule is behind every point of it, whatever else settled the region beside
         // it: it is the line a row here stands at or beside, and an author moving it moves the
         // point.
-        PointAttribution own = PointAttribution.by(origin.authoredLine());
+        PointContributions own = PointContributions.by(origin.authoredLine());
         return switch (answer(role)) {
             case PointAnswer.NotOwed _ -> java.util.List.of();
             case PointAnswer.AtLine _ -> java.util.List.of(
-                    new OwedPoint(new BorderObligationPoint.AtLine(line, role), own));
+                    new OwedPoint(new BorderObligationPoint.AtLine(line, role),
+                            PointAttribution.of(own)));
             case PointAnswer.InRegion in -> in.claims().stream()
                     .map(claim -> new OwedPoint(
                             new BorderObligationPoint.InRegion(line, role, claim.basis()),
-                            own.and(claim.attribution())))
+                            PointAttribution.of(own.and(claim.contributions()))))
                     .toList();
         };
     }
@@ -180,6 +186,56 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, PointA
      *  {@link #label(PointRole)}, and the two differ at three of the four. */
     public String label() {
         return cut.left() + " = " + cut.right();
+    }
+
+    /**
+     * The position this line is on, as a report names it.
+     *
+     * <p>Asked of the shape of the line rather than of a field every shape was assumed to have. A
+     * line between two positions is on neither of them, and answering with one of the two would name
+     * a border after half of itself.
+     */
+    public String axis() {
+        return cut.named();
+    }
+
+    /** How one point relates a row's value to what it is against, or null where none is owed. */
+    public String operator(PointRole role) {
+        Criterion criterion = demand(role).criterion();
+        return criterion == null ? null : criterion.operator();
+    }
+
+    /** What that point is against, or null where none is owed. */
+    public String against(PointRole role) {
+        Criterion criterion = demand(role).criterion();
+        // Asked of the criterion, which is what knows whether it is written against a level or
+        // against a run of them. Two of the four points name a level and two name a run, and a
+        // reader that took a level from every shape wrote a value inside a run as though it were
+        // the run.
+        return criterion == null ? null : criterion.written(cut.of());
+    }
+
+    /** The rule that drew this line, as a report about {@code sectionSource} writes it. */
+    public String describe(souther.compiler.diag.SourceNameResolver names,
+                           souther.compiler.source.SourceId sectionSource) {
+        return origin.describe(names, sectionSource);
+    }
+
+    /**
+     * The class a row at one point of this line falls in, as one line of a class list is written.
+     *
+     * <p>One place, because more than one reader names it: the document a consumer joins a finding
+     * to its item by, the class a generated row is offered against, and a block that shows the line
+     * whosever the row at each point is. Written once per reader, the spellings agreed for a point
+     * on the line and had nothing to say to each other away from it.
+     *
+     * <p>A point on the line is the value it is at. A point away from it carries the relation as
+     * well, because what it is against alone names the border there rather than the side of it a row
+     * is owed in.
+     */
+    public String said(PointRole role) {
+        return role.againstTheLine() ? axis() + " = " + against(role)
+                : axis() + " " + operator(role) + " " + against(role);
     }
 
     /**
@@ -681,7 +737,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, PointA
         return provablyHoldsNothing(side, space, within)
                 ? new PointAnswer.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT)
                 : new PointAnswer.InRegion(side, java.util.List.of(new RegionClaim(
-                        RegionBasis.TheRest.INSTANCE, PointAttribution.NONE)));
+                        RegionBasis.TheRest.INSTANCE, PointContributions.none())));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/OwedPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OwedPoint.java
@@ -1,12 +1,12 @@
 package souther.compiler.partition;
 
 /**
- * A point a row is owed at, as one reading of one border says it: what is owed, and who can move
- * what settled it.
+ * A point a row is owed at, as one reading of one border says it: what is owed, and whose account
+ * it falls in.
  *
  * <p>Both from the one branch that worked the region out, because both are known there and neither
  * can be worked out from the other afterwards. Which point this is is settled by the model and is
- * the same wherever the line is read; who can move what settled it is a fact about this reading's
+ * the same wherever the line is read; whose account it falls in is a fact about this reading's
  * surroundings and is no part of which point it is.
  *
  * <p>Read off the point instead — the lines that happen to be inside its identity — a run stopping
@@ -14,14 +14,53 @@ package souther.compiler.partition;
  * and the declaration that put the end there was told nothing about a row it could be asked for.
  *
  * @param point       what a row here is owed for, which two readings of it share
- * @param attribution who settled that, at this reading
+ * @param attribution whose it is to write a row here, as this reading settled it
  */
-public record OwedPoint(BorderObligationPoint point, PointAttribution attribution) {
+public final class OwedPoint {
 
-    public OwedPoint {
+    private final BorderObligationPoint point;
+    private final PointAttribution attribution;
+
+    /**
+     * Made where a border says what it owes, and nowhere else.
+     *
+     * <p>Package-private for that reason. Whose it is to write a row here is read off everything
+     * that settled the point ({@link PointAttribution#of}), and a value anybody could assemble is a
+     * way to hand an account an answer that classifier never gave — the arm chosen by whoever was
+     * writing rather than by what the model says.
+     */
+    OwedPoint(BorderObligationPoint point, PointAttribution attribution) {
         if (point == null || attribution == null) {
             throw new IllegalArgumentException(
                     "a point owed a row is owed for something, by somebody: " + point);
         }
+        this.point = point;
+        this.attribution = attribution;
+    }
+
+    /** What a row here is owed for, which two readings of it share. */
+    public BorderObligationPoint point() {
+        return point;
+    }
+
+    /** Whose it is to write a row here, as this reading settled it. */
+    public PointAttribution attribution() {
+        return attribution;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof OwedPoint that
+                && point.equals(that.point) && attribution.equals(that.attribution);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(point, attribution);
+    }
+
+    @Override
+    public String toString() {
+        return point + " owed to " + attribution;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PointAttribution.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PointAttribution.java
@@ -6,93 +6,102 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Who can move what settled one point a row is owed at.
+ * Whose account one point a row is owed at falls in.
  *
- * <p><b>Beside what the point is, and never part of it.</b> Which point a row is owed at is settled
- * by the line and by what stops the region beside it ({@link BorderObligationPoint}); who could move
- * either of those is a fact about the reading's surroundings, and two readings that answer it
- * differently are still one point. Read off the identity instead — the lines that happen to be
- * inside it — a run stopping where a declaration narrowed the position came back owed to the line
- * below it and to nobody else, and the declaration that put the end there was told nothing.
+ * <p>The one answer read off what settled the point ({@link PointContributions}), and the only
+ * thing downstream is given: a row here is this reading's to write, or it is owed to the
+ * declarations that put the line there and one row anywhere in the module settles it. A reader
+ * handed the contributors instead has to ask the question itself, and a reader that forgets to ask
+ * measures a body against a line no row written for it is owed.
  *
- * <p><b>Two kinds of contributor, because the model has two.</b> A rule wrote a line, and that rule
- * is a clause of a type or a comparison in a body ({@link AuthoredLine}); or a declaration took in
- * where a position stops, which is not a line of its own and is named by the reading that placed the
- * end. What a reader asks of either is the same two questions: whether every one of them is a
- * declaration, and which of them are one module's.
+ * <p><b>Read once, when everything that settled the point has arrived.</b> A point's own line and
+ * whatever stops the region beside it are gathered as the reading works the region out, and either
+ * of them alone answers about itself rather than about the point. So the contributors are what can
+ * be added to and this is what is concluded, and nothing here can be added to.
  *
- * @param lines     the rules that drew what settled this point
- * @param narrowers the declarations that took in where the position stops, where that is what stops
- *                  the region
+ * <p><b>Two arms and no third, because a row here is somebody's to write.</b> Written as "not the
+ * declarations'", a value nothing contributed to would answer that a body owes the row, and a value
+ * everything contributed to would have to be read twice to find out which.
  */
-public record PointAttribution(List<AuthoredLine> lines, List<TypeSymbol.AtModule> narrowers) {
+public sealed interface PointAttribution {
 
-    /** Nobody: what an end of the order is settled by. */
-    public static final PointAttribution NONE = new PointAttribution(List.of(), List.of());
+    /**
+     * A body's, because a rule written in one settled it.
+     *
+     * <p>A comparison states something about that body at that position, so a run that stops at one
+     * exists in that body and nowhere else, and a row for it is written for this behavior.
+     */
+    record TheReading() implements PointAttribution {
 
-    public PointAttribution {
-        lines = List.copyOf(lines);
-        narrowers = List.copyOf(narrowers);
-    }
-
-    /** One rule's. */
-    public static PointAttribution by(AuthoredLine line) {
-        return new PointAttribution(List.of(line), List.of());
-    }
-
-    /** The declarations that took in where a position stops. */
-    public static PointAttribution byNarrowing(List<TypeSymbol.AtModule> narrowers) {
-        return new PointAttribution(List.of(), narrowers);
+        public static final TheReading INSTANCE = new TheReading();
     }
 
     /**
-     * This and {@code also} together, each contributor once.
+     * The declarations', because nothing but clauses and the declarations that took the position in
+     * settled it.
      *
-     * <p>What a point's own line and what stops the region beside it come to, and what two readings
-     * of one point come to over the readings. A contributor named twice is one contributor: what
-     * counts these is what says how many places a finding about the point names.
+     * <p>What such a row shows is a fact about the type — whether a string of one character is a
+     * {@code Sku} is the same question wherever a {@code Sku} goes — so one row anywhere in the
+     * module settles it, and the behaviors carrying the type have nothing to add.
+     *
+     * @param owners every declaration that owes a row here, in the order they contributed. Never
+     *               empty: an arm saying the declarations owe it and naming none of them would be a
+     *               debt with nobody to answer for it
      */
-    public PointAttribution and(PointAttribution also) {
-        List<AuthoredLine> both = new ArrayList<>(lines);
-        also.lines.stream().filter(each -> !both.contains(each)).forEach(both::add);
-        List<TypeSymbol.AtModule> declarations = new ArrayList<>(narrowers);
-        also.narrowers.stream().filter(each -> !declarations.contains(each))
-                .forEach(declarations::add);
-        return new PointAttribution(both, declarations);
-    }
+    record TheDeclarations(List<TypeSymbol.AtModule> owners) implements PointAttribution {
 
-    /**
-     * Whether everything that settled this point is a declaration's.
-     *
-     * <p>Which is what says whether one row anywhere settles it. A clause of a {@code data} states
-     * something about the type wherever the type is carried, so a row at a point settled only by
-     * clauses is evidence about the type; a comparison is written in a body and states something
-     * about that body, so a run that stops at one exists in that body and nowhere else.
-     *
-     * <p>A declaration that took an end in is a declaration, and an end of the order is nobody's —
-     * neither makes a point a body's.
-     */
-    public boolean owedToDeclarations() {
-        return lines.stream().noneMatch(each -> each.obligationOwners().isEmpty());
-    }
-
-    /**
-     * The declarations of {@code module} that owe a row here, in the order they were contributed.
-     *
-     * <p>This module's own and not everything that settled the point. What settled it can be several
-     * modules' — a line one module wrote, stopped where another module's declaration takes the
-     * position in — and a report of this module naming a foreign declaration would be telling its
-     * author to go and change somebody else's source. Each module's account names its own
-     * ({@link AuthoredLine#ownersIn}).
-     */
-    public List<TypeSymbol.AtModule> ownersIn(String module) {
-        List<TypeSymbol.AtModule> out = new ArrayList<>();
-        for (AuthoredLine each : lines) {
-            each.ownersIn(module).stream().filter(owner -> !out.contains(owner)).forEach(out::add);
+        public TheDeclarations {
+            owners = List.copyOf(owners);
+            if (owners.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a point owed to the declarations is owed to some declaration");
+            }
         }
-        narrowers.stream()
-                .filter(each -> module.equals(each.module()) && !out.contains(each))
-                .forEach(out::add);
-        return List.copyOf(out);
+
+        /**
+         * Which of them {@code module} wrote, in the order this names them.
+         *
+         * <p>What a module's account of this point is filed under. A point with none of these here
+         * is one this module has nothing to answer for: its values are held to the line, and a row
+         * at it is somebody else's to write.
+         */
+        public List<TypeSymbol.AtModule> ownersIn(String module) {
+            return owners.stream().filter(each -> module.equals(each.module())).toList();
+        }
+
+        /**
+         * This and {@code also}, each owner once.
+         *
+         * <p>Two readings of one point, each naming what settled it where it was read. A point one
+         * module's declaration narrowed at one position and another's at another is owed to both.
+         * A union of owners and not a second classification: both sides are already the
+         * declarations'.
+         */
+        public TheDeclarations and(TheDeclarations also) {
+            List<TypeSymbol.AtModule> both = new ArrayList<>(owners);
+            also.owners.stream().filter(each -> !both.contains(each)).forEach(both::add);
+            return new TheDeclarations(both);
+        }
+    }
+
+    /**
+     * What the contributors come to.
+     *
+     * <p>The one place this is decided. Everything that measures a behavior, counts what it covers,
+     * raises a finding about it or offers it a row reads the answer rather than the contributors, so
+     * there is nowhere for the rule to be remembered wrongly.
+     *
+     * @throws IllegalArgumentException where nothing contributed, which is not a point either side
+     *                                  owes a row at. A claim about the end of the order carries
+     *                                  such a value, and the point it is part of is settled by the
+     *                                  line the region lies beside as well
+     */
+    static PointAttribution of(PointContributions contributions) {
+        if (contributions.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "a point nothing settled, which nobody can be owed a row at");
+        }
+        return contributions.allDeclarations()
+                ? new TheDeclarations(contributions.owners()) : TheReading.INSTANCE;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PointContributions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PointContributions.java
@@ -1,0 +1,117 @@
+package souther.compiler.partition;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What settled one point a row is owed at, gathered as the reading works it out.
+ *
+ * <p>Evidence and not the answer read off it. A point is settled by its own line and by whatever
+ * stops the region beside it, and those arrive one at a time — so this is the value that can be
+ * added to, and whose account the point falls in is asked of the whole of it once it is complete
+ * ({@link PointAttribution}). Asked of a part, the answer would be about whichever contributor had
+ * arrived.
+ *
+ * <p><b>Two kinds of contributor, because the model has two.</b> A rule wrote a line, and that rule
+ * is a clause of a type or a comparison in a body ({@link AuthoredLine}); or a declaration took in
+ * where a position stops, which is not a line of its own and is named by the reading that placed the
+ * end.
+ *
+ * <p><b>Beside what the point is, and never part of it.</b> Which point a row is owed at is settled
+ * by the line and by what stops the region beside it ({@link BorderObligationPoint}); who could move
+ * either of those is a fact about the reading's surroundings, and two readings that answer it
+ * differently are still one point.
+ *
+ * @param lines     the rules that drew what settled this point
+ * @param narrowers the declarations that took in where the position stops, where that is what stops
+ *                  the region
+ */
+public record PointContributions(List<AuthoredLine> lines, List<TypeSymbol.AtModule> narrowers) {
+
+    private static final PointContributions NONE = new PointContributions(List.of(), List.of());
+
+    public PointContributions {
+        lines = List.copyOf(lines);
+        narrowers = List.copyOf(narrowers);
+    }
+
+    /**
+     * Nothing yet: what an end of the order is settled by, and what a claim about it carries.
+     *
+     * <p>Not a point owed to nobody. A claim on its own is one contributor's worth of an answer, and
+     * the point it is part of is settled by the line the region lies beside as well — so what
+     * reaches {@link PointAttribution} is this together with that line, and this alone is refused
+     * there rather than classified as one side or the other.
+     */
+    public static PointContributions none() {
+        return NONE;
+    }
+
+    /** One rule's. */
+    public static PointContributions by(AuthoredLine line) {
+        return new PointContributions(List.of(line), List.of());
+    }
+
+    /** The declarations that took in where a position stops. */
+    public static PointContributions byNarrowing(List<TypeSymbol.AtModule> narrowers) {
+        return new PointContributions(List.of(), narrowers);
+    }
+
+    /** Whether nothing has contributed, which is a value nothing can be concluded from. */
+    public boolean isEmpty() {
+        return lines.isEmpty() && narrowers.isEmpty();
+    }
+
+    /**
+     * This and {@code also} together, each contributor once.
+     *
+     * <p>What a point's own line and what stops the region beside it come to. A contributor named
+     * twice is one contributor: what counts these is what says how many places a finding about the
+     * point names.
+     */
+    public PointContributions and(PointContributions also) {
+        List<AuthoredLine> both = new ArrayList<>(lines);
+        also.lines.stream().filter(each -> !both.contains(each)).forEach(both::add);
+        List<TypeSymbol.AtModule> declarations = new ArrayList<>(narrowers);
+        also.narrowers.stream().filter(each -> !declarations.contains(each))
+                .forEach(declarations::add);
+        return new PointContributions(both, declarations);
+    }
+
+    /**
+     * Whether everything that contributed is a declaration's.
+     *
+     * <p>A clause of a {@code data} states something about the type wherever the type is carried, so
+     * a row at a point settled only by clauses is evidence about the type; a comparison is written
+     * in a body and states something about that body, so a run that stops at one exists in that body
+     * and nowhere else.
+     *
+     * <p>A declaration that took an end in is a declaration, and an end of the order contributes
+     * nothing — neither makes a point a body's. Asked of a value nothing has contributed to, this
+     * answers vacuously, which is why {@link PointAttribution} refuses that value rather than
+     * reading this.
+     */
+    boolean allDeclarations() {
+        return lines.stream().noneMatch(each -> each.obligationOwners().isEmpty());
+    }
+
+    /**
+     * The declarations that owe a row here, in the order they contributed.
+     *
+     * <p>Every one of them, whichever module wrote it. What settled a point can be several modules' —
+     * a line one module wrote, stopped where another module's declaration takes the position in —
+     * and which of them a module answers for is that module's account to decide
+     * ({@link PointAttribution.TheDeclarations#ownersIn}).
+     */
+    List<TypeSymbol.AtModule> owners() {
+        List<TypeSymbol.AtModule> out = new ArrayList<>();
+        for (AuthoredLine each : lines) {
+            each.obligationOwners().stream().filter(owner -> !out.contains(owner))
+                    .forEach(out::add);
+        }
+        narrowers.stream().filter(each -> !out.contains(each)).forEach(out::add);
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -79,7 +79,7 @@ public record QuantityArrangement(List<Parting> partings, List<Run> runs) {
             if (reaches == null) {
                 if (!claims.equals(List.of(new RegionClaim(
                         new RegionBasis.Beside(new FarEnd.AtTheOrderEnd(side)),
-                        PointAttribution.NONE)))) {
+                        PointContributions.none())))) {
                     throw new IllegalArgumentException("a run nothing stops at its " + side
                             + " end, stopped by " + claims);
                 }
@@ -137,7 +137,7 @@ public record QuantityArrangement(List<Parting> partings, List<Run> runs) {
         if (reaches == null) {
             return List.of(new RegionClaim(
                     new RegionBasis.Beside(new FarEnd.AtTheOrderEnd(inward.opposite())),
-                    PointAttribution.NONE));
+                    PointContributions.none()));
         }
         List<RegionClaim> out = new ArrayList<>();
         if (parted != null
@@ -145,12 +145,12 @@ public record QuantityArrangement(List<Parting> partings, List<Run> runs) {
                         reaches.canonical())) {
             parted.alternatives().forEach(line -> out.add(new RegionClaim(
                     new RegionBasis.Beside(new FarEnd.AtALine(line, parted.geometry())),
-                    PointAttribution.by(line))));
+                    PointContributions.by(line))));
         }
         if (leaves != null && leaves.bound().canonical().equals(reaches.canonical())) {
             out.add(new RegionClaim(
                     new RegionBasis.Beside(new FarEnd.AtTheDomain(leaves.bound())),
-                    PointAttribution.byNarrowing(leaves.narrowers())));
+                    PointContributions.byNarrowing(leaves.narrowers())));
         }
         if (out.isEmpty()) {
             // Where the run reaches is the tighter of the two, so one of them is it. Reaching here

--- a/souther-compiler/src/main/java/souther/compiler/partition/RegionClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RegionClaim.java
@@ -12,15 +12,17 @@ import java.util.List;
  * in two places instead, a reader would have to put them back together by whatever they had in
  * common, and what they have in common is where they were read.
  *
- * @param basis       what a row here is owed for, which is part of the point's identity
- * @param attribution who settled that, which is not
+ * @param basis         what a row here is owed for, which is part of the point's identity
+ * @param contributions what settled that at this end, which is not. One end's worth of what the
+ *                      point is owed to, since the line the region lies beside settled it as well
  */
-public record RegionClaim(RegionBasis basis, PointAttribution attribution) {
+public record RegionClaim(RegionBasis basis, PointContributions contributions) {
 
     public RegionClaim {
-        if (basis == null || attribution == null) {
+        if (basis == null || contributions == null) {
             throw new IllegalArgumentException(
-                    "a claim is something owed for, by somebody: " + basis + " " + attribution);
+                    "a claim is something owed for, settled by something: " + basis + " "
+                            + contributions);
         }
     }
 
@@ -50,7 +52,7 @@ public record RegionClaim(RegionBasis basis, PointAttribution attribution) {
                 out.add(each);
             } else {
                 out.set(at, new RegionClaim(each.basis(),
-                        out.get(at).attribution().and(each.attribution())));
+                        out.get(at).contributions().and(each.contributions())));
             }
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -65,10 +65,10 @@ public sealed interface About {
     /**
      * A point of a border no row is at.
      *
-     * <p>The assessment's own item, which is what the count, the document and this are three
-     * readings of. Held as the point rather than as the axis, the value, the rule and the role,
-     * which is what those four fields were: a copy that did not identify a point, since several
-     * rules can draw a line at one value.
+     * <p>One entry of this behavior's account, which is what the count, the document and this are
+     * three readings of. Held as the point rather than as the axis, the value, the rule and the
+     * role, which is what those four fields were: a copy that did not identify a point, since
+     * several rules can draw a line at one value.
      *
      * <p>What is here is what was measured, and a reader wanting more than that says so. A
      * generation composes values at these lines whatever the build was measuring, so what it can do
@@ -77,30 +77,15 @@ public sealed interface About {
      * because that is what a finding is about: a search settles what can be written at the point and
      * changes nothing about the point being missed.
      *
-     * <p><b>What is owed and where it was measured, apart.</b> One role of one reading can owe more
-     * than one row — a place two rules of this body drew a line at leaves a run owed to each — so
-     * which of them this is is {@code owed}, and where it was measured is {@code point}. Said as the
-     * reading's role alone, two things to write came out as one finding, and the reading was
-     * standing in for the debt again.
+     * <p>That this behavior is owed a row here at all is settled where the account is made, so
+     * nothing is checked again: a point owed to the declarations that drew the line is answered once
+     * for the module and never reaches this.
      *
-     * @param point where it was measured: this reading, in this role
-     * @param owed  what a row here is owed for, which is one of the things that role owes
+     * @param point what this behavior is owed a row for, and what became of it
      */
-    record APointOfABorder(BorderAssessment.Point point,
-                           souther.compiler.partition.BorderObligationPoint owed)
-            implements About {
+    record APointOfABorder(OwedBoundaryPoint point) implements About {
         public APointOfABorder {
             java.util.Objects.requireNonNull(point, "a finding is about something");
-            java.util.Objects.requireNonNull(owed, "and a row here is owed for something");
-            // One of the things this reading owes here, and not something that merely looks like
-            // one. What a role owes is the border's own answer, so a finding naming anything else
-            // would be a second reading of it — and a reader joining the finding back to what was
-            // measured would find nothing to join it to.
-            if (point.owedHere().stream().noneMatch(each -> each.point().equals(owed))) {
-                throw new IllegalArgumentException("a finding about " + owed
-                        + ", which is not among what this reading owes at its " + point.role()
-                        + " point: " + point.owedHere());
-            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -373,8 +373,20 @@ public final class Adequacy {
     /** What the build asked for. Absent is {@link Asked#NOTHING}. */
     public record Requested() implements Input<Asked> {}
 
-    /** Everything measured about one module, for a caller that wants it in one piece. A map is null
-     * where the question could not be answered at all, which is not the same as an empty one. */
+    /**
+     * Everything measured about one module, for a caller that wants it in one piece. A map is null
+     * where the question could not be answered at all, which is not the same as an empty one.
+     *
+     * <p>The lines each behavior's positions met are not here. A reader that measures a behavior
+     * reads its account, and a reader that shows a border whole asks {@link BoundaryReadings} by
+     * name — put here beside the accounts made from it, it would be a surface nobody asked for and
+     * a second way to reach the same answer.
+     *
+     * @param signatures what the rows establish about each behavior's inputs and output
+     * @param partitions what they establish about its classes, and what it is owed a row for at the
+     *                   lines its rules draw
+     * @param branches   what they establish about the arms of each body
+     */
     public record Of(Map<String, SignatureEvidence> signatures,
                      Map<String, PartitionEvidence> partitions,
                      Map<String, BranchEvidence> branches) {}
@@ -1154,6 +1166,11 @@ public final class Adequacy {
             // input: a composition is measured at its stages whether or not its own signature
             // worked out, and answering "the boundary was not derived" for one would be this
             // measure reporting a prerequisite it never had.
+            Map<String, Measure<List<BorderAssessment>>> lines =
+                    db.ask(new BoundaryReadings(name)).value();
+            if (lines == null) {
+                return Answer.absent();
+            }
             return answerEveryBehavior(prepared.value(), behavior -> {
                 if (!(behavior instanceof Hir.SpecBehavior spec)) {
                     return PartitionEvidence.NONE;   // measured at its stages, not here
@@ -1163,7 +1180,7 @@ public final class Adequacy {
                             PartitionEvidence.boundaryNotDerived(spec.name());
                     case BoundaryForMeasurement.Derived(Sig sig) ->
                             measured(db, name, spec, sig, level, scope.value(), readInputs,
-                                    byTarget);
+                                    byTarget, lines.get(spec.name()));
                 };
             });
         }
@@ -1173,7 +1190,8 @@ public final class Adequacy {
         private PartitionEvidence measured(Db db, String name, Hir.SpecBehavior spec, Sig sig,
                                            Level level, Symbols scope,
                                            Map<String, InputDomain> readInputs,
-                                           Map<String, RowReading> byTarget) {
+                                           Map<String, RowReading> byTarget,
+                                           Measure<List<BorderAssessment>> lines) {
             // A behavior with a signature is one the model divides somewhere or nowhere, and
             // either is an answer. Nothing is a compile that stopped after this had already
             // read the signature, which is the two disagreeing rather than a behavior to skip.
@@ -1184,17 +1202,7 @@ public final class Adequacy {
                         + " reading of what the model divides it into");
             }
             RowReading seen = Rows.readingFor(byTarget, spec.name());
-            // Counted with nothing a body claims in scope. What was claimed travels beside the
-            // numbers rather than into them ({@link Claimed}), and the two meet where a report
-            // is written.
-            // Whether the values are composed is the build's to ask for, and it is asked here
-            // rather than inside either key. A level says how much work to do; what a search
-            // does when it is asked is not a thing it may decide, which is the reading that put
-            // the composing inside the measurement in the first place.
-            List<BorderAssessment> edges = level.composesValues()
-                    ? db.ask(new BoundarySearch(name, spec.name())).value()
-                    : db.ask(new Boundaries(name, spec.name())).value();
-            if (edges == null) {
+            if (lines == null) {
                 // Nothing came back about this behavior's lines, from a question that has
                 // everything it needs to answer. Read as no lines, a behavior whose measure
                 // stopped would be counted as one the model draws nothing about.
@@ -1202,8 +1210,11 @@ public final class Adequacy {
                         + " reading of what the model divides it into, and no answer about the"
                         + " lines that reading drew");
             }
+            // Counted with nothing a body claims in scope. What was claimed travels beside the
+            // numbers rather than into them ({@link Claimed}), and the two meet where a report
+            // is written.
             return Coverages.of(spec, domainOf(readInputs, spec), sig, scope,
-                    db.ask(new Front.Reading()).value(), divided, seen, level, edges,
+                    db.ask(new Front.Reading()).value(), divided, seen, level, lines,
                     db.ask(new Front.Adequacy()).value().measures());
         }
     }
@@ -1399,6 +1410,25 @@ public final class Adequacy {
     }
 
     /**
+     * The lines each behavior was measured at, as the measurement read them.
+     *
+     * <p>{@link BoundaryReadings} without the measure beside each answer, for a caller asking what
+     * the lines are rather than how far the reading that found them got. Which of the two questions
+     * this is answers whether values were composed as well: a build that composes them is measured
+     * at the searched lines, and this is those.
+     */
+    public static Map<String, List<BorderAssessment>> readingsOf(Db db, String module) {
+        Map<String, Measure<List<BorderAssessment>>> lines =
+                db.ask(new BoundaryReadings(module)).value();
+        if (lines == null) {
+            return null;
+        }
+        Map<String, List<BorderAssessment>> out = new LinkedHashMap<>();
+        lines.forEach((behavior, read) -> out.put(behavior, read.made().orElseGet(List::of)));
+        return java.util.Collections.unmodifiableMap(out);
+    }
+
+    /**
      * What a generation comes to where writing a row could not answer a finding, or null where one
      * could.
      *
@@ -1509,13 +1539,13 @@ public final class Adequacy {
      */
     public static DeclaredRows generatedForDeclarationsOf(Db db, String module,
                                                           GenerationScope scope) {
-        List<DeclaredDebt> debts = db.ask(new DeclaredBorders(module)).value();
+        DeclaredBoundaries account = db.ask(new DeclaredBorders(module)).value();
         java.util.SequencedMap<souther.compiler.partition.BorderObligationPoint,
                 DeclaredRows.Answer> resolved = new LinkedHashMap<>();
-        if (debts == null) {
+        if (account == null) {
             return new DeclaredRows(scope, resolved);
         }
-        for (DeclaredDebt owed : debts) {
+        for (DeclaredDebt owed : account.owed()) {
             BorderObligationPointAssessment debt = owed.debt();
             // Which lines this request is about, settled once and here. A line no reading the
             // request asked about carries is not a question this was put — read further down, a
@@ -1621,6 +1651,65 @@ public final class Adequacy {
     }
 
     /**
+     * Every line each of a module's behaviors met, and how far the reading that found them got.
+     *
+     * <p>Where the lines a behavior was read at are kept. Two accounts are made from these — what a
+     * behavior is owed a row for ({@link PartitionEvidence#owes}) and what a module's declarations
+     * are ({@link DeclaredBorders}) — and what a report shows of a border whole is this: a block
+     * accounts for a border's four points whosever they are, which is a different question from
+     * whose debt each of them is.
+     *
+     * <p>Whether the values are composed is the build's to ask for, and it is asked here rather than
+     * inside either key below. A level says how much work to do; what a search does when it is asked
+     * is not a thing it may decide, which is the reading that put the composing inside the
+     * measurement in the first place.
+     */
+    public record BoundaryReadings(String name)
+            implements Key<Map<String, Measure<List<BorderAssessment>>>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Measure<List<BorderAssessment>>>> compute(Db db) {
+            Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!prepared.present() || !sigs.present()) {
+                return Answer.absent();
+            }
+            Level level = levelOf(db);
+            return answerEveryBehavior(prepared.value(), behavior -> {
+                if (!(behavior instanceof Hir.SpecBehavior spec)) {
+                    return BoundaryDerivation.noSubject();   // measured at its stages, not here
+                }
+                if (BoundaryForMeasurement.of(sigs.value(), spec.name())
+                        instanceof BoundaryForMeasurement.NotDerived) {
+                    // No boundary to read the rules at, so the lines are a measure that was asked
+                    // for and could not be finished rather than a model that draws none.
+                    return BoundaryForMeasurement.failed(spec.name());
+                }
+                souther.compiler.partition.Partitions.Partitioning divided =
+                        db.ask(new Divided(name, spec.name())).value();
+                if (divided == null) {
+                    throw new IllegalStateException("`" + spec.name() + "` has a signature and no"
+                            + " reading of what the model divides it into");
+                }
+                List<BorderAssessment> read = level.composesValues()
+                        ? db.ask(new BoundarySearch(name, spec.name())).value()
+                        : db.ask(new Boundaries(name, spec.name())).value();
+                if (read == null) {
+                    throw new IllegalStateException("`" + spec.name() + "` has a reading of what"
+                            + " the model divides it into, and no answer about the lines that"
+                            + " reading drew");
+                }
+                return BoundaryDerivation.of(read, divided.borderClosure());
+            });
+        }
+    }
+
+    /**
      * What the rows established about every line one behavior's rules drew.
      *
      * <p>The one authority on a boundary. Whether a row sits at it and whether a row could sit at it
@@ -1634,9 +1723,8 @@ public final class Adequacy {
      * {@link BoundarySearch}'s, which reads this and adds to it — so what everybody pays for is the
      * reading, and what costs a decoder run for each point it settles is paid by whoever asked for it.
      *
-     * <p>Its own key rather than part of the coverage, because the coverage is not the only reader:
-     * what a build is refused over, what a report prints and what a generator offers are three
-     * readings of this one answer and not three measurements.
+     * <p>The lines alone, without how far the reading that found them got. What holds the two
+     * together is {@link BoundaryReadings}, and everything that accounts for rows reads that.
      */
     public record Boundaries(String name, String behavior)
             implements Key<List<BorderAssessment>> {
@@ -2694,7 +2782,7 @@ public final class Adequacy {
                 GenerationOutcome none = whereNoRowCouldAnswer(finding.about());
                 out.add(new GenerationDisposition(finding, none != null ? none
                         : switch (finding.about()) {
-                            case About.APointOfABorder(var point, var _) -> atEdge(finding, point, edges);
+                            case About.APointOfABorder(var point) -> atEdge(finding, point, edges);
                             case About.ACaseNoRowAppliesItTo(var input, var missing) ->
                                     atCase(input, missing, composed, spec);
                             case About.AClassNoRowIsIn(var missing) -> atClass(missing, composed);
@@ -2865,7 +2953,7 @@ public final class Adequacy {
          * copy back three fields deep, which does not identify a point: several rules can draw a
          * line at one value. A border is a value, and two lines that are equal are one line.
          */
-        private static GenerationOutcome atEdge(Finding gap, BorderAssessment.Point point,
+        private static GenerationOutcome atEdge(Finding gap, OwedBoundaryPoint point,
                                                 List<BorderAssessment> searched) {
             // Of whichever of the border's four points the finding is about. Which of them a build
             // refuses over is the criterion's answer and the loop above has already asked it; asking
@@ -2873,7 +2961,7 @@ public final class Adequacy {
             // is a second criterion, and it said the impossible about the two a build held to
             // reliable domain coverage refuses over.
             String subject = point.said();
-            if (!(BorderAssessment.owedAt(searched, point.border().border(), point.role())
+            if (!(BorderAssessment.owedAt(searched, point.line(), point.role())
                     instanceof ItemAssessment.Owed owed)) {
                 // A gap was found at a point nobody is owed a row at, which is the finding and
                 // the assessment disagreeing about the same border rather than a row that could
@@ -2950,33 +3038,23 @@ public final class Adequacy {
          * row worth offering. Keying what is offered on what a build refuses would leave a model
          * with no rows at all — the one an author most wants rows for — with nothing.
          *
-         * <p><b>The points this reading is owed a row at, and no others.</b> The two points against
+         * <p><b>The points this behavior is owed a row at, and no others.</b> The two points against
          * a line an {@code invariant} drew are the declaration's — one row settles the line however
          * many positions carry the type — and they are offered once, where the line is resolved
-         * ({@link DeclaredRows}). Offered from here as well, one authored line came out as a row per
-         * position of every behavior that carries it (issue #1076). The regions either side stay,
-         * because where a region stops is settled by every other rule reaching this position.
+         * ({@link DeclaredRows}). Offered from here as well, one authored line comes out as a row
+         * per position of every behavior that carries it. The regions either side stay, because
+         * where a region stops is settled by every other rule reaching this position.
          */
         private static Generator.GenerationResult offeredHere(String behavior,
                                                           List<BorderAssessment> boundaries) {
             List<Generator.GeneratedRow> rows = new ArrayList<>();
             List<Generator.UnresolvedCombination> unresolved = new ArrayList<>();
             List<souther.compiler.partition.GenerationReason> stopped = new ArrayList<>();
-            for (BorderAssessment border : boundaries) {
-              for (BorderAssessment.Point point : border.points()) {
-                souther.compiler.partition.PointRole role = point.role();
-                // The points this reading is owed a row at, which is what a filling is the answer
-                // about. A line an `invariant` drew is owed once over every behavior carrying the
-                // type, so the two points against it are the declaration's — offered from here as
-                // well, one authored line came out as a row per position of every behavior that
-                // carries it (issue #1076). They are offered once, where the line is resolved
-                // ({@link DeclaredRows}).
-                if (point.owedHere().isEmpty()) {
-                    continue;
-                }
-                if (!(point.item() instanceof ItemAssessment.Owed each)) {
-                    continue;   // nothing is owed here, so nothing was tried and nothing is offered
-                }
+            // What this behavior is owed a row for, as the values a row is composed at: one per
+            // point, since a row at a point answers everything a row there is owed for.
+            for (OwedBoundaryPoint point
+                    : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(boundaries))) {
+                ItemAssessment.Owed each = point.item();
                 switch (each.attempt()) {
                     case ItemAssessment.Attempt.Built built -> rows.add(built.row());
                     case ItemAssessment.Attempt.Unresolved why -> {
@@ -3010,12 +3088,11 @@ public final class Adequacy {
                     // hole in it is the search having skipped a point it was asked about.
                     case null -> {
                         if (each.worthSearching()) {
-                            throw new IllegalStateException("nothing was searched for at a point of "
-                                    + border.label() + " that is worth searching");
+                            throw new IllegalStateException("nothing was searched for at "
+                                    + point.said() + ", which is worth searching");
                         }
                     }
                 }
-              }
             }
             return new Generator.GenerationResult(rows, unresolved,
                     stopped.stream().distinct().toList());
@@ -3558,7 +3635,7 @@ public final class Adequacy {
                 // the same two codes.
                 case About.APointOfADeclaredBorder(var debt) -> debt.role().againstTheLine()
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
-                case About.APointOfABorder(var point, var _) -> point.role().againstTheLine()
+                case About.APointOfABorder(var point) -> point.role().againstTheLine()
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APositionNoLineDivides _ -> Kind.PARTITION_NOT_DERIVABLE;
                 case About.ARuleWithoutALine _ -> Kind.PARTITION_NOT_READ;
@@ -3661,12 +3738,7 @@ public final class Adequacy {
     }
 
     /**
-     * Every line this module's declarations are owed, made once.
-     *
-     * <p>The one place the readings of a line are folded into what is owed. A report, a build's
-     * refusal, a document and a generation all ask what became of a line an {@code invariant} drew,
-     * and four foldings of one set of readings are four answers about it — which is the shape
-     * issue #1062 is about, one layer up from where it was found.
+     * What a module's declarations are owed, and how far the reading it was made from got.
      *
      * <p>Every debt and not only the ones something is short of. A line a row already stands at is
      * what a verdict rests on as much as one nothing stands at: read off the findings, the debts
@@ -3681,8 +3753,89 @@ public final class Adequacy {
      * cannot check. Reading it is what there is to measure with — what a point asks of a row is read
      * off the readings — so a module that owes a line no behavior of it carries holds no debt for it
      * here, and nothing is said about the line at all.
+     *
+     * <p>An account and not a list, for the reason a behavior's is a {@link Measure}: what is owed
+     * is read off the lines this module's behaviors met, so a reading that did not run out may have
+     * left this short of debts it never saw. Handed the debts alone, a reader has a list that is
+     * empty for two reasons — a module whose declarations owe nothing, and one whose lines nobody
+     * could read — and the second reads as the first.
+     *
+     * <p>Two halves, because they are short of different things. {@code reading} is what finding
+     * the debts went without; what became of each debt is the debt's own measurement, and
+     * {@link #weakening()} is both.
+     *
+     * @param owed    every debt this module's declarations hold, covered or not
+     * @param reading what finding them went without, under the behavior whose reading went without
+     *                it. By behavior and not as one set, because a reader shown some of a module's
+     *                behaviors is owed what those behaviors' readings went without and not what the
+     *                rest did — folded into one set here, a view filtered to one behavior would
+     *                carry a reason about a position its reader cannot see
      */
-    public record DeclaredBorders(String name) implements Key<List<DeclaredDebt>> {
+    public record DeclaredBoundaries(List<DeclaredDebt> owed,
+                                     Map<String, WeakeningSet> reading) {
+
+        public DeclaredBoundaries {
+            owed = List.copyOf(owed);
+            // In the order the readings were made, which is what everything downstream of a
+            // weakening is written in: a set of reasons keeps the order they were discovered in so
+            // that two runs of one compile write one document, and a copy that did not would hand
+            // that set its causes in whatever order a hash gave.
+            reading = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(reading));
+        }
+
+        /**
+         * The same account as a reader shown only {@code behaviors} is owed.
+         *
+         * <p><b>Every part of it and not the ones that are easy to filter.</b> A debt is what its
+         * readings came to together, so a debt kept whole while its readings are filtered carries
+         * what a behavior the reader cannot see went without — the same fact, arriving by the half
+         * of the account nobody trimmed. So a debt none of them reads is dropped and a debt some of
+         * them read is made again from those readings, beside the reading each of them went
+         * without.
+         *
+         * <p>What is not sliced is who owes the line: a declaration owes it wherever the type is
+         * carried, and which behaviors a reader is shown is no part of that.
+         */
+        public DeclaredBoundaries keptFor(java.util.Set<String> behaviors) {
+            Map<String, WeakeningSet> kept = new LinkedHashMap<>(reading);
+            kept.keySet().retainAll(behaviors);
+            List<DeclaredDebt> owedHere = new ArrayList<>();
+            for (DeclaredDebt each : owed) {
+                BorderObligationPointAssessment debt = each.debt().keptFor(behaviors);
+                if (debt != null) {
+                    owedHere.add(new DeclaredDebt(debt, each.owners()));
+                }
+            }
+            return new DeclaredBoundaries(owedHere, kept);
+        }
+
+        /**
+         * What this account went without, all of it.
+         *
+         * <p>The reading that found the debts and the measurement of each of them. A verdict and a
+         * report read this rather than adding the two up themselves, which is what left the reading
+         * out of the module's status while every debt said it had been measured in full.
+         */
+        public WeakeningSet weakening() {
+            WeakeningSet out = WeakeningSet.none();
+            for (WeakeningSet went : reading.values()) {
+                out = out.union(went);
+            }
+            for (DeclaredDebt each : owed) {
+                out = out.union(each.debt().item().weakening());
+            }
+            return out;
+        }
+    }
+
+    /**
+     * That account, made once.
+     *
+     * <p>The one place the readings of a line are folded into what is owed. A report, a build's
+     * refusal, a document and a generation all ask what became of a line an {@code invariant} drew,
+     * and four foldings of one set of readings are four answers about it.
+     */
+    public record DeclaredBorders(String name) implements Key<DeclaredBoundaries> {
 
         @Override
         public String module() {
@@ -3690,23 +3843,40 @@ public final class Adequacy {
         }
 
         @Override
-        public Answer<List<DeclaredDebt>> compute(Db db) {
-            Map<String, PartitionEvidence> partitions = db.ask(new Coverage(name)).value();
-            if (partitions == null) {
-                return Answer.of(List.of());
+        public Answer<DeclaredBoundaries> compute(Db db) {
+            Map<String, Measure<List<BorderAssessment>>> lines =
+                    db.ask(new BoundaryReadings(name)).value();
+            if (lines == null) {
+                // Nobody read this module's lines, so what its declarations are owed was not
+                // measured either. Answered as an account with no debts, that would be this module
+                // owing nothing — which is what a module whose every line is covered also answers.
+                return Answer.absent();
             }
+            // What finding the debts went without, which is what the readings they are found from
+            // went without. Carried rather than dropped: a reading that did not run out may have
+            // left a line this module's declarations owe unread, and an account that said nothing
+            // about it would report the debts it happened to see as all there are.
+            Map<String, WeakeningSet> went = new LinkedHashMap<>();
+            lines.forEach((behavior, read) -> {
+                if (!read.weakening().isEmpty()) {
+                    went.put(behavior, read.weakening());
+                }
+            });
             Map<String, List<BorderAssessment>> readings = new LinkedHashMap<>();
-            partitions.forEach((behavior, evidence) -> {
+            lines.forEach((behavior, read) -> {
                 // Every reading, because which of them this module keeps an account of is a question
                 // about the points they owe and not about the lines they are readings of. A line
                 // another module wrote can be stopped where this module's declaration takes the
                 // position in, and the run beside it is then this module's to answer for — dropped
                 // here, that point was accounted nowhere at all.
+                //
+                // The lines a reading found, with how far it got carried above rather than here: a
+                // debt is made from the lines and is short of whatever finding them was short of.
                 readings.computeIfAbsent(behavior, _ -> new ArrayList<>())
-                        .addAll(evidence.boundaries());
+                        .addAll(read.made().orElseGet(List::of));
             });
             if (readings.isEmpty()) {
-                return Answer.of(List.of());
+                return Answer.of(new DeclaredBoundaries(List.of(), went));
             }
             // What names a line and where its declaration is are read from the declaration, and
             // neither is something a debt can go without — so they are asked here, once, and their
@@ -3721,15 +3891,12 @@ public final class Adequacy {
             List<DeclaredDebt> out = new ArrayList<>();
             // A run that stops at a body's own rule exists in that body and nowhere else, so no
             // declaration is owed a row inside it however the line beside it was written; and this
-            // module keeps an account only where its own declarations are among what settled the
-            // point. Both are asked of what settled it rather than of what identifies it — a
-            // declaration that took the position in put the end there without being a line of the
-            // point at all. A module reading a line another module wrote and narrowing nothing about
-            // it owes nothing here, which is the dependency it carries rather than a debt (#1077).
+            // module keeps an account only where its own declarations are among what owes the
+            // point. Which points those are is the reading's own answer and is asked there: a module
+            // reading a line another module wrote and narrowing nothing about it owes nothing here,
+            // which is the dependency it carries rather than a debt.
             for (BorderObligationPointAssessment debt : BorderObligationPointAssessment.across(
-                    readings,
-                    owed -> owed.attribution().owedToDeclarations()
-                            && !owed.attribution().ownersIn(name).isEmpty(),
+                    readings, name,
                     point -> axisOf(point.line(), declarations, symbols, policy))) {
                 List<DeclaredDebt.Owner> owners = new ArrayList<>();
                 for (TypeSymbol.AtModule owner : debt.attribution().ownersIn(name)) {
@@ -3738,7 +3905,7 @@ public final class Adequacy {
                 }
                 out.add(new DeclaredDebt(debt, owners));
             }
-            return Answer.of(List.copyOf(out));
+            return Answer.of(new DeclaredBoundaries(out, went));
         }
 
         /**
@@ -3852,11 +4019,11 @@ public final class Adequacy {
          * answering from the readings and the aggregation would hold in none of them.
          */
         private static void declaredFindings(Db db, String module, List<Finding> out) {
-            List<DeclaredDebt> debts = db.ask(new DeclaredBorders(module)).value();
-            if (debts == null) {
+            DeclaredBoundaries account = db.ask(new DeclaredBorders(module)).value();
+            if (account == null) {
                 return;
             }
-            for (DeclaredDebt owed : debts) {
+            for (DeclaredDebt owed : account.owed()) {
                 ItemAssessment item = owed.debt().item();
                 if (!item.isUnmetGap()) {
                     continue;
@@ -3953,37 +4120,21 @@ public final class Adequacy {
                             Citation.of(behavior.pos()), new About.AClassNoRowIsIn(missing)));
                 }
             }
-            // The assessment's own items, walked as items. Flattened here a second way, a reader
-            // that forgot a role would be short by it — which is the shape the whole measure was in
-            // before a border owed its four.
-            for (BorderAssessment.Point point
-                    : BorderAssessment.pointsOf(partition.boundaries())) {
+            // This behavior's account, walked as the things it is owed. One finding per thing and
+            // not one per role: a place two of this body's rules drew a line at leaves a run owed to
+            // each of them, and each is one obligation to be told about — a single row may well
+            // answer both. A line the declarations are owed is answered once for the module and is
+            // no part of this account.
+            for (OwedBoundaryPoint owed : partition.owedPoints()) {
                 // Both halves, asked of the two answers the assessment keeps apart. A point no
                 // row was measured against is not a gap, and neither is one nothing has shown a
                 // row can be written at — that point is where the reading stopped rather than
-                // where the model does, and a row at it may be one nobody can write. A point
-                // nobody is owed a row at is not a gap either, and it says so as its own shape.
-                if (!point.item().isUnmetGap()) {
+                // where the model does, and a row at it may be one nobody can write.
+                if (!owed.item().isUnmetGap()) {
                     continue;
                 }
-                // A line the declaration is owed is answered once for the module, from every
-                // reading of it. Left here as well, one clause of `UserId` is 126 findings over
-                // `crm` — one per position of every behavior carrying the type — for a rule the
-                // author wrote once (issue #1062). Asked of the rule rather than matched on which
-                // kind it is: which of them are the declaration's is the rule's own answer.
-                // This behavior's own. A line a declaration is owed is answered once for the
-                // module, from every reading of it.
-                // One finding per thing this reading is owed a row for, and not one per role: a
-                // place two of this body's rules drew a line at leaves a run owed to each of them,
-                // and each is one obligation to be told about — a single row may well answer both.
-                // The axis, the value, the rule and the role used to be copied out here, and a
-                // reader then matched the copy back against the assessments to find the one it came
-                // from.
-                for (souther.compiler.partition.OwedPoint owed : point.owedHere()) {
-                    out.add(Finding.by(behavior.name(), point.item().weakeningSource(),
-                            Citation.of(behavior.pos()),
-                            new About.APointOfABorder(point, owed.point())));
-                }
+                out.add(Finding.by(behavior.name(), owed.item().weakeningSource(),
+                        Citation.of(behavior.pos()), new About.APointOfABorder(owed)));
             }
             // What the model divides this position no way at all, which is the classes question and
             // is answered only for a position that has none.
@@ -4192,28 +4343,28 @@ public final class Adequacy {
                                                 .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
                                                 debt.role().name(), debt.axis(), debt.against(),
                                                 debt.id().named());
-                        case About.APointOfABorder(var point, var _) ->
+                        case About.APointOfABorder(var point) ->
                                 point.role().againstTheLine()
-                                        ? point.border().origin().isWrittenRatherThanNamed()
+                                        ? point.origin().isWrittenRatherThanNamed()
                                                 ? new ExampleMessage
                                                         .NoRowIsAtThePointOfTheBorderAConstructDrew(
-                                                        point.role().name(), point.border().axis(),
+                                                        point.role().name(), point.axis(),
                                                         point.against(), constructOf(point))
                                                 : new ExampleMessage
                                                         .NoRowIsAtThePointOfTheBorderARuleDrew(
-                                                        point.role().name(), point.border().axis(),
+                                                        point.role().name(), point.axis(),
                                                         point.against(),
-                                                        point.border().origin().named())
-                                        : point.border().origin().isWrittenRatherThanNamed()
+                                                        point.origin().named())
+                                        : point.origin().isWrittenRatherThanNamed()
                                                 ? new ExampleMessage
                                                         .NoRowIsAtThePointAwayFromTheBorderAConstructDrew(
-                                                        point.role().name(), point.border().axis(),
+                                                        point.role().name(), point.axis(),
                                                         point.against(), constructOf(point))
                                                 : new ExampleMessage
                                                         .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
-                                                        point.role().name(), point.border().axis(),
+                                                        point.role().name(), point.axis(),
                                                         point.against(),
-                                                        point.border().origin().named());
+                                                        point.origin().named());
                         case About.AnArmNoRowGoesThrough(var arm) ->
                                 new ExampleMessage.NoRowGoesThroughThatArm(
                                         phraseFor(arm), arm.behavior());
@@ -4239,7 +4390,7 @@ public final class Adequacy {
                 // The same hints, asked of the role. What a row at each point shows is a fact
                 // about the point and not about which of the two questions raised it.
                 case About.APointOfADeclaredBorder(var debt) -> hintFor(debt.role(), built);
-                case About.APointOfABorder(var point, var _) -> {
+                case About.APointOfABorder(var point) -> {
                     // Asked of the point, and in the point's own vocabulary. A hint saying which
                     // side of the line the value falls on would be keyed on the border being closed
                     // or open rather than on the role — `n <= 100` is at its ON point on the line
@@ -4255,7 +4406,7 @@ public final class Adequacy {
                     // dropped, on the grounds that a label naming no source would be read against
                     // the file the diagnostic is in; a label no longer takes its file from where it
                     // is shown, so what was left unsaid can be said.
-                    point.border().origin().citation().ifPresent(cited -> {
+                    point.origin().citation().ifPresent(cited -> {
                         switch (cited) {
                             case souther.compiler.diag.Citation.Written w ->
                                     built.secondary(souther.compiler.diag.Region.point(w.at()),
@@ -4326,7 +4477,7 @@ public final class Adequacy {
          *  supplies. One phrase, because a rule found by where it is written is a comparison —
          *  which construct stands around it is a fact about the body and not about the rule. */
         private static souther.compiler.diag.Localizable constructOf(
-                BorderAssessment.Point point) {
+                OwedBoundaryPoint point) {
             return souther.compiler.diag.Localizable.of("construct.comparison");
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/BehaviorEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BehaviorEvidence.java
@@ -22,19 +22,50 @@ package souther.compiler.query;
  * with nothing: every measure that ran says why it has no number. The reading is always there,
  * because there is always an answer to how far the rows were read — including that nobody asked.
  *
- * @param reading   how far the reading of this behavior's rows got, and what it read
- * @param signature what the rows establish about the cases of its inputs and its output
- * @param partition what they establish about the classes and the lines its rules draw
- * @param branch    what they establish about the arms of its body
+ * <p><b>The lines are read here and accounted for beside it.</b> Which lines this behavior's
+ * positions meet, and how far the reading that found them got, is one measure and is held once; what
+ * this behavior is owed a row for at them is one account of it, and what the module's declarations
+ * are owed is another. A reader that describes a border whole — a block that accounts for its four
+ * points, a document that publishes them — reads the lines; a reader that measures this behavior
+ * reads its account.
+ *
+ * @param reading          how far the reading of this behavior's rows got, and what it read
+ * @param signature        what the rows establish about the cases of its inputs and its output
+ * @param partition        what they establish about the classes, and what this behavior is owed a
+ *                         row for at the lines its rules draw
+ * @param boundaryReadings every line its positions met, in every role, whosever the row at each
+ *                         point is
+ * @param branch           what they establish about the arms of its body
  */
 public record BehaviorEvidence(Adequacy.RowReading reading,
                                Adequacy.SignatureEvidence signature,
                                PartitionEvidence partition,
+                               Measure<java.util.List<BorderAssessment>> boundaryReadings,
                                Adequacy.BranchEvidence branch) {
 
     public BehaviorEvidence {
         java.util.Objects.requireNonNull(reading,
                 "there is always an answer to how far a behavior's rows were read");
+        // The account and the lines it was read from arrive together or not at all. They are two
+        // readings of one measurement, so a behavior holding one of them is this compiler having
+        // answered half a question — and whoever met it next would have to decide what the half it
+        // was holding meant.
+        if ((partition == null) != (boundaryReadings == null)) {
+            throw new IllegalArgumentException("a behavior measured at the lines its positions met"
+                    + " and not at what it is owed a row for, or the other way about: "
+                    + partition + " / " + boundaryReadings);
+        }
+        // And two readings of one measurement rather than two measurements. What this behavior is
+        // owed is read off the lines it met, so the account beside them is the one they come to —
+        // and the two are read by different readers: a block and a document show the lines, and a
+        // finding, a verdict and an editor read the account. Held apart without being held together,
+        // one behavior could show one reading's borders under another reading's findings, and
+        // nothing downstream is in a position to notice.
+        if (partition != null
+                && !partition.owes().equals(OwedBoundaryPoint.accountOf(boundaryReadings))) {
+            throw new IllegalArgumentException("a behavior whose account is not what the lines it"
+                    + " was read at come to: " + partition.owes() + " from " + boundaryReadings);
+        }
     }
 
     /**
@@ -56,7 +87,7 @@ public record BehaviorEvidence(Adequacy.RowReading reading,
         parts.put("reading", reading.measured());
         parts.put("signature", signature == null ? null : signature.counted());
         parts.put("partition", partition == null ? null : partition.partitioned());
-        parts.put("border", partition == null ? null : partition.bounded());
+        parts.put("border", boundaryReadings);
         parts.put("branch", branch == null ? null : branch.measured());
         return java.util.Collections.unmodifiableMap(parts);
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -88,15 +88,10 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
         return at(role) instanceof ItemAssessment.Owed owed ? owed : null;
     }
 
-    /**
-     * The position this border is on, as a report names it.
-     *
-     * <p>Asked of the shape of the line rather than of a field every shape was assumed to have. A line
-     * between two positions is on neither of them, and answering with one of the two would name a
-     * border after half of itself.
-     */
+    /** The position this border is on, as a report names it. The line's own answer, so that a point
+     *  taken out of this and the block printed round it name it alike. */
     public String axis() {
-        return border.cut().named();
+        return border.axis();
     }
 
     /** Which shape this line has, which is what says how to read what each item asks for. */
@@ -106,7 +101,7 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
 
     /** The rule that drew the line, as a report about {@code sectionSource} writes it. */
     public String describe(SourceNameResolver names, SourceId sectionSource) {
-        return border.origin().describe(names, sectionSource);
+        return border.describe(names, sectionSource);
     }
 
     /**
@@ -136,18 +131,12 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
 
     /** How one point relates a row's value to what it is against, or null where none is owed. */
     public String operator(PointRole role) {
-        souther.compiler.partition.Criterion criterion = border.demand(role).criterion();
-        return criterion == null ? null : criterion.operator();
+        return border.operator(role);
     }
 
     /** What that point is against, or null where none is owed. */
     public String against(PointRole role) {
-        souther.compiler.partition.Criterion criterion = border.demand(role).criterion();
-        // Asked of the criterion, which is what knows whether it is written against a level or
-        // against a run of them. Two of the four points name a level and two name a run, and a
-        // reader that took a level from every shape wrote a value inside a run as though it were
-        // the run.
-        return criterion == null ? null : criterion.written(border.cut().of());
+        return border.against(role);
     }
 
     /** The left of the {@code left = right} a report names this line by. */
@@ -186,51 +175,11 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
             return border.against(role);
         }
 
-        /**
-         * The class a row here falls in, as one line of a class list is written.
-         *
-         * <p>One place, because more than one reader names it: the document a consumer joins a
-         * finding to its item by, and the class a generated row is offered against. Written twice,
-         * the two agreed for a point on the line and had nothing to say to each other away from it.
-         *
-         * <p>A point on the line is the value it is at. A point away from it carries the relation as
-         * well, because {@link #against()} alone names the border there rather than the side of it a
-         * row is owed in.
-         */
+        /** The class a row here falls in, as one line of a class list is written. The line's own
+         *  answer, so that a point taken out of this and one of a behavior's account say it
+         *  alike. */
         public String said() {
-            return role.againstTheLine() ? border.axis() + " = " + against()
-                    : border.axis() + " " + asked();
-        }
-
-        /**
-         * What the behavior this reading belongs to is owed a row for here.
-         *
-         * <p>A point can be owed to a declaration rather than to any body carrying the type: what a
-         * row standing at the line shows is a fact about the type, and one row anywhere settles it.
-         * A region beside the line is the same where nothing but declarations settled where it stops
-         * — and this reading's where a rule of this body did, since such a run exists in this body
-         * and nowhere else.
-         *
-         * <p>The points and not whether there are any, because one role can owe more than one: a
-         * place two rules drew a line at leaves a run owed to each of them, and each is its own
-         * obligation to be told about — a single row may well answer both, which is a question for
-         * whoever offers rows and not for this. Answered as a yes, everything downstream went on
-         * accounting in this reading's roles, which is the occurrence standing in for the debt one
-         * level down from where it was taken out.
-         *
-         * <p>Asked here and not at each reader. Everything that measures a behavior, counts what it
-         * covers or raises a finding about it has to leave the declaration's points out, and the
-         * rule written at each of them is a rule each of them can forget: a verdict that kept them
-         * weighed one behavior's row against another behavior having no rows, and a count that keeps
-         * them says a body is short of something no row written for it is owed.
-         *
-         * <p>A reader that only describes may show them all the same. What is not this behavior's to
-         * be measured for is still a line its values are held to, and the block that says so is
-         * telling an author about the type they wrote.
-         */
-        public java.util.List<souther.compiler.partition.OwedPoint> owedHere() {
-            return border.border().owes(role).stream()
-                    .filter(owed -> !owed.attribution().owedToDeclarations()).toList();
+            return border.border().said(role);
         }
 
         /** The measured half, or null where no row is owed here. */

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public record BorderObligationPointAssessment(BorderObligationPoint point, String axis,
                                               souther.compiler.partition.PointAttribution
-                                                      attribution,
+                                                      .TheDeclarations attribution,
                                               Demand demand, ItemAssessment.Owed item,
                                               java.util.SequencedMap<Reading, BorderAssessment>
                                                       met) {
@@ -92,35 +92,56 @@ public record BorderObligationPointAssessment(BorderObligationPoint point, Strin
     }
 
     /**
-     * The points of a module, from every reading of every one of them.
+     * The points {@code module}'s declarations owe, from every reading of every one of them.
      *
      * <p>In the order the readings were made, so that what a report prints is read against the one
      * before it. What tells the points apart is what a border says it owes and nothing here: a
      * caller that grouped by anything else — the label, the rule, the position — would be deciding
      * what a debt is a second time and somewhere else.
+     *
+     * <p><b>Which points those are is asked of the attribution and of nothing else.</b> A row this
+     * reading's own rule settled is that body's to write and is no debt of any declaration; a row
+     * owed to declarations none of which are this module's is a line this module's values are held
+     * to and somebody else's to answer for. Both are the reading's own answer, read here rather
+     * than re-derived, and the module is what this account is of.
      */
     public static List<BorderObligationPointAssessment> across(
-            Map<String, List<BorderAssessment>> byBehavior,
-            java.util.function.Predicate<souther.compiler.partition.OwedPoint> keep,
+            Map<String, List<BorderAssessment>> byBehavior, String module,
             java.util.function.Function<BorderObligationPoint, String> named) {
         Map<BorderObligationPoint, java.util.SequencedMap<Reading, BorderAssessment>> byPoint =
                 new LinkedHashMap<>();
-        Map<BorderObligationPoint, souther.compiler.partition.PointAttribution> attribution =
+        Map<BorderObligationPoint,
+                souther.compiler.partition.PointAttribution.TheDeclarations> attribution =
                 new LinkedHashMap<>();
         byBehavior.forEach((behavior, readings) -> {
             for (BorderAssessment reading : readings) {
                 Reading where = new Reading(behavior, reading.border().cut().left());
                 for (souther.compiler.partition.OwedPoint each : reading.border().owes()) {
-                    if (!keep.test(each)) {
+                    // Every arm answered, for the reason the account beside this one answers them
+                    // all: a point whose arm neither producer names is a point measured nowhere,
+                    // and both of them would go on compiling.
+                    souther.compiler.partition.PointAttribution.TheDeclarations owedTo =
+                            switch (each.attribution()) {
+                                // A row a rule of this body settled is that behavior's own account
+                                // ({@link OwedBoundaryPoint#across}).
+                                case souther.compiler.partition.PointAttribution.TheReading _ ->
+                                        null;
+                                case souther.compiler.partition.PointAttribution
+                                        .TheDeclarations it -> it;
+                            };
+                    // And this module keeps the account only where its own declarations are among
+                    // the owners: a line another module wrote and this one narrowed nothing about
+                    // is the dependency it carries rather than a debt.
+                    if (owedTo == null || owedTo.ownersIn(module).isEmpty()) {
                         continue;
                     }
                     BorderObligationPoint owed = each.point();
-                    // What settled the point is the reading's, so a point read twice is settled by
-                    // what either reading says settled it. Kept as the first reading's, a point one
+                    // What settled the point is the reading's, so a point read twice is owed to
+                    // what either reading says owes it. Kept as the first reading's, a point one
                     // module's declaration narrowed at one position and another's at another would
                     // be attributed to whichever the walk reached first.
-                    attribution.merge(owed, each.attribution(),
-                            souther.compiler.partition.PointAttribution::and);
+                    attribution.merge(owed, owedTo,
+                            souther.compiler.partition.PointAttribution.TheDeclarations::and);
                     BorderAssessment already = byPoint
                             .computeIfAbsent(owed, _ -> new LinkedHashMap<>()).put(where, reading);
                     if (already != null) {
@@ -151,12 +172,39 @@ public record BorderObligationPointAssessment(BorderObligationPoint point, Strin
      */
     public static BorderObligationPointAssessment of(
             BorderObligationPoint point, String axis,
-            souther.compiler.partition.PointAttribution attribution,
+            souther.compiler.partition.PointAttribution.TheDeclarations attribution,
             java.util.SequencedMap<Reading, BorderAssessment> met) {
         List<BorderAssessment> readings = List.copyOf(met.values());
         Demand asked = asked(point, readings);
         return new BorderObligationPointAssessment(point, axis, attribution, asked,
                 came(point.role(), readings, asked), met);
+    }
+
+    /**
+     * The same point as a reader shown only {@code behaviors} is owed it, or null where none of
+     * them reads it.
+     *
+     * <p>What a debt came to is what its readings came to together, so a view that shows some of
+     * them is owed what those came to and not what the rest did: a row that was not read in a
+     * behavior the reader cannot see leaves this debt undecided for a reader who cannot act on it,
+     * and the reason it is undecided names a position that is not on the page.
+     *
+     * <p>Made again from the readings that are left rather than trimmed, because everything about a
+     * debt but its identity follows from them — what it asks of a row, what became of it, which
+     * behaviors carry it. Trimming the ones a reader can name and keeping the answer folded from
+     * all of them is how a filtered view came to carry a hidden behavior's evidence.
+     *
+     * <p>Who owes it is not re-derived. A declaration owes a line wherever the type is carried, and
+     * which behaviors this reader is shown is no part of that.
+     */
+    public BorderObligationPointAssessment keptFor(java.util.Set<String> behaviors) {
+        java.util.SequencedMap<Reading, BorderAssessment> kept = new LinkedHashMap<>();
+        met.forEach((where, reading) -> {
+            if (behaviors.contains(where.behavior())) {
+                kept.put(where, reading);
+            }
+        });
+        return kept.isEmpty() ? null : of(point, axis, attribution, kept);
     }
 
     /** Every reading of the line that owes this point, in the order they were made. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -138,18 +138,21 @@ final class Coverages {
      *                   {@link souther.compiler.query.Adequacy.Divided} and read here. Worked out
      *                   again on the way in, this and the boundaries beside it would be two
      *                   derivations of one thing and two chances to disagree about it
-     * @param boundaries what was established about every line this behavior's rules drew, made once
-     *                   by {@link souther.compiler.query.Adequacy.Boundaries} and read here. Measuring
-     *                   a line takes putting a value through the module's decoders, which is not
-     *                   something a coverage count can do on its own and not something that should
-     *                   happen twice.
+     * @param lines      what was established about every line this behavior's rules drew, and how
+     *                   far the reading that found them got, made once by
+     *                   {@link souther.compiler.query.Adequacy.BoundaryReadings} and read here.
+     *                   Measuring a line takes putting a value through the module's decoders, which
+     *                   is not something a coverage count can do on its own and not something that
+     *                   should happen twice. What comes out of it here is this behavior's own
+     *                   account: which of a border's points are its to write a row at is the
+     *                   reading's answer and is read once, where the account is made
      */
     static PartitionEvidence of(Hir.SpecBehavior behavior, InputDomain inputs, Sig sig,
                                 Symbols symbols, ReadingPolicy policy,
                                 Partitions.Partitioning partitioning,
                                 souther.compiler.query.Adequacy.RowReading observed,
                                 souther.compiler.query.Adequacy.Level level,
-                                List<BorderAssessment> boundaries,
+                                Measure<List<BorderAssessment>> lines,
                                 souther.compiler.partition.AdequacyPolicy.OfTheMeasures budget) {
         List<RowOutcome> rows = observed.rowsSeen();
         List<String> parameters = behavior.params().stream().map(Hir.Param::name).toList();
@@ -179,7 +182,7 @@ final class Coverages {
         // in full, and the enumeration above is the same case the other way round.
         return new PartitionEvidence(
                 PartitionDerivation.of(axes, partitioning.partitionClosure()),
-                BoundaryDerivation.of(boundaries, partitioning.borderClosure()),
+                OwedBoundaryPoint.accountOf(lines),
                 pairsOf(behavior.name(), divided, readings, level.readsRows(), budget),
                 partitioning.undivided(), partitioning.rulesWithoutALine(), partitioning.blocked(),
                 // What the model asked and nothing answered, taken whole and not gathered as the

--- a/souther-compiler/src/main/java/souther/compiler/query/Measure.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Measure.java
@@ -61,6 +61,31 @@ public sealed interface Measure<T> permits Measurement, Measure.NotApplicable {
     MeasureReason why();
 
     /**
+     * The same answer, about what {@code as} makes of what this found.
+     *
+     * <p>For a value read off another measure's: what a behavior is owed a row for is read off the
+     * lines its positions met, and the two are one measurement rather than two. What that
+     * measurement came to is decided where the reading is, so every arm is carried over unchanged
+     * and nothing here chooses between them — a projection that decided again could call a reading
+     * that did not run out complete over whatever it happened to produce.
+     *
+     * <p>The one place a measure's arms are carried over, which is why it is here and not beside
+     * each value that does it. Written by each of them, an arm added later would reach only the
+     * ones somebody remembered.
+     */
+    default <U> Measure<U> readAs(java.util.function.Function<T, U> as) {
+        return switch (this) {
+            case NotApplicable<T> none -> new NotApplicable<>(none.why());
+            case Measurement.Complete<T> made -> new Measurement.Complete<>(as.apply(made.value()));
+            case Measurement.Partial<T> made ->
+                    new Measurement.Partial<>(as.apply(made.value()), made.by());
+            case Measurement.NotMeasured<T> not -> new Measurement.NotMeasured<>(not.why());
+            case Measurement.FailedToMeasure<T> failed ->
+                    new Measurement.FailedToMeasure<>(failed.why(), failed.by());
+        };
+    }
+
+    /**
      * There is nothing here for the measure to be about, and no row would change that.
      *
      * <p>A positive claim about the model, and the strongest thing anything here says. It is not

--- a/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
@@ -1,0 +1,233 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.partition.Border;
+import souther.compiler.partition.BorderObligationPoint;
+import souther.compiler.partition.OriginRef;
+import souther.compiler.partition.OwedPoint;
+import souther.compiler.partition.PointAttribution;
+import souther.compiler.partition.PointRole;
+import souther.compiler.source.SourceId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One thing a behavior is owed a row for at a line its values are held to, and what became of it.
+ *
+ * <p>The unit everything that measures a behavior works in: what a verdict rests on, what a finding
+ * is about, and what a generator offers a row for. A behavior's account is a list of these and holds
+ * nothing else, so a reader cannot ask about a point that is not the behavior's — which is the one
+ * question, asked of a border's four points, that every reader used to have to remember not to put.
+ *
+ * <p><b>The line and not a reading of the line's four points.</b> What a report writes about one of
+ * these is written from the line, which is what the author moved; the assessments of the border's
+ * other roles are the block's to print and no part of this. Held here, a measure would reach the
+ * points beside this one, and two of a border's four can be the declarations' — so the account would
+ * hand back what it exists to keep out.
+ *
+ * <p><b>One per obligation and not one per role.</b> A place two of this body's rules drew a line at
+ * leaves a run owed to each of them, and each is its own thing to be told about; a single row may
+ * well answer both, which is a question for whoever offers rows.
+ *
+ * <p><b>Made in one place, because the four readings of it have to be of one point.</b> Where it is,
+ * what is owed there and what became of it are read by three different readers — a report, a debt,
+ * a verdict — so a value assembled from three points would be noticed by none of them.
+ */
+public final class OwedBoundaryPoint {
+
+    private final Border line;
+    private final PointRole role;
+    private final BorderObligationPoint owed;
+    private final ItemAssessment.Owed item;
+
+    /**
+     * Made from one assessed line and one of its roles, and not from four values.
+     *
+     * <p>A class rather than a record for that reason. The four are one point read four ways — where
+     * it is, what a row there is owed for, and what became of it — and a shape anybody can fill in
+     * lets a value show one line, name another line's debt and be judged by a third line's
+     * measurement. Nothing downstream would notice: the three are read by three different readers.
+     *
+     * <p>So the assessment is what is handed in, the role picks the point out of it, and what came
+     * to it is taken from there rather than passed alongside. The assessment itself is not kept —
+     * an entry of a behavior's account may not reach the points beside it, which is the whole of
+     * what the account is for.
+     */
+    private OwedBoundaryPoint(BorderAssessment at, PointRole role, BorderObligationPoint owed) {
+        if (at == null || role == null || owed == null) {
+            throw new IllegalArgumentException("a row owed here is owed at a point of a line, for"
+                    + " something: " + owed);
+        }
+        // And the thing owed is a thing owed at that point of that line. Checked rather than
+        // trusted: the line and the role say where a report writes this, and what is owed says what
+        // a row here answers, so a value whose halves named different points would be a finding
+        // about one line printed at another.
+        if (!owed.line().equals(at.border().obligation()) || owed.role() != role) {
+            throw new IllegalArgumentException("a point of " + at.border().label() + " at " + role
+                    + " owed for something at another point: " + owed);
+        }
+        if (!(at.at(role) instanceof ItemAssessment.Owed measured)) {
+            throw new IllegalArgumentException("a row owed at a point this border owes none at: "
+                    + at.border().label() + " " + role);
+        }
+        this.line = at.border();
+        this.role = role;
+        this.owed = owed;
+        this.item = measured;
+    }
+
+    /** The line, as this behavior's position met it. */
+    public Border line() {
+        return line;
+    }
+
+    /** Which of the border's four points this is. */
+    public PointRole role() {
+        return role;
+    }
+
+    /** What a row here is owed for, which several readings of the line share. */
+    public BorderObligationPoint owed() {
+        return owed;
+    }
+
+    /** What became of it. Owed, because a point nobody is owed a row at is no part of any account. */
+    public ItemAssessment.Owed item() {
+        return item;
+    }
+
+    /**
+     * What this behavior is owed a row for, over the lines its positions met.
+     *
+     * <p>The one place a behavior's account is made, and the only place one of these is. Which
+     * points are this behavior's is the reading's own answer ({@link PointAttribution}), read here
+     * rather than decided again: a row owed to the declarations that drew the line is answered once
+     * for the module, from every reading of it, and a behavior measured against it is weighed
+     * against another behavior's rows.
+     */
+    public static List<OwedBoundaryPoint> across(List<BorderAssessment> lines) {
+        List<OwedBoundaryPoint> out = new ArrayList<>();
+        for (BorderAssessment each : lines) {
+            for (PointRole role : PointRole.values()) {
+                // Nothing is owed in this role at all, so neither account holds anything here and
+                // the border says as much. What a report shows of such a point is the block's.
+                if (!(each.at(role) instanceof ItemAssessment.Owed)) {
+                    continue;
+                }
+                for (OwedPoint owed : each.border().owes(role)) {
+                    // Every arm answered, so that whose a point is stays a question with as many
+                    // answers as there are accounts. Asked as "is it this one", an arm added later
+                    // would fall out of both accounts and be measured nowhere, and both producers
+                    // would go on compiling.
+                    switch (owed.attribution()) {
+                        case PointAttribution.TheReading _ ->
+                                out.add(new OwedBoundaryPoint(each, role, owed.point()));
+                        // Answered once for the module, from every reading of it
+                        // ({@link Adequacy.DeclaredBorders}).
+                        case PointAttribution.TheDeclarations _ -> { }
+                    }
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * Two of these are one where they are the same point of the same line, measured alike.
+     *
+     * <p>Written out because this is not a record, and because something asks: what a behavior is
+     * owed is read off the lines it met, so two readings of one measurement come to the same
+     * account and a reader holding both is entitled to find that out
+     * ({@link BehaviorEvidence}).
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof OwedBoundaryPoint that && role == that.role
+                && line.equals(that.line) && owed.equals(that.owed) && item.equals(that.item);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(line, role, owed, item);
+    }
+
+    @Override
+    public String toString() {
+        return said() + " (" + role + " of " + line.label() + ")";
+    }
+
+    /**
+     * A behavior's account, as a measure: what it is owed a row for, and how far the reading that
+     * found the lines got.
+     *
+     * <p>The lines' own measure and not a second one. Which lines a behavior's positions meet is
+     * what the reading of them came to, and an account made from a reading that did not run out is
+     * an account that may be short of entries — so what weakened the reading weakens this, and a
+     * verdict reading the entries alone would take a behavior whose lines nobody could derive for
+     * one with nothing to answer for.
+     *
+     * <p>Complete and empty is a different answer from either: the lines were read to the end, and
+     * every point of them is owed to the declarations that drew them.
+     */
+    public static Measure<List<OwedBoundaryPoint>> accountOf(
+            Measure<List<BorderAssessment>> lines) {
+        return lines.readAs(OwedBoundaryPoint::across);
+    }
+
+    /**
+     * The account with one entry per point of a line rather than one per thing owed there.
+     *
+     * <p>For a reader whose unit is the row and not the obligation. A row stands at a point of a
+     * line, and what a row there shows answers everything a row there is owed for — so a place two
+     * of this body's rules drew a line at is two things to be told about and one value to compose.
+     * Walked as the obligations, a search that composed one value would offer it twice.
+     *
+     * <p>What is dropped is {@link #owed()} and nothing else: the entries that come back name one of
+     * the things owed at their point, and everything a row is composed and labelled from — the line,
+     * the role and what was measured — is the same at all of them.
+     */
+    public static List<OwedBoundaryPoint> oneForEachPoint(List<OwedBoundaryPoint> account) {
+        List<OwedBoundaryPoint> at = new ArrayList<>();
+        for (OwedBoundaryPoint each : account) {
+            if (at.stream().noneMatch(
+                    seen -> seen.role() == each.role() && seen.line().equals(each.line()))) {
+                at.add(each);
+            }
+        }
+        return List.copyOf(at);
+    }
+
+    /** The position the line is on, as a report names it. */
+    public String axis() {
+        return line.axis();
+    }
+
+    /** What this asks of a row, as a report writes it. */
+    public String asked() {
+        return line.operator(role) + " " + line.against(role);
+    }
+
+    /** What the point is against. */
+    public String against() {
+        return line.against(role);
+    }
+
+    /** The class a row here falls in, as one line of a class list is written. The line's own
+     *  answer, so that a finding about this point and the block that shows the line name it
+     *  alike. */
+    public String said() {
+        return line.said(role);
+    }
+
+    /** The rule that drew the line, as a report about {@code sectionSource} writes it. */
+    public String describe(SourceNameResolver names, SourceId sectionSource) {
+        return line.describe(names, sectionSource);
+    }
+
+    /** The rule as this reading met it, for a reader that renders it rather than printing what
+     *  {@link #describe} would. */
+    public OriginRef origin() {
+        return line.origin();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -13,8 +13,17 @@ import java.util.Set;
  * everything downstream would recompute on every ask. What a report needs is the names and the
  * numbers; the functions are used on the way here and left behind.
  *
+ * <p><b>This behavior's account and not the lines it was read from.</b> Two of a border's four
+ * points can be owed to the declarations that drew the line rather than to any body carrying the
+ * type, and a row for one of those is written once for the module. So what is here is what this
+ * behavior is owed a row for, and the lines themselves — every point of them, whosever they are —
+ * are what a reader that describes them asks for ({@link BehaviorEvidence#boundaryReadings}).
+ * Handed the lines, every reader that measures a behavior, counts what it covers or raises a finding
+ * about it had to remember to leave the declarations' points out.
+ *
  * @param axes         one entry per position the model divides
- * @param boundaries   one entry per rule that drew a line, per side of it
+ * @param owes         one entry per thing this behavior is owed a row for at the lines its
+ *                     positions meet
  * @param notDerivable positions no class came back for, each saying whether the model divides them
  *                     no way at all or this could not read what it divides them by. Both used to be
  *                     one list of paths, and the sentence written from it claimed the first about
@@ -39,7 +48,7 @@ import java.util.Set;
  *                     everything else a module could not read happens where that list is built
  */
 public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
-                                Measure<List<BorderAssessment>> bounded,
+                                Measure<List<OwedBoundaryPoint>> owes,
                                 PairSpace pairs,
                                 List<souther.compiler.partition.UndividedPosition> notDerivable,
                                 List<souther.compiler.inputs.RuleWithoutALine> rulesWithoutALine,
@@ -58,7 +67,8 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      * in it open for a measurement that was never anybody's to make.
      */
     public static final PartitionEvidence NONE = new PartitionEvidence(
-            PartitionDerivation.noSubject(), BoundaryDerivation.noSubject(),
+            PartitionDerivation.noSubject(),
+            OwedBoundaryPoint.accountOf(BoundaryDerivation.noSubject()),
             PairSpace.NONE, List.of(), List.of(), List.of(), List.of(),
             List.of(), List.of());
 
@@ -323,20 +333,27 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      * What every measure of this behavior's positions went without, all of them.
      *
      * <p>Asked here rather than assembled by whoever wants it. There are six measures under this —
-     * the two derivations, each position, each point of each border, and the combinations — and a
-     * reader listing them is a reader who has to be told when a seventh arrives. The report listed
-     * them, so a measure added here would have been a measure the report left out of every whole
-     * above it, silently (issue #953).
+     * the two derivations, each position, each thing this behavior is owed a row for, and the
+     * combinations — and a reader listing them is a reader who has to be told when a seventh
+     * arrives. The report listed them, so a measure added here would have been a measure the report
+     * left out of every whole above it, silently.
+     *
+     * <p><b>This behavior's account and no more.</b> A row owed to the declarations that drew a line
+     * is answered once for the module and is short or not short there ({@link Adequacy.DeclaredBorders});
+     * counted here as well, a behavior would be reported as having gone without something no row
+     * written for it is owed. What the two share is the reading that found the lines: an account
+     * built from a reading that did not run out may be short of entries whosever they are, so that
+     * weakens both.
      */
     public WeakeningSet weakening() {
         WeakeningSet out = partitioned.weakening()
-                .union(bounded.weakening())
+                .union(owes.weakening())
                 .union(pairs.counted().weakening());
         for (AxisCoverage axis : axes()) {
             out = out.union(axis.reached().weakening());
         }
-        for (BorderAssessment.Point point : BorderAssessment.pointsOf(boundaries())) {
-            out = out.union(point.item().weakening());
+        for (OwedBoundaryPoint owed : owedPoints()) {
+            out = out.union(owed.item().weakening());
         }
         return out;
     }
@@ -347,9 +364,9 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         return PartitionDerivation.at(partitioned);
     }
 
-    /** The lines, likewise. */
-    public List<BorderAssessment> boundaries() {
-        return BoundaryDerivation.at(bounded);
+    /** What this behavior is owed a row for, likewise. */
+    public List<OwedBoundaryPoint> owedPoints() {
+        return owes.made().orElseGet(List::of);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -94,10 +94,17 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         UNDETERMINED
     }
 
+    /**
+     * @param owedByDeclarations what this module's declarations are owed and how far the reading it
+     *                           was made from got. An account and not a list of debts: a module
+     *                           whose lines nobody could read holds no debts anybody found, and read
+     *                           as a list that is the same answer as a module whose declarations owe
+     *                           nothing. Null where the compile did not get far enough to be asked
+     */
     public record ModuleReport(String module, SourceId declaredIn,
                                List<BehaviorReport> behaviors,
                                List<Adequacy.Finding> declarations,
-                               List<Adequacy.DeclaredDebt> debts) {
+                               Adequacy.DeclaredBoundaries owedByDeclarations) {
 
         /**
          * What the module is short of that is not any behavior's.
@@ -113,7 +120,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         public ModuleReport {
             behaviors = List.copyOf(behaviors);
             declarations = List.copyOf(declarations);
-            debts = List.copyOf(debts);
+        }
+
+        /** The debts themselves, for a reader walking them. Empty where nobody could be asked,
+         *  which {@link #declarationsWeakenedBy()} is what says. */
+        public List<Adequacy.DeclaredDebt> debts() {
+            return owedByDeclarations == null ? List.of() : owedByDeclarations.owed();
         }
 
         /**
@@ -139,7 +151,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         }
 
         /**
-         * What this module went without: the union of its behaviors, and nothing of its own.
+         * What this module went without: the union of its parts, and nothing of its own.
+         *
+         * <p>Its parts are its behaviors and what its declarations are owed. The second is a part
+         * because a row owed to a declaration is answered once for the module and is short there: no
+         * behavior carrying the type is short by it, so a module that read only its behaviors would
+         * call itself measured in full over a debt nobody could measure.
          *
          * <p>Derived and not held. What a module could not read reaches it through the measures that
          * lost by it — a source none of whose rows were seen counts against every behavior the
@@ -152,7 +169,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             for (BehaviorReport behavior : behaviors) {
                 out = out.union(behavior.weakenedBy());
             }
-            return out;
+            return out.union(declarationsWeakenedBy());
+        }
+
+        /**
+         * What the measurement of what this module's declarations are owed went without.
+         *
+         * <p>The other account of the same lines, and the module's own. A row owed to the
+         * declaration that drew a line is answered once here, from every reading of it — so a
+         * search that could not read a value at such a point leaves this short, and no behavior
+         * carrying the type is short of anything by it. Counted under a behavior instead, an author
+         * would be told their body was measured in part for a row nothing written for it is owed.
+         *
+         * <p>What found the lines is the behaviors' and is counted there: the two accounts rest on
+         * one reading, and a reading that did not run out may have left either of them short of
+         * entries.
+         */
+        public WeakeningSet declarationsWeakenedBy() {
+            return owedByDeclarations == null
+                    ? WeakeningSet.none() : owedByDeclarations.weakening();
         }
 
         /** How far this module's measurement got. Derived, for the reason
@@ -192,9 +227,28 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             return evidence.signature();
         }
 
-        /** What they establish about the classes and the lines its rules draw. */
+        /** What they establish about the classes, and what this behavior is owed a row for at the
+         *  lines its rules draw. */
         public PartitionEvidence partition() {
             return evidence.partition();
+        }
+
+        /** Every line its positions met, in every role — what a block that shows a border whole is
+         *  written from. */
+        public Measure<List<BorderAssessment>> boundaryReadings() {
+            return evidence.boundaryReadings();
+        }
+
+        /**
+         * The same as the lines alone, empty where the reading has none to show.
+         *
+         * <p>The one place the absence of the measure itself is read, which is the compile not
+         * having got far enough to be asked — the same absence the partition beside it answers with,
+         * since the two arrive together ({@link BehaviorEvidence}).
+         */
+        public List<BorderAssessment> lines() {
+            return boundaryReadings() == null ? List.of()
+                    : boundaryReadings().made().orElseGet(List::of);
         }
 
         /** What they establish about the arms of its body. */
@@ -291,6 +345,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 compilation.db().ask(new Adequacy.Witnesses(name)).value();
         Map<String, PartitionEvidence> partitions =
                 compilation.db().ask(new Adequacy.Coverage(name)).value();
+        Map<String, Measure<List<BorderAssessment>>> lines =
+                compilation.db().ask(new Adequacy.BoundaryReadings(name)).value();
         Map<String, Adequacy.BranchEvidence> branches =
                 compilation.db().ask(new Adequacy.BranchCoverage(name)).value();
         // What each body declared, read where it was judged. Beside the measures and never inside
@@ -322,22 +378,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // came back with nothing. Every measure that did run says why it has no number.
             Adequacy.BranchEvidence branch =
                     branches == null ? null : branches.get(behavior.name());
+            // The lines this behavior's positions met, held beside the account made from them: what
+            // a block shows of a border is its four points, and whose debt each of them is is a
+            // different question.
+            Measure<List<BorderAssessment>> read =
+                    lines == null ? null : lines.get(behavior.name());
             behaviors.add(new BehaviorReport(behavior.name(),
                     module.implementationOf(behavior),
-                    new BehaviorEvidence(reading, signature, partition, branch),
+                    new BehaviorEvidence(reading, signature, partition, read, branch),
                     claims == null ? ClaimAnnotations.NONE
                             : claims.getOrDefault(behavior.name(), ClaimAnnotations.NONE),
                     ofBehavior(findings, behavior.name())));
         }
-        List<Adequacy.DeclaredDebt> debts =
-                compilation.db().ask(new Adequacy.DeclaredBorders(name)).value();
         return new ModuleReport(name, compilation.sourceIdOf(name), behaviors,
                 findings == null ? List.of()
                         : findings.stream()
                                 .filter(each -> !(each.subject()
                                         instanceof souther.compiler.query.FindingSubject.OfABehavior))
                                 .toList(),
-                debts == null ? List.of() : debts);
+                compilation.db().ask(new Adequacy.DeclaredBorders(name)).value());
     }
 
     /**
@@ -427,11 +486,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // cannot see.
             java.util.Set<String> names = behaviors.stream().map(BehaviorReport::name)
                     .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+            // And the account of what its declarations are owed, as a reader shown these behaviors
+            // is owed it. Which parts of it that is is the account's own answer: a debt none of them
+            // carries and a reading none of them made are both about what this reader cannot see,
+            // and deciding that here would be this view working out what an account means.
             ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
                     carriedBy(m.declarations(), behaviors),
-                    m.debts().stream()
-                            .filter(owed -> names.stream().anyMatch(owed.debt()::carriedBy))
-                            .toList());
+                    m.owedByDeclarations() == null ? null
+                            : m.owedByDeclarations().keptFor(names));
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }
@@ -591,7 +653,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // that was.
                 if (refusesAny(Adequacy.Kind.BOUNDARY_UNMET,
                         Adequacy.Kind.DOMAIN_POINT_UNCOVERED)) {
-                    add(measures, behavior.partition().bounded());
+                    add(measures, behavior.boundaryReadings());
                 }
                 // What the rows reach of each position, which finds a class no row is in — a gap
                 // the `classes` bar refuses over and no other does. A bar that asks nothing about
@@ -610,19 +672,18 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     add(measures, behavior.partition().partitioned());
                     behavior.partition().axes().forEach(axis -> add(measures, axis.reached()));
                 }
-                // And of a border's four points, the ones the bar asks for — of the lines this
-                // behavior is owed. A line a declaration is owed is answered once for the module
-                // below, from every reading of it: read here as well, a row standing at it in one
-                // behavior would be weighed against another behavior having no rows, and the
-                // verdict would hold open what the aggregation had settled (issue #1062).
-                // One measurement per thing the reading is owed a row for, since each of them is an
-                // obligation: a place two of this body's rules drew a line at leaves a run owed to
-                // each, and a verdict counting the role once would be short by the rest. How many
-                // rows answer them is a different count and is the generator's.
-                BorderAssessment.pointsOf(behavior.partition().boundaries()).stream()
-                        .filter(p -> held.requires(p.role()))
-                        .forEach(p -> p.owedHere()
-                                .forEach(_ -> add(measures, measurementOf(p.item()))));
+                // And of what this behavior is owed a row for, the points the bar asks for. A line
+                // the declarations are owed is answered once for the module below, from every
+                // reading of it, and is no part of this account: weighed here as well, a row
+                // standing at it in one behavior would be weighed against another behavior having
+                // no rows, and the verdict would hold open what the aggregation had settled.
+                // One measurement per thing the behavior is owed a row for, since each of them is
+                // an obligation: a place two of this body's rules drew a line at leaves a run owed
+                // to each, and a verdict counting the role once would be short by the rest. How
+                // many rows answer them is a different count and is the generator's.
+                behavior.partition().owedPoints().stream()
+                        .filter(owed -> held.requires(owed.role()))
+                        .forEach(owed -> add(measures, measurementOf(owed.item())));
                 // Which of the four those are is the bar's answer and not a second reading of it
                 // here: a build refusing over a missing IN row and calling a model satisfied while
                 // the IN point could not be measured would be held to one bar in one place and
@@ -1048,8 +1109,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // points, so a count of borders would say a border with one point met and three missed was
         // as covered as one with nothing to owe but that point — and how many items a border owes is
         // the rule's answer rather than a constant.
+        // The lines this behavior's positions met, whosever the row at each point is. What this
+        // block accounts for is a border and its four points; which of them this behavior is owed a
+        // row at is the account beside it, and the findings printed below are written from that.
+        ReportMeasurement<List<BorderAssessment>> bounded =
+                ReportMeasurement.of(behavior.boundaryReadings());
+        List<BorderAssessment> lines = behavior.lines();
         List<BorderAssessment.Point> points =
-                BorderAssessment.pointsOf(partition.boundaries()).stream()
+                BorderAssessment.pointsOf(lines).stream()
                         .filter(p -> p.item() instanceof ItemAssessment.Owed).toList();
         List<BorderAssessment.Point> measured = points.stream()
                 .filter(p -> owed(p).coverage().made().isPresent())
@@ -1066,10 +1133,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // The points the model's own rules discharged. Said rather than left out of the numbers: a
         // reader working to a coverage criterion counts four items per border, and a border showing
         // two of them with nothing beside it reads as this compiler being short of the other two.
-        long excluded = partition.boundaries().stream()
+        long excluded = lines.stream()
                 .mapToLong(b -> b.excluded().size()).sum();
-        ReportMeasurement<List<BorderAssessment>> bounded =
-                ReportMeasurement.of(partition.bounded());
         if (!bounded.counted()) {
             // `0/0` said the rows were at every line there was. What it meant was that nobody found
             // a line to be at, which a model whose bounds sit one type away from the position the
@@ -1078,7 +1143,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     whyNoBoundary(bounded.reason())));
         } else {
             out.append(String.format("    border      borders %d   coverage items %d/%d%s%s%s%s%n",
-                    partition.boundaries().size(), met, measured.size(),
+                    lines.size(), met, measured.size(),
                     excluded == 0 ? "" : "   excluded " + excluded,
                     notes(points,
                             p -> owed(p).coverage().made().isEmpty(),
@@ -1104,18 +1169,18 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // together, and printed in that order the two halves would be interleaved.
         for (boolean againstTheLine : List.of(true, false)) {
             for (Adequacy.Finding f : behavior.findings()) {
-                if (f.about() instanceof About.APointOfABorder(var point, var _)
+                if (f.about() instanceof About.APointOfABorder(var point)
                         && point.role().againstTheLine() == againstTheLine) {
                     // `the` for a point and `an` for a run. Two of the four are one value and the
                     // other two are met anywhere in a run of them, so a reader told there is no row
                     // at `the IN point` is being sent after a value that does not exist.
                     out.append(againstTheLine
                             ? String.format("      %s no row is at the %s point %s = %s (%s)%n",
-                                    mark(f), point.role(), point.border().axis(),
-                                    point.against(), point.border().describe(names, declaredIn))
+                                    mark(f), point.role(), point.axis(),
+                                    point.against(), point.describe(names, declaredIn))
                             : String.format("      %s no row is at an %s point of %s, %s (%s)%n",
-                                    mark(f), point.role(), point.border().axis(),
-                                    point.against(), point.border().describe(names, declaredIn)));
+                                    mark(f), point.role(), point.axis(),
+                                    point.against(), point.describe(names, declaredIn)));
                 }
             }
         }
@@ -1136,7 +1201,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // And what the model itself answered, which is not a row anybody is behind on. Named by the
         // reason rather than left blank: a point the rules refuse and a point this language cannot
         // write down are counted out for opposite reasons, and a reader acts on them differently.
-        for (BorderAssessment.Point p : BorderAssessment.pointsOf(partition.boundaries())) {
+        for (BorderAssessment.Point p : BorderAssessment.pointsOf(lines)) {
             if (p.item() instanceof ItemAssessment.NotOwed not) {
                 out.append(String.format("      · no %s point is owed at %s (%s): %s%n",
                         p.role(), p.border().label(), p.border().describe(names, declaredIn),
@@ -1885,7 +1950,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 b.put("status", wire(behavior.status()));
                 weakening(b, behavior.weakenedBy());
                 signature(b, behavior.signature());
-                partition(b, behavior.partition(), behavior.claimed(), sources);
+                partition(b, behavior.partition(), behavior.boundaryReadings(),
+                        behavior.claimed(), sources);
                 branch(b, behavior.branch(), sources);
                 findings(b, behavior, sources);
             }
@@ -2006,6 +2072,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     private void partition(ObjectNode behavior, PartitionEvidence partition,
+                                  Measure<List<BorderAssessment>> lines,
                                   ClaimAnnotations claimed, DocumentSources sources) {
         // The one decision, the same one the page reads. Written here as well, the two surfaces
         // answered a reader differently about which behaviors have a section at all.
@@ -2020,8 +2087,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // the same measure-level fact in the one place that had nowhere to put it.
         measured(out.putObject("axesMeasure"),
                 partition.partitioned());
-        measured(out.putObject("boundariesMeasure"),
-                partition.bounded());
+        measured(out.putObject("boundariesMeasure"), lines);
         ArrayNode axes = out.putArray("axes");
         for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
             ObjectNode a = axes.addObject();
@@ -2104,7 +2170,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             }
         }
         ArrayNode boundaries = out.putArray("boundaries");
-        for (BorderAssessment boundary : partition.boundaries()) {
+        for (BorderAssessment boundary : lines.made().orElseGet(List::of)) {
             ObjectNode b = boundaries.addObject();
             b.put("axis", boundary.axis());
             // The identity, and never left out. This document says what it is about with the
@@ -2432,7 +2498,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     missing.name() + " (in #" + (input.at() + 1) + ")";
             // What the point asks of a row, which is what joins it to one of a border's `items`.
             // Asked of the point, which is where the two readers of that name meet.
-            case About.APointOfABorder(var point, var _) -> point.said();
+            case About.APointOfABorder(var point) -> point.said();
             // The same sentence, on what the declaration wrote. A line owed once over every reading
             // of it is named by the terms the author used and not by the position some behavior met
             // it at, which is what the debt is (issue #1062).

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -723,7 +723,7 @@ public final class GeneratedRows {
             // above ({@code saidOf}). Spelled out here as well, the two vocabularies differed by
             // the role: a point away from the line was written as the value the line is at, which
             // is the one place in reach that such a point is not.
-            case About.APointOfABorder(var point, var _) -> point.said();
+            case About.APointOfABorder(var point) -> point.said();
             // The same words on what the declaration wrote. Nothing composes a row for one of
             // these yet — the search walks one behavior's inputs and this line is owed once over
             // all of them — so what is printed beside it is that, in its own sentence.

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsDrawnOnATermAndNotAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsDrawnOnATermAndNotAPositionTest.java
@@ -78,8 +78,14 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
         return compilation.db().ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
     }
 
-    private static List<String> labels(PartitionEvidence partition) {
-        return partition.boundaries().stream().map(BorderAssessment::label).sorted().toList();
+    /** The lines each behavior of the one module in {@code source} was measured at. */
+    private static Map<String, List<BorderAssessment>> lines(String source) {
+        Compilation compilation = compiled(source);
+        return Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+    }
+
+    private static List<String> labels(List<BorderAssessment> lines) {
+        return lines.stream().map(BorderAssessment::label).sorted().toList();
     }
 
     /** A size call in an invariant draws the line its number names, and the line is named by the term
@@ -92,7 +98,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
                         "Set.size(t.codes) = 1",
                         "String.length(t.label) = 1",
                         "t.size = 1"),
-                labels(partitions(MODEL).get("look")));
+                labels(lines(MODEL).get("look")));
     }
 
     /** One point against the line each, and it is the {@code ON} point. Everything outside an
@@ -101,7 +107,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
      * words. */
     @Test
     void anInvariantsEdgeIsOwedOnceAndNotOnBothSides() {
-        for (BorderAssessment line : partitions(MODEL).get("look").boundaries()) {
+        for (BorderAssessment line : lines(MODEL).get("look")) {
             assertNotNull(line.owedAt(souther.compiler.partition.PointRole.ON), line.label());
             assertEquals(new ItemAssessment.NotOwed(
                             souther.compiler.partition.NotOwedReason.THE_RULES_REFUSE_IT),
@@ -117,7 +123,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
     @Test
     void aRowIsReadThroughTheTermThatDrewTheLine() {
         Map<String, BorderAssessment> byLabel = new java.util.LinkedHashMap<>();
-        partitions(MODEL).get("look").boundaries().forEach(b -> byLabel.put(b.label(), b));
+        lines(MODEL).get("look").forEach(b -> byLabel.put(b.label(), b));
 
         assertTrue(onPointOf(byLabel, "String.length(t.label) = 1").hasRowWitness(),
                 "the row's label is one character long");
@@ -131,7 +137,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
     /** The borders of {@code behavior} in {@code source}, by the line each is at. */
     private static Map<String, BorderAssessment> byLabel(String source, String behavior) {
         Map<String, BorderAssessment> out = new java.util.LinkedHashMap<>();
-        partitions(source).get(behavior).boundaries().forEach(b -> out.put(b.label(), b));
+        lines(source).get(behavior).forEach(b -> out.put(b.label(), b));
         return out;
     }
 
@@ -190,7 +196,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
         assertEquals(List.of(
                         "String.length(t.label) = 1",
                         "String.length(t.label) = 3"),
-                labels(partitions(GUARDED).get("guarded")),
+                labels(lines(GUARDED).get("guarded")),
                 "two borders, and the guard's owes a row at 4 as its OFF point rather than being a"
                         + " line of its own");
         // `> 3` puts the 3 outside the partition it names, so the row there is the border's OFF
@@ -241,7 +247,7 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
         assertEquals(List.of(
                         "String.length(t.label) = 1",
                         "String.length(t.label) = 3"),
-                labels(partitions(IMPORTED).get("look")));
+                labels(lines(IMPORTED).get("look")));
     }
 
     private static final String UNBOUNDED = """
@@ -270,6 +276,6 @@ class ABoundaryIsDrawnOnATermAndNotAPositionTest {
     @Test
     void aSizeIsNeverNegativeAndNoRowIsAskedForBelowZero() {
         assertEquals(List.of("List.length(t.names) = 0"),
-                labels(partitions(UNBOUNDED).get("atLeastNone")));
+                labels(lines(UNBOUNDED).get("atLeastNone")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -387,7 +387,7 @@ class AMeasureWithNoNumberSaysWhyTest {
     @Test
     void anInvariantsLineIsNeverWaitingOnTheArms() {
         List<BorderAssessment.Point> lines =
-                BorderAssessment.pointsOf(partitions().get("rated").boundaries()).stream()
+                BorderAssessment.pointsOf(lines().get("rated")).stream()
                         .filter(p -> p.owed() != null).toList();
         assertFalse(lines.isEmpty(), "the invariant draws two");
         for (BorderAssessment.Point line : lines) {
@@ -480,10 +480,10 @@ class AMeasureWithNoNumberSaysWhyTest {
         assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(branch.measured()),
                 "there are arms, and which of them were reached is undecided");
 
-        PartitionEvidence partition = compilation.db()
-                .ask(new Adequacy.Coverage("example.unseen")).value().get("elsewhere");
-        assertFalse(partition.boundaries().isEmpty(), "the invariant and the guard draw lines");
-        for (BorderAssessment.Point line : BorderAssessment.pointsOf(partition.boundaries())) {
+        List<BorderAssessment> read =
+                Adequacy.readingsOf(compilation.db(), "example.unseen").get("elsewhere");
+        assertFalse(read.isEmpty(), "the invariant and the guard draw lines");
+        for (BorderAssessment.Point line : BorderAssessment.pointsOf(read)) {
             if (line.owed() == null) {
                 continue;   // nothing was measured there and nothing was waiting on a row
             }
@@ -607,12 +607,12 @@ class AMeasureWithNoNumberSaysWhyTest {
             measures.add(new Object[] {"partition " + each.getKey(),
                     partition.partitioned()});
             measures.add(new Object[] {"boundary " + each.getKey(),
-                    partition.bounded()});
+                    boundaryReadings().get(each.getKey())});
             measures.add(new Object[] {"pairs " + each.getKey(),
                     partition.pairs().counted()});
             partition.axes().forEach(a -> measures.add(
                     new Object[] {"axis " + each.getKey(), a.reached()}));
-            BorderAssessment.pointsOf(partition.boundaries()).stream()
+            BorderAssessment.pointsOf(lines().get(each.getKey())).stream()
                     .filter(p -> p.owed() != null)
                     .forEach(p -> measures.add(new Object[] {"line " + each.getKey(),
                             p.item().weakeningSource()}));
@@ -718,6 +718,20 @@ class AMeasureWithNoNumberSaysWhyTest {
     private static Map<String, PartitionEvidence> partitions() {
         Compilation compilation = compiled();
         return compilation.db().ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+    }
+
+    /** The lines each behavior's positions met, whosever the row at each point is. */
+    private static Map<String, List<BorderAssessment>> lines() {
+        Compilation compilation = compiled();
+        return Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+    }
+
+    /** How far the reading that found each behavior's lines got. */
+    private static Map<String, souther.compiler.query.Measure<List<BorderAssessment>>>
+            boundaryReadings() {
+        Compilation compilation = compiled();
+        return compilation.db()
+                .ask(new Adequacy.BoundaryReadings(compilation.modules().get(0))).value();
     }
 
     private static List<Adequacy.Finding> findings(String behavior, Adequacy.Kind kind) {

--- a/souther-compiler/src/test/java/souther/compiler/AModuleEveryMeasureOfWhichDoesNotApplyStillSaysWhatItWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleEveryMeasureOfWhichDoesNotApplyStillSaysWhatItWentWithoutTest.java
@@ -67,7 +67,7 @@ class AModuleEveryMeasureOfWhichDoesNotApplyStillSaysWhatItWentWithoutTest {
                 "the output is not a sum");
         assertInstanceOf(Measure.NotApplicable.class, behavior.partition().partitioned(),
                 "the rules divide no position");
-        assertInstanceOf(Measure.NotApplicable.class, behavior.partition().bounded(),
+        assertInstanceOf(Measure.NotApplicable.class, behavior.boundaryReadings(),
                 "and draw no line");
         assertInstanceOf(Measure.NotApplicable.class, behavior.branch().measured(),
                 "and there is no body");

--- a/souther-compiler/src/test/java/souther/compiler/AValueSingledOutIsNotABorderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AValueSingledOutIsNotABorderTest.java
@@ -49,6 +49,14 @@ class AValueSingledOutIsNotABorderTest {
         return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0).partition();
     }
 
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<souther.compiler.query.BorderAssessment> lines(String condition) {
+        Compilation compilation = Compilation.ofSource(SOURCE.formatted(condition), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0).lines();
+    }
+
     /** The classes the rules divide the behavior's positions into, each named as a document names
      *  it. */
     private static List<String> classes(String condition) {
@@ -59,7 +67,7 @@ class AValueSingledOutIsNotABorderTest {
     /** How many borders the rules draw, which is what a rule placing no order across a value does
      *  not add to. */
     private static int borders(String condition) {
-        return measured(condition).boundaries().size();
+        return lines(condition).size();
     }
 
     /** What the rules left unread, as the position and the reason. */

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -8,7 +8,6 @@ import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.report.GeneratedRows;
@@ -217,12 +216,10 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                     wrong.add("axis " + axis.path() + ": " + axis.uncovered());
                 }
             }
-            for (BorderAssessment.Point point
-                    : BorderAssessment.pointsOf(partition.boundaries())) {
-                if (point.owed() != null
-                        && point.item().weakeningSource() instanceof Measurement.Complete<?>
-                        && !point.owed().hasRowWitness()) {
-                    wrong.add("boundary " + point.border().axis() + " " + point.asked());
+            for (souther.compiler.query.OwedBoundaryPoint point : partition.owedPoints()) {
+                if (point.item().weakeningSource() instanceof Measurement.Complete<?>
+                        && !point.item().hasRowWitness()) {
+                    wrong.add("boundary " + point.axis() + " " + point.asked());
                 }
             }
             if (partition.pairs().counted() instanceof Measurement.Complete<?>
@@ -318,8 +315,8 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.of(compilation).status());
         assertTrue(partition.axes().stream().anyMatch(a -> !a.uncovered().isEmpty()),
                 "a class nothing is in");
-        assertTrue(BorderAssessment.pointsOf(partition.boundaries()).stream()
-                        .anyMatch(p -> p.owed() != null && !p.owed().hasRowWitness()),
+        assertTrue(partition.owedPoints().stream()
+                        .anyMatch(p -> !p.item().hasRowWitness()),
                 "a boundary nothing is at");
         assertTrue(partition.pairs().counts().unknown() > 0, "a combination nothing reaches");
         assertFalse(compilation.db().ask(new Adequacy.BranchCoverage(module)).value()

--- a/souther-compiler/src/test/java/souther/compiler/AnEnsuresBetweenTwoPositionsSinglesNothingOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEnsuresBetweenTwoPositionsSinglesNothingOutTest.java
@@ -4,12 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * The other producer of the same claim, held to the same reading of it.
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class AnEnsuresBetweenTwoPositionsSinglesNothingOutTest {
 
-    private static PartitionEvidence measured(String clause) {
+    private static AdequacyReport.BehaviorReport measured(String clause) {
         Compilation compilation = Compilation.ofSource("""
                 module m
 
@@ -37,12 +37,12 @@ class AnEnsuresBetweenTwoPositionsSinglesNothingOutTest {
                 """.formatted(clause), "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0).partition();
+        return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0);
     }
 
     /** The classes the clause divides the behavior's positions into. */
     private static List<String> classes(String clause) {
-        return measured(clause).axes().stream()
+        return measured(clause).partition().axes().stream()
                 .flatMap(each -> each.classes().stream()).toList();
     }
 
@@ -51,7 +51,10 @@ class AnEnsuresBetweenTwoPositionsSinglesNothingOutTest {
     void anEqualityBetweenTwoPositionsDividesNeitherOfThem() {
         assertEquals(List.of(), classes("r.a == r.other"));
         assertEquals(List.of(), classes("r.a /= r.other"));
-        assertEquals(0, measured("r.a == r.other").boundaries().size(),
+        // The measure's own answer and not a count read off it, which nought would also be where
+        // nobody measured: what the rule leaves is no line for a row to be at.
+        assertInstanceOf(souther.compiler.query.Measure.NotApplicable.class,
+                measured("r.a == r.other").boundaryReadings(),
                 "and it is not a line either: the values either side of the place they meet are"
                         + " one class");
     }

--- a/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 
@@ -30,12 +31,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
 
-    private static PartitionEvidence measured(String type, String guards) {
+    private static souther.compiler.query.PartitionEvidence measured(String type, String guards) {
         return measured(type, guards,
                 "    | \"one\" : (" + (type.equals("Decimal") ? "0.1m" : "1") + ") -> Yes { v = 1 }");
     }
 
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(String type, String guards, String rows) {
+        Compilation compilation = compiled(type, guards, rows);
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        return all.get("f");
+    }
+
     private static PartitionEvidence measured(String type, String guards, String rows) {
+        Compilation compilation = compiled(type, guards, rows);
+        Map<String, PartitionEvidence> all = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        assertNotNull(all, "the model under test compiles");
+        return all.get("f");
+    }
+
+    private static Compilation compiled(String type, String guards, String rows) {
         Compilation compilation = Compilation.ofSource("""
                 module example.exact
 
@@ -56,10 +74,7 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
                 """.formatted(type, guards, rows), "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
-        assertNotNull(all, "the model under test compiles");
-        return all.get("f");
+        return compilation;
     }
 
     private static List<String> classesOf(String type, String guards) {
@@ -262,7 +277,10 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
 
         assertEquals("n/1 < 3 * x <= 2", middle);
         assertEquals("1 < 3 * n <= 2",
-                measured.boundaries().stream()
+                lines("Decimal", """
+                            guard 3m * n > 1m else No { why = 0 }
+                            guard 3m * n > 2m else No { why = 1 }""",
+                        "    | \"one\" : (0.1m) -> No { why = 0 }").stream()
                         .filter(each -> each.label().equals("3 * n = 1")).findFirst()
                         .orElseThrow().against(souther.compiler.partition.PointRole.IN),
                 "the run the border at a third bounds is the class between the two lines, said in"
@@ -286,7 +304,10 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
                 "    | \"one\" : (0.1m) -> No { why = 0 }");
 
         assertEquals("1 < 3 * n and 6 * n <= 5",
-                measured.boundaries().stream()
+                lines("Decimal", """
+                            guard 3m * n > 1m else No { why = 0 }
+                            guard 6m * n > 5m else No { why = 1 }""",
+                        "    | \"one\" : (0.1m) -> No { why = 0 }").stream()
                         .filter(each -> each.label().equals("3 * n = 1")).findFirst()
                         .orElseThrow().against(souther.compiler.partition.PointRole.IN),
                 "and not `2 * 3 * n`, which is the same rule said twice over");

--- a/souther-compiler/src/test/java/souther/compiler/AnInPointLiesInsideThePartitionItsBorderBoundsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnInPointLiesInsideThePartitionItsBorderBoundsTest.java
@@ -7,8 +7,8 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ItemAssessment;
-import souther.compiler.query.PartitionEvidence;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,10 +57,10 @@ class AnInPointLiesInsideThePartitionItsBorderBoundsTest {
         Compilation compilation = Compilation.ofSource(BANDS.formatted(rows), "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
-        return all.get("band").boundaries().stream()
+        return all.get("band").stream()
                 .filter(each -> each.value().equals(value)).findFirst()
                 .orElseThrow(() -> new AssertionError("no border at " + value));
     }
@@ -140,10 +140,10 @@ border.owedAt(PointRole.IN).coverage().made().orElseThrow());
                 """, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
-        BorderAssessment first = all.get("f").boundaries().stream()
+        BorderAssessment first = all.get("f").stream()
                 .filter(each -> each.label().equals("3 * a + 6 * b = 48")).findFirst()
                 .orElseThrow(() -> new AssertionError("no border at 48"));
 
@@ -188,8 +188,8 @@ border.owedAt(PointRole.IN).coverage().made().orElseThrow());
                 """, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
 
         assertEquals("51 < 3 * a + 6 * b <= 60",
@@ -200,11 +200,12 @@ border.owedAt(PointRole.IN).coverage().made().orElseThrow());
                 "and the second's runs on to what the form itself reaches, said in its own units");
     }
 
-    private static BorderAssessment borderNamed(Map<String, PartitionEvidence> all, String label) {
-        return all.get("f").boundaries().stream()
+    private static BorderAssessment borderNamed(Map<String, List<BorderAssessment>> all,
+                                                String label) {
+        return all.get("f").stream()
                 .filter(each -> each.label().equals(label)).findFirst()
                 .orElseThrow(() -> new AssertionError("no border " + label + " in "
-                        + all.get("f").boundaries().stream().map(BorderAssessment::label).toList()));
+                        + all.get("f").stream().map(BorderAssessment::label).toList()));
     }
 
     /**
@@ -243,8 +244,8 @@ border.owedAt(PointRole.IN).coverage().made().orElseThrow());
                 """, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
 
         assertEquals("0.2 < n and 3 * n <= 1", borderNamed(all, "n = 0.2").against(PointRole.IN),

--- a/souther-compiler/src/test/java/souther/compiler/AskingForNothingIsAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AskingForNothingIsAnAnswerTest.java
@@ -60,7 +60,8 @@ class AskingForNothingIsAnAnswerTest {
     /** Every measure that reads the rows says nobody asked, and says it in the same word. */
     @Test
     void everyMeasureThatReadsTheRowsSaysNobodyAsked() {
-        Adequacy.Of measured = compiled(Adequacy.Level.OFF).adequacy("example.off");
+        Compilation compilation = compiled(Adequacy.Level.OFF);
+        Adequacy.Of measured = compilation.adequacy("example.off");
 
         Adequacy.SignatureEvidence signature = measured.signatures().get("submit");
         assertEquals(NothingWasAsked.NOT_ASKED, signature.counted().why());
@@ -78,7 +79,8 @@ class AskingForNothingIsAnAnswerTest {
         }
         assertEquals(NothingWasAsked.NOT_ASKED, partition.pairs().counted().why());
         for (souther.compiler.query.BorderAssessment.Point point
-                : souther.compiler.query.BorderAssessment.pointsOf(partition.boundaries())) {
+                : souther.compiler.query.BorderAssessment.pointsOf(
+                        Adequacy.readingsOf(compilation.db(), "example.off").get("submit"))) {
             if (point.owed() != null) {
                 assertEquals(souther.compiler.query.ItemAssessment.Coverage.NotAsked.NOT_ASKED,
                         point.owed().coverage().why(), point.label());
@@ -91,13 +93,15 @@ class AskingForNothingIsAnAnswerTest {
     /** What the model says is there all the same. A measurement made none of it true. */
     @Test
     void whatTheModelDeclaresIsStillThere() {
-        Adequacy.Of measured = compiled(Adequacy.Level.OFF).adequacy("example.off");
+        Compilation compilation = compiled(Adequacy.Level.OFF);
+        Adequacy.Of measured = compilation.adequacy("example.off");
 
         assertEquals(2, measured.signatures().get("submit").output().declared().size(),
                 "the output is a sum of two whether or not anybody counted");
         PartitionEvidence partition = measured.partitions().get("submit");
         assertEquals(List.of("Yes", "No"), partition.axes().get(0).classes());
-        assertFalse(partition.boundaries().isEmpty(), "the invariant and the guard draw lines");
+        assertFalse(Adequacy.readingsOf(compilation.db(), "example.off").get("submit").isEmpty(),
+                "the invariant and the guard draw lines");
     }
 
     /** A verdict over measures none of which was made is undetermined, which is what the

--- a/souther-compiler/src/test/java/souther/compiler/CompileAdequacyShapesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAdequacyShapesTest.java
@@ -41,6 +41,14 @@ class CompileAdequacyShapesTest {
         return all.get(behavior);
     }
 
+    /** The lines that behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(Compilation compilation, String behavior) {
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        return all.get(behavior);
+    }
+
     /**
      * A bare `Decimal` position compared against a fraction.
      *
@@ -51,7 +59,7 @@ class CompileAdequacyShapesTest {
      */
     @Test
     void aFractionalGuardOnAPlainDecimalIsMeasuredRatherThanThrown() {
-        PartitionEvidence evidence = partition(measured("""
+        Compilation compilation = measured("""
                 module example.dec
 
                 data Yes = { r: Decimal }
@@ -67,20 +75,21 @@ class CompileAdequacyShapesTest {
 
                 example classify
                     | (0.1m) -> Yes { r = 0.1m }
-                """), "classify");
+                """);
+        PartitionEvidence evidence = partition(compilation, "classify");
+        List<BorderAssessment> lines = lines(compilation, "classify");
 
         assertEquals(1, evidence.axes().size());
         assertEquals(List.of("rate/x < 0.5", "rate/0.5 <= x"), evidence.axes().get(0).classes());
         assertEquals(List.of("0.5"),
-                evidence.boundaries().stream().map(BorderAssessment::value)
-                        .toList());
+                lines.stream().map(BorderAssessment::value).toList());
         // A `Decimal` names no value one step over, so the border owes its own point and says why
         // the other one is not a gap rather than leaving it out.
         // `< 0.5` puts the cut outside the partition it names, so the row at 0.5 is the border's
         // OFF point — and the ON point one step in is a value a `Decimal` names none of.
         assertEquals(new souther.compiler.query.ItemAssessment.NotOwed(
                         souther.compiler.partition.NotOwedReason.THE_CARRIER_NAMES_NO_NEIGHBOUR),
-                evidence.boundaries().get(0).at(souther.compiler.partition.PointRole.ON));
+                lines.get(0).at(souther.compiler.partition.PointRole.ON));
     }
 
     /**
@@ -123,7 +132,7 @@ class CompileAdequacyShapesTest {
                 "the behavior's own arms are countable whatever its helpers look like");
         assertEquals(2, branch.arms().all().size(), "the guard's two arms, and none of the helper's");
 
-        assertTrue(BorderAssessment.pointsOf(partition(compilation, "check").boundaries()).stream()
+        assertTrue(BorderAssessment.pointsOf(lines(compilation, "check")).stream()
                         .anyMatch(p -> p.item().weakeningSource() instanceof Measurement.Complete<?>),
                 "and the guard's boundary is decided rather than unavailable");
     }
@@ -216,7 +225,7 @@ class CompileAdequacyShapesTest {
      */
     @Test
     void aValueWrittenAtTwoScalesIsOneLine() {
-        PartitionEvidence evidence = partition(measured("""
+        Compilation compilation = measured("""
                 module example.scale
 
                 data Rate = Decimal
@@ -235,9 +244,10 @@ class CompileAdequacyShapesTest {
 
                 example classify
                     | (Rate(1m)) -> No { r = Rate(1m) }
-                """), "classify");
+                """);
+        PartitionEvidence evidence = partition(compilation, "classify");
 
-        List<String> at = evidence.boundaries().stream()
+        List<String> at = lines(compilation, "classify").stream()
                 .map(BorderAssessment::value).filter(v -> v.equals("0")).toList();
         assertEquals(2, at.size(), "one line, and two rules that drew it there");
         assertFalse(evidence.axes().isEmpty());

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -49,13 +49,27 @@ class CompileExampleBoundaryTest {
             }
             """;
 
-    private static PartitionEvidence evidence(String source) {
+    private static Compilation measured(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         // Measuring the arms is opted into, so a test about them opts in.
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
+        return compilation;
+    }
+
+    private static PartitionEvidence evidence(String source) {
+        Compilation compilation = measured(source);
         Map<String, PartitionEvidence> all = compilation.db()
                 .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        assertNotNull(all, "the model under test compiles");
+        return all.get("submit");
+    }
+
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(String source) {
+        Compilation compilation = measured(source);
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
         return all.get("submit");
     }
@@ -66,8 +80,8 @@ class CompileExampleBoundaryTest {
     }
 
     /** The points against a line at {@code value}, which is what a row there is owed for. */
-    private static List<BorderAssessment.Point> at(PartitionEvidence evidence, String value) {
-        return BorderAssessment.pointsOf(evidence.boundaries()).stream()
+    private static List<BorderAssessment.Point> at(List<BorderAssessment> lines, String value) {
+        return BorderAssessment.pointsOf(lines).stream()
                 .filter(p -> p.role().againstTheLine()).filter(p -> p.owed() != null)
                 .filter(p -> value.equals(p.against())).toList();
     }
@@ -96,7 +110,7 @@ class CompileExampleBoundaryTest {
      * is to reach — and reaching it needs no branch to have run. */
     @Test
     void anInvariantsBoundIsMetByWritingTheValue() {
-        PartitionEvidence away = evidence(MODEL + """
+        List<BorderAssessment> away = lines(MODEL + """
 
                 example submit
                     | (Draft { cost = Amount(50) }) -> Submitted
@@ -107,7 +121,7 @@ class CompileExampleBoundaryTest {
         assertTrue(zero.border().origin().named().startsWith("invariant"),
                 zero.border().origin().named());
 
-        PartitionEvidence edge = evidence(MODEL + """
+        List<BorderAssessment> edge = lines(MODEL + """
 
                 example submit
                     | (Draft { cost = Amount(0) }) -> Submitted
@@ -119,13 +133,13 @@ class CompileExampleBoundaryTest {
     /** A row that writes the value and reaches the comparison meets the line the guard drew. */
     @Test
     void aGuardsBoundaryIsMetByARowThatReachesTheComparison() {
-        PartitionEvidence evidence = evidence(MODEL + """
+        List<BorderAssessment> lines = lines(MODEL + """
 
                 example submit
                     | (Draft { cost = Amount(100) }) -> Submitted
                 """);
 
-        BorderAssessment.Point hundred = at(evidence, "100").get(0);
+        BorderAssessment.Point hundred = at(lines, "100").get(0);
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(hundred.item().weakeningSource()));
         assertTrue(hundred.owed().hasRowWitness(),
                 "the row wrote 100 and the guard compared it");
@@ -143,7 +157,7 @@ class CompileExampleBoundaryTest {
      */
     @Test
     void aValueWrittenButNeverComparedDoesNotMeetTheLine() {
-        PartitionEvidence evidence = evidence("""
+        List<BorderAssessment> lines = lines("""
                 module example.trip
 
                 data Amount = Int
@@ -166,9 +180,9 @@ class CompileExampleBoundaryTest {
                     | (Draft { cost = Amount(-1) }) -> Waiting { cost = Amount(-1) }
                 """);
 
-        BorderAssessment.Point first = at(evidence, "0").stream()
+        BorderAssessment.Point first = at(lines, "0").stream()
                 .filter(p -> p.border().origin().isWrittenRatherThanNamed()).findFirst().orElseThrow();
-        BorderAssessment.Point second = at(evidence, "100").get(0);
+        BorderAssessment.Point second = at(lines, "100").get(0);
 
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(second.item().weakeningSource()),
                 "the arms were measured");
@@ -178,14 +192,14 @@ class CompileExampleBoundaryTest {
 
     @Test
     void bothSidesOfAGuardsLineAreAskedFor() {
-        PartitionEvidence evidence = evidence(MODEL + """
+        List<BorderAssessment> lines = lines(MODEL + """
 
                 example submit
                     | (Draft { cost = Amount(50) }) -> Submitted
                 """);
 
-        assertEquals(1, at(evidence, "100").size(), "the value itself");
-        assertEquals(1, at(evidence, "101").size(), "and the first value on the other side");
+        assertEquals(1, at(lines, "100").size(), "the value itself");
+        assertEquals(1, at(lines, "101").size(), "and the first value on the other side");
     }
 
     /** Not a gap. The model draws no line through a plain String, so there was nothing to measure,
@@ -221,6 +235,7 @@ class CompileExampleBoundaryTest {
         assertTrue(keep.notDerivable().get(0).isAbsent(),
                 "the model divides it no way, which is established rather than assumed");
         assertEquals(List.of(), keep.axes());
-        assertEquals(List.of(), keep.boundaries());
+        assertEquals(List.of(),
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0)).get("keep"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -218,10 +218,10 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBoundaryWhosePositionWasNotReadIsUndecided() {
-        PartitionEvidence partition = measured(budgetSpent("")).db()
-                .ask(new Adequacy.Coverage("example.budget")).value().get("take");
+        List<BorderAssessment> lines = Adequacy.readingsOf(
+                measured(budgetSpent("")).db(), "example.budget").get("take");
 
-        List<BorderAssessment.Point> at = pointsAgainstTheLine(partition).stream()
+        List<BorderAssessment.Point> at = pointsAgainstTheLine(lines).stream()
                 .filter(p -> "0".equals(p.against())).toList();
         assertEquals(1, at.size());
         assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(at.get(0).item().weakeningSource()));
@@ -459,11 +459,11 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBoundaryIsUndecidedWhereSomeRowsWereNeverRead() {
-        PartitionEvidence partition = split().db()
-                .ask(new Adequacy.Coverage("example.split")).value().get("take");
+        List<BorderAssessment> lines =
+                Adequacy.readingsOf(split().db(), "example.split").get("take");
 
-        assertEquals(2, pointsAgainstTheLine(partition).size());
-        for (BorderAssessment.Point boundary : pointsAgainstTheLine(partition)) {
+        assertEquals(2, pointsAgainstTheLine(lines).size());
+        for (BorderAssessment.Point boundary : pointsAgainstTheLine(lines)) {
             assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(boundary.item().weakeningSource()), boundary.against());
             assertFalse(boundary.owed().hasRowWitness());
         }
@@ -697,7 +697,7 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBoundaryARowDemonstrablyMetStaysMet() {
-        PartitionEvidence partition = measured("mix", """
+        Compilation compilation = measured("mix", """
                 module example.mix
 
                 data Amount = Int
@@ -725,24 +725,27 @@ class CompilePartialAdequacyTest {
                     | "at the line" : (Draft { kind = Overseas, cost = Amount(100) }) -> Ok { n = 100 }
                     | "over it"     : (Draft { kind = Domestic, cost = Amount(500) }) -> Big { n = 0 }
                 """, DoesNotComeBack.overrunningOn(
-                        DoesNotComeBack.everythingAboutTheRowNamed("over it")), Adequacy.Asked.fullReport())
-                .db().ask(new Adequacy.Coverage("example.mix")).value().get("take");
+                        DoesNotComeBack.everythingAboutTheRowNamed("over it")),
+                Adequacy.Asked.fullReport());
+        List<BorderAssessment> lines =
+                Adequacy.readingsOf(compilation.db(), "example.mix").get("take");
 
-        BorderAssessment.Point line = pointsAgainstTheLine(partition).stream()
+        BorderAssessment.Point line = pointsAgainstTheLine(lines).stream()
                 .filter(p -> "100".equals(p.against())).findFirst().orElseThrow();
         assertTrue(line.owed().hasRowWitness(),
                 "a row wrote 100 and went through the comparison");
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(line.item().weakeningSource()));
 
-        BorderAssessment.Point beyond = pointsAgainstTheLine(partition).stream()
+        BorderAssessment.Point beyond = pointsAgainstTheLine(lines).stream()
                 .filter(p -> "101".equals(p.against())).findFirst().orElseThrow();
         assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(beyond.item().weakeningSource()),
                 "and the one nothing was found at is undecided, not missed");
     }
 
     /** The points a row is owed at against a line, which is what a value names. */
-    private static List<BorderAssessment.Point> pointsAgainstTheLine(PartitionEvidence partition) {
-        return BorderAssessment.pointsOf(partition.boundaries()).stream()
+    private static List<BorderAssessment.Point> pointsAgainstTheLine(
+            List<BorderAssessment> lines) {
+        return BorderAssessment.pointsOf(lines).stream()
                 .filter(p -> p.role().againstTheLine()).filter(p -> p.owed() != null).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
+++ b/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
@@ -25,7 +25,7 @@ import java.util.function.Predicate;
  * {@code CompilePartialAdequacyTest} walks four thousand nodes to spend the observation budget, and
  * it holds no looping helper at all.
  */
-final class DoesNotComeBack {
+public final class DoesNotComeBack {
 
     /**
      * The wait a test quotes when it says work did not come back.
@@ -93,7 +93,7 @@ final class DoesNotComeBack {
      * <p>Only the work picked out overruns, so whatever else the model does still has to finish: it
      * is run inline, and a loop nothing picked out would not be cut short but would hang.
      */
-    static Deadline overrunningOn(Predicate<Deadline.Work> which) {
+    public static Deadline overrunningOn(Predicate<Deadline.Work> which) {
         return new Deadline() {
 
             @Override
@@ -161,7 +161,7 @@ final class DoesNotComeBack {
     }
 
     /** Everything a row of {@code target} is worked on for: read, and evaluated. */
-    static Predicate<Deadline.Work> everythingAboutRowsOf(String target) {
+    public static Predicate<Deadline.Work> everythingAboutRowsOf(String target) {
         return everyRowOf(target).or(theFixturesOfEveryRowOf(target));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EveryReasonAPositionGivesIsCarriedByAMeasureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryReasonAPositionGivesIsCarriedByAMeasureTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.query.Adequacy;
-import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 
@@ -59,14 +58,14 @@ class EveryReasonAPositionGivesIsCarriedByAMeasureTest {
         Set<Object> out = new LinkedHashSet<>();
         partition.partitioned().weakening().observationCauses()
                 .forEach(gap -> out.add(gap.identity()));
-        partition.bounded().weakening().observationCauses()
+        partition.owes().weakening().observationCauses()
                 .forEach(gap -> out.add(gap.identity()));
         partition.pairs().counted().weakening().observationCauses()
                 .forEach(gap -> out.add(gap.identity()));
         for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
             axis.reached().weakening().observationCauses().forEach(gap -> out.add(gap.identity()));
         }
-        for (BorderAssessment.Point point : BorderAssessment.pointsOf(partition.boundaries())) {
+        for (souther.compiler.query.OwedBoundaryPoint point : partition.owedPoints()) {
             point.item().weakeningSource().weakening().observationCauses()
                     .forEach(gap -> out.add(gap.identity()));
         }

--- a/souther-compiler/src/test/java/souther/compiler/OneDivisionReadsAlikeHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OneDivisionReadsAlikeHoweverItIsWrittenTest.java
@@ -64,7 +64,8 @@ class OneDivisionReadsAlikeHoweverItIsWrittenTest {
         // spellings of one division name the same two classes differently. What has to agree is the
         // division: how many there are, and what each of the border's four points asks for.
         evidence.axes().forEach(axis -> read.add("classes " + axis.classes().size()));
-        for (BorderAssessment border : evidence.boundaries()) {
+        for (BorderAssessment border
+                : Adequacy.readingsOf(compilation.db(), compilation.modules().get(0)).get("f")) {
             for (PointRole role : PointRole.values()) {
                 read.add(role + " " + border.operator(role) + " " + border.against(role));
             }

--- a/souther-compiler/src/test/java/souther/compiler/WhatAFindingIsAboutIsHeldByTheTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAFindingIsAboutIsHeldByTheTypeTest.java
@@ -39,7 +39,7 @@ class WhatAFindingIsAboutIsHeldByTheTypeTest {
     void aSubjectThatIsNotThereIsRefusedWhereTheFindingIsMade() {
         assertThrows(NullPointerException.class, () -> new About.ACaseNoRowExpects(null));
         assertThrows(NullPointerException.class, () -> new About.AClassNoRowIsIn(null));
-        assertThrows(NullPointerException.class, () -> new About.APointOfABorder(null, null));
+        assertThrows(NullPointerException.class, () -> new About.APointOfABorder(null));
         assertThrows(NullPointerException.class, () -> new About.AQuestionNothingAnswered(null));
         assertThrows(NullPointerException.class, () -> new About.AnArmNoRowGoesThrough(null));
         assertThrows(NullPointerException.class,

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABodyThatBindsItsInputBeforeComparingItComparesItsInputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABodyThatBindsItsInputBeforeComparingItComparesItsInputTest.java
@@ -104,8 +104,16 @@ class ABodyThatBindsItsInputBeforeComparingItComparesItsInputTest {
                 .toList();
     }
 
-    private static List<String> linesOf(PartitionEvidence evidence) {
-        return BorderAssessment.pointsOf(evidence.boundaries()).stream()
+    /** The lines each behavior's positions met, whosever the row at each point is. */
+    private static Map<String, List<BorderAssessment>> lines() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+    }
+
+    private static List<String> linesOf(List<BorderAssessment> lines) {
+        return BorderAssessment.pointsOf(lines).stream()
                 .filter(p -> p.role().againstTheLine()).filter(p -> p.owed() != null)
                 .map(p -> p.label() + " " + p.role())
                 .sorted()
@@ -122,18 +130,20 @@ class ABodyThatBindsItsInputBeforeComparingItComparesItsInputTest {
                 classesOf(read));
         assertEquals(List.of("temp = 239 ON", "temp = 240 OFF",
                         "temp = 259 ON", "temp = 260 OFF"),
-                linesOf(read));
+                linesOf(lines().get("throughTheField")));
     }
 
     /** And every spelling that binds the input first divides it the same way. */
     @Test
     void aBoundSpellingDividesWhatTheFieldSpellingDivides() {
         Map<String, PartitionEvidence> measured = measured();
+        Map<String, List<BorderAssessment>> lines = lines();
         PartitionEvidence held = measured.get("throughTheField");
 
         for (String behavior : BOUND) {
             assertEquals(classesOf(held), classesOf(measured.get(behavior)), behavior);
-            assertEquals(linesOf(held), linesOf(measured.get(behavior)), behavior);
+            assertEquals(linesOf(lines.get("throughTheField")), linesOf(lines.get(behavior)),
+                    behavior);
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -559,8 +559,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         Compilation compilation = Compilation.ofSource(UNMEETABLE, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        compilation.db().ask(new Adequacy.Coverage("unmeetable")).value()
-                .forEach((behavior, evidence) -> evidence.boundaries()
+        Adequacy.readingsOf(compilation.db(), "unmeetable")
+                .forEach((behavior, read) -> read
                         .forEach(line -> lines.put(behavior + "/" + line.label(), line)));
 
         assertEquals(Set.of("onFlagsN/Set.size(v) = 2", "onNumbersN/Set.size(v) = 3",
@@ -811,8 +811,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
         Map<String, BorderAssessment> lines = new LinkedHashMap<>();
-        compilation.db().ask(new Adequacy.Coverage(module)).value()
-                .forEach((behavior, evidence) -> evidence.boundaries()
+        Adequacy.readingsOf(compilation.db(), module)
+                .forEach((behavior, read) -> read
                         .forEach(line -> lines.put(behavior + "/" + line.label(), line)));
         return lines;
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonDrawsALineWhereverItsTruthIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonDrawsALineWhereverItsTruthIsReadTest.java
@@ -83,8 +83,16 @@ class AComparisonDrawsALineWhereverItsTruthIsReadTest {
         return evidence.axes().stream().map(axis -> axis.path() + ": " + axis.classes()).toList();
     }
 
-    private static List<String> linesOf(PartitionEvidence evidence) {
-        return BorderAssessment.pointsOf(evidence.boundaries()).stream()
+    /** The lines each behavior's positions met, whosever the row at each point is. */
+    private static Map<String, List<BorderAssessment>> lines() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+    }
+
+    private static List<String> linesOf(List<BorderAssessment> lines) {
+        return BorderAssessment.pointsOf(lines).stream()
                 .filter(p -> p.role().againstTheLine()).filter(p -> p.owed() != null)
                 .map(p -> p.label() + " " + p.role())
                 .sorted()
@@ -106,11 +114,12 @@ class AComparisonDrawsALineWhereverItsTruthIsReadTest {
     @Test
     void everySpellingThatReadsTheTruthDividesWhatTheForkSpellingDivides() {
         Map<String, PartitionEvidence> measured = measured();
+        Map<String, List<BorderAssessment>> lines = lines();
         PartitionEvidence held = measured.get("underAFork");
 
         for (String behavior : READ_ELSEWHERE) {
             assertEquals(classesOf(held), classesOf(measured.get(behavior)), behavior);
-            assertEquals(linesOf(held), linesOf(measured.get(behavior)), behavior);
+            assertEquals(linesOf(lines.get("underAFork")), linesOf(lines.get(behavior)), behavior);
         }
     }
 
@@ -137,7 +146,7 @@ class AComparisonDrawsALineWhereverItsTruthIsReadTest {
         PartitionEvidence dead = measured().get("namedAndNeverRead");
 
         assertEquals(List.of(), classesOf(dead));
-        assertEquals(List.of(), linesOf(dead));
+        assertEquals(List.of(), linesOf(lines().get("namedAndNeverRead")));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
@@ -6,7 +6,6 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ItemAssessment;
-import souther.compiler.query.PartitionEvidence;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +52,7 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
     /** The line is drawn, over the counts the operation was declared with. */
     @Test
     void theLineIsStillDrawn() {
-        assertEquals(List.of("b - 86400 * d - t = 0"), measured().boundaries().stream()
+        assertEquals(List.of("b - 86400 * d - t = 0"), measured().stream()
                 .map(BorderAssessment::label).toList());
     }
 
@@ -68,7 +67,7 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
     @Test
     void thePointBelowItIsUnresolvedRatherThanThrown() {
         List<String> reasons = new ArrayList<>();
-        for (BorderAssessment border : measured().boundaries()) {
+        for (BorderAssessment border : measured()) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
                         && owed.attempt() instanceof ItemAssessment.Attempt.Unresolved unresolved) {
@@ -86,7 +85,7 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
     @Test
     void thePointsWithValuesKeepThem() {
         List<String> rows = new ArrayList<>();
-        for (BorderAssessment border : measured().boundaries()) {
+        for (BorderAssessment border : measured()) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
                         && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
@@ -102,15 +101,16 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
                 "the two points that have a value, at the counts the declared form puts them at");
     }
 
-    private static PartitionEvidence measured() {
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> measured() {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> coverage =
-                compilation.db().ask(new Adequacy.Coverage("demo")).value();
-        assertNotNull(coverage, "the model under test compiles");
-        PartitionEvidence measured = coverage.get("f");
-        assertNotNull(measured, "f was measured");
-        return measured;
+        Map<String, List<BorderAssessment>> read =
+                Adequacy.readingsOf(compilation.db(), "demo");
+        assertNotNull(read, "the model under test compiles");
+        List<BorderAssessment> lines = read.get("f");
+        assertNotNull(lines, "f was measured");
+        return lines;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
@@ -545,7 +545,7 @@ class ALineBetweenTwoPositionsIsStillALineTest {
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
         return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0)
-                .partition().boundaries().size();
+                .lines().size();
     }
 
     private static String generated(String model) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
@@ -98,6 +98,8 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
     @Test
     void aPositionTheWalkDidNotReachIntoLeavesBothMeasuresShort() {
         PartitionEvidence evidence = evidenceFor(RULES_NOT_REACHED, "f");
+        souther.compiler.query.Measure<List<souther.compiler.query.BorderAssessment>> reading =
+                readingFor(RULES_NOT_REACHED, "f");
 
         // What the partition did measure, so that the two answers below are one model saying two
         // things rather than one measure with nothing in it. A fixture whose every position is out
@@ -109,8 +111,8 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
 
         assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(evidence.partitioned()),
                 () -> "partition: " + evidence.partitioned());
-        assertEquals(MeasurementStatus.NOT_MEASURED, AdequacyReport.statusOf(evidence.bounded()),
-                () -> "border: " + evidence.bounded());
+        assertEquals(MeasurementStatus.NOT_MEASURED, AdequacyReport.statusOf(reading),
+                () -> "border: " + reading);
     }
 
     /**
@@ -126,7 +128,8 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
         PartitionEvidence evidence = evidenceFor(SET_ASIDE_COSTING_NEITHER, "f");
 
         assertInstanceOf(Measurement.NotApplicable.class, evidence.partitioned());
-        assertInstanceOf(Measurement.NotApplicable.class, evidence.bounded());
+        assertInstanceOf(Measurement.NotApplicable.class,
+                readingFor(SET_ASIDE_COSTING_NEITHER, "f"));
         // And the rule is named beside them, so the two answers are about a model with a rule in it
         // and not about one with none.
         assertEquals(2, evidence.rulesWithoutALine().size(), () -> "unread: " + evidence.rulesWithoutALine());
@@ -139,5 +142,17 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
         Map<String, PartitionEvidence> partitions = compilation.db()
                 .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
         return partitions.get(behavior);
+    }
+
+    /** How far the reading that found the behavior's lines got. */
+    private static souther.compiler.query.Measure<
+            List<souther.compiler.query.BorderAssessment>> readingFor(
+            String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation.db()
+                .ask(new Adequacy.BoundaryReadings(compilation.modules().get(0)))
+                .value().get(behavior);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
@@ -78,6 +78,15 @@ class APositionUnderANameIsReachedThroughItTest {
         return compilation;
     }
 
+    /** The lines that behavior's positions met, whosever the row at each point is. */
+    private static java.util.List<souther.compiler.query.BorderAssessment> lines(
+            Compilation compilation, String behavior) {
+        java.util.List<souther.compiler.query.BorderAssessment> found =
+                Adequacy.readingsOf(compilation.db(), "demo").get(behavior);
+        assertNotNull(found, behavior + " was measured");
+        return found;
+    }
+
     private static PartitionEvidence evidence(Compilation compilation, String behavior) {
         PartitionEvidence found = compilation.db()
                 .ask(new Adequacy.Coverage("demo")).value().get(behavior);
@@ -128,10 +137,10 @@ class APositionUnderANameIsReachedThroughItTest {
     void theRulesARecordWritesAboutItsFieldsReachThemUnderAName() {
         Compilation compilation = measured(PAIRS);
 
-        assertEquals(evidence(compilation, "bare").boundaries().size(),
-                evidence(compilation, "wrapped").boundaries().size(),
+        assertEquals(lines(compilation, "bare").size(),
+                lines(compilation, "wrapped").size(),
                 "the same record is bounded the same way under a name");
-        assertTrue(evidence(compilation, "wrapped").boundaries().size() >= 4);
+        assertTrue(lines(compilation, "wrapped").size() >= 4);
 
         String rows = GeneratedRows.of(compilation, "demo", "wrapped", true,
                 SourceNameResolver.identity()).text();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
@@ -89,7 +89,7 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
     void everyRowComposedStandsAtThePointItWasComposedFor() {
         List<String> missed = new ArrayList<>();
         forEachComposedRow((model, point, row) -> {
-            if (!met(measured(model + example(row)), point)) {
+            if (!met(lines(model + example(row)), point)) {
                 missed.add(point + " -> " + row);
             }
         });
@@ -114,8 +114,7 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
     private static void forEachComposedRow(OfAComposedRow held) {
         EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.MEASURED.forEach((operation, observed) -> {
             String model = EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.modelOf(observed);
-            PartitionEvidence measured = measured(model);
-            for (BorderAssessment border : measured.boundaries()) {
+            for (BorderAssessment border : lines(model)) {
                 border.items().forEach((role, item) -> {
                     if (item instanceof ItemAssessment.Owed owed
                             && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
@@ -137,8 +136,8 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
     }
 
     /** Whether the point is met, read off the item rather than out of a report's text. */
-    private static boolean met(PartitionEvidence evidence, String point) {
-        for (BorderAssessment border : evidence.boundaries()) {
+    private static boolean met(List<BorderAssessment> lines, String point) {
+        for (BorderAssessment border : lines) {
             for (Map.Entry<PointRole, ItemAssessment> each : border.items().entrySet()) {
                 if (!point.equals(border.label() + " " + each.getKey())) {
                     continue;
@@ -164,6 +163,18 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
             }
         }
         return said;
+    }
+
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> read = Adequacy.readingsOf(compilation.db(), "demo");
+        assertNotNull(read, () -> "the model under test compiles: " + source);
+        List<BorderAssessment> lines = read.get("f");
+        assertNotNull(lines, () -> "f was measured: " + source);
+        return lines;
     }
 
     private static PartitionEvidence measured(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -6,7 +6,6 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ItemAssessment;
-import souther.compiler.query.PartitionEvidence;
 
 import java.util.List;
 import java.util.Map;
@@ -449,12 +448,12 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     /** The one point of one border, found by the line and the level it names. */
     private static BorderAssessment.Point pointAt(String source, String level) {
         List<BorderAssessment.Point> found =
-                BorderAssessment.pointsOf(evidence(source).boundaries()).stream()
+                BorderAssessment.pointsOf(lines(source)).stream()
                         .filter(point -> point.label() != null && point.label().endsWith(level))
                         .toList();
         assertEquals(1, found.size(),
                 "one point is named `" + level + "`, and these are the points: "
-                        + BorderAssessment.pointsOf(evidence(source).boundaries()).stream()
+                        + BorderAssessment.pointsOf(lines(source)).stream()
                                 .map(BorderAssessment.Point::label).toList());
         return found.get(0);
     }
@@ -464,12 +463,13 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
                 "a row is owed at " + point.label());
     }
 
-    private static PartitionEvidence evidence(String source) {
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> all = compilation.db()
-                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        Map<String, List<BorderAssessment>> all =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
         return all.get("checkout");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -68,12 +68,12 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      */
     @Test
     void theBorderThisIsAboutIsDrawnAndItsPointsAreOpen() {
-        PartitionEvidence measured = measured(SPAN);
+        List<BorderAssessment> lines = lines(SPAN);
 
-        assertEquals(List.of("b - 10"), measured.boundaries().stream()
+        assertEquals(List.of("b - 10"), lines.stream()
                 .map(BorderAssessment::value).filter(each -> each.contains("b")).toList(),
                 "the line `Date.daysBetween(a, b) > 10` draws");
-        assertTrue(!open(measured).isEmpty(),
+        assertTrue(!open(lines).isEmpty(),
                 "and points of it nothing has covered, for a row to be offered at");
     }
 
@@ -90,7 +90,7 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      */
     @Test
     void thePointsOfThatBorderAreOfferedRows() {
-        Map<String, String> rows = offeredAt(measured(SPAN));
+        Map<String, String> rows = offeredAt(lines(SPAN));
 
         assertEquals(List.of("a = b - 10 ON", "a = b - 10 OFF", "a = b - 10 IN", "a = b - 10 OUT"),
                 rows.keySet().stream().filter(each -> each.startsWith("a = b - 10 ")).toList(),
@@ -131,7 +131,7 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      */
     @Test
     void thePointsOfABorderAcrossTwoOrdersAreOfferedRowsWrittenOnEachOrder() {
-        Map<String, String> rows = inputsOf(measured(ACROSS_TWO_ORDERS));
+        Map<String, String> rows = inputsOf(lines(ACROSS_TWO_ORDERS));
 
         assertEquals(List.of("b = a OFF", "b = a IN", "b = a OUT"),
                 rows.keySet().stream().filter(each -> each.startsWith("b = a ")).toList(),
@@ -181,7 +181,7 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      */
     @Test
     void andThePairIsSearchedForOnBothOrders() {
-        Map<String, String> rows = inputsOf(measured(A_RUN_ONE_ORDER_FILLS));
+        Map<String, String> rows = inputsOf(lines(A_RUN_ONE_ORDER_FILLS));
 
         assertEquals("(0, Amount(0.5m))", rows.get("b = a + 0.5 OFF"),
                 "the point on the line has the one whole number the line leaves, and the decimal"
@@ -197,9 +197,9 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      */
     @Test
     void everyRowOfferedAtAPointStandsAtIt() {
-        Map<String, String> rows = offeredAt(measured(SPAN));
+        Map<String, String> rows = offeredAt(lines(SPAN));
 
-        PartitionEvidence again = measured(SPAN + "\nexample f\n"
+        List<BorderAssessment> again = lines(SPAN + "\nexample f\n"
                 + String.join("\n", rows.values()) + "\n");
 
         assertEquals(List.of(), open(again).stream().filter(rows::containsKey).toList(),
@@ -207,9 +207,9 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
     }
 
     /** The points of every border a row is owed at and nothing stands at. */
-    private static List<String> open(PartitionEvidence evidence) {
+    private static List<String> open(List<BorderAssessment> lines) {
         List<String> points = new ArrayList<>();
-        for (BorderAssessment border : evidence.boundaries()) {
+        for (BorderAssessment border : lines) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
                         && !owed.hasRowWitness()) {
@@ -226,22 +226,22 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      * <p>Empty where the search composed nothing, which is what a point with no row is. Whether that
      * happens is the search's answer and no part of what this holds.
      */
-    private static Map<String, String> offeredAt(PartitionEvidence evidence) {
-        return offeredAt(evidence, ARowOfferedForABorderOverAnOperationStandsAtItTest::written);
+    private static Map<String, String> offeredAt(List<BorderAssessment> lines) {
+        return offeredAt(lines, ARowOfferedForABorderOverAnOperationStandsAtItTest::written);
     }
 
     /** The same, as each row's inputs alone — for a model whose rows are not written as dates and
      *  whose answer nothing here works out. */
-    private static Map<String, String> inputsOf(PartitionEvidence evidence) {
-        return offeredAt(evidence, row -> "("
+    private static Map<String, String> inputsOf(List<BorderAssessment> lines) {
+        return offeredAt(lines, row -> "("
                 + String.join(", ", row.inputs().stream().map(FixtureTemplate::text).toList()) + ")");
     }
 
     private static Map<String, String> offeredAt(
-            PartitionEvidence evidence,
+            List<BorderAssessment> lines,
             java.util.function.Function<Generator.GeneratedRow, String> as) {
         Map<String, String> rows = new LinkedHashMap<>();
-        for (BorderAssessment border : evidence.boundaries()) {
+        for (BorderAssessment border : lines) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
                         && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
@@ -287,5 +287,18 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
         PartitionEvidence measured = coverage.get("f");
         assertNotNull(measured, () -> "f was measured: " + source);
         return measured;
+    }
+
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> lines(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> read =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(read, () -> "the model under test compiles: " + source);
+        List<BorderAssessment> lines = read.get("f");
+        assertNotNull(lines, () -> "f was measured: " + source);
+        return lines;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.PartitionEvidence;
 import souther.compiler.semantics.OperationFacts;
 import souther.compiler.types.ValueName;
 
@@ -126,11 +125,10 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> coverage =
-                compilation.db().ask(new Adequacy.Coverage("demo")).value();
-        assertNotNull(coverage, () -> "the model under test compiles: " + model);
-        PartitionEvidence measured = coverage.get("f");
-        assertNotNull(measured, () -> "f was measured: " + model);
-        return measured.boundaries().stream().map(BorderAssessment::label).toList();
+        Map<String, List<BorderAssessment>> read = Adequacy.readingsOf(compilation.db(), "demo");
+        assertNotNull(read, () -> "the model under test compiles: " + model);
+        List<BorderAssessment> lines = read.get("f");
+        assertNotNull(lines, () -> "f was measured: " + model);
+        return lines.stream().map(BorderAssessment::label).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
@@ -120,6 +120,14 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
         return compilation.db().ask(new Adequacy.Coverage(module)).value();
     }
 
+    /** The lines each behavior's positions met, whosever the row at each point is. */
+    private static Map<String, List<BorderAssessment>> lines(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return Adequacy.readingsOf(compilation.db(), module);
+    }
+
     private static List<String> axesOf(PartitionEvidence evidence) {
         return evidence.axes().stream().map(axis -> axis.path() + ": " + axis.classes()).toList();
     }
@@ -127,8 +135,8 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
     /** Every point of every line, and whether a row is owed at it. Not only the owed ones: a line
      *  whose points no row can be written at is still the line the rule draws, and a spelling that
      *  lost it would look like a spelling that kept it under a filter for what is owed. */
-    private static List<String> linesOf(PartitionEvidence evidence) {
-        return BorderAssessment.pointsOf(evidence.boundaries()).stream()
+    private static List<String> linesOf(List<BorderAssessment> lines) {
+        return BorderAssessment.pointsOf(lines).stream()
                 .filter(point -> point.role().againstTheLine())
                 .map(point -> point.label() + " " + point.role()
                         + (point.owed() != null ? " owed" : " excluded"))
@@ -159,7 +167,7 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
         Map<String, PartitionEvidence> measured = measured(MODEL, "example.named");
         // The pair says the two spellings agree; this says what they agree on is a line, so a
         // reading that lost it in both would not pass for agreement.
-        assertFalse(linesOf(measured.get("overOnePosition")).isEmpty(),
+        assertFalse(linesOf(lines(MODEL, "example.named").get("overOnePosition")).isEmpty(),
                 "the spelling that writes the arithmetic draws a line");
         agree("overOnePositionNamed");
     }
@@ -181,11 +189,12 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
 
     private static void agree(String named) {
         Map<String, PartitionEvidence> measured = measured(MODEL, "example.named");
+        Map<String, List<BorderAssessment>> lines = lines(MODEL, "example.named");
         PartitionEvidence written = measured.get(PAIRS.get(named));
         PartitionEvidence bound = measured.get(named);
         assertEquals(cutsOf(PAIRS.get(named)), cutsOf(named), named);
         assertEquals(axesOf(written), axesOf(bound), named);
-        assertEquals(linesOf(written), linesOf(bound), named);
+        assertEquals(linesOf(lines.get(PAIRS.get(named))), linesOf(lines.get(named)), named);
         assertEquals(reasonsOf(written), reasonsOf(bound), named);
     }
 
@@ -268,7 +277,8 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
         Map<String, PartitionEvidence> measured = measured(DERIVED, "example.roster");
         assertEquals(List.of(), axesOf(measured.get("counted")));
         assertEquals(List.of(), axesOf(measured.get("countedNamed")));
-        assertEquals(List.of(), linesOf(measured.get("counted")));
-        assertEquals(List.of(), linesOf(measured.get("countedNamed")));
+        Map<String, List<BorderAssessment>> lines = lines(DERIVED, "example.roster");
+        assertEquals(List.of(), linesOf(lines.get("counted")));
+        assertEquals(List.of(), linesOf(lines.get("countedNamed")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -519,7 +519,8 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
             // value one step over is what this table is about, and a border is one whether or not
             // its second point exists — counted as borders, every carrier answers alike.
             out.put(behavior, new Measured(evidence.axes().size(),
-                    (int) souther.compiler.query.BorderAssessment.pointsOf(evidence.boundaries())
+                    (int) souther.compiler.query.BorderAssessment.pointsOf(
+                            Adequacy.readingsOf(compilation.db(), "example.matrix").get(behavior))
                             .stream().filter(point -> point.role().againstTheLine())
                             .filter(point -> point.owed() != null).count(),
                     unread));

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
@@ -154,7 +154,27 @@ class OneStatementDrawsOneBorderHoweverItIsSpelledTest {
                 "Date.daysBetween(a, b) <= 1"));
     }
 
+    /** The lines the behavior's positions met, whosever the row at each point is. */
+    private static List<BorderAssessment> linesOf(String parameters, String condition) {
+        Compilation compilation = compiled(parameters, condition);
+        Map<String, List<BorderAssessment>> read = Adequacy.readingsOf(compilation.db(), "demo");
+        assertNotNull(read, "the model under test compiles");
+        List<BorderAssessment> lines = read.get("f");
+        assertNotNull(lines, "f was measured");
+        return lines;
+    }
+
     private static PartitionEvidence measured(String parameters, String condition) {
+        Compilation compilation = compiled(parameters, condition);
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, "the model under test compiles");
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, "f was measured");
+        return measured;
+    }
+
+    private static Compilation compiled(String parameters, String condition) {
         String model = """
                 module demo
 
@@ -171,16 +191,11 @@ class OneStatementDrawsOneBorderHoweverItIsSpelledTest {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Map<String, PartitionEvidence> coverage =
-                compilation.db().ask(new Adequacy.Coverage("demo")).value();
-        assertNotNull(coverage, () -> "the model under test compiles: " + model);
-        PartitionEvidence measured = coverage.get("f");
-        assertNotNull(measured, () -> "f was measured: " + model);
-        return measured;
+        return compilation;
     }
 
     private static List<String> bordersOf(String parameters, String condition) {
-        return measured(parameters, condition).boundaries().stream()
+        return linesOf(parameters, condition).stream()
                 .map(BorderAssessment::value).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/SemanticDiscoveryFinishesBeforeAnyBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/SemanticDiscoveryFinishesBeforeAnyBudgetTest.java
@@ -98,16 +98,18 @@ class SemanticDiscoveryFinishesBeforeAnyBudgetTest {
      */
     @Test
     void positionsTheBodyDividesAreMeasuredBesideTheOnesTheDeclarationsDo() {
-        PartitionEvidence evidence = evidenceFor(DECLARED_AND_COMPARED);
+        Compilation compilation = measured(DECLARED_AND_COMPARED);
+        PartitionEvidence evidence = evidenceFor(compilation);
+        java.util.List<souther.compiler.query.BorderAssessment> lines = linesOf(compilation);
 
         assertEquals(17, evidence.axes().size(),
                 () -> "twelve declared and five compared, all of them divided: " + paths(evidence));
-        assertEquals(5, evidence.boundaries().size(),
-                () -> "and every compared one carries a line: " + borders(evidence));
+        assertEquals(5, lines.size(),
+                () -> "and every compared one carries a line: " + borders(lines));
         // Both measures answered everything they answer for. A reading that had left a position out
         // would say so here, and saying nothing is what makes the counts above a measurement.
         assertInstanceOf(Measurement.Complete.class, evidence.partitioned());
-        assertInstanceOf(Measurement.Complete.class, evidence.bounded());
+        assertInstanceOf(Measurement.Complete.class, readingOf(compilation));
     }
 
     /**
@@ -120,33 +122,52 @@ class SemanticDiscoveryFinishesBeforeAnyBudgetTest {
      */
     @Test
     void aPositionOnlyTheBodyDividesStillCarriesItsLine() {
-        PartitionEvidence evidence = evidenceFor(ONE_COMPARED);
+        Compilation compilation = measured(ONE_COMPARED);
+        java.util.List<souther.compiler.query.BorderAssessment> lines = linesOf(compilation);
 
-        assertEquals(1, evidence.boundaries().size(),
-                () -> "the compared position carries a line: " + borders(evidence));
+        assertEquals(1, lines.size(),
+                () -> "the compared position carries a line: " + borders(lines));
         // The axis the line is on, which the border answers for itself. Read off the assessment's
         // `toString` instead, the test would pass on any rendering that happened to contain the
         // field's name and fail on a rendering that changed nothing about the line.
-        assertEquals("calc/c.n1", evidence.boundaries().get(0).axis(),
-                () -> "and it is the position the body compared: " + borders(evidence));
-        assertInstanceOf(Measurement.Complete.class, evidence.bounded());
+        assertEquals("calc/c.n1", lines.get(0).axis(),
+                () -> "and it is the position the body compared: " + borders(lines));
+        assertInstanceOf(Measurement.Complete.class, readingOf(compilation));
     }
 
-    private static java.util.List<String> borders(PartitionEvidence evidence) {
-        return evidence.boundaries().stream()
-                .map(souther.compiler.query.BorderAssessment::axis).toList();
+    private static java.util.List<String> borders(
+            java.util.List<souther.compiler.query.BorderAssessment> lines) {
+        return lines.stream().map(souther.compiler.query.BorderAssessment::axis).toList();
     }
 
     private static java.util.List<String> paths(PartitionEvidence evidence) {
         return evidence.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList();
     }
 
-    private static PartitionEvidence evidenceFor(String source) {
+    private static Compilation measured(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
+        return compilation;
+    }
+
+    private static PartitionEvidence evidenceFor(Compilation compilation) {
         Map<String, PartitionEvidence> partitions = compilation.db()
                 .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
         return partitions.get("calc");
+    }
+
+    /** The lines that behavior's positions met, whosever the row at each point is. */
+    private static java.util.List<souther.compiler.query.BorderAssessment> linesOf(
+            Compilation compilation) {
+        return Adequacy.readingsOf(compilation.db(), compilation.modules().get(0)).get("calc");
+    }
+
+    /** How far the reading that found those lines got. */
+    private static souther.compiler.query.Measure<
+            java.util.List<souther.compiler.query.BorderAssessment>> readingOf(
+            Compilation compilation) {
+        return compilation.db().ask(new Adequacy.BoundaryReadings(compilation.modules().get(0)))
+                .value().get("calc");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -24,6 +24,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhatStoppedADerivationIsWhatIsReportedTest {
 
+    /** The lines that behavior's positions met, whosever the row at each point is. */
+    private static java.util.List<souther.compiler.query.BorderAssessment> lines(
+            String model, String behavior) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        java.util.List<souther.compiler.query.BorderAssessment> read =
+                Adequacy.readingsOf(compilation.db(), "demo").get(behavior);
+        assertNotNull(read, behavior + " was measured");
+        return read;
+    }
+
     private static PartitionEvidence measured(String model, String behavior) {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
@@ -197,17 +209,18 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
      */
     @Test
     void aRuleMeasuringTheCollectionItselfIsStillMeasured() {
-        PartitionEvidence evidence = measured("""
+        String model = """
                 module demo
                 data Ok
                 data Item = { charge: Int }
                 behavior run : (items: List<Item>) -> Ok
                 let run (items) = { guard List.length(items) < 3 else Ok
                     Ok }
-                """, "run");
+                """;
+        PartitionEvidence evidence = measured(model, "run");
 
         assertEquals(1, evidence.axes().size(), "the length is a line on the position itself");
-        assertTrue(evidence.boundaries().size() >= 1, "and it owes rows at its edges");
+        assertTrue(lines(model, "run").size() >= 1, "and it owes rows at its edges");
         assertEquals(List.of(), evidence.notDerivable().stream()
                         .filter(each -> each.at().toString().equals("items")).toList(),
                 "so nothing is left to report about the collection itself");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -93,7 +93,7 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
         assertThrows(IllegalArgumentException.class,
                 () -> new QuantityArrangement.Run(values, stoppedByTheOrder(Towards.BELOW),
                         List.of(new RegionClaim(RegionBasis.TheRest.INSTANCE,
-                                PointAttribution.NONE))),
+                                PointContributions.none()))),
                 "and what a rule leaves outside one value is not a run of the arrangement at all");
         assertThrows(IllegalArgumentException.class,
                 () -> new QuantityArrangement.Run(values, stoppedByTheOrder(Towards.ABOVE),
@@ -103,12 +103,12 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
 
     private static List<RegionClaim> stoppedByTheOrder(Towards towards) {
         return List.of(new RegionClaim(new RegionBasis.Beside(new FarEnd.AtTheOrderEnd(towards)),
-                PointAttribution.NONE));
+                PointContributions.none()));
     }
 
     private static List<RegionClaim> stoppedByTheDomain(Bound at) {
         return List.of(new RegionClaim(new RegionBasis.Beside(new FarEnd.AtTheDomain(at)),
-                PointAttribution.NONE));
+                PointContributions.none()));
     }
 
     /** What stops the first run of {@code arranged} at its high end, without who can move it. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
@@ -128,7 +128,7 @@ class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
         assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
                 partition.partitioned().why());
         assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
-                partition.bounded().why());
+                partition.owes().why());
 
         // The arms are measured off the bodies and not off the boundary, so they say what happened
         // to them. Two measures short of two different things is two sentences, and a behavior

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorsAccountDoesNotReachTheLinesOtherPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorsAccountDoesNotReachTheLinesOtherPointsTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a behavior's account hands out does not reach the points beside the ones in it.
+ *
+ * <p>A behavior is measured against what it is owed a row for, and two of a border's four points can
+ * be owed to the declarations that drew the line instead. Naming the account {@code owes} says which
+ * question it answers; it does not stop a reader holding one of its entries from walking back to the
+ * border and reading the roles beside it, and a reader that did would be measuring a body against a
+ * row nothing written for it is owed — which is the whole of what this account exists to prevent.
+ *
+ * <p>So an entry carries the line and not the assessment of it. The line is what a report writes
+ * about a point — the position, the rule, what the point asks for — and what became of the border's
+ * other roles is no part of it. What a reader that shows a border whole reads is
+ * {@link BehaviorEvidence#boundaryReadings}, and it asks for that by name.
+ *
+ * <p>Read as a closure from the account rather than as a list of what is allowed: a field or a
+ * reader added later that reaches an assessment is caught by having been added, not by anybody
+ * remembering to name it here.
+ */
+class ABehaviorsAccountDoesNotReachTheLinesOtherPointsTest {
+
+    /** The vocabulary this walks, which is where an assessment could be reached from. Types outside
+     *  it — a string, a list, a source id — hold nothing of this compiler's measures. */
+    private static final Set<String> WALKED = Set.of(
+            "souther.compiler.query", "souther.compiler.partition");
+
+    @Test
+    void nothingReachableFromWhatABehaviorIsOwedIsAnAssessmentOfALine() {
+        Set<Class<?>> reached = reachableFrom(PartitionEvidence.class);
+
+        // The walk went somewhere. A closure that came back holding nothing would pass every
+        // assertion below by having read no method at all.
+        assertTrue(reached.contains(OwedBoundaryPoint.class),
+                () -> "the account is what a behavior's evidence hands out: " + named(reached));
+        assertTrue(reached.contains(souther.compiler.partition.Border.class),
+                () -> "and an entry carries the line it is a point of: " + named(reached));
+
+        assertFalse(reached.contains(BorderAssessment.class),
+                () -> "a behavior's account reaches an assessment of a whole line: "
+                        + named(reached));
+        assertFalse(reached.contains(BorderAssessment.Point.class),
+                () -> "a behavior's account reaches a point of one it may not be measured for: "
+                        + named(reached));
+    }
+
+    /** Every type this compiler's own vocabulary reaches from {@code from}, through what its public
+     *  readers answer with. */
+    private static Set<Class<?>> reachableFrom(Class<?> from) {
+        Set<Class<?>> found = new LinkedHashSet<>();
+        Deque<Class<?>> left = new ArrayDeque<>();
+        left.add(from);
+        while (!left.isEmpty()) {
+            Class<?> each = left.removeFirst();
+            if (!found.add(each)) {
+                continue;
+            }
+            for (Method method : each.getMethods()) {
+                if (Modifier.isStatic(method.getModifiers())) {
+                    continue;   // a factory is not something a value in hand hands out
+                }
+                for (Class<?> answered : namedIn(method.getGenericReturnType())) {
+                    if (ours(answered)) {
+                        left.add(answered);
+                    }
+                }
+            }
+            // The arms of a sum are reached by reading one, so they are part of what it hands out.
+            for (Class<?> arm : each.getPermittedSubclasses() == null
+                    ? new Class<?>[0] : each.getPermittedSubclasses()) {
+                if (ours(arm)) {
+                    left.add(arm);
+                }
+            }
+        }
+        return found;
+    }
+
+    /** The classes a type names, itself and whatever it is written over. */
+    private static Set<Class<?>> namedIn(Type type) {
+        Set<Class<?>> out = new LinkedHashSet<>();
+        switch (type) {
+            case Class<?> named -> out.add(named);
+            case ParameterizedType over -> {
+                out.addAll(namedIn(over.getRawType()));
+                for (Type argument : over.getActualTypeArguments()) {
+                    out.addAll(namedIn(argument));
+                }
+            }
+            case WildcardType any -> {
+                for (Type bound : any.getUpperBounds()) {
+                    out.addAll(namedIn(bound));
+                }
+            }
+            default -> { }
+        }
+        return out;
+    }
+
+    private static boolean ours(Class<?> type) {
+        return type.getPackage() != null && WALKED.contains(type.getPackage().getName());
+    }
+
+    private static Set<String> named(Set<Class<?>> types) {
+        Set<String> out = new LinkedHashSet<>();
+        types.forEach(each -> out.add(each.getSimpleName()));
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ALineIsOwedByTheDeclarationsThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALineIsOwedByTheDeclarationsThatWroteItTest.java
@@ -305,10 +305,10 @@ class ALineIsOwedByTheDeclarationsThatWroteItTest {
 
     /** The module's debts, in the order the query answers them. */
     private static List<Adequacy.DeclaredDebt> debtsOf(Compilation compilation, String module) {
-        List<Adequacy.DeclaredDebt> debts =
+        Adequacy.DeclaredBoundaries account =
                 compilation.db().ask(new Adequacy.DeclaredBorders(module)).value();
-        assertNotNull(debts, "the model under test compiles");
-        return debts;
+        assertNotNull(account, "the model under test compiles");
+        return account.owed();
     }
 
     /** The one debt of {@code module} whose end something took in. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ARunIsOwedToWhoeverMovedWhereItStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARunIsOwedToWhoeverMovedWhereItStopsTest.java
@@ -90,9 +90,10 @@ class ARunIsOwedToWhoeverMovedWhereItStopsTest {
         Compilation compilation = Compilation.ofSource(NARROWED, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        List<Adequacy.DeclaredDebt> debts =
+        Adequacy.DeclaredBoundaries account =
                 compilation.db().ask(new Adequacy.DeclaredBorders("example.narrow")).value();
-        assertNotNull(debts, "the model under test compiles");
+        assertNotNull(account, "the model under test compiles");
+        List<Adequacy.DeclaredDebt> debts = account.owed();
         return debts.stream()
                 .filter(each -> each.debt().role() == role && each.debt().said().equals(said))
                 .findFirst()

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryPointOwedIsInOneAccountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryPointOwedIsInOneAccountTest.java
@@ -1,0 +1,307 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.partition.BorderObligationPoint;
+import souther.compiler.partition.OwedPoint;
+import souther.compiler.partition.PointAttribution;
+import souther.compiler.partition.PointRole;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every point a row is owed at is in one account, and the two accounts are made from the readings.
+ *
+ * <p>A border owes a row at up to four points, and whose it is to write one there is settled per
+ * point: a run that stops at this body's own rule exists in this body and nowhere else, and a line a
+ * {@code data} clause drew is answered once for the module by a row written for any behavior
+ * carrying the type. So the readings refine into two accounts, and this holds them to it — a point
+ * in both would be a row asked for twice, and a point in neither would be one nothing measures.
+ *
+ * <p><b>Counting is not the check.</b> The declarations' side collapses every reading of one point
+ * into one debt, so the number of debts is smaller than the number of readings that owe them and no
+ * total is conserved. What holds is the refinement: each reading's point goes to exactly one side,
+ * and each debt is what some readings on the declarations' side came to together.
+ */
+class EveryPointOwedIsInOneAccountTest {
+
+    /**
+     * A type whose clause draws a line, carried at a position of two behaviors, and one of those
+     * behaviors drawing a line of its own.
+     */
+    private static final String MODEL = """
+            module example.both
+
+            data Amount = Int
+                invariant value >= 10
+
+            data Draft = { cost: Amount }
+            data Ok = { n: Int }
+            data No = { n: Int }
+
+            behavior keep : (d: Draft) -> Ok | No
+                constructs Ok, No
+
+            let keep (d) = {
+                guard d.cost.value <= 100 else No { n = 0 }
+                Ok { n = d.cost.value }
+            }
+
+            behavior hold : (d: Draft) -> Ok
+                constructs Ok
+
+            let hold (d) = Ok { n = d.cost.value }
+
+            example keep
+                | "mid" : (Draft { cost = Amount(50) }) -> Ok { n = 50 }
+
+            example hold
+                | "mid" : (Draft { cost = Amount(50) }) -> Ok { n = 50 }
+            """;
+
+    @Test
+    void abehaviorIsOwedNothingThatIsOwedToTheDeclarations() {
+        Compilation compilation = measured();
+        Map<String, PartitionEvidence> partitions =
+                compilation.db().ask(new Adequacy.Coverage("example.both")).value();
+        Map<String, List<BorderAssessment>> lines =
+                Adequacy.readingsOf(compilation.db(), "example.both");
+
+        List<OwedPoint> theDeclarations = new ArrayList<>();
+        List<OwedPoint> theReadings = new ArrayList<>();
+        for (List<BorderAssessment> read : lines.values()) {
+            for (BorderAssessment border : read) {
+                for (PointRole role : PointRole.values()) {
+                    for (OwedPoint owed : border.border().owes(role)) {
+                        (owed.attribution() instanceof PointAttribution.TheDeclarations
+                                ? theDeclarations : theReadings).add(owed);
+                    }
+                }
+            }
+        }
+        // Both sides are there, so the two assertions below are about something. A model whose
+        // every point fell on one side would pass them by having nothing to tell apart.
+        assertFalse(theDeclarations.isEmpty(), "the clause's line is owed to the declaration");
+        assertFalse(theReadings.isEmpty(), "and the guard's line is owed to the body that drew it");
+
+        List<BorderObligationPoint> account = new ArrayList<>();
+        partitions.forEach((behavior, evidence) ->
+                evidence.owedPoints().forEach(owed -> account.add(owed.owed())));
+        assertEquals(theReadings.stream().map(OwedPoint::point).toList(), account,
+                "a behavior's account is the points its own rules settled, and no others");
+
+        Set<BorderObligationPoint> owedToDeclarations = new LinkedHashSet<>(
+                theDeclarations.stream().map(OwedPoint::point).toList());
+        assertTrue(account.stream().noneMatch(owedToDeclarations::contains),
+                "and nothing in it is a point the declarations are owed a row at");
+    }
+
+    /**
+     * And what the module's declarations are owed is what those readings came to together.
+     *
+     * <p>Which is why no count is conserved: {@code Amount}'s line is met at a position of both
+     * behaviors, and the two readings of one point are one debt.
+     */
+    @Test
+    void theDeclarationsAccountIsOneDebtHoweverManyReadingsOwedIt() {
+        Compilation compilation = measured();
+        List<Adequacy.DeclaredDebt> debts = compilation.db()
+                .ask(new Adequacy.DeclaredBorders("example.both")).value().owed();
+
+        assertFalse(debts.isEmpty(), "the module's own declaration draws a line its behaviors meet");
+        for (Adequacy.DeclaredDebt owed : debts) {
+            assertTrue(owed.debt().met().size() >= 1, "a debt is what some readings came to");
+        }
+        List<Adequacy.DeclaredDebt> acrossBoth = debts.stream()
+                .filter(owed -> owed.debt().met().size() > 1).toList();
+        assertFalse(acrossBoth.isEmpty(),
+                () -> "both behaviors carry the type, so a point of its line is read twice and owed"
+                        + " once: " + debts.stream().map(each -> each.debt().said()).toList());
+    }
+
+    /**
+     * A module whose declarations draw a line the walk never reached the position of.
+     *
+     * <p>What the mapping holds is a value this compiler names no position for, so {@code Amount}'s
+     * clause is written under a position no reading is ever opened at.
+     */
+    private static final String NOT_REACHED = """
+            module example.notreached
+
+            data Amount = Int
+                invariant value >= 0 && value <= 100
+            data Req = { cost: Map<String, Amount>, flag: Bool }
+            data Res = { n: Int }
+
+            behavior f : (r: Req) -> Res
+                constructs Res
+            let f (r) = Res { n = 0 }
+
+            example f
+                | "one" : (Req { cost = [ ("a", Amount(1)) ], flag = true }) -> Res { n = 0 }
+            """;
+
+    /**
+     * A reading that did not run out leaves the declarations' account short, and it says so.
+     *
+     * <p>The other half of what a behavior's account answers. What a module's declarations are owed
+     * is read off the lines its behaviors met, so a reading that stopped may have left a line their
+     * declarations owe unseen — and an account that came back with no debts and nothing to say would
+     * be a module whose declarations owe nothing, which is what a module every line of which is
+     * covered also answers.
+     *
+     * <p>{@code Amount} is such a declaration: it states something about its values, and this run
+     * could not get to the position carrying it to find out what is owed there.
+     */
+    @Test
+    void aReadingThatDidNotRunOutLeavesTheDeclarationsAccountShort() {
+        Compilation compilation = Compilation.ofSources(List.of(NOT_REACHED), ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+
+        Adequacy.DeclaredBoundaries account =
+                compilation.db().ask(new Adequacy.DeclaredBorders("example.notreached")).value();
+        assertNotNull(account, "the model under test compiles");
+
+        assertEquals(List.of(), account.owed(),
+                "the walk never reached the position, so no debt of the declaration was found");
+        assertFalse(account.weakening().isEmpty(),
+                "and the account says the reading it was made from did not run out, so the debts it"
+                        + " holds are not all there are");
+    }
+
+    /**
+     * An entry of an account is made where the account is, and nowhere else.
+     *
+     * <p>The four readings of one of these — the line, the role, what is owed there and what became
+     * of it — go to three different readers, so a value assembled from parts of different points
+     * would be shown by one, named by another and judged by a third with nothing to notice. What
+     * keeps them one point is that nobody outside can make one.
+     */
+    @Test
+    void nothingOutsideTheAccountCanMakeAnEntryOfIt() {
+        assertEquals(List.of(), List.of(OwedBoundaryPoint.class.getConstructors()),
+                "a public constructor is a way to assemble a point out of parts of others");
+    }
+
+    /**
+     * And a behavior's two readings of one measurement are of one measurement.
+     *
+     * <p>What it is owed a row for is read off the lines it met, and the two are read by different
+     * readers: a block and a document show the lines, a finding and a verdict read the account. Held
+     * apart without being held together, a behavior could show one reading's borders under another
+     * reading's findings.
+     */
+    @Test
+    void aBehaviorsAccountIsWhatItsOwnLinesComeTo() {
+        Compilation compilation = measured();
+        Map<String, PartitionEvidence> partitions =
+                compilation.db().ask(new Adequacy.Coverage("example.both")).value();
+        Map<String, Measure<List<BorderAssessment>>> lines = compilation.db()
+                .ask(new Adequacy.BoundaryReadings("example.both")).value();
+
+        // The two behaviors meet different lines, so one's account is not the other's — which is
+        // what makes the refusal below about something.
+        assertNotEquals(partitions.get("keep").owes(), partitions.get("hold").owes(),
+                "the two behaviors are owed different rows");
+
+        assertDoesNotThrow(() -> new BehaviorEvidence(Adequacy.RowReading.NONE, null,
+                partitions.get("keep"), lines.get("keep"), null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BehaviorEvidence(Adequacy.RowReading.NONE, null,
+                        partitions.get("keep"), lines.get("hold"), null),
+                "an account and the lines of another behavior are two measurements");
+    }
+
+    /**
+     * Two behaviors carrying one declared type, one of whose rows does not come back.
+     *
+     * <p>So the debt {@code Amount}'s line leaves is read twice and what the two readings came to
+     * differs: one of them is undecided for a reason about a position of {@code stalls}.
+     */
+    private static final String ONE_ROW_STOPS = """
+            module example.stopped
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Draft = { n: Amount }
+            data Ok = { n: Int }
+
+            behavior seen : (d: Draft) -> Ok
+                constructs Ok
+            let seen (d) = Ok { n = d.n.value }
+
+            behavior stalls : (d: Draft) -> Ok
+                constructs Ok
+            let stalls (d) = Ok { n = d.n.value }
+
+            example seen
+                | "inside the run" : (Draft { n = Amount(5) }) -> Ok { n = 5 }
+
+            example stalls
+                | "never read" : (Draft { n = Amount(7) }) -> Ok { n = 7 }
+            """;
+
+    /**
+     * A view shown some of a module's behaviors carries nothing a hidden one went without.
+     *
+     * <p>A debt is what its readings came to together, so the account a reader is shown has to be
+     * made again from the readings that reader can see. Filtered by dropping debts nobody shown
+     * carries — and keeping the ones somebody does whole — a view carries the hidden behavior's
+     * evidence inside the debt it kept: undecided, for a reason naming a position that is not on
+     * the page and a row its reader cannot write.
+     */
+    @Test
+    void aViewOfSomeBehaviorsCarriesNothingAHiddenOneWentWithout() {
+        // The row of `stalls` is not read at all, which is what bears on a line an `invariant`
+        // drew: meeting one of those takes writing the value and no comparison has to have run, so
+        // a row that was read and stopped leaves it settled and a row nobody read does not.
+        Compilation compilation = Compilation.ofSource(ONE_ROW_STOPS, "Main");
+        compilation.withDeadline(souther.compiler.DoesNotComeBack.overrunningOn(
+                souther.compiler.DoesNotComeBack.everythingAboutRowsOf("stalls")));
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+
+        Adequacy.DeclaredBoundaries account =
+                compilation.db().ask(new Adequacy.DeclaredBorders("example.stopped")).value();
+        assertNotNull(account, "the model under test compiles");
+        assertFalse(account.owed().isEmpty(), "the clause draws a line both behaviors carry");
+
+        // Over both behaviors the debt is undecided, because one of the rows that would settle it
+        // never came back. Asserted so that what the filtered view drops is something it had.
+        assertFalse(account.weakening().isEmpty(),
+                () -> "a row of `stalls` did not come back, so the debt is not settled: "
+                        + account.owed().stream().map(each -> each.debt().said()).toList());
+
+        Adequacy.DeclaredBoundaries shown = account.keptFor(java.util.Set.of("seen"));
+        assertFalse(shown.owed().isEmpty(), "`seen` carries the line, so the debt is still work");
+        assertTrue(shown.weakening().isEmpty(),
+                () -> "a view of `seen` carries what `stalls` went without: "
+                        + shown.weakening().causes());
+    }
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSources(List.of(MODEL), ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.db().allReports().stream()
+                        .filter(each -> each.report().isError())
+                        .map(each -> each.report().diagnostic().code()).toList(),
+                "the model under test compiles");
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichModuleKeepsTheAccountOfARunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichModuleKeepsTheAccountOfARunTest.java
@@ -174,10 +174,10 @@ class WhichModuleKeepsTheAccountOfARunTest {
     }
 
     private static List<Adequacy.DeclaredDebt> debtsOf(Compilation compilation, String module) {
-        List<Adequacy.DeclaredDebt> debts =
+        Adequacy.DeclaredBoundaries account =
                 compilation.db().ask(new Adequacy.DeclaredBorders(module)).value();
-        assertNotNull(debts, "the model under test compiles");
-        return debts;
+        assertNotNull(account, "the model under test compiles");
+        return account.owed();
     }
 
     private static Compilation compiled(String... sources) {

--- a/souther-compiler/src/test/java/souther/compiler/report/AMeasureWeakerThanCompleteSaysWhatMadeItSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AMeasureWeakerThanCompleteSaysWhatMadeItSoTest.java
@@ -167,7 +167,10 @@ class AMeasureWeakerThanCompleteSaysWhatMadeItSoTest {
                 }
                 if (behavior.partition() != null) {
                     failed.add(behavior.partition().partitioned());
-                    failed.add(behavior.partition().bounded());
+                    failed.add(behavior.partition().owes());
+                }
+                if (behavior.boundaryReadings() != null) {
+                    failed.add(behavior.boundaryReadings());
                 }
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
@@ -3,7 +3,6 @@ package souther.compiler.report;
 import org.junit.jupiter.api.Test;
 import souther.compiler.examples.EvaluationPolicy;
 import souther.compiler.query.Adequacy;
-import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.InputCaseEvidence;
 import souther.compiler.query.PartitionEvidence;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -145,27 +145,38 @@ class WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest {
                     parts = parts.union(behavior.branch().measured().weakening());
                     apart.add(behavior.branch().measured().weakening());
                 }
+                if (behavior.boundaryReadings() != null) {
+                    parts = parts.union(behavior.boundaryReadings().weakening());
+                    apart.add(behavior.boundaryReadings().weakening());
+                }
                 if (behavior.partition() != null) {
                     PartitionEvidence partition = behavior.partition();
                     parts = parts.union(partition.partitioned().weakening())
-                            .union(partition.bounded().weakening())
+                            .union(partition.owes().weakening())
                             .union(partition.pairs().counted().weakening());
                     for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
                         parts = parts.union(axis.reached().weakening());
                     }
-                    for (BorderAssessment.Point point
-                            : BorderAssessment.pointsOf(partition.boundaries())) {
+                    // This behavior's own account, which is what its weakening is over. A row owed
+                    // to the declarations that drew a line is short or not short in the module's
+                    // account of them.
+                    for (souther.compiler.query.OwedBoundaryPoint point : partition.owedPoints()) {
                         parts = parts.union(point.item().weakening());
                     }
                     apart.add(partition.partitioned().weakening());
-                    apart.add(partition.bounded().weakening());
+                    apart.add(partition.owes().weakening());
                     apart.add(partition.pairs().counted().weakening());
                 }
                 loadBearing += loadBearing(apart);
                 holds(lost, "behavior " + behavior.name(), behavior.weakenedBy(), parts);
                 acrossBehaviors = acrossBehaviors.union(behavior.weakenedBy());
             }
-            holds(lost, "module " + module.module(), module.weakenedBy(), acrossBehaviors);
+            // What the module's declarations are owed is a part of the module the way a behavior is.
+            // Left out, a module that went without something only its declaration account knows
+            // would report itself measured in full — and the account is where a row owed to a
+            // declaration is short, since no behavior carrying the type is short by it.
+            holds(lost, "module " + module.module(), module.weakenedBy(),
+                    acrossBehaviors.union(module.declarationsWeakenedBy()));
             acrossModules = acrossModules.union(module.weakenedBy());
             everything.addAll(module.weakenedBy().causes());
         }
@@ -192,6 +203,76 @@ class WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest {
                         + " one of them from the union would leave this saying nothing");
 
         assertEquals(List.of(), lost, "a whole and its parts disagreeing about what was gone without");
+    }
+
+    /**
+     * A type whose clause draws a line, carried by two behaviors, one of whose rows is never read.
+     *
+     * <p>Both points of that line are owed to the declaration that drew it, so neither behavior is
+     * owed a row at either — and the row nobody read leaves the value at that point unreadable. What
+     * comes of that is a reason only the module's declaration account holds.
+     */
+    private static final String ONE_ROW_UNREAD = """
+            module example.owed
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Draft = { n: Amount }
+            data Ok = { n: Int }
+
+            behavior seen : (d: Draft) -> Ok
+                constructs Ok
+            let seen (d) = Ok { n = d.n.value }
+
+            behavior unread : (d: Draft) -> Ok
+                constructs Ok
+            let unread (d) = Ok { n = d.n.value }
+
+            example seen
+                | "inside the run" : (Draft { n = Amount(5) }) -> Ok { n = 5 }
+
+            example unread
+                | "never read" : (Draft { n = Amount(7) }) -> Ok { n = 7 }
+            """;
+
+    /**
+     * And a module holds what its declaration account went without, where no behavior of it did.
+     *
+     * <p>The load-bearing half of the rule above for that part. Over most models the two accounts
+     * are short of the same reading, so the union holds whether or not anybody adds the declarations
+     * to it — and a part that is only ever carried by another part is a part this rule says nothing
+     * about.
+     *
+     * <p>What is only ever the declaration account's is a row owed to a declaration that could not
+     * be read at. The behaviors carrying the type are owed no row there, so no measure of theirs is
+     * short by it: what they went without is that a row was not read, which is their own reading's
+     * to say and is a different reason.
+     */
+    @Test
+    void aModuleHoldsWhatOnlyItsDeclarationsWentWithout() {
+        Compilation compilation = Compilation.ofSource(ONE_ROW_UNREAD, "Main");
+        compilation.withDeadline(souther.compiler.DoesNotComeBack.overrunningOn(
+                souther.compiler.DoesNotComeBack.everythingAboutRowsOf("unread")));
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport.ModuleReport module =
+                AdequacyReport.of(compilation).modules().getFirst();
+
+        WeakeningSet behaviors = WeakeningSet.none();
+        for (AdequacyReport.BehaviorReport behavior : module.behaviors()) {
+            behaviors = behaviors.union(behavior.weakenedBy());
+        }
+        Set<Weakening> onlyTheDeclarations =
+                new LinkedHashSet<>(module.declarationsWeakenedBy().causes());
+        onlyTheDeclarations.removeAll(behaviors.causes());
+
+        assertFalse(onlyTheDeclarations.isEmpty(),
+                () -> "nothing here is the declaration account's alone, so this holds the module to"
+                        + " nothing: " + module.declarationsWeakenedBy().causes());
+        assertTrue(module.weakenedBy().causes().containsAll(onlyTheDeclarations),
+                () -> "a module that did not hear what only its declaration account went without: "
+                        + module.weakenedBy().causes());
     }
 
     /** How many of {@code parts} hold a fact none of the others do. */

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
@@ -81,7 +81,7 @@ class WhatWasObservedDecidesWhatAReportMayNameTest {
                 new AdequacyReport.BehaviorReport("b", BehaviorImplementation.IMPLEMENTED,
                         new souther.compiler.query.BehaviorEvidence(
                                 souther.compiler.query.Adequacy.RowReading.NONE,
-                                null, null, read()),
+                                null, null, null, read()),
                         null, List.of()),
                 null, SourceNameResolver.identity());
 

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -586,16 +586,20 @@ public final class Analyzer {
         souther.compiler.query.PartitionEvidence partition =
                 adequacy.partitions() == null ? null : adequacy.partitions().get(behavior);
         if (partition != null) {
-            // Over the coverage items and not over the borders. A border owes a row at up to four
-            // points, and counting borders would call one with a single point met as covered as one
-            // that owes only that point.
-            List<souther.compiler.query.ItemAssessment> settled =
-                    souther.compiler.query.BorderAssessment.pointsOf(partition.boundaries()).stream()
-                            .map(souther.compiler.query.BorderAssessment.Point::item)
+            // What this behavior is owed a row for, and not every point of every line it met. A
+            // line the declarations drew is answered once for the module by a row written for any
+            // behavior carrying the type, so a lens over a behavior that counted those would be
+            // telling this author about work that is not theirs.
+            //
+            // Over the points and not over the borders. A border owes a row at up to four of them,
+            // and counting borders would call one with a single point met as covered as one that
+            // owes only that point.
+            List<souther.compiler.query.ItemAssessment.Owed> settled =
+                    partition.owedPoints().stream()
+                            .map(souther.compiler.query.OwedBoundaryPoint::item)
                             .filter(Analyzer::settled).toList();
             long met = settled.stream()
-                    .filter(item -> item instanceof souther.compiler.query.ItemAssessment.Owed owed
-                            && owed.hasRowWitness())
+                    .filter(souther.compiler.query.ItemAssessment.Owed::hasRowWitness)
                     .count();
             if (!settled.isEmpty()) {
                 parts.add("boundary " + met + "/" + settled.size());
@@ -631,13 +635,12 @@ public final class Analyzer {
      * <p>Nor a point nobody is owed a row at. Nothing was measured there and nothing is missing, and
      * a lens that counted it would put the model's own answer into a ratio of what the rows reach.
      */
-    private static boolean settled(souther.compiler.query.ItemAssessment item) {
+    private static boolean settled(souther.compiler.query.ItemAssessment.Owed owed) {
         // The measurement was made and made in full, which is the whole of what this asks. It used
         // to list the two verdicts that count as settled and leave out the two that do not; a
         // verdict is now what was seen and how far it can be trusted is the measurement's, so this
         // is one question again.
-        return item instanceof souther.compiler.query.ItemAssessment.Owed owed
-                && owed.coverage() instanceof souther.compiler.query.Measurement.Complete<?>;
+        return owed.coverage() instanceof souther.compiler.query.Measurement.Complete<?>;
     }
 
     /** The caret at one position, as a range of no width. */

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -104,7 +104,14 @@ class AdequacyLensTest {
         assertFalse(analyzer.measuring());
     }
 
-    /** Asked for, the numbers appear on the behavior's own line. */
+    /**
+     * Asked for, the numbers appear on the behavior's own line.
+     *
+     * <p>The boundary ratio is over what this behavior is owed a row for. The line
+     * {@code Amount}'s invariant draws is owed to that declaration and answered by a row written
+     * for any behavior carrying the type, so the point against it is not this author's work and is
+     * not in the ratio drawn over their behavior.
+     */
     @Test
     void theNumbersAreDrawnOnTheDeclarationTheyAreAbout() {
         List<CodeLens> lenses = measuring(Adequacy.Level.ALL)
@@ -112,7 +119,7 @@ class AdequacyLensTest {
 
         assertEquals(1, lenses.size());
         assertEquals(9, lenses.get(0).range().start().line(), "the `behavior` line, zero-based");
-        assertEquals("1 row · out 1/2 · boundary 2/6 · branch 1/2", lenses.get(0).title());
+        assertEquals("1 row · out 1/2 · boundary 2/5 · branch 1/2", lenses.get(0).title());
     }
 
     /**
@@ -135,7 +142,7 @@ class AdequacyLensTest {
         List<CodeLens> lenses = measuring(Adequacy.Level.ALL).codeLenses(MODULE, graphOf(workspace));
 
         assertEquals(1, lenses.size());
-        assertEquals("2 rows · out 2/2 · boundary 3/6 · branch 2/2", lenses.get(0).title());
+        assertEquals("2 rows · out 2/2 · boundary 3/5 · branch 2/2", lenses.get(0).title());
     }
 
     /** Nothing has been claimed about a behavior no row names, so there is nothing to draw over it. */


### PR DESCRIPTION
Closes #1078.

## What was wrong

`PartitionEvidence.boundaries()` answered two questions with one value: which lines a behavior's positions met, and what that behavior is owed a row for. Two of a border's four points can be owed to the declarations that drew the line (#1062), so the second was obtained by every reader applying the rule at `BorderAssessment.Point.owedHere` for itself. `AdequacyReport.requiredEvidence` forgot, and held a build undetermined about a line the module's own account had settled — found by review rather than by the types.

## The shape now

Raw reading → attribution → two accounts, one way:

- `PointContributions` is what settled a point and is what can be merged; `PointAttribution` is `TheReading | TheDeclarations(owners)` and is what that comes to. A value nothing contributed to is refused rather than classified, which removes the vacuous `noneMatch` the old boolean answered with for an empty set.
- The classifier is called from `Border.owes` and nowhere else; the arms are read by the two account producers and by no consumer.
- `OwedBoundaryPoint` is one thing a behavior is owed a row for. It carries the `Border`, not the `BorderAssessment`, so the other roles of the line are not reachable from a behavior's account.
- `PartitionEvidence` holds `Measure<List<OwedBoundaryPoint>> owes` and no longer the lines. The lines, and how far the reading that found them got, are `BehaviorEvidence.boundaryReadings` (produced by the new `Adequacy.BoundaryReadings` key, which is also where the level's choice between the searched and unsearched lines is made — so the coverage and the generation read one answer).
- `Measure.readAs` is the one place a measure's arms are carried over to a value read off what it found. An account is the reading's own measurement, not a second one.

Consumers now say which question they ask: findings, the verdict, the generator and the editor's lens read the account; the report's border block, the document and the module's declaration account read the lines.

## What a behavior went without

A behavior's `weakening()` is over its own account. A row owed to a declaration is short or not short in the module's account of them, which the module's status reads through `ModuleReport.declarationsWeakenedBy`. The reading that found the lines is common to both accounts and weakens both.

Measured over `souther-examples` (crm, hr, shippingfee, ordering, issuetracker — 24 modules): the account of every behavior is exactly the points its own rules settled. Four behaviors — `activity/touchCount`, `activity/lastActivityOn`, `payroll/buildPaySlip`, `inventory/stockFrom` — stop carrying `BorderValueUnreadable` reasons that belong to points only the declarations are owed; the declaration accounts of those modules carry them instead. The editor's lens over the fixture goes from `boundary 2/6` to `2/5`, the point dropped being the one an author of that behavior cannot write a row for.

## Checks

Three, each shown to go red with the rule broken:

- `WhoseARowIsIsDecidedInOnePlaceTest` — over the compiled classes: `PointAttribution.of` is called from one method, and the arms are read by the two accounts only.
- `EveryPointOwedIsInOneAccountTest` — every point a reading owes falls in exactly one account, and a behavior's holds nothing owed to the declarations. Written as a refinement rather than as a count: the declarations' side collapses the readings of one point into one debt, so no total is conserved.
- `ABehaviorsAccountDoesNotReachTheLinesOtherPointsTest` — the closure of what a behavior's evidence hands out reaches the line and never an assessment of one.

`mvn -o test` is green across the reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
