### PR TITLE
Offer a row only where nothing else offered answers it

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -77,7 +77,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
             Map.ofEntries(
             Map.entry("souther.compiler.query.Coverages#pairsOf(Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/Coverages$Readings;ZLsouther/compiler/partition/AdequacyPolicy$OfTheMeasures;)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 2),
             Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/partition/Partitions$Partitioning;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
-            Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/query/Coverages$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$RowReading;)Lsouther/compiler/query/Measurement;", 3),
+            Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/partition/StandingAtAPoint$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$RowReading;)Lsouther/compiler/query/Measurement;", 3),
             Map.entry("souther.compiler.query.Coverages#whyNoGuardLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 2),
             Map.entry("souther.compiler.query.Coverages#whyNoInvariantLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 1),
             // The reading of a behavior's rows, which is a measure like the ones counted over them

--- a/souther-cli/src/test/java/souther/cli/AnArmNoCombinationIsOverIsStillOfferedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnArmNoCombinationIsOverIsStillOfferedARowTest.java
@@ -91,19 +91,25 @@ class AnArmNoCombinationIsOverIsStillOfferedARowTest {
             """;
 
     /**
-     * An arm this compiler cannot state a way into says what is missing here.
+     * An arm this compiler cannot state a way into is said nothing about where a row goes through it.
      *
-     * <p>Which is not that the body does not reach it. The block runs under whatever applies it, so
-     * what steers a row there is not a class of this behavior's inputs — and a reader who writes the
-     * row by hand has been told the truth about why nothing offered one (issue #643).
+     * <p>No search composes a value for such an arm: the block runs under whatever applies it, so
+     * what steers a row there is not a class of this behavior's inputs. What is offered here is a
+     * row composed for the class the arm's own value is in, and running it goes through the arm — so
+     * the work is in front of the reader, and a line saying nothing offers a row for it would send
+     * them after work they have been handed.
+     *
+     * <p>The measurement is untouched: the gap is still a gap until the row is written and answered.
      */
     @Test
-    void anArmInsideABlockSaysWhatIsMissingRatherThanThatNothingReachesIt() throws Exception {
+    void anArmInsideABlockIsSaidNothingAboutWhereAnOfferedRowGoesThroughIt() throws Exception {
         Run run = examples(IN_A_BLOCK, "--generate");
 
         assertTrue(run.out().contains("no row goes through `case Off`"), run.out());
-        assertTrue(run.out().contains("nothing offers a row for `case Off` in `mark`: this arm is"
-                + " inside a block"), run.out());
+        assertTrue(run.out().contains("| \"flags[*]=Off\" : ([Off])"),
+                "a row whose run goes through the arm is offered: " + run.out());
+        assertFalse(run.out().contains("nothing offers a row for `case Off`"),
+                "so nothing says the arm has none: " + run.out());
     }
 
     private record Run(int code, String out, String err) {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
@@ -1,0 +1,57 @@
+package souther.compiler.partition;
+
+import souther.compiler.observe.Counting;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.RowOutcome;
+
+import java.util.List;
+
+/**
+ * A tuple of values and what running them recorded.
+ *
+ * <p>The two things anything here reads of a row, and neither of them is the row. Where the values
+ * sit is what says which classes they fill and whether they stand at a line; what the run did is
+ * what says which arms of the body they went through. The second does not follow from the first — a
+ * tuple whose values sit in a combination's classes and whose run went elsewhere took none of the
+ * arms it names, and looks from the values alone exactly like one that took them.
+ *
+ * <p><b>What a caller has a tuple for, it hands over.</b> A written {@code example} row has one and
+ * so does a candidate the generator has just built, and the questions put to them here are the same
+ * questions. Written to take a row, every one of those questions could only be asked of what is
+ * already in the file, and a second answer written for the other kind would be the same rule twice
+ * — free to agree until one of them moved.
+ *
+ * <p>Nothing here says a tuple covers anything. What it is a tuple of, and what its run reached, are
+ * facts about the values; whether the module is covered is a measure over the rows that are written,
+ * and it is made elsewhere.
+ *
+ * @param inputs  one value per parameter, in the order the behavior takes them
+ * @param watched what came of running it. A sum and not an account that may be empty: a run that
+ *                recorded nothing and a tuple nothing recorded are the same empty account and are
+ *                not the same fact, and which of them this is decides what may be concluded
+ */
+public record ObservedInputs(List<ObservedValue> inputs, Generator.Watched watched) {
+
+    public ObservedInputs {
+        inputs = List.copyOf(inputs);
+        // Said and not left out. Having no account of the run is one of the two answers here, and a
+        // caller that has nothing to say says that one; taken as an absence to be filled in, the
+        // distinction this holds would be made by whoever forgot to pass it.
+        java.util.Objects.requireNonNull(watched, "a tuple says what came of running it");
+    }
+
+    /**
+     * A written row read as the two things above.
+     *
+     * <p>What the run recorded, and not whether this build was recording. Whether anything was
+     * watching is the caller's own — it follows from what was asked for rather than from the row —
+     * and a reading that took it in would answer differently about one row depending on who asked.
+     */
+    public static ObservedInputs of(RowOutcome row) {
+        return new ObservedInputs(row.inputs(), switch (row.run().counting()) {
+            case Counting.Read read -> new Generator.Watched.Ran(read.observation());
+            case Counting.Unread _ -> new Generator.Watched.NoAccount();
+        });
+    }
+
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -1,0 +1,226 @@
+package souther.compiler.partition;
+
+import souther.compiler.coverage.ComparisonOccurrence;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.observe.ObservedValue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Whether a tuple of values stands at one point of a border.
+ *
+ * <p>One walk for every kind of line, and the one place this is asked. What a value put at the point
+ * is is the quantity's to read — it is the one thing that knows what it is a quantity of — and what
+ * this adds is what belongs to the rows: which reading of a row a point is tried against, and that a
+ * line a fork drew is met by getting the comparison to answer as well as by writing the value.
+ *
+ * <p>Asked of a tuple and not of a row, so that what is already written and what a generation has
+ * just composed are put the same question. Written against a row, the question could only be asked
+ * of what is in the file — and the second answer somebody wrote for a candidate would be this rule
+ * again, free to agree with it until one of them moved.
+ *
+ * <p>Nothing here concludes anything about coverage. It says what these values do at this point; who
+ * may act on that, and what a point nothing was seen at means, is the caller's.
+ */
+public final class StandingAtAPoint {
+
+    /**
+     * What a walk over some tuples came to at one point.
+     *
+     * <p>Four answers because the two that are not found are not one fact. A tuple that could not be
+     * read leaves the point undecided; a tuple that stands at the level and has no account of its
+     * run is one nothing can say reached the comparison, which is not the same as one that ran and
+     * did not reach it. Which of them a caller may treat as a miss is the caller's to say.
+     */
+    public enum Met { YES, NO, NOT_WATCHED, UNREADABLE }
+
+    /**
+     * The first of {@code rows} that stands there, or why none was found.
+     *
+     * @param site which comparison a row has to have got an answer out of, for a rule that meeting
+     *             takes more than standing at the level. Empty where standing there is the whole
+     *             of it
+     */
+    public static Met met(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
+                          Criterion criterion, Optional<ComparisonOccurrence> site) {
+        boolean unreadable = false;
+        boolean unwatched = false;
+        for (ObservedInputs row : rows) {
+            // A row has more than one value at a position inside a sequence, and standing at a point
+            // is one element standing there. Asked for one value, such a row answered with none and
+            // every point on such a line came back undecided — a measurement that could not look,
+            // said of a row that wrote the values plainly.
+            // The first reading both answers the point and says which steps the line's positions
+            // take; the rest are tried under each choice those steps allow.
+            Map<TermPath, Integer> held = new LinkedHashMap<>();
+            OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
+            boolean stands = false;
+            boolean stopped = false;
+            for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
+                switch (quantity.standsAt(criterion, reading)) {
+                    // A reading that could not look, unless what it could not find was an element
+                    // the row wrote none of — that is a row that was read and does not stand, and
+                    // said of the reading it happened in rather than of the row, since another
+                    // reading of the same row may reach the point.
+                    case UNREADABLE -> stopped = stopped || !reading.wroteNothing();
+                    case NO -> { }
+                    case YES -> stands = true;
+                }
+                if (stands) {
+                    break;
+                }
+            }
+            if (stands) {
+                if (site.isEmpty()) {
+                    return Met.YES;   // writing the value is the whole of what there is to reach
+                }
+                switch (row.watched()) {
+                    case Generator.Watched.Ran(var account) -> {
+                        if (site.stream().allMatch(account::reached)) {
+                            return Met.YES;
+                        }
+                    }
+                    // It stands where the line is and nothing watched it get there. Said rather
+                    // than counted as a row that did not reach the comparison: a run that reached
+                    // nothing is something this found out, and a run nobody watched is not.
+                    case Generator.Watched.NoAccount _ -> unwatched = true;
+                }
+            }
+            unreadable = unreadable || stopped;
+        }
+        if (unreadable) {
+            return Met.UNREADABLE;
+        }
+        return unwatched ? Met.NOT_WATCHED : Met.NO;
+    }
+
+    /**
+     * One row's values under one reading of it: an element chosen at each step inside a sequence
+     * the line's positions take.
+     *
+     * <p>A row standing at a point is one of its readings standing there, and a reading has to be
+     * one: two positions under one person are that person's two values, and offering the first
+     * person's age beside the second person's status would have a row stand at a point neither
+     * element is at. So an element is chosen per step and every position takes the one chosen for
+     * the steps it shares — the same rule a pair of classes is read by, since it is the same
+     * question.
+     *
+     * <p>Which readings there are is not known before the quantity has asked, since which positions
+     * a line is over is its to say. So the choices are collected as it asks and the reading is run
+     * again under each, until one stands or they are used up.
+     */
+    private static final class OneReadingOfARow implements BorderQuantity.Observation {
+
+        private final BehaviorInputs where;
+        private final ObservedInputs row;
+        /** The element chosen at each step, for this reading. */
+        private final Map<TermPath, Integer> chosen;
+        /** How many elements each step was found to have, over every reading so far. */
+        private final Map<TermPath, Integer> held;
+        private boolean wroteNothing;
+
+        OneReadingOfARow(BehaviorInputs where, ObservedInputs row,
+                         Map<TermPath, Integer> chosen,
+                         Map<TermPath, Integer> held) {
+            this.where = where;
+            this.row = row;
+            this.chosen = chosen;
+            this.held = held;
+        }
+
+        @Override
+        public ObservedValue at(TermPath path) {
+            List<BehaviorInputs.Occurrence> values = where.occurrencesAt(row.inputs(), path);
+            if (values == null) {
+                return null;   // the walk and the type disagree, which is the quantity's to report
+            }
+            if (values.isEmpty()) {
+                // The row wrote no element here, so nothing of it stands anywhere on this line.
+                // That is a row that was read and does not reach the point, and reporting it as a
+                // value nothing could read leaves the point undecided over a row that plainly
+                // settles it.
+                wroteNothing = true;
+                return null;
+            }
+            for (BehaviorInputs.Occurrence each : values) {
+                each.at().forEach((step, ordinal) -> held.merge(step, ordinal + 1, Math::max));
+            }
+            for (BehaviorInputs.Occurrence each : values) {
+                if (agrees(each)) {
+                    return each.value();
+                }
+            }
+            // No value here under this reading. Not a stop: the reading names an element this
+            // position does not have, and another reading is where its values are.
+            return null;
+        }
+
+        /** Whether {@code each} was reached through the elements this reading chose. */
+        private boolean agrees(BehaviorInputs.Occurrence each) {
+            for (Map.Entry<TermPath, Integer> step : each.at().entrySet()) {
+                Integer picked = chosen.get(step.getKey());
+                if (picked != null && !picked.equals(step.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /** Whether the row wrote nothing at some position this line is over. */
+        boolean wroteNothing() {
+            return wroteNothing;
+        }
+    }
+
+    /**
+     * The readings of one row a point is tried against.
+     *
+     * <p>The first is run before the rest are known: which steps the line's positions take is the
+     * quantity's to say as it reads them, so it says so by being asked once. Every choice those
+     * steps allow follows it.
+     */
+    private static List<OneReadingOfARow> readings(BehaviorInputs where, ObservedInputs row,
+                                                   BorderQuantity quantity, Criterion criterion,
+                                                   OneReadingOfARow first,
+                                                   Map<TermPath, Integer> held) {
+        quantity.standsAt(criterion, first);
+        List<OneReadingOfARow> out = new ArrayList<>();
+        for (Map<TermPath, Integer> choice : readingsOver(held)) {
+            out.add(new OneReadingOfARow(where, row, choice, held));
+        }
+        return out;
+    }
+
+    /**
+     * Every reading of a row over the steps {@code held} says its positions take.
+     *
+     * <p>One choice per step, in every combination — which is a product and not a zip, because two
+     * steps a row's positions do not take together are two independent choices. Bounded, since a
+     * row holding several long lists has more readings than a measure is worth.
+     */
+    private static List<Map<TermPath, Integer>> readingsOver(Map<TermPath, Integer> held) {
+        List<Map<TermPath, Integer>> out = new ArrayList<>();
+        out.add(Map.of());
+        for (Map.Entry<TermPath, Integer> step : held.entrySet()) {
+            List<Map<TermPath, Integer>> wider = new ArrayList<>();
+            for (Map<TermPath, Integer> each : out) {
+                for (int i = 0; i < step.getValue() && wider.size() < MOST_READINGS; i++) {
+                    Map<TermPath, Integer> deeper = new LinkedHashMap<>(each);
+                    deeper.put(step.getKey(), i);
+                    wider.add(deeper);
+                }
+            }
+            out = wider;
+        }
+        return out;
+    }
+
+    /** How many readings of one row a point is tried against. */
+    private static final int MOST_READINGS = 256;
+
+    private StandingAtAPoint() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1690,6 +1690,68 @@ public final class Adequacy {
         return Ordered.map(out);
     }
 
+    /**
+     * How a row of one behavior is read: where its positions are, and what the model divides them
+     * into.
+     *
+     * <p>What it takes to read a row, and nothing about what anybody was asked to compose. The two
+     * arrived together while the only reader was the search that composes rows — so a row composed
+     * by a behavior nothing else was asked of could not be read at all, and every question put to it
+     * came back as one nothing could tell about.
+     *
+     * @param axes empty where the model divides this behavior's positions into nothing, or where
+     *             what it divides them into could not be read. A row still has values and still
+     *             stands where it stands; what is missing is the classes to place them in
+     */
+    record HowARowIsRead(souther.compiler.partition.BehaviorInputs where, List<Axis> axes) {
+
+        HowARowIsRead {
+            axes = List.copyOf(axes);
+        }
+    }
+
+    /**
+     * The reading, from the pieces a caller already holds.
+     *
+     * <p>The one place a {@link souther.compiler.partition.BehaviorInputs} is made for a generation.
+     * A second assembly of the same four things is a second answer to where a row's values are, and
+     * the two would agree until one of them moved.
+     */
+    static HowARowIsRead readingOf(Hir.SpecBehavior spec, Sig sig, Symbols symbols,
+                                   souther.compiler.check.ReadingPolicy policy,
+                                   souther.compiler.partition.Partitions.Partitioning divided) {
+        List<String> parameters = spec.params().stream().map(Hir.Param::name).toList();
+        return new HowARowIsRead(
+                new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
+                        symbols, policy),
+                divided == null ? List.of() : divided.axes());
+    }
+
+    /**
+     * The same, asked of the store for any behavior of a module.
+     *
+     * <p>For a reader that holds a row and not a search. A row a declaration's line is owed is
+     * composed by whichever reading could compose it, and that behavior need not be one anything
+     * else was asked about — so what it takes to read the row is asked for here rather than taken
+     * off an answer about generating rows, which such a behavior has none of.
+     */
+    static HowARowIsRead readingOf(Db db, String module, String behavior) {
+        souther.compiler.check.Prepared prepared = db.ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = db.ask(new Bodies.Signatures(module)).value();
+        Answer<Symbols> symbols = Names.derivedSymbols(db, module);
+        souther.compiler.check.ReadingPolicy policy = db.ask(new Front.Reading()).value();
+        if (prepared == null || sigs == null || !symbols.present() || policy == null) {
+            return null;
+        }
+        Hir.SpecBehavior spec = specOf(prepared, behavior);
+        Sig sig = sigs.get(behavior);
+        if (spec == null || sig == null) {
+            return null;
+        }
+        return readingOf(spec, sig, symbols.value(), policy,
+                db.ask(new Divided(module, behavior)).value());
+    }
+
     /** The behavior of that name that has inputs of its own, or null. A composition's inputs are its
      *  first stage's and are divided there. */
     private static Hir.SpecBehavior specOf(souther.compiler.check.Prepared prepared, String name) {
@@ -3379,14 +3441,13 @@ public final class Adequacy {
                 souther.compiler.check.ReadingPolicy policy,
                 souther.compiler.partition.Partitions.Partitioning partitioning,
                 InputDomain domain, List<Finding> owed, PartitionEvidence evidence) {
-            List<String> parameters = spec.params().stream().map(Hir.Param::name).toList();
             // One reading of what the behavior takes, for both halves of this: the rows already
-            // written are read by it, and the rows offered are generated from it.
-            souther.compiler.partition.BehaviorInputs inputs =
-                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
-                            symbols, policy);
+            // written are read by it, and the rows offered are generated from it. Made where every
+            // reading of a row is made, so that a reader holding one of these rows and a reader
+            // holding none read it the same way.
+            HowARowIsRead read = readingOf(spec, sig, symbols, policy, partitioning);
             Generator.Subject subject =
-                    new Generator.Subject(spec.name(), inputs, partitioning.axes(),
+                    new Generator.Subject(spec.name(), read.where(), read.axes(),
                             souther.compiler.partition.HeldCounts.of(domain, symbols));
             // The arms this build is owed a row at, which the measure established and this reads.
             // A combination the body settles together is where one is looked for and is not itself

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1594,7 +1594,7 @@ public final class Adequacy {
         // And what the module's own declarations are owed, which is no behavior's and so is in none
         // of the fillings above. Asked only where the request asked for the edges: a request that
         // asked for no boundary rows is not asking about these either.
-        Offering composed = Offering.composed(request, generated, request.boundaries()
+        Composition composed = Composition.composed(request, generated, request.boundaries()
                 ? generatedForDeclarationsOf(db, request.module(), request.scope()) : null);
         // And then only the rows whose going would cost the offering something. A candidate is
         // composed for one thing and the positions that thing does not name hold whatever the row

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3133,27 +3133,6 @@ public final class Adequacy {
         }
 
         /**
-         * A way to run this behavior's composed rows, said in the generator's words.
-         *
-         * <p>Two seams and one adaptation, the way the check that a value can be built already is.
-         * What runs a row is the evaluation's business and speaks in what a fixture states; what a
-         * generator has is a template it composed. Neither has to know the other's word for a row.
-         */
-        private static Generator.Trial runningRowsOf(
-                RowTrials trials, String behavior, Sig sig) {
-            if (trials == null) {
-                return Generator.Trial.NOTHING_RUNS;
-            }
-            RowTrials.OfBehavior application =
-                    trials.forBehavior(behavior, sig);
-            return inputs -> application
-                    .run(inputs.stream()
-                            .map(souther.compiler.partition.FixtureTemplate::value).toList())
-                    .<Generator.Watched>map(Generator.Watched.Ran::new)
-                    .orElseGet(Generator.Watched.NoAccount::new);
-        }
-
-        /**
          * The values a row's positions can be composed against, in the order the search should try
          * them.
          *
@@ -3437,6 +3416,29 @@ public final class Adequacy {
         }
         ExampleExecution asked = ExampleExecutions.of(db, module);
         return asked == null ? null : db.execution().trials(asked, armsAsked(db));
+    }
+
+    /**
+     * A way to run one behavior's composed rows, said in the generator's words.
+     *
+     * <p>Two seams and one adaptation, the way the check that a value can be built already is. What
+     * runs a row is the evaluation's business and speaks in what a fixture states; what a generator
+     * has is a template it composed. Neither has to know the other's word for a row.
+     *
+     * <p>Beside {@link #trialling} rather than inside the search, because running a composed row is
+     * what anybody asking after one does — the search that composes them, and whoever asks what one
+     * of them would settle.
+     */
+    static Generator.Trial runningRowsOf(RowTrials trials, String behavior, Sig sig) {
+        if (trials == null) {
+            return Generator.Trial.NOTHING_RUNS;
+        }
+        RowTrials.OfBehavior application = trials.forBehavior(behavior, sig);
+        return inputs -> application
+                .run(inputs.stream()
+                        .map(souther.compiler.partition.FixtureTemplate::value).toList())
+                .<Generator.Watched>map(Generator.Watched.Ran::new)
+                .orElseGet(Generator.Watched.NoAccount::new);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1594,8 +1594,25 @@ public final class Adequacy {
         // And what the module's own declarations are owed, which is no behavior's and so is in none
         // of the fillings above. Asked only where the request asked for the edges: a request that
         // asked for no boundary rows is not asking about these either.
-        return Offering.of(request, generated, request.boundaries()
+        Offering composed = Offering.of(request, generated, request.boundaries()
                 ? generatedForDeclarationsOf(db, request.module(), request.scope()) : null);
+        // And then only the rows whose going would cost the offering something. A candidate is
+        // composed for one thing and the positions that thing does not name hold whatever the row
+        // has to hold, so a row composed for one item can stand where another item asks — and the
+        // two went out as two pieces of work because nothing asked what an offered row settles.
+        Settlements table = Settlements.of(db, composed);
+        Set<RowKey> kept = table.keeping();
+        // And what the rows that are left answer, which is what the block may not say nothing
+        // offers. A row composed for one thing standing where another asks is the whole of this,
+        // and a note printed over it would send a person after work that is already in front of
+        // them.
+        Set<OfferItem> answered = new LinkedHashSet<>();
+        for (OfferItem item : table.requested()) {
+            if (kept.stream().anyMatch(row -> table.at(row, item).settles())) {
+                answered.add(item);
+            }
+        }
+        return composed.keeping(kept, answered);
     }
 
     /**
@@ -2673,7 +2690,25 @@ public final class Adequacy {
      * finding: the two are separate readings of one set of findings, and a name that said gap kept
      * the older arrangement alive in every reader that met it.
      */
-    public record GenerationDisposition(Finding finding, GenerationOutcome outcome) {}
+    public record GenerationDisposition(Finding finding, java.util.Optional<OfferItem> item,
+                                        GenerationOutcome outcome) {
+
+        public GenerationDisposition {
+            item = item == null ? java.util.Optional.empty() : item;
+        }
+
+        /**
+         * The finding and what came of it, for a finding nothing offers a row for.
+         *
+         * <p>Empty and not a name for the finding: what a row would be offered for is the thing an
+         * offering answers, and a measure this compiler could not make is not one of those. A
+         * reader asking whether something else answers this has nothing to ask about, which is what
+         * having no item says.
+         */
+        public GenerationDisposition(Finding finding, GenerationOutcome outcome) {
+            this(finding, java.util.Optional.empty(), outcome);
+        }
+    }
 
     public record Generated(String name, String behavior) implements Key<Filling> {
 
@@ -2814,7 +2849,8 @@ public final class Adequacy {
             List<GenerationDisposition> out = new ArrayList<>();
             for (Finding finding : findings) {
                 GenerationOutcome none = whereNoRowCouldAnswer(finding.about());
-                out.add(new GenerationDisposition(finding, none != null ? none
+                out.add(new GenerationDisposition(finding, itemOf(finding, composed, spec),
+                        none != null ? none
                         : switch (finding.about()) {
                             case About.APointOfABorder(var point) -> atEdge(finding, point, edges);
                             case About.ACaseNoRowAppliesItTo(var input, var missing) ->
@@ -2836,6 +2872,56 @@ public final class Adequacy {
                         }));
             }
             return out;
+        }
+
+        /**
+         * What a row would be offered for, where the finding is something a row is offered for.
+         *
+         * <p>Made where the outcome is and from the same reading. What tells two of them apart is
+         * the thing itself — a class of a position, an arm of a body, a point of a line — and a
+         * second walk that worked the identity out again would be free to name a different one than
+         * the search answered for.
+         *
+         * <p>Empty for the rest. A case whose position this run has no axis at is not something a
+         * row is offered for, and neither is a measure this compiler could not make.
+         */
+        private static java.util.Optional<OfferItem> itemOf(
+                Finding finding, souther.compiler.partition.FillResult composed,
+                Hir.SpecBehavior spec) {
+            return switch (finding.about()) {
+                case About.APointOfABorder(var point) ->
+                        java.util.Optional.of(new OfferItem.APointOfALine(point.owed()));
+                case About.AnArmNoRowGoesThrough(var arm) -> java.util.Optional.of(
+                        new OfferItem.AnArm(new Generator.ArmOwed(arm.index())));
+                case About.AClassNoRowIsIn(var missing) -> java.util.Optional.of(
+                        new OfferItem.AClass(new Generator.ClassOwed(missing.axis().at(),
+                                missing.name())));
+                case About.ACaseNoRowAppliesItTo(var input, var missing) ->
+                        classOfTheCase(input, missing, composed, spec)
+                                .map(OfferItem.AClass::new);
+                default -> java.util.Optional.empty();
+            };
+        }
+
+        /**
+         * The class a case of an input is, where this run has an axis at that position.
+         *
+         * <p>Asked of the subject the search was made over, which is what says what this run had
+         * classes for — the same question {@link #atCase} puts, so that what is offered for the
+         * case and what it is called are one thing.
+         */
+        private static java.util.Optional<Generator.ClassOwed> classOfTheCase(
+                InputCaseEvidence input, TypeSymbol case_,
+                souther.compiler.partition.FillResult composed, Hir.SpecBehavior spec) {
+            int at = input.at();
+            if (at < 0 || at >= spec.params().size()) {
+                return java.util.Optional.empty();
+            }
+            Generator.ClassOwed owed = new Generator.ClassOwed(
+                    new souther.compiler.partition.AxisId(spec.name(), spec.params().get(at).name()),
+                    case_.name());
+            return composed.plan().subject().divides(owed)
+                    ? java.util.Optional.of(owed) : java.util.Optional.empty();
         }
 
         /**
@@ -3043,21 +3129,12 @@ public final class Adequacy {
         private static GenerationOutcome atCase(InputCaseEvidence input, TypeSymbol case_,
                                                 souther.compiler.partition.FillResult composed,
                                                 Hir.SpecBehavior spec) {
-            String missing = case_.name();
-            int at = input.at();
-            String parameter = at >= 0 && at < spec.params().size()
-                    ? spec.params().get(at).name() : null;
-            if (parameter == null) {
-                return new GenerationOutcome.NotSupported(
-                        GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION);
-            }
             // Asked of the subject the search was made over, which is what says what this run had
             // classes for. Worked out from a partition's axes beside it, the answer was a second
             // reading of the search's own universe, and a case whose position the search divides
             // could be told there was no axis there.
-            Generator.ClassOwed owed = new Generator.ClassOwed(
-                    new souther.compiler.partition.AxisId(spec.name(), parameter), missing);
-            if (!composed.plan().subject().divides(owed)) {
+            if (!(classOfTheCase(input, case_, composed, spec)
+                    .orElse(null) instanceof Generator.ClassOwed owed)) {
                 return new GenerationOutcome.NotSupported(
                         GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION);
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -20,7 +20,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.Incompleteness;
-import souther.compiler.observe.Counting;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
 import souther.compiler.partition.Axis;
@@ -29,6 +28,7 @@ import souther.compiler.inputs.InputDomain;
 import souther.compiler.partition.GenerationOutcome;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.InputClassifications;
+import souther.compiler.partition.ObservedInputs;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -4740,15 +4740,14 @@ public final class Adequacy {
     /**
      * What a row is known to have done.
      *
-     * <p>Read as a {@code switch} so that a counting this does not know about is a compile error
-     * here rather than a row silently counted as having done nothing. A row whose counting was never
-     * read is known to have done none of it, and that it was left undecided is said where the row is
-     * reported.
+     * <p>For the two readers here that a run reaching nothing and a run nobody watched are one
+     * answer for. A row whose counting was never read is known to have done none of it, and that it
+     * was left undecided is said where the row is reported.
      */
     private static souther.compiler.coverage.Observation seenBy(RowOutcome row) {
-        return switch (row.run().counting()) {
-            case Counting.Read read -> read.observation();
-            case Counting.Unread _ -> souther.compiler.coverage.Observation.NONE;
+        return switch (ObservedInputs.of(row).watched()) {
+            case Generator.Watched.Ran(var account) -> account;
+            case Generator.Watched.NoAccount _ -> souther.compiler.coverage.Observation.NONE;
         };
     }
 
@@ -4768,11 +4767,10 @@ public final class Adequacy {
             // row that reached nothing leaves and is a different thing to have found out.
             return new souther.compiler.partition.Generator.Watched.NoAccount();
         }
-        return switch (row.run().counting()) {
-            case Counting.Read read ->
-                    new souther.compiler.partition.Generator.Watched.Ran(read.observation());
-            case Counting.Unread _ -> new souther.compiler.partition.Generator.Watched.NoAccount();
-        };
+        // What the row's own run came to, which is one reading and is made where a tuple of values
+        // is read. Whether this build was recording is the question above and is this caller's: it
+        // follows from what was asked for rather than from the row.
+        return ObservedInputs.of(row).watched();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3164,7 +3164,7 @@ public final class Adequacy {
             // What this behavior is owed a row for, as the values a row is composed at: one per
             // point, since a row at a point answers everything a row there is owed for.
             for (OwedBoundaryPoint point
-                    : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(boundaries))) {
+                    : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(boundaries)).at()) {
                 ItemAssessment.Owed each = point.item();
                 switch (each.attempt()) {
                     case ItemAssessment.Attempt.Built built -> rows.add(built.row());

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1594,7 +1594,7 @@ public final class Adequacy {
         // And what the module's own declarations are owed, which is no behavior's and so is in none
         // of the fillings above. Asked only where the request asked for the edges: a request that
         // asked for no boundary rows is not asking about these either.
-        Offering composed = Offering.of(request, generated, request.boundaries()
+        Offering composed = Offering.composed(request, generated, request.boundaries()
                 ? generatedForDeclarationsOf(db, request.module(), request.scope()) : null);
         // And then only the rows whose going would cost the offering something. A candidate is
         // composed for one thing and the positions that thing does not name hold whatever the row

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1565,6 +1565,40 @@ public final class Adequacy {
     }
 
     /**
+     * The rows one request is offered, from the two searches that compose them.
+     *
+     * <p>Both halves and one answer. A behavior's own rows and the rows a declaration's line is owed
+     * are asked for in two ways and are work for one person, so which rows go out is settled here
+     * rather than wherever they are printed — and the joining of them is a question about the work
+     * rather than a step of the layout.
+     *
+     * <p>Here rather than in a key of its own, for the reason the two aggregations above are: what a
+     * generation costs is paid by {@link Generated} and {@link BoundarySearch}, which are keyed, so
+     * nothing is searched twice however many times this is asked. What identifies the question is
+     * the request, and it is a value the caller states.
+     */
+    public static Offering offeredFor(Db db, OfferingRequest request) {
+        Map<String, Filling> generated;
+        if (request.scope() instanceof GenerationScope.Behavior one) {
+            // One behavior, asked about on its own. Generating rows searches the pair space and
+            // composes values at the edges, and a caller that named a behavior would otherwise pay
+            // for every other behavior of the module to find out about the one it asked for.
+            Filling only = db.ask(new Generated(request.module(), one.name())).value();
+            generated = only == null ? Map.of() : Map.of(one.name(), only);
+        } else {
+            generated = generatedOf(db, request.module());
+        }
+        if (generated == null) {
+            return null;
+        }
+        // And what the module's own declarations are owed, which is no behavior's and so is in none
+        // of the fillings above. Asked only where the request asked for the edges: a request that
+        // asked for no boundary rows is not asking about these either.
+        return Offering.of(request, generated, request.boundaries()
+                ? generatedForDeclarationsOf(db, request.module(), request.scope()) : null);
+    }
+
+    /**
      * What one behavior's reading of one line holds at one of its points.
      *
      * <p>Asked of {@link BoundarySearch} and never of the measurement. The two are both called an

--- a/souther-compiler/src/main/java/souther/compiler/query/Composition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Composition.java
@@ -1,0 +1,167 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.Generator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+
+/**
+ * Everything the two searches composed, under the behavior each row is written for.
+ *
+ * <p>Where both halves meet. A behavior's own rows and the rows a declaration's line is owed are
+ * composed by two searches asked in two ways, and they meet as work for one person: a line is one
+ * piece of work and is offered once, in the terms of whichever reading composed it. Put together
+ * where the block is written, the meeting was a step of the layout — so what a run offers could
+ * only be said by printing it.
+ *
+ * <p><b>Not what a person is handed.</b> A row here may answer what another here answers, and which
+ * of them goes out is settled by asking what each would settle. {@link Offering} is that answer, and
+ * this is what it is made from — two types, because a renderer handed one of these would print rows
+ * nobody chose, which is what the reduction exists to stop.
+ *
+ * <p>Nothing here is evidence of coverage. A row this holds is a question — these inputs, and what
+ * does the system answer? — and what it would settle if it were written is not something this says.
+ *
+ * @param request  what was asked for, which is what settles which rows are here
+ * @param rows     one entry per behavior with rows, in the order they were asked about
+ * @param searched what each behavior's own search came to, keyed the way a report keys them
+ * @param declared what the module's declarations are owed, or null where the request asked for no
+ *                 boundary rows — which is not the same as a request that asked and found none
+ */
+public record Composition(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
+                          SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared) {
+
+    public Composition {
+        rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
+        searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
+    }
+
+    /**
+     * What the two searches composed, before anything asks what the rows settle.
+     *
+     * <p>Not what a person is handed. A row here may answer what another here answers, and which of
+     * them goes out is settled by asking — {@link Adequacy#offeredFor} is where that happens, and
+     * what it hands back is the offering. So {@link #answered} is empty on one of these, which says
+     * nobody has asked rather than that the rows answer nothing.
+     *
+     * <p>Walked in the order the behaviors were asked about, and within a behavior the cells before
+     * the lines. The order a person is offered the rows in is the order they were composed in, and a
+     * block read against the one before it is read by somebody who did not change the model between
+     * them.
+     *
+     * @param generated one filling per behavior, keyed the way a report keys them
+     * @param declared  the rows the module's declarations are owed, or null where the request asked
+     *                  for no boundary rows. One row per point of a line however many behaviors
+     *                  carry the type, and under the behavior whose reading composed it
+     */
+    public static Composition composed(OfferingRequest request,
+                                    Map<String, Adequacy.Filling> generated,
+                                    DeclaredRows declared) {
+        Map<String, List<Generator.GeneratedRow>> owed = declared == null
+                ? Map.of() : declared.rowsByCarrier();
+        SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior = new LinkedHashMap<>();
+        for (Map.Entry<String, Adequacy.Filling> behavior : generated.entrySet()) {
+            take(byBehavior, behavior.getKey(), behavior.getValue().composed().rows(),
+                    request.boundaries()
+                            ? atTheLines(behavior.getValue().boundaries().rows(),
+                                    owed.get(behavior.getKey()))
+                            : List.of());
+        }
+        // A behavior with nothing of its own to fill can still be the one reading that composed the
+        // row a declaration is owed. Left out, that row would be resolved and then dropped on the
+        // way to the block.
+        for (Map.Entry<String, List<Generator.GeneratedRow>> carrier : owed.entrySet()) {
+            if (!generated.containsKey(carrier.getKey())) {
+                take(byBehavior, carrier.getKey(), List.of(), carrier.getValue());
+            }
+        }
+        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
+        byBehavior.forEach((behavior, here) -> out.put(behavior, List.copyOf(here.values())));
+        return new Composition(request, out, new LinkedHashMap<>(generated), declared);
+    }
+
+    /** One behavior's rows, joined onto whatever it already offers. */
+    private static void take(SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior,
+                             String behavior, List<Generator.GeneratedRow> cells,
+                             List<Generator.GeneratedRow> lines) {
+        // One block per behavior, however many kinds of row it holds. Rows of one behavior written
+        // under two headings are legal and read as two lists of something, which they are not.
+        Map<RowKey, OfferedRow> here =
+                byBehavior.computeIfAbsent(behavior, _ -> new LinkedHashMap<>());
+        for (Generator.GeneratedRow row : cells) {
+            RowKey key = RowKey.of(behavior, row);
+            here.put(key, here.computeIfAbsent(key,
+                    _ -> new OfferedRow(key, row.inputs(), List.of())).and(row.purposes()));
+        }
+        for (Generator.GeneratedRow row : lines) {
+            RowKey key = RowKey.of(behavior, row);
+            here.putIfAbsent(key, new OfferedRow(key, row.inputs(), List.of()));
+        }
+    }
+
+    /**
+     * The rows at one behavior's lines: the ones its own readings are owed, and the ones a
+     * declaration is owed that this behavior's reading composed.
+     *
+     * <p>Two sources and one list, because they are one kind of row — a value standing at a line —
+     * and what tells them apart is who owes the line rather than anything a reader of the block
+     * would act on. Where they coincide the block offers one row, which is what it already does for
+     * two of a behavior's own lines that meet.
+     *
+     * <p>Public because it is a question and not a step of the layout: what is offered at one
+     * behavior's lines is what a reader of the block beside that behavior sees, and it is asked
+     * elsewhere. Written twice, the two would come apart the day either half of the join moved.
+     */
+    public static List<Generator.GeneratedRow> atTheLines(List<Generator.GeneratedRow> own,
+                                                          List<Generator.GeneratedRow> owed) {
+        if (owed == null || owed.isEmpty()) {
+            return own;
+        }
+        List<Generator.GeneratedRow> out = new ArrayList<>(own);
+        out.addAll(owed);
+        return List.copyOf(out);
+    }
+
+    /**
+     * Every row of this, as an offering, for a caller with no store to ask what they settle.
+     *
+     * <p>Which is what a test that builds its fillings by hand has: there is nothing to run the
+     * rows against and nothing to read their values with, so no row can be shown to answer what
+     * another answers and every one of them goes out. Nothing is said to be answered either — the
+     * question was not put — so the block says of every finding what the search came to.
+     *
+     * <p>Named, so that it is a thing a caller asks for. The reduction is what
+     * {@link Adequacy#offeredFor} does, and a caller with a store that came through here instead
+     * would be choosing to skip it.
+     */
+    public Offering offeringEverything() {
+        return new Offering(request, rows, searched, declared, java.util.Set.of());
+    }
+
+    /** How many pieces of work this holds, which is what a block says at the top of it. */
+    public int count() {
+        return rows.values().stream().mapToInt(List::size).sum();
+    }
+
+    /**
+     * What a person is handed: these rows, less the ones nothing would miss.
+     *
+     * <p>The rows and nothing else changes. What the searches came to is what they came to whatever
+     * a person is handed afterwards — a row not offered was still composed, and the note beside a
+     * search that came to nothing says what happened rather than what is in the block.
+     */
+    public Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
+        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
+        rows.forEach((behavior, here) -> {
+            List<OfferedRow> left = here.stream().filter(row -> kept.contains(row.key())).toList();
+            if (!left.isEmpty()) {
+                out.put(behavior, left);
+            }
+        });
+        return new Offering(request, out, searched, declared, answered);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Composition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Composition.java
@@ -45,8 +45,7 @@ public record Composition(OfferingRequest request, SequencedMap<String, List<Off
      *
      * <p>Not what a person is handed. A row here may answer what another here answers, and which of
      * them goes out is settled by asking — {@link Adequacy#offeredFor} is where that happens, and
-     * what it hands back is the offering. So {@link #answered} is empty on one of these, which says
-     * nobody has asked rather than that the rows answer nothing.
+     * what it hands back is the offering. So what it answers is a question nobody has put yet.
      *
      * <p>Walked in the order the behaviors were asked about, and within a behavior the cells before
      * the lines. The order a person is offered the rows in is the order they were composed in, and a
@@ -124,22 +123,6 @@ public record Composition(OfferingRequest request, SequencedMap<String, List<Off
         List<Generator.GeneratedRow> out = new ArrayList<>(own);
         out.addAll(owed);
         return List.copyOf(out);
-    }
-
-    /**
-     * Every row of this, as an offering, for a caller with no store to ask what they settle.
-     *
-     * <p>Which is what a test that builds its fillings by hand has: there is nothing to run the
-     * rows against and nothing to read their values with, so no row can be shown to answer what
-     * another answers and every one of them goes out. Nothing is said to be answered either — the
-     * question was not put — so the block says of every finding what the search came to.
-     *
-     * <p>Named, so that it is a thing a caller asks for. The reduction is what
-     * {@link Adequacy#offeredFor} does, and a caller with a store that came through here instead
-     * would be choosing to skip it.
-     */
-    public Offering offeringEverything() {
-        return new Offering(request, rows, searched, declared, java.util.Set.of());
     }
 
     /** How many pieces of work this holds, which is what a block says at the top of it. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Composition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Composition.java
@@ -136,8 +136,14 @@ public record Composition(OfferingRequest request, SequencedMap<String, List<Off
      * <p>The rows and nothing else changes. What the searches came to is what they came to whatever
      * a person is handed afterwards — a row not offered was still composed, and the note beside a
      * search that came to nothing says what happened rather than what is in the block.
+     *
+     * <p><b>Reachable from this package and no further.</b> What may be passed here is what asking
+     * came to, and the asking is {@link Settlements}; a caller outside could hand in every row and
+     * an empty answer, which is the raw composition under the name of an offering. Closing the
+     * constructor and leaving the one call that reaches it open would have left the same door with
+     * a longer name on it.
      */
-    public Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
+    Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
         SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
         rows.forEach((behavior, here) -> {
             List<OfferedRow> left = here.stream().filter(row -> kept.contains(row.key())).toList();

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -20,6 +20,7 @@ import souther.compiler.partition.ReachingCuts;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.PointRole;
 import souther.compiler.partition.BorderQuantity;
+import souther.compiler.partition.StandingAtAPoint;
 import souther.compiler.partition.LevelRealizer;
 import souther.compiler.partition.Realization;
 import souther.compiler.inputs.InputDomain;
@@ -661,7 +662,7 @@ final class Coverages {
     private interface OneShapeOfBorder {
 
         /** Whether one of {@code rows} meets {@code criterion}, and whether that could be told. */
-        Met met(Criterion criterion, List<ObservedInputs> rows);
+        StandingAtAPoint.Met met(Criterion criterion, List<ObservedInputs> rows);
 
         /** What reading the rules this reading took in established about a row being writable at
          *  this border. Three answers rather than two: a shape whose rules were never put the
@@ -748,8 +749,8 @@ final class Coverages {
         return new OneShapeOfBorder() {
 
             @Override
-            public Met met(Criterion criterion, List<ObservedInputs> rows) {
-                return metOn(quantity, where, rows, criterion, site);
+            public StandingAtAPoint.Met met(Criterion criterion, List<ObservedInputs> rows) {
+                return StandingAtAPoint.met(quantity, where, rows, criterion, site);
             }
 
             @Override
@@ -813,200 +814,6 @@ final class Coverages {
                 };
             }
         };
-    }
-
-    /**
-     * One row's values under one reading of it: an element chosen at each step inside a sequence
-     * the line's positions take.
-     *
-     * <p>A row standing at a point is one of its readings standing there, and a reading has to be
-     * one: two positions under one person are that person's two values, and offering the first
-     * person's age beside the second person's status would have a row stand at a point neither
-     * element is at. So an element is chosen per step and every position takes the one chosen for
-     * the steps it shares — the same rule a pair of classes is read by, since it is the same
-     * question.
-     *
-     * <p>Which readings there are is not known before the quantity has asked, since which positions
-     * a line is over is its to say. So the choices are collected as it asks and the reading is run
-     * again under each, until one stands or they are used up.
-     */
-    private static final class OneReadingOfARow implements BorderQuantity.Observation {
-
-        private final BehaviorInputs where;
-        private final ObservedInputs row;
-        /** The element chosen at each step, for this reading. */
-        private final Map<souther.compiler.inputs.TermPath, Integer> chosen;
-        /** How many elements each step was found to have, over every reading so far. */
-        private final Map<souther.compiler.inputs.TermPath, Integer> held;
-        private boolean wroteNothing;
-        private boolean unreadable;
-
-        OneReadingOfARow(BehaviorInputs where, ObservedInputs row,
-                         Map<souther.compiler.inputs.TermPath, Integer> chosen,
-                         Map<souther.compiler.inputs.TermPath, Integer> held) {
-            this.where = where;
-            this.row = row;
-            this.chosen = chosen;
-            this.held = held;
-        }
-
-        @Override
-        public souther.compiler.observe.ObservedValue at(souther.compiler.inputs.TermPath path) {
-            List<BehaviorInputs.Occurrence> values = where.occurrencesAt(row.inputs(), path);
-            if (values == null) {
-                unreadable = true;
-                return null;   // the walk and the type disagree, which is the quantity's to report
-            }
-            if (values.isEmpty()) {
-                // The row wrote no element here, so nothing of it stands anywhere on this line.
-                // That is a row that was read and does not reach the point, and reporting it as a
-                // value nothing could read leaves the point undecided over a row that plainly
-                // settles it.
-                wroteNothing = true;
-                return null;
-            }
-            for (BehaviorInputs.Occurrence each : values) {
-                each.at().forEach((step, ordinal) ->
-                        held.merge(step, ordinal + 1, Math::max));
-            }
-            for (BehaviorInputs.Occurrence each : values) {
-                if (agrees(each)) {
-                    return each.value();
-                }
-            }
-            // No value here under this reading. Not a stop: the reading names an element this
-            // position does not have, and another reading is where its values are.
-            return null;
-        }
-
-        /** Whether {@code each} was reached through the elements this reading chose. */
-        private boolean agrees(BehaviorInputs.Occurrence each) {
-            for (Map.Entry<souther.compiler.inputs.TermPath, Integer> step : each.at().entrySet()) {
-                Integer picked = chosen.get(step.getKey());
-                if (picked != null && !picked.equals(step.getValue())) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /** Whether the row wrote nothing at some position this line is over. */
-        boolean wroteNothing() {
-            return wroteNothing;
-        }
-
-        /** Whether some position this line is over could not be read at all. */
-        boolean unreadable() {
-            return unreadable;
-        }
-    }
-
-    /**
-     * The readings of one row a point is tried against.
-     *
-     * <p>The first is run before the rest are known: which steps the line's positions take is the
-     * quantity's to say as it reads them, so it says so by being asked once. Every choice those
-     * steps allow follows it.
-     */
-    private static List<OneReadingOfARow> readings(BehaviorInputs where, ObservedInputs row,
-                                                   BorderQuantity quantity, Criterion criterion,
-                                                   OneReadingOfARow first,
-                                                   Map<souther.compiler.inputs.TermPath,
-                                                           Integer> held) {
-        quantity.standsAt(criterion, first);
-        List<OneReadingOfARow> out = new ArrayList<>();
-        for (Map<souther.compiler.inputs.TermPath, Integer> choice : readingsOver(held)) {
-            out.add(new OneReadingOfARow(where, row, choice, held));
-        }
-        return out;
-    }
-
-    /**
-     * Every reading of a row over the steps {@code held} says its positions take.
-     *
-     * <p>One choice per step, in every combination — which is a product and not a zip, because two
-     * steps a row's positions do not take together are two independent choices. Bounded, since a
-     * row holding several long lists has more readings than a measure is worth.
-     */
-    private static List<Map<souther.compiler.inputs.TermPath, Integer>> readingsOver(
-            Map<souther.compiler.inputs.TermPath, Integer> held) {
-        List<Map<souther.compiler.inputs.TermPath, Integer>> out = new ArrayList<>();
-        out.add(Map.of());
-        for (Map.Entry<souther.compiler.inputs.TermPath, Integer> step : held.entrySet()) {
-            List<Map<souther.compiler.inputs.TermPath, Integer>> wider = new ArrayList<>();
-            for (Map<souther.compiler.inputs.TermPath, Integer> each : out) {
-                for (int i = 0; i < step.getValue() && wider.size() < MOST_READINGS; i++) {
-                    Map<souther.compiler.inputs.TermPath, Integer> deeper =
-                            new LinkedHashMap<>(each);
-                    deeper.put(step.getKey(), i);
-                    wider.add(deeper);
-                }
-            }
-            out = wider;
-        }
-        return out;
-    }
-
-    /** How many readings of one row a point is tried against. */
-    private static final int MOST_READINGS = 256;
-
-    /**
-     * Whether any row stands at one item of a border.
-     *
-     * <p>One walk for every kind of line. What a row put at the item is the quantity's to read — it
-     * is the one thing that knows what it is a quantity of — and what this adds is the two facts that
-     * belong to the rows: that a row nothing could read leaves the item undecided rather than missed,
-     * and that a line a fork drew is met by getting the comparison to answer as well.
-     *
-     * @param site which comparison a row has to have got an answer out of, for a rule that meeting
-     *             takes more than standing at the level. Empty where standing there is the whole
-     *             of it
-     */
-    private static Met metOn(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
-                             Criterion criterion,
-                             java.util.Optional<souther.compiler.coverage.ComparisonOccurrence>
-                                     site) {
-        boolean unreadable = false;
-        for (ObservedInputs row : rows) {
-            // A row has more than one value at a position inside a sequence, and standing at a point
-            // is one element standing there. Asked for one value, such a row answered with none and
-            // every point on such a line came back undecided — a measurement that could not look,
-            // said of a row that wrote the values plainly.
-            // The first reading both answers the point and says which steps the line's positions
-            // take; the rest are tried under each choice those steps allow.
-            Map<souther.compiler.inputs.TermPath, Integer> held = new LinkedHashMap<>();
-            OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
-            boolean stands = false;
-            boolean stopped = false;
-            for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
-                switch (quantity.standsAt(criterion, reading)) {
-                    // A reading that could not look, unless what it could not find was an element
-                    // the row wrote none of — that is a row that was read and does not stand, and
-                    // said of the reading it happened in rather than of the row, since another
-                    // reading of the same row may reach the point.
-                    case UNREADABLE -> stopped = stopped || !reading.wroteNothing();
-                    case NO -> { }
-                    case YES -> stands = true;
-                }
-                if (stands) {
-                    break;
-                }
-            }
-            // A row nobody watched reached no comparison here. What that costs the measure is not
-            // said here — the reading of the rows carries it, and the verdict below weakens what it
-            // says by every row it could not read — so what this asks of such a row is what it
-            // asks of one that ran and got no answer out of the comparison.
-            souther.compiler.coverage.Observation seen = switch (row.watched()) {
-                case souther.compiler.partition.Generator.Watched.Ran(var account) -> account;
-                case souther.compiler.partition.Generator.Watched.NoAccount _ ->
-                        souther.compiler.coverage.Observation.NONE;
-            };
-            if (stands && site.stream().allMatch(seen::reached)) {
-                return Met.YES;
-            }
-            unreadable = unreadable || stopped;
-        }
-        return unreadable ? Met.UNREADABLE : Met.NO;
     }
 
     /**
@@ -1145,12 +952,20 @@ final class Coverages {
         return List.copyOf(out);
     }
 
-    /** What a reading of the rows comes to, once what could not be read is accounted for. */
+    /**
+     * What a reading of the rows comes to, once what could not be read is accounted for.
+     *
+     * <p>A row standing where the line is that nothing watched reach the comparison is counted here
+     * as a row that did not meet the point. It is a miss the measure can hide: what the rows went
+     * without is said below, and a run nobody watched is one of the things it says. So the
+     * distinction the walk makes is not carried further — a hit needs a row seen reaching the
+     * comparison, and everything else is answered by how whole the reading was.
+     */
     private static Measurement<ItemAssessment.Coverage> verdictOf(
-            Met met, boolean guard, souther.compiler.partition.Border border,
+            StandingAtAPoint.Met met, boolean guard, souther.compiler.partition.Border border,
             souther.compiler.query.Adequacy.RowReading observed) {
         List<RowOutcome> rows = observed.rowsSeen();
-        if (met == Met.YES) {
+        if (met == StandingAtAPoint.Met.YES) {
             // Found is found: a row settles this whatever else went unread, so nothing weakens it.
             return new Measurement.Complete<>(new ItemAssessment.Coverage.Hit());
         }
@@ -1159,7 +974,7 @@ final class Coverages {
         // nothing read at all, which may be the row that is at this value; and, for a line a fork
         // drew, a row that never finished and so never reached the comparison.
         Set<Weakening> by = new LinkedHashSet<>();
-        if (met == Met.UNREADABLE) {
+        if (met == StandingAtAPoint.Met.UNREADABLE) {
             by.add(new Weakening.BorderValueUnreadable(border));
         }
         for (Incompleteness gap : observed.gaps()) {
@@ -1243,15 +1058,6 @@ final class Coverages {
                 ? new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS) : null;
     }
 
-    /**
-     * Whether a row was at a boundary, and whether that could be told at all.
-     *
-     * <p>Three answers, because a value the observer could not read is not a value that missed. A row
-     * writing the very number the rule names, whose observation was cut short by a limit somewhere
-     * else in the same input, reads as "no row is at this boundary" — which is a sentence about the
-     * model that is not true.
-     */
-    private enum Met { YES, NO, UNREADABLE, UNDECIDED }
 
     private Coverages() {}
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -10,8 +10,8 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
-import souther.compiler.observe.Counting;
 import souther.compiler.observe.RowOutcome;
+import souther.compiler.partition.ObservedInputs;
 import souther.compiler.partition.Axis;
 import souther.compiler.partition.AxisId;
 import souther.compiler.partition.Border;
@@ -661,7 +661,7 @@ final class Coverages {
     private interface OneShapeOfBorder {
 
         /** Whether one of {@code rows} meets {@code criterion}, and whether that could be told. */
-        Met met(Criterion criterion, List<RowOutcome> rows);
+        Met met(Criterion criterion, List<ObservedInputs> rows);
 
         /** What reading the rules this reading took in established about a row being writable at
          *  this border. Three answers rather than two: a shape whose rules were never put the
@@ -706,13 +706,18 @@ final class Coverages {
                 ? whyNoGuardLine(observed, level)
                 : whyNoInvariantLine(observed, level);
 
+        // The rows as the values they hold and what running them recorded, which is the whole of
+        // what a point is met by. Read once for the border: what a row is stays the same however
+        // many of the four points it is put to.
+        List<ObservedInputs> rows = observed.rowsSeen().stream().map(ObservedInputs::of).toList();
+
         java.util.EnumMap<PointRole, ItemAssessment> items = new java.util.EnumMap<>(PointRole.class);
         for (PointRole role : PointRole.values()) {
             items.put(role, switch (border.demand(role)) {
                 case Demand.NotOwed not -> new ItemAssessment.NotOwed(not.reason());
                 case Demand.Owed owed -> {
                     Measurement<ItemAssessment.Coverage> coverage = absent != null ? absent
-                            : verdictOf(shape.met(owed.criterion(), observed.rowsSeen()), guard,
+                            : verdictOf(shape.met(owed.criterion(), rows), guard,
                                     border, observed);
                     // No attempt. Nothing was searched for here, and that is said by there being no
                     // attempt rather than by an attempt saying nobody asked: whether a value was
@@ -743,7 +748,7 @@ final class Coverages {
         return new OneShapeOfBorder() {
 
             @Override
-            public Met met(Criterion criterion, List<RowOutcome> rows) {
+            public Met met(Criterion criterion, List<ObservedInputs> rows) {
                 return metOn(quantity, where, rows, criterion, site);
             }
 
@@ -828,7 +833,7 @@ final class Coverages {
     private static final class OneReadingOfARow implements BorderQuantity.Observation {
 
         private final BehaviorInputs where;
-        private final RowOutcome row;
+        private final ObservedInputs row;
         /** The element chosen at each step, for this reading. */
         private final Map<souther.compiler.inputs.TermPath, Integer> chosen;
         /** How many elements each step was found to have, over every reading so far. */
@@ -836,7 +841,7 @@ final class Coverages {
         private boolean wroteNothing;
         private boolean unreadable;
 
-        OneReadingOfARow(BehaviorInputs where, RowOutcome row,
+        OneReadingOfARow(BehaviorInputs where, ObservedInputs row,
                          Map<souther.compiler.inputs.TermPath, Integer> chosen,
                          Map<souther.compiler.inputs.TermPath, Integer> held) {
             this.where = where;
@@ -903,7 +908,7 @@ final class Coverages {
      * quantity's to say as it reads them, so it says so by being asked once. Every choice those
      * steps allow follows it.
      */
-    private static List<OneReadingOfARow> readings(BehaviorInputs where, RowOutcome row,
+    private static List<OneReadingOfARow> readings(BehaviorInputs where, ObservedInputs row,
                                                    BorderQuantity quantity, Criterion criterion,
                                                    OneReadingOfARow first,
                                                    Map<souther.compiler.inputs.TermPath,
@@ -957,12 +962,12 @@ final class Coverages {
      *             takes more than standing at the level. Empty where standing there is the whole
      *             of it
      */
-    private static Met metOn(BorderQuantity quantity, BehaviorInputs where, List<RowOutcome> rows,
+    private static Met metOn(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
                              Criterion criterion,
                              java.util.Optional<souther.compiler.coverage.ComparisonOccurrence>
                                      site) {
         boolean unreadable = false;
-        for (RowOutcome row : rows) {
+        for (ObservedInputs row : rows) {
             // A row has more than one value at a position inside a sequence, and standing at a point
             // is one element standing there. Asked for one value, such a row answered with none and
             // every point on such a line came back undecided — a measurement that could not look,
@@ -987,7 +992,16 @@ final class Coverages {
                     break;
                 }
             }
-            if (stands && site.stream().allMatch(seenBy(row)::reached)) {
+            // A row nobody watched reached no comparison here. What that costs the measure is not
+            // said here — the reading of the rows carries it, and the verdict below weakens what it
+            // says by every row it could not read — so what this asks of such a row is what it
+            // asks of one that ran and got no answer out of the comparison.
+            souther.compiler.coverage.Observation seen = switch (row.watched()) {
+                case souther.compiler.partition.Generator.Watched.Ran(var account) -> account;
+                case souther.compiler.partition.Generator.Watched.NoAccount _ ->
+                        souther.compiler.coverage.Observation.NONE;
+            };
+            if (stands && site.stream().allMatch(seen::reached)) {
                 return Met.YES;
             }
             unreadable = unreadable || stopped;
@@ -1240,20 +1254,5 @@ final class Coverages {
     private enum Met { YES, NO, UNREADABLE, UNDECIDED }
 
     private Coverages() {}
-
-    /**
-     * What a row is known to have done.
-     *
-     * <p>Read as a {@code switch} so that a counting this does not know about is a compile error
-     * here rather than a row silently counted as having done nothing. A row whose counting was never
-     * read is known to have done none of it, and that it was left undecided is said where the row is
-     * reported.
-     */
-    private static souther.compiler.coverage.Observation seenBy(RowOutcome row) {
-        return switch (row.run().counting()) {
-            case Counting.Read read -> read.observation();
-            case Counting.Unread _ -> souther.compiler.coverage.Observation.NONE;
-        };
-    }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/DeclaredRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/DeclaredRows.java
@@ -98,14 +98,14 @@ public record DeclaredRows(GenerationScope scope,
      * sentence a reader may act on (ADR-0091) was printed under the declaration's own name for a
      * line one reading had merely refused.
      */
-    public List<Unmet> unmet() {
-        List<Unmet> out = new ArrayList<>();
-        resolved.forEach((_, answer) -> {
+    public SequencedMap<BorderObligationPoint, Unmet> unmet() {
+        SequencedMap<BorderObligationPoint, Unmet> out = new LinkedHashMap<>();
+        resolved.forEach((at, answer) -> {
             if (answer.resolution() instanceof DeclarationResolution.Unresolved _) {
-                out.add(unmet(answer));
+                out.put(at, unmet(answer));
             }
         });
-        return List.copyOf(out);
+        return java.util.Collections.unmodifiableSequencedMap(out);
     }
 
     /**
@@ -147,7 +147,8 @@ public record DeclaredRows(GenerationScope scope,
             return new Unmet.NothingWasSearched(answer.owedBy(), answer.said());
         }
         return coverage.provesTheLineCannotBeWritten()
-                ? new Unmet.TheLineCannotBeWritten(answer.owedBy(), answer.said(), List.copyOf(came))
+                ? new Unmet.TheLineCannotBeWritten(answer.owedBy(), answer.said(),
+                        List.copyOf(came))
                 : new Unmet.WhatTheReadingsCameTo(answer.owedBy(), answer.said(),
                         List.copyOf(came));
     }
@@ -248,7 +249,9 @@ public record DeclaredRows(GenerationScope scope,
                         "a finding about a line this generation was asked about and holds no answer"
                                 + " for: " + at);
             }
-            out.add(new Adequacy.GenerationDisposition(finding, switch (answer.resolution()) {
+            out.add(new Adequacy.GenerationDisposition(finding,
+                    java.util.Optional.of(new OfferItem.APointOfALine(at)),
+                    switch (answer.resolution()) {
                 case DeclarationResolution.Generated(var _, var row) ->
                         new GenerationOutcome.Generated(List.of(row));
                 case DeclarationResolution.Unresolved _ -> cannot(unmet(answer));

--- a/souther-compiler/src/main/java/souther/compiler/query/OfferItem.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OfferItem.java
@@ -1,0 +1,33 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.BorderObligationPoint;
+import souther.compiler.partition.Generator;
+
+/**
+ * One thing a run of the generator is asked to offer a row for.
+ *
+ * <p>Three kinds in one set, which is the whole of what this is for. What a class, an arm and a
+ * point of a line are is already settled — each of them is a value some other part of this compiler
+ * owns — and this puts them where one question can be asked of all three: which of them does a row
+ * this run offers settle?
+ *
+ * <p><b>Nothing of an identity is written again here.</b> A wrapper that spelled out an axis and a
+ * class id, a probe, or a line and a role would be a second answer to what tells two of them apart —
+ * and the third would be wrong the day a point stopped being a line and a role, which it already
+ * has: two points of one line and one role are two things where the sides they are inside of are
+ * different. So each arm holds the value and adds nothing to it, and every arm holds exactly one.
+ */
+public sealed interface OfferItem {
+
+    /** One class of one position. The axis names the behavior, so two behaviors dividing their own
+     *  positions the same way are two of these. */
+    record AClass(Generator.ClassOwed owed) implements OfferItem {}
+
+    /** One arm of one body. The sites of a module are numbered across it, so the probe is the whole
+     *  of what tells two arms apart. */
+    record AnArm(Generator.ArmOwed owed) implements OfferItem {}
+
+    /** One point of one authored line: what a row standing there answers, however many positions
+     *  read the line and whichever of them a row is written at. */
+    record APointOfALine(BorderObligationPoint point) implements OfferItem {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/OfferedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OfferedRow.java
@@ -1,0 +1,61 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.FixtureTemplate;
+import souther.compiler.partition.Generator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One row as it will be written, and what it may be named after.
+ *
+ * <p>A candidate is composed once per thing it is owed for and the positions that thing does not
+ * name hold whatever the row has to hold, so two of them can come out as one row. What is
+ * offered is the row: a reader is handed one piece of work rather than the same values twice.
+ *
+ * <p><b>Every purpose a cell composed it for, and not the first.</b> Two purposes converging on
+ * one row is a fact about this run, and keeping one of them leaves a name that says the row is
+ * about one thing while it answers two.
+ *
+ * <p><b>And nothing from a line.</b> A cell can name a row — a candidate's values follow from
+ * the classes it was composed for, so the cell a row is named by is the row's own and is there
+ * whatever else this run offers. A line cannot: lines coincide, each probe filling the positions
+ * its own edge does not name from the bottom of their domains, so two minimum edges compose one
+ * row and which of them is offered is exactly what changes when something else is written. A row
+ * named for whichever line happened to be offered would be renamed by an edit that did not touch
+ * it. So a row composed only at lines is offered with nothing to be named after, which the
+ * language allows — an unnamed row cannot be addressed from outside, and that is the state of a
+ * row nobody has named yet.
+ *
+ * @param key      what tells this row from the others a person is handed
+ * @param inputs   the values, as the search composed them. One row's worth: rows that came out
+ *                 as one piece of work are written the same way, so which of them these came
+ *                 from is not a difference anybody can read
+ * @param namedFor the classes and arms this row was composed for, in the order they were taken
+ */
+public record OfferedRow(RowKey key, List<FixtureTemplate> inputs,
+                         List<Generator.Purpose> namedFor) {
+
+    public OfferedRow {
+        inputs = List.copyOf(inputs);
+        namedFor = List.copyOf(namedFor);
+        for (Generator.Purpose purpose : namedFor) {
+            if (!(purpose instanceof Generator.Purpose.ForAClass
+                    || purpose instanceof Generator.Purpose.ForAnArm)) {
+                throw new IllegalArgumentException(
+                        "a row is named after a class or an arm, and never after a line: "
+                                + purpose);
+            }
+        }
+    }
+
+    /** The row with {@code more} added to what it may be named after. */
+    OfferedRow and(List<Generator.Purpose> more) {
+        if (more.isEmpty()) {
+            return this;
+        }
+        List<Generator.Purpose> both = new ArrayList<>(namedFor);
+        both.addAll(more);
+        return new OfferedRow(key, inputs, both);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -24,23 +24,63 @@ import java.util.SequencedMap;
  * what a person is owed: a block that printed only what it managed would read as though it had
  * filled everything.
  *
- * @param request  what was asked for, which is what settles which rows are here
- * @param rows     one entry per behavior with rows to offer, in the order they were asked about
- * @param searched what each behavior's own search came to, keyed the way a report keys them
- * @param declared what the module's declarations are owed, or null where the request asked for no
- *                 boundary rows — which is not the same as a request that asked and found none
- * @param answered what the rows here settle: every item one of them would answer if it were
- *                 written, whichever row it was composed for. Empty where nobody put the question,
- *                 which is what {@link Composition#offeringEverything()} hands back
+ * <p><b>Made in one place.</b> A class rather than a record, so that the way to hold one is to have
+ * asked: {@link Composition#keeping} is in this package and nothing outside it can write the
+ * constructor. A record would publish the constructor with the type, and the sentence above — that
+ * a renderer cannot be handed rows nobody chose — would be a thing to remember rather than a thing
+ * that holds.
  */
-public record Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
-                       SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared,
-                       Set<OfferItem> answered) {
+public final class Offering {
 
-    public Offering {
-        rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
-        searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
-        answered = Collections.unmodifiableSet(new LinkedHashSet<>(answered));
+    private final OfferingRequest request;
+    private final SequencedMap<String, List<OfferedRow>> rows;
+    private final SequencedMap<String, Adequacy.Filling> searched;
+    private final DeclaredRows declared;
+    private final Set<OfferItem> answered;
+
+    /**
+     * @param request  what was asked for, which is what settles which rows are here
+     * @param rows     one entry per behavior with rows to offer, in the order they were asked about
+     * @param searched what each behavior's own search came to, keyed the way a report keys them
+     * @param declared what the module's declarations are owed, or null where the request asked for
+     *                 no boundary rows — which is not the same as a request that asked and found
+     *                 none
+     * @param answered what the rows here settle: every item one of them would answer if it were
+     *                 written, whichever row it was composed for
+     */
+    Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
+             SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared,
+             Set<OfferItem> answered) {
+        this.request = request;
+        this.rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
+        this.searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
+        this.declared = declared;
+        this.answered = Collections.unmodifiableSet(new LinkedHashSet<>(answered));
+    }
+
+    /** What was asked for. */
+    public OfferingRequest request() {
+        return request;
+    }
+
+    /** The rows a person is handed, under the behavior each is written for. */
+    public SequencedMap<String, List<OfferedRow>> rows() {
+        return rows;
+    }
+
+    /** What each behavior's own search came to. */
+    public SequencedMap<String, Adequacy.Filling> searched() {
+        return searched;
+    }
+
+    /** What the module's declarations are owed, or null where none were asked for. */
+    public DeclaredRows declared() {
+        return declared;
+    }
+
+    /** The items one of these rows would answer if it were written. */
+    public Set<OfferItem> answered() {
+        return answered;
     }
 
     /** How many pieces of work this offers, which is what a block says at the top of it. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -1,31 +1,28 @@
 package souther.compiler.query;
 
-import souther.compiler.partition.FixtureTemplate;
-import souther.compiler.partition.Generator;
-
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.SequencedMap;
 
 /**
  * The rows one run hands a person, under the behavior each is written for.
  *
- * <p>What a run offers is one answer, made where both halves of it are. A behavior's own rows and
- * the rows a declaration's line is owed are composed by two searches asked in two ways, and they
- * meet as work for one person: a line is one piece of work and is offered once, in the terms of
- * whichever reading composed it. Put together where the block is written, the meeting was a step of
- * the layout — so what a run offers could only be said by printing it.
+ * <p>What is left of a {@link Composition} once what each row would settle has been asked: a row
+ * answering only what another row here answers is not one of these. So this is what a block is
+ * written from, and there is no way to write one from the rows before that question was put — which
+ * there was while both were one type, and a renderer that reached for the wrong one printed work
+ * nobody had chosen.
  *
  * <p>Nothing here is evidence of coverage. A row this holds is a question — these inputs, and what
- * does the system answer? — and what it would settle if it were written is not something this says.
+ * does the system answer? — and what it would settle if it were written is not something this says
+ * about the file.
  *
  * <p>And what the two searches came to beside the rows they composed, which is the other half of
  * what a person is owed: a block that printed only what it managed would read as though it had
- * filled everything. The rows are this one's answer; those are the searches' own, carried here so
- * that whoever writes the block asks one question rather than putting the halves together again.
+ * filled everything.
  *
  * @param request  what was asked for, which is what settles which rows are here
  * @param rows     one entry per behavior with rows to offer, in the order they were asked about
@@ -33,182 +30,21 @@ import java.util.SequencedMap;
  * @param declared what the module's declarations are owed, or null where the request asked for no
  *                 boundary rows — which is not the same as a request that asked and found none
  * @param answered what the rows here settle: every item one of them would answer if it were
- *                 written, whichever row it was composed for. Empty on a composition nobody has
- *                 put the question to, which is a run that has not been asked rather than one whose
- *                 rows answer nothing
+ *                 written, whichever row it was composed for. Empty where nobody put the question,
+ *                 which is what {@link Composition#offeringEverything()} hands back
  */
 public record Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
                        SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared,
-                       java.util.Set<OfferItem> answered) {
+                       Set<OfferItem> answered) {
 
     public Offering {
         rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
         searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
-        answered = java.util.Collections.unmodifiableSet(
-                new java.util.LinkedHashSet<>(answered));
-    }
-
-    /**
-     * One row as it will be written, and what it may be named after.
-     *
-     * <p>A candidate is composed once per thing it is owed for and the positions that thing does not
-     * name hold whatever the row has to hold, so two of them can come out as one row. What is
-     * offered is the row: a reader is handed one piece of work rather than the same values twice.
-     *
-     * <p><b>Every purpose a cell composed it for, and not the first.</b> Two purposes converging on
-     * one row is a fact about this run, and keeping one of them leaves a name that says the row is
-     * about one thing while it answers two.
-     *
-     * <p><b>And nothing from a line.</b> A cell can name a row — a candidate's values follow from
-     * the classes it was composed for, so the cell a row is named by is the row's own and is there
-     * whatever else this run offers. A line cannot: lines coincide, each probe filling the positions
-     * its own edge does not name from the bottom of their domains, so two minimum edges compose one
-     * row and which of them is offered is exactly what changes when something else is written. A row
-     * named for whichever line happened to be offered would be renamed by an edit that did not touch
-     * it. So a row composed only at lines is offered with nothing to be named after, which the
-     * language allows — an unnamed row cannot be addressed from outside, and that is the state of a
-     * row nobody has named yet.
-     *
-     * @param key      what tells this row from the others a person is handed
-     * @param inputs   the values, as the search composed them. One row's worth: rows that came out
-     *                 as one piece of work are written the same way, so which of them these came
-     *                 from is not a difference anybody can read
-     * @param namedFor the classes and arms this row was composed for, in the order they were taken
-     */
-    public record OfferedRow(RowKey key, List<FixtureTemplate> inputs,
-                             List<Generator.Purpose> namedFor) {
-
-        public OfferedRow {
-            inputs = List.copyOf(inputs);
-            namedFor = List.copyOf(namedFor);
-            for (Generator.Purpose purpose : namedFor) {
-                if (!(purpose instanceof Generator.Purpose.ForAClass
-                        || purpose instanceof Generator.Purpose.ForAnArm)) {
-                    throw new IllegalArgumentException(
-                            "a row is named after a class or an arm, and never after a line: "
-                                    + purpose);
-                }
-            }
-        }
-
-        /** The row with {@code more} added to what it may be named after. */
-        OfferedRow and(List<Generator.Purpose> more) {
-            if (more.isEmpty()) {
-                return this;
-            }
-            List<Generator.Purpose> both = new ArrayList<>(namedFor);
-            both.addAll(more);
-            return new OfferedRow(key, inputs, both);
-        }
-    }
-
-    /**
-     * What the two searches composed, before anything asks what the rows settle.
-     *
-     * <p>Not what a person is handed. A row here may answer what another here answers, and which of
-     * them goes out is settled by asking — {@link Adequacy#offeredFor} is where that happens, and
-     * what it hands back is the offering. So {@link #answered} is empty on one of these, which says
-     * nobody has asked rather than that the rows answer nothing.
-     *
-     * <p>Walked in the order the behaviors were asked about, and within a behavior the cells before
-     * the lines. The order a person is offered the rows in is the order they were composed in, and a
-     * block read against the one before it is read by somebody who did not change the model between
-     * them.
-     *
-     * @param generated one filling per behavior, keyed the way a report keys them
-     * @param declared  the rows the module's declarations are owed, or null where the request asked
-     *                  for no boundary rows. One row per point of a line however many behaviors
-     *                  carry the type, and under the behavior whose reading composed it
-     */
-    public static Offering composed(OfferingRequest request,
-                                    Map<String, Adequacy.Filling> generated,
-                                    DeclaredRows declared) {
-        Map<String, List<Generator.GeneratedRow>> owed = declared == null
-                ? Map.of() : declared.rowsByCarrier();
-        SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior = new LinkedHashMap<>();
-        for (Map.Entry<String, Adequacy.Filling> behavior : generated.entrySet()) {
-            take(byBehavior, behavior.getKey(), behavior.getValue().composed().rows(),
-                    request.boundaries()
-                            ? atTheLines(behavior.getValue().boundaries().rows(),
-                                    owed.get(behavior.getKey()))
-                            : List.of());
-        }
-        // A behavior with nothing of its own to fill can still be the one reading that composed the
-        // row a declaration is owed. Left out, that row would be resolved and then dropped on the
-        // way to the block.
-        for (Map.Entry<String, List<Generator.GeneratedRow>> carrier : owed.entrySet()) {
-            if (!generated.containsKey(carrier.getKey())) {
-                take(byBehavior, carrier.getKey(), List.of(), carrier.getValue());
-            }
-        }
-        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
-        byBehavior.forEach((behavior, here) -> out.put(behavior, List.copyOf(here.values())));
-        return new Offering(request, out, new LinkedHashMap<>(generated), declared,
-                java.util.Set.of());
-    }
-
-    /** One behavior's rows, joined onto whatever it already offers. */
-    private static void take(SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior,
-                             String behavior, List<Generator.GeneratedRow> cells,
-                             List<Generator.GeneratedRow> lines) {
-        // One block per behavior, however many kinds of row it holds. Rows of one behavior written
-        // under two headings are legal and read as two lists of something, which they are not.
-        Map<RowKey, OfferedRow> here =
-                byBehavior.computeIfAbsent(behavior, _ -> new LinkedHashMap<>());
-        for (Generator.GeneratedRow row : cells) {
-            RowKey key = RowKey.of(behavior, row);
-            here.put(key, here.computeIfAbsent(key,
-                    _ -> new OfferedRow(key, row.inputs(), List.of())).and(row.purposes()));
-        }
-        for (Generator.GeneratedRow row : lines) {
-            RowKey key = RowKey.of(behavior, row);
-            here.putIfAbsent(key, new OfferedRow(key, row.inputs(), List.of()));
-        }
-    }
-
-    /**
-     * The rows at one behavior's lines: the ones its own readings are owed, and the ones a
-     * declaration is owed that this behavior's reading composed.
-     *
-     * <p>Two sources and one list, because they are one kind of row — a value standing at a line —
-     * and what tells them apart is who owes the line rather than anything a reader of the block
-     * would act on. Where they coincide the block offers one row, which is what it already does for
-     * two of a behavior's own lines that meet.
-     *
-     * <p>Public because it is a question and not a step of the layout: what is offered at one
-     * behavior's lines is what a reader of the block beside that behavior sees, and it is asked
-     * elsewhere. Written twice, the two would come apart the day either half of the join moved.
-     */
-    public static List<Generator.GeneratedRow> atTheLines(List<Generator.GeneratedRow> own,
-                                                          List<Generator.GeneratedRow> owed) {
-        if (owed == null || owed.isEmpty()) {
-            return own;
-        }
-        List<Generator.GeneratedRow> out = new ArrayList<>(own);
-        out.addAll(owed);
-        return List.copyOf(out);
+        answered = Collections.unmodifiableSet(new LinkedHashSet<>(answered));
     }
 
     /** How many pieces of work this offers, which is what a block says at the top of it. */
     public int count() {
         return rows.values().stream().mapToInt(List::size).sum();
-    }
-
-    /**
-     * The same offering with only {@code kept} in it.
-     *
-     * <p>The rows and nothing else. What the searches came to is what they came to whatever a person
-     * is handed afterwards — a row not offered was still composed, and the note beside a search that
-     * came to nothing says what happened rather than what is in the block.
-     */
-    public Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
-        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
-        rows.forEach((behavior, here) -> {
-            List<OfferedRow> left = here.stream().filter(row -> kept.contains(row.key())).toList();
-            if (!left.isEmpty()) {
-                out.put(behavior, left);
-            }
-        });
-        return new Offering(request, out, searched, declared, answered);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -103,7 +103,12 @@ public record Offering(OfferingRequest request, SequencedMap<String, List<Offere
     }
 
     /**
-     * What a run offers, from what its two searches composed.
+     * What the two searches composed, before anything asks what the rows settle.
+     *
+     * <p>Not what a person is handed. A row here may answer what another here answers, and which of
+     * them goes out is settled by asking — {@link Adequacy#offeredFor} is where that happens, and
+     * what it hands back is the offering. So {@link #answered} is empty on one of these, which says
+     * nobody has asked rather than that the rows answer nothing.
      *
      * <p>Walked in the order the behaviors were asked about, and within a behavior the cells before
      * the lines. The order a person is offered the rows in is the order they were composed in, and a
@@ -115,8 +120,9 @@ public record Offering(OfferingRequest request, SequencedMap<String, List<Offere
      *                  for no boundary rows. One row per point of a line however many behaviors
      *                  carry the type, and under the behavior whose reading composed it
      */
-    public static Offering of(OfferingRequest request, Map<String, Adequacy.Filling> generated,
-                              DeclaredRows declared) {
+    public static Offering composed(OfferingRequest request,
+                                    Map<String, Adequacy.Filling> generated,
+                                    DeclaredRows declared) {
         Map<String, List<Generator.GeneratedRow>> owed = declared == null
                 ? Map.of() : declared.rowsByCarrier();
         SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -1,0 +1,182 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.FixtureTemplate;
+import souther.compiler.partition.Generator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+
+/**
+ * The rows one run hands a person, under the behavior each is written for.
+ *
+ * <p>What a run offers is one answer, made where both halves of it are. A behavior's own rows and
+ * the rows a declaration's line is owed are composed by two searches asked in two ways, and they
+ * meet as work for one person: a line is one piece of work and is offered once, in the terms of
+ * whichever reading composed it. Put together where the block is written, the meeting was a step of
+ * the layout — so what a run offers could only be said by printing it.
+ *
+ * <p>Nothing here is evidence of coverage. A row this holds is a question — these inputs, and what
+ * does the system answer? — and what it would settle if it were written is not something this says.
+ *
+ * <p>And what the two searches came to beside the rows they composed, which is the other half of
+ * what a person is owed: a block that printed only what it managed would read as though it had
+ * filled everything. The rows are this one's answer; those are the searches' own, carried here so
+ * that whoever writes the block asks one question rather than putting the halves together again.
+ *
+ * @param request  what was asked for, which is what settles which rows are here
+ * @param rows     one entry per behavior with rows to offer, in the order they were asked about
+ * @param searched what each behavior's own search came to, keyed the way a report keys them
+ * @param declared what the module's declarations are owed, or null where the request asked for no
+ *                 boundary rows — which is not the same as a request that asked and found none
+ */
+public record Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
+                       SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared) {
+
+    public Offering {
+        rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
+        searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
+    }
+
+    /**
+     * One row as it will be written, and what it may be named after.
+     *
+     * <p>A candidate is composed once per thing it is owed for and the positions that thing does not
+     * name hold whatever the row has to hold, so two of them can come out as one row. What is
+     * offered is the row: a reader is handed one piece of work rather than the same values twice.
+     *
+     * <p><b>Every purpose a cell composed it for, and not the first.</b> Two purposes converging on
+     * one row is a fact about this run, and keeping one of them leaves a name that says the row is
+     * about one thing while it answers two.
+     *
+     * <p><b>And nothing from a line.</b> A cell can name a row — a candidate's values follow from
+     * the classes it was composed for, so the cell a row is named by is the row's own and is there
+     * whatever else this run offers. A line cannot: lines coincide, each probe filling the positions
+     * its own edge does not name from the bottom of their domains, so two minimum edges compose one
+     * row and which of them is offered is exactly what changes when something else is written. A row
+     * named for whichever line happened to be offered would be renamed by an edit that did not touch
+     * it. So a row composed only at lines is offered with nothing to be named after, which the
+     * language allows — an unnamed row cannot be addressed from outside, and that is the state of a
+     * row nobody has named yet.
+     *
+     * @param key      what tells this row from the others a person is handed
+     * @param inputs   the values, as the search composed them. One row's worth: rows that came out
+     *                 as one piece of work are written the same way, so which of them these came
+     *                 from is not a difference anybody can read
+     * @param namedFor the classes and arms this row was composed for, in the order they were taken
+     */
+    public record OfferedRow(RowKey key, List<FixtureTemplate> inputs,
+                             List<Generator.Purpose> namedFor) {
+
+        public OfferedRow {
+            inputs = List.copyOf(inputs);
+            namedFor = List.copyOf(namedFor);
+            for (Generator.Purpose purpose : namedFor) {
+                if (!(purpose instanceof Generator.Purpose.ForAClass
+                        || purpose instanceof Generator.Purpose.ForAnArm)) {
+                    throw new IllegalArgumentException(
+                            "a row is named after a class or an arm, and never after a line: "
+                                    + purpose);
+                }
+            }
+        }
+
+        /** The row with {@code more} added to what it may be named after. */
+        OfferedRow and(List<Generator.Purpose> more) {
+            if (more.isEmpty()) {
+                return this;
+            }
+            List<Generator.Purpose> both = new ArrayList<>(namedFor);
+            both.addAll(more);
+            return new OfferedRow(key, inputs, both);
+        }
+    }
+
+    /**
+     * What a run offers, from what its two searches composed.
+     *
+     * <p>Walked in the order the behaviors were asked about, and within a behavior the cells before
+     * the lines. The order a person is offered the rows in is the order they were composed in, and a
+     * block read against the one before it is read by somebody who did not change the model between
+     * them.
+     *
+     * @param generated one filling per behavior, keyed the way a report keys them
+     * @param declared  the rows the module's declarations are owed, or null where the request asked
+     *                  for no boundary rows. One row per point of a line however many behaviors
+     *                  carry the type, and under the behavior whose reading composed it
+     */
+    public static Offering of(OfferingRequest request, Map<String, Adequacy.Filling> generated,
+                              DeclaredRows declared) {
+        Map<String, List<Generator.GeneratedRow>> owed = declared == null
+                ? Map.of() : declared.rowsByCarrier();
+        SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior = new LinkedHashMap<>();
+        for (Map.Entry<String, Adequacy.Filling> behavior : generated.entrySet()) {
+            take(byBehavior, behavior.getKey(), behavior.getValue().composed().rows(),
+                    request.boundaries()
+                            ? atTheLines(behavior.getValue().boundaries().rows(),
+                                    owed.get(behavior.getKey()))
+                            : List.of());
+        }
+        // A behavior with nothing of its own to fill can still be the one reading that composed the
+        // row a declaration is owed. Left out, that row would be resolved and then dropped on the
+        // way to the block.
+        for (Map.Entry<String, List<Generator.GeneratedRow>> carrier : owed.entrySet()) {
+            if (!generated.containsKey(carrier.getKey())) {
+                take(byBehavior, carrier.getKey(), List.of(), carrier.getValue());
+            }
+        }
+        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
+        byBehavior.forEach((behavior, here) -> out.put(behavior, List.copyOf(here.values())));
+        return new Offering(request, out, new LinkedHashMap<>(generated), declared);
+    }
+
+    /** One behavior's rows, joined onto whatever it already offers. */
+    private static void take(SequencedMap<String, Map<RowKey, OfferedRow>> byBehavior,
+                             String behavior, List<Generator.GeneratedRow> cells,
+                             List<Generator.GeneratedRow> lines) {
+        // One block per behavior, however many kinds of row it holds. Rows of one behavior written
+        // under two headings are legal and read as two lists of something, which they are not.
+        Map<RowKey, OfferedRow> here =
+                byBehavior.computeIfAbsent(behavior, _ -> new LinkedHashMap<>());
+        for (Generator.GeneratedRow row : cells) {
+            RowKey key = RowKey.of(behavior, row);
+            here.put(key, here.computeIfAbsent(key,
+                    _ -> new OfferedRow(key, row.inputs(), List.of())).and(row.purposes()));
+        }
+        for (Generator.GeneratedRow row : lines) {
+            RowKey key = RowKey.of(behavior, row);
+            here.putIfAbsent(key, new OfferedRow(key, row.inputs(), List.of()));
+        }
+    }
+
+    /**
+     * The rows at one behavior's lines: the ones its own readings are owed, and the ones a
+     * declaration is owed that this behavior's reading composed.
+     *
+     * <p>Two sources and one list, because they are one kind of row — a value standing at a line —
+     * and what tells them apart is who owes the line rather than anything a reader of the block
+     * would act on. Where they coincide the block offers one row, which is what it already does for
+     * two of a behavior's own lines that meet.
+     *
+     * <p>Public because it is a question and not a step of the layout: what is offered at one
+     * behavior's lines is what a reader of the block beside that behavior sees, and it is asked
+     * elsewhere. Written twice, the two would come apart the day either half of the join moved.
+     */
+    public static List<Generator.GeneratedRow> atTheLines(List<Generator.GeneratedRow> own,
+                                                          List<Generator.GeneratedRow> owed) {
+        if (owed == null || owed.isEmpty()) {
+            return own;
+        }
+        List<Generator.GeneratedRow> out = new ArrayList<>(own);
+        out.addAll(owed);
+        return List.copyOf(out);
+    }
+
+    /** How many pieces of work this offers, which is what a block says at the top of it. */
+    public int count() {
+        return rows.values().stream().mapToInt(List::size).sum();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -32,13 +32,20 @@ import java.util.SequencedMap;
  * @param searched what each behavior's own search came to, keyed the way a report keys them
  * @param declared what the module's declarations are owed, or null where the request asked for no
  *                 boundary rows — which is not the same as a request that asked and found none
+ * @param answered what the rows here settle: every item one of them would answer if it were
+ *                 written, whichever row it was composed for. Empty on a composition nobody has
+ *                 put the question to, which is a run that has not been asked rather than one whose
+ *                 rows answer nothing
  */
 public record Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
-                       SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared) {
+                       SequencedMap<String, Adequacy.Filling> searched, DeclaredRows declared,
+                       java.util.Set<OfferItem> answered) {
 
     public Offering {
         rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
         searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
+        answered = java.util.Collections.unmodifiableSet(
+                new java.util.LinkedHashSet<>(answered));
     }
 
     /**
@@ -130,7 +137,8 @@ public record Offering(OfferingRequest request, SequencedMap<String, List<Offere
         }
         SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
         byBehavior.forEach((behavior, here) -> out.put(behavior, List.copyOf(here.values())));
-        return new Offering(request, out, new LinkedHashMap<>(generated), declared);
+        return new Offering(request, out, new LinkedHashMap<>(generated), declared,
+                java.util.Set.of());
     }
 
     /** One behavior's rows, joined onto whatever it already offers. */
@@ -178,5 +186,23 @@ public record Offering(OfferingRequest request, SequencedMap<String, List<Offere
     /** How many pieces of work this offers, which is what a block says at the top of it. */
     public int count() {
         return rows.values().stream().mapToInt(List::size).sum();
+    }
+
+    /**
+     * The same offering with only {@code kept} in it.
+     *
+     * <p>The rows and nothing else. What the searches came to is what they came to whatever a person
+     * is handed afterwards — a row not offered was still composed, and the note beside a search that
+     * came to nothing says what happened rather than what is in the block.
+     */
+    public Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
+        SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
+        rows.forEach((behavior, here) -> {
+            List<OfferedRow> left = here.stream().filter(row -> kept.contains(row.key())).toList();
+            if (!left.isEmpty()) {
+                out.put(behavior, left);
+            }
+        });
+        return new Offering(request, out, searched, declared, answered);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/OfferingRequest.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OfferingRequest.java
@@ -1,0 +1,39 @@
+package souther.compiler.query;
+
+/**
+ * What one run was asked to offer rows for.
+ *
+ * <p>Everything that decides which rows a run composes, said in one value. Which readings it may
+ * walk is one half ({@link GenerationScope}) and whether it was asked about the lines a model draws
+ * is the other, and a request stating only the first cannot tell two runs apart that offer different
+ * rows: the lines are searched for one of them and not the other, so a reader handed the answer
+ * would have no way of knowing which question it answers.
+ *
+ * <p>Said by the caller before anything is asked, for the reason the scope is. What a run offers
+ * follows from what was asked for, and a request that read either half back off what some earlier
+ * caller happened to have paid for would answer differently depending on the order the requests
+ * arrived in.
+ *
+ * @param module     the module the rows are about
+ * @param scope      which readings of a declaration's line this request searches
+ * @param boundaries whether the rows at the lines a model draws were asked for
+ */
+public record OfferingRequest(String module, GenerationScope scope, boolean boundaries) {
+
+    public OfferingRequest {
+        if (module == null || scope == null) {
+            throw new IllegalArgumentException("a request for rows is about a module, over some"
+                    + " readings of it: " + module + " " + scope);
+        }
+    }
+
+    /** What a caller printing a block for the whole module asks: every reading of it. */
+    public static OfferingRequest overTheModule(String module, boolean boundaries) {
+        return new OfferingRequest(module, new GenerationScope.Module(), boundaries);
+    }
+
+    /** Whether {@code behavior}'s own rows are part of what this asks for. */
+    public boolean admits(String behavior) {
+        return scope.admits(behavior);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
@@ -176,18 +176,35 @@ public final class OwedBoundaryPoint {
     }
 
     /**
-     * The account with one entry per point of a line rather than one per thing owed there.
+     * The places a row is composed at, one per point of a line rather than one per thing owed there.
      *
-     * <p>For a reader whose unit is the row and not the obligation. A row stands at a point of a
-     * line, and what a row there shows answers everything a row there is owed for — so a place two
-     * of this body's rules drew a line at is two things to be told about and one value to compose.
-     * Walked as the obligations, a search that composed one value would offer it twice.
+     * <p><b>Its own type, because it is not the account.</b> What is dropped getting here is
+     * {@link OwedBoundaryPoint#owed()} — the thing owed, which is what tells two obligations at one
+     * point apart — so a reader whose unit is the obligation and one whose unit is the row want
+     * different lists. Handed back as the account's own type, either could be passed where the other
+     * was meant, and the one that wanted the obligations would silently be given as many as there
+     * are points.
      *
-     * <p>What is dropped is {@link #owed()} and nothing else: the entries that come back name one of
-     * the things owed at their point, and everything a row is composed and labelled from — the line,
-     * the role and what was measured — is the same at all of them.
+     * @param at one entry per point, each naming one of the things owed there. Everything a row is
+     *           composed and labelled from — the line, the role and what was measured — is the same
+     *           at all of them, which is what makes one value enough
      */
-    public static List<OwedBoundaryPoint> oneForEachPoint(List<OwedBoundaryPoint> account) {
+    public record WhereARowIsComposed(List<OwedBoundaryPoint> at) {
+
+        public WhereARowIsComposed {
+            at = List.copyOf(at);
+        }
+    }
+
+    /**
+     * The account read as the places a row is composed at.
+     *
+     * <p>A row stands at a point of a line, and what a row there shows answers everything a row
+     * there is owed for — so a place two of this body's rules drew a line at is two things to be
+     * told about and one value to compose. Walked as the obligations, a search that composed one
+     * value would offer it twice.
+     */
+    public static WhereARowIsComposed oneForEachPoint(List<OwedBoundaryPoint> account) {
         List<OwedBoundaryPoint> at = new ArrayList<>();
         for (OwedBoundaryPoint each : account) {
             if (at.stream().noneMatch(
@@ -195,7 +212,7 @@ public final class OwedBoundaryPoint {
                 at.add(each);
             }
         }
-        return List.copyOf(at);
+        return new WhereARowIsComposed(at);
     }
 
     /** The position the line is on, as a report names it. */

--- a/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
@@ -200,11 +200,15 @@ public final class OwedBoundaryPoint {
      * The points this run was asked for a row at, which is not everything that is owed one.
      *
      * <p><b>Its own type, because it is not the account either.</b> What is owed is what the lines
-     * ask of the rows; what a generation is asked for is that less what the measurement has already
-     * settled — a point a written row stands at, and a point nothing measured. Read as the account,
-     * a run counts work nobody is owed: a candidate that stands where a written row already stands
-     * is the only offer for a point in nobody's way, so nothing may drop it and it goes out beside
-     * the row that made it unnecessary.
+     * ask of the rows; what a generation is asked for is the part of that
+     * {@link ItemAssessment.Owed#worthSearching()} says a candidate would tell anybody anything at.
+     * Which of the two a caller means is not restated here — the measurement's answer is the
+     * authority, and a second reading of it would be free to disagree with the search, which is
+     * gated on the same one.
+     *
+     * <p>Read as the account, a run counts work nobody is owed: a candidate that stands where a
+     * written row already stands is the only offer for a point in nobody's way, so nothing may drop
+     * it and it goes out beside the row that made it unnecessary.
      *
      * @param at the points, in the account's own order
      */

--- a/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OwedBoundaryPoint.java
@@ -197,6 +197,43 @@ public final class OwedBoundaryPoint {
     }
 
     /**
+     * The points this run was asked for a row at, which is not everything that is owed one.
+     *
+     * <p><b>Its own type, because it is not the account either.</b> What is owed is what the lines
+     * ask of the rows; what a generation is asked for is that less what the measurement has already
+     * settled — a point a written row stands at, and a point nothing measured. Read as the account,
+     * a run counts work nobody is owed: a candidate that stands where a written row already stands
+     * is the only offer for a point in nobody's way, so nothing may drop it and it goes out beside
+     * the row that made it unnecessary.
+     *
+     * @param at the points, in the account's own order
+     */
+    public record WhereARowWasAskedFor(List<OwedBoundaryPoint> at) {
+
+        public WhereARowWasAskedFor {
+            at = List.copyOf(at);
+        }
+    }
+
+    /**
+     * The account read as what this run has to offer a row for.
+     *
+     * <p>Asked of {@link ItemAssessment.Owed#worthSearching()} and of nothing else. Whether a
+     * candidate here would tell anybody anything is the measurement's answer — it is what the search
+     * itself is gated on — and a second reading of it would be a second answer to one question,
+     * free to disagree the day either moved.
+     */
+    public static WhereARowWasAskedFor askedForARow(List<OwedBoundaryPoint> account) {
+        List<OwedBoundaryPoint> at = new ArrayList<>();
+        for (OwedBoundaryPoint each : account) {
+            if (each.item().worthSearching()) {
+                at.add(each);
+            }
+        }
+        return new WhereARowWasAskedFor(at);
+    }
+
+    /**
      * The account read as the places a row is composed at.
      *
      * <p>A row stands at a point of a line, and what a row there shows answers everything a row

--- a/souther-compiler/src/main/java/souther/compiler/query/RowKey.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/RowKey.java
@@ -1,0 +1,47 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.FixtureTemplate;
+import souther.compiler.partition.Generator;
+
+import java.util.List;
+
+/**
+ * What tells one piece of work from another among the rows a run offers.
+ *
+ * <p>The row as a person is handed it: the behavior it is written under and the values it is written
+ * with, in the form they will be written in. A candidate is composed once per thing it is owed for
+ * and the positions that thing does not name hold whatever the row has to hold, so two of them come
+ * out as one piece of work — and what a reader would otherwise be pasting twice is one row here.
+ *
+ * <p><b>What is written, and not what the values are.</b> Two rows of one behavior that mean the
+ * same thing and are spelt differently stay two rows, each answering what it was composed for. That
+ * is the direction to be wrong in: a person reads the row, and an identity over the values would
+ * need something none of them has — a fixture carries the position it was parsed at and the path it
+ * was constructed through, neither of which is what a reader is looking at.
+ *
+ * <p>Under one behavior, because a row is written in one behavior's terms. The same values written
+ * for two behaviors are two rows in two blocks, and a key that left the behavior out would join them
+ * into one piece of work nobody can write.
+ *
+ * @param behavior the behavior the row is written under
+ * @param written  one value per parameter, as the source an author is handed
+ */
+public record RowKey(String behavior, List<String> written) {
+
+    public RowKey {
+        written = List.copyOf(written);
+        if (behavior == null) {
+            throw new IllegalArgumentException("a row is written under some behavior");
+        }
+    }
+
+    /** The key of one composed row, under the behavior whose block it belongs in. */
+    public static RowKey of(String behavior, Generator.GeneratedRow row) {
+        return new RowKey(behavior, row.inputs().stream().map(FixtureTemplate::text).toList());
+    }
+
+    /** The values as one line, which is how a row reads where it is written. */
+    public String inputs() {
+        return String.join(", ", written);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlement.java
@@ -1,0 +1,64 @@
+package souther.compiler.query;
+
+/**
+ * What one row a run offers would do about one thing the run is asked to offer a row for.
+ *
+ * <p>A conditional and never a measure. What this says is that <em>if</em> the row were written, the
+ * item would be answered — which is a fact about the offering, not about the file. A row this run
+ * composed is a question with no answer written yet, and nothing here makes it evidence that
+ * anything is covered.
+ *
+ * <p><b>Three answers, because not found is not the same as not known.</b> A run nobody watched
+ * cannot say which arms a row takes; a value the decoders would not build cannot be placed anywhere.
+ * Read as a miss, either of them would let a row be dropped that was the only one answering
+ * something — so only {@link Settles} may ever be acted on, and the other two differ in what a
+ * reader may do about them: one is an answer, the other is the absence of one.
+ */
+public sealed interface Settlement {
+
+    /** The row answers the item. */
+    record Settles() implements Settlement {}
+
+    /** It does not: this was read, and what it holds is not what the item asks for. */
+    record DoesNotSettle() implements Settlement {}
+
+    /** Nothing here can tell. */
+    record Undetermined(Reason why) implements Settlement {
+
+        public Undetermined {
+            if (why == null) {
+                throw new IllegalArgumentException("not knowing is for a reason");
+            }
+        }
+    }
+
+    /**
+     * Why a row and an item could not be put together.
+     *
+     * <p>What was observed and never why the run was arranged as it was. Whether this build runs the
+     * rows it composes is what the caller asked for, and a reason that named it would be answering a
+     * question about the request in an answer about a row.
+     */
+    enum Reason {
+
+        /** There is no account of the row's run, so which arms it takes is not something anything
+         *  here saw. */
+        NO_ACCOUNT_OF_THE_RUN,
+
+        /** Nothing built the row's values, so where they sit is not something anything here read. */
+        NOTHING_BUILT_THE_VALUES,
+
+        /** Something built them and the model refused one, so there is no value to place. Beside
+         *  the one above rather than folded into it: a run with nothing to build against found out
+         *  nothing, and this found out that the value the row names is not one the model takes. */
+        THE_VALUES_WERE_REFUSED,
+
+        /** They were built and the walk to the item could not read one of them. */
+        THE_VALUES_COULD_NOT_BE_READ
+    }
+
+    /** Whether a reader may act on this, which only one of the three allows. */
+    default boolean settles() {
+        return this instanceof Settles;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -57,28 +57,51 @@ public record Settlements(List<OfferItem> requested,
     }
 
     /**
+     * What a set of rows puts in front of a person for one item.
+     *
+     * <p>Two ways, and a reduction has to keep both. A row that settles the item answers it whoever
+     * it was composed for; and the row composed <em>for</em> the item is what a person was offered
+     * for it, whether or not this walk can tell that it settles it — a row whose reading came back
+     * undetermined is still the one piece of work anybody was handed there.
+     *
+     * <p>Written once because it is what {@link #keeping()} preserves. Said as two rules in two
+     * places, the second is the one a later reader drops as an oversight.
+     */
+    public boolean offers(Set<RowKey> rows, OfferItem item) {
+        for (RowKey row : rows) {
+            if (byRow.get(row).get(item).settles()) {
+                return true;
+            }
+        }
+        return rows.contains(composedFor.get(item));
+    }
+
+    /**
      * The rows to keep: every one whose going would cost the offering something.
      *
-     * <p><b>What is preserved is what the offering can do, and not what each row was for.</b> Two
-     * things would go wrong with a rule written per row. One is that a row's own purpose can be
-     * handed on and then handed on again — a row answering what another was for is itself dropped
-     * for a third, and the first item ends up answered by nothing — so what is counted is how many
-     * kept rows settle each item, and a row goes only while every item it settles is settled by
-     * another. The other is that an item whose row settles nothing this could tell about would lose
-     * the only row anybody was offered for it, so a row also stays while something composed for it
-     * is not settled elsewhere.
+     * <p>What is preserved is {@link #offers}, for every item. So the result holds, of the rows
+     * {@code R*} it comes back with and the rows {@code R} it was given:
      *
-     * <p>Only {@link Settlement.Settles} counts. A row that cannot be told about is not a row that
-     * answers, and counting it would drop the row that did.
+     * <ol>
+     *   <li>every item {@code R} offers something for, {@code R*} offers something for;</li>
+     *   <li>no row of {@code R*} can go and leave that true.</li>
+     * </ol>
+     *
+     * <p><b>Which is not "every row left settles something nothing else does".</b> A row kept by the
+     * second half of {@code offers} settles nothing this could tell about — it is there because it
+     * is the only thing composed for its item — and a reduction written to the shorter sentence
+     * would drop it and take that item's only offer with it.
+     *
+     * <p>Nor is it the smallest set: a different, smaller set of rows may offer for the same items.
+     * Irredundant is what this is, and finding a minimum is a different question.
+     *
+     * <p>Only {@link Settlement.Settles} counts as settling. A row that cannot be told about is not
+     * a row that answers, and counting it would drop the row that did.
      *
      * <p>Walked from the back, so a row that came first stays. Which of two rows answering the same
      * things a person is handed is arbitrary, and taking the earlier one keeps the block steady:
      * the order rows are composed in is the order the searches were asked, and an edit somewhere
      * later in the model does not move what is offered above it.
-     *
-     * <p>What comes out is irredundant and not smallest. Every row left is the only kept row
-     * settling something, so nothing more can go without the offering answering less; a smaller set
-     * answering the same items may exist, and finding one is a different question from this.
      */
     public Set<RowKey> keeping() {
         Map<OfferItem, Integer> count = new LinkedHashMap<>();
@@ -115,11 +138,12 @@ public record Settlements(List<OfferItem> requested,
     }
 
     /**
-     * Whether the offering answers as much without {@code row} as with it.
+     * Whether the offering offers as much without {@code row} as with it — {@link #offers} for
+     * every item, read off the counts rather than walked again.
      *
-     * <p>Asked of the counts, which hold the kept rows and this one among them. So an item this row
-     * settles needs a second settler to be left after it goes, and an item it was composed for and
-     * settles nothing of needs one at all.
+     * <p>The counts hold the kept rows and this one among them. So an item this row settles needs a
+     * second settler to be left after it goes, and an item it was composed for and settles nothing
+     * of needs one at all: without a settler, taking the row away takes the item's only offer.
      *
      * @param composedHere what this row was composed for
      */
@@ -271,11 +295,13 @@ public record Settlements(List<OfferItem> requested,
                 List<BorderAssessment> edges =
                         db.ask(new Adequacy.BoundarySearch(module, behavior)).value();
                 if (edges != null) {
-                    // One entry per point, which is what a row standing there answers. Two readings
-                    // of one line at one role are one thing to be told about, and the walk that
-                    // offers the rows takes the same view.
-                    for (OwedBoundaryPoint point
-                            : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(edges))) {
+                    // The account, and not the places a row is composed at. Those drop what tells
+                    // two obligations at one point apart — a region stopped by two different things
+                    // is two of them — and this is asking what the run is owed rather than how many
+                    // values it has to compose. Dropped here, the second obligation would be in no
+                    // item universe: nothing would count a row as settling it, and a note saying
+                    // nothing offers a row for it would print over the row that stands there.
+                    for (OwedBoundaryPoint point : OwedBoundaryPoint.across(edges)) {
                         OfferItem.APointOfALine item =
                                 new OfferItem.APointOfALine(point.owed());
                         owedHere.put(item, point);

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -188,7 +188,7 @@ public record Settlements(List<OfferItem> requested,
      * questions a measurement puts to the rows in a file, put here to the rows a person is being
      * handed.
      */
-    public static Settlements of(Db db, Offering offering) {
+    public static Settlements of(Db db, Composition offering) {
         String module = offering.request().module();
         Map<String, Sig> sigs = db.ask(new Bodies.Signatures(module)).value();
         BoundaryValues building = Adequacy.constructing(db, module);
@@ -248,7 +248,7 @@ public record Settlements(List<OfferItem> requested,
         List<OfferItem> items = List.copyOf(new LinkedHashSet<>(requested));
         offering.rows().forEach((behavior, rows) -> {
             OneBehavior read = reading.get(behavior);
-            for (Offering.OfferedRow row : rows) {
+            for (OfferedRow row : rows) {
                 // Read once for the row and asked of every item. What a row is — where its values
                 // sit and what running it recorded — does not change between the questions put to
                 // it, and reading it per item would be the same row read as many times as this run

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -1,0 +1,340 @@
+package souther.compiler.query;
+
+import souther.compiler.check.Sig;
+import souther.compiler.execute.BoundaryValues;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.partition.Axis;
+import souther.compiler.partition.BehaviorInputs;
+import souther.compiler.partition.FixtureTemplate;
+import souther.compiler.partition.Generator;
+import souther.compiler.partition.InputClassifications;
+import souther.compiler.partition.ObservedInputs;
+import souther.compiler.partition.StandingAtAPoint;
+import souther.compiler.observe.Classification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+import java.util.Set;
+
+/**
+ * What each row a run offers would do about each thing the run was asked to offer a row for.
+ *
+ * <p>The whole table and not the diagonal. A row is composed for one thing, and what else it turns
+ * out to answer is the question this exists to put — so every row is asked about every item, and a
+ * row's own item is one entry of its column like any other.
+ *
+ * <p><b>The items are what was asked for.</b> They come from the plan a run was made with and from
+ * the points its searches were put, never from what the rows say they were composed for: a row
+ * carries the classes and arms it may be named after and never a line, so an item universe read off
+ * the rows would be missing every line in the block.
+ *
+ * <p>Nothing here is a measurement. Each entry says what would follow if the row were written, and
+ * the rows are questions nobody has answered yet.
+ */
+public record Settlements(List<OfferItem> requested,
+                          SequencedMap<OfferItem, RowKey> composedFor,
+                          SequencedMap<RowKey, Map<OfferItem, Settlement>> byRow) {
+
+    public Settlements {
+        requested = List.copyOf(requested);
+        composedFor = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(composedFor));
+        byRow = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(byRow));
+    }
+
+    /** What {@code row} would do about {@code item}, for a reader holding both. */
+    public Settlement at(RowKey row, OfferItem item) {
+        Map<OfferItem, Settlement> here = byRow.get(row);
+        if (here == null || !here.containsKey(item)) {
+            throw new IllegalArgumentException("no entry for " + row + " at " + item);
+        }
+        return here.get(item);
+    }
+
+    /** The items some row of this offering settles, which is what a reduction has to keep answered. */
+    public Set<OfferItem> settled() {
+        Set<OfferItem> out = new LinkedHashSet<>();
+        for (OfferItem item : requested) {
+            for (Map<OfferItem, Settlement> here : byRow.values()) {
+                if (here.get(item).settles()) {
+                    out.add(item);
+                    break;
+                }
+            }
+        }
+        return Collections.unmodifiableSet(out);
+    }
+
+    /**
+     * The table for one offering.
+     *
+     * <p>Read with the same walk a written row is read with. Where a candidate's values sit is
+     * {@link InputClassifications}'s answer, whether it stands at a line is
+     * {@link StandingAtAPoint}'s, and which arms it takes is what running it recorded — the three
+     * questions a measurement puts to the rows in a file, put here to the rows a person is being
+     * handed.
+     */
+    public static Settlements of(Db db, Offering offering) {
+        String module = offering.request().module();
+        Map<String, Sig> sigs = db.ask(new Bodies.Signatures(module)).value();
+        BoundaryValues building = Adequacy.constructing(db, module);
+        souther.compiler.execute.RowTrials trials = Adequacy.trialling(db, module);
+        List<OfferItem> requested = new ArrayList<>();
+        SequencedMap<OfferItem, RowKey> composedFor = new LinkedHashMap<>();
+        SequencedMap<RowKey, Map<OfferItem, Settlement>> byRow = new LinkedHashMap<>();
+        Map<String, OneBehavior> reading = new LinkedHashMap<>();
+        for (Map.Entry<String, Adequacy.Filling> behavior : offering.searched().entrySet()) {
+            OneBehavior read = OneBehavior.of(db, module, behavior.getKey(), behavior.getValue(),
+                    sigs == null ? null : sigs.get(behavior.getKey()), building, trials,
+                    offering.request().boundaries());
+            reading.put(behavior.getKey(), read);
+            requested.addAll(read.owed());
+            composedFor.putAll(read.composed(behavior.getValue()));
+        }
+        // And the points the module's declarations are owed, which are no behavior's own. A row of
+        // whichever behavior composed one answers the line for everybody, so they are items of the
+        // offering rather than of the block a row happens to sit in.
+        if (offering.declared() != null) {
+            offering.declared().resolved().forEach((point, answer) -> {
+                OfferItem item = new OfferItem.APointOfALine(point);
+                requested.add(item);
+                if (answer.resolution() instanceof DeclarationResolution.Generated(var by,
+                        var row)) {
+                    composedFor.put(item, RowKey.of(by, row));
+                }
+            });
+        }
+        List<OfferItem> items = List.copyOf(new LinkedHashSet<>(requested));
+        offering.rows().forEach((behavior, rows) -> {
+            OneBehavior read = reading.get(behavior);
+            for (Offering.OfferedRow row : rows) {
+                // Read once for the row and asked of every item. What a row is — where its values
+                // sit and what running it recorded — does not change between the questions put to
+                // it, and reading it per item would be the same row read as many times as this run
+                // happens to be asked about, at the price of running it that many times.
+                OneRow one = read == null ? OneRow.nothingRead() : read.read(row.inputs());
+                Map<OfferItem, Settlement> here = new LinkedHashMap<>();
+                for (OfferItem item : items) {
+                    here.put(item, read == null ? one.undetermined() : read.settlementOf(one, item));
+                }
+                byRow.put(row.key(), Collections.unmodifiableMap(here));
+            }
+        });
+        return new Settlements(items, composedFor, byRow);
+    }
+
+    /**
+     * One behavior's own reading of a candidate: what it is asked for, and how a row of it is read.
+     *
+     * <p>Made once per behavior and not once per row. What a row is read against — where its
+     * positions are, what the model divides them into, and which lines this behavior's readings meet
+     * — is the behavior's and does not move between the rows of one block.
+     */
+    private record OneBehavior(String behavior, BehaviorInputs where, List<Axis> axes, Sig sig,
+                               BoundaryValues building, Generator.Trial trial,
+                               List<Generator.ClassOwed> classes, List<Generator.ArmOwed> arms,
+                               Map<OfferItem.APointOfALine, OwedBoundaryPoint> points) {
+
+        static OneBehavior of(Db db, String module, String behavior, Adequacy.Filling filling,
+                              Sig sig, BoundaryValues building,
+                              souther.compiler.execute.RowTrials trials, boolean boundaries) {
+            Generator.Subject subject = filling.composed().plan().subject();
+            Map<OfferItem.APointOfALine, OwedBoundaryPoint> points = new LinkedHashMap<>();
+            if (boundaries) {
+                List<BorderAssessment> edges =
+                        db.ask(new Adequacy.BoundarySearch(module, behavior)).value();
+                if (edges != null) {
+                    // One entry per point, which is what a row standing there answers. Two readings
+                    // of one line at one role are one thing to be told about, and the walk that
+                    // offers the rows takes the same view.
+                    OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(edges))
+                            .forEach(point -> points.put(
+                                    new OfferItem.APointOfALine(point.owed()), point));
+                }
+            }
+            return new OneBehavior(behavior, subject.inputs(), subject.axes(), sig, building,
+                    sig == null || trials == null ? Generator.Trial.NOTHING_RUNS
+                            : Adequacy.runningRowsOf(trials, behavior, sig),
+                    filling.composed().plan().classesOwed(), filling.composed().plan().armsOwed(),
+                    points);
+        }
+
+        /**
+         * Which row was composed for each of them, where one was.
+         *
+         * <p>Read off what the searches answered with and never off the rows. A row carries the
+         * classes and arms it may be named after and never a line, so a walk from the rows would
+         * have every line in the block composed for nothing.
+         */
+        Map<OfferItem, RowKey> composed(Adequacy.Filling filling) {
+            Map<OfferItem, RowKey> out = new LinkedHashMap<>();
+            for (Generator.ClassOwed each : classes) {
+                if (filling.composed().discharge().at(each)
+                        instanceof souther.compiler.partition.ClassDisposition.Built built) {
+                    out.put(new OfferItem.AClass(each),
+                            RowKey.of(behavior, filling.composed().rowFor(built.row())));
+                }
+            }
+            for (Generator.ArmOwed each : arms) {
+                if (filling.composed().discharge().at(each)
+                        instanceof souther.compiler.partition.ArmDisposition.Built built) {
+                    out.put(new OfferItem.AnArm(each),
+                            RowKey.of(behavior, filling.composed().rowFor(built.row())));
+                }
+            }
+            points.forEach((item, point) -> {
+                if (point.item().attempt() instanceof ItemAssessment.Attempt.Built built) {
+                    out.put(item, RowKey.of(behavior, built.row()));
+                }
+            });
+            return out;
+        }
+
+        /** What this behavior was asked to offer a row for. */
+        List<OfferItem> owed() {
+            List<OfferItem> out = new ArrayList<>();
+            classes.forEach(each -> out.add(new OfferItem.AClass(each)));
+            arms.forEach(each -> out.add(new OfferItem.AnArm(each)));
+            out.addAll(points.keySet());
+            return out;
+        }
+
+        /**
+         * The row as the two things every question here is put to.
+         *
+         * <p>Made once. The values are built through this module's own decoders and the account is
+         * what running it recorded — and a row read again for the next item would be run again for
+         * it, which is the same row asked to do the same thing as many times as this run has
+         * questions.
+         */
+        OneRow read(List<FixtureTemplate> inputs) {
+            Generator.Watched watched = trial.run(inputs);
+            if (building == null || sig == null) {
+                return new OneRow(null, Settlement.Reason.NOTHING_BUILT_THE_VALUES, watched);
+            }
+            List<ObservedValue> values = new ArrayList<>();
+            for (int at = 0; at < inputs.size(); at++) {
+                if (at >= sig.ins().size()) {
+                    return new OneRow(null, Settlement.Reason.NOTHING_BUILT_THE_VALUES, watched);
+                }
+                switch (building.build(sig.ins().get(at), inputs.get(at).value())) {
+                    case BoundaryValues.Built.Value(var observed) -> values.add(observed);
+                    // The model would not take the value the row names. Told apart from having
+                    // nothing to build against: this found something out about the row, and that
+                    // found nothing out at all.
+                    case BoundaryValues.Built.Refused _ -> {
+                        return new OneRow(null, Settlement.Reason.THE_VALUES_WERE_REFUSED, watched);
+                    }
+                }
+            }
+            return new OneRow(List.copyOf(values), null, watched);
+        }
+
+        Settlement settlementOf(OneRow row, OfferItem item) {
+            return switch (item) {
+                case OfferItem.AClass(var owed) -> inClass(row, owed);
+                case OfferItem.AnArm(var owed) -> throughArm(row, owed);
+                case OfferItem.APointOfALine at -> atThePoint(row, at);
+            };
+        }
+
+        /**
+         * Whether the row's value at the position falls in the class.
+         *
+         * <p>Of this behavior's positions only. An axis names the behavior it divides, so a class of
+         * another one is not something a row written here has a value at — which is a row that does
+         * not settle it rather than one nothing could tell about.
+         */
+        private Settlement inClass(OneRow row, Generator.ClassOwed owed) {
+            if (!behavior.equals(owed.at().behavior())) {
+                return new Settlement.DoesNotSettle();
+            }
+            if (row.values() == null) {
+                return row.undetermined();
+            }
+            Classification at =
+                    InputClassifications.of(row.values(), where, axes).get(owed.at());
+            if (at == null) {
+                return new Settlement.DoesNotSettle();
+            }
+            return switch (at) {
+                case Classification.Classified in -> in.classIds().contains(owed.classId())
+                        ? new Settlement.Settles() : new Settlement.DoesNotSettle();
+                case Classification.Unclassified _ -> new Settlement.Undetermined(
+                        Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
+            };
+        }
+
+        /**
+         * Whether running the row goes through the arm.
+         *
+         * <p>Not something the values answer. A row whose values sit in the classes a way into an
+         * arm leaves may still go elsewhere, so the account of the run is the whole of the evidence
+         * — and where there is none, this says so rather than reading the absence as a row that
+         * missed.
+         */
+        private Settlement throughArm(OneRow row, Generator.ArmOwed owed) {
+            return switch (row.watched()) {
+                case Generator.Watched.Ran(var account) -> account.taken().contains(owed.probe())
+                        ? new Settlement.Settles() : new Settlement.DoesNotSettle();
+                case Generator.Watched.NoAccount _ ->
+                        new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
+            };
+        }
+
+        /**
+         * Whether the row stands at the point, as this behavior reads the line.
+         *
+         * <p>A line is owed a row once and is met at whichever position reads it, so a point this
+         * behavior's readings do not meet is one a row written here does not settle. Where they do,
+         * the walk that reads a written row against the point reads this one.
+         */
+        private Settlement atThePoint(OneRow read, OfferItem.APointOfALine at) {
+            OwedBoundaryPoint point = points.get(at);
+            if (point == null) {
+                return new Settlement.DoesNotSettle();
+            }
+            if (read.values() == null) {
+                return read.undetermined();
+            }
+            ObservedInputs row = new ObservedInputs(read.values(), read.watched());
+            return switch (StandingAtAPoint.met(point.line().cut().of(), where, List.of(row),
+                    point.item().criterion(), point.line().origin().comparisonAt())) {
+                case YES -> new Settlement.Settles();
+                case NO -> new Settlement.DoesNotSettle();
+                case NOT_WATCHED ->
+                        new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
+                case UNREADABLE -> new Settlement.Undetermined(
+                        Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
+            };
+        }
+
+    }
+
+    /**
+     * One row of the offering, read.
+     *
+     * @param values      what its inputs build to, or null where they do not all build
+     * @param whyNotBuilt why they did not, where they did not, and null where they did
+     * @param watched     what running it recorded, which a row whose values would not build still
+     *                    has: the two are found out separately and one failing is not the other
+     *                    failing
+     */
+    private record OneRow(List<ObservedValue> values, Settlement.Reason whyNotBuilt,
+                          Generator.Watched watched) {
+
+        static OneRow nothingRead() {
+            return new OneRow(null, Settlement.Reason.NOTHING_BUILT_THE_VALUES,
+                    new Generator.Watched.NoAccount());
+        }
+
+        /** What an item that needs the values is told, where they are not here. */
+        Settlement undetermined() {
+            return new Settlement.Undetermined(whyNotBuilt);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -217,10 +217,18 @@ public record Settlements(List<OfferItem> requested,
         if (offering.declared() != null) {
             offering.declared().resolved().forEach((point, answer) -> {
                 OfferItem item = new OfferItem.APointOfALine(point);
-                requested.add(item);
-                if (answer.resolution() instanceof DeclarationResolution.Generated(var by,
-                        var row)) {
-                    composedFor.put(item, RowKey.of(by, row));
+                switch (answer.resolution()) {
+                    case DeclarationResolution.Generated(var by, var row) -> {
+                        requested.add(item);
+                        composedFor.put(item, RowKey.of(by, row));
+                    }
+                    // Asked for and nothing came of it, which is still a thing this run is short of
+                    // — and something else may stand there, which is what makes it worth asking.
+                    case DeclarationResolution.Unresolved _ -> requested.add(item);
+                    // Not asked for at all: a row already stands there, or nothing measured it. A
+                    // point in nobody's way is not work this run offers, and holding it here would
+                    // let a candidate be the only offer for it.
+                    case DeclarationResolution.NoSearch _ -> { }
                 }
             });
         }
@@ -295,13 +303,14 @@ public record Settlements(List<OfferItem> requested,
                 List<BorderAssessment> edges =
                         db.ask(new Adequacy.BoundarySearch(module, behavior)).value();
                 if (edges != null) {
-                    // The account, and not the places a row is composed at. Those drop what tells
-                    // two obligations at one point apart — a region stopped by two different things
-                    // is two of them — and this is asking what the run is owed rather than how many
-                    // values it has to compose. Dropped here, the second obligation would be in no
-                    // item universe: nothing would count a row as settling it, and a note saying
-                    // nothing offers a row for it would print over the row that stands there.
-                    for (OwedBoundaryPoint point : OwedBoundaryPoint.across(edges)) {
+                    // What this run was asked for a row at. Neither of the readings beside it will
+                    // do: the places a row is composed at drop what tells two obligations at one
+                    // point apart, and the account holds points the measurement has already
+                    // settled — a point a written row stands at is owed and is nobody's work, and
+                    // counted here a candidate standing there would be its only offer and could
+                    // never be dropped.
+                    for (OwedBoundaryPoint point
+                            : OwedBoundaryPoint.askedForARow(OwedBoundaryPoint.across(edges)).at()) {
                         OfferItem.APointOfALine item =
                                 new OfferItem.APointOfALine(point.owed());
                         owedHere.put(item, point);

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -5,6 +5,7 @@ import souther.compiler.execute.BoundaryValues;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.partition.Axis;
 import souther.compiler.partition.BehaviorInputs;
+import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.partition.FixtureTemplate;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.InputClassifications;
@@ -86,11 +87,17 @@ public record Settlements(List<OfferItem> requested,
         List<OfferItem> requested = new ArrayList<>();
         SequencedMap<OfferItem, RowKey> composedFor = new LinkedHashMap<>();
         SequencedMap<RowKey, Map<OfferItem, Settlement>> byRow = new LinkedHashMap<>();
+        // How each behavior reads the lines the module's declarations own. A behavior's own account
+        // holds the lines it is owed a row at and none of these — that is what the account is for —
+        // so a walk that looked only there would find no reading of a declared line anywhere and
+        // answer that no row stands at one, of rows composed to stand at exactly that.
+        Map<BorderObligationPoint, Map<String, List<BorderAssessment>>> declaredReadings =
+                readingsOfTheDeclaredLines(db, module, offering.request().boundaries());
         Map<String, OneBehavior> reading = new LinkedHashMap<>();
         for (Map.Entry<String, Adequacy.Filling> behavior : offering.searched().entrySet()) {
             OneBehavior read = OneBehavior.of(db, module, behavior.getKey(), behavior.getValue(),
                     sigs == null ? null : sigs.get(behavior.getKey()), building, trials,
-                    offering.request().boundaries());
+                    offering.request().boundaries(), declaredReadings);
             reading.put(behavior.getKey(), read);
             requested.addAll(read.owed());
             composedFor.putAll(read.composed(behavior.getValue()));
@@ -128,6 +135,33 @@ public record Settlements(List<OfferItem> requested,
     }
 
     /**
+     * Which behaviors read each line a declaration owns, and what each of their readings is.
+     *
+     * <p>Asked of the debts and not of any behavior. A line a declaration draws is read wherever the
+     * type is carried, and where a row written in one behavior's terms stands is a question about
+     * that behavior's reading of it — so the readings are what a row is put to, one per position
+     * that meets the line.
+     */
+    private static Map<BorderObligationPoint, Map<String, List<BorderAssessment>>>
+            readingsOfTheDeclaredLines(Db db, String module, boolean boundaries) {
+        Map<BorderObligationPoint, Map<String, List<BorderAssessment>>> out = new LinkedHashMap<>();
+        if (!boundaries) {
+            return out;
+        }
+        Adequacy.DeclaredBoundaries account = db.ask(new Adequacy.DeclaredBorders(module)).value();
+        if (account == null) {
+            return out;
+        }
+        for (Adequacy.DeclaredDebt owed : account.owed()) {
+            Map<String, List<BorderAssessment>> here =
+                    out.computeIfAbsent(owed.debt().point(), _ -> new LinkedHashMap<>());
+            owed.debt().met().forEach((reading, at) ->
+                    here.computeIfAbsent(reading.behavior(), _ -> new ArrayList<>()).add(at));
+        }
+        return out;
+    }
+
+    /**
      * One behavior's own reading of a candidate: what it is asked for, and how a row of it is read.
      *
      * <p>Made once per behavior and not once per row. What a row is read against — where its
@@ -137,13 +171,17 @@ public record Settlements(List<OfferItem> requested,
     private record OneBehavior(String behavior, BehaviorInputs where, List<Axis> axes, Sig sig,
                                BoundaryValues building, Generator.Trial trial,
                                List<Generator.ClassOwed> classes, List<Generator.ArmOwed> arms,
-                               Map<OfferItem.APointOfALine, OwedBoundaryPoint> points) {
+                               Map<OfferItem.APointOfALine, OwedBoundaryPoint> owedHere,
+                               Map<OfferItem.APointOfALine, List<AtAPoint>> reads) {
 
         static OneBehavior of(Db db, String module, String behavior, Adequacy.Filling filling,
                               Sig sig, BoundaryValues building,
-                              souther.compiler.execute.RowTrials trials, boolean boundaries) {
+                              souther.compiler.execute.RowTrials trials, boolean boundaries,
+                              Map<BorderObligationPoint, Map<String, List<BorderAssessment>>>
+                                      declared) {
             Generator.Subject subject = filling.composed().plan().subject();
-            Map<OfferItem.APointOfALine, OwedBoundaryPoint> points = new LinkedHashMap<>();
+            Map<OfferItem.APointOfALine, OwedBoundaryPoint> owedHere = new LinkedHashMap<>();
+            Map<OfferItem.APointOfALine, List<AtAPoint>> reads = new LinkedHashMap<>();
             if (boundaries) {
                 List<BorderAssessment> edges =
                         db.ask(new Adequacy.BoundarySearch(module, behavior)).value();
@@ -151,16 +189,32 @@ public record Settlements(List<OfferItem> requested,
                     // One entry per point, which is what a row standing there answers. Two readings
                     // of one line at one role are one thing to be told about, and the walk that
                     // offers the rows takes the same view.
-                    OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(edges))
-                            .forEach(point -> points.put(
-                                    new OfferItem.APointOfALine(point.owed()), point));
+                    for (OwedBoundaryPoint point
+                            : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(edges))) {
+                        OfferItem.APointOfALine item =
+                                new OfferItem.APointOfALine(point.owed());
+                        owedHere.put(item, point);
+                        reads.computeIfAbsent(item, _ -> new ArrayList<>())
+                                .add(new AtAPoint(point.line(), point.item().criterion()));
+                    }
                 }
             }
+            // And this behavior's readings of the lines the declarations own, which its own account
+            // holds none of.
+            declared.forEach((point, byBehavior) -> {
+                for (BorderAssessment at : byBehavior.getOrDefault(behavior, List.of())) {
+                    if (at.at(point.role()) instanceof ItemAssessment.Owed owed) {
+                        reads.computeIfAbsent(new OfferItem.APointOfALine(point),
+                                _ -> new ArrayList<>())
+                                .add(new AtAPoint(at.border(), owed.criterion()));
+                    }
+                }
+            });
             return new OneBehavior(behavior, subject.inputs(), subject.axes(), sig, building,
                     sig == null || trials == null ? Generator.Trial.NOTHING_RUNS
                             : Adequacy.runningRowsOf(trials, behavior, sig),
                     filling.composed().plan().classesOwed(), filling.composed().plan().armsOwed(),
-                    points);
+                    owedHere, reads);
         }
 
         /**
@@ -186,7 +240,7 @@ public record Settlements(List<OfferItem> requested,
                             RowKey.of(behavior, filling.composed().rowFor(built.row())));
                 }
             }
-            points.forEach((item, point) -> {
+            owedHere.forEach((item, point) -> {
                 if (point.item().attempt() instanceof ItemAssessment.Attempt.Built built) {
                     out.put(item, RowKey.of(behavior, built.row()));
                 }
@@ -199,7 +253,7 @@ public record Settlements(List<OfferItem> requested,
             List<OfferItem> out = new ArrayList<>();
             classes.forEach(each -> out.add(new OfferItem.AClass(each)));
             arms.forEach(each -> out.add(new OfferItem.AnArm(each)));
-            out.addAll(points.keySet());
+            out.addAll(owedHere.keySet());
             return out;
         }
 
@@ -294,26 +348,46 @@ public record Settlements(List<OfferItem> requested,
          * the walk that reads a written row against the point reads this one.
          */
         private Settlement atThePoint(OneRow read, OfferItem.APointOfALine at) {
-            OwedBoundaryPoint point = points.get(at);
-            if (point == null) {
+            List<AtAPoint> here = reads.get(at);
+            if (here == null || here.isEmpty()) {
+                // No reading of this line in this behavior. A row written here has no value on the
+                // line at all, which is a row that does not settle the point rather than one
+                // nothing could tell about.
                 return new Settlement.DoesNotSettle();
             }
             if (read.values() == null) {
                 return read.undetermined();
             }
             ObservedInputs row = new ObservedInputs(read.values(), read.watched());
-            return switch (StandingAtAPoint.met(point.line().cut().of(), where, List.of(row),
-                    point.item().criterion(), point.line().origin().comparisonAt())) {
-                case YES -> new Settlement.Settles();
-                case NO -> new Settlement.DoesNotSettle();
-                case NOT_WATCHED ->
-                        new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
-                case UNREADABLE -> new Settlement.Undetermined(
-                        Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
-            };
+            // Existential over the readings, the way a point met at one position of a behavior is
+            // met: a row standing on the line anywhere the behavior reads it is a row at the point.
+            Settlement answer = new Settlement.DoesNotSettle();
+            for (AtAPoint one : here) {
+                Settlement said = switch (StandingAtAPoint.met(one.line().cut().of(), where,
+                        List.of(row), one.criterion(), one.line().origin().comparisonAt())) {
+                    case YES -> new Settlement.Settles();
+                    case NO -> new Settlement.DoesNotSettle();
+                    case NOT_WATCHED ->
+                            new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
+                    case UNREADABLE -> new Settlement.Undetermined(
+                            Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
+                };
+                if (said.settles()) {
+                    return said;
+                }
+                if (said instanceof Settlement.Undetermined) {
+                    answer = said;
+                }
+            }
+            return answer;
         }
 
     }
+
+    /** One position's reading of one line, as a row is put to it: the border this behavior met and
+     *  what a row there has to do. */
+    private record AtAPoint(souther.compiler.partition.Border line,
+                            souther.compiler.partition.Criterion criterion) {}
 
     /**
      * One row of the offering, read.
@@ -324,6 +398,7 @@ public record Settlements(List<OfferItem> requested,
      *                    has: the two are found out separately and one failing is not the other
      *                    failing
      */
+
     private record OneRow(List<ObservedValue> values, Settlement.Reason whyNotBuilt,
                           Generator.Watched watched) {
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -56,6 +56,86 @@ public record Settlements(List<OfferItem> requested,
         return here.get(item);
     }
 
+    /**
+     * The rows to keep: every one whose going would cost the offering something.
+     *
+     * <p><b>What is preserved is what the offering can do, and not what each row was for.</b> Two
+     * things would go wrong with a rule written per row. One is that a row's own purpose can be
+     * handed on and then handed on again — a row answering what another was for is itself dropped
+     * for a third, and the first item ends up answered by nothing — so what is counted is how many
+     * kept rows settle each item, and a row goes only while every item it settles is settled by
+     * another. The other is that an item whose row settles nothing this could tell about would lose
+     * the only row anybody was offered for it, so a row also stays while something composed for it
+     * is not settled elsewhere.
+     *
+     * <p>Only {@link Settlement.Settles} counts. A row that cannot be told about is not a row that
+     * answers, and counting it would drop the row that did.
+     *
+     * <p>Walked from the back, so a row that came first stays. Which of two rows answering the same
+     * things a person is handed is arbitrary, and taking the earlier one keeps the block steady:
+     * the order rows are composed in is the order the searches were asked, and an edit somewhere
+     * later in the model does not move what is offered above it.
+     *
+     * <p>What comes out is irredundant and not smallest. Every row left is the only kept row
+     * settling something, so nothing more can go without the offering answering less; a smaller set
+     * answering the same items may exist, and finding one is a different question from this.
+     */
+    public Set<RowKey> keeping() {
+        Map<OfferItem, Integer> count = new LinkedHashMap<>();
+        for (OfferItem item : requested) {
+            int settling = 0;
+            for (Map<OfferItem, Settlement> here : byRow.values()) {
+                if (here.get(item).settles()) {
+                    settling++;
+                }
+            }
+            count.put(item, settling);
+        }
+        List<RowKey> inOrder = new ArrayList<>(byRow.keySet());
+        Set<RowKey> kept = new LinkedHashSet<>(inOrder);
+        for (int at = inOrder.size() - 1; at >= 0; at--) {
+            RowKey row = inOrder.get(at);
+            if (goes(row, kept, count)) {
+                kept.remove(row);
+                byRow.get(row).forEach((item, settlement) -> {
+                    if (settlement.settles()) {
+                        count.merge(item, -1, Integer::sum);
+                    }
+                });
+            }
+        }
+        return Collections.unmodifiableSet(new LinkedHashSet<>(
+                inOrder.stream().filter(kept::contains).toList()));
+    }
+
+    /** Whether the offering answers as much without {@code row} as with it. */
+    private boolean goes(RowKey row, Set<RowKey> kept, Map<OfferItem, Integer> count) {
+        for (Map.Entry<OfferItem, Settlement> each : byRow.get(row).entrySet()) {
+            if (each.getValue().settles() && count.get(each.getKey()) <= 1) {
+                return false;
+            }
+        }
+        // And what was composed for it. An item whose own row settles nothing this could tell about
+        // is one nobody would be offered a row for at all, which is a piece of work going missing
+        // rather than a row being said once instead of twice.
+        for (Map.Entry<OfferItem, RowKey> each : composedFor.entrySet()) {
+            if (!each.getValue().equals(row)) {
+                continue;
+            }
+            boolean elsewhere = false;
+            for (RowKey other : kept) {
+                if (!other.equals(row) && byRow.get(other).get(each.getKey()).settles()) {
+                    elsewhere = true;
+                    break;
+                }
+            }
+            if (!elsewhere) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /** The items some row of this offering settles, which is what a reduction has to keep answered. */
     public Set<OfferItem> settled() {
         Set<OfferItem> out = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -91,11 +91,17 @@ public record Settlements(List<OfferItem> requested,
             }
             count.put(item, settling);
         }
+        // What each row was composed for, the way round this asks it. Read out of the map the other
+        // way for every row, the walk would go over every item once per row to find the few that
+        // name it.
+        Map<RowKey, List<OfferItem>> composedHere = new LinkedHashMap<>();
+        composedFor.forEach((item, row) ->
+                composedHere.computeIfAbsent(row, _ -> new ArrayList<>()).add(item));
         List<RowKey> inOrder = new ArrayList<>(byRow.keySet());
         Set<RowKey> kept = new LinkedHashSet<>(inOrder);
         for (int at = inOrder.size() - 1; at >= 0; at--) {
             RowKey row = inOrder.get(at);
-            if (goes(row, kept, count)) {
+            if (goes(row, composedHere.getOrDefault(row, List.of()), count)) {
                 kept.remove(row);
                 byRow.get(row).forEach((item, settlement) -> {
                     if (settlement.settles()) {
@@ -108,9 +114,18 @@ public record Settlements(List<OfferItem> requested,
                 inOrder.stream().filter(kept::contains).toList()));
     }
 
-    /** Whether the offering answers as much without {@code row} as with it. */
-    private boolean goes(RowKey row, Set<RowKey> kept, Map<OfferItem, Integer> count) {
-        for (Map.Entry<OfferItem, Settlement> each : byRow.get(row).entrySet()) {
+    /**
+     * Whether the offering answers as much without {@code row} as with it.
+     *
+     * <p>Asked of the counts, which hold the kept rows and this one among them. So an item this row
+     * settles needs a second settler to be left after it goes, and an item it was composed for and
+     * settles nothing of needs one at all.
+     *
+     * @param composedHere what this row was composed for
+     */
+    private boolean goes(RowKey row, List<OfferItem> composedHere, Map<OfferItem, Integer> count) {
+        Map<OfferItem, Settlement> here = byRow.get(row);
+        for (Map.Entry<OfferItem, Settlement> each : here.entrySet()) {
             if (each.getValue().settles() && count.get(each.getKey()) <= 1) {
                 return false;
             }
@@ -118,18 +133,8 @@ public record Settlements(List<OfferItem> requested,
         // And what was composed for it. An item whose own row settles nothing this could tell about
         // is one nobody would be offered a row for at all, which is a piece of work going missing
         // rather than a row being said once instead of twice.
-        for (Map.Entry<OfferItem, RowKey> each : composedFor.entrySet()) {
-            if (!each.getValue().equals(row)) {
-                continue;
-            }
-            boolean elsewhere = false;
-            for (RowKey other : kept) {
-                if (!other.equals(row) && byRow.get(other).get(each.getKey()).settles()) {
-                    elsewhere = true;
-                    break;
-                }
-            }
-            if (!elsewhere) {
+        for (OfferItem item : composedHere) {
+            if (!here.get(item).settles() && count.get(item) < 1) {
                 return false;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -304,6 +304,20 @@ public record Settlements(List<OfferItem> requested,
                                Map<OfferItem.APointOfALine, OwedBoundaryPoint> owedHere,
                                Map<OfferItem.APointOfALine, List<AtAPoint>> reads) {
 
+        /**
+         * A reader for one behavior, and what this run asked of that behavior.
+         *
+         * <p><b>Two things, and a carrier may have only the first.</b> How a row is read is what its
+         * positions are and what runs it; what this run asked for is a search's answer, and a
+         * behavior that composed a row for somebody else's line was asked nothing. Read together,
+         * the account of a behavior nothing was searched for is fetched to build it — which asks the
+         * search this run had decided not to make, and puts its points into a universe as work
+         * nobody was set.
+         *
+         * @param filling what this run asked of the behavior, or null where it asked nothing. A
+         *                carrier with rows and no filling still has its rows read: what it holds is
+         *                a row somebody else's line needed
+         */
         static OneBehavior of(Db db, String module, String behavior, Adequacy.Filling filling,
                               Sig sig, BoundaryValues building,
                               souther.compiler.execute.RowTrials trials, boolean boundaries,
@@ -318,7 +332,11 @@ public record Settlements(List<OfferItem> requested,
             }
             Map<OfferItem.APointOfALine, OwedBoundaryPoint> owedHere = new LinkedHashMap<>();
             Map<OfferItem.APointOfALine, List<AtAPoint>> reads = new LinkedHashMap<>();
-            if (boundaries) {
+            // Its own account, where this run asked it for rows and nowhere else. Whether the
+            // search was made is what `searched` says, and asking for it here would make it: the
+            // behavior would come back owing points at its own lines, which are not work this run
+            // set anybody.
+            if (boundaries && filling != null) {
                 List<BorderAssessment> edges =
                         db.ask(new Adequacy.BoundarySearch(module, behavior)).value();
                 if (edges != null) {
@@ -339,7 +357,9 @@ public record Settlements(List<OfferItem> requested,
                 }
             }
             // And this behavior's readings of the lines the declarations own, which its own account
-            // holds none of.
+            // holds none of. Read whether or not anything was asked of the behavior: a row written
+            // under it stands where it stands, and that is how it answers the line it was composed
+            // for.
             declared.forEach((point, byBehavior) -> {
                 for (BorderAssessment at : byBehavior.getOrDefault(behavior, List.of())) {
                     if (at.at(point.role()) instanceof ItemAssessment.Owed owed) {
@@ -350,8 +370,7 @@ public record Settlements(List<OfferItem> requested,
                 }
             });
             // What this behavior was asked to offer a row for, which is the search's answer and
-            // is nothing where nothing asked it. A behavior with rows and no search of its own is
-            // owed no class and no arm here: what it holds is a row somebody else's line needed.
+            // is nothing where nothing asked it.
             return new OneBehavior(behavior, read.where(), read.axes(), sig, building,
                     sig == null || trials == null ? Generator.Trial.NOTHING_RUNS
                             : Adequacy.runningRowsOf(trials, behavior, sig),

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -202,14 +202,27 @@ public record Settlements(List<OfferItem> requested,
         // answer that no row stands at one, of rows composed to stand at exactly that.
         Map<BorderObligationPoint, Map<String, List<BorderAssessment>>> declaredReadings =
                 readingsOfTheDeclaredLines(db, module, offering.request().boundaries());
+        // A reader for every behavior a row is written under, and not only for the ones a search
+        // answered about. A row a declaration's line is owed is composed by whichever reading could
+        // compose it, and that behavior need not be one anything else was asked of — read off the
+        // searches alone, such a row came back undetermined at every item, so nothing it stands at
+        // could ever make another row redundant.
         Map<String, OneBehavior> reading = new LinkedHashMap<>();
-        for (Map.Entry<String, Adequacy.Filling> behavior : offering.searched().entrySet()) {
-            OneBehavior read = OneBehavior.of(db, module, behavior.getKey(), behavior.getValue(),
-                    sigs == null ? null : sigs.get(behavior.getKey()), building, trials,
+        Set<String> carriers = new LinkedHashSet<>(offering.rows().keySet());
+        carriers.addAll(offering.searched().keySet());
+        for (String behavior : carriers) {
+            Adequacy.Filling filling = offering.searched().get(behavior);
+            OneBehavior read = OneBehavior.of(db, module, behavior, filling,
+                    sigs == null ? null : sigs.get(behavior), building, trials,
                     offering.request().boundaries(), declaredReadings);
-            reading.put(behavior.getKey(), read);
+            if (read == null) {
+                continue;   // nothing here can read a row of it, which its rows are told below
+            }
+            reading.put(behavior, read);
             requested.addAll(read.owed());
-            composedFor.putAll(read.composed(behavior.getValue()));
+            if (filling != null) {
+                composedFor.putAll(read.composed(filling));
+            }
         }
         // And the points the module's declarations are owed, which are no behavior's own. A row of
         // whichever behavior composed one answers the line for everybody, so they are items of the
@@ -296,7 +309,13 @@ public record Settlements(List<OfferItem> requested,
                               souther.compiler.execute.RowTrials trials, boolean boundaries,
                               Map<BorderObligationPoint, Map<String, List<BorderAssessment>>>
                                       declared) {
-            Generator.Subject subject = filling.composed().plan().subject();
+            // How a row of this behavior is read, asked of the store rather than taken off a
+            // search. A behavior that composed a row for a declaration's line and was asked
+            // nothing else has no search to take it from, and its rows are read like any other.
+            Adequacy.HowARowIsRead read = Adequacy.readingOf(db, module, behavior);
+            if (read == null) {
+                return null;
+            }
             Map<OfferItem.APointOfALine, OwedBoundaryPoint> owedHere = new LinkedHashMap<>();
             Map<OfferItem.APointOfALine, List<AtAPoint>> reads = new LinkedHashMap<>();
             if (boundaries) {
@@ -330,10 +349,14 @@ public record Settlements(List<OfferItem> requested,
                     }
                 }
             });
-            return new OneBehavior(behavior, subject.inputs(), subject.axes(), sig, building,
+            // What this behavior was asked to offer a row for, which is the search's answer and
+            // is nothing where nothing asked it. A behavior with rows and no search of its own is
+            // owed no class and no arm here: what it holds is a row somebody else's line needed.
+            return new OneBehavior(behavior, read.where(), read.axes(), sig, building,
                     sig == null || trials == null ? Generator.Trial.NOTHING_RUNS
                             : Adequacy.runningRowsOf(trials, behavior, sig),
-                    filling.composed().plan().classesOwed(), filling.composed().plan().armsOwed(),
+                    filling == null ? List.of() : filling.composed().plan().classesOwed(),
+                    filling == null ? List.of() : filling.composed().plan().armsOwed(),
                     owedHere, reads);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -11,6 +11,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.DeclaredRows;
 import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
 import souther.compiler.query.Offering;
 import souther.compiler.query.OfferingRequest;
 
@@ -123,10 +124,18 @@ public final class GeneratedRows {
      * is said once, under the declaration that drew the line, and cannot be written from evidence
      * that does not support it.
      */
-    private static void declarations(StringBuilder out, DeclaredRows declared) {
+    private static void declarations(StringBuilder out, DeclaredRows declared,
+                                     Offering offering) {
         java.util.Set<String> said = new java.util.LinkedHashSet<>();
-        for (DeclaredRows.Unmet unmet : declared.unmet()) {
-            switch (unmet) {
+        for (Map.Entry<souther.compiler.partition.BorderObligationPoint, DeclaredRows.Unmet> each
+                : declared.unmet().entrySet()) {
+            // Nothing about a point one of the rows above stands at. What is left to write is what
+            // this says, and a line telling a person no row was composed for something they are
+            // being handed a row for is work that is not left.
+            if (offering.answered().contains(new OfferItem.APointOfALine(each.getKey()))) {
+                continue;
+            }
+            switch (each.getValue()) {
                 // Said once, of the line, and in the declaration's own words. What each reading
                 // proved it of is not repeated: they agree, which is what let this be said at all.
                 case DeclaredRows.Unmet.TheLineCannotBeWritten(var owedBy, var asked, var _) ->
@@ -214,7 +223,7 @@ public final class GeneratedRows {
             out.append(commented(stated(blocks(module, offered), ensures)));
         }
         for (Map.Entry<String, Adequacy.Filling> behavior : offering.searched().entrySet()) {
-            notes(out, behavior.getKey(), behavior.getValue(), boundaries, names);
+            notes(out, behavior.getKey(), behavior.getValue(), boundaries, names, offering);
         }
         // And what the module's declarations are owed that nothing composed a row for. Here rather
         // than after this returns, because what this builds is the block: a caller that rendered
@@ -222,7 +231,7 @@ public final class GeneratedRows {
         // holds, and the one that forgot would print rows with nothing said about the work beside
         // them.
         if (declared != null) {
-            declarations(out, declared);
+            declarations(out, declared, offering);
         }
         // The count leaves with the text. It was worked out here and thrown away, and the one
         // caller that needed it read the text instead.
@@ -247,11 +256,17 @@ public final class GeneratedRows {
      * a list of the author's work. The report says those findings, which is where they belong.
      */
     private static List<Adequacy.GenerationDisposition> shown(Adequacy.Filling filling,
-                                                              boolean boundaries) {
+                                                              boolean boundaries,
+                                                              Offering offering) {
         return filling.generation().stream()
                 .filter(each -> !(each.outcome() instanceof GenerationOutcome.NotApplicable))
                 .filter(each -> boundaries
                         || !(each.finding().about() instanceof About.APointOfABorder))
+                // And nothing about something one of the rows above stands at. What the search for
+                // this finding came to is what it came to, and a person reading the block is being
+                // told what is left to write — which a row in front of them is not.
+                .filter(each -> each.item().stream()
+                        .noneMatch(offering.answered()::contains))
                 .toList();
     }
 
@@ -508,7 +523,7 @@ public final class GeneratedRows {
      * the rows it was offering were printed two lines above the line saying it had stopped.
      */
     private static void notes(StringBuilder out, String behavior, Adequacy.Filling filling,
-                              boolean boundaries, SourceNameResolver names) {
+                              boolean boundaries, SourceNameResolver names, Offering offering) {
         Set<String> said = new LinkedHashSet<>();
         List<Generator.UnresolvedCombination> left =
                 new ArrayList<>(filling.composed().unresolved());
@@ -522,7 +537,7 @@ public final class GeneratedRows {
         // Every finding a row could answer, and not only the ones a strategy took. One printed in
         // the report and left out of this block is one an author is told nothing about, while the
         // rows above it read as though they filled everything.
-        for (Adequacy.GenerationDisposition each : shown(filling, boundaries)) {
+        for (Adequacy.GenerationDisposition each : shown(filling, boundaries, offering)) {
             switch (each.outcome()) {
                 case GenerationOutcome.Generated _ -> { }
                 // Each of what was tried, because they are not one fact: a combination the model

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -359,7 +359,7 @@ public final class GeneratedRows {
         offering.rows().forEach((behavior, rows) -> {
             Map<Integer, String> arms = armNames(offering.searched().get(behavior));
             List<Offered> here = new ArrayList<>();
-            for (Offering.OfferedRow row : rows) {
+            for (souther.compiler.query.OfferedRow row : rows) {
                 Offered offered = new Offered(row.key().inputs(), List.of());
                 for (String name : named(row.namedFor(), arms)) {
                     offered = offered.and(name);

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -124,8 +124,8 @@ public final class GeneratedRows {
      * is said once, under the declaration that drew the line, and cannot be written from evidence
      * that does not support it.
      */
-    private static void declarations(StringBuilder out, DeclaredRows declared,
-                                     Offering offering) {
+    private static void declarations(StringBuilder out, Offering offering) {
+        DeclaredRows declared = offering.declared();
         java.util.Set<String> said = new java.util.LinkedHashSet<>();
         for (Map.Entry<souther.compiler.partition.BorderObligationPoint, DeclaredRows.Unmet> each
                 : declared.unmet().entrySet()) {
@@ -169,32 +169,6 @@ public final class GeneratedRows {
     }
 
     /**
-     * The whole block for one request, from what its two searches came to.
-     *
-     * <p>For a caller that holds the searches. The request says what was asked for, and it is said
-     * rather than worked out from what was handed over: which readings a run was about and whether
-     * it asked after the lines a model draws are what decide which rows there are, and a block that
-     * guessed at either would be describing a run nobody made.
-     *
-     * @param request   what was asked for
-     * @param generated one filling per behavior, keyed the way a report keys them
-     * @param declared  the rows the module's declarations are owed, or null where the request asked
-     *                  for no boundary rows. One row per point of a line however many behaviors
-     *                  carry the type, and under the behavior whose reading composed it — how many
-     *                  there are was settled where the search was resolved
-     * @param ensures   what each behavior has written in its {@code ensures}, in the author's own
-     *                  words and keyed as {@code generated} is. Read before this is called and
-     *                  handed over: what the source says is not something a renderer works out, and
-     *                  a form of this that could be called without it would be a way of dropping it
-     * @param names     what the caller calls its sources, for the notes that name one
-     */
-    public static Block of(OfferingRequest request, Map<String, Adequacy.Filling> generated,
-                           DeclaredRows declared, Map<String, List<String>> ensures,
-                           SourceNameResolver names) {
-        return of(Offering.of(request, generated, declared), ensures, names);
-    }
-
-    /**
      * The block for one offering.
      *
      * <p>Which rows go out is settled before this is called and is not decided again here. What
@@ -231,7 +205,7 @@ public final class GeneratedRows {
         // holds, and the one that forgot would print rows with nothing said about the work beside
         // them.
         if (declared != null) {
-            declarations(out, declared, offering);
+            declarations(out, offering);
         }
         // The count leaves with the text. It was worked out here and thrown away, and the one
         // caller that needed it read the text instead.

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -3,7 +3,6 @@ package souther.compiler.report;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.fmt.Formatter;
 import souther.compiler.observe.Incompleteness;
-import souther.compiler.partition.FixtureTemplate;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.GenerationOutcome;
 import souther.compiler.partition.Generator;
@@ -12,6 +11,8 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.DeclaredRows;
 import souther.compiler.query.GenerationScope;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -83,36 +84,17 @@ public final class GeneratedRows {
             if (module != null && !module.equals(name)) {
                 continue;
             }
-            Map<String, Adequacy.Filling> filling;
-            if (behavior != null) {
-                // One behavior, asked about on its own. Generating rows searches the pair space and
-                // composes values at the edges, and a caller that named a behavior would otherwise
-                // pay for every other behavior of the module to find out about the one it asked for.
-                Adequacy.Filling only =
-                        compilation.db().ask(new Adequacy.Generated(name, behavior)).value();
-                filling = only == null ? Map.of() : Map.of(behavior, only);
-            } else {
-                filling = Adequacy.generatedOf(compilation.db(), name);
-            }
-            if (filling == null) {
+            // What this run offers, asked as one question. Which rows go out is settled where both
+            // searches are read ({@link Adequacy#offeredFor}) — a behavior's own and the ones a
+            // declaration's line is owed are work for one person, and a renderer putting them
+            // together would be deciding that where the layout is.
+            Offering offering = Adequacy.offeredFor(compilation.db(),
+                    new OfferingRequest(name, behavior == null ? new GenerationScope.Module()
+                            : new GenerationScope.Behavior(behavior), boundaries));
+            if (offering == null) {
                 continue;
             }
-            // And what the module's own declarations are owed, which is no behavior's and so is in
-            // none of the fillings above. The rows go in beside the rest — a line is one piece of
-            // work and is offered once, in the terms of whichever reading composed it — and what
-            // nothing composed a row for is said afterwards, for the reason every other disposition
-            // is said: a block that printed only what it managed reads as though it filled
-            // everything (issue #1062).
-            //
-            // Only where the caller asked for the edges, as the lines about them are: a caller that
-            // asked for no boundary rows is not asking about these either.
-            DeclaredRows declared = boundaries
-                    ? Adequacy.generatedForDeclarationsOf(compilation.db(), name,
-                            behavior == null ? new GenerationScope.Module()
-                                    : new GenerationScope.Behavior(behavior))
-                    : null;
-            Block one = of(name, filling, declared, WrittenEnsures.of(compilation.db(), name),
-                    boundaries, names);
+            Block one = of(offering, WrittenEnsures.of(compilation.db(), name), names);
             out.append(one.text());
             rows += one.rows();
         }
@@ -178,51 +160,49 @@ public final class GeneratedRows {
     }
 
     /**
-     * The whole block for one module, or an empty string where there is nothing to fill.
+     * The whole block for one request, from what its two searches came to.
      *
-     * @param module     the module the rows are about, which an attached file names in its header
-     * @param generated  one filling per behavior, keyed the way a report keys them
-     * @param declared   the rows the module's declarations are owed, or null where the caller asked
-     *                   for no boundary rows. One row per point of a line however many behaviors
-     *                   carry the type, and under the behavior whose reading composed it — how many
-     *                   there are was settled where the search was resolved, and this puts each in
-     *                   the block its terms belong to
-     * @param ensures    what each behavior has written in its {@code ensures}, in the author's own
-     *                   words and keyed as {@code generated} is. Read before this is called and
-     *                   handed over: what the source says is not something a renderer works out, and
-     *                   a form of this that could be called without it would be a way of dropping it
-     * @param boundaries whether to add the rows that sit on an edge nothing has been written at
-     * @param names      what the caller calls its sources, for the notes that name one
+     * <p>For a caller that holds the searches. The request says what was asked for, and it is said
+     * rather than worked out from what was handed over: which readings a run was about and whether
+     * it asked after the lines a model draws are what decide which rows there are, and a block that
+     * guessed at either would be describing a run nobody made.
+     *
+     * @param request   what was asked for
+     * @param generated one filling per behavior, keyed the way a report keys them
+     * @param declared  the rows the module's declarations are owed, or null where the request asked
+     *                  for no boundary rows. One row per point of a line however many behaviors
+     *                  carry the type, and under the behavior whose reading composed it — how many
+     *                  there are was settled where the search was resolved
+     * @param ensures   what each behavior has written in its {@code ensures}, in the author's own
+     *                  words and keyed as {@code generated} is. Read before this is called and
+     *                  handed over: what the source says is not something a renderer works out, and
+     *                  a form of this that could be called without it would be a way of dropping it
+     * @param names     what the caller calls its sources, for the notes that name one
      */
-    public static Block of(String module, Map<String, Adequacy.Filling> generated,
+    public static Block of(OfferingRequest request, Map<String, Adequacy.Filling> generated,
                            DeclaredRows declared, Map<String, List<String>> ensures,
-                           boolean boundaries, SourceNameResolver names) {
-        Map<String, List<Generator.GeneratedRow>> owed = declared == null
-                ? Map.of() : declared.rowsByCarrier();
-        List<Map.Entry<String, Composed>> asked = new ArrayList<>();
-        for (Map.Entry<String, Adequacy.Filling> behavior : generated.entrySet()) {
-            asked.add(Map.entry(behavior.getKey(),
-                    new Composed(behavior.getValue().composed().rows(),
-                            boundaries ? atTheLines(behavior.getValue().boundaries().rows(),
-                                    owed.get(behavior.getKey()))
-                                    : List.of(),
-                            armNames(behavior.getValue()))));
-        }
-        // A behavior with nothing of its own to fill can still be the one reading that composed the
-        // row a declaration is owed. Left out, that row would be resolved and then dropped on the
-        // way to the block.
-        for (Map.Entry<String, List<Generator.GeneratedRow>> carrier : owed.entrySet()) {
-            if (!generated.containsKey(carrier.getKey())) {
-                asked.add(Map.entry(carrier.getKey(),
-                        new Composed(List.of(), carrier.getValue(), Map.of())));
-            }
-        }
+                           SourceNameResolver names) {
+        return of(Offering.of(request, generated, declared), ensures, names);
+    }
+
+    /**
+     * The block for one offering.
+     *
+     * <p>Which rows go out is settled before this is called and is not decided again here. What
+     * this adds is what they are called and how they are laid out — an arm's name is the report's
+     * word, and a heading, a note and a comment marker are not things a row carries.
+     */
+    public static Block of(Offering offering, Map<String, List<String>> ensures,
+                           SourceNameResolver names) {
+        String module = offering.request().module();
+        boolean boundaries = offering.request().boundaries();
+        DeclaredRows declared = offering.declared();
         // Written once and then read three times — printed, counted, and asked whether there is
         // anything to answer. Counting the candidates instead gives a number about work a reader
         // cannot see, and asking the candidates whether the block holds a hole prints the line
         // telling them to fill one over a block that has none.
-        Map<String, List<Offered>> offered = offered(asked);
-        int rows = offered.values().stream().mapToInt(List::size).sum();
+        Map<String, List<Offered>> offered = named(offering);
+        int rows = offering.count();
         StringBuilder out = new StringBuilder();
         if (rows > 0) {
             out.append(String.format(
@@ -233,7 +213,7 @@ public final class GeneratedRows {
                     UNANSWERED));
             out.append(commented(stated(blocks(module, offered), ensures)));
         }
-        for (Map.Entry<String, Adequacy.Filling> behavior : generated.entrySet()) {
+        for (Map.Entry<String, Adequacy.Filling> behavior : offering.searched().entrySet()) {
             notes(out, behavior.getKey(), behavior.getValue(), boundaries, names);
         }
         // And what the module's declarations are owed that nothing composed a row for. Here rather
@@ -283,22 +263,15 @@ public final class GeneratedRows {
     /**
      * One row as it will be written, and everything it was composed for.
      *
-     * <p>A candidate is composed once per thing it is owed for, and the positions that thing does
-     * not name hold whatever the row has to hold — so two of them can come out as one row. What is
-     * offered is the row: a reader is handed one piece of work rather than the same values twice.
-     *
-     * <p><b>Every purpose, and not the first.</b> Two purposes converging on one row is a fact
-     * about this run, and dropping one of them keeps a name that says the row is about one thing
-     * while it answers two — which is what a name for the first arrival was. Joining them into one
-     * name is the other way of being wrong: {@code "a x b"} reads as one thing owed at two
-     * positions at once, which is the shape this whole block was written against.
-     *
-     * <p>So one purpose is a name and several are a note apiece over a row with none. The language
-     * lets a row be written without a name and an author names it when they answer it; what it is
-     * for is said in words above it, once per thing.
+     * <p>One name is a name and several are a note apiece over a row with none. Joining them into
+     * one name is the way of being wrong that reads worst: {@code "a x b"} reads as one thing owed
+     * at two positions at once, which is the shape this whole block was written against. The
+     * language lets a row be written without a name and an author names it when they answer it;
+     * what it is for is said in words above it, once per thing.
      *
      * @param inputs   the row's values, in the form they are written in
-     * @param purposes what it was composed for, in the order the things were taken
+     * @param purposes what this layer calls the things it was composed for, in the order they were
+     *                 taken
      */
     private record Offered(String inputs, List<String> purposes) {
 
@@ -333,41 +306,6 @@ public final class GeneratedRows {
     }
 
     /**
-     * What one behavior's rows were composed for: the classes and arms of it, and the lines a rule
-     * draws. Kept apart because a row's name comes from what it was composed for.
-     *
-     * @param armNames what each arm of the body is called, by the probe the plan gave it. The
-     *                 generator composes a row for an arm by that number and spells no name for it:
-     *                 what an arm is called is this layer's word, and a second spelling made where
-     *                 the search runs would be free to drift from the one the finding is written in
-     */
-    private record Composed(List<Generator.GeneratedRow> cells, List<Generator.GeneratedRow> lines,
-                            Map<Integer, String> armNames) {}
-
-    /**
-     * The rows at one behavior's lines: the ones its own readings are owed, and the ones a
-     * declaration is owed that this behavior's reading composed.
-     *
-     * <p>Two sources and one list, because they are one kind of row — a value standing at a line —
-     * and what tells them apart is who owes the line rather than anything a reader of the block
-     * would act on. Where they coincide the block offers one row, which is what it already does for
-     * two of a behavior's own lines that meet.
-     *
-     * <p>Public because it is a question and not a step of the layout: what is offered at one
-     * behavior's lines is what a reader of the block beside that behavior sees, and it is asked
-     * elsewhere. Written twice, the two would come apart the day either half of the join moved.
-     */
-    public static List<Generator.GeneratedRow> atTheLines(List<Generator.GeneratedRow> own,
-                                                          List<Generator.GeneratedRow> owed) {
-        if (owed == null || owed.isEmpty()) {
-            return own;
-        }
-        List<Generator.GeneratedRow> out = new ArrayList<>(own);
-        out.addAll(owed);
-        return List.copyOf(out);
-    }
-
-    /**
      * What each arm of one behavior is called, by the probe the plan gave it.
      *
      * <p>Read off the findings the generation answers, which is where an arm's name is already
@@ -376,6 +314,12 @@ public final class GeneratedRows {
      */
     private static Map<Integer, String> armNames(Adequacy.Filling filling) {
         Map<Integer, String> out = new LinkedHashMap<>();
+        if (filling == null) {
+            // A behavior with no search of its own, which is one that composed a row a declaration
+            // is owed and nothing else. A row at a line is offered without a name, so there is no
+            // arm here to be called anything.
+            return out;
+        }
         for (Adequacy.GenerationDisposition each : filling.generation()) {
             if (each.finding().about() instanceof About.AnArmNoRowGoesThrough(var arm)) {
                 out.put(arm.index(), ArmVocabulary.label(arm));
@@ -391,9 +335,9 @@ public final class GeneratedRows {
      * two things, and `a x b` spelt over the pair reads as an obligation nobody raised — the same
      * fault as naming a row for everything it turns out to settle, arriving from the other side.
      */
-    private static List<String> named(Generator.GeneratedRow row, Map<Integer, String> arms) {
+    private static List<String> named(List<Generator.Purpose> purposes, Map<Integer, String> arms) {
         List<String> out = new ArrayList<>();
-        for (Generator.Purpose purpose : row.purposes()) {
+        for (Generator.Purpose purpose : purposes) {
             if (purpose instanceof Generator.Purpose.ForAnArm(int probe)) {
                 // Left unnamed where nothing named the arm, which is the state of a row nobody has
                 // named yet and is what the language writes for one. A name invented here would be
@@ -409,61 +353,32 @@ public final class GeneratedRows {
     }
 
     /**
-     * The candidates as rows, one per row rather than one per obligation.
+     * The rows this run offers, each under the words this layer calls what it was composed for.
      *
-     * <p>Grouped on what is written, which is what a reader would be pasting twice. Not on the values
-     * themselves: two rows of one behavior meaning the same thing and spelt differently stay two rows,
-     * each naming its own obligation, and that is the direction to be wrong in. A grouping on values
-     * would need an identity for them that nothing here has — a fixture carries the position it was
-     * parsed at and the path it was constructed through — and the row a person reads is the row.
+     * <p>Which rows go out and what each was composed for is {@link Offering}'s; what those things
+     * are called is this layer's. An arm is named by the report ({@link ArmVocabulary}) and a
+     * generation spells no name for one, so the two are joined here — and a row whose arm nothing
+     * named is offered without a name, which is the state of a row nobody has named yet and is what
+     * the language writes for one.
      *
-     * <p>A row is named for what it was composed for and not for everything it turned out to settle.
-     * The two are different questions: which row this is, and what this run of the generator is
-     * handing it. The second changes with the rest of the model — a row written elsewhere can meet a
-     * line this row also sits on, and the line stops being offered — and a name that moved with it
-     * would be a name for the state of the generation rather than for the row.
-     *
-     * <p>A cell can name a row: two cells never compose one row, since a candidate's values follow
-     * from the classes it was composed for, so the cell a row is named by is the row's own and is
-     * there whatever else this run offers. A line cannot. Lines coincide — each probe fills the
-     * positions its own edge does not name from the bottom of their domains, so two minimum edges
-     * compose one row — and which of them is offered is exactly what changes when something else is
-     * written: a row meeting one of the two leaves the other, and a row named for whichever line
-     * happened to be offered would be renamed by an edit that did not touch it. That is the same
-     * fault as naming a row for everything it settles, with the joining written as a choice.
-     *
-     * <p>So a row composed only for lines is offered without a name. Nothing here can name it from
-     * one thing, and the language lets a row be written without one — an unnamed row cannot be
-     * addressed from outside, which is exactly the state of a row nobody has named yet. The author
-     * names it when they answer it. What a row sits on is in the report, where what this run owes is
-     * said.
+     * <p>Names without repeats. Two purposes with one name are one thing said twice, and what tells
+     * them apart is the name rather than the purpose: a class of one position and a class of another
+     * can be written the same way, and a reader handed both would be told the same fact twice.
      */
-    private static Map<String, List<Offered>> offered(List<Map.Entry<String, Composed>> asked) {
-        // One block per behavior, however many kinds of row it holds. Rows of one behavior written
-        // under two headings are legal and read as two lists of something, which they are not.
-        Map<String, Map<String, Offered>> byBehavior = new LinkedHashMap<>();
-        for (Map.Entry<String, Composed> behavior : asked) {
-            Map<String, Offered> here =
-                    byBehavior.computeIfAbsent(behavior.getKey(), _ -> new LinkedHashMap<>());
-            for (Generator.GeneratedRow row : behavior.getValue().cells()) {
-                String inputs = String.join(", ", textsOf(row.inputs()));
-                Offered offered = here.computeIfAbsent(inputs, _ -> new Offered(inputs, List.of()));
-                for (String purpose : named(row, behavior.getValue().armNames())) {
-                    offered = offered.and(purpose);
-                }
-                here.put(inputs, offered);
-            }
-            // A row composed for an edge is offered without one. The points of a border coincide —
-            // each probe fills the positions its own edge does not name from the bottom of their
-            // domains, so two minimum edges compose one row — and which of them is offered is
-            // exactly what changes when something else is written.
-            for (Generator.GeneratedRow row : behavior.getValue().lines()) {
-                String inputs = String.join(", ", textsOf(row.inputs()));
-                here.putIfAbsent(inputs, new Offered(inputs, List.of()));
-            }
-        }
+    private static Map<String, List<Offered>> named(Offering offering) {
         Map<String, List<Offered>> out = new LinkedHashMap<>();
-        byBehavior.forEach((behavior, rows) -> out.put(behavior, List.copyOf(rows.values())));
+        offering.rows().forEach((behavior, rows) -> {
+            Map<Integer, String> arms = armNames(offering.searched().get(behavior));
+            List<Offered> here = new ArrayList<>();
+            for (Offering.OfferedRow row : rows) {
+                Offered offered = new Offered(row.key().inputs(), List.of());
+                for (String name : named(row.namedFor(), arms)) {
+                    offered = offered.and(name);
+                }
+                here.add(offered);
+            }
+            out.put(behavior, List.copyOf(here));
+        });
         return out;
     }
 
@@ -810,9 +725,6 @@ public final class GeneratedRows {
         };
     }
 
-    private static List<String> textsOf(List<FixtureTemplate> inputs) {
-        return inputs.stream().map(FixtureTemplate::text).toList();
-    }
 
     private GeneratedRows() {}
 }

--- a/souther-compiler/src/test/java/souther/compiler/AGeneratedRowIsNamedForWhatItWasComposedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGeneratedRowIsNamedForWhatItWasComposedForTest.java
@@ -73,12 +73,12 @@ class AGeneratedRowIsNamedForWhatItWasComposedForTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filling = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(filling, "the model under test compiles");
-        return GeneratedRows.of(compilation.modules().get(0), filling,
+        return GeneratedRows.of(souther.compiler.query.OfferingRequest.overTheModule(
+                        compilation.modules().get(0), boundaries), filling,
                 boundaries ? Adequacy.generatedForDeclarationsOf(compilation.db(),
                         compilation.modules().get(0),
                         new souther.compiler.query.GenerationScope.Module()) : null,
-                Map.of(), boundaries,
-                SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** Two minimum edges of one behavior, which compose one row between them. */

--- a/souther-compiler/src/test/java/souther/compiler/AGeneratedRowIsNamedForWhatItWasComposedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGeneratedRowIsNamedForWhatItWasComposedForTest.java
@@ -73,11 +73,9 @@ class AGeneratedRowIsNamedForWhatItWasComposedForTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filling = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(filling, "the model under test compiles");
-        return GeneratedRows.of(souther.compiler.query.OfferingRequest.overTheModule(
-                        compilation.modules().get(0), boundaries), filling,
-                boundaries ? Adequacy.generatedForDeclarationsOf(compilation.db(),
-                        compilation.modules().get(0),
-                        new souther.compiler.query.GenerationScope.Module()) : null,
+        return GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                compilation.modules().get(0), boundaries)),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 
@@ -133,23 +131,16 @@ class AGeneratedRowIsNamedForWhatItWasComposedForTest {
         String block = block(LIMIT, true);
         List<String> offered = names(block);
 
-        assertEquals(7, rows(block),
-                "a row for each class owed one, two of them meeting in one row, and four at the"
-                        + " points of the border:\n" + block);
+        assertEquals(4, rows(block),
+                "two rows for the classes and two at the points of the border:\n" + block);
 
-        // Every class owed a row is said, and each of them once. Two of them come out as one row —
-        // the class at the bottom of the range and the first tier hold the same values — and that
-        // row is offered under neither name. Naming it for whichever of the two arrived first is
-        // a name that says the row is about one thing while it answers two, and joining them into
-        // `a x b` reads as one thing owed at two positions at once. So it is unnamed and what it
-        // fills is said over it, once per class.
-        List<String> said = new ArrayList<>(offered);
-        block.lines().filter(line -> line.contains("fills "))
-                .map(line -> line.substring(line.indexOf("fills ") + "fills ".length()))
-                .forEach(said::add);
-        assertEquals(List.of("request.cost=0 <= x <= 100", "request.cost=100 < x",
-                        "request.tier=Gold", "request.tier=Silver"),
-                said.stream().sorted().toList(), block);
+        // Two of the four classes are named, and the two that are not are where the named rows
+        // stand: the row at the top of the range holds the first tier, and the row for the other
+        // tier holds the bottom of the range. A row is named for what it was composed for, so
+        // neither name moves onto the row that answers it — what a class is offered under is the
+        // row a person writes, and which class that row also settles is in the report.
+        assertEquals(List.of("request.cost=100 < x", "request.tier=Silver"),
+                offered.stream().sorted().toList(), block);
 
         Set<String> distinct = new LinkedHashSet<>(offered);
         assertEquals(offered.size(), distinct.size(),

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -82,10 +82,12 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     }
 
     private static String written(souther.compiler.partition.FillResult result) {
-        return GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.trip", false),
-                Map.of("submit", new Adequacy.Filling(result, Generator.GenerationResult.NONE,
-                        List.of())), null,
+        // The composition and not what is offered: this filling is built here rather than searched
+        // for, so there is no store to ask what its rows would settle.
+        return GeneratedRows.of(souther.compiler.query.Offering.composed(
+                        souther.compiler.query.OfferingRequest.overTheModule("example.trip", false),
+                        Map.of("submit", new Adequacy.Filling(result,
+                                Generator.GenerationResult.NONE, List.of())), null),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -84,10 +84,11 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     private static String written(souther.compiler.partition.FillResult result) {
         // The composition and not what is offered: this filling is built here rather than searched
         // for, so there is no store to ask what its rows would settle.
-        return GeneratedRows.of(souther.compiler.query.Composition.composed(
+        return GeneratedRows.of(souther.compiler.query.EveryRowOfIt.offered(
+                        souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.trip", false),
                         Map.of("submit", new Adequacy.Filling(result,
-                                Generator.GenerationResult.NONE, List.of())), null).offeringEverything(),
+                                Generator.GenerationResult.NONE, List.of())), null)),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -82,10 +82,11 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     }
 
     private static String written(souther.compiler.partition.FillResult result) {
-        return GeneratedRows.of("example.trip",
+        return GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.trip", false),
                 Map.of("submit", new Adequacy.Filling(result, Generator.GenerationResult.NONE,
                         List.of())), null,
-                Map.of(), false, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** A run asked for nothing, which is what a reason about the run alone is written against. */

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -84,10 +84,10 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     private static String written(souther.compiler.partition.FillResult result) {
         // The composition and not what is offered: this filling is built here rather than searched
         // for, so there is no store to ask what its rows would settle.
-        return GeneratedRows.of(souther.compiler.query.Offering.composed(
+        return GeneratedRows.of(souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.trip", false),
                         Map.of("submit", new Adequacy.Filling(result,
-                                Generator.GenerationResult.NONE, List.of())), null),
+                                Generator.GenerationResult.NONE, List.of())), null).offeringEverything(),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/APointNothingIsAskedForARowAtIsNotOfferedOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APointNothingIsAskedForARowAtIsNotOfferedOneTest.java
@@ -1,0 +1,177 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.DeclarationResolution;
+import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.OwedBoundaryPoint;
+import souther.compiler.query.Settlements;
+import souther.compiler.partition.BorderObligationPoint;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a run is asked for a row at is not everything a line is owed one at.
+ *
+ * <p>A point a written row already stands at is owed and is nobody's work: the measurement says so,
+ * and the search is gated on the same answer. Held in the offering's items all the same, a candidate
+ * standing there would be the only thing offering for it — so nothing could drop that candidate, and
+ * it would go out beside the row that made it unnecessary.
+ *
+ * <p>The declarations say it in their own words. A point resolved as {@code NoSearch} is one nothing
+ * was looked for at, and its two causes are a row already standing there and nothing having measured
+ * it. Neither is a piece of work this run hands anybody.
+ */
+class APointNothingIsAskedForARowAtIsNotOfferedOneTest {
+
+    /**
+     * A line with a row written at one of its points and nothing at the others.
+     *
+     * <p>The guard draws a line at 50 and the example row sits on it, so the point against the line
+     * is answered and the ones beside it are not.
+     */
+    private static final String ONE_POINT_WRITTEN = """
+            module example.written
+
+            data Hours = Int
+                invariant value >= 0 && value <= 24
+
+            let over (h: Hours): Int = if h.value > 8 then 1 else 0
+
+            behavior tally : (worked: Hours) -> Int
+
+            let tally (worked) = over(worked)
+
+            example tally
+                | "on the line" : (Hours(8)) -> 0
+            """;
+
+    @Test
+    void aPointAWrittenRowStandsAtIsNotAnItemOfTheOffering() {
+        Compilation compilation = compiled();
+        List<BorderAssessment> edges = compilation.db()
+                .ask(new Adequacy.BoundarySearch("example.written", "tally")).value();
+        assertNotNull(edges, "the model under test is measured");
+
+        List<OwedBoundaryPoint> account = OwedBoundaryPoint.across(edges);
+        List<OwedBoundaryPoint> settledAlready = account.stream()
+                .filter(point -> !point.item().worthSearching()).toList();
+        assertFalse(settledAlready.isEmpty(),
+                "the written row leaves some point owed and not worth a candidate: " + account);
+
+        Set<BorderObligationPoint> asked = Settlements.of(compilation.db(), composed(compilation))
+                .requested().stream()
+                .filter(OfferItem.APointOfALine.class::isInstance)
+                .map(item -> ((OfferItem.APointOfALine) item).point())
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+
+        for (OwedBoundaryPoint point : settledAlready) {
+            assertFalse(asked.contains(point.owed()),
+                    "nothing is asked for a row at " + point + ", so it is not an item: " + asked);
+        }
+        // And what is asked for is still there, so this is not the items going missing.
+        for (OwedBoundaryPoint point : account) {
+            if (point.item().worthSearching()) {
+                assertTrue(asked.contains(point.owed()),
+                        "a point a row is asked for at is an item: " + point);
+            }
+        }
+    }
+
+    @Test
+    void nothingOfferedStandsAloneAtAPointNobodyIsAskedAbout() {
+        Compilation compilation = compiled();
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+
+        // Every kept row answers something this run was asked for. A row kept because it was the
+        // only thing standing at a point already answered is the defect this is against.
+        for (var row : table.keeping()) {
+            assertTrue(table.requested().stream().anyMatch(item -> table.offers(Set.of(row), item)),
+                    row + " is kept for something this run was asked for");
+        }
+    }
+
+    /**
+     * A declaration's line with a row written at one of its points.
+     *
+     * <p>So one point of it resolves to nothing having been looked for, and another to a search.
+     */
+    private static final String DECLARED = """
+            module example.declaredwritten
+
+            data Code = String
+                invariant longEnough = String.length(value) >= 4
+
+            data Ok
+
+            behavior take : (code: Code) -> Ok
+                constructs Ok
+
+            let take (code) = Ok
+
+            example take
+                | "on the line" : (Code("abcd")) -> Ok
+            """;
+
+    @Test
+    void aDeclaredPointNothingWasLookedForAtIsNotAnItem() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.declaredwritten");
+        assertNotNull(generated, "the model under test compiles: " + compilation.errors());
+        var declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
+                "example.declaredwritten", new GenerationScope.Module());
+        Offering composed = Offering.composed(
+                OfferingRequest.overTheModule("example.declaredwritten", true), generated, declared);
+        Settlements table = Settlements.of(compilation.db(), composed);
+
+        Set<BorderObligationPoint> asked = table.requested().stream()
+                .filter(OfferItem.APointOfALine.class::isInstance)
+                .map(item -> ((OfferItem.APointOfALine) item).point())
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+
+        boolean sawOne = false;
+        for (var each : declared.resolved().entrySet()) {
+            if (each.getValue().resolution() instanceof DeclarationResolution.NoSearch _) {
+                sawOne = true;
+                assertFalse(asked.contains(each.getKey()),
+                        "nothing was looked for at " + each.getKey() + ", so it is not an item");
+            } else {
+                assertTrue(asked.contains(each.getKey()),
+                        "a point this run asked about is an item: " + each.getKey());
+            }
+        }
+        assertTrue(sawOne, "the written row leaves a declared point nothing is looked for at: "
+                + declared.resolved());
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(ONE_POINT_WRITTEN, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static Offering composed(Compilation compilation) {
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.written");
+        assertNotNull(generated, "the model under test compiles: " + compilation.errors());
+        return Offering.composed(OfferingRequest.overTheModule("example.written", true), generated,
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.written",
+                        new GenerationScope.Module()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/APointNothingIsAskedForARowAtIsNotOfferedOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APointNothingIsAskedForARowAtIsNotOfferedOneTest.java
@@ -7,7 +7,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.DeclarationResolution;
 import souther.compiler.query.GenerationScope;
 import souther.compiler.query.OfferItem;
-import souther.compiler.query.Offering;
+import souther.compiler.query.Composition;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.OwedBoundaryPoint;
 import souther.compiler.query.Settlements;
@@ -135,7 +135,7 @@ class APointNothingIsAskedForARowAtIsNotOfferedOneTest {
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
         var declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
                 "example.declaredwritten", new GenerationScope.Module());
-        Offering composed = Offering.composed(
+        Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.declaredwritten", true), generated, declared);
         Settlements table = Settlements.of(compilation.db(), composed);
 
@@ -166,11 +166,11 @@ class APointNothingIsAskedForARowAtIsNotOfferedOneTest {
         return compilation;
     }
 
-    private static Offering composed(Compilation compilation) {
+    private static Composition composed(Compilation compilation) {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.written");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        return Offering.composed(OfferingRequest.overTheModule("example.written", true), generated,
+        return Composition.composed(OfferingRequest.overTheModule("example.written", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.written",
                         new GenerationScope.Module()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
@@ -1,0 +1,93 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlement;
+import souther.compiler.query.Settlements;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row a search composed for something answers that something when it is read back.
+ *
+ * <p>The two are separate walks over one model — a search that composes a value at a line, and a
+ * reading that asks where a row's values sit — and they have to agree. Where they do not, one of
+ * them is wrong about the model and neither says which: a reduction acting on the second would drop
+ * a row the first had just written, and the item it was for would go out with nothing offering it.
+ *
+ * <p><b>A line a declaration owns is the case worth writing down.</b> A behavior's account holds the
+ * lines that behavior is owed a row at, and a declaration's lines are none of them — so a reading
+ * that looked only there found no reading of a declared line anywhere, and answered that no row
+ * stands at one, of rows composed to stand at exactly that.
+ */
+class ARowComposedForAnItemSettlesThatItemTest {
+
+    /** A module whose only lines are the ones its declarations draw, and no rows written at them. */
+    private static final String DECLARED = """
+            module example.declared
+
+            data Code = String
+                invariant longEnough = String.length(value) >= 4
+
+            data Amount = Int
+                invariant within = value >= 1 && value <= 100
+
+            data Ok
+
+            behavior take : (code: Code, amount: Amount) -> Ok
+
+            let take (code, amount) = Ok
+            """;
+
+    @Test
+    void aRowComposedAtADeclaredLineStandsAtIt() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Offering offering = Adequacy.offeredFor(compilation.db(),
+                OfferingRequest.overTheModule("example.declared", true));
+        assertNotNull(offering, "the model under test compiles");
+        Settlements table = Settlements.of(compilation.db(), offering);
+
+        assertFalse(table.composedFor().isEmpty(),
+                "the declarations draw lines and rows are composed at them: " + table.requested());
+        assertTrue(table.composedFor().keySet().stream()
+                        .anyMatch(OfferItem.APointOfALine.class::isInstance),
+                "and at least one of them is a point of a line: " + table.composedFor().keySet());
+        table.composedFor().forEach((item, row) -> {
+            Map<OfferItem, Settlement> here = table.byRow().get(row);
+            assertNotNull(here, "the row composed for " + item + " is one this offers: " + row);
+            assertInstanceOf(Settlement.Settles.class, here.get(item),
+                    "a row composed for " + item + " settles it");
+        });
+    }
+
+    @Test
+    void everyOfferedRowIsAnsweredForAtEveryItem() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Offering offering = Adequacy.offeredFor(compilation.db(),
+                OfferingRequest.overTheModule("example.declared", true));
+        assertNotNull(offering, "the model under test compiles");
+        Settlements table = Settlements.of(compilation.db(), offering);
+
+        assertFalse(table.byRow().isEmpty(), "there are rows to answer for");
+        for (Map.Entry<RowKey, Map<OfferItem, Settlement>> row : table.byRow().entrySet()) {
+            for (OfferItem item : table.requested()) {
+                assertNotNull(row.getValue().get(item),
+                        row.getKey() + " is answered for at " + item);
+            }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
@@ -96,7 +96,7 @@ class ARowComposedForAnItemSettlesThatItemTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.declared");
         assertNotNull(generated, "the model under test compiles");
-        return Offering.of(OfferingRequest.overTheModule("example.declared", true), generated,
+        return Offering.composed(OfferingRequest.overTheModule("example.declared", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.declared",
                         new souther.compiler.query.GenerationScope.Module()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
@@ -54,10 +54,7 @@ class ARowComposedForAnItemSettlesThatItemTest {
         Compilation compilation = Compilation.ofSource(DECLARED, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Offering offering = Adequacy.offeredFor(compilation.db(),
-                OfferingRequest.overTheModule("example.declared", true));
-        assertNotNull(offering, "the model under test compiles");
-        Settlements table = Settlements.of(compilation.db(), offering);
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
 
         assertFalse(table.composedFor().isEmpty(),
                 "the declarations draw lines and rows are composed at them: " + table.requested());
@@ -77,10 +74,7 @@ class ARowComposedForAnItemSettlesThatItemTest {
         Compilation compilation = Compilation.ofSource(DECLARED, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        Offering offering = Adequacy.offeredFor(compilation.db(),
-                OfferingRequest.overTheModule("example.declared", true));
-        assertNotNull(offering, "the model under test compiles");
-        Settlements table = Settlements.of(compilation.db(), offering);
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
 
         assertFalse(table.byRow().isEmpty(), "there are rows to answer for");
         for (Map.Entry<RowKey, Map<OfferItem, Settlement>> row : table.byRow().entrySet()) {
@@ -89,5 +83,21 @@ class ARowComposedForAnItemSettlesThatItemTest {
                         row.getKey() + " is answered for at " + item);
             }
         }
+    }
+
+    /**
+     * What the searches composed, before anything asks what the rows settle.
+     *
+     * <p>What a row was composed for is a fact about the composition. Read off what a person is
+     * finally handed, a row answering something another row also answers is not there to be asked
+     * about — so the two would agree by one of them being gone.
+     */
+    private static Offering composed(Compilation compilation) {
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.declared");
+        assertNotNull(generated, "the model under test compiles");
+        return Offering.of(OfferingRequest.overTheModule("example.declared", true), generated,
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.declared",
+                        new souther.compiler.query.GenerationScope.Module()));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowComposedForAnItemSettlesThatItemTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.OfferItem;
-import souther.compiler.query.Offering;
+import souther.compiler.query.Composition;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
 import souther.compiler.query.Settlement;
@@ -92,11 +92,11 @@ class ARowComposedForAnItemSettlesThatItemTest {
      * finally handed, a row answering something another row also answers is not there to be asked
      * about — so the two would agree by one of them being gone.
      */
-    private static Offering composed(Compilation compilation) {
+    private static Composition composed(Compilation compilation) {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.declared");
         assertNotNull(generated, "the model under test compiles");
-        return Offering.composed(OfferingRequest.overTheModule("example.declared", true), generated,
+        return Composition.composed(OfferingRequest.overTheModule("example.declared", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.declared",
                         new souther.compiler.query.GenerationScope.Module()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
@@ -1,0 +1,168 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlements;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two rows answering the same thing are one piece of work.
+ *
+ * <p>A candidate is composed for one item and the positions that item does not name hold whatever
+ * the row has to hold, so a row composed for one thing can stand where another asks. Nothing used to
+ * put that question: rows were joined where their values were written the same way and nowhere else,
+ * so a row inside a region and a row at the end of it went out as two.
+ *
+ * <p>The model here is the one the shipping rules are written from, with the three rows a person
+ * writes first. What is left uncovered is a class at two of the regions, four arms, two points of
+ * the comparison a guard draws and two of a declaration's own line — and the rows composed at the
+ * declaration's line stand inside the comparison's regions, which is what takes two rows out.
+ */
+class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
+
+    private static final String MODULE = """
+            module example.shippingfee
+
+            data 商品合計 = Int
+                invariant value >= 0 && value <= 1000000
+
+            data 本州
+            data 北海道沖縄
+            data 離島
+            data 配送地域 = 本州 | 北海道沖縄 | 離島
+
+            data 一般
+            data プレミアム
+            data 会員区分 = 一般 | プレミアム
+
+            data 注文 =
+                { 合計: 商品合計
+                , 地域: 配送地域
+                , 会員: 会員区分
+                }
+
+            data 送料無料
+            data 送料あり = { 金額: Int }
+
+            behavior 送料を求める : (注文: 注文) -> 送料無料 | 送料あり
+                constructs 送料あり
+
+            let 送料を求める (注文) =
+                match 注文.会員 with
+                    | プレミアム -> 送料無料
+                    | 一般 -> 一般会員の送料(注文)
+
+            let 一般会員の送料 (注文: 注文): 送料無料 | 送料あり = {
+                guard 注文.合計.value < 5000 else 離島以外は無料(注文.地域)
+                送料あり { 金額 = 地域別送料(注文.地域) }
+            }
+
+            let 離島以外は無料 (地域: 配送地域): 送料無料 | 送料あり =
+                match 地域 with
+                    | 離島 -> 送料あり { 金額 = 1500 }
+                    | 本州 -> 送料無料
+                    | 北海道沖縄 -> 送料無料
+
+            let 地域別送料 (地域: 配送地域): Int =
+                match 地域 with
+                    | 本州 -> 500
+                    | 北海道沖縄 -> 800
+                    | 離島 -> 1500
+
+            example 送料を求める
+                | "プレミアム会員は無料" :
+                    (注文 { 合計 = 商品合計(1000), 地域 = 本州, 会員 = プレミアム })
+                        -> 送料無料
+                | "5,000円以上は無料" :
+                    (注文 { 合計 = 商品合計(5000), 地域 = 本州, 会員 = 一般 })
+                        -> 送料無料
+                | "5,000円未満の本州は500円" :
+                    (注文 { 合計 = 商品合計(4999), 地域 = 本州, 会員 = 一般 })
+                        -> 送料あり { 金額 = 500 }
+            """;
+
+    @Test
+    void aRowStandingWhereAnotherAlreadyStandsIsNotOfferedTwice() {
+        Compilation compilation = compiled();
+        Offering composed = composed(compilation);
+        Offering offered = Adequacy.offeredFor(compilation.db(),
+                OfferingRequest.overTheModule("example.shippingfee", true));
+        assertNotNull(offered, "the model under test compiles");
+
+        // Six, of the eight the searches composed. The two that go are the rows at the ends of the
+        // comparison's regions: a row at the bottom of the declaration's line sits inside the one,
+        // and a row at its top inside the other.
+        assertEquals(6, offered.count(),
+                "a row answering what another answers is not offered: " + composed.count()
+                        + " composed, " + offered.count() + " offered");
+    }
+
+    @Test
+    void whatTheRowsAnswerIsWhatTheyAnsweredBefore() {
+        Compilation compilation = compiled();
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+        Set<OfferItem> before = table.settled();
+        Set<RowKey> kept = table.keeping();
+
+        assertTrue(kept.size() < table.byRow().size(), "something goes: " + kept.size()
+                + " of " + table.byRow().size());
+        for (OfferItem item : before) {
+            assertTrue(kept.stream().anyMatch(row -> table.at(row, item).settles()),
+                    "and " + item + " is still answered by one of the rows that are left");
+        }
+    }
+
+    @Test
+    void theRowsThatGoAreTheOnesInsideARegionAnotherRowSitsIn() {
+        Compilation compilation = compiled();
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+        Set<RowKey> kept = table.keeping();
+        for (Map.Entry<RowKey, Map<OfferItem, souther.compiler.query.Settlement>> row
+                : table.byRow().entrySet()) {
+            if (kept.contains(row.getKey())) {
+                continue;
+            }
+            // Everything it answered, another row that is left answers as well. Anything else would
+            // be a piece of work going missing rather than one being said once instead of twice.
+            row.getValue().forEach((item, settlement) -> {
+                if (settlement.settles()) {
+                    assertTrue(kept.stream().anyMatch(one -> table.at(one, item).settles()),
+                            row.getKey() + " went, and nothing left answers " + item);
+                }
+            });
+        }
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(MODULE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /** What the searches composed, before anything asks what the rows settle. */
+    private static Offering composed(Compilation compilation) {
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.shippingfee");
+        assertNotNull(generated, "the model under test compiles: " + compilation.errors());
+        Offering composed = Offering.of(
+                OfferingRequest.overTheModule("example.shippingfee", true), generated,
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shippingfee",
+                        new GenerationScope.Module()));
+        assertEquals(8, composed.count(),
+                "the searches compose one row per thing they are asked for");
+        return composed;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
@@ -157,7 +157,7 @@ class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.shippingfee");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        Offering composed = Offering.of(
+        Offering composed = Offering.composed(
                 OfferingRequest.overTheModule("example.shippingfee", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shippingfee",
                         new GenerationScope.Module()));

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
@@ -5,6 +5,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.GenerationScope;
 import souther.compiler.query.OfferItem;
+import souther.compiler.query.Composition;
 import souther.compiler.query.Offering;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
@@ -101,7 +102,7 @@ class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
     @Test
     void aRowStandingWhereAnotherAlreadyStandsIsNotOfferedTwice() {
         Compilation compilation = compiled();
-        Offering composed = composed(compilation);
+        Composition composed = composed(compilation);
         Offering offered = Adequacy.offeredFor(compilation.db(),
                 OfferingRequest.overTheModule("example.shippingfee", true));
         assertNotNull(offered, "the model under test compiles");
@@ -200,11 +201,11 @@ class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
     }
 
     /** What the searches composed, before anything asks what the rows settle. */
-    private static Offering composed(Compilation compilation) {
+    private static Composition composed(Compilation compilation) {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.shippingfee");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        Offering composed = Offering.composed(
+        Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.shippingfee", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shippingfee",
                         new GenerationScope.Module()));

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest.java
@@ -29,6 +29,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * writes first. What is left uncovered is a class at two of the regions, four arms, two points of
  * the comparison a guard draws and two of a declaration's own line — and the rows composed at the
  * declaration's line stand inside the comparison's regions, which is what takes two rows out.
+ *
+ * <p>What says five is enough is not the arithmetic above but the findings: every gap the report
+ * raises is something this run is asked about, and one of the rows that are offered stands at it.
+ * The issue counted six by hand, one of which was the only thing offering for a point a written row
+ * already stands at — which is nobody's work.
  */
 class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
 
@@ -101,12 +106,54 @@ class ARowIsNotOfferedForWhatAnotherOfferedRowAnswersTest {
                 OfferingRequest.overTheModule("example.shippingfee", true));
         assertNotNull(offered, "the model under test compiles");
 
-        // Six, of the eight the searches composed. The two that go are the rows at the ends of the
-        // comparison's regions: a row at the bottom of the declaration's line sits inside the one,
-        // and a row at its top inside the other.
-        assertEquals(6, offered.count(),
+        // Five, of the eight the searches composed. Two of them stand at the ends of the
+        // comparison's regions, where the rows composed at the declaration's line already stand.
+        // The third is the only thing offering for a point nobody is asked about — a row is written
+        // at it already — and what it stands at besides, another offered row stands at too.
+        assertEquals(5, offered.count(),
                 "a row answering what another answers is not offered: " + composed.count()
                         + " composed, " + offered.count() + " offered");
+    }
+
+    @Test
+    void everyGapTheReportRaisesIsAnsweredByAnOfferedRow() {
+        Compilation compilation = compiled();
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+        Set<RowKey> kept = table.keeping();
+
+        // Read off the findings and not off the items: what a person is short of is the report's
+        // answer, and a reduction that shrank its own universe would otherwise be marking its own
+        // homework.
+        java.util.List<Adequacy.Finding> findings = compilation.db()
+                .ask(new Adequacy.Findings("example.shippingfee")).value();
+        assertNotNull(findings, "the model under test is measured");
+        int asked = 0;
+        for (Adequacy.Finding finding : findings) {
+            OfferItem item = switch (finding.about()) {
+                case souther.compiler.query.About.APointOfABorder(var point) ->
+                        new OfferItem.APointOfALine(point.owed());
+                case souther.compiler.query.About.APointOfADeclaredBorder(var debt) ->
+                        new OfferItem.APointOfALine(debt.point());
+                case souther.compiler.query.About.AnArmNoRowGoesThrough(var arm) ->
+                        new OfferItem.AnArm(
+                                new souther.compiler.partition.Generator.ArmOwed(arm.index()));
+                case souther.compiler.query.About.AClassNoRowIsIn(var missing) ->
+                        new OfferItem.AClass(new souther.compiler.partition.Generator.ClassOwed(
+                                missing.axis().at(), missing.name()));
+                default -> null;
+            };
+            if (item == null) {
+                continue;
+            }
+            // In the universe, and not skipped where it is not. A gap whose item this run left out
+            // is the reduction shrinking what it is judged against, which is the thing to catch.
+            assertTrue(table.requested().contains(item),
+                    "a gap the report raises is something this run is asked about: " + item);
+            asked++;
+            assertTrue(table.offers(kept, item),
+                    "a gap the report raises is answered by a row that is offered: " + item);
+        }
+        assertTrue(asked > 0, "the model under test has gaps of the kinds a row is offered for");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest.java
@@ -68,9 +68,10 @@ class ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filling = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(filling, "the model under test compiles");
-        return GeneratedRows.of(souther.compiler.query.OfferingRequest.overTheModule(
-                        compilation.modules().get(0), false), filling, null, Map.of(),
-                SourceNameResolver.identity()).text();
+        return GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                compilation.modules().get(0), false)),
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     @Test
@@ -235,18 +236,20 @@ class ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest {
      * A group's combinations cost no rows of their own.
      *
      * <p>Three outcomes against four used to be twelve rows — the product of the group's factors,
-     * which is the space the search walked and which nothing reports. What is offered here is the
-     * classes: three of one position and four of the other, two of which meet in one row, so six.
-     * No row is written for a combination, and this model writes none either — it has no `example`
-     * block, so nothing read its rows and no arm is established as unreached for one to be owed at.
+     * which is the space the search walked and which nothing reports. What is offered is the
+     * classes, and fewer rows than there are of those: a row composed for a class of one position
+     * holds some class of the other, so the two whose rows would have been the third position's
+     * are answered where they stand. No row is written for a combination, and this model writes
+     * none either — it has no `example` block, so nothing read its rows and no arm is established
+     * as unreached for one to be owed at.
      */
     @Test
     void aGroupsCombinationsCostNoRowsOfTheirOwn() {
         String block = block(TWELVE);
 
-        assertEquals(6, rows(block),
-                "the seven classes, two of them meeting in one row — not the twelve combinations "
-                        + "they make: " + block);
+        assertEquals(5, rows(block),
+                "five rows for the seven classes — not the twelve combinations they make, and not "
+                        + "one row apiece: " + block);
         assertTrue(!block.contains("generation stopped"),
                 "and nothing was left for a limit to cut off: " + block);
     }
@@ -287,7 +290,8 @@ class ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest {
 
         assertEquals(List.of(), names(block).stream().filter(name -> name.contains(" x ")).toList(),
                 "every row is named for one class, none for a combination of them: " + block);
-        assertEquals(5, rows(block),
-                "the four positions' second classes and the one they meet in: " + block);
+        assertEquals(4, rows(block),
+                "four rows for the eight classes: each row holds a class of every position, so the"
+                        + " ones nothing was composed for are answered where they stand: " + block);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest.java
@@ -68,7 +68,8 @@ class ARowIsOfferedForEveryCombinationOfTheDecisionsOneValueIsMadeOfTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filling = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(filling, "the model under test compiles");
-        return GeneratedRows.of(compilation.modules().get(0), filling, null, Map.of(), false,
+        return GeneratedRows.of(souther.compiler.query.OfferingRequest.overTheModule(
+                        compilation.modules().get(0), false), filling, null, Map.of(),
                 SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
@@ -6,16 +6,19 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.DeclarationResolution;
 import souther.compiler.query.DeclaredRows;
 import souther.compiler.query.GenerationScope;
+import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.query.OfferItem;
 import souther.compiler.query.Composition;
-import souther.compiler.query.Offering;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
 import souther.compiler.query.Settlement;
 import souther.compiler.query.Settlements;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>A line a declaration draws is owed a row once over every behavior carrying the type, and the
  * row is composed by whichever reading could compose it. That behavior need not be one anything else
  * was asked about — an offering holds the row under it either way, which is what
- * {@link Offering#composed} says in as many words.
+ * {@link Composition#composed} says in as many words.
  *
  * <p>Read off the searches instead, such a row has no reading at all: every question put to it comes
  * back as one nothing could tell about, so nothing it stands at can make another row redundant and
@@ -49,7 +52,10 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
 
             behavior take : (code: Code, amount: Amount) -> Ok
 
-            let take (code, amount) = Ok
+            let take (code, amount) = {
+                guard amount.value > 50 else Ok
+                Ok
+            }
             """;
 
     @Test
@@ -63,7 +69,7 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
                 "a declaration's line is owed a row and one behavior composed it: " + declared);
 
         // The offering a run makes when nothing was asked of the carrier itself. Which is the state
-        // `Offering.composed` is written for, and the one a reader off the searches cannot read.
+        // `Composition.composed` is written for, and the one a reader off the searches cannot read.
         Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
         assertFalse(composed.rows().isEmpty(), "the row is offered under its carrier: " + composed);
@@ -83,6 +89,44 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
                     "a row composed by a behavior nothing else was asked of settles what it was"
                             + " composed for");
         });
