### PR TITLE
Measure a position at every number the rules name of it

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -186,7 +186,7 @@ final class AReportOfOneBorder {
                 new Measurement.FailedToMeasure<>(
                         PartitionDerivation.TheReadingDidNotRunOut.THE_READING_DID_NOT_RUN_OUT,
                         WeakeningSet.of(new Weakening.ModelReadingIncomplete(
-                                new souther.compiler.partition.ClosureGap.RulesNotReached(
+                                new souther.compiler.partition.ClosureGap.RulesNotReached("b",
                                         new souther.compiler.inputs.PositionId(
                                                 souther.compiler.inputs.TermPath.of("t")))))),
                 souther.compiler.query.OwedBoundaryPoint.accountOf(border),
@@ -205,7 +205,7 @@ final class AReportOfOneBorder {
     static Measurement<List<BorderAssessment>> shortOfSomething(BorderAssessment boundary) {
         return new Measurement.Partial<>(List.of(boundary),
                 WeakeningSet.of(new Weakening.ModelReadingIncomplete(
-                        new souther.compiler.partition.ClosureGap.RulesNotReached(
+                        new souther.compiler.partition.ClosureGap.RulesNotReached("b",
                                 new souther.compiler.inputs.PositionId(
                                         souther.compiler.inputs.TermPath.of("m"))))));
     }

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -187,7 +187,8 @@ final class AReportOfOneBorder {
                         PartitionDerivation.TheReadingDidNotRunOut.THE_READING_DID_NOT_RUN_OUT,
                         WeakeningSet.of(new Weakening.ModelReadingIncomplete(
                                 new souther.compiler.partition.ClosureGap.RulesNotReached(
-                                        new souther.compiler.partition.AxisId("b", "t"))))),
+                                        new souther.compiler.inputs.PositionId(
+                                                souther.compiler.inputs.TermPath.of("t")))))),
                 souther.compiler.query.OwedBoundaryPoint.accountOf(border),
                 PartitionEvidence.PairSpace.NONE,
                 List.of(), List.of(), List.of(), List.of(), List.of(),