+    }
+
+    /**
+     * And nothing this run did not ask of it comes back as work.
+     *
+     * <p>The behavior draws a line of its own, and a run that asked it for nothing has no search of
+     * it: what it holds is a row somebody else's line needed. Asked for the search while reading
+     * that row, the run would make the search it had decided not to make, and the behavior's own
+     * points would arrive as items nobody was set — which is a candidate standing at one of them
+     * becoming the only offer for work nobody asked for.
+     */
+    @Test
+    void andNothingOfItsOwnIsAskedForWhereNothingWasAskedOfIt() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
+                "example.carried", new GenerationScope.Module());
+        Composition composed = Composition.composed(
+                OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
+        Settlements table = Settlements.of(compilation.db(), composed);
+
+        // The behavior has lines of its own, so this says something.
+        assertFalse(Adequacy.generatedOf(compilation.db(), "example.carried").isEmpty(),
+                "the model under test has a behavior with a search of its own to be asked for");
+
+        Set<BorderObligationPoint> asked = new LinkedHashSet<>();
+        for (OfferItem item : table.requested()) {
+            if (item instanceof OfferItem.APointOfALine(var point)) {
+                asked.add(point);
+            }
+        }
+        assertEquals(new LinkedHashSet<>(declared.resolved().keySet().stream()
+                        .filter(point -> !(declared.resolved().get(point).resolution()
+                                instanceof DeclarationResolution.NoSearch))
+                        .toList()),
+                asked,
+                "only the declarations' points are asked about, and none of the behavior's own");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
@@ -1,0 +1,118 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.DeclarationResolution;
+import souther.compiler.query.DeclaredRows;
+import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlement;
+import souther.compiler.query.Settlements;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row is read under the behavior that composed it, whatever else that behavior was asked.
+ *
+ * <p>A line a declaration draws is owed a row once over every behavior carrying the type, and the
+ * row is composed by whichever reading could compose it. That behavior need not be one anything else
+ * was asked about — an offering holds the row under it either way, which is what
+ * {@link Offering#composed} says in as many words.
+ *
+ * <p>Read off the searches instead, such a row has no reading at all: every question put to it comes
+ * back as one nothing could tell about, so nothing it stands at can make another row redundant and
+ * the two go out as two pieces of work. Which is this issue's own defect, on the side nobody
+ * measured.
+ */
+class ARowIsReadUnderWhateverBehaviorComposedItTest {
+
+    private static final String DECLARED = """
+            module example.carried
+
+            data Code = String
+                invariant longEnough = String.length(value) >= 4
+
+            data Amount = Int
+                invariant within = value >= 1 && value <= 100
+
+            data Ok
+
+            behavior take : (code: Code, amount: Amount) -> Ok
+
+            let take (code, amount) = Ok
+            """;
+
+    @Test
+    void aRowComposedByABehaviorNothingElseWasAskedOfIsStillRead() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
+                "example.carried", new GenerationScope.Module());
+        assertFalse(declared.rowsByCarrier().isEmpty(),
+                "a declaration's line is owed a row and one behavior composed it: " + declared);
+
+        // The offering a run makes when nothing was asked of the carrier itself. Which is the state
+        // `Offering.composed` is written for, and the one a reader off the searches cannot read.
+        Offering composed = Offering.composed(
+                OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
+        assertFalse(composed.rows().isEmpty(), "the row is offered under its carrier: " + composed);
+        for (String carrier : composed.rows().keySet()) {
+            assertFalse(composed.searched().containsKey(carrier),
+                    "and nothing was searched for that behavior: " + carrier);
+        }
+
+        Settlements table = Settlements.of(compilation.db(), composed);
+        assertFalse(table.byRow().isEmpty(), "the row is in the table");
+        assertFalse(table.composedFor().isEmpty(),
+                "and something was composed for: " + table.requested());
+        table.composedFor().forEach((item, row) -> {
+            Map<OfferItem, Settlement> here = table.byRow().get(row);
+            assertNotNull(here, "the row composed for " + item + " is one this offers");
+            assertInstanceOf(Settlement.Settles.class, here.get(item),
+                    "a row composed by a behavior nothing else was asked of settles what it was"
+                            + " composed for");
+        });
+    }
+
+    @Test
+    void andWhatItSettlesCanMakeAnotherRowRedundant() {
+        Compilation compilation = Compilation.ofSource(DECLARED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
+                "example.carried", new GenerationScope.Module());
+        Offering composed = Offering.composed(
+                OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
+        Settlements table = Settlements.of(compilation.db(), composed);
+
+        // Nothing here is undetermined for want of a reading. What a run cannot tell about is a
+        // value it could not build or a run nobody watched, and neither is what a carrier without a
+        // search of its own is.
+        long settles = 0;
+        for (Map.Entry<RowKey, Map<OfferItem, Settlement>> row : table.byRow().entrySet()) {
+            settles += row.getValue().values().stream().filter(Settlement::settles).count();
+        }
+        assertTrue(settles > 0, "the rows settle something: " + table.byRow());
+
+        for (var each : declared.resolved().entrySet()) {
+            if (!(each.getValue().resolution() instanceof DeclarationResolution.Generated(var by,
+                    var row))) {
+                continue;
+            }
+            OfferItem item = new OfferItem.APointOfALine(each.getKey());
+            assertTrue(table.offers(table.keeping(), item),
+                    "what the carrier's row was composed for is offered after the reduction: "
+                            + item + " " + by + " " + row);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
@@ -7,6 +7,7 @@ import souther.compiler.query.DeclarationResolution;
 import souther.compiler.query.DeclaredRows;
 import souther.compiler.query.GenerationScope;
 import souther.compiler.query.OfferItem;
+import souther.compiler.query.Composition;
 import souther.compiler.query.Offering;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
@@ -63,7 +64,7 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
 
         // The offering a run makes when nothing was asked of the carrier itself. Which is the state
         // `Offering.composed` is written for, and the one a reader off the searches cannot read.
-        Offering composed = Offering.composed(
+        Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
         assertFalse(composed.rows().isEmpty(), "the row is offered under its carrier: " + composed);
         for (String carrier : composed.rows().keySet()) {
@@ -91,7 +92,7 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
         compilation.answerEverything();
         DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(),
                 "example.carried", new GenerationScope.Module());
-        Offering composed = Offering.composed(
+        Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
         Settlements table = Settlements.of(compilation.db(), composed);
 

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -264,10 +264,8 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                     Adequacy.generatedOf(compilation.db(), module);
             assertNotNull(generated);
 
-            String written = GeneratedRows.of(
-                    souther.compiler.query.OfferingRequest.overTheModule(module, true), generated,
-                    Adequacy.generatedForDeclarationsOf(compilation.db(), module,
-                            new souther.compiler.query.GenerationScope.Module()),
+            String written = GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                            souther.compiler.query.OfferingRequest.overTheModule(module, true)),
                     Map.of(), SourceNameResolver.identity()).text();
             assertFalse(written.contains("example "),
                     module + " offers a row that may already be written: " + written);
@@ -322,11 +320,8 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
         assertTrue(partition.pairs().counts().unknown() > 0, "a combination nothing reaches");
         assertFalse(compilation.db().ask(new Adequacy.BranchCoverage(module)).value()
                 .get("take").unreached().orElseThrow().isEmpty(), "an arm nothing goes through");
-        assertFalse(GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule(module, true),
-                Adequacy.generatedOf(compilation.db(), module),
-                Adequacy.generatedForDeclarationsOf(compilation.db(), module,
-                        new souther.compiler.query.GenerationScope.Module()),
+        assertFalse(GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(module, true)),
                 Map.of(), SourceNameResolver.identity()).text().isEmpty(),
                 "and rows offered for them");
     }

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -264,10 +264,11 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                     Adequacy.generatedOf(compilation.db(), module);
             assertNotNull(generated);
 
-            String written = GeneratedRows.of(module, generated,
+            String written = GeneratedRows.of(
+                    souther.compiler.query.OfferingRequest.overTheModule(module, true), generated,
                     Adequacy.generatedForDeclarationsOf(compilation.db(), module,
                             new souther.compiler.query.GenerationScope.Module()),
-                    Map.of(), true, SourceNameResolver.identity()).text();
+                    Map.of(), SourceNameResolver.identity()).text();
             assertFalse(written.contains("example "),
                     module + " offers a row that may already be written: " + written);
             // Either word, because the two models get here differently: one has rows nothing read
@@ -321,12 +322,12 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
         assertTrue(partition.pairs().counts().unknown() > 0, "a combination nothing reaches");
         assertFalse(compilation.db().ask(new Adequacy.BranchCoverage(module)).value()
                 .get("take").unreached().orElseThrow().isEmpty(), "an arm nothing goes through");
-        assertFalse(GeneratedRows.of(module,
+        assertFalse(GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule(module, true),
                 Adequacy.generatedOf(compilation.db(), module),
                 Adequacy.generatedForDeclarationsOf(compilation.db(), module,
                         new souther.compiler.query.GenerationScope.Module()),
-                Map.of(), true,
-                SourceNameResolver.identity()).text().isEmpty(),
+                Map.of(), SourceNameResolver.identity()).text().isEmpty(),
                 "and rows offered for them");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
@@ -138,9 +138,10 @@ class AnEqualityDividesTheValuesInTwoTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> all = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
-        return GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.ratio", false),
-                all, null, Map.of(), SourceNameResolver.identity()).text();
+        return GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                "example.ratio", false)),
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** An ordering comparison beside it is a distinction the model does draw, and is kept. */

--- a/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
@@ -138,8 +138,9 @@ class AnEqualityDividesTheValuesInTwoTest {
         compilation.answerEverything();
         Map<String, Adequacy.Filling> all = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
         assertNotNull(all, "the model under test compiles");
-        return GeneratedRows.of("example.ratio", all, null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        return GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.ratio", false),
+                all, null, Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** An ordering comparison beside it is a distinction the model does draw, and is kept. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.partition.Generator;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.OfferingRequest;
 import souther.compiler.report.GeneratedRows;
 
 import java.util.ArrayList;
@@ -349,8 +350,8 @@ class CompileExampleGenerateTest {
                 inputs(generated(tabbed).get("take").composed()),
                 "the tab is written the way a literal spells one");
 
-        String block = GeneratedRows.of("example.tabbed", generated(tabbed), null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.tabbed", false),
+                generated(tabbed), null, Map.of(), SourceNameResolver.identity()).text();
         String pasted = tabbed + block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example take"))
                 .map(line -> line.substring("// ".length()).replace("<?>", "Ok { n = 0 }"))
@@ -675,8 +676,8 @@ class CompileExampleGenerateTest {
 
     /** The rows of the block, with the placeholder answered the way an author answers it. */
     private static String answered(String source, String expected) {
-        String block = GeneratedRows.of("example.trip", generated(source), null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                generated(source), null, Map.of(), SourceNameResolver.identity()).text();
         String rows = block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example submit"))
                 .map(line -> line.substring("// ".length()).replace("<?>", expected))
@@ -721,8 +722,8 @@ class CompileExampleGenerateTest {
             assertEquals(souther.compiler.observe.Disposition.HELD, row.disposition(),
                     row.identity().shown() + " -> " + row.failurePhase());
         }
-        assertEquals("", GeneratedRows.of("example.trip", generated(source), null, Map.of(), false,
-                        SourceNameResolver.identity()).text(),
+        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                        generated(source), null, Map.of(), SourceNameResolver.identity()).text(),
                 "nothing is left to fill");
     }
 
@@ -749,16 +750,16 @@ class CompileExampleGenerateTest {
      */
     @Test
     void theBlockPastedUnchangedLeavesTheModelWhereItWas() {
-        String block = GeneratedRows.of("example.trip", generated(TRIP), null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                generated(TRIP), null, Map.of(), SourceNameResolver.identity()).text();
         String pasted = TRIP + block;
 
         Compilation compilation = Compilation.ofSource(pasted, "Main");
         compilation.answerEverything();
 
         assertEquals(1, outcomes(compilation).size(), "no row was added");
-        assertEquals(block, GeneratedRows.of("example.trip", generated(pasted), null, Map.of(), false,
-                        SourceNameResolver.identity()).text(),
+        assertEquals(block, GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                        generated(pasted), null, Map.of(), SourceNameResolver.identity()).text(),
                 "the same rows are still owed");
     }
 
@@ -828,8 +829,8 @@ class CompileExampleGenerateTest {
             assertEquals(souther.compiler.observe.Disposition.HELD, row.disposition(),
                     row.identity().shown() + " -> " + row.failurePhase());
         }
-        assertEquals("", GeneratedRows.of("example.trip", generated(source), null, Map.of(), false,
-                        SourceNameResolver.identity()).text(),
+        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                        generated(source), null, Map.of(), SourceNameResolver.identity()).text(),
                 "and nothing is left to offer once they are answered");
     }
 
@@ -1038,8 +1039,8 @@ class CompileExampleGenerateTest {
      */
     @Test
     void theBlockIsWrittenInTheFormattersOwnShape() {
-        String block = GeneratedRows.of("example.trip", generated(TRIP), null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                generated(TRIP), null, Map.of(), SourceNameResolver.identity()).text();
         String rows = block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example submit"))
                 .map(line -> line.substring("// ".length()).replace("<?>", "unanswered__"))
@@ -1115,8 +1116,8 @@ class CompileExampleGenerateTest {
                     | (Request { kind = Overseas, urgent = false }) -> Accepted { at = "now" }
                 """;
 
-        assertEquals("", GeneratedRows.of("example.trip", generated(covered), null, Map.of(), false,
-                SourceNameResolver.identity()).text());
+        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
+                generated(covered), null, Map.of(), SourceNameResolver.identity()).text());
     }
 
     /**
@@ -1157,10 +1158,10 @@ class CompileExampleGenerateTest {
     void aNoteAboutABorderPointIsSaidWhereTheBordersWereAskedFor() {
         Map<String, Adequacy.Filling> generated = generated(EVERY_POINT_UNFILLED);
 
-        String asked = GeneratedRows.of("sz.gen", generated, null, Map.of(), true,
-                SourceNameResolver.identity()).text();
-        String notAsked = GeneratedRows.of("sz.gen", generated, null, Map.of(), false,
-                SourceNameResolver.identity()).text();
+        String asked = GeneratedRows.of(OfferingRequest.overTheModule("sz.gen", true),
+                generated, null, Map.of(), SourceNameResolver.identity()).text();
+        String notAsked = GeneratedRows.of(OfferingRequest.overTheModule("sz.gen", false),
+                generated, null, Map.of(), SourceNameResolver.identity()).text();
 
         // One against the line and one away from it, so neither kind is answering for the other.
         assertTrue(asked.contains("// no row for `s = 5` in `label`"), asked);

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -58,6 +58,20 @@ class CompileExampleGenerateTest {
         return compilation;
     }
 
+    /**
+     * The block a person is handed for {@code module}.
+     *
+     * <p>What is offered and not what was composed: a row another offered row answers is not one of
+     * these, and a test that rendered the composition would be reading rows nobody is given.
+     */
+    private static String blockOf(String source, String module, boolean boundaries) {
+        Compilation compilation = compiledOf(source);
+        souther.compiler.query.Offering offering = Adequacy.offeredFor(compilation.db(),
+                OfferingRequest.overTheModule(module, boundaries));
+        assertNotNull(offering, "the model under test compiles");
+        return GeneratedRows.of(offering, Map.of(), SourceNameResolver.identity()).text();
+    }
+
     private static Map<String, Adequacy.Filling> generated(String source) {
         Compilation compilation = compiledOf(source);
         Map<String, Adequacy.Filling> all = Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
@@ -350,8 +364,7 @@ class CompileExampleGenerateTest {
                 inputs(generated(tabbed).get("take").composed()),
                 "the tab is written the way a literal spells one");
 
-        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.tabbed", false),
-                generated(tabbed), null, Map.of(), SourceNameResolver.identity()).text();
+        String block = blockOf(tabbed, "example.tabbed", false);
         String pasted = tabbed + block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example take"))
                 .map(line -> line.substring("// ".length()).replace("<?>", "Ok { n = 0 }"))
@@ -676,8 +689,7 @@ class CompileExampleGenerateTest {
 
     /** The rows of the block, with the placeholder answered the way an author answers it. */
     private static String answered(String source, String expected) {
-        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                generated(source), null, Map.of(), SourceNameResolver.identity()).text();
+        String block = blockOf(source, "example.trip", false);
         String rows = block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example submit"))
                 .map(line -> line.substring("// ".length()).replace("<?>", expected))
@@ -722,8 +734,7 @@ class CompileExampleGenerateTest {
             assertEquals(souther.compiler.observe.Disposition.HELD, row.disposition(),
                     row.identity().shown() + " -> " + row.failurePhase());
         }
-        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                        generated(source), null, Map.of(), SourceNameResolver.identity()).text(),
+        assertEquals("", blockOf(source, "example.trip", false),
                 "nothing is left to fill");
     }
 
@@ -750,16 +761,14 @@ class CompileExampleGenerateTest {
      */
     @Test
     void theBlockPastedUnchangedLeavesTheModelWhereItWas() {
-        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                generated(TRIP), null, Map.of(), SourceNameResolver.identity()).text();
+        String block = blockOf(TRIP, "example.trip", false);
         String pasted = TRIP + block;
 
         Compilation compilation = Compilation.ofSource(pasted, "Main");
         compilation.answerEverything();
 
         assertEquals(1, outcomes(compilation).size(), "no row was added");
-        assertEquals(block, GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                        generated(pasted), null, Map.of(), SourceNameResolver.identity()).text(),
+        assertEquals(block, blockOf(pasted, "example.trip", false),
                 "the same rows are still owed");
     }
 
@@ -829,8 +838,7 @@ class CompileExampleGenerateTest {
             assertEquals(souther.compiler.observe.Disposition.HELD, row.disposition(),
                     row.identity().shown() + " -> " + row.failurePhase());
         }
-        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                        generated(source), null, Map.of(), SourceNameResolver.identity()).text(),
+        assertEquals("", blockOf(source, "example.trip", false),
                 "and nothing is left to offer once they are answered");
     }
 
@@ -1039,8 +1047,7 @@ class CompileExampleGenerateTest {
      */
     @Test
     void theBlockIsWrittenInTheFormattersOwnShape() {
-        String block = GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                generated(TRIP), null, Map.of(), SourceNameResolver.identity()).text();
+        String block = blockOf(TRIP, "example.trip", false);
         String rows = block.lines()
                 .filter(line -> line.startsWith("//     ") || line.equals("// example submit"))
                 .map(line -> line.substring("// ".length()).replace("<?>", "unanswered__"))
@@ -1116,8 +1123,7 @@ class CompileExampleGenerateTest {
                     | (Request { kind = Overseas, urgent = false }) -> Accepted { at = "now" }
                 """;
 
-        assertEquals("", GeneratedRows.of(OfferingRequest.overTheModule("example.trip", false),
-                generated(covered), null, Map.of(), SourceNameResolver.identity()).text());
+        assertEquals("", blockOf(covered, "example.trip", false));
     }
 
     /**
@@ -1156,12 +1162,8 @@ class CompileExampleGenerateTest {
      */
     @Test
     void aNoteAboutABorderPointIsSaidWhereTheBordersWereAskedFor() {
-        Map<String, Adequacy.Filling> generated = generated(EVERY_POINT_UNFILLED);
-
-        String asked = GeneratedRows.of(OfferingRequest.overTheModule("sz.gen", true),
-                generated, null, Map.of(), SourceNameResolver.identity()).text();
-        String notAsked = GeneratedRows.of(OfferingRequest.overTheModule("sz.gen", false),
-                generated, null, Map.of(), SourceNameResolver.identity()).text();
+        String asked = blockOf(EVERY_POINT_UNFILLED, "sz.gen", true);
+        String notAsked = blockOf(EVERY_POINT_UNFILLED, "sz.gen", false);
 
         // One against the line and one away from it, so neither kind is answering for the other.
         assertTrue(asked.contains("// no row for `s = 5` in `label`"), asked);

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -285,11 +285,9 @@ class CompilePartialAdequacyTest {
                 "the flag's classes are undecided, so nothing is written for them");
         assertFalse(generated.get("take").composed().reasons().isEmpty(),
                 "and the position that could not be read is named");
-        String written = GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.budget", true),
-                generated,
-                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.budget",
-                        new souther.compiler.query.GenerationScope.Module()),
+        String written = GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                "example.budget", true)),
                 Map.of(), SourceNameResolver.identity()).text();
         assertFalse(written.contains("example take"), "no row is offered: " + written);
         assertTrue(written.contains("no rows offered at"),
@@ -485,11 +483,9 @@ class CompilePartialAdequacyTest {
 
         assertEquals(List.of(), generated.get("take").composed().rows());
         assertEquals(List.of(), generated.get("take").boundaries().rows());
-        String written = GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.split", true),
-                generated,
-                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.split",
-                        new souther.compiler.query.GenerationScope.Module()),
+        String written = GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                "example.split", true)),
                 Map.of(), SourceNameResolver.identity()).text();
         assertFalse(written.contains("example take"),
                 "the row may be sitting in the file that could not be read: " + written);

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -285,10 +285,12 @@ class CompilePartialAdequacyTest {
                 "the flag's classes are undecided, so nothing is written for them");
         assertFalse(generated.get("take").composed().reasons().isEmpty(),
                 "and the position that could not be read is named");
-        String written = GeneratedRows.of("example.budget", generated,
+        String written = GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.budget", true),
+                generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.budget",
                         new souther.compiler.query.GenerationScope.Module()),
-                Map.of(), true, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
         assertFalse(written.contains("example take"), "no row is offered: " + written);
         assertTrue(written.contains("no rows offered at"),
                 "the position it could not read is what there is to say: " + written);
@@ -483,10 +485,12 @@ class CompilePartialAdequacyTest {
 
         assertEquals(List.of(), generated.get("take").composed().rows());
         assertEquals(List.of(), generated.get("take").boundaries().rows());
-        String written = GeneratedRows.of("example.split", generated,
+        String written = GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.split", true),
+                generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.split",
                         new souther.compiler.query.GenerationScope.Module()),
-                Map.of(), true, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
         assertFalse(written.contains("example take"),
                 "the row may be sitting in the file that could not be read: " + written);
         assertTrue(written.contains("generation stopped"),

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -895,10 +895,10 @@ class EveryFindingHasAGenerationDispositionTest {
                                     souther.compiler.partition.GenerationReason alsoAtTheEdges) {
         // The composition and not what is offered: these fillings are built here rather than
         // searched for, so there is no store to ask what their rows would settle.
-        return GeneratedRows.of(souther.compiler.query.Offering.composed(
+        return GeneratedRows.of(souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.kind", true),
                         Map.of("pick", new Adequacy.Filling(stopped(why),
-                                atTheEdges(alsoAtTheEdges), List.of())), null),
+                                atTheEdges(alsoAtTheEdges), List.of())), null).offeringEverything(),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -893,10 +893,12 @@ class EveryFindingHasAGenerationDispositionTest {
 
     private static String saidAbout(souther.compiler.partition.GenerationReason why,
                                     souther.compiler.partition.GenerationReason alsoAtTheEdges) {
-        return GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.kind", true),
-                Map.of("pick", new Adequacy.Filling(stopped(why), atTheEdges(alsoAtTheEdges),
-                        List.of())), null,
+        // The composition and not what is offered: these fillings are built here rather than
+        // searched for, so there is no store to ask what their rows would settle.
+        return GeneratedRows.of(souther.compiler.query.Offering.composed(
+                        souther.compiler.query.OfferingRequest.overTheModule("example.kind", true),
+                        Map.of("pick", new Adequacy.Filling(stopped(why),
+                                atTheEdges(alsoAtTheEdges), List.of())), null),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 
@@ -968,13 +970,9 @@ class EveryFindingHasAGenerationDispositionTest {
     @Test
     void anArmNoStrategyReachesIsNamedInTheBlock() {
         Compilation compilation = compiled(POLICY);
-        Map<String, Adequacy.Filling> generated =
-                Adequacy.generatedOf(compilation.db(), "example.policy");
-        String block = GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.policy", true),
-                generated,
-                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.policy",
-                        new GenerationScope.Module()),
+        String block = GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(
+                                "example.policy", true)),
                 Map.of(), SourceNameResolver.identity()).text();
 
         assertTrue(block.contains("`then`"),

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -893,10 +893,11 @@ class EveryFindingHasAGenerationDispositionTest {
 
     private static String saidAbout(souther.compiler.partition.GenerationReason why,
                                     souther.compiler.partition.GenerationReason alsoAtTheEdges) {
-        return GeneratedRows.of("example.kind",
+        return GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.kind", true),
                 Map.of("pick", new Adequacy.Filling(stopped(why), atTheEdges(alsoAtTheEdges),
                         List.of())), null,
-                Map.of(), true, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** A run asked for nothing that came to a reason about itself, which is what a stopped
@@ -969,10 +970,12 @@ class EveryFindingHasAGenerationDispositionTest {
         Compilation compilation = compiled(POLICY);
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.policy");
-        String block = GeneratedRows.of("example.policy", generated,
+        String block = GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.policy", true),
+                generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.policy",
                         new GenerationScope.Module()),
-                Map.of(), true, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
 
         assertTrue(block.contains("`then`"),
                 "the arm nothing offers a row for is named: " + block);

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -895,10 +895,11 @@ class EveryFindingHasAGenerationDispositionTest {
                                     souther.compiler.partition.GenerationReason alsoAtTheEdges) {
         // The composition and not what is offered: these fillings are built here rather than
         // searched for, so there is no store to ask what their rows would settle.
-        return GeneratedRows.of(souther.compiler.query.Composition.composed(
+        return GeneratedRows.of(souther.compiler.query.EveryRowOfIt.offered(
+                        souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.kind", true),
                         Map.of("pick", new Adequacy.Filling(stopped(why),
-                                atTheEdges(alsoAtTheEdges), List.of())), null).offeringEverything(),
+                                atTheEdges(alsoAtTheEdges), List.of())), null)),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EveryThingOwedAtAPointIsAnItemOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryThingOwedAtAPointIsAnItemOfItsOwnTest.java
@@ -1,0 +1,136 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.OwedBoundaryPoint;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlements;
+import souther.compiler.partition.BorderObligationPoint;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two things owed at one point are two items, however many rows they take.
+ *
+ * <p>A region is stopped by whatever reaches the position, and where two rules stop it in two places
+ * the line is owed a row in that role twice — two obligations at one point of one line. One value
+ * answers both, which is why the search composes one row for them; the account is what says there
+ * are two.
+ *
+ * <p><b>Those are two questions and only one of them is about rows.</b> Read as the places a row is
+ * composed at, the second obligation is in no item universe: nothing counts a row as settling it,
+ * nothing can say it is answered, and a note saying no row is offered for it prints over the row
+ * standing at it. That is the shape this whole change is against, arriving from the inside.
+ */
+class EveryThingOwedAtAPointIsAnItemOfItsOwnTest {
+
+    /**
+     * One position whose line is stopped in two places.
+     *
+     * <p>Two helpers compare the same position at the same value, so the region beside the
+     * declaration's line runs up to a line each of them drew. The values coincide; the rules do not.
+     */
+    private static final String TWO_STOPS = """
+            module example.stops
+
+            data Hours = Int
+                invariant value >= 0 && value <= 24
+
+            let over (h: Hours): Int = if h.value > 8 then 1 else 0
+
+            let also (h: Hours): Int = if h.value > 8 then 2 else 0
+
+            behavior tally : (worked: Hours) -> Int
+
+            let tally (worked) = over(worked) + also(worked)
+            """;
+
+    @Test
+    void aPointOwedTwiceIsTwoItemsOfTheOffering() {
+        Compilation compilation = compiled();
+        List<BorderAssessment> edges = compilation.db()
+                .ask(new Adequacy.BoundarySearch("example.stops", "tally")).value();
+        assertNotNull(edges, "the model under test is measured");
+        List<OwedBoundaryPoint> account = OwedBoundaryPoint.across(edges);
+        assertTrue(account.size() > OwedBoundaryPoint.oneForEachPoint(account).at().size(),
+                "the model under test owes some point more than once: " + account);
+
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+        List<BorderObligationPoint> asked = new ArrayList<>();
+        for (OfferItem item : table.requested()) {
+            if (item instanceof OfferItem.APointOfALine(var point)) {
+                asked.add(point);
+            }
+        }
+        // The behavior's own account, entry for entry, before the points the declarations own. Two
+        // of these differ in nothing a row is composed or labelled from, and one row answers both:
+        // asked as the places a row is composed at, there would be ten of them here.
+        List<BorderObligationPoint> owed = account.stream().map(OwedBoundaryPoint::owed).toList();
+        assertTrue(asked.size() >= owed.size(), "every point of the account is asked about: " + asked);
+        assertEquals(owed, asked.subList(0, owed.size()),
+                "every thing owed at a point is asked about, and not one per point");
+    }
+
+    @Test
+    void theTwoOfThemAreAnsweredByTheOneRowComposedThere() {
+        Compilation compilation = compiled();
+        Settlements table = Settlements.of(compilation.db(), composed(compilation));
+
+        // The obligations that share a point, which is what a row there answers at once.
+        Map<String, Set<OfferItem>> byPoint = new LinkedHashMap<>();
+        for (OfferItem item : table.requested()) {
+            if (item instanceof OfferItem.APointOfALine(var point)) {
+                byPoint.computeIfAbsent(point.line() + " " + point.role(),
+                        _ -> new LinkedHashSet<>()).add(item);
+            }
+        }
+        List<Set<OfferItem>> shared = byPoint.values().stream().filter(at -> at.size() > 1).toList();
+        assertFalse(shared.isEmpty(), "a point of this model is owed more than once: " + byPoint);
+
+        for (Set<OfferItem> at : shared) {
+            Set<RowKey> composedThere = new LinkedHashSet<>();
+            at.forEach(item -> composedThere.add(table.composedFor().get(item)));
+            assertEquals(1, composedThere.size(),
+                    "one row is composed for everything owed at one point: " + at + " -> "
+                            + composedThere);
+            // And it answers all of them, so a reduction counts it once for each.
+            RowKey row = composedThere.iterator().next();
+            if (row != null) {
+                at.forEach(item -> assertTrue(table.at(row, item).settles(),
+                        "the row composed there settles " + item));
+            }
+        }
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(TWO_STOPS, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static Offering composed(Compilation compilation) {
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.stops");
+        assertNotNull(generated, "the model under test compiles: " + compilation.errors());
+        return Offering.composed(OfferingRequest.overTheModule("example.stops", true), generated,
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.stops",
+                        new GenerationScope.Module()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/EveryThingOwedAtAPointIsAnItemOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryThingOwedAtAPointIsAnItemOfItsOwnTest.java
@@ -6,7 +6,7 @@ import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.GenerationScope;
 import souther.compiler.query.OfferItem;
-import souther.compiler.query.Offering;
+import souther.compiler.query.Composition;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.OwedBoundaryPoint;
 import souther.compiler.query.RowKey;
@@ -125,11 +125,11 @@ class EveryThingOwedAtAPointIsAnItemOfItsOwnTest {
         return compilation;
     }
 
-    private static Offering composed(Compilation compilation) {
+    private static Composition composed(Compilation compilation) {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.stops");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        return Offering.composed(OfferingRequest.overTheModule("example.stops", true), generated,
+        return Composition.composed(OfferingRequest.overTheModule("example.stops", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.stops",
                         new GenerationScope.Module()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
+++ b/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
@@ -35,7 +35,7 @@ public final class OfferedAtTheLines {
                 ? Generator.GenerationResult.NONE : filling.boundaries();
         DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(), module,
                 new GenerationScope.Module());
-        List<Generator.GeneratedRow> rows = souther.compiler.query.Offering.atTheLines(
+        List<Generator.GeneratedRow> rows = souther.compiler.query.Composition.atTheLines(
                 own.rows(), declared.rowsByCarrier().get(behavior));
         List<Generator.UnresolvedCombination> unresolved = new ArrayList<>(own.unresolved());
         declared.unmet().forEach((_, unmet) -> {

--- a/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
+++ b/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
@@ -38,7 +38,7 @@ public final class OfferedAtTheLines {
         List<Generator.GeneratedRow> rows = souther.compiler.query.Offering.atTheLines(
                 own.rows(), declared.rowsByCarrier().get(behavior));
         List<Generator.UnresolvedCombination> unresolved = new ArrayList<>(own.unresolved());
-        declared.unmet().forEach(unmet -> {
+        declared.unmet().forEach((_, unmet) -> {
             switch (unmet) {
                 case DeclaredRows.Unmet.TheLineCannotBeWritten(var _, var _, var proving) ->
                         proving.forEach(at -> searched(unresolved, at));

--- a/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
+++ b/souther-compiler/src/test/java/souther/compiler/OfferedAtTheLines.java
@@ -35,7 +35,7 @@ public final class OfferedAtTheLines {
                 ? Generator.GenerationResult.NONE : filling.boundaries();
         DeclaredRows declared = Adequacy.generatedForDeclarationsOf(compilation.db(), module,
                 new GenerationScope.Module());
-        List<Generator.GeneratedRow> rows = souther.compiler.report.GeneratedRows.atTheLines(
+        List<Generator.GeneratedRow> rows = souther.compiler.query.Offering.atTheLines(
                 own.rows(), declared.rowsByCarrier().get(behavior));
         List<Generator.UnresolvedCombination> unresolved = new ArrayList<>(own.unresolved());
         declared.unmet().forEach(unmet -> {

--- a/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
@@ -88,10 +88,8 @@ class TheBlockAndItsHeaderComeFromOneListOfRowsTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), module);
         assertNotNull(generated, "the model under test compiles");
-        return GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule(module, true), generated,
-                Adequacy.generatedForDeclarationsOf(compilation.db(), module,
-                        new souther.compiler.query.GenerationScope.Module()),
+        return GeneratedRows.of(Adequacy.offeredFor(compilation.db(),
+                        souther.compiler.query.OfferingRequest.overTheModule(module, true)),
                 Map.of(), SourceNameResolver.identity()).text();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
@@ -88,10 +88,11 @@ class TheBlockAndItsHeaderComeFromOneListOfRowsTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), module);
         assertNotNull(generated, "the model under test compiles");
-        return GeneratedRows.of(module, generated,
+        return GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule(module, true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), module,
                         new souther.compiler.query.GenerationScope.Module()),
-                Map.of(), true, SourceNameResolver.identity()).text();
+                Map.of(), SourceNameResolver.identity()).text();
     }
 
     /** Where each row starts. A row the formatter wrapped is still one row, and one {@code |}. */

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -251,10 +251,11 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
      *  against, and a behavior nothing is offering a row for has none to fill. */
     @Test
     void aBehaviorWithNoRowToFillIsNotQuoted() {
-        String block = GeneratedRows.of("example.todo",
+        String block = GeneratedRows.of(
+                souther.compiler.query.OfferingRequest.overTheModule("example.todo", true),
                 Map.of("findTodo", nothingOffered()), null,
                 Map.of("findTodo", List.of("ensures asked = NotFound -> id.value > 0")),
-                true, SourceNameResolver.identity()).text();
+                SourceNameResolver.identity()).text();
 
         assertEquals("", block);
     }

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -253,9 +253,10 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
     void aBehaviorWithNoRowToFillIsNotQuoted() {
         // The composition and not what is offered: this filling is built here rather than searched
         // for, so there is no store to ask what its rows would settle.
-        String block = GeneratedRows.of(souther.compiler.query.Composition.composed(
+        String block = GeneratedRows.of(souther.compiler.query.EveryRowOfIt.offered(
+                        souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.todo", true),
-                        Map.of("findTodo", nothingOffered()), null).offeringEverything(),
+                        Map.of("findTodo", nothingOffered()), null)),
                 Map.of("findTodo", List.of("ensures asked = NotFound -> id.value > 0")),
                 SourceNameResolver.identity()).text();
 

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -251,9 +251,11 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
      *  against, and a behavior nothing is offering a row for has none to fill. */
     @Test
     void aBehaviorWithNoRowToFillIsNotQuoted() {
-        String block = GeneratedRows.of(
-                souther.compiler.query.OfferingRequest.overTheModule("example.todo", true),
-                Map.of("findTodo", nothingOffered()), null,
+        // The composition and not what is offered: this filling is built here rather than searched
+        // for, so there is no store to ask what its rows would settle.
+        String block = GeneratedRows.of(souther.compiler.query.Offering.composed(
+                        souther.compiler.query.OfferingRequest.overTheModule("example.todo", true),
+                        Map.of("findTodo", nothingOffered()), null),
                 Map.of("findTodo", List.of("ensures asked = NotFound -> id.value > 0")),
                 SourceNameResolver.identity()).text();
 

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -253,9 +253,9 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
     void aBehaviorWithNoRowToFillIsNotQuoted() {
         // The composition and not what is offered: this filling is built here rather than searched
         // for, so there is no store to ask what its rows would settle.
-        String block = GeneratedRows.of(souther.compiler.query.Offering.composed(
+        String block = GeneratedRows.of(souther.compiler.query.Composition.composed(
                         souther.compiler.query.OfferingRequest.overTheModule("example.todo", true),
-                        Map.of("findTodo", nothingOffered()), null),
+                        Map.of("findTodo", nothingOffered()), null).offeringEverything(),
                 Map.of("findTodo", List.of("ensures asked = NotFound -> id.value > 0")),
                 SourceNameResolver.identity()).text();
 

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
@@ -21,14 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A row goes only where the offering answers as much without it.
  *
- * <p>Three things hold of what is left, and they are what the reduction is. Everything some row
- * settled is still settled by one. Everything a row was composed for still has a row that answers
- * it. And nothing else can go: every row left is the only one settling something, which is what
- * makes the result irredundant rather than merely smaller.
+ * <p>What is preserved is what the offering puts in front of a person for each item: a row that
+ * settles it, or the row composed for it. Everything the rows offered for before, the rows that are
+ * left offer for; and no row of what is left can go and leave that true.
  *
- * <p>The fourth is what may not be acted on. A row that cannot be told about is not a row that
- * answers, so nothing is dropped on the strength of one — a reduction that counted what it could not
- * tell would drop the row that was the only offer for something.
+ * <p>The first of those is checked here in the narrower words as well — everything some row settled
+ * is still settled — so that the two statements do not both rest on one method. The second reads
+ * {@link Settlements#offers}, which is what the reduction preserves: written out again here, this
+ * test and the reduction would be two statements of one contract.
+ *
+ * <p>And what may not be acted on. A row that cannot be told about is not a row that answers, so
+ * nothing is dropped on the strength of one — a reduction that counted what it could not tell would
+ * drop the row that was the only offer for something.
  */
 class WhatTheOfferingAnswersSurvivesDroppingARowTest {
 
@@ -119,19 +123,17 @@ class WhatTheOfferingAnswersSurvivesDroppingARowTest {
         }
     }
 
-    /** Whether {@code without} answers less than {@code kept} does. */
+    /**
+     * Whether {@code without} offers less than {@code kept} does.
+     *
+     * <p>Asked of {@link Settlements#offers}, which is what the reduction preserves — both halves of
+     * it, so a row that is the only offer for something it could not be told to settle counts as
+     * something lost. Written out here instead, this test and the reduction would be two statements
+     * of one contract, and the one that drifted would be the one nobody reads.
+     */
     private static boolean lost(Settlements table, Set<RowKey> kept, Set<RowKey> without) {
         for (OfferItem item : table.requested()) {
-            boolean here = kept.stream().anyMatch(row -> table.at(row, item).settles());
-            boolean there = without.stream().anyMatch(row -> table.at(row, item).settles());
-            if (here && !there) {
-                return true;
-            }
-        }
-        // Or a row that was the only offer for something it could not be told to settle.
-        for (Map.Entry<OfferItem, RowKey> each : table.composedFor().entrySet()) {
-            if (kept.contains(each.getValue()) && !without.contains(each.getValue())
-                    && without.stream().noneMatch(row -> table.at(row, each.getKey()).settles())) {
+            if (table.offers(kept, item) && !table.offers(without, item)) {
                 return true;
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
@@ -145,13 +145,19 @@ class WhatTheOfferingAnswersSurvivesDroppingARowTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.shipping");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        Offering composed = Offering.of(
+        Offering composed = Offering.composed(
                 OfferingRequest.overTheModule("example.shipping", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shipping",
                         new GenerationScope.Module()));
         Settlements table = Settlements.of(compilation.db(), composed);
         assertFalse(table.byRow().isEmpty(), "the model under test is offered rows");
         assertFalse(table.settled().isEmpty(), "and some of them settle something");
+        // And something here is redundant, so that what the three tests below hold of the result is
+        // held of a result a row was actually taken out of. A model with nothing to drop satisfies
+        // every one of them by there being nothing to say.
+        assertTrue(table.keeping().size() < table.byRow().size(),
+                "the model under test has a row another row answers for: " + table.byRow().size()
+                        + " rows, " + table.keeping().size() + " kept");
         return table;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
@@ -1,0 +1,157 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.GenerationScope;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlements;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row goes only where the offering answers as much without it.
+ *
+ * <p>Three things hold of what is left, and they are what the reduction is. Everything some row
+ * settled is still settled by one. Everything a row was composed for still has a row that answers
+ * it. And nothing else can go: every row left is the only one settling something, which is what
+ * makes the result irredundant rather than merely smaller.
+ *
+ * <p>The fourth is what may not be acted on. A row that cannot be told about is not a row that
+ * answers, so nothing is dropped on the strength of one — a reduction that counted what it could not
+ * tell would drop the row that was the only offer for something.
+ */
+class WhatTheOfferingAnswersSurvivesDroppingARowTest {
+
+    /**
+     * Lines a declaration draws, classes the model divides its positions into, and arms a body
+     * takes — the three kinds of thing a row is offered for, in one model with no rows written.
+     */
+    private static final String MODEL = """
+            module example.shipping
+
+            data Total = Int
+                invariant value >= 0
+                invariant value <= 1000000
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (total: Total, member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (total: Total, member: Membership): Int =
+                match member with
+                    | Premium -> 0
+                    | Standard -> if total.value >= 5000 then 0 else 500
+
+            let expressFee (delivery: Delivery): Int =
+                match delivery with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (total, member, delivery) =
+                Fee(baseFee(total, member) + expressFee(delivery))
+            """;
+
+    @Test
+    void everythingSomeRowSettledIsStillSettled() {
+        Settlements table = table();
+        Set<OfferItem> before = table.settled();
+        Set<RowKey> kept = table.keeping();
+        assertFalse(kept.isEmpty(), "something is offered: " + table.byRow().keySet());
+        for (OfferItem item : before) {
+            assertTrue(kept.stream().anyMatch(row -> table.at(row, item).settles()),
+                    "a kept row still settles " + item);
+        }
+    }
+
+    @Test
+    void everyItemARowWasComposedForStillHasOneThatAnswersIt() {
+        Settlements table = table();
+        Set<RowKey> kept = table.keeping();
+        table.composedFor().forEach((item, row) -> assertTrue(
+                kept.contains(row) || kept.stream().anyMatch(one -> table.at(one, item).settles()),
+                "the row composed for " + item + " went, and nothing kept settles it"));
+    }
+
+    @Test
+    void nothingElseCanGo() {
+        Settlements table = table();
+        Set<RowKey> kept = table.keeping();
+        for (RowKey row : kept) {
+            Set<RowKey> without = new LinkedHashSet<>(kept);
+            without.remove(row);
+            assertTrue(lost(table, kept, without),
+                    row + " could go too, so what is left is not irredundant");
+        }
+    }
+
+    @Test
+    void nothingGoesOnWhatCouldNotBeToldAbout() {
+        Settlements table = table();
+        Set<RowKey> kept = table.keeping();
+        for (RowKey row : table.byRow().keySet()) {
+            if (kept.contains(row)) {
+                continue;
+            }
+            // What it was dropped for has to be something another kept row settles. A row dropped
+            // where the only reading of it was undetermined is a row dropped on not knowing.
+            table.composedFor().forEach((item, composed) -> {
+                if (composed.equals(row)) {
+                    assertTrue(kept.stream().anyMatch(one -> table.at(one, item).settles()),
+                            "the row composed for " + item + " went on an answer nobody has");
+                }
+            });
+        }
+    }
+
+    /** Whether {@code without} answers less than {@code kept} does. */
+    private static boolean lost(Settlements table, Set<RowKey> kept, Set<RowKey> without) {
+        for (OfferItem item : table.requested()) {
+            boolean here = kept.stream().anyMatch(row -> table.at(row, item).settles());
+            boolean there = without.stream().anyMatch(row -> table.at(row, item).settles());
+            if (here && !there) {
+                return true;
+            }
+        }
+        // Or a row that was the only offer for something it could not be told to settle.
+        for (Map.Entry<OfferItem, RowKey> each : table.composedFor().entrySet()) {
+            if (kept.contains(each.getValue()) && !without.contains(each.getValue())
+                    && without.stream().noneMatch(row -> table.at(row, each.getKey()).settles())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Settlements table() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> generated =
+                Adequacy.generatedOf(compilation.db(), "example.shipping");
+        assertNotNull(generated, "the model under test compiles: " + compilation.errors());
+        Offering composed = Offering.of(
+                OfferingRequest.overTheModule("example.shipping", true), generated,
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shipping",
+                        new GenerationScope.Module()));
+        Settlements table = Settlements.of(compilation.db(), composed);
+        assertFalse(table.byRow().isEmpty(), "the model under test is offered rows");
+        assertFalse(table.settled().isEmpty(), "and some of them settle something");
+        return table;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheOfferingAnswersSurvivesDroppingARowTest.java
@@ -5,7 +5,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.GenerationScope;
 import souther.compiler.query.OfferItem;
-import souther.compiler.query.Offering;
+import souther.compiler.query.Composition;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
 import souther.compiler.query.Settlements;
@@ -147,7 +147,7 @@ class WhatTheOfferingAnswersSurvivesDroppingARowTest {
         Map<String, Adequacy.Filling> generated =
                 Adequacy.generatedOf(compilation.db(), "example.shipping");
         assertNotNull(generated, "the model under test compiles: " + compilation.errors());
-        Offering composed = Offering.composed(
+        Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.shipping", true), generated,
                 Adequacy.generatedForDeclarationsOf(compilation.db(), "example.shipping",
                         new GenerationScope.Module()));

--- a/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
@@ -3,7 +3,7 @@ package souther.compiler.conformance;
 import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.OfferItem;
-import souther.compiler.query.Offering;
+import souther.compiler.query.Composition;
 import souther.compiler.query.OfferingRequest;
 import souther.compiler.query.RowKey;
 import souther.compiler.query.Settlement;
@@ -43,11 +43,18 @@ class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
         for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
             ConformanceCorpus.Analysed analysed = corpus.analyse();
             for (String module : analysed.compilation().modules()) {
-                Offering offering = Adequacy.offeredFor(analysed.compilation().db(),
-                        OfferingRequest.overTheModule(module, true));
-                if (offering == null) {
+                java.util.Map<String, Adequacy.Filling> filled =
+                        Adequacy.generatedOf(analysed.compilation().db(), module);
+                if (filled == null) {
                     continue;
                 }
+                // The composition, because what a row was composed for is a fact about it: read
+                // off what a person is finally handed, a row another row answers for is not there
+                // to be asked about.
+                Composition offering = Composition.composed(
+                        OfferingRequest.overTheModule(module, true), filled,
+                        Adequacy.generatedForDeclarationsOf(analysed.compilation().db(), module,
+                                new souther.compiler.query.GenerationScope.Module()));
                 Settlements settlements =
                         Settlements.of(analysed.compilation().db(), offering);
                 rows += settlements.byRow().size();

--- a/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
@@ -28,8 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>The numbers are printed rather than pinned. What the corpus happens to hold moves as the corpus
  * is written, and a checked-in count would be a snapshot of the models rather than of this walk.
- * What is asserted is the shape: the table is total, the items are what was asked for, and a row
- * composed for something settles the thing it was composed for.
+ * What is asserted is the shape: the table is total, the items are what was asked for, and no row
+ * composed for something is read as not settling it.
+ *
+ * <p><b>Of this corpus, and not of every model.</b> Over souther-examples that last one does not
+ * hold: twenty-four points there have a row composed at them that this walk reads as standing
+ * somewhere else, which is the search and this reading of one model coming to two answers. It costs
+ * no row — what a row was composed for keeps it whatever this walk can tell — but it is a
+ * disagreement, and it is written down here rather than left to be found by whoever strengthens the
+ * assertion next.
  */
 class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
 
@@ -78,7 +85,8 @@ class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
 
                 // What the searches composed a row for, against what the rows turn out to settle.
                 // A row composed for an item and read as not settling it is the generator and this
-                // walk reading one model two ways.
+                // walk reading one model two ways. Held of this corpus: over souther-examples there
+                // are points where the two disagree, which is said above.
                 settlements.composedFor().forEach((item, row) -> {
                     Map<OfferItem, Settlement> here = settlements.byRow().get(row);
                     if (here != null) {

--- a/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
@@ -1,0 +1,115 @@
+package souther.compiler.conformance;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.OfferItem;
+import souther.compiler.query.Offering;
+import souther.compiler.query.OfferingRequest;
+import souther.compiler.query.RowKey;
+import souther.compiler.query.Settlement;
+import souther.compiler.query.Settlements;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What every row the corpus is offered would settle, counted over the whole of it.
+ *
+ * <p>The table this is about is what a reduction of the offering would act on, and a reduction acts
+ * only on what a row is known to settle. So the two things worth holding are that the walk answers
+ * for the whole table — every row against every item the run was asked about — and that what it
+ * cannot tell stays told apart from what it read and found not to be the case.
+ *
+ * <p>The numbers are printed rather than pinned. What the corpus happens to hold moves as the corpus
+ * is written, and a checked-in count would be a snapshot of the models rather than of this walk.
+ * What is asserted is the shape: the table is total, the items are what was asked for, and a row
+ * composed for something settles the thing it was composed for.
+ */
+class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
+
+    @Test
+    void everyOfferedRowIsAnsweredForAtEveryItemTheRunWasAskedAbout() {
+        Map<String, Integer> answers = new TreeMap<>();
+        Map<String, Integer> undetermined = new TreeMap<>();
+        int rows = 0;
+        int items = 0;
+        int settledNotComposedFor = 0;
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            ConformanceCorpus.Analysed analysed = corpus.analyse();
+            for (String module : analysed.compilation().modules()) {
+                Offering offering = Adequacy.offeredFor(analysed.compilation().db(),
+                        OfferingRequest.overTheModule(module, true));
+                if (offering == null) {
+                    continue;
+                }
+                Settlements settlements =
+                        Settlements.of(analysed.compilation().db(), offering);
+                rows += settlements.byRow().size();
+                items += settlements.requested().size();
+
+                // Total over the two axes it names. A pair with no entry is a row nobody asked
+                // about at an item, and a reduction reading that absence would be free to read it
+                // either way.
+                for (Map.Entry<RowKey, Map<OfferItem, Settlement>> row
+                        : settlements.byRow().entrySet()) {
+                    assertEquals(new LinkedHashSet<>(settlements.requested()),
+                            row.getValue().keySet(),
+                            "every item this run was asked about is answered for " + row.getKey());
+                    row.getValue().forEach((item, settlement) -> {
+                        answers.merge(kindOf(item) + " " + nameOf(settlement), 1, Integer::sum);
+                        if (settlement instanceof Settlement.Undetermined(var why)) {
+                            undetermined.merge(why.name(), 1, Integer::sum);
+                        }
+                    });
+                }
+
+                // What the searches composed a row for, against what the rows turn out to settle.
+                // A row composed for an item and read as not settling it is the generator and this
+                // walk reading one model two ways.
+                settlements.composedFor().forEach((item, row) -> {
+                    Map<OfferItem, Settlement> here = settlements.byRow().get(row);
+                    if (here != null) {
+                        assertFalse(here.get(item) instanceof Settlement.DoesNotSettle,
+                                "a row composed for " + item + " does not settle it: " + row);
+                    }
+                });
+                Set<OfferItem> settled = settlements.settled();
+                for (OfferItem item : settled) {
+                    if (!settlements.composedFor().containsKey(item)) {
+                        settledNotComposedFor++;
+                    }
+                }
+                assertTrue(settlements.requested().containsAll(settled),
+                        "nothing is settled that was not asked about");
+            }
+        }
+        System.out.println("rows " + rows + ", items " + items
+                + ", settled with no row composed for them " + settledNotComposedFor);
+        System.out.println("answers " + answers);
+        System.out.println("undetermined " + undetermined);
+        assertTrue(rows > 0, "the corpus offers rows");
+        assertTrue(items > 0, "and is asked for something");
+    }
+
+    private static String kindOf(OfferItem item) {
+        return switch (item) {
+            case OfferItem.AClass _ -> "class";
+            case OfferItem.AnArm _ -> "arm";
+            case OfferItem.APointOfALine _ -> "point";
+        };
+    }
+
+    private static String nameOf(Settlement settlement) {
+        return switch (settlement) {
+            case Settlement.Settles _ -> "settles";
+            case Settlement.DoesNotSettle _ -> "does not";
+            case Settlement.Undetermined _ -> "undetermined";
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
@@ -31,12 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * What is asserted is the shape: the table is total, the items are what was asked for, and no row
  * composed for something is read as not settling it.
  *
- * <p><b>Of this corpus, and not of every model.</b> Over souther-examples that last one does not
- * hold: twenty-four points there have a row composed at them that this walk reads as standing
- * somewhere else, which is the search and this reading of one model coming to two answers. It costs
- * no row — what a row was composed for keeps it whatever this walk can tell — but it is a
- * disagreement, and it is written down here rather than left to be found by whoever strengthens the
- * assertion next.
+ * <p><b>Of this corpus, and not of every model.</b> There are models where that last one does not
+ * hold: a point the search composed a row at, which this walk reads as standing somewhere else. It
+ * costs no row — what a row was composed for keeps it whatever this walk can tell — but it is the
+ * search and this reading coming to two answers about one model, so this asserts what it has seen
+ * rather than a law. Whoever strengthens it to {@code Settles} should expect to be told where.
  */
 class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
 
@@ -85,8 +84,8 @@ class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
 
                 // What the searches composed a row for, against what the rows turn out to settle.
                 // A row composed for an item and read as not settling it is the generator and this
-                // walk reading one model two ways. Held of this corpus: over souther-examples there
-                // are points where the two disagree, which is said above.
+                // walk reading one model two ways. Held of this corpus, and not of every model,
+                // which is said above.
                 settlements.composedFor().forEach((item, row) -> {
                     Map<OfferItem, Settlement> here = settlements.byRow().get(row);
                     if (here != null) {

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryRowOfIt.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryRowOfIt.java
@@ -1,0 +1,29 @@
+package souther.compiler.query;
+
+/**
+ * A composition rendered as though every row of it were offered, for a test with no store.
+ *
+ * <p>What is offered is what is left once each row has been asked what it would settle, and asking
+ * takes a store: values to build the row through and something to run it against. A test that
+ * builds its fillings by hand has neither, and what it is testing is not which rows go out but what
+ * the block says beside them.
+ *
+ * <p>Here rather than beside {@link Composition}, and in the tests rather than in what ships. A
+ * production caller has a store, and one that came through something like this would be choosing to
+ * skip the question — which is the way back to a renderer printing rows nobody chose.
+ */
+public final class EveryRowOfIt {
+
+    /** The offering that keeps every row of {@code composed} and says nothing is answered, which is
+     *  what not having asked means. */
+    public static Offering offered(Composition composed) {
+        return composed.keeping(
+                composed.rows().values().stream().flatMap(java.util.List::stream)
+                        .map(OfferedRow::key)
+                        .collect(java.util.stream.Collectors.toCollection(
+                                java.util.LinkedHashSet::new)),
+                java.util.Set.of());
+    }
+
+    private EveryRowOfIt() {}
+}


### PR DESCRIPTION
Closes #1083.

A candidate is composed for one thing, and the positions that thing does not name hold whatever the row has to hold — so a row composed for one item can stand where another asks. Nothing put that question. The two searches that compose rows met where the block was written, and there the rows had become text, so the only join available was the text of one against the text of another: a row inside a region and a row at the end of it went out as two pieces of work.

## Three readings of one account

The correction that took three passes, written down so the next reader does not repeat it. A behavior's boundary account can be read three ways, and they are not interchangeable:

| | |
|---|---|
| `OwedBoundaryPoint.across` | **the account** — everything the lines are owed a row at |
| `askedForARow` → `WhereARowWasAskedFor` | **the universe** — that, less what the measurement has already settled (`worthSearching()`) |
| `oneForEachPoint` → `WhereARowIsComposed` | **the composition places** — one per point, dropping what tells two obligations at one point apart |

The item universe is the middle one. I first took the third (two obligations at one point collapsed into one item) and then, correcting, the first (points a written row already stands at counted as work). Each of the three now has its own type, so the bare list is only ever the account.

## What each commit does

**Read a row as the values it holds and what running them recorded.** Every question a border puts to a row is put to two things, and neither is the row. `ObservedInputs` is that pair, so a written row and a candidate are put the same question.

**Settle what a run offers where both searches are read.** `Composition` is where a behavior's own rows and the rows a declaration's line is owed meet. `RowKey` is what tells one piece of work from another: the behavior it is written under and the values as they will be written.

**Ask in one place whether a tuple stands at a point.** The walk lived inside the measurement, so only what is already written could be asked. Its answer now tells a row nobody watched from a row that ran and did not reach the comparison.

**Ask what each row a run offers would settle.** `OfferItem` puts the three kinds of thing a run is asked for into one set, each arm holding the identity its own part of the compiler already owns. `Settlement` is three answers, and only what settles may be acted on.

**Read a row against the lines its behavior does not own.** A behavior's account holds the lines it is owed a row at, and a declaration's are none of them — so the first walk answered that no row stands at a declared line, of rows composed to stand at exactly that.

**Offer a row only where nothing else offered answers it.** The reduction, and the block no longer saying nothing offers a row for something one of the rows above it stands at.

**Render what is offered, and not what was composed.** The entry twenty tests reached for rendered the composition, so what they read never went through the reduction.

**Ask the account what is owed, and not where a row is composed.** Two obligations at one point of one line are two items and one value to compose.

**Ask for a row only where this run was asked for one.** `worthSearching()` and `DeclarationResolution.NoSearch` are the two sides of it, and neither is worked out again here.

**Read a row under whatever behavior composed it.** A row a declaration's line is owed is composed by whichever reading could compose it, and that behavior need not be one anything else was asked of. Read off the searches, such a row came back undetermined at every item.

**Tell the composition from what a person is handed.** `Composition` and `Offering` are two types, so a renderer cannot be handed the rows before the question was put.

## What the reduction preserves

For every item, what the rows put in front of a person: a row that settles it, **or** the row composed for it. Both halves — a row whose reading came back undetermined is still the only piece of work anybody was handed for its item.

1. every item the composed rows offer something for, the offered rows offer something for;
2. no offered row can go and leave that true.

Irredundant, not of least cardinality. `Settlements.offers` is that predicate, written once and read by the contract test.

## Measured

The shipping rules with the three rows a person writes first: **8 rows composed, 5 offered**. The issue counted six by hand; the sixth was the only offer for a point a written row already stands at, which is nobody's work. What says five is enough is not arithmetic — every gap the report raises is asked about, and one of the five stands at it.

Over souther-examples (13 modules; `cli` and `invoicing` do not compile in the harness): **1072 composed, 909 offered, 1629 items requested, 1336 settled.**

## Known, and not claimed

A row composed for two items is redundant exactly when other rows settle both, which two positions with two classes apiece always manage — so the `fills` lines have no test left, and whether that shape survives is worth asking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)