@@ -205,7 +206,8 @@ final class AReportOfOneBorder {
         return new Measurement.Partial<>(List.of(boundary),
                 WeakeningSet.of(new Weakening.ModelReadingIncomplete(
                         new souther.compiler.partition.ClosureGap.RulesNotReached(
-                                new souther.compiler.partition.AxisId("b", "m")))));
+                                new souther.compiler.inputs.PositionId(
+                                        souther.compiler.inputs.TermPath.of("m"))))));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -1,0 +1,50 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.NumericMeasures;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+
+/**
+ * Which number of a behavior's input an expression names, or nothing where it names none.
+ *
+ * <p>The companion of {@link InputPath}, one question further in. That answers which location an
+ * expression points at; this answers which number a rule about it is written on, which is the
+ * location's own content or something taken of it — and the two are not the same answer, because a
+ * position holding a string is a position holding no number while every rule about its length is
+ * about one.
+ *
+ * <p>One answer, for every reader that has to say which number a comparison is about. The reading
+ * that draws lines and the reading that names what a run was steered by both ask it, and each
+ * working it out for itself is two accounts of one number: matched afterwards by how a path is
+ * spelled, two numbers taken of one location are one, which is the whole of what a line drawn on
+ * the second of them is lost to.
+ *
+ * <p>Which of the standard library's calls take a number of a location is asked of
+ * {@link NumericMeasures} rather than decided here, and asked of the operation the call resolved to
+ * rather than of its spelling.
+ */
+public final class InputNumber {
+
+    private InputNumber() {
+    }
+
+    /**
+     * The number {@code e} names.
+     *
+     * <p>The argument of a taking has to be a location: {@code List.length(List.map(f, xs))} counts
+     * something no path names, and a boundary on it could not be looked for in a row.
+     */
+    public static NumericTerm of(Core e, InputReads reads, Symbols symbols) {
+        NumericMeasures.Measured measured = NumericMeasures.takenIn(e);
+        if (measured != null) {
+            TermPath of = reads.pathOf(measured.of(), symbols);
+            // Null where the call names a location the operation is not taken of, which a guard can
+            // write and the type checker has already refused elsewhere. Answered here as "no
+            // number", which is what every reader of one is ready for.
+            return of == null ? null : NumericTerm.TakenOf.of(measured.operation(), of,
+                    reads.read().typeAt(of, symbols), symbols);
+        }
+        TermPath path = reads.pathOf(e, symbols);
+        return path == null ? null : new NumericTerm.ValueOf(path);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -47,4 +47,10 @@ public final class InputNumber {
         TermPath path = reads.pathOf(e, symbols);
         return path == null ? null : new NumericTerm.ValueOf(path);
     }
+
+    /** The number a comparison is about, from whichever side names one. */
+    public static NumericTerm compared(Core.Binary comparison, InputReads reads, Symbols symbols) {
+        NumericTerm left = of(comparison.left(), reads, symbols);
+        return left != null ? left : of(comparison.right(), reads, symbols);
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -5,6 +5,7 @@ import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
+import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.ReadMeaning;
@@ -149,7 +150,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
 
             @Override
             public LinearForm<NumericTerm> leafOf(Core node, InputReads at) {
-                NumericTerm term = GuardThresholds.termOf(node, at, symbols);
+                NumericTerm term = InputNumber.of(node, at, symbols);
                 return term == null ? null : LinearForm.atom(term);
             }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Requirements;
-import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.Type;
 
@@ -66,29 +65,21 @@ public record Axis(AxisId id, NumericTerm term, PositionAccount at, List<Partiti
                 NarrowedBounds.NOTHING);
     }
 
-    /** The position's type, which is what a value read here is of. Not the term's: a string is
-     *  measured at how long it is, and what stands at the location is still a string. */
+    /**
+     * The position's type, which is what a value read here is of. Not the term's: a string is
+     * measured at how long it is, and what stands at the location is still a string.
+     *
+     * <p>One of two things read off {@link #at} here, with {@link #path}. Both are about the
+     * measure — where it reads from and what stands there — and everything else the position's
+     * account holds is asked of the account, in the open. What its reading came to, where the walk
+     * stopped and what it is left with are true of the location once however many numbers measure
+     * it, and a measure that answered them would let any reader ask a location's question through
+     * whichever measure it happened to hold.
+     */
     public Type type() {
         return at.type();
     }
 
-    /** What the reading of this position left behind that nothing later takes away. Beside the
-     *  questions and not among them — a position whose rules were never enumerated raises no
-     *  question and is not one whose rules were all accounted for, and an empty list says the
-     *  second (issue #791). */
-    public ReadingResidue residue() {
-        return at.residue();
-    }
-
-    /** Where nothing has answered for this position yet, what the structural reading found. */
-    public StructuralInspection.Continuation pending() {
-        return at.pending();
-    }
-
-    /** What the position is left with where the local reading gave it no axis. */
-    public LeftAtThePosition leftWith() {
-        return at.leftWith();
-    }
 
     /**
      * A position nothing has answered for yet, and what the readings of it found.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -61,8 +61,8 @@ public record Axis(AxisId id, NumericTerm term, PositionAccount at, List<Partiti
 
     public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
                 List<Cut> cuts) {
-        this(id, term, PositionAccount.at(term.path(), type), classes, cuts, List.of(),
-                NarrowedBounds.NOTHING);
+        this(id, term, PositionAccount.at(id.behavior(), term.path(), type), classes, cuts,
+                List.of(), NarrowedBounds.NOTHING);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -44,8 +44,8 @@ import java.util.List;
  *                a value a row can be written against and a bound has one without parting
  *                anything; a rule that wrote a multiple of the position parts its values where the
  *                position may hold none, and has no cut. What every border on this position owes
- *                away from its line is a run of what these leave together, so a border built from
- *                the cuts alone read its two sides past the lines that have no value (issue #880)
+ *                away from its line is a run of what these leave together, and the cuts alone are
+ *                short of the lines that have no value
  */
 public record Axis(AxisId id, NumericTerm term, PositionAccount at, List<PartitionClass> classes,
                    List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
@@ -97,10 +97,8 @@ public record Axis(AxisId id, NumericTerm term, PositionAccount at, List<Partiti
      *
      * <p>A transition rather than a constructor at the call site. What a body's rules add is a term,
      * classes and cuts; what the position came to was settled by the reading that made this one,
-     * and a caller rebuilding an axis from its parts drops whatever it did not think to name. What
-     * went that way was the continuation: a position whose elements could not be reached came back
-     * out of the second phase with nothing to say it had ever stopped, and was reported as one the
-     * model divides no way. It is one field now, so a rebuild names it or does not compile.
+     * and a caller rebuilding an axis from its parts drops whatever it does not think to name. What
+     * the position came to is one field, so a rebuild names it or does not compile.
      */
     public Axis measuredAt(AxisId id, NumericTerm term) {
         return new Axis(id, term, at, classes, cuts, parted, narrowed);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -33,61 +33,61 @@ import java.util.List;
  * beside the report rather than taken out of the count — a claim the rules bear out has already
  * left, because the reading these classes come from is what took it out.
  *
- * @param term     the number this axis is of: a location's own content, or something taken of it
- * @param classes  exclusive and exhaustive over the term's values, or empty where the model does
- *                 not divide them
- * @param cuts     the values the classes meet at, each carrying every rule that drew it there
- * @param parted   where the rules part this position's values, which is not the same list. A cut is
- *                 a value a row can be written against and a bound has one without parting
- *                 anything; a rule that wrote a multiple of the position parts its values where the
- *                 position may hold none, and has no cut. What every border on this position owes
- *                 away from its line is a run of what these leave together, so a border built from
- *                 the cuts alone read its two sides past the lines that have no value (issue #880)
- * @param pending  where nothing has answered for this position yet, what the structural reading
- *                 found — and so what this position is left with if nothing else answers. Null on
- *                 an axis that already has evidence, which needs no fallback.
- *
- *                 <p>Carried here rather than beside: the reason and the position it is about are
- *                 one fact, and holding them in two lists joined afterwards by the spelling of a
- *                 path is how a reason came to be recovered by string match. A reason travels with
- *                 the position or it is a reason about whatever the strings happened to pair it
- *                 with.
- * @param residue  what the reading of this position left behind that nothing later takes away: the
- *                 rules it was owed and did not reach, and whether the walk could go into what it
- *                 holds. Beside the questions and not among them — a position whose rules were never
- *                 enumerated raises no question and is not one whose rules were all accounted for,
- *                 and an empty list says the second (issue #791).
- *
- *                 <p>Apart from {@link #pending} because the two do not live as long. A position a
- *                 body's rule divides keeps no continuation to be pending on, and was still never
- *                 entered; read off the continuation, that stop went unsaid (issue #1084)
- * @param leftWith what the position is left with where the local reading gave it no axis, or null
- *                 where nothing is. Which of the two it is comes with it: a reading stopped, or a
- *                 rule was read to the end and draws no line. Carried for the same reason
- *                 {@link #pending} is, and kept apart from it because the two are lifted by
- *                 different work and one outranks the other — where the walk could not reach into
- *                 what the position holds, a rule about what is inside describes that same stop
- *                 from the other end
+ * @param term    the number this axis is of: a location's own content, or something taken of it
+ * @param at      the position the number is read from, and what this phase is left answering for
+ *                there. Pointed at rather than copied out, because a position carries as many of
+ *                these axes as the rules name numbers of it and what is in there is true of the
+ *                position once ({@link PositionAccount})
+ * @param classes exclusive and exhaustive over the term's values, or empty where the model does
+ *                not divide them
+ * @param cuts    the values the classes meet at, each carrying every rule that drew it there
+ * @param parted  where the rules part this position's values, which is not the same list. A cut is
+ *                a value a row can be written against and a bound has one without parting
+ *                anything; a rule that wrote a multiple of the position parts its values where the
+ *                position may hold none, and has no cut. What every border on this position owes
+ *                away from its line is a run of what these leave together, so a border built from
+ *                the cuts alone read its two sides past the lines that have no value (issue #880)
  */
-public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed,
-                   ReadingResidue residue,
-                   StructuralInspection.Continuation pending, LeftAtThePosition leftWith) {
+public record Axis(AxisId id, NumericTerm term, PositionAccount at, List<PartitionClass> classes,
+                   List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
 
     public Axis {
         classes = List.copyOf(classes);
         cuts = List.copyOf(cuts);
         parted = List.copyOf(parted);
-        if (residue == null) {
-            throw new IllegalArgumentException(
-                    "an axis with no account of what its reading came to");
+        if (at == null) {
+            throw new IllegalArgumentException("an axis of no position");
         }
     }
 
     public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
                 List<Cut> cuts) {
-        this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING,
-                ReadingResidue.NOTHING, null, null);
+        this(id, term, PositionAccount.at(term.path(), type), classes, cuts, List.of(),
+                NarrowedBounds.NOTHING);
+    }
+
+    /** The position's type, which is what a value read here is of. Not the term's: a string is
+     *  measured at how long it is, and what stands at the location is still a string. */
+    public Type type() {
+        return at.type();
+    }
+
+    /** What the reading of this position left behind that nothing later takes away. Beside the
+     *  questions and not among them — a position whose rules were never enumerated raises no
+     *  question and is not one whose rules were all accounted for, and an empty list says the
+     *  second (issue #791). */
+    public ReadingResidue residue() {
+        return at.residue();
+    }
+
+    /** Where nothing has answered for this position yet, what the structural reading found. */
+    public StructuralInspection.Continuation pending() {
+        return at.pending();
+    }
+
+    /** What the position is left with where the local reading gave it no axis. */
+    public LeftAtThePosition leftWith() {
+        return at.leftWith();
     }
 
     /**
@@ -97,32 +97,27 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * and only where none does is what was found here what a report says — an absence where every
      * reading ran to the end and found nothing, and what stopped one where it did not.
      */
-    public static Axis pendingAt(AxisId id, NumericTerm term, Type type, ReadingResidue residue,
-                                 StructuralInspection.Continuation found,
-                                 LeftAtThePosition leftWith) {
-        return new Axis(id, term, type, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING,
-                residue, found, leftWith);
+    public static Axis pendingAt(AxisId id, NumericTerm term, PositionAccount at) {
+        return new Axis(id, term, at, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
     }
 
     /**
      * The same position, measured at another number.
      *
      * <p>A transition rather than a constructor at the call site. What a body's rules add is a term,
-     * classes and cuts; everything else about the position was settled by the reading that made
-     * this one, and a caller rebuilding an axis from its parts drops whatever it did not think to
-     * name. What went that way was {@link #pending}: a position whose elements could not be reached
-     * came back out of the second phase with nothing to say it had ever stopped, and was reported
-     * as one the model divides no way.
+     * classes and cuts; what the position came to was settled by the reading that made this one,
+     * and a caller rebuilding an axis from its parts drops whatever it did not think to name. What
+     * went that way was the continuation: a position whose elements could not be reached came back
+     * out of the second phase with nothing to say it had ever stopped, and was reported as one the
+     * model divides no way. It is one field now, so a rebuild names it or does not compile.
      */
     public Axis measuredAt(AxisId id, NumericTerm term) {
-        return new Axis(id, term, type, classes, cuts, parted, narrowed, residue, pending,
-                leftWith);
+        return new Axis(id, term, at, classes, cuts, parted, narrowed);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
     public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted) {
-        return new Axis(id, term, type, classes, cuts, parted, narrowed, residue, pending,
-                leftWith);
+        return new Axis(id, term, at, classes, cuts, parted, narrowed);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -66,4 +66,36 @@ public sealed interface BodyCutInspection {
             }
         }
     }
+
+    /**
+     * What this phase came to about one position, where it answered once per number the position is
+     * measured at.
+     *
+     * <p>A location is measured at as many numbers as the rules name of it, and this phase answers
+     * about each of those. What a report says about the location is one sentence, so the answers are
+     * put together here rather than printed one apiece — a position is not divided no way twice
+     * over.
+     *
+     * <p>A line anywhere outranks everything: the position is divided, whichever of its numbers the
+     * line is on. Then a rule that came to nothing outranks the rules having been exhausted, for the
+     * reason the arms are three and not two — a rule is written here, and saying the reading ran out
+     * would be the opposite of what that rule says. Between two of those, whichever
+     * {@link LeftAtThePosition#outranking} puts first.
+     */
+    static BodyCutInspection outranking(BodyCutInspection first, BodyCutInspection second) {
+        if (first == null) {
+            return second;
+        }
+        if (second == null) {
+            return first;
+        }
+        if (first instanceof Evidence || second instanceof Evidence) {
+            return new Evidence();
+        }
+        if (first instanceof NoLine(LeftAtThePosition one)
+                && second instanceof NoLine(LeftAtThePosition other)) {
+            return new NoLine(LeftAtThePosition.outranking(one, other));
+        }
+        return first instanceof NoLine ? first : second;
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -72,9 +72,9 @@ public sealed interface ClosureGap {
      * not all reached, which is what this says. The reason stays inside
      * ({@link souther.compiler.inputs.RulesLeftUnread}) because a document naming it would make a
      * change to how this compiler traverses a model into a change to what its documents carry. Two
-     * of these at one axis are one entry, which is that sentence said once.
+     * of these at one position are one entry, which is that sentence said once.
      */
-    record RulesNotReached(AxisId at) implements ClosureGap {}
+    record RulesNotReached(souther.compiler.inputs.PositionId at) implements ClosureGap {}
 
     /**
      * A position the walk could not reach into, with what the structural reading found instead.
@@ -86,17 +86,19 @@ public sealed interface ClosureGap {
      * an arm taken from a second representation of a fact, which is the mistake #953 is about, in
      * miniature.
      *
-     * <p><b>{@code at} names the axis carrying the fact, and the position is that axis's path.</b>
-     * The two come apart: a {@code Map} nothing can be read into, under a rule about its size, is
-     * measured at the size and the axis is named for that term. So this is not "the identity of the
-     * position that was blocked" — it is the axis a reader holding these numbers is being told
-     * something about, which is the one thing a gap beside a measurement is for. Keyed by the
-     * position instead, this arm and {@link RulesNotReached} would name a behavior's findings in two
-     * vocabularies.
+     * <p><b>{@code at} names the position.</b> It was the axis carrying the fact, on the reading
+     * that a gap beside a measurement is about the measure a reader holds. That reading needs one
+     * measure per position to be a naming at all: a location is measured at as many numbers as the
+     * rules name of it, and one stop under it then came out once per number. What weakens a
+     * measurement is already said per measurement elsewhere; these are one behavior's account, and
+     * a reader holding a measure reaches its position by the path it reads from.
+     *
+     * <p>{@link RulesNotReached} is keyed the same way, so the two are still one vocabulary.
      *
      * <p>Written from {@link souther.compiler.inputs.BlockedDescent} and never from what the axis is
      * still waiting on. A position something answered for keeps no continuation, and was still never
      * entered.
      */
-    record PositionNotReachedInto(AxisId at, BlockReason.AboutThePosition why) implements ClosureGap {}
+    record PositionNotReachedInto(souther.compiler.inputs.PositionId at,
+                                  BlockReason.AboutThePosition why) implements ClosureGap {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -86,14 +86,14 @@ public sealed interface ClosureGap {
      * an arm taken from a second representation of a fact, which is the mistake #953 is about, in
      * miniature.
      *
-     * <p><b>{@code at} names the position.</b> It was the axis carrying the fact, on the reading
-     * that a gap beside a measurement is about the measure a reader holds. That reading needs one
-     * measure per position to be a naming at all: a location is measured at as many numbers as the
-     * rules name of it, and one stop under it then came out once per number. What weakens a
-     * measurement is already said per measurement elsewhere; these are one behavior's account, and
-     * a reader holding a measure reaches its position by the path it reads from.
+     * <p><b>{@code at} names the position, and not a number measured of it.</b> A location is
+     * measured at as many numbers as the rules name of it, and one stop under the location is one
+     * thing that went wrong however many of those there are. Named for a measure, it is one entry
+     * per number and no reader can tell that from several stops. What weakens one measurement is
+     * said per measurement elsewhere; these are one behavior's account of what its reading of the
+     * model came to, and a reader holding a measure reaches its position by the path it reads from.
      *
-     * <p>{@link RulesNotReached} is keyed the same way, so the two are still one vocabulary.
+     * <p>{@link RulesNotReached} is keyed the same way, so the two are one vocabulary.
      *
      * <p>Written from {@link souther.compiler.inputs.BlockedDescent} and never from what the axis is
      * still waiting on. A position something answered for keeps no continuation, and was still never

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -73,8 +73,14 @@ public sealed interface ClosureGap {
      * ({@link souther.compiler.inputs.RulesLeftUnread}) because a document naming it would make a
      * change to how this compiler traverses a model into a change to what its documents carry. Two
      * of these at one position are one entry, which is that sentence said once.
+     *
+     * <p><b>And whose position it is.</b> An account of one behavior is put together with another's
+     * — a module's is the union of them — and a union keeps one of two equal facts. Two behaviors
+     * taking one type have positions spelled alike, so without the behavior the second of them
+     * would be the first said again.
      */
-    record RulesNotReached(souther.compiler.inputs.PositionId at) implements ClosureGap {}
+    record RulesNotReached(String behavior, souther.compiler.inputs.PositionId at)
+            implements ClosureGap {}
 
     /**
      * A position the walk could not reach into, with what the structural reading found instead.
@@ -93,12 +99,13 @@ public sealed interface ClosureGap {
      * said per measurement elsewhere; these are one behavior's account of what its reading of the
      * model came to, and a reader holding a measure reaches its position by the path it reads from.
      *
-     * <p>{@link RulesNotReached} is keyed the same way, so the two are one vocabulary.
+     * <p>{@link RulesNotReached} is keyed the same way, so the two are one vocabulary, and both
+     * carry whose position it is for the reason given there.
      *
      * <p>Written from {@link souther.compiler.inputs.BlockedDescent} and never from what the axis is
      * still waiting on. A position something answered for keeps no continuation, and was still never
      * entered.
      */
-    record PositionNotReachedInto(souther.compiler.inputs.PositionId at,
+    record PositionNotReachedInto(String behavior, souther.compiler.inputs.PositionId at,
                                   BlockReason.AboutThePosition why) implements ClosureGap {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -86,16 +86,12 @@ public final class EnsuresThresholds {
         /** The lines, read off what the walk said. Not a list of their own, for the reason
          *  {@link GuardThresholds.Guards#thresholds} is not one. */
         public List<Threshold> thresholds() {
-            return evidence.stream()
-                    .filter(LineEvidence.Divides.class::isInstance)
-                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+            return LineEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<GuardThresholds.Guards.Singled> singled() {
-            return evidence.stream()
-                    .filter(LineEvidence.Singles.class::isInstance)
-                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
+            return LineEvidence.pointsIn(evidence);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -72,17 +72,30 @@ public final class EnsuresThresholds {
      *                lines alone would have that said of it — which is a sentence about the model,
      *                and the model says otherwise in its own declaration
      */
-    public record Clauses(List<Threshold> thresholds, List<GuardThresholds.Guards.Singled> singled,
+    public record Clauses(List<LineEvidence> evidence,
                           List<LineDrawn> between, List<RuleWithoutALine> rulesWithoutALine) {
 
-        public static final Clauses NONE =
-                new Clauses(List.of(), List.of(), List.of(), List.of());
+        public static final Clauses NONE = new Clauses(List.of(), List.of(), List.of());
 
         public Clauses {
-            thresholds = List.copyOf(thresholds);
-            singled = List.copyOf(singled);
+            evidence = List.copyOf(evidence);
             between = List.copyOf(between);
             rulesWithoutALine = List.copyOf(rulesWithoutALine);
+        }
+
+        /** The lines, read off what the walk said. Not a list of their own, for the reason
+         *  {@link GuardThresholds.Guards#thresholds} is not one. */
+        public List<Threshold> thresholds() {
+            return evidence.stream()
+                    .filter(LineEvidence.Divides.class::isInstance)
+                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+        }
+
+        /** The values singled out, likewise. */
+        public List<GuardThresholds.Guards.Singled> singled() {
+            return evidence.stream()
+                    .filter(LineEvidence.Singles.class::isInstance)
+                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
         }
     }
 
@@ -117,7 +130,7 @@ public final class EnsuresThresholds {
         }
         InputReads reads = InputReads.ofWhatIsDeclared(inputs, rootsOf(stated.params()));
         Drawn drawn = new Drawn(stated.behavior().name(), new ArrayList<>(), new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>());
         for (StatedContract.StatedRule rule : stated.rules()) {
             String clause = labelOf(rule);
             // Which line of the clause each one is, counted over every comparison the clause states
@@ -134,13 +147,12 @@ public final class EnsuresThresholds {
                                 quantities, drawn);
             }
         }
-        return new Clauses(drawn.thresholds(), drawn.singled(), drawn.between(), drawn.rulesWithoutALine());
+        return new Clauses(drawn.evidence(), drawn.between(), drawn.rulesWithoutALine());
     }
 
     /** What the walk has found so far, and the behavior a line between two positions is named
      *  after. Together because they are filled together and are one answer. */
-    private record Drawn(String behavior, List<Threshold> thresholds,
-                         List<GuardThresholds.Guards.Singled> singled,
+    private record Drawn(String behavior, List<LineEvidence> evidence,
                          List<LineDrawn> between, List<RuleWithoutALine> rulesWithoutALine) {}
 
     /**
@@ -215,12 +227,13 @@ public final class EnsuresThresholds {
                     // The value the rule names, for the reason a body's rule gets: where its line
                     // falls and not the value beside it.
                     if (at.value() != null) {
-                        out.singled().add(new GuardThresholds.Guards.Singled(
-                                at.position(), at.value(), origin));
+                        out.evidence().add(new LineEvidence.Singles(
+                                new GuardThresholds.Guards.Singled(
+                                        at.position(), at.value(), origin)));
                     }
                 } else {
-                    out.thresholds().add(new Threshold(at.position(), at.cutting().seam(),
-                            at.cutting().valueBelongsBelow(), origin));
+                    out.evidence().add(new LineEvidence.Divides(new Threshold(at.position(),
+                            at.cutting().seam(), at.cutting().valueBelongsBelow(), origin)));
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at: the classes either side are what the model tells apart, and the border is

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -7,12 +7,11 @@ import java.util.Map;
 /**
  * What became of each thing the rules said, across the stage that turns it into a measure.
  *
- * <p><b>The account starts where the loss is.</b> {@link LinesRead} holds the reading that draws
+ * <p><b>Anchored to what this stage is handed.</b> {@link LinesRead} holds the reading that draws
  * borders to what it produced, and it is written from the axes: a piece of evidence that never
- * reached an axis is not a line that reading ever found, so nothing there could say it went
- * missing. A position whose body drew two lines on it came back reported as one whose body draws
- * none, with the measurement called complete (issue #1140). An account is worth what it is anchored
- * to, and this one is anchored to what this stage was handed.
+ * reaches an axis is not a line that reading ever finds, so nothing there can say it went missing,
+ * and a measure short of every line a body drew on a position reads as complete. An account is
+ * worth what it is anchored to, and the two are anchored a stage apart for that reason.
  *
  * <p><b>One disposition each, and the same one however often it is said.</b> A piece of evidence
  * measured at one axis and left aside at another is this stage saying two things about one fact, and

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -111,11 +111,18 @@ final class EvidenceAccount {
      *  terms. */
     private static boolean carries(Axis axis, LineEvidence evidence) {
         OriginRef by = evidence.by();
-        if (evidence instanceof LineEvidence.Divides(Threshold line) && line.value() == null) {
-            return axis.parted().stream()
-                    .anyMatch(each -> each.alternatives().contains(by.authoredLine()));
-        }
-        return axis.cuts().stream().anyMatch(each -> each.origins().contains(by));
+        return switch (evidence) {
+            // A line the position has no value beside is not a cut of it. It parts the values all
+            // the same, and where it parts them is what carries the rule — as the authored line,
+            // which is the key that side keeps.
+            case LineEvidence.Divides(Threshold line) when line.value() == null ->
+                    axis.parted().stream()
+                            .anyMatch(each -> each.alternatives().contains(by.authoredLine()));
+            // And one it has a value beside is a cut, as is a value singled out: a rule that
+            // singles nothing out is not one of those, so there is always a value here.
+            case LineEvidence.Divides _, LineEvidence.Singles _ ->
+                    axis.cuts().stream().anyMatch(each -> each.origins().contains(by));
+        };
     }
 
     /** That this stage said what became of everything it was handed. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -1,10 +1,8 @@
 package souther.compiler.partition;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * What became of each thing the rules said, across the stage that turns it into a measure.
@@ -57,28 +55,50 @@ final class EvidenceAccount {
      *  {@link Disposition.Measured} can ask the evidence what it should have left behind. */
     private record Answered(LineEvidence what, Disposition how) {}
 
-    private final Set<LineEvidence.FiledEvidenceId> owed = new LinkedHashSet<>();
+    private final Map<LineEvidence.FiledEvidenceId, LineEvidence> owed = new LinkedHashMap<>();
     private final Map<LineEvidence.FiledEvidenceId, Answered> answered = new LinkedHashMap<>();
 
+    /**
+     * The evidence this stage was handed, and the one thing about it this has to establish rather
+     * than assume.
+     *
+     * <p><b>That the identity tells the pieces apart.</b> Everything below counts by
+     * {@link LineEvidence#id}, so two pieces sharing one is one entry here — and then the piece that
+     * went missing is the one the other answered for. An account whose denominator is short before
+     * any work happens reports a complete measure over evidence it never held, which is the sentence
+     * this whole type exists to refuse.
+     *
+     * <p>Checked where the input is taken and not where two of them meet. A check that fires only
+     * when both arrive assumes what it is meant to establish: the case it has to catch is exactly
+     * the one where the second never comes.
+     *
+     * <p>The same piece handed over twice is one piece. What that would say about the stage is
+     * nothing, and nothing here counts arrivals.
+     */
     EvidenceAccount(List<LineEvidence> evidence) {
-        evidence.forEach(each -> owed.add(each.id()));
+        for (LineEvidence each : evidence) {
+            LineEvidence already = owed.put(each.id(), each);
+            if (already != null && !already.equals(each)) {
+                throw new IllegalStateException("two pieces of evidence are called " + each.id()
+                        + ": " + already + " and " + each
+                        + " — an account that cannot tell them apart has one denominator for two");
+            }
+        }
     }
 
     void disposedOf(LineEvidence what, Disposition how) {
-        Answered already = answered.put(what.id(), new Answered(what, how));
-        if (already == null) {
-            return;
+        // Held against what was handed over rather than against whatever else was disposed of. The
+        // identity is one to one over the input, so a piece arriving here under an id belonging to
+        // another is a piece this stage was never given.
+        LineEvidence given = owed.get(what.id());
+        if (given != null && !given.equals(what)) {
+            throw new IllegalStateException("this stage disposed of " + what
+                    + " under the name of " + given);
         }
-        if (!already.how().equals(how)) {
+        Answered already = answered.put(what.id(), new Answered(what, how));
+        if (already != null && !already.how().equals(how)) {
             throw new IllegalStateException("what became of " + what.id()
                     + " was said twice, as " + already.how() + " and as " + how);
-        }
-        // And that the two are one piece of evidence, which the identity says and this is what
-        // checks it. Two pieces sharing a rule and a number while parting the position's values in
-        // different places would be one entry here, with whichever came last behind it.
-        if (!already.what().equals(what)) {
-            throw new IllegalStateException("two pieces of evidence share " + what.id() + ": "
-                    + already.what() + " and " + what);
         }
     }
 
@@ -139,7 +159,7 @@ final class EvidenceAccount {
 
     /** That this stage said what became of everything it was handed. */
     private void everyPieceWasDisposedOf() {
-        List<LineEvidence.FiledEvidenceId> lost = owed.stream()
+        List<LineEvidence.FiledEvidenceId> lost = owed.keySet().stream()
                 .filter(each -> !answered.containsKey(each)).toList();
         if (!lost.isEmpty()) {
             throw new IllegalStateException(
@@ -148,7 +168,7 @@ final class EvidenceAccount {
                             + " is what this account exists to refuse");
         }
         List<LineEvidence.FiledEvidenceId> strangers = answered.keySet().stream()
-                .filter(each -> !owed.contains(each)).toList();
+                .filter(each -> !owed.containsKey(each)).toList();
         if (!strangers.isEmpty()) {
             throw new IllegalStateException(
                     "this stage said what became of evidence it was not handed: " + strangers);

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -16,9 +16,11 @@ import java.util.Set;
  * none, with the measurement called complete (issue #1140). An account is worth what it is anchored
  * to, and this one is anchored to what this stage was handed.
  *
- * <p><b>Exactly one disposition each.</b> Not at least one: a piece of evidence measured at one axis
- * and left aside at another is this stage saying two things about one fact. Not at most one either —
- * that is the whole point.
+ * <p><b>One disposition each, and the same one however often it is said.</b> A piece of evidence
+ * measured at one axis and left aside at another is this stage saying two things about one fact, and
+ * it is refused where the second is said. Saying the same thing twice about one piece is one answer:
+ * what this holds the stage to is that everything it was handed has an answer, and not that the
+ * stage reached each piece exactly once.
  *
  * <p>What the dispositions are is not decided here. Each is written where the stage does the thing
  * it names, so an outcome added to the stage is an outcome named at the place it happens; gathered
@@ -55,18 +57,28 @@ final class EvidenceAccount {
      *  {@link Disposition.Measured} can ask the evidence what it should have left behind. */
     private record Answered(LineEvidence what, Disposition how) {}
 
-    private final Set<LineEvidence.FiledOccurrence> owed = new LinkedHashSet<>();
-    private final Map<LineEvidence.FiledOccurrence, Answered> answered = new LinkedHashMap<>();
+    private final Set<LineEvidence.FiledEvidenceId> owed = new LinkedHashSet<>();
+    private final Map<LineEvidence.FiledEvidenceId, Answered> answered = new LinkedHashMap<>();
 
     EvidenceAccount(List<LineEvidence> evidence) {
-        evidence.forEach(each -> owed.add(each.occurrence()));
+        evidence.forEach(each -> owed.add(each.id()));
     }
 
     void disposedOf(LineEvidence what, Disposition how) {
-        Answered already = answered.put(what.occurrence(), new Answered(what, how));
-        if (already != null && !already.how().equals(how)) {
-            throw new IllegalStateException("what became of " + what.occurrence()
+        Answered already = answered.put(what.id(), new Answered(what, how));
+        if (already == null) {
+            return;
+        }
+        if (!already.how().equals(how)) {
+            throw new IllegalStateException("what became of " + what.id()
                     + " was said twice, as " + already.how() + " and as " + how);
+        }
+        // And that the two are one piece of evidence, which the identity says and this is what
+        // checks it. Two pieces sharing a rule and a number while parting the position's values in
+        // different places would be one entry here, with whichever came last behind it.
+        if (!already.what().equals(what)) {
+            throw new IllegalStateException("two pieces of evidence share " + what.id() + ": "
+                    + already.what() + " and " + what);
         }
     }
 
@@ -96,11 +108,11 @@ final class EvidenceAccount {
             if (axis == null) {
                 throw new IllegalStateException(
                         "this stage says it measured evidence at an axis it did not keep: "
-                                + each.what().occurrence());
+                                + each.what().id());
             }
             if (!carries(axis, each.what())) {
                 throw new IllegalStateException(
-                        "this stage says it measured " + each.what().occurrence() + " at " + at
+                        "this stage says it measured " + each.what().id() + " at " + at
                                 + ", which carries nothing that rule drew");
             }
         }
@@ -127,7 +139,7 @@ final class EvidenceAccount {
 
     /** That this stage said what became of everything it was handed. */
     private void everyPieceWasDisposedOf() {
-        List<LineEvidence.FiledOccurrence> lost = owed.stream()
+        List<LineEvidence.FiledEvidenceId> lost = owed.stream()
                 .filter(each -> !answered.containsKey(each)).toList();
         if (!lost.isEmpty()) {
             throw new IllegalStateException(
@@ -135,7 +147,7 @@ final class EvidenceAccount {
                             + " — a measure reported as complete over evidence that went missing"
                             + " is what this account exists to refuse");
         }
-        List<LineEvidence.FiledOccurrence> strangers = answered.keySet().stream()
+        List<LineEvidence.FiledEvidenceId> strangers = answered.keySet().stream()
                 .filter(each -> !owed.contains(each)).toList();
         if (!strangers.isEmpty()) {
             throw new IllegalStateException(

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -1,0 +1,120 @@
+package souther.compiler.partition;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What became of each thing the rules said, across the stage that turns it into a measure.
+ *
+ * <p><b>The account starts where the loss is.</b> {@link LinesRead} holds the reading that draws
+ * borders to what it produced, and it is written from the axes: a piece of evidence that never
+ * reached an axis is not a line that reading ever found, so nothing there could say it went
+ * missing. A position whose body drew two lines on it came back reported as one whose body draws
+ * none, with the measurement called complete (issue #1140). An account is worth what it is anchored
+ * to, and this one is anchored to what this stage was handed.
+ *
+ * <p><b>Exactly one disposition each.</b> Not at least one: a piece of evidence measured at one axis
+ * and left aside at another is this stage saying two things about one fact. Not at most one either —
+ * that is the whole point.
+ *
+ * <p>What the dispositions are is not decided here. Each is written where the stage does the thing
+ * it names, so an outcome added to the stage is an outcome named at the place it happens; gathered
+ * here from what was left over, the name would be this account's guess about somebody else's code.
+ *
+ * <p>The filing that runs before this owns its own losses — a rule it could not place comes out as a
+ * finding naming the rule ({@link LinesWhereTheyFall.Filed#notPlaced}), and those never reach here.
+ * Each stage answers for what it was given.
+ */
+final class EvidenceAccount {
+
+    /** What this stage did with one piece of evidence. */
+    sealed interface Disposition {
+
+        /** It divides an axis, which carries its cut. */
+        record Measured(AxisId at) implements Disposition {}
+
+        /**
+         * It falls where the position holds no value, so it divides nothing there. Not a rule that
+         * went unread: what it says was understood, and where it says it is outside the position.
+         */
+        record OutsideThePosition() implements Disposition {}
+
+        /** Nothing reaches the comparison it was read from, so what it divides is nothing that
+         *  gets there. */
+        record NothingArrivesAtIt() implements Disposition {}
+
+        /**
+         * The declarations already measure this position at another number, and this stage does not
+         * add a second measure of a position a rule of its own divides.
+         *
+         * <p>A policy of this stage and not a fact about the model, which is why it is said rather
+         * than left out: an author is not told anything, and an account that simply had no entry
+         * would be an account that cannot tell this from a loss.
+         */
+        record ThePositionIsAlreadyMeasured(AxisId by) implements Disposition {}
+    }
+
+    private final Set<LineEvidence.FiledOccurrence> owed = new LinkedHashSet<>();
+    private final Map<LineEvidence.FiledOccurrence, Disposition> answered = new LinkedHashMap<>();
+
+    EvidenceAccount(List<LineEvidence> evidence) {
+        evidence.forEach(each -> owed.add(each.occurrence()));
+    }
+
+    void disposedOf(LineEvidence.FiledOccurrence what, Disposition how) {
+        Disposition already = answered.put(what, how);
+        if (already != null && !already.equals(how)) {
+            throw new IllegalStateException("what became of " + what + " was said twice, as "
+                    + already + " and as " + how);
+        }
+    }
+
+    void measured(LineEvidence what, AxisId at) {
+        disposedOf(what.occurrence(), new Disposition.Measured(at));
+    }
+
+    /**
+     * That this stage said what became of everything it was handed, and that an axis it says
+     * something was measured at is one it kept.
+     *
+     * <p><b>What this does not hold.</b> That the axis carries a cut of the rule. A line the
+     * position has no value beside divides it and has no cut to be at — {@code 3 * d <= 1} cuts at
+     * a third — so requiring one would call a measured line lost. What holds a border to the line it
+     * was made of is {@link LinesRead}, downstream of here, and the two are anchored a stage apart
+     * on purpose.
+     */
+    void everyPieceWasDisposedOf(List<Axis> kept) {
+        Set<AxisId> there = new LinkedHashSet<>();
+        kept.forEach(each -> there.add(each.id()));
+        List<LineEvidence.FiledOccurrence> nowhere = answered.entrySet().stream()
+                .filter(each -> each.getValue() instanceof Disposition.Measured(AxisId at)
+                        && !there.contains(at))
+                .map(Map.Entry::getKey).toList();
+        if (!nowhere.isEmpty()) {
+            throw new IllegalStateException(
+                    "this stage says it measured evidence at an axis it did not keep: " + nowhere);
+        }
+        everyPieceWasDisposedOf();
+    }
+
+    /** That this stage said what became of everything it was handed. */
+    private void everyPieceWasDisposedOf() {
+        List<LineEvidence.FiledOccurrence> lost = owed.stream()
+                .filter(each -> !answered.containsKey(each)).toList();
+        if (!lost.isEmpty()) {
+            throw new IllegalStateException(
+                    "the rules said something this stage did not say what became of: " + lost
+                            + " — a measure reported as complete over evidence that went missing"
+                            + " is what this account exists to refuse");
+        }
+        List<LineEvidence.FiledOccurrence> strangers = answered.keySet().stream()
+                .filter(each -> !owed.contains(each)).toList();
+        if (!strangers.isEmpty()) {
+            throw new IllegalStateException(
+                    "this stage said what became of evidence it was not handed: " + strangers);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -36,12 +36,6 @@ final class EvidenceAccount {
         /** It divides an axis, which carries its cut. */
         record Measured(AxisId at) implements Disposition {}
 
-        /**
-         * It falls where the position holds no value, so it divides nothing there. Not a rule that
-         * went unread: what it says was understood, and where it says it is outside the position.
-         */
-        record OutsideThePosition() implements Disposition {}
-
         /** Nothing reaches the comparison it was read from, so what it divides is nothing that
          *  gets there. */
         record NothingArrivesAtIt() implements Disposition {}
@@ -57,47 +51,71 @@ final class EvidenceAccount {
         record ThePositionIsAlreadyMeasured(AxisId by) implements Disposition {}
     }
 
+    /** One piece of evidence and what became of it, held together so that holding the stage to a
+     *  {@link Disposition.Measured} can ask the evidence what it should have left behind. */
+    private record Answered(LineEvidence what, Disposition how) {}
+
     private final Set<LineEvidence.FiledOccurrence> owed = new LinkedHashSet<>();
-    private final Map<LineEvidence.FiledOccurrence, Disposition> answered = new LinkedHashMap<>();
+    private final Map<LineEvidence.FiledOccurrence, Answered> answered = new LinkedHashMap<>();
 
     EvidenceAccount(List<LineEvidence> evidence) {
         evidence.forEach(each -> owed.add(each.occurrence()));
     }
 
-    void disposedOf(LineEvidence.FiledOccurrence what, Disposition how) {
-        Disposition already = answered.put(what, how);
-        if (already != null && !already.equals(how)) {
-            throw new IllegalStateException("what became of " + what + " was said twice, as "
-                    + already + " and as " + how);
+    void disposedOf(LineEvidence what, Disposition how) {
+        Answered already = answered.put(what.occurrence(), new Answered(what, how));
+        if (already != null && !already.how().equals(how)) {
+            throw new IllegalStateException("what became of " + what.occurrence()
+                    + " was said twice, as " + already.how() + " and as " + how);
         }
     }
 
     void measured(LineEvidence what, AxisId at) {
-        disposedOf(what.occurrence(), new Disposition.Measured(at));
+        disposedOf(what, new Disposition.Measured(at));
     }
 
     /**
-     * That this stage said what became of everything it was handed, and that an axis it says
-     * something was measured at is one it kept.
+     * That this stage said what became of everything it was handed, and that what it says it
+     * measured is on the axis it names.
      *
-     * <p><b>What this does not hold.</b> That the axis carries a cut of the rule. A line the
-     * position has no value beside divides it and has no cut to be at — {@code 3 * d <= 1} cuts at
-     * a third — so requiring one would call a measured line lost. What holds a border to the line it
-     * was made of is {@link LinesRead}, downstream of here, and the two are anchored a stage apart
-     * on purpose.
+     * <p><b>Held to what the axis carries, and not to the word.</b> Saying a piece of evidence was
+     * measured is a claim about an axis, and a claim nothing checks is what this account exists to
+     * refuse one stage earlier. Each kind of evidence is looked for by its own key: a line the
+     * position has a value beside leaves a cut carrying the rule, one it has no value beside leaves
+     * the place the values part with the authored line against it, and a value singled out leaves a
+     * cut like the first. Looked for by one key, the second would be reported lost.
      */
     void everyPieceWasDisposedOf(List<Axis> kept) {
-        Set<AxisId> there = new LinkedHashSet<>();
-        kept.forEach(each -> there.add(each.id()));
-        List<LineEvidence.FiledOccurrence> nowhere = answered.entrySet().stream()
-                .filter(each -> each.getValue() instanceof Disposition.Measured(AxisId at)
-                        && !there.contains(at))
-                .map(Map.Entry::getKey).toList();
-        if (!nowhere.isEmpty()) {
-            throw new IllegalStateException(
-                    "this stage says it measured evidence at an axis it did not keep: " + nowhere);
+        Map<AxisId, Axis> there = new LinkedHashMap<>();
+        kept.forEach(each -> there.put(each.id(), each));
+        for (Answered each : answered.values()) {
+            if (!(each.how() instanceof Disposition.Measured(AxisId at))) {
+                continue;
+            }
+            Axis axis = there.get(at);
+            if (axis == null) {
+                throw new IllegalStateException(
+                        "this stage says it measured evidence at an axis it did not keep: "
+                                + each.what().occurrence());
+            }
+            if (!carries(axis, each.what())) {
+                throw new IllegalStateException(
+                        "this stage says it measured " + each.what().occurrence() + " at " + at
+                                + ", which carries nothing that rule drew");
+            }
         }
         everyPieceWasDisposedOf();
+    }
+
+    /** Whether {@code axis} carries what {@code evidence} draws, asked in that evidence's own
+     *  terms. */
+    private static boolean carries(Axis axis, LineEvidence evidence) {
+        OriginRef by = evidence.by();
+        if (evidence instanceof LineEvidence.Divides(Threshold line) && line.value() == null) {
+            return axis.parted().stream()
+                    .anyMatch(each -> each.alternatives().contains(by.authoredLine()));
+        }
+        return axis.cuts().stream().anyMatch(each -> each.origins().contains(by));
     }
 
     /** That this stage said what became of everything it was handed. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3257,8 +3257,8 @@ public final class Generator {
                             && decided.write(path, values.written())
                                     == LocationWrites.Written.CONFLICTING) {
                         // Two of this row's classes are of one location and offer different values
-                        // for it. Whichever was reached last used to be written and the other's
-                        // class went unanswered while the row was offered as covering it.
+                        // for it. Taking either leaves the other's class unanswered while the row
+                        // is offered as covering it, so neither is taken.
                         return new Attempt(null,
                                 UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, at,
                                 Optional.of("`" + path + "` would have to hold two values at once"));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2195,7 +2195,14 @@ public final class Generator {
                     instanceof RepresentativeSource.Evaluation.Values values)) {
                 return null;
             }
-            fields.put(field.name(), values.written().get(0));
+            // A field two of the moved axes are of. The baseline can be written for one of them or
+            // for the other and this walk writes fields, so it writes neither and says the
+            // parameter cannot be written — which is what every other thing it cannot do here
+            // answers with.
+            FixtureTemplate already = fields.put(field.name(), values.written().get(0));
+            if (already != null && !already.equals(values.written().get(0))) {
+                return null;
+            }
         }
         if (fields.isEmpty()) {
             return null;
@@ -2340,7 +2347,7 @@ public final class Generator {
                                               java.util.function.Function<NumericTerm, Carrier> on,
                                               Map<NumericTerm, Place> fixing,
                                               Reachability.Reaching reaching, CandidateCheck check) {
-        Map<TermPath, List<FixtureTemplate>> decided = new LinkedHashMap<>();
+        LocationWrites decided = new LocationWrites();
         // What the rest of the row has to sit beside. A field of a record is not chosen from its own
         // type once another field of that record is fixed: the rule relating them says what is left,
         // and taking the bottom of the type's range instead is how a boundary that can be written
@@ -2385,12 +2392,18 @@ public final class Generator {
             // length and the string itself — and what a row writes at a location is one value. The
             // fixing keeps them apart ({@link Realization.Found}) and this cannot, so it says so
             // rather than writing whichever came last and offering half the point as the whole.
-            if (decided.containsKey(at)) {
+            //
+            // Refused whatever the second edge offers, and not only where it offers something else.
+            // What is recorded beside the value here — where the row settles and what the edge held
+            // back — is the edge's own answer, and two edges have two of those however alike their
+            // values are. Written as one, the row would carry one edge's account of a place both
+            // were asked about.
+            if (decided.holds(at)) {
                 return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
                         UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE),
                         where.unrepresented());
             }
-            decided.put(at, edge.values());
+            decided.write(at, edge.values());
             // The orders the value was built against, kept so that reading it back asks the
             // question building it asked rather than a second reading of the same position.
             builtOn.put(each.getKey(), edge.on());
@@ -2420,7 +2433,7 @@ public final class Generator {
                 // refuse.
                 if (term.path().head().equals(head)
                         && reaching.requirements().at(term.path()) == null) {
-                    here.put(term.path(), decided.get(term.path()));
+                    here.put(term.path(), decided.at(term.path()));
                 }
             }
             Outcome tried = valueAt(subject, p, here, settled, reaching.requirements(), certified);
@@ -3196,7 +3209,7 @@ public final class Generator {
      */
     private static Attempt build(Subject subject, List<Axis> axes, int[] where,
                                  CandidateCheck check, Map<String, FixtureTemplate> given) {
-        Map<TermPath, List<FixtureTemplate>> decided = new LinkedHashMap<>();
+        LocationWrites decided = new LocationWrites();
         // What every position of this row has to be for the classes it sits in to exist. Read off
         // the paths and off the classes together, because both state one: a position under a
         // refinement requires it by being there at all, and a class of the position above states
@@ -3237,8 +3250,15 @@ public final class Generator {
                 // location decided twice, under two names. The plan reads the first of them and the
                 // class fixed at the narrowed position is never looked at.
                 case RepresentativeSource.Evaluation.Values values -> {
-                    if (cls.selects() == null) {
-                        decided.put(path, values.written());
+                    if (cls.selects() == null
+                            && decided.write(path, values.written())
+                                    == LocationWrites.Written.CONFLICTING) {
+                        // Two of this row's classes are of one location and offer different values
+                        // for it. Whichever was reached last used to be written and the other's
+                        // class went unanswered while the row was offered as covering it.
+                        return new Attempt(null,
+                                UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, at,
+                                Optional.of("`" + path + "` would have to hold two values at once"));
                     }
                 }
                 // Not a value but how one is arrived at: the walk below builds one at this position,
@@ -3294,14 +3314,13 @@ public final class Generator {
      * parameters of eight either-or fields are two searches of 256, not one of 65,536.
      */
     private static Outcome valueFor(Subject subject, int p, List<Axis> axes,
-                                    Map<TermPath, List<FixtureTemplate>> decided,
+                                    LocationWrites decided,
                                     Requirements required, CandidateCheck check) {
         TermPath at = TermPath.of(subject.parameters().get(p));
         Map<TermPath, List<FixtureTemplate>> here = new LinkedHashMap<>();
         for (Axis axis : axes) {
-            if (axis.path().head().equals(at.head())
-                    && decided.containsKey(axis.path())) {
-                here.put(axis.path(), decided.get(axis.path()));
+            if (axis.path().head().equals(at.head()) && decided.holds(axis.path())) {
+                here.put(axis.path(), decided.at(axis.path()));
             }
         }
         return valueAt(subject, p, here, settledIn(here), required, check);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2176,6 +2176,7 @@ public final class Generator {
             return null;
         }
         Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
+        LocationWrites writing = new LocationWrites();
         for (int i : moved) {
             Axis axis = axes.get(i);
             if (axis.path().steps().size() != 1
@@ -2199,10 +2200,12 @@ public final class Generator {
             // for the other and this walk writes fields, so it writes neither and says the
             // parameter cannot be written — which is what every other thing it cannot do here
             // answers with.
-            FixtureTemplate already = fields.put(field.name(), values.written().get(0));
-            if (already != null && !already.equals(values.written().get(0))) {
+            FixtureTemplate written = values.written().get(0);
+            if (writing.write(axis.path(), List.of(written))
+                    == LocationWrites.Written.CONFLICTING) {
                 return null;
             }
+            fields.put(field.name(), written);
         }
         if (fields.isEmpty()) {
             return null;

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -80,16 +80,12 @@ public final class GuardThresholds {
         /** The lines, read off what the walk said. Not a list of their own: the walk met these and
          *  the values it singled out in one order, and holding two lists loses it. */
         public List<Threshold> thresholds() {
-            return evidence.stream()
-                    .filter(LineEvidence.Divides.class::isInstance)
-                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+            return LineEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<Singled> singled() {
-            return evidence.stream()
-                    .filter(LineEvidence.Singles.class::isInstance)
-                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
+            return LineEvidence.pointsIn(evidence);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -1,12 +1,12 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.UnreadComparison;
 import souther.compiler.check.ValueOrigin;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.ReadMeaning;
@@ -49,7 +49,7 @@ import java.util.List;
  * <p>Three readers are kept apart and are easy to run together. Which comparisons exist is
  * {@link souther.compiler.coverage.ComparisonCatalog}'s answer and which of them a line may be drawn
  * on is {@link BoundaryPolicy}'s; which positions a comparison names at all is
- * {@link #mentioned}; which number a line can be drawn on is {@link #termOf}. The last is the
+ * {@link #mentioned}; which number a line can be drawn on is {@link InputNumber}'s. The last is the
  * narrowest, and asking it the first two questions is how a position a body compares became a
  * position nothing compares.
  */
@@ -280,9 +280,9 @@ public final class GuardThresholds {
     /**
      * Every position an expression names, however it is written.
      *
-     * <p>Weaker than {@link #termOf} on purpose, and asked instead of it. That one answers whether a
-     * line can be drawn — it wants a number the terms name — and this one answers whether the model
-     * says anything about a position at all. Sharing a reader between the two turns an expression
+     * <p>Weaker than {@link InputNumber#of} on purpose, and asked instead of it. That one answers
+     * whether a line can be drawn — it wants a number the terms name — and this one answers whether
+     * the model says anything about a position at all. Sharing a reader between the two turns an expression
      * the derivation does not model into a position nothing compares: {@code p.x + 1 < 10} named no
      * position, and came back as one the model divides no way two tokens from a comparison about it.
      *
@@ -442,7 +442,7 @@ public final class GuardThresholds {
      * What one side of a comparison came to here.
      *
      * <p>Which positions it names is {@link #mentioned}'s recursive question and which number a
-     * line could be drawn on is {@link #termOf}'s narrower one, and the two are what tell a
+     * line could be drawn on is {@link InputNumber}'s narrower one, and the two are what tell a
      * position inside an expression from a position. Asked the narrow question alone,
      * {@code y + 1} named nothing and a comparison of two positions came back as a form nobody
      * could read.
@@ -642,12 +642,6 @@ public final class GuardThresholds {
                 cutting.valueBelongsBelow(), cutting.holdsAtTheValue(), cutting.singles());
     }
 
-    /** The number a comparison is about, from whichever side names one. */
-    static NumericTerm comparedTerm(Core.Binary comparison, InputReads reads, Symbols symbols) {
-        NumericTerm left = termOf(comparison.left(), reads, symbols);
-        return left != null ? left : termOf(comparison.right(), reads, symbols);
-    }
-
     /**
      * How a reader finds a comparison, which is where it is written.
      *
@@ -669,29 +663,6 @@ public final class GuardThresholds {
                         "a rule was cited at a comparison this catalog does not hold, at "
                                 + comparison.pos())).at());
     }
-
-    /**
-     * The number a comparison names, which is a location's content or something taken of it.
-     *
-     * <p>Which of the standard library's calls count is asked of {@link NumericMeasures} rather than
-     * decided here, and asked of the operation the call resolved to rather than of its spelling. The
-     * argument has to be a location: {@code List.length(List.map(f, xs))} counts something no path
-     * names, and a boundary on it could not be looked for in a row.
-     */
-    static NumericTerm termOf(Core e, InputReads reads, Symbols symbols) {
-        NumericMeasures.Measured measured = NumericMeasures.takenIn(e);
-        if (measured != null) {
-            TermPath of = reads.pathOf(measured.of(), symbols);
-            // Null where the call names a location the operation is not taken of, which a guard can
-            // write and the type checker has already refused elsewhere. Answered here as "no term",
-            // which is what every reader of one is ready for.
-            return of == null ? null : NumericTerm.TakenOf.of(measured.operation(), of,
-                    reads.read().typeAt(of, symbols), symbols);
-        }
-        TermPath path = reads.pathOf(e, symbols);
-        return path == null ? null : new NumericTerm.ValueOf(path);
-    }
-
 
     /** Whether a line can be drawn on what this type carries, asked of the one place that says so. */
     static boolean orderable(Type type, Symbols symbols) {
@@ -717,7 +688,7 @@ public final class GuardThresholds {
      *
      * <p>The two together because no reader of a line wants one without the other, and both readings
      * of a comparison want them the same way round. Neither answer is made here: which position an
-     * expression names is {@link #termOf}'s and which order that position is counted on is the
+     * expression names is {@link InputNumber}'s and which order that position is counted on is the
      * reading of the declarations' ({@link InputDomain#carrierOf}).
      *
      * <p>In particular the expression's own type is not read, here or anywhere a line is drawn. It
@@ -728,7 +699,7 @@ public final class GuardThresholds {
      * border nothing could meet (#1018).
      */
     static Named namedBy(Core e, InputReads reads, Symbols symbols) {
-        NumericTerm term = termOf(e, reads, symbols);
+        NumericTerm term = InputNumber.of(e, reads, symbols);
         if (term == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -63,13 +63,34 @@ public final class GuardThresholds {
      * {@code c} on the low side and are two different rules about it — so it is read where the
      * operator is still in hand, and which values arrive is asked of the reading of the whole body.
      */
-    public record Guards(List<Threshold> thresholds,
-                         List<RuleWithoutALine> rulesWithoutALine, List<Singled> singled,
+    public record Guards(List<LineEvidence> evidence,
+                         List<RuleWithoutALine> rulesWithoutALine,
                          List<LineDrawn> between,
                          ReachingCuts reaching) {
 
         public static final Guards NONE =
-                new Guards(List.of(), List.of(), List.of(), List.of(), ReachingCuts.NONE);
+                new Guards(List.of(), List.of(), List.of(), ReachingCuts.NONE);
+
+        public Guards {
+            evidence = List.copyOf(evidence);
+            rulesWithoutALine = List.copyOf(rulesWithoutALine);
+            between = List.copyOf(between);
+        }
+
+        /** The lines, read off what the walk said. Not a list of their own: the walk met these and
+         *  the values it singled out in one order, and holding two lists loses it. */
+        public List<Threshold> thresholds() {
+            return evidence.stream()
+                    .filter(LineEvidence.Divides.class::isInstance)
+                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+        }
+
+        /** The values singled out, likewise. */
+        public List<Singled> singled() {
+            return evidence.stream()
+                    .filter(LineEvidence.Singles.class::isInstance)
+                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
+        }
 
         /**
          * A value a body singles out rather than orders.
@@ -95,12 +116,6 @@ public final class GuardThresholds {
             }
         }
 
-        public Guards {
-            thresholds = List.copyOf(thresholds);
-            rulesWithoutALine = List.copyOf(rulesWithoutALine);
-            singled = List.copyOf(singled);
-            between = List.copyOf(between);
-        }
     }
 
 
@@ -124,9 +139,8 @@ public final class GuardThresholds {
                             InputDomain inputs, souther.compiler.inputs.Quantities quantities,
                             Symbols symbols,
                             souther.compiler.check.ElementBindings elements) {
-        List<Threshold> found = new ArrayList<>();
+        List<LineEvidence> found = new ArrayList<>();
         List<RuleWithoutALine> withoutALine = new ArrayList<>();
-        List<Guards.Singled> singled = new ArrayList<>();
         List<LineDrawn> between = new ArrayList<>();
         // The comparisons this reader assessed, and not the positions they were about. A position
         // carries more than one statement and reading one of them settles nothing about the others.
@@ -144,11 +158,11 @@ public final class GuardThresholds {
         ComparisonReadings read = ComparisonReadings.of(body, plan, InputReads.of(inputs, elements), symbols);
         for (ComparisonReadings.Reading each : read.drawn()) {
             lineAt(behavior, each.comparison(), plan, each.reads(), symbols, quantities, found,
-                    singled, between, assessed, withoutALine);
+                    between, assessed, withoutALine);
         }
         // And every comparison the model states something by that this reader never saw.
         noticed(behavior, read, assessed, plan, symbols, withoutALine);
-        return new Guards(found, withoutALine, singled, between, read.reaching(plan));
+        return new Guards(found, withoutALine, between, read.reaching(plan));
     }
 
     /**
@@ -518,7 +532,7 @@ public final class GuardThresholds {
     private static void lineAt(String behavior, Core.Binary each, CoverageSites.Plan plan,
                                InputReads reads, Symbols symbols,
                                souther.compiler.inputs.Quantities quantities,
-                               List<Threshold> out, List<Guards.Singled> singled,
+                               List<LineEvidence> out,
                                List<LineDrawn> between,
                                List<Core> assessed, List<RuleWithoutALine> withoutALine) {
         // The plan numbered every comparison of an instrumented condition before anything read a
@@ -546,11 +560,12 @@ public final class GuardThresholds {
                     // beside it. A rule that names no value of the position singles nothing out
                     // here — the position is divided all the same, and what divides it is the line.
                     if (at.value() != null) {
-                        singled.add(new Guards.Singled(at.position(), at.value(), origin));
+                        out.add(new LineEvidence.Singles(
+                                new Guards.Singled(at.position(), at.value(), origin)));
                     }
                 } else {
-                    out.add(new Threshold(at.position(), at.cutting().seam(),
-                            at.cutting().valueBelongsBelow(), origin));
+                    out.add(new LineEvidence.Divides(new Threshold(at.position(),
+                            at.cutting().seam(), at.cutting().valueBelongsBelow(), origin)));
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at. It divides the position — the classes either side are what the model

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -459,9 +459,8 @@ public final class InteractionCells {
      *
      * <p>The number and never the path it is read from. A location may be measured at more than one
      * number — which hour of a time it is and which minute — and those are one path: asked by path,
-     * a comparison about the second of them is answered by the first's axis, which carries no cut
-     * of that comparison and so narrows nothing. The condition then goes missing without a word
-     * (issue #1140).
+     * a comparison about the second of them is answered by the first's axis, which carries no cut of
+     * that comparison and so narrows nothing, with nothing saying the condition went unread.
      *
      * <p>Exact and not the nearest. The reading that named this condition and the reading that made
      * the axis ask {@link souther.compiler.inputs.InputNumber} for the number, so a name worn over

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -409,7 +409,7 @@ public final class InteractionCells {
                 return null;
             }
             case Condition.Side one -> {
-                int axis = axisAt(axes, one.at());
+                int axis = axisOf(axes, one.at());
                 if (axis < 0) {
                     return null;
                 }
@@ -455,12 +455,38 @@ public final class InteractionCells {
     }
 
     /**
+     * The axis measuring {@code term}, or -1 where none does.
+     *
+     * <p>The number and never the path it is read from. A location may be measured at more than one
+     * number — which hour of a time it is and which minute — and those are one path: asked by path,
+     * a comparison about the second of them is answered by the first's axis, which carries no cut
+     * of that comparison and so narrows nothing. The condition then goes missing without a word
+     * (issue #1140).
+     *
+     * <p>Exact and not the nearest. The reading that named this condition and the reading that made
+     * the axis ask {@link souther.compiler.inputs.InputNumber} for the number, so a name worn over
+     * a type is already looked through on both sides and there is nothing left for a match to be
+     * lenient about.
+     */
+    private static int axisOf(List<Axis> axes, souther.compiler.inputs.NumericTerm term) {
+        for (int i = 0; i < axes.size(); i++) {
+            if (axes.get(i).term().equals(term)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Which position the condition is about, allowing for the names a value is written under.
      *
      * <p>{@code total.value} and {@code total} are one position where {@code Total} is a name worn
      * over an {@code Int}: the body reads through the name and the partition divides the position
      * the name is at. The longest match wins, so a record whose own field is divided keeps its own
      * axis rather than being answered by the record's.
+     *
+     * <p>For a case of a union, which is about the location and not about a number of it. What a
+     * comparison is about is {@link #axisOf}'s, exactly.
      */
     private static int axisAt(List<Axis> axes, TermPath path) {
         int found = -1;

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
@@ -16,7 +16,7 @@ import souther.compiler.inputs.NumericTerm;
  *
  * <p><b>Not an identity, before filing.</b> One rule about a name every case of a sum spreads is
  * filed at each of those positions, and what the partition is owed is each of them. The identity of
- * a filed one is {@link #occurrence}, which is that expansion's answer and not this reading's.
+ * a filed one is {@link #id}, which is that expansion's answer and not this reading's.
  */
 public sealed interface LineEvidence {
 
@@ -27,15 +27,15 @@ public sealed interface LineEvidence {
     OriginRef by();
 
     /**
-     * What tells one filed piece of evidence from another.
+     * What tells one filed piece of evidence from another, once it has been filed.
      *
      * <p>The rule and the number together, because filing takes one rule to the positions the name
      * it is written at reaches: three cases of a sum spreading one field is one rule and three
      * numbers, and the partition owes an answer at each. Keyed by the rule alone, answering at one
      * of them would close the account over all three.
      */
-    default FiledOccurrence occurrence() {
-        return new FiledOccurrence(by(), at());
+    default FiledEvidenceId id() {
+        return new FiledEvidenceId(by(), at());
     }
 
     /** Where a run of the position's values ends and the next begins. */
@@ -72,8 +72,9 @@ public sealed interface LineEvidence {
         }
     }
 
-    /** One filed piece of evidence, told from every other. */
-    record FiledOccurrence(OriginRef by, NumericTerm at) {}
+    /** What one filed piece of evidence is called: the rule that said it and the number it was
+     *  filed at. Not a count of how many times anything reached it. */
+    record FiledEvidenceId(OriginRef by, NumericTerm at) {}
 
     /**
      * The lines among {@code evidence}, for a reader that wants only those.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
@@ -1,0 +1,77 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.NumericTerm;
+
+/**
+ * One thing the rules say about a number's values, as the reading of them met it.
+ *
+ * <p>Two variants of one kind and not two kinds. A rule either says where a run of values ends and
+ * the next begins or puts one value in a class of its own, and both of them are the reading of the
+ * rules arriving at something to divide a position by. Held as two lists, the reading's own order
+ * across them is gone and every reader that wants all of what was said has to put the lists back
+ * together — which the fan-out below and the account beside it both do, and which is where a
+ * position measured at one of the two came to be measured at neither (issue #1140).
+ *
+ * <p>So the list of these is what a reading answers with, and the two lists are read off it.
+ *
+ * <p><b>Not an identity, before filing.</b> One rule about a name every case of a sum spreads is
+ * filed at each of those positions, and what the partition is owed is each of them. The identity of
+ * a filed one is {@link #occurrence}, which is that expansion's answer and not this reading's.
+ */
+public sealed interface LineEvidence {
+
+    /** The number this is about. */
+    NumericTerm at();
+
+    /** The rule that said it. */
+    OriginRef by();
+
+    /**
+     * What tells one filed piece of evidence from another.
+     *
+     * <p>The rule and the number together, because filing takes one rule to the positions the name
+     * it is written at reaches: three cases of a sum spreading one field is one rule and three
+     * numbers, and the partition owes an answer at each. Keyed by the rule alone, answering at one
+     * of them would close the account over all three.
+     */
+    default FiledOccurrence occurrence() {
+        return new FiledOccurrence(by(), at());
+    }
+
+    /** Where a run of the position's values ends and the next begins. */
+    record Divides(Threshold line) implements LineEvidence {
+
+        @Override
+        public NumericTerm at() {
+            return line.term();
+        }
+
+        @Override
+        public OriginRef by() {
+            return line.origin();
+        }
+    }
+
+    /**
+     * A value the rules put in a class of its own.
+     *
+     * <p>Apart from {@link Divides} because an equality says nothing about ranges: what it
+     * distinguishes is the value from every other value, and reading it as a place to cut would put
+     * a distinction between the two sides into a partition the model never drew.
+     */
+    record Singles(GuardThresholds.Guards.Singled point) implements LineEvidence {
+
+        @Override
+        public NumericTerm at() {
+            return point.term();
+        }
+
+        @Override
+        public OriginRef by() {
+            return point.origin();
+        }
+    }
+
+    /** One filed piece of evidence, told from every other. */
+    record FiledOccurrence(OriginRef by, NumericTerm at) {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
@@ -7,10 +7,9 @@ import souther.compiler.inputs.NumericTerm;
  *
  * <p>Two variants of one kind and not two kinds. A rule either says where a run of values ends and
  * the next begins or puts one value in a class of its own, and both of them are the reading of the
- * rules arriving at something to divide a position by. Held as two lists, the reading's own order
- * across them is gone and every reader that wants all of what was said has to put the lists back
- * together — which the fan-out below and the account beside it both do, and which is where a
- * position measured at one of the two came to be measured at neither (issue #1140).
+ * rules arriving at something to divide a position by. A reader wanting all of what was said about a
+ * number wants both — which numbers a position is measured at is one such reader, and so is the
+ * account of what became of each thing the rules said — and one list is what they are given.
  *
  * <p>So the list of these is what a reading answers with, and the two lists are read off it.
  *

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineEvidence.java
@@ -74,4 +74,22 @@ public sealed interface LineEvidence {
 
     /** One filed piece of evidence, told from every other. */
     record FiledOccurrence(OriginRef by, NumericTerm at) {}
+
+    /**
+     * The lines among {@code evidence}, for a reader that wants only those.
+     *
+     * <p>Here and not at each holder of a list. Four of them wanted the same two projections and
+     * each wrote its own, which is four places to answer the day a third variant is written.
+     */
+    static java.util.List<Threshold> linesIn(java.util.List<LineEvidence> evidence) {
+        return evidence.stream().filter(Divides.class::isInstance)
+                .map(each -> ((Divides) each).line()).toList();
+    }
+
+    /** The values singled out among {@code evidence}, likewise. */
+    static java.util.List<GuardThresholds.Guards.Singled> pointsIn(
+            java.util.List<LineEvidence> evidence) {
+        return evidence.stream().filter(Singles.class::isInstance)
+                .map(each -> ((Singles) each).point()).toList();
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -59,32 +59,17 @@ public final class LinesWhereTheyFall {
             evidence = List.copyOf(evidence);
             between = List.copyOf(between);
             notPlaced = List.copyOf(notPlaced);
-            // What the next stage owes an answer at, each told from the others. One rule filed at
-            // three cases of a sum is three of these, and a second at one of them would close the
-            // account over both while one went unmeasured — which is the reason the identity is the
-            // rule and the number together and not the rule alone.
-            java.util.Set<LineEvidence.FiledOccurrence> seen = new java.util.LinkedHashSet<>();
-            for (LineEvidence each : evidence) {
-                if (!seen.add(each.occurrence())) {
-                    throw new IllegalStateException(
-                            "one rule filed twice at one number: " + each.occurrence());
-                }
-            }
         }
 
         /** The lines, for a reader that wants only those. Read off the one list and not kept
          *  beside it. */
         public List<Threshold> thresholds() {
-            return evidence.stream()
-                    .filter(LineEvidence.Divides.class::isInstance)
-                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+            return LineEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<GuardThresholds.Guards.Singled> singled() {
-            return evidence.stream()
-                    .filter(LineEvidence.Singles.class::isInstance)
-                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
+            return LineEvidence.pointsIn(evidence);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -110,7 +110,38 @@ public final class LinesWhereTheyFall {
         for (LineDrawn each : between) {
             place(inputs, each, quantities, symbols, outBetween, notPlaced);
         }
+        everyRuleWasPlacedSomewhere(evidence, out);
         return new Filed(out, outBetween, notPlaced);
+    }
+
+    /**
+     * That every rule handed to this stage came out of it somewhere.
+     *
+     * <p>Its own conservation, and the reason the stage after this one keeps a separate account of
+     * its own. This is where a rule becomes one filed at each of the positions the name it is
+     * written at reaches, so what it holds is not one in and one out: a rule comes out at one
+     * position or at several, and coming out at none is a rule that went missing between the reader
+     * that found it and the measure that would have been made of it.
+     *
+     * <p>The rule and not the number, because the number is what this stage changes. Two rules about
+     * one number are two entries here, and a rule filed at three positions is one.
+     *
+     * <p>What made this worth writing is that it holds today by the shape of the walk above and not
+     * by anything saying so. A {@code continue} added to that walk would take a rule out of the
+     * model with nothing failing, which is the shape of issue #1140 one stage up.
+     */
+    private static void everyRuleWasPlacedSomewhere(List<LineEvidence> given,
+                                                    List<LineEvidence> filed) {
+        java.util.Set<OriginRef> placed = new java.util.LinkedHashSet<>();
+        filed.forEach(each -> placed.add(each.by()));
+        List<OriginRef> lost = given.stream().map(LineEvidence::by)
+                .filter(each -> !placed.contains(each)).distinct().toList();
+        if (!lost.isEmpty()) {
+            throw new IllegalStateException(
+                    "a rule this stage was given came out of it nowhere: " + lost
+                            + " — filing a rule at the positions its name reaches may put it at"
+                            + " several and never at none");
+        }
     }
 
     /** The same piece of evidence, measured at {@code at}. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -84,6 +84,7 @@ public final class LinesWhereTheyFall {
         // once per kind, a body writing an equality and then a range came out with the range first,
         // and every reader taking the numbers in this order took them in one this reading never saw.
         for (LineEvidence each : evidence) {
+            int before = out.size();
             switch (standingOf(inputs, each.at(), symbols, each.by())) {
                 case WhereTheNameStands.AsWritten(NumericTerm at) -> out.add(measuredAt(each, at));
                 case WhereTheNameStands.FiledAt(NumericTerm first, List<NumericTerm> rest) -> {
@@ -91,43 +92,23 @@ public final class LinesWhereTheyFall {
                     rest.forEach(at -> out.add(measuredAt(each, at)));
                 }
             }
+            // Counted here, where the piece is in hand. Reconciled afterwards by the rule each
+            // piece came from, this would have had to establish that no two pieces share one — and
+            // the case it is for is the one where the second of two never comes out, which is
+            // exactly the case a shared name hides. Nothing derives a name at all now.
+            if (out.size() == before) {
+                throw new IllegalStateException(
+                        "a rule this stage was given came out of it nowhere: " + each
+                                + " — filing a rule at the positions its name reaches may put it"
+                                + " at several and never at none");
+            }
         }
         for (LineDrawn each : between) {
             place(inputs, each, quantities, symbols, outBetween, notPlaced);
         }
-        everyRuleWasPlacedSomewhere(evidence, out);
         return new Filed(out, outBetween, notPlaced);
     }
 
-    /**
-     * That every rule handed to this stage came out of it somewhere.
-     *
-     * <p>Its own conservation, and the reason the stage after this one keeps a separate account of
-     * its own. This is where a rule becomes one filed at each of the positions the name it is
-     * written at reaches, so what it holds is not one in and one out: a rule comes out at one
-     * position or at several, and coming out at none is a rule that went missing between the reader
-     * that found it and the measure that would have been made of it.
-     *
-     * <p>The rule and not the number, because the number is what this stage changes. Two rules about
-     * one number are two entries here, and a rule filed at three positions is one.
-     *
-     * <p>What made this worth writing is that it holds today by the shape of the walk above and not
-     * by anything saying so. A {@code continue} added to that walk would take a rule out of the
-     * model with nothing failing, which is the shape of issue #1140 one stage up.
-     */
-    private static void everyRuleWasPlacedSomewhere(List<LineEvidence> given,
-                                                    List<LineEvidence> filed) {
-        java.util.Set<OriginRef> placed = new java.util.LinkedHashSet<>();
-        filed.forEach(each -> placed.add(each.by()));
-        List<OriginRef> lost = given.stream().map(LineEvidence::by)
-                .filter(each -> !placed.contains(each)).distinct().toList();
-        if (!lost.isEmpty()) {
-            throw new IllegalStateException(
-                    "a rule this stage was given came out of it nowhere: " + lost
-                            + " — filing a rule at the positions its name reaches may put it at"
-                            + " several and never at none");
-        }
-    }
 
     /** The same piece of evidence, measured at {@code at}. */
     private static LineEvidence measuredAt(LineEvidence evidence, NumericTerm at) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -80,9 +80,9 @@ public final class LinesWhereTheyFall {
         List<LineEvidence> out = new ArrayList<>();
         List<LineDrawn> outBetween = new ArrayList<>();
         List<RuleWithoutALine> notPlaced = new ArrayList<>();
-        // One pass in the order the rules were read, so what comes out is in that order too. Walked
-        // once per kind, a body writing an equality and then a range came out with the range first,
-        // and every reader taking the numbers in this order took them in one this reading never saw.
+        // One pass in the order the rules were read, so what comes out is in that order too. A pass
+        // per kind of thing a rule can say puts every range before every equality, whatever order a
+        // body wrote them in, and every reader downstream takes the numbers in that order.
         for (LineEvidence each : evidence) {
             int before = out.size();
             switch (standingOf(inputs, each.at(), symbols, each.by())) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -52,49 +52,75 @@ public final class LinesWhereTheyFall {
      * place nobody meant and a reason nobody established. So it comes back as a finding naming the
      * rule, and a reader is told what actually happened to it.
      */
-    public record Filed(List<Threshold> thresholds, List<GuardThresholds.Guards.Singled> singled,
-                        List<LineDrawn> between, List<RuleWithoutALine> notPlaced) {
+    public record Filed(List<LineEvidence> evidence, List<LineDrawn> between,
+                        List<RuleWithoutALine> notPlaced) {
 
         public Filed {
-            thresholds = List.copyOf(thresholds);
-            singled = List.copyOf(singled);
+            evidence = List.copyOf(evidence);
             between = List.copyOf(between);
             notPlaced = List.copyOf(notPlaced);
+            // What the next stage owes an answer at, each told from the others. One rule filed at
+            // three cases of a sum is three of these, and a second at one of them would close the
+            // account over both while one went unmeasured — which is the reason the identity is the
+            // rule and the number together and not the rule alone.
+            java.util.Set<LineEvidence.FiledOccurrence> seen = new java.util.LinkedHashSet<>();
+            for (LineEvidence each : evidence) {
+                if (!seen.add(each.occurrence())) {
+                    throw new IllegalStateException(
+                            "one rule filed twice at one number: " + each.occurrence());
+                }
+            }
+        }
+
+        /** The lines, for a reader that wants only those. Read off the one list and not kept
+         *  beside it. */
+        public List<Threshold> thresholds() {
+            return evidence.stream()
+                    .filter(LineEvidence.Divides.class::isInstance)
+                    .map(each -> ((LineEvidence.Divides) each).line()).toList();
+        }
+
+        /** The values singled out, likewise. */
+        public List<GuardThresholds.Guards.Singled> singled() {
+            return evidence.stream()
+                    .filter(LineEvidence.Singles.class::isInstance)
+                    .map(each -> ((LineEvidence.Singles) each).point()).toList();
         }
     }
 
     /** Every measurement where its name was filed, and the lines this had nowhere to put. */
-    public static Filed of(InputDomain inputs, List<Threshold> thresholds,
-                           List<GuardThresholds.Guards.Singled> singled, List<LineDrawn> between,
+    public static Filed of(InputDomain inputs, List<LineEvidence> evidence,
+                           List<LineDrawn> between,
                            souther.compiler.inputs.Quantities quantities, Symbols symbols) {
-        List<Threshold> outThresholds = new ArrayList<>();
-        List<GuardThresholds.Guards.Singled> outSingled = new ArrayList<>();
+        List<LineEvidence> out = new ArrayList<>();
         List<LineDrawn> outBetween = new ArrayList<>();
         List<RuleWithoutALine> notPlaced = new ArrayList<>();
-        for (Threshold each : thresholds) {
-            switch (standingOf(inputs, each.term(), symbols, each.origin())) {
-                case WhereTheNameStands.AsWritten(NumericTerm at) ->
-                        outThresholds.add(thresholdAt(each, at));
+        // One pass in the order the rules were read, so what comes out is in that order too. Walked
+        // once per kind, a body writing an equality and then a range came out with the range first,
+        // and every reader taking the numbers in this order took them in one this reading never saw.
+        for (LineEvidence each : evidence) {
+            switch (standingOf(inputs, each.at(), symbols, each.by())) {
+                case WhereTheNameStands.AsWritten(NumericTerm at) -> out.add(measuredAt(each, at));
                 case WhereTheNameStands.FiledAt(NumericTerm first, List<NumericTerm> rest) -> {
-                    outThresholds.add(thresholdAt(each, first));
-                    rest.forEach(at -> outThresholds.add(thresholdAt(each, at)));
-                }
-            }
-        }
-        for (GuardThresholds.Guards.Singled each : singled) {
-            switch (standingOf(inputs, each.term(), symbols, each.origin())) {
-                case WhereTheNameStands.AsWritten(NumericTerm at) ->
-                        outSingled.add(singledAt(each, at));
-                case WhereTheNameStands.FiledAt(NumericTerm first, List<NumericTerm> rest) -> {
-                    outSingled.add(singledAt(each, first));
-                    rest.forEach(at -> outSingled.add(singledAt(each, at)));
+                    out.add(measuredAt(each, first));
+                    rest.forEach(at -> out.add(measuredAt(each, at)));
                 }
             }
         }
         for (LineDrawn each : between) {
             place(inputs, each, quantities, symbols, outBetween, notPlaced);
         }
-        return new Filed(outThresholds, outSingled, outBetween, notPlaced);
+        return new Filed(out, outBetween, notPlaced);
+    }
+
+    /** The same piece of evidence, measured at {@code at}. */
+    private static LineEvidence measuredAt(LineEvidence evidence, NumericTerm at) {
+        return switch (evidence) {
+            case LineEvidence.Divides(Threshold line) ->
+                    new LineEvidence.Divides(thresholdAt(line, at));
+            case LineEvidence.Singles(GuardThresholds.Guards.Singled point) ->
+                    new LineEvidence.Singles(singledAt(point, at));
+        };
     }
 
     /** The same threshold, measured at {@code at}. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -84,24 +84,14 @@ public final class LinesWhereTheyFall {
         // per kind of thing a rule can say puts every range before every equality, whatever order a
         // body wrote them in, and every reader downstream takes the numbers in that order.
         for (LineEvidence each : evidence) {
-            int before = out.size();
-            switch (standingOf(inputs, each.at(), symbols, each.by())) {
-                case WhereTheNameStands.AsWritten(NumericTerm at) -> out.add(measuredAt(each, at));
-                case WhereTheNameStands.FiledAt(NumericTerm first, List<NumericTerm> rest) -> {
-                    out.add(measuredAt(each, first));
-                    rest.forEach(at -> out.add(measuredAt(each, at)));
-                }
-            }
-            // Counted here, where the piece is in hand. Reconciled afterwards by the rule each
-            // piece came from, this would have had to establish that no two pieces share one — and
-            // the case it is for is the one where the second of two never comes out, which is
-            // exactly the case a shared name hides. Nothing derives a name at all now.
-            if (out.size() == before) {
-                throw new IllegalStateException(
-                        "a rule this stage was given came out of it nowhere: " + each
-                                + " — filing a rule at the positions its name reaches may put it"
-                                + " at several and never at none");
-            }
+            // Every number the name stands at, filed together. Filing is one rule to as many
+            // positions as its name reaches, so a piece put out one part at a time can leave the
+            // others behind — and the account that runs after this begins with what comes out of
+            // here, so it has nothing to say those others were ever expected. There is no partial
+            // filing to write: what a name stands at is one list and this maps it.
+            List<NumericTerm> destinations =
+                    standingOf(inputs, each.at(), symbols, each.by()).all();
+            destinations.forEach(at -> out.add(measuredAt(each, at)));
         }
         for (LineDrawn each : between) {
             place(inputs, each, quantities, symbols, outBetween, notPlaced);
@@ -279,6 +269,26 @@ public final class LinesWhereTheyFall {
      * these two, so a reader asking whether the name moved never reads it off a length.
      */
     private sealed interface WhereTheNameStands {
+
+        /**
+         * Every number the name stands at, never none.
+         *
+         * <p>Asked as the whole list so that filing a piece of evidence is one step. Taken apart by
+         * the caller — the first here, the rest there — the walk has as many places to add as the
+         * shape has parts, and a piece filed at three positions can leave two behind while the
+         * account beside it, which starts after this stage, has no way of knowing there were three.
+         */
+        default List<NumericTerm> all() {
+            return switch (this) {
+                case AsWritten(NumericTerm term) -> List.of(term);
+                case FiledAt(NumericTerm first, List<NumericTerm> rest) -> {
+                    List<NumericTerm> every = new ArrayList<>();
+                    every.add(first);
+                    every.addAll(rest);
+                    yield List.copyOf(every);
+                }
+            };
+        }
 
         /**
          * Nothing was filed for this name, so the line stays where the model wrote it.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocationWrites.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocationWrites.java
@@ -1,0 +1,63 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.TermPath;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What a row being composed has been asked to write at each of its locations.
+ *
+ * <p>A row writes one value at a location. Two numbers taken of one location — how long a string is
+ * and the string itself, which hour of a time it is and which minute — are two things to ask a row
+ * for and one place to write, so a search fixing both has been asked for something a row may not
+ * be able to be.
+ *
+ * <p><b>What is refused is not the second ask.</b> Two asks at one location is a shape the model
+ * has, and a search that composed one value satisfying both would be answering it. What cannot
+ * happen is taking one of them and writing it as though it were the whole: the row then stands
+ * where one number said and says nothing about the other, and the point it was composed for is
+ * offered half-answered. So an ask that does not agree with what is already here comes back as
+ * {@link Written#CONFLICTING}, and a caller says {@code NOTHING_COMPOSES_ONE} — which is what that
+ * reason is for: not that the model has no such value, but that this compiler composed none.
+ *
+ * <p>The same ask twice is one ask. What is held here is what will be written, and asking for what
+ * is already going to be written changes nothing about the row.
+ */
+final class LocationWrites {
+
+    /** What an ask came to. */
+    enum Written {
+        /** Nothing had been asked for here, and this is what will be written. */
+        FIRST,
+        /** What is already going to be written is what was asked for. */
+        AGAIN,
+        /** Something else is already going to be written here, and nothing composes the two. */
+        CONFLICTING
+    }
+
+    private final Map<TermPath, List<FixtureTemplate>> written = new LinkedHashMap<>();
+
+    Written write(TermPath at, List<FixtureTemplate> values) {
+        List<FixtureTemplate> already = written.get(at);
+        if (already == null) {
+            written.put(at, values);
+            return Written.FIRST;
+        }
+        return already.equals(values) ? Written.AGAIN : Written.CONFLICTING;
+    }
+
+    boolean holds(TermPath at) {
+        return written.containsKey(at);
+    }
+
+    List<FixtureTemplate> at(TermPath path) {
+        return written.get(path);
+    }
+
+    /** What is to be written, for the walk that composes each parameter out of it. */
+    Map<TermPath, List<FixtureTemplate>> all() {
+        return written;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -186,8 +186,8 @@ public final class MeasureClosure {
         }
         // Over the positions and not over the measures made of them. What a reading of a position
         // came to is the position's, and a location is measured at as many numbers as the rules
-        // name of it — read off the measures, one stop at one location came out once per number
-        // the location is measured by, which is a compiler's own state counted several times.
+        // name of it: read off the measures, one stop at one location is one entry per number, which
+        // is a compiler's own state counted several times.
         for (PositionAccount at : positions) {
             // Read off what the reading settled and never off what the position is still waiting
             // on. A position a body's rule divides keeps no continuation, and was still never

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -159,7 +159,7 @@ public final class MeasureClosure {
      * afterwards, the two would be built from whatever their caller had in hand at the time, which
      * is the second bookkeeping this type exists to prevent.
      *
-     * @param axes    every position the reading kept, measured or not
+     * @param positions every position the reading kept, measured or not
      * @param lines   what the line reading of this behavior found and what it made of each, from
      *                both of the producers there are. Here so that a conclusion about the reading is
      *                drawn from what it produced beside what it found, and not from the gaps alone
@@ -170,7 +170,8 @@ public final class MeasureClosure {
      *                and it is the rule's own reason that answers
      *                ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort})
      */
-    static Both of(List<Axis> axes, List<souther.compiler.inputs.StandingQuestion> asked,
+    static Both of(List<PositionAccount> positions,
+                   List<souther.compiler.inputs.StandingQuestion> asked,
                    List<souther.compiler.inputs.RuleWithoutALine> refused, LinesRead lines) {
         lines.everyLineFoundWasDrawn();
         Set<ClosureGap> partition = new LinkedHashSet<>();
@@ -183,22 +184,26 @@ public final class MeasureClosure {
                 border.add(new ClosureGap.RuleUnread(rule));
             }
         }
-        for (Axis axis : axes) {
-            // Read off what the reading settled and never off what the axis is still waiting on. A
-            // position a body's rule divides keeps no continuation, and was still never entered:
-            // asked of the continuation, the one model where the two come apart said nothing at all
-            // about the position it could not read (issue #1084).
-            BlockedDescent blocked = axis.residue().blockedDescent();
+        // Over the positions and not over the measures made of them. What a reading of a position
+        // came to is the position's, and a location is measured at as many numbers as the rules
+        // name of it — read off the measures, one stop at one location came out once per number
+        // the location is measured by, which is a compiler's own state counted several times.
+        for (PositionAccount at : positions) {
+            // Read off what the reading settled and never off what the position is still waiting
+            // on. A position a body's rule divides keeps no continuation, and was still never
+            // entered: asked of the continuation, the one model where the two come apart said
+            // nothing at all about the position it could not read (issue #1084).
+            BlockedDescent blocked = at.residue().blockedDescent();
             if (blocked != null) {
-                ClosureGap gap = new ClosureGap.PositionNotReachedInto(axis.id(), blocked.why());
+                ClosureGap gap = new ClosureGap.PositionNotReachedInto(at.id(), blocked.why());
                 partition.add(gap);
                 border.add(gap);
             }
-            for (RulesLeftUnread unread : axis.residue().rulesLeftUnread()) {
+            for (RulesLeftUnread unread : at.residue().rulesLeftUnread()) {
                 if (derived(unread)) {
                     continue;
                 }
-                ClosureGap gap = new ClosureGap.RulesNotReached(axis.id());
+                ClosureGap gap = new ClosureGap.RulesNotReached(at.id());
                 partition.add(gap);
                 border.add(gap);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -195,7 +195,8 @@ public final class MeasureClosure {
             // nothing at all about the position it could not read (issue #1084).
             BlockedDescent blocked = at.residue().blockedDescent();
             if (blocked != null) {
-                ClosureGap gap = new ClosureGap.PositionNotReachedInto(at.id(), blocked.why());
+                ClosureGap gap = new ClosureGap.PositionNotReachedInto(at.behavior(), at.id(),
+                        blocked.why());
                 partition.add(gap);
                 border.add(gap);
             }
@@ -203,7 +204,7 @@ public final class MeasureClosure {
                 if (derived(unread)) {
                     continue;
                 }
-                ClosureGap gap = new ClosureGap.RulesNotReached(at.id());
+                ClosureGap gap = new ClosureGap.RulesNotReached(at.behavior(), at.id());
                 partition.add(gap);
                 border.add(gap);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -70,7 +70,7 @@ public final class Partitions {
      * @param along   the lines drawn on one position, by the axis they are on. Every measurable axis
      *                has an entry, and an axis that is not measurable has no lines to have one for
      */
-    public record Partitioning(List<Axis> axes,
+    public record Partitioning(List<PositionAccount> positions, List<Axis> axes,
                                List<souther.compiler.inputs.StandingQuestion> unanswered,
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
@@ -83,6 +83,7 @@ public final class Partitions {
                                MeasureClosure.OfThePartition partitionClosure,
                                MeasureClosure.OfTheBorder borderClosure) {
         public Partitioning {
+            positions = List.copyOf(positions);
             axes = List.copyOf(axes);
             unanswered = List.copyOf(unanswered);
             uncertain = java.util.Set.copyOf(uncertain);
@@ -188,6 +189,11 @@ public final class Partitions {
         // has something to say, and a position with none is no more affected than any other.
         List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated = new ArrayList<>();
         List<souther.compiler.inputs.StandingQuestion> standing = new ArrayList<>();
+        // The positions this phase answers for, kept as they are made. A collection of its own
+        // because a position is what a reader of a stop or an absence is asking about, and the only
+        // other way to reach one is to walk the measures and put them back together — which is a
+        // rule about which measure answers for the location, invented once per reader.
+        List<PositionAccount> positions = new ArrayList<>();
         for (Position position : inputs.positions()) {
             // Not at a position made of positions. Such a one is given up in favour of what is
             // under it and carries no classes of its own, so what this qualifies is not there —
@@ -199,7 +205,8 @@ public final class Partitions {
                 notSeparated.add(
                         new souther.compiler.inputs.PositionValuesNotSeparated(position.path()));
             }
-            axisOf(behavior, position, symbols, policy, found, uncertain, rulesWithoutALine);
+            axisOf(behavior, position, symbols, policy, found, positions, uncertain,
+                    rulesWithoutALine);
             // What the rules of this position raise that nothing answered, gathered from the
             // reading that found it. Once per position and not once per axis: a question is the
             // model's, and which axis is standing beside it is this compiler's business.
@@ -235,9 +242,12 @@ public final class Partitions {
         LinesRead read = new LinesRead();
         java.util.Map<AxisId, List<Border>> lines = linesAlong(kept, quantities, symbols, read);
         read.returning(lines.values().stream().flatMap(List::stream).toList());
-        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine, read);
-        return new Partitioning(kept, standing, uncertain, undividedIn(measured),
-                List.copyOf(rulesWithoutALine), blockedIn(measured), List.copyOf(notSeparated),
+        MeasureClosure.Both closed =
+                MeasureClosure.of(positions, standing, rulesWithoutALine, read);
+        return new Partitioning(List.copyOf(positions), kept, standing, uncertain,
+                undividedIn(positions, measured),
+                List.copyOf(rulesWithoutALine), blockedIn(positions, measured),
+                List.copyOf(notSeparated),
                 List.of(), lines, ReachingCuts.NONE,
                 closed.partition(), closed.border());
     }
@@ -445,37 +455,40 @@ public final class Partitions {
      * the model does divide. What this phase came to about the location is
      * {@link BodyCutInspection#outranking}'s to fold.
      */
-    private static List<UndividedPosition> undividedIn(List<Measured> measured) {
+    private static List<UndividedPosition> undividedIn(List<PositionAccount> positions,
+                                                       List<Measured> measured) {
         List<UndividedPosition> out = new ArrayList<>();
-        for (AtOnePosition each : byPosition(measured)) {
-            PendingPosition pending = PendingPosition.of(each.at(), each.measured());
+        for (PositionAccount at : positions) {
+            PendingPosition pending = PendingPosition.of(at, anythingMeasures(at, measured));
             if (pending != null) {
-                out.add(pending.complete(each.body()));
+                out.add(pending.complete(cameTo(at, measured)));
             }
         }
         return List.copyOf(out);
     }
 
-    /** One position, whether anything measures it, and what this phase came to about it. */
-    private record AtOnePosition(PositionAccount at, boolean measured, BodyCutInspection body) {}
+    /** Whether any measure of this position has something to divide it by. */
+    private static boolean anythingMeasures(PositionAccount at, List<Measured> measured) {
+        return measured.stream()
+                .anyMatch(each -> each.axis().path().equals(at.path())
+                        && each.axis().measurable());
+    }
 
     /**
-     * The measures gathered back into the positions they are of.
+     * What this phase came to about one position, over every number it measures the position at.
      *
      * <p>A location is measured at as many numbers as the rules name of it, and what a report says
-     * about the location is one sentence. Whether anything measures it is any of them measuring it;
-     * what this phase came to about it is {@link BodyCutInspection#outranking}'s to fold.
+     * about the location is one sentence. Which of the answers it is is
+     * {@link BodyCutInspection#outranking}'s, and null where nothing was measured here at all.
      */
-    private static List<AtOnePosition> byPosition(List<Measured> measured) {
-        Map<TermPath, AtOnePosition> out = new LinkedHashMap<>();
+    private static BodyCutInspection cameTo(PositionAccount at, List<Measured> measured) {
+        BodyCutInspection came = null;
         for (Measured each : measured) {
-            out.merge(each.axis().path(),
-                    new AtOnePosition(each.axis().at(), each.axis().measurable(), each.body()),
-                    (had, also) -> new AtOnePosition(had.at(),
-                            had.measured() || also.measured(),
-                            BodyCutInspection.outranking(had.body(), also.body())));
+            if (each.axis().path().equals(at.path())) {
+                came = BodyCutInspection.outranking(came, each.body());
+            }
         }
-        return List.copyOf(out.values());
+        return came;
     }
 
     /**
@@ -489,10 +502,10 @@ public final class Partitions {
      * a list of what this compiler cannot generally do rather than of what it did not read here.
      */
     private static List<souther.compiler.inputs.PositionReadingBlocked> blockedIn(
-            List<Measured> measured) {
+            List<PositionAccount> positions, List<Measured> measured) {
         List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
-        for (AtOnePosition each : byPosition(measured)) {
-            PendingPosition pending = PendingPosition.of(each.at(), each.measured());
+        for (PositionAccount at : positions) {
+            PendingPosition pending = PendingPosition.of(at, anythingMeasures(at, measured));
             souther.compiler.inputs.PositionReadingBlocked stopped =
                     pending == null ? null : pending.reportable();
             if (stopped != null && !out.contains(stopped)) {
@@ -675,9 +688,11 @@ public final class Partitions {
         List<Border> across = Border.allOf(between, partedByQuantity(out), read);
         read.returning(lines.values().stream().flatMap(List::stream).toList());
         read.returning(across);
-        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules, read);
-        return new Partitioning(out, base.unanswered(), base.uncertain(),
-                undividedIn(measured), List.copyOf(rules), blockedIn(measured),
+        MeasureClosure.Both closed =
+                MeasureClosure.of(base.positions(), base.unanswered(), rules, read);
+        return new Partitioning(base.positions(), out, base.unanswered(), base.uncertain(),
+                undividedIn(base.positions(), measured), List.copyOf(rules),
+                blockedIn(base.positions(), measured),
                 // Carried across: what a reading could not hold together is a fact about the
                 // declarations, and a body drawing a line on a position does not make the product
                 // it was read from the relation the rules admit.
@@ -995,7 +1010,8 @@ public final class Partitions {
      */
     private static void axisOf(String behavior, Position position, Symbols symbols,
                                ReadingPolicy policy,
-                               List<Axis> out, java.util.Set<NumericTerm> uncertain,
+                               List<Axis> out, List<PositionAccount> positions,
+                               java.util.Set<NumericTerm> uncertain,
                                List<RuleWithoutALine> rulesWithoutALine) {
         for (RuleWithoutALine each : position.rulesWithoutALine()) {
             if (rulesWithoutALine.stream().noneMatch(had -> had.sameAs(each))) {
@@ -1020,8 +1036,9 @@ public final class Partitions {
                 // all the same: a `Map` a rule about its size divides is one nothing was read into,
                 // and taking that off the axis with the fallback is how the stop went unreported
                 // (issue #1084).
-                out.add(new Axis(id, term, PositionAccount.of(position, null, null),
-                        divided.classes(), divided.cuts().cuts(), List.of(),
+                PositionAccount at = PositionAccount.of(position, null, null);
+                positions.add(at);
+                out.add(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(), List.of(),
                         position.narrowedEnds()));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
@@ -1038,9 +1055,12 @@ public final class Partitions {
                     // carries what it is left with if nothing answers — including a rule about this
                     // position that the local reading could not take in, which is what keeps the
                     // position from completing as one the model divides no way.
-                    case StructuralInspection.Retained retained ->
-                            out.add(Axis.pendingAt(id, term, PositionAccount.of(position,
-                                    retained.continuation(), leftAt(position))));
+                    case StructuralInspection.Retained retained -> {
+                        PositionAccount at = PositionAccount.of(position,
+                                retained.continuation(), leftAt(position));
+                        positions.add(at);
+                        out.add(Axis.pendingAt(id, term, at));
+                    }
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -309,24 +309,23 @@ public final class Partitions {
     private static List<NumericTerm> numbersMeasuring(Axis axis, List<LineEvidence> evidence,
                                                       EvidenceAccount account) {
         NumericTerm declared = axis.term();
-        if (evidence.stream().anyMatch(each -> each.at().equals(declared))) {
-            return List.of(declared);
-        }
         List<LineEvidence> here = evidence.stream()
                 .filter(each -> each.at().path().equals(axis.path())).toList();
-        // A position the declarations already divide. What a body says about another number of it is
-        // not taken up as a second measure, and this is where that is said: an account with no entry
-        // could not tell a policy from a loss.
-        if (axis.measurable()) {
-            here.forEach(each -> account.disposedOf(each,
-                    new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(axis.id())));
-            return List.of();
-        }
         List<NumericTerm> numbers = new ArrayList<>();
         for (LineEvidence each : here) {
             if (!numbers.contains(each.at())) {
                 numbers.add(each.at());
             }
+        }
+        // A position the declarations already divide keeps the measure they gave it. What a body
+        // says about another number of such a position is not taken up as a second measure, and
+        // this is where that is said: an account with no entry could not tell a policy from a loss.
+        if (axis.measurable()) {
+            here.stream().filter(each -> !each.at().equals(declared))
+                    .forEach(each -> account.disposedOf(each,
+                            new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(
+                                    axis.id())));
+            return numbers.contains(declared) ? List.of(declared) : List.of();
         }
         return numbers;
     }
@@ -346,12 +345,8 @@ public final class Partitions {
                                   List<RuleWithoutALine> rules, EvidenceAccount account) {
         List<LineEvidence> mine = evidence.stream()
                 .filter(each -> each.at().equals(term)).toList();
-        List<Threshold> here = mine.stream()
-                .filter(LineEvidence.Divides.class::isInstance)
-                .map(each -> ((LineEvidence.Divides) each).line()).toList();
-        List<GuardThresholds.Guards.Singled> points = mine.stream()
-                .filter(LineEvidence.Singles.class::isInstance)
-                .map(each -> ((LineEvidence.Singles) each).point()).toList();
+        List<Threshold> here = LineEvidence.linesIn(mine);
+        List<GuardThresholds.Guards.Singled> points = LineEvidence.pointsIn(mine);
         // What this term's values can be, which is the type's bound already narrowed by whatever
         // the record it sits in says about it. Reading the type again here would put a threshold
         // back inside a range the record has no values in.
@@ -451,26 +446,36 @@ public final class Partitions {
      * {@link BodyCutInspection#outranking}'s to fold.
      */
     private static List<UndividedPosition> undividedIn(List<Measured> measured) {
-        Map<TermPath, Measured> byPosition = new LinkedHashMap<>();
-        for (Measured each : measured) {
-            // The measure that answers for the location, and what this phase came to about it.
-            // A measurable one wins the axis, because whether the position is still waiting on
-            // anything is asked of the position and any measure of it settles that ({@link
-            // PendingPosition#of}). Read off whichever measure came first, a location divided at one
-            // of its numbers and not at another asked the undivided one and was told the position
-            // has no evidence, beside a fold saying it has.
-            byPosition.merge(each.axis().path(), each, (had, also) -> new Measured(
-                    had.axis().measurable() ? had.axis() : also.axis(),
-                    BodyCutInspection.outranking(had.body(), also.body())));
-        }
         List<UndividedPosition> out = new ArrayList<>();
-        for (Measured each : byPosition.values()) {
-            PendingPosition pending = PendingPosition.of(each.axis());
+        for (AtOnePosition each : byPosition(measured)) {
+            PendingPosition pending = PendingPosition.of(each.at(), each.measured());
             if (pending != null) {
                 out.add(pending.complete(each.body()));
             }
         }
         return List.copyOf(out);
+    }
+
+    /** One position, whether anything measures it, and what this phase came to about it. */
+    private record AtOnePosition(PositionAccount at, boolean measured, BodyCutInspection body) {}
+
+    /**
+     * The measures gathered back into the positions they are of.
+     *
+     * <p>A location is measured at as many numbers as the rules name of it, and what a report says
+     * about the location is one sentence. Whether anything measures it is any of them measuring it;
+     * what this phase came to about it is {@link BodyCutInspection#outranking}'s to fold.
+     */
+    private static List<AtOnePosition> byPosition(List<Measured> measured) {
+        Map<TermPath, AtOnePosition> out = new LinkedHashMap<>();
+        for (Measured each : measured) {
+            out.merge(each.axis().path(),
+                    new AtOnePosition(each.axis().at(), each.axis().measurable(), each.body()),
+                    (had, also) -> new AtOnePosition(had.at(),
+                            had.measured() || also.measured(),
+                            BodyCutInspection.outranking(had.body(), also.body())));
+        }
+        return List.copyOf(out.values());
     }
 
     /**
@@ -486,8 +491,8 @@ public final class Partitions {
     private static List<souther.compiler.inputs.PositionReadingBlocked> blockedIn(
             List<Measured> measured) {
         List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
-        for (Measured each : measured) {
-            PendingPosition pending = PendingPosition.of(each.axis());
+        for (AtOnePosition each : byPosition(measured)) {
+            PendingPosition pending = PendingPosition.of(each.at(), each.measured());
             souther.compiler.inputs.PositionReadingBlocked stopped =
                     pending == null ? null : pending.reportable();
             if (stopped != null && !out.contains(stopped)) {
@@ -636,12 +641,6 @@ public final class Partitions {
                                             souther.compiler.check.PathReachability.Answers
                                                     arrives,
                                             ReachingCuts reaching) {
-        List<Threshold> thresholds = evidence.stream()
-                .filter(LineEvidence.Divides.class::isInstance)
-                .map(each -> ((LineEvidence.Divides) each).line()).toList();
-        List<GuardThresholds.Guards.Singled> singled = evidence.stream()
-                .filter(LineEvidence.Singles.class::isInstance)
-                .map(each -> ((LineEvidence.Singles) each).point()).toList();
         // Both producers of one kind of evidence. What a body compared and what a type's own rules
         // bound are read by different readers and answer the same question, so a position either of
         // them wrote about and neither could turn into a line is named once, whichever wrote it.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -313,15 +313,14 @@ public final class Partitions {
      *
      * <p>A position no rule of its own divides, whose body measures numbers of it: a bare
      * {@code List<String>} nothing bounds, under a {@code guard List.length(t.names) > 0}. The line
-     * is on that number, so an axis about it is what there is to make — there was nothing else here
-     * for one to be about, and dropping the evidence would lose a line the body draws.
+     * is on that number, so an axis about it is what there is to make — there is nothing else here
+     * for one to be about, and dropping the evidence loses a line the body draws.
      *
      * <p><b>As many as the rules name.</b> {@code Time.hour(slot.at) >= 9 && Time.minute(slot.at)
-     * >= 30} draws two lines on two numbers of one location. Answered with the one number a body
-     * measures a position by, this said there were none — a model that draws two lines reported as
-     * one that draws none, which is the sentence a body with no comparison in it gets. Choosing one
-     * of them silently drops the other's lines, which is why choosing was refused; not choosing
-     * dropped both (issue #1140).
+     * >= 30} draws two lines on two numbers of one location, and both are measures. There is no
+     * answering such a location with one of its numbers: picking one drops the other's lines and
+     * picking neither drops both, and a location with two lines drawn on it then gets the sentence
+     * a body with no comparison in it gets.
      *
      * <p>In the order the rules were read, so that what a report lists and what a search enumerates
      * are in the order an author wrote them.
@@ -398,15 +397,15 @@ public final class Partitions {
                 account.measured(each, axis.id());
                 continue;
             }
-            // Asked of the place the line falls at, which the position need not hold a
-            // value at. Read off the value, a line between two of the position's values was
-            // dropped as one the rules leave nothing at.
+            // Asked of the place the line falls at, which the position need not hold a value at.
+            // Read off the value instead, a line between two of the position's values is one the
+            // rules leave nothing at.
+            //
             // No disposition, and that is the point: this is not a way evidence may leave this
-            // stage. The reader that produced it already refuses a line falling outside what the
-            // quantity it cuts ever holds, naming the rule — measured twice, once against a type's
-            // own range and once against the range the record it sits in leaves, and both times the
-            // line came back named rather than reaching here. So what gets past that reader and is
-            // dropped here is a line lost with nothing said, and the account below says so.
+            // stage. The reader that produces it already refuses a line falling outside what the
+            // quantity it cuts ever holds and names the rule, against a type's own range and
+            // against the range the record it sits in leaves. So a line that gets past that reader
+            // and is dropped here is a line lost with nothing said, and the account below says so.
             if (domain != null && !admits(domain, line.parts())) {
                 continue;
             }
@@ -650,10 +649,10 @@ public final class Partitions {
      *
      * <p>One list and not one per kind of thing a rule can say. What this stage does with a piece of
      * evidence — divide a position by it, leave it outside what the position holds, or not take it
-     * up at all — is the same question whichever kind it is, and the account below is over all of
-     * them ({@link EvidenceAccount}). Handed two lists, both the fan-out and the account put them
-     * back together, and a position measured at one kind came back measured at neither
-     * (issue #1140).
+     * up at all — is the same question whichever kind it is, and the account of what became of each
+     * is over all of them ({@link EvidenceAccount}). Handed one list per kind, both the numbers a
+     * position is measured at and that account have to put them back together, and a position
+     * measured at one kind alone is measured at neither.
      */
     public static Partitioning withEvidence(Partitioning base,
                                             souther.compiler.inputs.Quantities reading,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -318,7 +318,7 @@ public final class Partitions {
         // not taken up as a second measure, and this is where that is said: an account with no entry
         // could not tell a policy from a loss.
         if (axis.measurable()) {
-            here.forEach(each -> account.disposedOf(each.occurrence(),
+            here.forEach(each -> account.disposedOf(each,
                     new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(axis.id())));
             return List.of();
         }
@@ -386,9 +386,13 @@ public final class Partitions {
             // Asked of the place the line falls at, which the position need not hold a
             // value at. Read off the value, a line between two of the position's values was
             // dropped as one the rules leave nothing at.
+            // No disposition, and that is the point: this is not a way evidence may leave this
+            // stage. The reader that produced it already refuses a line falling outside what the
+            // quantity it cuts ever holds, naming the rule — measured twice, once against a type's
+            // own range and once against the range the record it sits in leaves, and both times the
+            // line came back named rather than reaching here. So what gets past that reader and is
+            // dropped here is a line lost with nothing said, and the account below says so.
             if (domain != null && !admits(domain, line.parts())) {
-                account.disposedOf(each.occurrence(),
-                        new EvidenceAccount.Disposition.OutsideThePosition());
                 continue;
             }
             // And what the guards above it left. Only a proof drops a line: a comparison
@@ -399,8 +403,7 @@ public final class Partitions {
             // clause has no comparison a path can arrive at: it is checked whenever the
             // behavior answers, so nothing about which branch a body took drops its line.
             if (line.origin().comparisonAt().stream().anyMatch(arrives::dividesNothing)) {
-                account.disposedOf(each.occurrence(),
-                        new EvidenceAccount.Disposition.NothingArrivesAtIt());
+                account.disposedOf(each, new EvidenceAccount.Disposition.NothingArrivesAtIt());
                 continue;
             }
             account.measured(each, axis.id());
@@ -439,10 +442,29 @@ public final class Partitions {
      * <p>The structural reason outranks the rules': where the walk could not reach into what the
      * position holds, a rule naming something inside it is a second description of that same stop
      * and the first is the cause (issue #626).
+     *
+     * <p><b>Once per position and not once per measure.</b> That a position is divided no way is a
+     * sentence about the location, and a location is measured at as many numbers as the rules name
+     * of it. Written per measure, a report would say it as many times as the position has numbers —
+     * and say it at all where one of the numbers is divided and another is not, which is a position
+     * the model does divide. What this phase came to about the location is
+     * {@link BodyCutInspection#outranking}'s to fold.
      */
     private static List<UndividedPosition> undividedIn(List<Measured> measured) {
-        List<UndividedPosition> out = new ArrayList<>();
+        Map<TermPath, Measured> byPosition = new LinkedHashMap<>();
         for (Measured each : measured) {
+            // The measure that answers for the location, and what this phase came to about it.
+            // A measurable one wins the axis, because whether the position is still waiting on
+            // anything is asked of the position and any measure of it settles that ({@link
+            // PendingPosition#of}). Read off whichever measure came first, a location divided at one
+            // of its numbers and not at another asked the undivided one and was told the position
+            // has no evidence, beside a fold saying it has.
+            byPosition.merge(each.axis().path(), each, (had, also) -> new Measured(
+                    had.axis().measurable() ? had.axis() : also.axis(),
+                    BodyCutInspection.outranking(had.body(), also.body())));
+        }
+        List<UndividedPosition> out = new ArrayList<>();
+        for (Measured each : byPosition.values()) {
             PendingPosition pending = PendingPosition.of(each.axis());
             if (pending != null) {
                 out.add(pending.complete(each.body()));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -531,11 +531,17 @@ public final class Partitions {
      * what can exist; a {@code guard} says where the behavior does something else, and both sides of
      * that line hold values a row can write. The cuts merge into one partition and the origins stay
      * apart, so reaching the line through one rule still leaves the others unmet.
+     *
+     * <p><b>Not the way in.</b> These take a list per kind of thing a rule can say and put them
+     * together, and putting them together is not the reading's order — every range comes before
+     * every equality, whatever order a body wrote them in. What the rules said arrives as one list
+     * in that order ({@link #withEvidence}); these are here for a caller writing the lines itself,
+     * which has no reading to be in the order of.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy) {
         return withThresholds(base, reading, thresholds, symbols, policy, List.of());
     }
 
@@ -547,11 +553,11 @@ public final class Partitions {
      * written in is one no reader here takes apart. Carried rather than re-derived, because the only
      * place that knows is the reader that gave up.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> rulesWithoutALine) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy,
+                                       List<RuleWithoutALine> rulesWithoutALine) {
         return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, List.of());
     }
 
@@ -564,12 +570,12 @@ public final class Partitions {
      * divides the position as well, the model has drawn the further distinction itself and the value
      * is one more line among the ranges.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> rulesWithoutALine,
-                                              List<GuardThresholds.Guards.Singled> singled) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy,
+                                       List<RuleWithoutALine> rulesWithoutALine,
+                                       List<GuardThresholds.Guards.Singled> singled) {
         return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, List.of());
     }
 
@@ -581,13 +587,13 @@ public final class Partitions {
      * beside the partition, which is what keeps a position the classes could say nothing about from
      * losing the line its body draws about it.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> rulesWithoutALine,
-                                              List<GuardThresholds.Guards.Singled> singled,
-                                              List<LineDrawn> between) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy,
+                                       List<RuleWithoutALine> rulesWithoutALine,
+                                       List<GuardThresholds.Guards.Singled> singled,
+                                       List<LineDrawn> between) {
         return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, between,
                 souther.compiler.check.PathReachability.Answers.NONE);
     }
@@ -606,15 +612,15 @@ public final class Partitions {
      * of anything. Both are needed and neither is the other — a line well inside a position's values
      * can still be one nothing on the way to it can be either side of.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> rulesWithoutALine,
-                                              List<GuardThresholds.Guards.Singled> singled,
-                                              List<LineDrawn> between,
-                                              souther.compiler.check.PathReachability.Answers
-                                                      arrives) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy,
+                                       List<RuleWithoutALine> rulesWithoutALine,
+                                       List<GuardThresholds.Guards.Singled> singled,
+                                       List<LineDrawn> between,
+                                       souther.compiler.check.PathReachability.Answers
+                                               arrives) {
         return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, between,
                 arrives, ReachingCuts.NONE);
     }
@@ -627,16 +633,16 @@ public final class Partitions {
      * that recovered it from where a comparison sits would be free to name a condition nothing here
      * could read.
      */
-    public static Partitioning withThresholds(Partitioning base,
-                                              souther.compiler.inputs.Quantities reading,
-                                              List<Threshold> thresholds,
-                                              Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> rulesWithoutALine,
-                                              List<GuardThresholds.Guards.Singled> singled,
-                                              List<LineDrawn> between,
-                                              souther.compiler.check.PathReachability.Answers
-                                                      arrives,
-                                              ReachingCuts reaching) {
+    static Partitioning withThresholds(Partitioning base,
+                                       souther.compiler.inputs.Quantities reading,
+                                       List<Threshold> thresholds,
+                                       Symbols symbols, ReadingPolicy policy,
+                                       List<RuleWithoutALine> rulesWithoutALine,
+                                       List<GuardThresholds.Guards.Singled> singled,
+                                       List<LineDrawn> between,
+                                       souther.compiler.check.PathReachability.Answers
+                                               arrives,
+                                       ReachingCuts reaching) {
         List<LineEvidence> evidence = new ArrayList<>();
         thresholds.forEach(each -> evidence.add(new LineEvidence.Divides(each)));
         singled.forEach(each -> evidence.add(new LineEvidence.Singles(each)));
@@ -1045,7 +1051,7 @@ public final class Partitions {
                 // all the same: a `Map` a rule about its size divides is one nothing was read into,
                 // and taking that off the axis with the fallback is how the stop went unreported
                 // (issue #1084).
-                PositionAccount at = PositionAccount.of(position, null, null);
+                PositionAccount at = PositionAccount.of(behavior, position, null, null);
                 positions.add(at);
                 out.add(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(), List.of(),
                         position.narrowedEnds()));
@@ -1065,7 +1071,7 @@ public final class Partitions {
                     // position that the local reading could not take in, which is what keeps the
                     // position from completing as one the model divides no way.
                     case StructuralInspection.Retained retained -> {
-                        PositionAccount at = PositionAccount.of(position,
+                        PositionAccount at = PositionAccount.of(behavior, position,
                                 retained.continuation(), leftAt(position));
                         positions.add(at);
                         out.add(Axis.pendingAt(id, term, at));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -899,9 +899,9 @@ public final class Partitions {
                 // all the same: a `Map` a rule about its size divides is one nothing was read into,
                 // and taking that off the axis with the fallback is how the stop went unreported
                 // (issue #1084).
-                out.add(new Axis(id, term, position.type(), divided.classes(),
-                        divided.cuts().cuts(), List.of(), position.narrowedEnds(),
-                        ReadingResidue.of(position), null, null));
+                out.add(new Axis(id, term, PositionAccount.of(position, null, null),
+                        divided.classes(), divided.cuts().cuts(), List.of(),
+                        position.narrowedEnds()));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -918,9 +918,8 @@ public final class Partitions {
                     // position that the local reading could not take in, which is what keeps the
                     // position from completing as one the model divides no way.
                     case StructuralInspection.Retained retained ->
-                            out.add(Axis.pendingAt(id, term, position.type(),
-                                    ReadingResidue.of(position),
-                                    retained.continuation(), leftAt(position)));
+                            out.add(Axis.pendingAt(id, term, PositionAccount.of(position,
+                                    retained.continuation(), leftAt(position))));
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -62,10 +62,20 @@ public final class Partitions {
      *                whatever was written about it — and an axis is re-pointed at another number as
      *                a body's rules are read, which would carry a question about one number onto
      *                another
-     * @param axes    the positions this behavior is measured at, in parameter order. Every position
-     *                the model divides is one of them: what a behavior is measured at is settled by
-     *                what its types say and by what its body compares, and a count of positions is
-     *                not a measure of what any of that costs (see this package's documentation)
+     * @param positions the locations of this behavior's input this phase answers for, in the order
+     *                the reading found them. Beside the measures and not derived from them: what a
+     *                reading of a location came to, where the walk stopped and what the location is
+     *                left with are true of it once however many numbers measure it, and the only
+     *                other way to reach one is to walk the measures and put them back together —
+     *                which is a rule about which measure answers for the location, invented once
+     *                per reader
+     * @param axes    the measures made of those locations, in the order the rules name the numbers.
+     *                A location is measured at as many numbers as the rules name of it, so this is
+     *                not a list of positions and its length is not one: {@code Time.hour(slot.at)}
+     *                and {@code Time.minute(slot.at)} are two of these at one location. What a
+     *                behavior is measured at is settled by what its types say and by what its body
+     *                compares, and a count of either is not a measure of what any of that costs
+     *                (see this package's documentation)
      * @param between the lines drawn between two positions, which divide neither of them
      * @param along   the lines drawn on one position, by the axis they are on. Every measurable axis
      *                has an entry, and an axis that is not measurable has no lines to have one for

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -289,6 +289,146 @@ public final class Partitions {
     }
 
     /**
+     * The numbers this position is measured at, which is not always the one the declarations named.
+     *
+     * <p>A position no rule of its own divides, whose body measures numbers of it: a bare
+     * {@code List<String>} nothing bounds, under a {@code guard List.length(t.names) > 0}. The line
+     * is on that number, so an axis about it is what there is to make — there was nothing else here
+     * for one to be about, and dropping the evidence would lose a line the body draws.
+     *
+     * <p><b>As many as the rules name.</b> {@code Time.hour(slot.at) >= 9 && Time.minute(slot.at)
+     * >= 30} draws two lines on two numbers of one location. Answered with the one number a body
+     * measures a position by, this said there were none — a model that draws two lines reported as
+     * one that draws none, which is the sentence a body with no comparison in it gets. Choosing one
+     * of them silently drops the other's lines, which is why choosing was refused; not choosing
+     * dropped both (issue #1140).
+     *
+     * <p>In the order the rules were read, so that what a report lists and what a search enumerates
+     * are in the order an author wrote them.
+     */
+    private static List<NumericTerm> numbersMeasuring(Axis axis, List<LineEvidence> evidence,
+                                                      EvidenceAccount account) {
+        NumericTerm declared = axis.term();
+        if (evidence.stream().anyMatch(each -> each.at().equals(declared))) {
+            return List.of(declared);
+        }
+        List<LineEvidence> here = evidence.stream()
+                .filter(each -> each.at().path().equals(axis.path())).toList();
+        // A position the declarations already divide. What a body says about another number of it is
+        // not taken up as a second measure, and this is where that is said: an account with no entry
+        // could not tell a policy from a loss.
+        if (axis.measurable()) {
+            here.forEach(each -> account.disposedOf(each.occurrence(),
+                    new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(axis.id())));
+            return List.of();
+        }
+        List<NumericTerm> numbers = new ArrayList<>();
+        for (LineEvidence each : here) {
+            if (!numbers.contains(each.at())) {
+                numbers.add(each.at());
+            }
+        }
+        return numbers;
+    }
+
+    /**
+     * One axis, with what the rules about its number divide it into.
+     *
+     * <p>The same walk whichever number it is. What the declarations named and what a body measures
+     * a position by are two ways to arrive at a number and one thing to do with it, and a second
+     * route through this would be a second answer to what a rule about a number comes to.
+     */
+    private static void measureAt(List<Axis> out, List<Measured> measured, Axis axis,
+                                  NumericTerm term, List<LineEvidence> evidence,
+                                  souther.compiler.inputs.Quantities reading, Symbols symbols,
+                                  ReadingPolicy policy,
+                                  souther.compiler.check.PathReachability.Answers arrives,
+                                  List<RuleWithoutALine> rules, EvidenceAccount account) {
+        List<LineEvidence> mine = evidence.stream()
+                .filter(each -> each.at().equals(term)).toList();
+        List<Threshold> here = mine.stream()
+                .filter(LineEvidence.Divides.class::isInstance)
+                .map(each -> ((LineEvidence.Divides) each).line()).toList();
+        List<GuardThresholds.Guards.Singled> points = mine.stream()
+                .filter(LineEvidence.Singles.class::isInstance)
+                .map(each -> ((LineEvidence.Singles) each).point()).toList();
+        // What this term's values can be, which is the type's bound already narrowed by whatever
+        // the record it sits in says about it. Reading the type again here would put a threshold
+        // back inside a range the record has no values in.
+        NumericDomain.Bounds domain = domainOf(reading, term);
+        Carrier carrier = term.answeredOn(axis.type(), symbols);
+        if (here.isEmpty() && !points.isEmpty()) {
+            // Nothing orders this position, so its classes are the values singled out and
+            // everything else. Ranges here would ask the rows for a distinction between the two
+            // sides of a value the behavior treats alike.
+            mine.forEach(each -> account.measured(each, axis.id()));
+            keep(out, measured, refine(axis,
+                    () -> singledClasses(points, term, axis.type(), domain, symbols),
+                    mergedPoints(axis.cuts(), points, carrier),
+                    axis.parted()),
+                    new BodyCutInspection.Evidence(), rules);
+            return;
+        }
+        // Filtered once, and both answers read the filtered list. A line outside what the
+        // position holds divides nothing, and it is not a boundary either: leaving it in the
+        // cuts while the intervals dropped it asks for a row at a value the record refuses,
+        // which is the thing being fixed here happening again one field over. The end the
+        // position stops short of is outside it as much as anything past it is.
+        List<Threshold> reachable = new ArrayList<>();
+        for (LineEvidence each : mine) {
+            if (!(each instanceof LineEvidence.Divides(Threshold line))) {
+                // A value singled out beside an ordering. The model has drawn the further
+                // distinction itself, so the value is one more line among the ranges and it is
+                // merged with them below.
+                account.measured(each, axis.id());
+                continue;
+            }
+            // Asked of the place the line falls at, which the position need not hold a
+            // value at. Read off the value, a line between two of the position's values was
+            // dropped as one the rules leave nothing at.
+            if (domain != null && !admits(domain, line.parts())) {
+                account.disposedOf(each.occurrence(),
+                        new EvidenceAccount.Disposition.OutsideThePosition());
+                continue;
+            }
+            // And what the guards above it left. Only a proof drops a line: a comparison
+            // this could not settle keeps its line and its rows, which is the direction that
+            // leaves an author with work rather than with a report about a model of theirs
+            // that is fine.
+            // Asked of the comparison, where the rule is met by having produced one. A
+            // clause has no comparison a path can arrive at: it is checked whenever the
+            // behavior answers, so nothing about which branch a body took drops its line.
+            if (line.origin().comparisonAt().stream().anyMatch(arrives::dividesNothing)) {
+                account.disposedOf(each.occurrence(),
+                        new EvidenceAccount.Disposition.NothingArrivesAtIt());
+                continue;
+            }
+            account.measured(each, axis.id());
+            reachable.add(line);
+        }
+        // Through `excluding`, so that a class list replaced by the intervals a threshold cuts
+        // keeps only the exclusions it still has classes for.
+        //
+        // A rule read and left outside what the position holds divided nothing, and it is not
+        // a rule that went unread either: what it says was understood. So the answer there is
+        // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
+        // written about the position rather than everything that came to nothing.
+        NumericDomain.Bounds within = domain;
+        keep(out, measured, refine(axis,
+                () -> Intervals.classesOf(
+                        Intervals.of(reachable, within == null ? null : within.min(),
+                                within == null ? null : within.max(), carrier),
+                        term, axis.type(), policy, symbols,
+                        within == null ? null : within.min(),
+                        within == null ? null : within.max()),
+                mergedPoints(merged(axis.cuts(), reachable, carrier), points, carrier),
+                reachable.stream()
+                        .map(each -> Parting.by(each.parts(), each.origin().authoredLine()))
+                        .toList()),
+                reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
+    }
+
+    /**
      * What each position is left with, folded from the two readings that were made of it.
      *
      * <p>Nothing is searched for here. Both answers were settled where the position was read — the
@@ -448,6 +588,38 @@ public final class Partitions {
                                               souther.compiler.check.PathReachability.Answers
                                                       arrives,
                                               ReachingCuts reaching) {
+        List<LineEvidence> evidence = new ArrayList<>();
+        thresholds.forEach(each -> evidence.add(new LineEvidence.Divides(each)));
+        singled.forEach(each -> evidence.add(new LineEvidence.Singles(each)));
+        return withEvidence(base, reading, evidence, symbols, policy, rulesWithoutALine, between,
+                arrives, reaching);
+    }
+
+    /**
+     * The same, given what the rules said as the reading of them met it.
+     *
+     * <p>One list and not one per kind of thing a rule can say. What this stage does with a piece of
+     * evidence — divide a position by it, leave it outside what the position holds, or not take it
+     * up at all — is the same question whichever kind it is, and the account below is over all of
+     * them ({@link EvidenceAccount}). Handed two lists, both the fan-out and the account put them
+     * back together, and a position measured at one kind came back measured at neither
+     * (issue #1140).
+     */
+    public static Partitioning withEvidence(Partitioning base,
+                                            souther.compiler.inputs.Quantities reading,
+                                            List<LineEvidence> evidence,
+                                            Symbols symbols, ReadingPolicy policy,
+                                            List<RuleWithoutALine> rulesWithoutALine,
+                                            List<LineDrawn> between,
+                                            souther.compiler.check.PathReachability.Answers
+                                                    arrives,
+                                            ReachingCuts reaching) {
+        List<Threshold> thresholds = evidence.stream()
+                .filter(LineEvidence.Divides.class::isInstance)
+                .map(each -> ((LineEvidence.Divides) each).line()).toList();
+        List<GuardThresholds.Guards.Singled> singled = evidence.stream()
+                .filter(LineEvidence.Singles.class::isInstance)
+                .map(each -> ((LineEvidence.Singles) each).point()).toList();
         // Both producers of one kind of evidence. What a body compared and what a type's own rules
         // bound are read by different readers and answer the same question, so a position either of
         // them wrote about and neither could turn into a line is named once, whichever wrote it.
@@ -459,93 +631,21 @@ public final class Partitions {
         }
         List<Axis> out = new ArrayList<>();
         List<Measured> measured = new ArrayList<>();
+        EvidenceAccount account = new EvidenceAccount(evidence);
         for (Axis axis : base.axes()) {
-            NumericTerm declared = axis.term();
-            NumericTerm term = declared;
-            List<Threshold> here = thresholds.stream()
-                    .filter(t -> t.term().equals(declared)).toList();
-            List<GuardThresholds.Guards.Singled> points = singled.stream()
-                    .filter(one -> one.term().equals(declared)).toList();
-            if (here.isEmpty() && !points.isEmpty()) {
-                // Nothing orders this position, so its classes are the values singled out and
-                // everything else. Ranges here would ask the rows for a distinction between the two
-                // sides of a value the behavior treats alike.
-                NumericDomain.Bounds only = domainOf(reading, term);
-                NumericTerm at = term;
-                Axis here2 = axis;
-                keep(out, measured, refine(axis,
-                        () -> singledClasses(points, at, here2.type(), only, symbols),
-                        mergedPoints(axis.cuts(), points, at.answeredOn(axis.type(), symbols)),
-                        axis.parted()),
-                        new BodyCutInspection.Evidence(), rules);
+            List<NumericTerm> numbers = numbersMeasuring(axis, evidence, account);
+            if (numbers.isEmpty()) {
+                keep(out, measured, axis, null, rules);
                 continue;
             }
-            if (here.isEmpty()) {
-                // A position no rule divides, whose body measures some other number of it: a bare
-                // `List<String>` nothing bounds, under a `guard List.length(t.names) > 0`. The line
-                // is on that number, so the axis becomes one about it — there was nothing else here
-                // for it to be about, and dropping the threshold would lose a line the body draws.
-                NumericTerm drawn = axis.measurable() ? null : soleTermAt(thresholds, axis.path());
-                if (drawn == null) {
-                    keep(out, measured, axis, null, rules);
-                    continue;
-                }
-                term = drawn;
-                here = thresholds.stream().filter(t -> t.term().equals(drawn)).toList();
-                axis = axis.measuredAt(new AxisId(axis.id().behavior(), drawn.toString()), drawn);
+            for (NumericTerm term : numbers) {
+                AxisId id = term.equals(axis.term()) ? axis.id()
+                        : AxisId.of(axis.id().behavior(), term);
+                measureAt(out, measured, axis.measuredAt(id, term), term, evidence, reading,
+                        symbols, policy, arrives, rules, account);
             }
-            // What this term's values can be, which is the type's bound already narrowed by whatever
-            // the record it sits in says about it. Reading the type again here would put a threshold
-            // back inside a range the record has no values in.
-            NumericDomain.Bounds domain = domainOf(reading, term);
-            // Filtered once, and both answers read the filtered list. A line outside what the
-            // position holds divides nothing, and it is not a boundary either: leaving it in the
-            // cuts while the intervals dropped it asks for a row at a value the record refuses,
-            // which is the thing being fixed here happening again one field over. The end the
-            // position stops short of is outside it as much as anything past it is.
-            List<Threshold> reachable = here.stream()
-                    // Asked of the place the line falls at, which the position need not hold a
-                    // value at. Read off the value, a line between two of the position's values was
-                    // dropped as one the rules leave nothing at.
-                    .filter(t -> domain == null || admits(domain, t.parts()))
-                    // And what the guards above it left. Only a proof drops a line: a comparison
-                    // this could not settle keeps its line and its rows, which is the direction that
-                    // leaves an author with work rather than with a report about a model of theirs
-                    // that is fine.
-                    // Asked of the comparison, where the rule is met by having produced one. A
-                    // clause has no comparison a path can arrive at: it is checked whenever the
-                    // behavior answers, so nothing about which branch a body took drops its line.
-                    .filter(t -> t.origin().comparisonAt().stream()
-                            .noneMatch(arrives::dividesNothing))
-                    .toList();
-            // What the term is, not what an invariant said about it. There is a bound to read only
-            // where the type is a newtype carrying one, and a plain `Decimal` has none — read off the
-            // bound, every such position would be called an integer and a threshold of `0.5m` would
-            // be asked for its exact `long`. A size is a whole number whatever it is a size of.
-            Carrier carrier = term.answeredOn(axis.type(), symbols);
-            // Through `excluding`, so that a class list replaced by the intervals a threshold cuts
-            // keeps only the exclusions it still has classes for.
-            //
-            // A rule read and left outside what the position holds divided nothing, and it is not
-            // a rule that went unread either: what it says was understood. So the answer there is
-            // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
-            // written about the position rather than everything that came to nothing.
-            NumericDomain.Bounds within = domain;
-            NumericTerm measuredAt = term;
-            Axis read = axis;
-            keep(out, measured, refine(axis.measuredAt(axis.id(), term),
-                    () -> Intervals.classesOf(
-                            Intervals.of(reachable, within == null ? null : within.min(),
-                                    within == null ? null : within.max(), carrier),
-                            measuredAt, read.type(), policy, symbols,
-                            within == null ? null : within.min(),
-                            within == null ? null : within.max()),
-                    merged(axis.cuts(), reachable, carrier),
-                    reachable.stream()
-                            .map(each -> Parting.by(each.parts(), each.origin().authoredLine()))
-                            .toList()),
-                    reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
+        account.everyPieceWasDisposedOf(out);
         // Both producers into the one account. A line that divides a position leaves its border on
         // the position and a line between two leaves its border beside them; they are the same
         // reading, and an accounting over one of them says nothing about the other.

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -62,24 +62,30 @@ sealed interface PendingPosition {
             implements PendingPosition {}
 
     /**
-     * What is still to be answered for at {@code axis}, or null where the axis has evidence.
+     * What is still to be answered for at {@code at}, or null where something measures it.
      *
-     * <p>Null and not a case, because a position with evidence is not pending anything: it is
-     * measured, and the question this type is about does not arise for it. Which is also why
-     * {@link #complete} refuses a body that says it drew a line — two readings would then disagree
-     * about whether this position has evidence.
+     * <p>Null and not a case, because a position something measures is not pending anything: the
+     * question this type is about does not arise for it. Which is also why {@link #complete}
+     * refuses a body that says it drew a line — two readings would then disagree about whether this
+     * position has evidence.
+     *
+     * <p><b>Asked of the position and of whether anything measures it, and not through a measure.</b>
+     * A location is measured at as many numbers as the rules name of it, so a caller with a measure
+     * in hand has one of several and the question is not about any of them. Asked through one, a
+     * location divided at one of its numbers and not at another was answered by whichever measure
+     * the caller happened to hold.
      */
-    static PendingPosition of(Axis axis) {
-        if (axis.measurable()) {
+    static PendingPosition of(PositionAccount at, boolean measured) {
+        if (measured) {
             return null;
         }
-        return switch (axis.pending()) {
+        return switch (at.pending()) {
             // The structural stop outranks a rule the local reading could not take in, for the
             // reason it outranks the body's: where the walk could not reach into what the position
             // holds, a rule about what is inside is a second description of that same stop and the
             // first is the cause (issue #626).
             case StructuralInspection.Continuation.Blocked blocked ->
-                    new Blocked(axis.path(), blocked.why());
+                    new Blocked(at.path(), blocked.why());
             // And a rule about this position's own values that went unread is said ahead of what a
             // body's comparison came to, where both have something to say. Both are true of such a
             // position and one line is written: the rule on the declaration is the one whose being
@@ -89,7 +95,7 @@ sealed interface PendingPosition {
             //
             // It outranks nothing else. This is not a division, so the position is still pending
             // whatever a body says; it is a rule the model states, so an absence may not follow.
-            case StructuralInspection.Continuation.None _ -> pending(axis);
+            case StructuralInspection.Continuation.None _ -> pending(at);
             // A sequence, whose elements were reached and are a position of their own. Nothing
             // stopped here, so this is the same state a leaf is in: what the list itself divides
             // into is what its own rules say about how many it holds, and an absence may follow
@@ -99,12 +105,12 @@ sealed interface PendingPosition {
             // And a sum, whose cases were reached and stand under it. Nothing stopped here either:
             // a sum with no evidence is one whose own cases the rules left it none of, which is a
             // reading that ran to the end.
-                 StructuralInspection.Continuation.Branches _ -> pending(axis);
+                 StructuralInspection.Continuation.Branches _ -> pending(at);
             // A position with no evidence that was never read. Nothing about a model follows from
             // it — an answer here would be this compiler's state written down as what the model
             // divides, which is the sentence the whole protocol is against.
             case null -> throw new IllegalStateException(
-                    "nothing was read at " + axis.path() + " and it has no evidence");
+                    "nothing was read at " + at.path() + " and it has no evidence");
         };
     }
 
@@ -115,12 +121,12 @@ sealed interface PendingPosition {
      * the slot was filled at all, a rule read from end to end put the position in the state that
      * says this compiler could not read it.
      */
-    private static PendingPosition pending(Axis axis) {
-        return switch (axis.leftWith()) {
-            case null -> new Leaf(axis.path());
-            case LeftAtThePosition.AReadingStopped(var why) -> new Blocked(axis.path(), why);
+    private static PendingPosition pending(PositionAccount at) {
+        return switch (at.leftWith()) {
+            case null -> new Leaf(at.path());
+            case LeftAtThePosition.AReadingStopped(var why) -> new Blocked(at.path(), why);
             case LeftAtThePosition.ARuleWithNoLine(var why) ->
-                    new ARuleWithNoLine(axis.path(), why);
+                    new ARuleWithNoLine(at.path(), why);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
@@ -14,16 +14,14 @@ import souther.compiler.types.Type;
  * is if nothing answers are facts about the location — true of it once, whether it is measured at
  * its own content, at how long it is, or at both.
  *
- * <p><b>What this replaces was the same facts stored on the measure.</b> That said nothing false
- * while there was one measure per position, and it made two questions look like one: whether a
- * position is still waiting on something was asked through the axis standing at it
- * ({@link PendingPosition}), which is an answer about the location arrived at through whichever
- * number it happened to be measured by.
+ * <p><b>Kept on the position and not on a measure of it.</b> Whether a position is still waiting on
+ * anything is a question about the location ({@link PendingPosition}), and a measure that could
+ * answer it lets any reader ask through whichever number it happens to hold. Which one that is
+ * decides nothing, so a reader that has to pick has been handed the wrong thing.
  *
  * <p>An axis holds one of these rather than a copy of what is in it. A copy per measure is a fact
- * with as many representations as the position has numbers, and the first of them to be rebuilt
- * without one of its parts is the one a report reads — which is what {@link ReadingResidue} was
- * written to catch one field at a time.
+ * with as many representations as the position has numbers, and any of them may be rebuilt without
+ * one of its parts — which is what {@link ReadingResidue} guards one field at a time.
  *
  * @param pending  where nothing has answered for this position yet, what the structural reading
  *                 found — and so what the position is left with if nothing else answers. Null where

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
@@ -33,7 +33,7 @@ import souther.compiler.types.Type;
  *                 the walk could not reach into what the position holds, a rule about what is
  *                 inside describes that same stop from the other end
  */
-public record PositionAccount(TermPath path, Type type, ReadingResidue residue,
+public record PositionAccount(String behavior, TermPath path, Type type, ReadingResidue residue,
                               StructuralInspection.Continuation pending,
                               LeftAtThePosition leftWith) {
 
@@ -44,21 +44,29 @@ public record PositionAccount(TermPath path, Type type, ReadingResidue residue,
         }
     }
 
-    /** What names this position across a report, which is where it is. */
+    /**
+     * Where this position is, which is what tells it from the others of one behavior's input.
+     *
+     * <p>The path and nothing else, as the reading of the input names it. What tells it from a
+     * position of another behavior is {@link #behavior}, which travels beside this wherever an
+     * account of one behavior is put together with another's — every such account says whose it is
+     * ({@code Weakening.ProofContradicted}), and a fact that did not would be one fact where two
+     * behaviors happen to be shaped alike.
+     */
     public souther.compiler.inputs.PositionId id() {
         return new souther.compiler.inputs.PositionId(path);
     }
 
     /** What one position's reading came to, as the reading itself answered it. */
-    public static PositionAccount of(Position position,
+    public static PositionAccount of(String behavior, Position position,
                                      StructuralInspection.Continuation pending,
                                      LeftAtThePosition leftWith) {
-        return new PositionAccount(position.path(), position.type(),
+        return new PositionAccount(behavior, position.path(), position.type(),
                 ReadingResidue.of(position), pending, leftWith);
     }
 
     /** A position outside a reading of the declarations, which is where a test writes one. */
-    static PositionAccount at(TermPath path, Type type) {
-        return new PositionAccount(path, type, ReadingResidue.NOTHING, null, null);
+    static PositionAccount at(String behavior, TermPath path, Type type) {
+        return new PositionAccount(behavior, path, type, ReadingResidue.NOTHING, null, null);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
@@ -46,6 +46,11 @@ public record PositionAccount(TermPath path, Type type, ReadingResidue residue,
         }
     }
 
+    /** What names this position across a report, which is where it is. */
+    public souther.compiler.inputs.PositionId id() {
+        return new souther.compiler.inputs.PositionId(path);
+    }
+
     /** What one position's reading came to, as the reading itself answered it. */
     public static PositionAccount of(Position position,
                                      StructuralInspection.Continuation pending,

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
@@ -1,0 +1,61 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.Position;
+import souther.compiler.inputs.StructuralInspection;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.types.Type;
+
+/**
+ * One position of a behavior's input, and what this phase is left answering for at it.
+ *
+ * <p>Held once for the position and pointed at by every axis on it, because a position is measured
+ * at as many numbers as the rules name of it and none of what is here is one of those numbers.
+ * Where the walk stopped, what the reading of the declarations left standing, and what the position
+ * is if nothing answers are facts about the location — true of it once, whether it is measured at
+ * its own content, at how long it is, or at both.
+ *
+ * <p><b>What this replaces was the same facts stored on the measure.</b> That said nothing false
+ * while there was one measure per position, and it made two questions look like one: whether a
+ * position is still waiting on something was asked through the axis standing at it
+ * ({@link PendingPosition}), which is an answer about the location arrived at through whichever
+ * number it happened to be measured by.
+ *
+ * <p>An axis holds one of these rather than a copy of what is in it. A copy per measure is a fact
+ * with as many representations as the position has numbers, and the first of them to be rebuilt
+ * without one of its parts is the one a report reads — which is what {@link ReadingResidue} was
+ * written to catch one field at a time.
+ *
+ * @param pending  where nothing has answered for this position yet, what the structural reading
+ *                 found — and so what the position is left with if nothing else answers. Null where
+ *                 the reading of the declarations already answered, which needs no fallback
+ * @param leftWith what the position is left with where the local reading gave it no axis, or null
+ *                 where nothing is. Which of the two it is comes with it: a reading stopped, or a
+ *                 rule was read to the end and draws no line. Kept apart from {@link #pending}
+ *                 because the two are lifted by different work and one outranks the other — where
+ *                 the walk could not reach into what the position holds, a rule about what is
+ *                 inside describes that same stop from the other end
+ */
+public record PositionAccount(TermPath path, Type type, ReadingResidue residue,
+                              StructuralInspection.Continuation pending,
+                              LeftAtThePosition leftWith) {
+
+    public PositionAccount {
+        if (residue == null) {
+            throw new IllegalArgumentException(
+                    "a position with no account of what its reading came to");
+        }
+    }
+
+    /** What one position's reading came to, as the reading itself answered it. */
+    public static PositionAccount of(Position position,
+                                     StructuralInspection.Continuation pending,
+                                     LeftAtThePosition leftWith) {
+        return new PositionAccount(position.path(), position.type(),
+                ReadingResidue.of(position), pending, leftWith);
+    }
+
+    /** A position outside a reading of the declarations, which is where a test writes one. */
+    static PositionAccount at(TermPath path, Type type) {
+        return new PositionAccount(path, type, ReadingResidue.NOTHING, null, null);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -211,11 +211,22 @@ public sealed interface About {
         }
     }
 
-    /** A position the axes measure whose rules the walk never reached. */
+    /**
+     * A position the axes measure whose rules the walk never reached.
+     *
+     * <p>The gap the reading of the model already recorded, and not a measure that was weakened by
+     * it. A location is measured at as many numbers as the rules name of it, and every one of those
+     * measures is weakened by one stop under the location — so read off the measures, one stop is
+     * one finding per number, and two behaviors happening to be measured alike are told apart by
+     * nothing.
+     *
+     * <p>Which measures it weakened is beside this and is each measure's own
+     * ({@link PartitionEvidence.AxisCoverage.Reading}). What went wrong is here, once.
+     */
     record APositionWhoseRulesWereNotReached(
-            PartitionEvidence.AxisCoverage axis) implements About {
+            souther.compiler.partition.ClosureGap.RulesNotReached gap) implements About {
         public APositionWhoseRulesWereNotReached {
-            java.util.Objects.requireNonNull(axis, "a finding is about something");
+            java.util.Objects.requireNonNull(gap, "a finding is about something");
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4669,7 +4669,7 @@ public final class Adequacy {
                         // words — which are the words the report writes for the same finding.
                         case About.AClassNoRowIsIn(var missing) ->
                                 new ExampleMessage.NoRowIsInThatClass(missing.name(),
-                                        missing.axis().path(), finding.named());
+                                        missing.axis().name(), finding.named());
                         // Kinds no build is told about under any code. Listed rather than
                         // defaulted, so that one added later has to be answered here rather than
                         // arriving as a warning with no sentence.

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4466,18 +4466,19 @@ public final class Adequacy {
             }
             // A position the axes did measure, whose rules this reading is short of. A different
             // thing to act on from one nothing divided: the classes beside it are what the model
-            // was read to say, and what was left unread may yet refuse one of them. What says how
-            // much was read is what the axis carries — asked here rather than worked out a second
-            // time from the lists above, which answer about rules and not about positions.
-            for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
-                // A position the axes measure whose rules nothing looked at. Said apart from the
-                // rules below: there is no rule to name, and there is no rule to name because
-                // nothing was seen rather than because everything was accounted for.
-                if (axis.read().reach()
-                        == PartitionEvidence.AxisCoverage.Reach.SOME_OUT_OF_SIGHT) {
+            // was read to say, and what was left unread may yet refuse one of them.
+            //
+            // Read off what the reading of the model recorded, and not off the measures it
+            // weakened. A location is measured at as many numbers as the rules name of it and one
+            // stop under the location weakens every one of them, so a finding per measure is one
+            // thing that went wrong said as many times as the location has numbers. Which measures
+            // it weakened is each measure's own to carry beside its classes.
+            for (Weakening each : partition.partitioned().weakening().causes()) {
+                if (each instanceof Weakening.ModelReadingIncomplete(
+                        souther.compiler.partition.ClosureGap.RulesNotReached gap)) {
                     out.add(Finding.noticed(behavior.name(),
                             Citation.of(behavior.pos()),
-                            new About.APositionWhoseRulesWereNotReached(axis)));
+                            new About.APositionWhoseRulesWereNotReached(gap)));
                 }
             }
             // One per question a rule raised and nothing answered, whether or not the position it

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -449,7 +449,7 @@ final class Coverages {
         // different question, and borrowing it left a reader with a sentence that named neither
         // (issue #842).
         PartitionEvidence.AxisCoverage.Reading read = new PartitionEvidence.AxisCoverage.Reading(
-                axis.residue().rulesLeftUnread().isEmpty()
+                axis.at().residue().rulesLeftUnread().isEmpty()
                         ? PartitionEvidence.AxisCoverage.Reach.EVERY_RULE
                         : PartitionEvidence.AxisCoverage.Reach.SOME_OUT_OF_SIGHT,
                 // Of the questions standing at this position, the ones this measure is the reader

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -107,16 +107,14 @@ final class Coverages {
         // the same rule.
         souther.compiler.partition.LinesWhereTheyFall.Filed filed =
                 souther.compiler.partition.LinesWhereTheyFall.of(inputs,
-                        both(clauses.thresholds(), guards.thresholds()),
-                        both(clauses.singled(), guards.singled()),
+                        both(clauses.evidence(), guards.evidence()),
                         both(clauses.between(), guards.between()), quantities, symbols);
-        return new Partitioned(Partitions.withThresholds(partitioning, quantities,
-                filed.thresholds(), symbols, policy,
+        return new Partitioned(Partitions.withEvidence(partitioning, quantities,
+                filed.evidence(), symbols, policy,
                 // And the lines this had nowhere to put, which are findings of the same kind: a rule
                 // of the model that came to no line at a position it is about.
                 both(both(clauses.rulesWithoutALine(), guards.rulesWithoutALine()),
                         filed.notPlaced()),
-                filed.singled(),
                 filed.between(), arrives,
                 // What a row had to satisfy to arrive at each comparison, from the walk that
                 // assumed it. A clause of a declaration is not written at a place in a body and has

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -471,6 +471,18 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
                                Measurement<Reached> reached) {
 
         /**
+         * What a document calls this measure, which is the number it is of.
+         *
+         * <p>Not the location. A location is measured at as many numbers as the rules name of it —
+         * which hour of a time and which minute are two — and named by the location a reader is
+         * given two lines that say the same thing about different measures. The path is still here
+         * and is what a fact about the location is said of.
+         */
+        public String name() {
+            return at.term();
+        }
+
+        /**
          * What the rows reached at one position.
          *
          * @param unclassifiedRows rows whose value at this position could not be read. Above zero,

--- a/souther-compiler/src/main/java/souther/compiler/reading/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/Condition.java
@@ -2,6 +2,7 @@ package souther.compiler.reading;
 
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.coverage.ForkOccurrence;
+import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 
 /**
@@ -30,13 +31,19 @@ public sealed interface Condition {
     /**
      * A comparison in the body coming out one way.
      *
+     * <p><b>Said of the number it compares and not of the location that number is read from.</b>
+     * Two numbers taken of one location — which hour of a time it is and which minute — are two
+     * things to steer a row by and one path, so a reader given the path has to pick between them
+     * and has nothing to pick with.
+     *
+     * @param at         which number, which is a location's own content or something taken of it
      * @param comparison which comparison, which is what tells one reading of one rule from another:
      *                   a comparison inside a non-recursive helper is read once per call of that
      *                   helper. The occurrence and not the number it is instrumented under — the
      *                   number is how a run is recorded and is no part of what this decision is
      * @param held       the way it came out
      */
-    record Side(TermPath at, ComparisonOccurrence comparison, boolean held) implements Condition {
+    record Side(NumericTerm at, ComparisonOccurrence comparison, boolean held) implements Condition {
 
         @Override
         public String toString() {

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
@@ -8,7 +8,9 @@ import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.ForkOccurrence;
 import souther.compiler.flow.Naming;
+import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 
 import java.util.ArrayList;
@@ -87,8 +89,7 @@ final class CoverageNaming implements Naming<Outcome> {
             return null;
         }
         ComparisonOccurrence site = plan.comparisonAt(comparison).orElse(null);
-        TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
-                reads.pathOf(comparison.right(), symbols));
+        NumericTerm at = InputNumber.compared(comparison, reads, symbols);
         if (site == null || at == null) {
             return null;
         }
@@ -165,10 +166,6 @@ final class CoverageNaming implements Naming<Outcome> {
 
     private static Outcome one(Decision decision) {
         return new Outcome(List.of(decision));
-    }
-
-    private static TermPath firstOf(TermPath left, TermPath right) {
-        return left != null ? left : right;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1052,7 +1052,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     out.append(String.format("      %s %s `%s` at %s%n", mark(f),
                             f.weakenedBy().isEmpty()
                                     ? "no row is in" : "undecided whether a row is in",
-                            missing.name(), missing.axis().path()));
+                            missing.name(), missing.axis().name()));
                 }
             }
             // Not a finding: nothing is owed here, and what the line says is what the model already
@@ -1277,7 +1277,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (Adequacy.Finding f : behavior.findings()) {
             if (f.about() instanceof About.APositionWhoseRulesWereNotReached(var axis)) {
                 out.append(String.format("      %s rules not reached: %s%n",
-                        mark(f), axis.path()));
+                        mark(f), axis.name()));
             }
         }
         // The questions this measure answers: which values may stand where, which classes hold
@@ -2505,11 +2505,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.ACaseNoRowExpects(var missing) -> missing.name();
             case About.ACaseNothingWasSeenToProduce(var missing) -> missing.name();
             case About.AClassNoRowIsIn(var missing) ->
-                    missing.name() + " (at " + missing.axis().path() + ")";
+                    missing.name() + " (at " + missing.axis().name() + ")";
             case About.APositionNoLineDivides(var position) -> position.at().toString();
             case About.APositionThisCouldNotRead(var it) -> it.at();
             case About.ARuleWithoutALine(var it) -> it.at();
-            case About.APositionWhoseRulesWereNotReached(var axis) -> axis.path();
+            case About.APositionWhoseRulesWereNotReached(var axis) -> axis.name();
             // The position, as the two above write it. What is said of it is the kind's; there is
             // no rule to name and no class this is about, so the position is the whole subject.
             case About.APositionReadWiderThanItsRules(var it) -> it.at().toString();

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1277,7 +1277,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (Adequacy.Finding f : behavior.findings()) {
             if (f.about() instanceof About.APositionWhoseRulesWereNotReached(var axis)) {
                 out.append(String.format("      %s rules not reached: %s%n",
-                        mark(f), axis.name()));
+                        mark(f), axis.path()));
             }
         }
         // The questions this measure answers: which values may stand where, which classes hold
@@ -2509,7 +2509,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.APositionNoLineDivides(var position) -> position.at().toString();
             case About.APositionThisCouldNotRead(var it) -> it.at();
             case About.ARuleWithoutALine(var it) -> it.at();
-            case About.APositionWhoseRulesWereNotReached(var axis) -> axis.name();
+            // The position and not a number measured of it: which of this position's rules went
+            // unread is a fact about the location, and the measures on it are as many as the rules
+            // name numbers there.
+            case About.APositionWhoseRulesWereNotReached(var axis) -> axis.path();
             // The position, as the two above write it. What is said of it is the kind's; there is
             // no rule to name and no class this is about, so the position is the whole subject.
             case About.APositionReadWiderThanItsRules(var it) -> it.at().toString();

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1275,9 +1275,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // position nothing established anything about. Named by the rule, since a position is not
         // what an author edits.
         for (Adequacy.Finding f : behavior.findings()) {
-            if (f.about() instanceof About.APositionWhoseRulesWereNotReached(var axis)) {
+            if (f.about() instanceof About.APositionWhoseRulesWereNotReached(var gap)) {
                 out.append(String.format("      %s rules not reached: %s%n",
-                        mark(f), axis.path()));
+                        mark(f), gap.at()));
             }
         }
         // The questions this measure answers: which values may stand where, which classes hold
@@ -2512,7 +2512,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // The position and not a number measured of it: which of this position's rules went
             // unread is a fact about the location, and the measures on it are as many as the rules
             // name numbers there.
-            case About.APositionWhoseRulesWereNotReached(var axis) -> axis.path();
+            case About.APositionWhoseRulesWereNotReached(var gap) -> gap.at().toString();
             // The position, as the two above write it. What is said of it is the kind's; there is
             // no rule to name and no class this is about, so the position is the whole subject.
             case About.APositionReadWiderThanItsRules(var it) -> it.at().toString();

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -639,10 +639,11 @@ public final class GeneratedRows {
             case About.AnArmNoRowGoesThrough(var arm) -> ArmVocabulary.label(arm);
             case About.ACaseNoRowAppliesItTo(var input, var missing) -> missing.name();
             case About.ACaseNoRowExpects(var missing) -> missing.name();
-            // The class and the position it is a class of, which a class name alone does not say:
-            // two parameters of one type divide into classes of the same names.
+            // The class and the measure it is a class of, which a class name alone does not say:
+            // two parameters of one type divide into classes of the same names, and one location is
+            // measured at more than one number.
             case About.AClassNoRowIsIn(var missing) ->
-                    missing.name() + " at " + missing.axis().path();
+                    missing.name() + " at " + missing.axis().name();
             // Findings row synthesis is not about, which `shown` leaves out and nothing here is
             // asked to name. Listed rather than defaulted so that a shape added later has to be
             // given words here.

--- a/souther-compiler/src/test/java/souther/compiler/APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest.java
@@ -1,0 +1,118 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A position is measured at every number the rules name of it, and at every kind of thing they say.
+ *
+ * <p>One location carries one axis no longer. {@code Time.hour} and {@code Time.minute} are two
+ * numbers of one time, a body comparing both draws two lines, and what a report said was that the
+ * behavior divides no position and draws no line — the sentence a body with no comparison in it
+ * gets, with the measurement called complete beside it.
+ *
+ * <p>Two things were behind it and each is measured here. Which numbers a position is measured at
+ * was answered with the one a body names, so two were answered as none; and it was answered from
+ * the lines alone, so a body that only singles a value out named none either.
+ */
+class APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest {
+
+    private static final String MODEL = """
+            module example.gate
+
+            data Early
+            data Late
+            data When = Early | Late
+
+            data Slot = { at: Time }
+
+            behavior oneNumber : (slot: Slot) -> When
+            let oneNumber (slot) =
+                if Time.hour(slot.at) >= 9 then Late else Early
+
+            behavior twoNumbersAtOneLocation : (slot: Slot) -> When
+            let twoNumbersAtOneLocation (slot) =
+                if Time.hour(slot.at) >= 9 && Time.minute(slot.at) >= 30 then Late else Early
+
+            behavior oneNumberSingledOut : (slot: Slot) -> When
+            let oneNumberSingledOut (slot) =
+                if Time.hour(slot.at) == 9 then Late else Early
+
+            behavior oneSingledOneOrdered : (slot: Slot) -> When
+            let oneSingledOneOrdered (slot) =
+                if Time.hour(slot.at) == 9 && Time.minute(slot.at) >= 30 then Late else Early
+
+            behavior orderedAndSingledOnOneNumber : (slot: Slot) -> When
+            let orderedAndSingledOnOneNumber (slot) =
+                if Time.hour(slot.at) >= 9 && Time.hour(slot.at) == 12 then Late else Early
+            """;
+
+    private static String blockOf(String behavior) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+        StringBuilder block = new StringBuilder();
+        boolean inside = false;
+        for (String line : human.split("\n", -1)) {
+            if (line.startsWith("  ") && !line.startsWith("   ")) {
+                inside = line.startsWith("  " + behavior + " ");
+            }
+            if (inside) {
+                block.append(line).append('\n');
+            }
+        }
+        return block.toString();
+    }
+
+    /** The one this always got right, so that what the others assert is a difference and not a
+     *  reading of the report this test made up. */
+    @Test
+    void oneNumberOfALocationIsMeasured() {
+        assertTrue(blockOf("oneNumber").contains("partition   axes 1"), blockOf("oneNumber"));
+        assertTrue(blockOf("oneNumber").contains("border      borders 1"), blockOf("oneNumber"));
+    }
+
+    /** Two numbers of one location are two axes and two lines. Neither dropping both nor keeping
+     *  one is an outcome: each line is on a number of its own, and the numbers tell them apart. */
+    @Test
+    void twoNumbersOfOneLocationAreTwoAxes() {
+        String block = blockOf("twoNumbersAtOneLocation");
+        assertTrue(block.contains("partition   axes 2"), block);
+        assertTrue(block.contains("border      borders 2"), block);
+    }
+
+    /** A value singled out names a number as much as a line does. Read off the lines alone, a body
+     *  whose only comparison is an equality measured nothing at all. */
+    @Test
+    void aValueSingledOutNamesTheNumberItIsOf() {
+        String block = blockOf("oneNumberSingledOut");
+        assertTrue(block.contains("partition   axes 1"), block);
+        assertTrue(block.contains("border      borders 1"), block);
+    }
+
+    /** And the two kinds together at two numbers. Read off the lines alone, this measured the
+     *  ordered number and dropped the singled one, which is the same loss keeping one of two is. */
+    @Test
+    void aSingledNumberAndAnOrderedOneAreBothMeasured() {
+        String block = blockOf("oneSingledOneOrdered");
+        assertTrue(block.contains("partition   axes 2"), block);
+        assertTrue(block.contains("border      borders 2"), block);
+    }
+
+    /** Both kinds about one number. The ordering divides it and the equality puts one value in a
+     *  class of its own, and the second used to be dropped for the first having spoken. */
+    @Test
+    void aValueSingledOutBesideAnOrderingIsStillALine() {
+        String block = blockOf("orderedAndSingledOnOneNumber");
+        assertTrue(block.contains("partition   axes 1"), block);
+        assertTrue(block.contains("border      borders 2"), block);
+        assertTrue(block.contains("Time.hour(slot.at) = 12"), block);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest.java
@@ -31,6 +31,7 @@ class APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest {
             data When = Early | Late
 
             data Slot = { at: Time }
+            data Box = { s: String }
 
             behavior oneNumber : (slot: Slot) -> When
             let oneNumber (slot) =
@@ -51,6 +52,10 @@ class APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest {
             behavior orderedAndSingledOnOneNumber : (slot: Slot) -> When
             let orderedAndSingledOnOneNumber (slot) =
                 if Time.hour(slot.at) >= 9 && Time.hour(slot.at) == 12 then Late else Early
+
+            behavior itsOwnValueAndANumberTakenOfIt : (box: Box) -> When
+            let itsOwnValueAndANumberTakenOfIt (box) =
+                if box.s == "x" && String.length(box.s) > 3 then Late else Early
             """;
 
     private static String blockOf(String behavior) {
@@ -102,6 +107,18 @@ class APositionIsMeasuredAtEveryNumberTheRulesNameOfItTest {
     @Test
     void aSingledNumberAndAnOrderedOneAreBothMeasured() {
         String block = blockOf("oneSingledOneOrdered");
+        assertTrue(block.contains("partition   axes 2"), block);
+        assertTrue(block.contains("border      borders 2"), block);
+    }
+
+    /**
+     * What a location holds is one of the numbers the rules name of it, not the alternative to
+     * them. Answered as the alternative, a body naming both measured only the location's own value
+     * and the other went unsaid.
+     */
+    @Test
+    void aLocationsOwnValueIsOneOfItsNumbers() {
+        String block = blockOf("itsOwnValueAndANumberTakenOfIt");
         assertTrue(block.contains("partition   axes 2"), block);
         assertTrue(block.contains("border      borders 2"), block);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -45,7 +45,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.returning(List.of(read.drew(aBorder("cap"))));
 
         MeasureClosure.Both closed =
-                MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read);
+                MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read);
 
         assertInstanceOf(MeasureClosure.OfTheBorder.Closed.class, closed.border(),
                 "every question this measure answers was answered");
@@ -65,7 +65,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.found(aLine(), bound("cap"));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+                () -> MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith("a line this reading found and did not draw"),
                 refused.getMessage());
@@ -87,7 +87,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.drew(aBorder("cap"));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+                () -> MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith("a line drawn more than once"),
                 refused.getMessage());
@@ -102,7 +102,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.drew(aBorder("floor"));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+                () -> MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith("a border this reading cannot account for"),
                 refused.getMessage());
@@ -124,7 +124,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.returning(List.of(aBorder("cap"), aBorder("floor")));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+                () -> MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith(
                         "a border returned by a reading that did not write it down"),
@@ -142,11 +142,17 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         read.returning(List.of());
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+                () -> MeasureClosure.of(List.of(aPosition()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith(
                         "a border this reading drew and did not return"),
                 refused.getMessage());
+    }
+
+    /** The position the lines here are of. This measure's closure is about what the reading of a
+     *  position came to, and the axis on it is not what that is asked of. */
+    private static PositionAccount aPosition() {
+        return PositionAccount.at(TermPath.of("h").then("a"), Type.INT);
     }
 
     private static Axis anAxis() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -152,7 +152,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     /** The position the lines here are of. This measure's closure is about what the reading of a
      *  position came to, and the axis on it is not what that is asked of. */
     private static PositionAccount aPosition() {
-        return PositionAccount.at(TermPath.of("h").then("a"), Type.INT);
+        return PositionAccount.at("f", TermPath.of("h").then("a"), Type.INT);
     }
 
     private static Axis anAxis() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.BlockedDescent;
-import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.RulesLeftUnread;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.Type;
@@ -279,42 +278,45 @@ class AStopThisCompilerMadeIsSaidOnceTest {
      * Which kinds of gap one axis carrying {@code residue} leaves the partition measure short of.
      *
      * <p>The kinds and not the values: what a gap is keyed by is asserted where that decision is
-     * ({@link #theStopIsNamedForTheAxisCarryingIt}), and repeating it in every row here would make
+     * ({@link #theStopIsNamedForThePositionItIsAt}), and repeating it in every row here would make
      * every row of the arithmetic fail the day the identity is revisited.
      */
     private static Set<Class<?>> gapKindsOf(ReadingResidue residue) {
         MeasureClosure.Both closed = MeasureClosure.of(
-                List.of(new Axis(new AxisId("f", "r.cost"),
-                        new NumericTerm.ValueOf(TermPath.of("r").then("cost")),
-                        new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL, residue,
-                                null, null),
-                        List.of(), List.of(), List.of(),
-                        souther.compiler.check.NarrowedBounds.NOTHING)),
+                List.of(new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL, residue,
+                        null, null)),
                 List.of(), List.of(), new LinesRead());
         return ((MeasureClosure.OfThePartition.Open) closed.partition()).by().stream()
                 .map(Object::getClass).collect(java.util.stream.Collectors.toSet());
     }
 
     /**
-     * The stop is named for the axis carrying it, which is not always the position that was blocked.
+     * The stop is named for the position it is at, and not for a number that position is measured
+     * at.
      *
-     * <p>Where the two come apart, and the whole of why this arm is keyed by an axis. The map's
-     * contents are what the walk could not reach; the axis is the size a rule measures. A reader is
-     * being told something about the number it holds, so that is what the finding names — and the
-     * position is that axis's path.
+     * <p>Where the two come apart. The map's contents are what the walk could not reach and the
+     * size is what a rule measures, so the position and the number are different words here.
+     *
+     * <p><b>This used to name the number, and that reading needed one measure per position.</b> The
+     * argument for it was that a gap beside a measurement is about the measure a reader holds — but
+     * a location is measured at as many numbers as the rules name of it, and one stop under such a
+     * location came out once per number, which is a compiler's own state counted several times. What
+     * weakens one measurement is said per measurement elsewhere; these are one behavior's account of
+     * what its reading of the model came to, and a reader holding a measure reaches its position by
+     * the path it reads from.
      */
     @Test
-    void theStopIsNamedForTheAxisCarryingIt() {
+    void theStopIsNamedForThePositionItIsAt() {
         List<Weakening> said = weakeningOf(A_MAP_A_BODY_MEASURES, "f");
 
-        assertEquals(List.of("f/Map.size(r.cost)"),
+        assertEquals(List.of("r.cost"),
                 said.stream()
                         .filter(each -> each instanceof Weakening.ModelReadingIncomplete(
                                 ClosureGap.PositionNotReachedInto _))
                         .map(each -> ((ClosureGap.PositionNotReachedInto)
                                 ((Weakening.ModelReadingIncomplete) each).cause()).at().toString())
                         .toList(),
-                () -> "the axis carrying the stop, not the position blocked: " + said);
+                () -> "the position the walk stopped at, not a number measured of it: " + said);
     }
 
     private static List<Weakening> weakeningOf(String source, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -283,7 +283,7 @@ class AStopThisCompilerMadeIsSaidOnceTest {
      */
     private static Set<Class<?>> gapKindsOf(ReadingResidue residue) {
         MeasureClosure.Both closed = MeasureClosure.of(
-                List.of(new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL, residue,
+                List.of(new PositionAccount("f", TermPath.of("r").then("cost"), Type.BOOL, residue,
                         null, null)),
                 List.of(), List.of(), new LinesRead());
         return ((MeasureClosure.OfThePartition.Open) closed.partition()).by().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -286,9 +286,10 @@ class AStopThisCompilerMadeIsSaidOnceTest {
         MeasureClosure.Both closed = MeasureClosure.of(
                 List.of(new Axis(new AxisId("f", "r.cost"),
                         new NumericTerm.ValueOf(TermPath.of("r").then("cost")),
-                        Type.BOOL, List.of(), List.of(), List.of(),
-                        souther.compiler.check.NarrowedBounds.NOTHING,
-                        residue, null, null)),
+                        new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL, residue,
+                                null, null),
+                        List.of(), List.of(), List.of(),
+                        souther.compiler.check.NarrowedBounds.NOTHING)),
                 List.of(), List.of(), new LinesRead());
         return ((MeasureClosure.OfThePartition.Open) closed.partition()).by().stream()
                 .map(Object::getClass).collect(java.util.stream.Collectors.toSet());

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -69,7 +69,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static Axis pending(StructuralInspection.Continuation found, BlockReason unread) {
         return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT),
-                new PositionAccount(AT, Type.BOOL, ReadingResidue.NOTHING, found,
+                new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
                         unread == null ? null : LeftAtThePosition.of(unread)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -55,6 +55,12 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
                 List.of());
     }
 
+    /** What is still to be answered for at the position this axis is of. The fixtures here are
+     *  axis-shaped, and the question is the position's. */
+    private static PendingPosition of(Axis axis) {
+        return PendingPosition.of(axis.at(), axis.measurable());
+    }
+
     private static Axis pending(StructuralInspection.Continuation found) {
         return pending(found, null);
     }
@@ -79,13 +85,13 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     void aLeafCarryingAnUnreadRuleCompletesAsThatRule() {
         BlockReason unread = new BlockReason.UnreadValueRule();
 
-        UndividedPosition said = PendingPosition.of(pending(new StructuralInspection.Continuation.None(), unread))
+        UndividedPosition said = of(pending(new StructuralInspection.Continuation.None(), unread))
                 .complete(new BodyCutInspection.Exhausted());
 
         assertFalse(said.isAbsent(), said.toString());
         // And the verdict says only that: what stopped it is the rule's, said by the reader that
         // read the rule and naming which rule it was.
-        assertNull(PendingPosition.of(pending(new StructuralInspection.Continuation.None(), unread))
+        assertNull(of(pending(new StructuralInspection.Continuation.None(), unread))
                         .reportable(),
                 "a rule this read and could not use is not a position nothing was reached at");
     }
@@ -102,7 +108,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     void aLeafCarryingARuleReadToTheEndSaysNeitherOfThose() {
         BlockReason read = new BlockReason.ComparisonBetweenPositions();
 
-        UndividedPosition said = PendingPosition.of(
+        UndividedPosition said = of(
                         pending(new StructuralInspection.Continuation.None(), read))
                 .complete(new BodyCutInspection.Exhausted());
 
@@ -122,7 +128,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      */
     @Test
     void twoRulesLeaveThePositionWithNoAccountOfItsOwn() {
-        PendingPosition pending = PendingPosition.of(pending(new StructuralInspection.Continuation.None(),
+        PendingPosition pending = of(pending(new StructuralInspection.Continuation.None(),
                 new BlockReason.UnreadValueRule()));
 
         assertFalse(pending.complete(new BodyCutInspection.NoLine(new LeftAtThePosition.AReadingStopped(
@@ -136,23 +142,23 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      *  to an absence from it. */
     @Test
     void aPositionWithEvidenceIsNotPending() {
-        assertNull(PendingPosition.of(measured()));
+        assertNull(of(measured()));
     }
 
     /** And a position with no evidence that nothing read is not answered for at all: what would be
      *  said of it is this compiler's state, written down as what the model divides. */
     @Test
     void aPositionNothingReadIsNotAnsweredFor() {
-        assertThrows(IllegalStateException.class, () -> PendingPosition.of(
+        assertThrows(IllegalStateException.class, () -> of(
                 new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL, List.of(), List.of())));
     }
 
     @Test
     void aPositionWithoutEvidenceIsPendingWhatItsStructureFound() {
         assertEquals(new PendingPosition.Leaf(AT),
-                PendingPosition.of(pending(new StructuralInspection.Continuation.None())));
+                of(pending(new StructuralInspection.Continuation.None())));
         assertEquals(new PendingPosition.Blocked(AT, new BlockReason.TypeUnresolved()),
-                PendingPosition.of(pending(
+                of(pending(
                         new StructuralInspection.Continuation.Blocked(new BlockReason.TypeUnresolved()))));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -62,9 +62,9 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     /** The same, with a rule about the position's own values that the local reading could not take
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static Axis pending(StructuralInspection.Continuation found, BlockReason unread) {
-        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
-                ReadingResidue.NOTHING, found,
-                unread == null ? null : LeftAtThePosition.of(unread));
+        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT),
+                new PositionAccount(AT, Type.BOOL, ReadingResidue.NOTHING, found,
+                        unread == null ? null : LeftAtThePosition.of(unread)));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -1,0 +1,106 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Towards;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An account counts by a name it derives, so it says first that the name tells its input apart.
+ *
+ * <p>What a conservation account is for is the piece that never arrives. Two pieces sharing a name
+ * are one entry in what it is owed, and then the piece that went missing is the one the other
+ * answered for — the account closes over evidence it never held, and reports the measure complete.
+ * Which is the thing it exists to refuse, happening to the account itself.
+ *
+ * <p>So the check is where the input is taken. A check that fires when two pieces meet assumes what
+ * it is meant to establish: the case it has to catch is the one where the second never comes.
+ */
+class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
+
+    private static final NumericTerm AT = new NumericTerm.ValueOf(TermPath.of("r").then("cost"));
+
+    /**
+     * Two pieces of evidence called one name are refused where they are handed over.
+     *
+     * <p>One rule parting the position's values in two places is not something the reader above
+     * writes today. What this fixes is not that: it is that the account below would not have noticed
+     * if it were, and would have said so by reporting a complete reading.
+     */
+    @Test
+    void twoPiecesOfEvidenceUnderOneNameAreRefusedWhereTheyAreHandedOver() {
+        LineEvidence one = dividing("10");
+        LineEvidence other = dividing("20");
+        assertEquals(one.id(), other.id(), "the same rule and the same number");
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> new EvidenceAccount(List.of(one, other)));
+
+        assertTrue(refused.getMessage().startsWith("two pieces of evidence are called"),
+                refused.getMessage());
+    }
+
+    /**
+     * And the same piece handed over twice is one piece.
+     *
+     * <p>Nothing here counts arrivals. What the account holds the stage to is that everything it was
+     * given has an answer, so being given one thing twice is being given one thing.
+     */
+    @Test
+    void onePieceHandedOverTwiceIsOnePiece() {
+        LineEvidence one = dividing("10");
+
+        EvidenceAccount account = new EvidenceAccount(List.of(one, one));
+        account.measured(one, new AxisId("f", AT.toString()));
+
+        account.everyPieceWasDisposedOf(List.of(new Axis(new AxisId("f", AT.toString()), AT,
+                souther.compiler.types.Type.INT, List.of(),
+                List.of(Cut.at(new Carrier.Whole(),
+                        new Count(new java.math.BigDecimal("10")), origin())))));
+    }
+
+    /** A piece disposed of under a name belonging to another is refused. */
+    @Test
+    void aPieceDisposedOfUnderAnothersNameIsRefused() {
+        EvidenceAccount account = new EvidenceAccount(List.of(dividing("10")));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> account.measured(dividing("20"), new AxisId("f", AT.toString())));
+
+        assertTrue(refused.getMessage().contains("under the name of"), refused.getMessage());
+    }
+
+    private static LineEvidence dividing(String at) {
+        return new LineEvidence.Divides(new Threshold(AT,
+                Seam.of(LevelSpace.onACarrier(new Carrier.Whole()),
+                        new Level.OnACarrier(new Carrier.Whole(),
+                                new Count(new java.math.BigDecimal(at))),
+                        Towards.BELOW),
+                true, origin()));
+    }
+
+    /** One rule, written in one place. Two lines of it are told apart by where they part the
+     *  values, which is what the account may not be asked to do by name alone. */
+    private static OriginRef origin() {
+        return new OriginRef.ComparisonOrigin(
+                new RuleRef.Comparison("f", new souther.compiler.types.CoverageOrigin(
+                        "example.one", 2, 0, souther.compiler.types.CoverageConstruct.BINARY)),
+                new OriginRef.ComparisonOrigin.Read(
+                        new souther.compiler.coverage.ComparisonOccurrence(0),
+                        new RuleCitation.WrittenAt(Citation.of(
+                                new souther.compiler.diag.SourcePos(1, 1)))),
+                true, true, false);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
@@ -81,7 +81,7 @@ class OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest {
      */
     @Test
     void oneStopUnderOneLocationIsOneEntryHoweverManyMeasuresStandOnIt() {
-        PositionAccount at = new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL,
+        PositionAccount at = new PositionAccount("f", TermPath.of("r").then("cost"), Type.BOOL,
                 new ReadingResidue(new BlockedDescent(new BlockReason.ValueRulesNotReached()),
                         java.util.Set.of()),
                 null, null);
@@ -89,10 +89,39 @@ class OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest {
         MeasureClosure.Both closed = MeasureClosure.of(List.of(at), List.of(), List.of(),
                 new LinesRead());
 
-        assertEquals(List.of(new ClosureGap.PositionNotReachedInto(at.id(),
+        assertEquals(List.of(new ClosureGap.PositionNotReachedInto("f", at.id(),
                         new BlockReason.ValueRulesNotReached())),
                 List.copyOf(((MeasureClosure.OfThePartition.Open) closed.partition()).by()),
                 "the position, once");
+    }
+
+    /**
+     * And two behaviors measuring positions spelled alike leave two entries.
+     *
+     * <p>An account of one behavior is put together with another's, and a union keeps one of two
+     * equal facts. Told apart by where the position is and nothing else, the second behavior's stop
+     * is the first said again — so a module short of two readings reports one.
+     */
+    @Test
+    void oneStopInEachOfTwoBehaviorsIsTwoEntries() {
+        souther.compiler.query.WeakeningSet both =
+                weakeningOf("f").union(weakeningOf("g"));
+
+        assertEquals(2, both.causes().size(), both.toString());
+    }
+
+    private static souther.compiler.query.WeakeningSet weakeningOf(String behavior) {
+        PositionAccount at = new PositionAccount(behavior, TermPath.of("r").then("cost"),
+                Type.BOOL,
+                new ReadingResidue(new BlockedDescent(new BlockReason.ValueRulesNotReached()),
+                        java.util.Set.of()),
+                null, null);
+        MeasureClosure.Both closed = MeasureClosure.of(List.of(at), List.of(), List.of(),
+                new LinesRead());
+        return souther.compiler.query.WeakeningSet.of(
+                ((MeasureClosure.OfThePartition.Open) closed.partition()).by().stream()
+                        .map(souther.compiler.query.Weakening.ModelReadingIncomplete::new)
+                        .toArray(souther.compiler.query.Weakening[]::new));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
@@ -1,0 +1,147 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.inputs.BlockedDescent;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A location measured at two numbers is two measures and one location.
+ *
+ * <p>Issue #1140 was the first half of that: two numbers of one location came back as neither. The
+ * consumers below are the second half. Each of them held a premise that a location carries one
+ * measure, and each said something different when it stopped holding — a compiler's own stop
+ * reported once per number, and a row written for one class while another class of the same
+ * location went unanswered.
+ *
+ * <p><b>The cells that steer a row are not among them, and the reason is worth writing down.</b>
+ * They used to find an axis by the path a condition names, which answers a comparison about the
+ * second number with the first number's axis; they ask by the number now. Neither can be told from
+ * the other by anything observable, because narrowing an axis of a number taken of a location does
+ * not work either way: the class of such an axis recognises what stands at the location, and what
+ * it is handed there is the number — so the class holding the line is never found and the condition
+ * narrows nothing. That is issue #1144 and is no part of this one.
+ */
+class OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest {
+
+    private static final String TWO_NUMBERS = """
+            module example.two
+
+            data Early
+            data Late
+            data When = Early | Late
+
+            data Slot = { at: Time }
+
+            behavior gate : (slot: Slot) -> When
+            let gate (slot) =
+                if Time.hour(slot.at) >= 9 && Time.minute(slot.at) >= 30 then Late else Early
+            """;
+
+    /**
+     * One position and two measures of it, which is what the rest of this is about.
+     *
+     * <p>Asserted here so that the three below are about a shape this model actually has. Read as a
+     * count of axes alone, every one of them would pass over a model measured at one number.
+     */
+    @Test
+    void theModelHasTwoMeasuresOfOneLocation() {
+        Partitions.Partitioning read = partitioningOf();
+
+        assertEquals(List.of(TermPath.of("slot").then("at")),
+                read.positions().stream().map(PositionAccount::path).toList());
+        assertEquals(List.of("gate/Time.hour(slot.at)", "gate/Time.minute(slot.at)"),
+                read.axes().stream().map(each -> each.id().toString()).toList(),
+                "in the order the rules were read");
+    }
+
+    /**
+     * What a reading of a position came to is one entry, however many numbers measure the position.
+     *
+     * <p>The account of what a measure's reading was short of is one behavior's, and each entry is a
+     * thing that went wrong. A stop under a location is one of those — read off the measures, a
+     * location measured at two numbers reported this compiler's one stop twice, under two names,
+     * and no reader could tell that from two stops.
+     *
+     * <p>Written against the closure rather than against a source, because a location this compiler
+     * cannot enter and that a body measures at two numbers is not a model that can be written today:
+     * the operations that take a second number of a location take it of a time or a date, and the
+     * walk enters both. What the closure is given is what decides this, so that is what is given.
+     */
+    @Test
+    void oneStopUnderOneLocationIsOneEntryHoweverManyMeasuresStandOnIt() {
+        PositionAccount at = new PositionAccount(TermPath.of("r").then("cost"), Type.BOOL,
+                new ReadingResidue(new BlockedDescent(new BlockReason.ValueRulesNotReached()),
+                        java.util.Set.of()),
+                null, null);
+
+        MeasureClosure.Both closed = MeasureClosure.of(List.of(at), List.of(), List.of(),
+                new LinesRead());
+
+        assertEquals(List.of(new ClosureGap.PositionNotReachedInto(at.id(),
+                        new BlockReason.ValueRulesNotReached())),
+                List.copyOf(((MeasureClosure.OfThePartition.Open) closed.partition()).by()),
+                "the position, once");
+    }
+
+    /**
+     * A row is not written for one class of a location while another class of it goes unanswered.
+     *
+     * <p>Two measures of one location want two values there and a row writes one. Whichever was
+     * reached last used to be written, so a row offered as covering both classes stood at one of
+     * them.
+     */
+    @Test
+    void twoClassesOfOneLocationWantingDifferentValuesComposeNoRow() {
+        Symbols symbols = symbolsOf();
+        Axis hour = new Axis(new AxisId("f", "Time.hour(a)"),
+                new NumericTerm.ValueOf(TermPath.of("a")), Type.INT,
+                List.of(number("early", 1)), List.of());
+        Axis minute = new Axis(new AxisId("f", "Time.minute(a)"),
+                new NumericTerm.ValueOf(TermPath.of("a")), Type.INT,
+                List.of(number("late", 40)), List.of());
+        Generator.Subject subject = new Generator.Subject("f",
+                new BehaviorInputs(List.of("a"), List.of(Type.INT), symbols,
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                List.of(hour, minute), HeldCounts.NONE);
+
+        FillResult filled = Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY,
+                Budgets.generation());
+
+        assertEquals(List.of(), filled.rows(), "neither class is answered by a row");
+        assertTrue(filled.unresolved().stream().anyMatch(left -> left.reason()
+                        == Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE),
+                filled.unresolved().toString());
+    }
+
+    private static PartitionClass number(String id, long candidate) {
+        return PartitionClass.of(id, id, new Recognition.Nothing(),
+                RepresentativeSource.of(FixtureTemplate.integer(candidate)));
+    }
+
+    private static Symbols symbolsOf() {
+        Compilation compilation = Compilation.ofSource(TWO_NUMBERS, "Main");
+        compilation.answerEverything();
+        return souther.compiler.query.Scopes.derived(compilation.db(),
+                compilation.modules().get(0)).value();
+    }
+
+    private static Partitions.Partitioning partitioningOf() {
+        Compilation compilation = Compilation.ofSource(TWO_NUMBERS, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation.db()
+                .ask(new Adequacy.Divided(compilation.modules().get(0), "gate")).value();
+    }
+}


### PR DESCRIPTION
Closes #1140.

A position carried one measure. Which number it was measured at was answered with "the one number a
body draws a line on there", and that answer is wrong twice over: there can be several, and a body
says things other than lines.

## What was measured

Six behaviors over `data Slot = { at: Time }`, before and after.

| body | before | after |
|---|---|---|
| `hour >= 9` | axes 1 / borders 1 | unchanged |
| `hour >= 9 && minute >= 30` | not applicable / not applicable | axes 2 / borders 2 |
| `hour >= 9 && hour <= 17` | axes 1 / borders 2 | unchanged |
| `hour == 9` | not applicable / not applicable | axes 1 / borders 1 |
| `hour == 9 && minute >= 30` | axes 1 / borders 1 | axes 2 / borders 2 |
| `hour >= 9 && hour == 12` | axes 1 / borders 1 | axes 1 / borders 2 |

The last three were not in the issue. Reading the numbers off the lines alone, a body whose only
comparison is an equality named no number at all; written beside an ordering on another number, the
equality went and the ordering stayed; written beside an ordering on the same number, the equality
went while the stage's own words said it becomes one more line among the ranges.

Every one of them was reported with `measurement: complete` beside it.

## What the rules said is one list

Held as one list per kind, the reading's own order across them is gone and every reader wanting all
of what was said puts the lists back together — which the fan-out and the account both do. So the
list is what a reading answers with and the two kinds are read off it, through the producers, the
filing that takes a rule to the positions its name reaches, and the stage that makes measures.

A filed piece of evidence is told from every other by the rule and the number together. One rule
filed at three cases of a sum is three of them, and the partition owes an answer at each.

## Two stages, each holding itself to what it was handed

`LinesRead` cannot hold this one. It is written from the axes, so evidence that never reached one is
not a line it ever found — an account is worth what it is anchored to, and the reading that lost two
lines called itself complete.

Each stage says first that the names it counts by tell its input apart, and then counts. The filing
counts each piece where it has it in hand, so it derives no name at all. The stage that makes
measures needs one — a disposal happens far from the entry — so the entry keeps each piece under its
name and refuses a second, different piece under it; every piece then has one answer, and the same
answer however often it is said. A piece it says it measured has to be carried by the axis it names:
by a cut where the position has a value beside the line, by the place the values part where it has
none.

Measured, by taking each one out in turn: dropping the disposition on the path that measures fails
forty-odd tests naming the evidence; emptying an arm of the filing walk names the rule; taking out
the merge that puts a singled value among the ranges makes the account say the axis carries nothing
that rule drew, where before it passed. And two pieces of evidence built to share a name are refused
where they are handed over, which is what keeps the denominator from being short before any of that
runs.

## The rest of the 1:N

- A position's own account — where the walk stopped, what the reading left standing, what it is if
  nothing answers — is a list of its own beside the measures, and an axis points at its position.
  None of it is about the number the axis measures, and a measure no longer answers for it: the
  closure over what a reading came to reads the positions and never sees the measures, and the two
  gaps that are about a location name the location.
- A decision a run was steered by says which number came out which way. Given the location, the
  cells that say what a condition admits took the nearest axis on the path, which carries no cut of
  that comparison, and the condition narrowed nothing with nothing said.
- Three walks write a row's values at its locations and one of them said what happens when a
  location is asked twice. The rule is one type; an ask that agrees is the same ask, one that does
  not composes nothing.
- That a position is divided no way is said once for the position and not once per measure.
- A document calls a measure by the number it is of. The location is still what a fact about the
  location is said of.

## Left out

[#1142](https://github.com/souther-lang/souther/issues/1142) — `axes N` counts positions this
compiler kept rather than the measures it made. Measured as not reached by this issue's shape, and
closing it moves where a report's account of a position comes from.

The disposition for a line falling outside what the position holds is not here. Two models written
to reach it were both refused earlier by the reader that produces the evidence, once against a
type's own range and once against the range the record it sits in leaves. An outcome nothing is
known to reach is not an outcome, so what gets past that reader and is dropped is a line lost and
the account says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
