### PR TITLE
Hold a module's classes as what their bytes say

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Generated.java
+++ b/souther-bench/src/main/java/souther/bench/Generated.java
@@ -2,6 +2,7 @@ package souther.bench;
 
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.GeneratedClasses;
 import souther.runtime.Behavior;
@@ -42,7 +43,7 @@ final class Generated {
         Corpus corpus = Corpus.load("runtime");
         Compilation compilation = corpus.compile();
         corpus.check(compilation);
-        Map<String, byte[]> classes = compilation.classes();
+        Map<String, ClassFileImage> classes = compilation.classes();
         ClassLoader loader = new MemoryClassLoader(classes, Generated.class.getClassLoader());
 
         Behavior<Object, Object> sumAll = behavior(loader, "SumAll");

--- a/souther-build-driver/src/main/java/souther/build/driver/CompilerBuildDriver.java
+++ b/souther-build-driver/src/main/java/souther/build/driver/CompilerBuildDriver.java
@@ -16,6 +16,7 @@ import souther.compiler.diag.Messages;
 import souther.compiler.diag.SourceContext;
 import souther.compiler.diag.SourceContextResolver;
 import souther.compiler.diag.SourceNames;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 
@@ -151,14 +152,14 @@ public final class CompilerBuildDriver implements SoutherBuildDriver {
      * another project imports it by, so a build downstream would go on importing a module that is
      * no longer written anywhere.
      */
-    private static void write(Map<String, byte[]> classes, Path outputDirectory, Path stateDirectory)
-            throws IOException {
+    private static void write(Map<String, ClassFileImage> classes, Path outputDirectory,
+                              Path stateDirectory) throws IOException {
         Set<String> written = new LinkedHashSet<>();
-        for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> entry : classes.entrySet()) {
             String relative = entry.getKey().replace('.', '/') + ".class";
             Path file = outputDirectory.resolve(relative);
             Files.createDirectories(file.getParent());
-            Files.write(file, entry.getValue());
+            Files.write(file, entry.getValue().bytes());
             written.add(relative);
         }
         remove(generatedBefore(stateDirectory), written, outputDirectory);

--- a/souther-cli/src/main/java/souther/cli/Main.java
+++ b/souther-cli/src/main/java/souther/cli/Main.java
@@ -2,6 +2,7 @@ package souther.cli;
 
 import souther.compiler.source.SourceId;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.JvmClassName;
 import souther.compiler.Compiler;
 import souther.compiler.Reserved;
@@ -230,7 +231,8 @@ public final class Main {
         }
         List<Located> warnings = new ArrayList<>();
         try {
-            Map<String, byte[]> classes = compiledClasses(sources, classPath, warnings, measure);
+            Map<String, ClassFileImage> classes =
+                    compiledClasses(sources, classPath, warnings, measure);
             // Before the written files: the warnings are about the source, and a long list of paths
             // between them and the command would bury them.
             report(warnings, sources, render);
@@ -1124,7 +1126,7 @@ public final class Main {
      * the classes are not the output of an accepted compile, and a directory holding them anyway is
      * what a later step would read as if they were.
      */
-    static Map<String, byte[]> compiledClasses(List<Path> sources, List<Path> classPath,
+    static Map<String, ClassFileImage> compiledClasses(List<Path> sources, List<Path> classPath,
                                                List<Located> warningsOut, Adequacy.Asked measure)
             throws IOException {
         List<String> texts = new ArrayList<>();
@@ -1145,12 +1147,13 @@ public final class Main {
     }
 
     /** Writes each class under {@code outDir}, and answers with the paths written, in order. */
-    static List<Path> writeClasses(Map<String, byte[]> classes, Path outDir) throws IOException {
+    static List<Path> writeClasses(Map<String, ClassFileImage> classes, Path outDir)
+            throws IOException {
         List<Path> written = new ArrayList<>();
-        for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> entry : classes.entrySet()) {
             Path file = outDir.resolve(JvmClassName.classFile(entry.getKey()));
             Files.createDirectories(file.getParent());
-            Files.write(file, entry.getValue());
+            Files.write(file, entry.getValue().bytes());
             written.add(file);
         }
         return written;

--- a/souther-cli/src/test/java/souther/cli/ANameIsCanonicalWhereverItEntersTest.java
+++ b/souther-cli/src/test/java/souther/cli/ANameIsCanonicalWhereverItEntersTest.java
@@ -8,6 +8,7 @@ import souther.compiler.frontend.CstFrontend;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -89,7 +90,7 @@ class ANameIsCanonicalWhereverItEntersTest {
 
     @Test
     void theGeneratedClassesAreNamedByTheCanonicalModule() {
-        Map<String, byte[]> classes = Compiler.compile(HEADERLESS, NFD);
+        Map<String, ClassFileImage> classes = Compiler.compile(HEADERLESS, NFD);
         assertTrue(classes.containsKey(NFC + ".Greet"),
                 "generated: " + classes.keySet());
     }

--- a/souther-cli/src/test/java/souther/cli/RunnerTest.java
+++ b/souther-cli/src/test/java/souther/cli/RunnerTest.java
@@ -1,5 +1,7 @@
 package souther.cli;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -177,7 +179,7 @@ class RunnerTest {
      */
     @Test
     void refusesAPipelineWhoseStageIsAnotherModulesInjectedBehavior() throws Exception {
-        java.util.Map<String, byte[]> published = souther.compiler.Compiler.compile("""
+        java.util.Map<String, ClassFileImage> published = souther.compiler.Compiler.compile("""
                 module app.a exposing ( In, Mid, f )
                 data In = { v: Int }
                 data Mid = { v: Int }
@@ -192,7 +194,7 @@ class RunnerTest {
                 """);
         Runner.RunException e = assertThrows(Runner.RunException.class,
                 () -> Runner.run(file, "flow", "{\"v\": 1}", new java.util.ArrayList<>(),
-                        published::get));
+                        souther.compiler.meta.ModulePath.of(published)));
         assertTrue(e.getMessage().contains("no implementation"), e.getMessage());
     }
 

--- a/souther-cli/src/test/java/souther/cli/init/TheGeneratedTestCompilesAgainstTheGeneratedModelTest.java
+++ b/souther-cli/src/test/java/souther/cli/init/TheGeneratedTestCompilesAgainstTheGeneratedModelTest.java
@@ -6,6 +6,7 @@ import souther.compiler.Compiler;
 import souther.compiler.diag.Located;
 import souther.compiler.jvm.JvmClassName;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Adequacy;
 
 import javax.tools.DiagnosticCollector;
@@ -51,7 +52,7 @@ class TheGeneratedTestCompilesAgainstTheGeneratedModelTest {
     }
 
     /** The classes the model compiles to, by binary name. */
-    private static Map<String, byte[]> compiled() {
+    private static Map<String, ClassFileImage> compiled() {
         List<String> texts = Templates.sourcesOf(PROJECT).stream()
                 .filter(file -> file.path().endsWith(".sou"))
                 .map(Templates.File::content)
@@ -76,11 +77,11 @@ class TheGeneratedTestCompilesAgainstTheGeneratedModelTest {
         };
     }
 
-    private static void write(Map<String, byte[]> classes, Path into) throws IOException {
-        for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+    private static void write(Map<String, ClassFileImage> classes, Path into) throws IOException {
+        for (Map.Entry<String, ClassFileImage> entry : classes.entrySet()) {
             Path file = into.resolve(JvmClassName.classFile(entry.getKey()));
             Files.createDirectories(file.getParent());
-            Files.write(file, entry.getValue());
+            Files.write(file, entry.getValue().bytes());
         }
     }
 

--- a/souther-cli/src/test/java/souther/cli/init/TheVersionsAProjectIsGivenAgreeWithThisBuildTest.java
+++ b/souther-cli/src/test/java/souther/cli/init/TheVersionsAProjectIsGivenAgreeWithThisBuildTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.Compiler;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.diag.Located;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Adequacy;
 
 import java.io.InputStream;
@@ -68,10 +69,10 @@ class TheVersionsAProjectIsGivenAgreeWithThisBuildTest {
     @Test
     void theJavaReleaseAProjectDeclaresIsTheOneTheCompilerEmits() {
         List<Located> warnings = new ArrayList<>();
-        Map<String, byte[]> classes = Compiler.compiledModules(
+        Map<String, ClassFileImage> classes = Compiler.compiledModules(
                 List.of("module probe\n\ndata Amount = Int\n    invariant value >= 0\n"),
                 ModulePath.EMPTY, warnings, Adequacy.Asked.NOTHING).classes();
-        byte[] emitted = classes.values().iterator().next();
+        byte[] emitted = classes.values().iterator().next().bytes();
         assertNotNull(emitted);
 
         int major = ((emitted[6] & 0xFF) << 8) | (emitted[7] & 0xFF);

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.source.SourceId;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.JvmClassName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
@@ -35,7 +36,7 @@ public final class Compiler {
     /** Compiles a single self-contained module (no imports) into binary class name → bytecode.
      * A source that omits the {@code module} header is named {@code Main} (the string API has no
      * file name to derive from; {@code souther run} passes the file-name stem instead). */
-    public static Map<String, byte[]> compile(String source) {
+    public static Map<String, ClassFileImage> compile(String source) {
         return compile(source, "Main");
     }
 
@@ -46,7 +47,7 @@ public final class Compiler {
      * @param classes the generated classes, by binary name
      * @param locatedWarnings the warnings, each with the source that holds it
      */
-    public record Compiled(Map<String, byte[]> classes, List<Located> locatedWarnings) {
+    public record Compiled(Map<String, ClassFileImage> classes, List<Located> locatedWarnings) {
 
         /** The warnings on their own, for a caller that only reads what they say. */
         public List<Diagnostic> warnings() {
@@ -63,16 +64,16 @@ public final class Compiler {
      * {@code defaultModuleName} (so the CLI's filename-stem naming can surface warnings too). */
     public static Compiled compileWithWarnings(String source, String defaultModuleName) {
         List<Located> warnings = new ArrayList<>();
-        Map<String, byte[]> classes = compile(source, defaultModuleName, warnings);
+        Map<String, ClassFileImage> classes = compile(source, defaultModuleName, warnings);
         return new Compiled(classes, warnings);
     }
 
     /** As {@link #compile(String)}, but a header-less source is named {@code defaultModuleName}. */
-    public static Map<String, byte[]> compile(String source, String defaultModuleName) {
+    public static Map<String, ClassFileImage> compile(String source, String defaultModuleName) {
         return compile(source, defaultModuleName, new ArrayList<>());
     }
 
-    private static Map<String, byte[]> compile(String source, String defaultModuleName,
+    private static Map<String, ClassFileImage> compile(String source, String defaultModuleName,
                                                List<Located> warningsOut) {
         return compiling(source, defaultModuleName, warningsOut);
     }
@@ -126,7 +127,7 @@ public final class Compiler {
      * with its own position rather than tagged with the file it came from, because there is only
      * the one.
      */
-    private static Map<String, byte[]> compiling(String source, String defaultModuleName,
+    private static Map<String, ClassFileImage> compiling(String source, String defaultModuleName,
                                                  List<Located> warningsOut) {
         return driven(() -> classesOf(compiled(source, defaultModuleName, warningsOut)));
     }
@@ -269,12 +270,12 @@ public final class Compiler {
         });
     }
 
-    private static Map<String, byte[]> classesOf(Compilation compilation) {
+    private static Map<String, ClassFileImage> classesOf(Compilation compilation) {
         return new LinkedHashMap<>(compilation.classes());
     }
 
     /** Compiles a set of modules together, resolving explicit imports and rejecting cycles. */
-    public static Map<String, byte[]> compileModules(List<String> sources) {
+    public static Map<String, ClassFileImage> compileModules(List<String> sources) {
         return compileModules(sources, ModulePath.EMPTY);
     }
 
@@ -284,7 +285,7 @@ public final class Compiler {
      * module found there is read for its declarations and nothing else: its classes are already
      * built, and this compile neither re-emits them nor re-runs its examples.
      */
-    public static Map<String, byte[]> compileModules(List<String> sources, ModulePath path) {
+    public static Map<String, ClassFileImage> compileModules(List<String> sources, ModulePath path) {
         return compileModules(sources, path, new ArrayList<>());
     }
 
@@ -301,7 +302,7 @@ public final class Compiler {
         return new Compiled(compileModules(sources, path, warnings), warnings);
     }
 
-    private static Map<String, byte[]> compileModules(List<String> sources, ModulePath path,
+    private static Map<String, ClassFileImage> compileModules(List<String> sources, ModulePath path,
                                                       List<Located> warningsOut) {
         return linking(sources, path, warningsOut);
     }
@@ -332,7 +333,7 @@ public final class Compiler {
      * collected, and that every module's examples are evaluated before any failing one is reported
      * (issue #114) — so a change to a widely-imported data says how far it reaches in one compile.
      */
-    private static Map<String, byte[]> linking(List<String> sources, ModulePath path,
+    private static Map<String, ClassFileImage> linking(List<String> sources, ModulePath path,
                                                List<Located> warningsOut) {
         return driven(() -> new LinkedHashMap<>(
                 linked(sources, path, warningsOut, Adequacy.Asked.NOTHING).classes()));
@@ -451,10 +452,10 @@ public final class Compiler {
     }
     /** Compiles source and writes each generated class under {@code outDir}. */
     public static void compileToDir(String source, Path outDir) throws IOException {
-        for (Map.Entry<String, byte[]> entry : compile(source).entrySet()) {
+        for (Map.Entry<String, ClassFileImage> entry : compile(source).entrySet()) {
             Path file = outDir.resolve(JvmClassName.classFile(entry.getKey()));
             Files.createDirectories(file.getParent());
-            Files.write(file, entry.getValue());
+            Files.write(file, entry.getValue().bytes());
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -10,6 +10,7 @@ import souther.compiler.diag.Messages;
 import souther.compiler.diag.SourceContext;
 import souther.compiler.diag.SourceContextResolver;
 import souther.compiler.diag.SourceNames;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.Compiler;
 import souther.compiler.query.Compilation;
 import souther.compiler.meta.ModulePath;
@@ -100,12 +101,12 @@ public final class SoutherProcessor extends AbstractProcessor {
             for (String reported : render(compiled.locatedWarnings(), sources)) {
                 processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, reported);
             }
-            Map<String, byte[]> classes = compiled.classes();
+            Map<String, ClassFileImage> classes = compiled.classes();
             Filer filer = processingEnv.getFiler();
-            for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+            for (Map.Entry<String, ClassFileImage> entry : classes.entrySet()) {
                 JavaFileObject file = filer.createClassFile(entry.getKey());
                 try (OutputStream out = file.openOutputStream()) {
-                    out.write(entry.getValue());
+                    out.write(entry.getValue().bytes());
                 }
             }
         } catch (CompileException e) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
@@ -56,7 +56,14 @@ public final class Emissions {
         this.module = module;
     }
 
-    /** That these are still being written, said where the writing is asked for. */
+    /**
+     * That these are still being written, said at every way in.
+     *
+     * <p>What is refused is asking to write, and not a write that turned out to have something in
+     * it. A guard reached only by the loop that writes an entry is a guard a caller handing over
+     * nothing walks past, so what it holds is "one class was written after the sealing" — which is
+     * not the rule. The rule is about the phase this is in, so it is asked of this, once per way in.
+     */
     private void stillOpen(String writing) {
         if (sealed != null) {
             throw new IllegalStateException("the classes of " + module
@@ -110,6 +117,7 @@ public final class Emissions {
     }
 
     void putAll(Map<GeneratedClass, byte[]> classes) {
+        stillOpen("emitting classes");
         classes.forEach(this::put);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
@@ -1,11 +1,13 @@
 package souther.compiler.codegen;
 
 import souther.compiler.generated.GeneratedImplementations;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.JvmClassName;
 import souther.compiler.jvm.SoutherJvmAbi;
 
 import java.lang.classfile.ClassFile;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -24,6 +26,13 @@ import java.util.Set;
  * §no-two-declarations-become-one-class). This says the same thing at the one place both are true of,
  * so a naming scheme changed later cannot bring the silence back.
  *
+ * <p><b>Where the bytes stop being writable.</b> A class is built, instrumented and written onto
+ * here, and all of that is one array being replaced by another. {@link #seal} is where that ends:
+ * what it answers with is the classes as values, and every way of writing refuses afterwards. So the
+ * one boundary between the mutable thing and the value is a call somebody makes, rather than an
+ * order of statements a later stamping step can be appended after — and nothing hands out the map
+ * underneath, because a caller holding that could write past the refusal.
+ *
  * <p>A caller says which {@link GeneratedClass} it is emitting, not what that class is called. The two
  * are not the same question and cannot be one key: {@code BridgeCase("m", a.Foo)} and
  * {@code BridgeCase("m", b.Foo)} are different identities that this ABI spells the same, and keying on
@@ -40,12 +49,25 @@ public final class Emissions {
     /** Which module these were emitted for, so a set with nothing of a kind in it still says whose
      *  it is. */
     private final String module;
+    /** What was handed out, once there is such a thing. */
+    private Map<String, ClassFileImage> sealed;
 
     public Emissions(String module) {
         this.module = module;
     }
 
+    /** That these are still being written, said where the writing is asked for. */
+    private void stillOpen(String writing) {
+        if (sealed != null) {
+            throw new IllegalStateException("the classes of " + module
+                    + " have been handed over as values, so " + writing + " would change what a"
+                    + " reader already holds; everything written onto a class is written before"
+                    + " they are sealed");
+        }
+    }
+
     public void put(GeneratedClass generated, byte[] bytes) {
+        stillOpen("emitting another class");
         JvmClassName name = SoutherJvmAbi.nameOf(generated);
         Emission held = byName.get(name);
         if (held != null) {
@@ -106,6 +128,7 @@ public final class Emissions {
      * never what it is.
      */
     public void rewrite(GeneratedClass generated, java.util.function.UnaryOperator<byte[]> rewriting) {
+        stillOpen("rewriting a class");
         JvmClassName name = SoutherJvmAbi.nameOf(generated);
         Emission held = byName.get(name);
         if (held == null) {
@@ -144,11 +167,25 @@ public final class Emissions {
         return new GeneratedImplementations(module, behaviors);
     }
 
-    /** What the compilation hands on: a class loader and a file path want the binary name, and by
-     *  here every one of them came from the ABI. */
-    public Map<String, byte[]> byBinaryName() {
-        Map<String, byte[]> out = new LinkedHashMap<>();
-        byName.forEach((name, emission) -> out.put(name.binaryName(), emission.bytes()));
-        return out;
+    /**
+     * The classes as values, under the binary name each is emitted as — what the compilation hands
+     * on, and the end of the writing.
+     *
+     * <p>By the binary name because that is what asks for a class: a loader, and a path to write it
+     * at. By here every one of them came from the ABI.
+     *
+     * <p>Built once. Asked a second time this answers with what it answered the first time rather
+     * than reading the arrays again, so what a reader was handed cannot come to differ from what
+     * the next reader is handed — and an array still reachable from somewhere inside cannot reach
+     * either of them.
+     */
+    public Map<String, ClassFileImage> seal() {
+        if (sealed == null) {
+            Map<String, ClassFileImage> out = new LinkedHashMap<>();
+            byName.forEach((name, emission) ->
+                    out.put(name.binaryName(), ClassFileImage.of(emission.bytes())));
+            sealed = Collections.unmodifiableMap(out);
+        }
+        return sealed;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -8,6 +8,7 @@ import souther.compiler.observe.WrittenStatements.UnreadFake;
 import souther.compiler.source.SourceId;
 
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Contract;
 import souther.compiler.check.Sig;
@@ -224,7 +225,8 @@ public final class ExampleStatements {
      * the two answers are compared as the written values they are built into.
      */
     public static Readings disagreements(souther.compiler.check.Prepared.Examples module, Symbols symbols,
-                                         Map<ValueName.Behavior, Sig> sigs, Map<String, byte[]> classes,
+                                         Map<ValueName.Behavior, Sig> sigs,
+                                         Map<String, ClassFileImage> classes,
                                          ClassLoader parent, Map<String, Hir.FnDef> values,
                                          Deadline deadline, EvaluationPolicy policy,
                                          Map<ValueName.Behavior, Contract> contracts,
@@ -316,7 +318,8 @@ public final class ExampleStatements {
      * step.
      */
     public static List<Diagnostic> fakeTables(souther.compiler.check.Prepared.Examples module, Symbols symbols,
-                                              Map<ValueName.Behavior, Sig> sigs, Map<String, byte[]> classes,
+                                              Map<ValueName.Behavior, Sig> sigs,
+                                              Map<String, ClassFileImage> classes,
                                               ClassLoader parent, Map<String, Hir.FnDef> values,
                                               SourceId sourceId,
                                               Deadline deadline, EvaluationPolicy policy,

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -16,6 +16,7 @@ import souther.compiler.check.BoundaryInput;
 import souther.compiler.check.BoundaryOutput;
 import souther.compiler.types.LeafScalar;
 import souther.compiler.types.Type;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.types.TypeSymbol;
@@ -93,7 +94,7 @@ public final class FixtureReader {
 
     /** A way to build values against this module's generated classes, without any rows to run. */
     public static BoundaryValues constructing(souther.compiler.check.Prepared.Examples module, Symbols symbols,
-                                            Map<String, byte[]> classes, ClassLoader parent,
+                                            Map<String, ClassFileImage> classes, ClassLoader parent,
                                             Map<String, Hir.FnDef> values) {
         // A reader is the whole of it. There are no rows, so nothing runs on a worker and no budget is
         // read; what a behavior takes and what stands in for what it depends on are not questions about

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -10,6 +10,7 @@ import souther.compiler.coverage.Probe;
 import souther.compiler.evaluate.EvaluationContext;
 import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +59,8 @@ public final class RowTrial {
      *              search's problem to stop rather than an author's to be told about
      */
     public static RowTrials over(souther.compiler.check.Prepared.Examples module,
-                              Symbols symbols, Map<String, byte[]> classes, ClassLoader parent,
+                              Symbols symbols, Map<String, ClassFileImage> classes,
+                              ClassLoader parent,
                               Map<String, Hir.FnDef> values, GeneratedImplementations generated,
                               EvaluationPolicy steps) {
         MemoryClassLoader loader = new MemoryClassLoader(classes, parent);

--- a/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
@@ -1,5 +1,7 @@
 package souther.compiler.generated;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,10 +27,10 @@ import java.util.Objects;
  * manifest is what a run needs — and one covering every linked module would be answering for
  * behaviors no answerer here is asked about.
  *
- * @param classes         binary name to bytecode, for this module and the ones its rows reach
+ * @param classes         binary name to class file, for this module and the ones its rows reach
  * @param implementations what the module being evaluated generated an implementation for
  */
-public record EvaluationArtifact(Map<String, byte[]> classes,
+public record EvaluationArtifact(Map<String, ClassFileImage> classes,
                                  GeneratedImplementations implementations) {
 
     public EvaluationArtifact {

--- a/souther-compiler/src/main/java/souther/compiler/generated/MemoryClassLoader.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/MemoryClassLoader.java
@@ -1,23 +1,29 @@
 package souther.compiler.generated;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * Loads freshly generated classes from an in-memory binary-name → bytecode map, delegating anything
- * unknown to the parent loader. Used to run generated code without writing {@code .class} files:
- * the compiler's compile-time {@code $Ctfe.check} evaluation, the rows an {@code example} states,
- * and the behavior {@code souther run} drives. None of the three is the reason it exists — it is
- * how a compilation's classes become classes at all.
+ * Loads freshly generated classes from an in-memory binary-name → class-file map, delegating
+ * anything unknown to the parent loader. Used to run generated code without writing {@code .class}
+ * files: the compiler's compile-time {@code $Ctfe.check} evaluation, the rows an {@code example}
+ * states, and the behavior {@code souther run} drives. None of the three is the reason it exists —
+ * it is how a compilation's classes become classes at all.
+ *
+ * <p>Holds the classes as what they are and asks for their octets where the JVM is handed them. A
+ * loader keeping a map of arrays would be the compilation's classes back in a form anything holding
+ * the map could write into, for as long as the loader lives — which is longer than any of them.
  */
 public final class MemoryClassLoader extends ClassLoader {
 
-    private final Map<String, byte[]> classes;
+    private final Map<String, ClassFileImage> classes;
     /** Classes defined on the fly (a multi-argument fake's base subclass; issue #57), cached so a name
      * is never defined twice — which would be a {@code LinkageError}. */
     private final Map<String, Class<?>> defined = new java.util.concurrent.ConcurrentHashMap<>();
 
-    public MemoryClassLoader(Map<String, byte[]> classes, ClassLoader parent) {
+    public MemoryClassLoader(Map<String, ClassFileImage> classes, ClassLoader parent) {
         super(parent);
         this.classes = classes;
     }
@@ -61,10 +67,11 @@ public final class MemoryClassLoader extends ClassLoader {
         if (onTheFly != null) {
             return onTheFly;
         }
-        byte[] b = classes.get(name);
-        if (b == null) {
+        ClassFileImage image = classes.get(name);
+        if (image == null) {
             throw new ClassNotFoundException(name);
         }
+        byte[] b = image.bytes();
         return defineClass(name, b, 0, b.length);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/jvm/ClassFileImage.java
+++ b/souther-compiler/src/main/java/souther/compiler/jvm/ClassFileImage.java
@@ -1,0 +1,79 @@
+package souther.compiler.jvm;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * A class file this compilation produced, held as what its bytes say rather than as which array they
+ * arrived in.
+ *
+ * <p>Every question that answers with a module's classes answers with these. A class file is its
+ * bytes: two compiles that emitted the same class emitted the same thing, and what lets a store stop
+ * work when a module comes out the same is holding them as something that says so. An array says
+ * which array it is however its elements compare, so an answer holding one can never equal its own
+ * recomputation — and a wrapper with an array inside is that same place one member further down.
+ *
+ * <p><b>Why the bytes are carried as a string.</b> Three things are wanted at once: the language has
+ * to settle what one of these means, the carrier has to be immutable, and the round trip has to be
+ * exact. ISO-8859-1 maps all 256 octets onto U+0000&ndash;U+00FF and back, one for one, so a string
+ * built this way holds the bytes and nothing else. What that buys is a value whose equality is every
+ * octet — not a digest, so nothing here rests on two different class files being unable to collide.
+ * How much room it takes is the runtime's business and no part of why it is written this way.
+ *
+ * <p>Copied on the way in and on the way out. A caller that goes on writing into the array it handed
+ * over does not change what this holds, and one that writes into the array it is given changes
+ * nothing but its own copy. That is what a value is, and it is what the {@code byte[]} this replaces
+ * never was: a module's classes were handed to every reader as arrays anyone could write into.
+ *
+ * <p>Named for what it is and not {@code ClassFile}, which is what the language calls the API that
+ * reads and writes one ({@link java.lang.classfile.ClassFile}). That one is a way of parsing bytes;
+ * this one is the bytes.
+ */
+public final class ClassFileImage {
+
+    /** The octets, one per character. */
+    private final String contents;
+
+    private ClassFileImage(String contents) {
+        this.contents = contents;
+    }
+
+    /** The class file in {@code bytes}, which this takes a copy of. */
+    public static ClassFileImage of(byte[] bytes) {
+        Objects.requireNonNull(bytes, "a class file is its bytes");
+        return new ClassFileImage(new String(bytes, StandardCharsets.ISO_8859_1));
+    }
+
+    /**
+     * The bytes, as a fresh array each time.
+     *
+     * <p>For handing to something that takes octets and nothing else — {@code defineClass}, a file,
+     * an archive. A reader that keeps what comes back is keeping an array again, which is the whole
+     * of what this type exists to stop; what is kept is one of these.
+     */
+    public byte[] bytes() {
+        return contents.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    /** How many bytes the class file is. */
+    public int size() {
+        return contents.length();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof ClassFileImage that && contents.equals(that.contents);
+    }
+
+    @Override
+    public int hashCode() {
+        return contents.hashCode();
+    }
+
+    /** What it is and how big, without the bytes: nothing reads a class file by looking at it. */
+    @Override
+    public String toString() {
+        return "a class file of " + contents.length() + " bytes";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
@@ -1,11 +1,13 @@
 package souther.compiler.meta;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.JvmClassName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -51,6 +53,32 @@ public interface ModulePath {
      * open between reads, so a path can be built as often as a compile is run. */
     static ModulePath ofClassPath(List<Path> entries) {
         return new ClassPath(List.copyOf(entries));
+    }
+
+    /**
+     * A path over class files already in hand — what another compile came to, without writing them
+     * anywhere.
+     *
+     * <p>Here rather than at each caller for the reason {@link ClassPath} is a record: two paths
+     * over the same classes are the same path, and a caller writing the lookup itself hands over
+     * something that is a new path every time it is built.
+     */
+    static ModulePath of(Map<String, ClassFileImage> classes) {
+        return new Held(classes);
+    }
+
+    /** A path over class files in hand, by the binary name each is under. */
+    record Held(Map<String, ClassFileImage> classes) implements ModulePath {
+
+        public Held {
+            classes = Map.copyOf(classes);
+        }
+
+        @Override
+        public byte[] bytes(String binaryName) {
+            ClassFileImage image = classes.get(binaryName);
+            return image == null ? null : image.bytes();
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -16,6 +16,7 @@ import souther.compiler.diag.Primary;
 import souther.compiler.diag.ReportContext;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.diag.WhereCodeIsWritten;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public final class Compilation {
     /** The loader over the classes as they were when it was made, and those classes — held so that
      *  {@link #loader()} can tell whether the one it has is still a loader over what there is. */
     private ClassLoader loader;
-    private Map<String, byte[]> loadedClasses;
+    private Map<String, ClassFileImage> loadedClasses;
 
     private Compilation() {
         // Read now, so this compilation is held to what the settings said when it started rather than
@@ -215,8 +216,8 @@ public final class Compilation {
     }
 
     /** Every class this compilation generated. */
-    public Map<String, byte[]> classes() {
-        Map<String, byte[]> all = db.ask(new Output.All()).value();
+    public Map<String, ClassFileImage> classes() {
+        Map<String, ClassFileImage> all = db.ask(new Output.All()).value();
         return all == null ? Map.of() : all;
     }
 
@@ -241,15 +242,25 @@ public final class Compilation {
      * loader that is kept and not one layer of it.
      *
      * <p>Kept against the classes rather than for the life of this compilation, because an edit
-     * makes a different program. {@link #classes()} answers with the map it answered with before
-     * until something a generation reads changes, and with a new one after, so this follows that
-     * answer rather than deciding for itself when a compilation is settled — which it never has to
-     * be, nothing here running until something asks. A loader held across an edit would be one that
-     * cannot see it, which is the first fault the other way round.
+     * makes a different program. A loader held across an edit would be one that cannot see it,
+     * which is the first fault the other way round.
+     *
+     * <p><b>Same classes means the same class files, not the same map.</b> An edit that recompiles
+     * a module to what it already was leaves a program nothing about has changed, and a loader made
+     * afresh over it would divide every type in it from the values already made under the first —
+     * which is this method's whole fault, reached by a route nobody edited anything to reach.
+     * Asking the map by which object it is would answer that question with where the answer came
+     * from, which is the mistake {@link ClassFileImage} exists to stop one level down. Being the
+     * same map is a shortcut and never the reason.
+     *
+     * <p>What decides this is the classes and nothing else, because a compilation's module path is
+     * settled where it is made and never after. Were one ever able to be given another path, its
+     * parent loader would move under classes that had not, and what a loader is kept against would
+     * have to be the two of them together.
      */
     public ClassLoader loader() {
-        Map<String, byte[]> classes = classes();
-        if (loader == null || loadedClasses != classes) {
+        Map<String, ClassFileImage> classes = classes();
+        if (loader == null || !(loadedClasses == classes || loadedClasses.equals(classes))) {
             // Built before either field is written, so a build that threw leaves this holding what it
             // held before rather than the classes it did not manage to make a loader for. Recording
             // them first would leave the two saying different things, and the next ask would read

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -56,10 +56,9 @@ public final class Compilation {
     private final Map<SourceId, Integer> indexOfId = new LinkedHashMap<>();
     /** The sources this compilation currently has, so one that goes away can be forgotten. */
     private final Set<SourceId> held = new LinkedHashSet<>();
-    /** The loader over the classes as they were when it was made, and those classes — held so that
-     *  {@link #loader()} can tell whether the one it has is still a loader over what there is. */
-    private ClassLoader loader;
-    private Map<String, ClassFileImage> loadedClasses;
+    /** The loader over the classes as they were when it was made, which says for itself whether the
+     *  one it has is still a loader over what there is. */
+    private final LoaderOverClasses loader = new LoaderOverClasses();
 
     private Compilation() {
         // Read now, so this compilation is held to what the settings said when it started rather than
@@ -245,32 +244,20 @@ public final class Compilation {
      * makes a different program. A loader held across an edit would be one that cannot see it,
      * which is the first fault the other way round.
      *
-     * <p><b>Same classes means the same class files, not the same map.</b> An edit that recompiles
-     * a module to what it already was leaves a program nothing about has changed, and a loader made
-     * afresh over it would divide every type in it from the values already made under the first —
-     * which is this method's whole fault, reached by a route nobody edited anything to reach.
-     * Asking the map by which object it is would answer that question with where the answer came
-     * from, which is the mistake {@link ClassFileImage} exists to stop one level down. Being the
-     * same map is a shortcut and never the reason.
+     * <p>Whether it still has one is {@link LoaderOverClasses}'s, which is where what "the same
+     * classes" means is written and what is held to it. Not a condition here: a rule inside the
+     * method that hands out a loader can only be reached through whatever produces two class sets,
+     * and the one that matters — a module built again to what it already was — is the one no
+     * ordinary edit reaches.
      *
-     * <p>What decides this is the classes and nothing else, because a compilation's module path is
+     * <p>What decides it is the classes and nothing else, because a compilation's module path is
      * settled where it is made and never after. Were one ever able to be given another path, its
      * parent loader would move under classes that had not, and what a loader is kept against would
      * have to be the two of them together.
      */
     public ClassLoader loader() {
         Map<String, ClassFileImage> classes = classes();
-        if (loader == null || !(loadedClasses == classes || loadedClasses.equals(classes))) {
-            // Built before either field is written, so a build that threw leaves this holding what it
-            // held before rather than the classes it did not manage to make a loader for. Recording
-            // them first would leave the two saying different things, and the next ask would read
-            // that as a loader it already has — handing out the one from before the edit, which is
-            // this whole method's fault with an exception in front of it.
-            ClassLoader built = Output.loader(db, classes);
-            loadedClasses = classes;
-            loader = built;
-        }
-        return loader;
+        return loader.of(classes, () -> Output.loader(db, classes));
     }
 
     /** A module as everything below the check reads it — derived, desugared, and carrying the

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -39,11 +39,12 @@ import java.util.Set;
  * builds against what a module declares, not against its bodies. Both are maps of records, and
  * {@code IncrementalCompilationTest} pins both.
  *
- * <p>It does not hold everywhere. A module's classes are a {@code Map<String, byte[]>}, and arrays
- * compare by identity, so regenerating them always counts as a change — and every module's examples
- * read every module's classes. Comparing the bytes would not help: after a real edit they differ.
- * What would is for an example to depend on the classes it reaches rather than on all of them,
- * which is per-definition work and not here.
+ * <p>A module's classes carry it too. Each is a {@link souther.compiler.jvm.ClassFileImage}, which
+ * is what its bytes say, so a module regenerated to what it already was leaves the examples that
+ * load it alone. What that does not reach is an example of one module and an edit to another it
+ * merely imports: the classes it is run against are the ones its module reaches, so they change
+ * when any of those does. Narrowing that to the classes an example actually loads is per-definition
+ * work and is not here.
  *
  * <p>Two rules run through the rest of them, and an answer can break either one.
  *

--- a/souther-compiler/src/main/java/souther/compiler/query/LoaderOverClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/LoaderOverClasses.java
@@ -1,0 +1,66 @@
+package souther.compiler.query;
+
+import souther.compiler.jvm.ClassFileImage;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * The loader over one set of class files, kept for as long as those are the class files.
+ *
+ * <p>A class is its binary name and the loader that defined it, so two loaders over one program are
+ * two definitions of every type in it, and a value made under the first is not a value of the
+ * second's. What that looks like is not an exception: a decoded key stops equalling the key a
+ * behavior looks up, the lookup misses, and the behavior answers with its default — a correct model
+ * reported as one whose example does not hold.
+ *
+ * <p><b>Which classes there are is asked by what they say.</b> A generation that ran again and came
+ * to the same class files is the same program, and a loader made afresh over it would divide the
+ * types of a program nothing about had changed. Being the same map is a shortcut past the
+ * comparison and never the reason for the answer — asking which object the map is would answer a
+ * question about a program with where the answer came from, which is the mistake
+ * {@link ClassFileImage} exists to stop one level down.
+ *
+ * <p><b>A thing of its own rather than a condition inside whoever caches.</b> Written as a branch in
+ * the method that hands out a loader, the rule can only be reached by whatever produces two class
+ * sets, and a rule nothing can ask on its own is one nothing can be held to on its own: the branch
+ * that keeps a loader over classes that were built again is exactly the one no ordinary edit
+ * reaches. Here it is a unit two class sets can be handed.
+ */
+final class LoaderOverClasses {
+
+    /** The classes the loader below was made over, or null where there is no loader yet. */
+    private Map<String, ClassFileImage> over;
+    private ClassLoader loader;
+
+    /**
+     * The loader over {@code classes}: the one already held where those are still the classes, and
+     * otherwise one {@code build} makes.
+     *
+     * <p>Built before either field is written, so a build that raised leaves this holding what it
+     * held rather than classes it did not manage to make a loader for. Recording them first would
+     * leave the two saying different things, and the next ask would read that as a loader it
+     * already has — handing out the one from before the edit.
+     */
+    ClassLoader of(Map<String, ClassFileImage> classes, Supplier<ClassLoader> build) {
+        if (loader != null && theSameClasses(over, classes)) {
+            return loader;
+        }
+        ClassLoader built = build.get();
+        over = classes;
+        loader = built;
+        return built;
+    }
+
+    /**
+     * Whether these are the same classes, which is whether they are the same class files.
+     *
+     * <p>The identity is asked first and is an answer to nothing: two names for one map are the
+     * same classes, and it saves comparing what the map holds. Two maps that hold the same class
+     * files are the same classes just as much.
+     */
+    static boolean theSameClasses(Map<String, ClassFileImage> one,
+                                  Map<String, ClassFileImage> other) {
+        return one == other || (one != null && one.equals(other));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -32,6 +32,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.frontend.CstFrontend;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.ModuleMetadata;
 import souther.compiler.meta.ModulePath;
@@ -65,14 +66,14 @@ public final class Output {
      * One module's classes, with its declarations stamped on. The declarations go on before anything
      * loads a class, so what a jar carries is the same bytes this compile checked.
      */
-    public record Classes(String name) implements Key<Map<String, byte[]>> {
+    public record Classes(String name) implements Key<Map<String, ClassFileImage>> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Map<String, byte[]>> compute(Db db) {
+        public Answer<Map<String, ClassFileImage>> compute(Db db) {
             Inputs in = inputs(db, name);
             if (in == null) {
                 return Answer.absent();
@@ -85,7 +86,7 @@ public final class Output {
                         in.callees(), in.requirements(), in.checked(), in.compositions(),
                         in.dischargeClauses(), in.shapes(), in.checks(), in.standingCalls());
                 stamp(db, emitted);
-                return Answer.of(Ordered.map(emitted.byBinaryName()));
+                return Answer.of(emitted.seal());
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -245,16 +246,16 @@ public final class Output {
      * what makes an example of a module that reaches it fail to load rather than run against
      * something that was never checked.
      */
-    public record All() implements Key<Map<String, byte[]>> {
+    public record All() implements Key<Map<String, ClassFileImage>> {
         @Override
-        public Answer<Map<String, byte[]>> compute(Db db) {
+        public Answer<Map<String, ClassFileImage>> compute(Db db) {
             List<String> declared = db.ask(new Front.Declared()).value();
-            Map<String, byte[]> all = new LinkedHashMap<>();
+            Map<String, ClassFileImage> all = new LinkedHashMap<>();
             if (declared == null) {
                 return Answer.of(Map.of());
             }
             for (String name : declared) {
-                Map<String, byte[]> classes = db.ask(new Classes(name)).value();
+                Map<String, ClassFileImage> classes = db.ask(new Classes(name)).value();
                 if (classes != null) {
                     all.putAll(classes);
                 }
@@ -305,29 +306,28 @@ public final class Output {
      * The classes an evaluation of one module's code loads: its own, and those of every module it
      * reaches.
      *
-     * <p>Not {@link All}. A module's classes are a map of arrays, and arrays compare by identity, so
-     * regenerating a module always counts as a change — and a key that read every module's classes
-     * would be recomputed by an edit anywhere in the workspace, however far from it. Reading only
-     * what it reaches is what keeps an edit to one module from re-running the examples of every
-     * other one.
+     * <p>Not {@link All}. What a module comes out as changes whenever anything its generation reads
+     * changes, and {@link All} reads every module's — so a key built on it is recomputed by an edit
+     * anywhere in the workspace, however far from what the edit was about. Reading only what it
+     * reaches is what keeps an edit to one module from re-running the examples of every other one.
      */
-    public record Linked(String name) implements Key<Map<String, byte[]>> {
+    public record Linked(String name) implements Key<Map<String, ClassFileImage>> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Map<String, byte[]>> compute(Db db) {
+        public Answer<Map<String, ClassFileImage>> compute(Db db) {
             List<String> reaches = db.ask(new Reaches(name)).value();
             if (reaches == null) {
                 return Answer.of(Map.of());
             }
-            Map<String, byte[]> linked = new LinkedHashMap<>();
+            Map<String, ClassFileImage> linked = new LinkedHashMap<>();
             // Furthest first, so the module being evaluated is put on last: a name two of them
             // generate is the near one's, which is the order All puts them in as well.
             for (int i = reaches.size() - 1; i >= 0; i--) {
-                Map<String, byte[]> classes = db.ask(new Classes(reaches.get(i))).value();
+                Map<String, ClassFileImage> classes = db.ask(new Classes(reaches.get(i))).value();
                 if (classes != null) {
                     linked.putAll(classes);
                 }
@@ -383,8 +383,7 @@ public final class Output {
                         instrumentation);
                 Classes.stamp(db, name, emitted);
                 // The classes and what they implement, from the one emission that decided both.
-                return Answer.of(new EvaluationArtifact(Ordered.map(emitted.byBinaryName()),
-                        emitted.implemented()));
+                return Answer.of(new EvaluationArtifact(emitted.seal(), emitted.implemented()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             } catch (IllegalStateException _) {
@@ -439,7 +438,7 @@ public final class Output {
                 return Answer.absent();
             }
             Front.Layout.Of layout = db.ask(new Front.Layout()).value();
-            Map<String, byte[]> linked = new LinkedHashMap<>();
+            Map<String, ClassFileImage> linked = new LinkedHashMap<>();
             GeneratedImplementations implemented = null;
             // Furthest first, so the module being evaluated is put on last, as Linked does.
             for (int i = reaches.size() - 1; i >= 0; i--) {
@@ -481,7 +480,7 @@ public final class Output {
 
     /** The class loader compile-time code runs against: this compilation's classes over the ones the
      * projects it depends on already built. */
-    static ClassLoader loader(Db db, Map<String, byte[]> classes) {
+    static ClassLoader loader(Db db, Map<String, ClassFileImage> classes) {
         ModulePath path = db.ask(new Front.Path()).value();
         ClassLoader parent = path == null ? Output.class.getClassLoader()
                 : path.loader(Output.class.getClassLoader());
@@ -501,14 +500,14 @@ public final class Output {
      * the same name on the path.
      */
     public static ClassFileDeclarations declarationsRead(Db db) {
-        Map<String, byte[]> generated = db.ask(new All()).value();
+        Map<String, ClassFileImage> generated = db.ask(new All()).value();
         ModulePath path = db.ask(new Front.Path()).value();
         return new ClassFileDeclarations(binaryName -> {
-            byte[] here = generated == null ? null : generated.get(binaryName);
-            if (here != null || path == null) {
-                return here;
+            ClassFileImage here = generated == null ? null : generated.get(binaryName);
+            if (here != null) {
+                return here.bytes();
             }
-            return path.bytes(binaryName);
+            return path == null ? null : path.bytes(binaryName);
         });
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/QueryJvmProgramImages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/QueryJvmProgramImages.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.execute.jvm.JvmProgramImage;
 import souther.compiler.execute.jvm.JvmProgramImages;
 import souther.compiler.generated.EvaluationArtifact;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.observe.ArmObservation;
 
 import java.util.Map;
@@ -29,7 +30,7 @@ final class QueryJvmProgramImages implements JvmProgramImages {
 
     @Override
     public ClassLoader compileTimeLoader(String module) {
-        Map<String, byte[]> classes = db.ask(new Output.Linked(module)).value();
+        Map<String, ClassFileImage> classes = db.ask(new Output.Linked(module)).value();
         return classes == null ? null : Output.loader(db, classes);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ABehaviorNobodyHasWrittenYetIsNotAnInjectionTargetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABehaviorNobodyHasWrittenYetIsNotAnInjectionTargetTest.java
@@ -9,6 +9,7 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Shapes;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.report.AdequacyReport;
 
 import java.lang.classfile.ClassFile;
@@ -77,11 +78,12 @@ class ABehaviorNobodyHasWrittenYetIsNotAnInjectionTargetTest {
      */
     @Test
     void nothingIsEmittedForJavaToExtend() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(OWED));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(OWED));
 
         assertFalse(classes.containsKey(Emitted.impl("example.owed", "outer")),
                 "no implementation was written, so none is emitted");
-        var outer = ClassFile.of().parse(classes.get(Emitted.behaviorInterface("example.owed", "outer")));
+        var outer = ClassFile.of()
+                .parse(classes.get(Emitted.behaviorInterface("example.owed", "outer")).bytes());
         assertTrue(outer.flags().has(java.lang.reflect.AccessFlag.INTERFACE),
                 "an unwritten behavior is not an abstract base a Java implementation extends");
     }

--- a/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
@@ -2,6 +2,8 @@ package souther.compiler;
 
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Severity;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
 
@@ -273,8 +275,9 @@ class ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest {
 
     /** The consumer compiled on its own, against the library's classes and none of its source. */
     private static List<Diagnostic> unprovenAgainst(String consumer, String library) {
-        Map<String, byte[]> classes = Compiler.compile(library);
-        return Compiler.compileModulesWithWarnings(List.of(consumer), classes::get).warnings()
+        Map<String, ClassFileImage> classes = Compiler.compile(library);
+        return Compiler.compileModulesWithWarnings(List.of(consumer), ModulePath.of(classes))
+                .warnings()
                 .stream().filter(d -> d.severity() == Severity.WARNING)
                 .filter(d -> d.code().equals("E2011")).toList();
     }

--- a/souther-compiler/src/test/java/souther/compiler/ACompilationAnswersWithOneLoaderForItsClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACompilationAnswersWithOneLoaderForItsClassesTest.java
@@ -8,6 +8,7 @@ import souther.compiler.generated.GeneratedBehavior;
 import souther.compiler.generated.JsonBoundary;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Adequacy;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Compilation;
 
 import tools.jackson.databind.json.JsonMapper;
@@ -108,6 +109,10 @@ final class ACompilationAnswersWithOneLoaderForItsClassesTest {
      * deciding what changed, and either is right here: what may not happen is a loader that is not
      * over what {@link Compilation#classes()} now answers, or a second one over classes that never
      * moved.
+     *
+     * <p>Never moved by what they say. A generation that ran a second time and came to the same
+     * class files answers with a map that was built again, and the program is the one that was
+     * already loaded.
      */
     @Test
     void itStandsExactlyWhileTheClassesDo() {
@@ -115,7 +120,7 @@ final class ACompilationAnswersWithOneLoaderForItsClassesTest {
         for (boolean lookingInBetween : new boolean[] {true, false}) {
             Compilation compilation = Compilation.ofDocuments(
                     Map.of("a.sou", SOURCE), Set.of(), ModulePath.EMPTY);
-            Map<String, byte[]> classes = compilation.classes();
+            Map<String, ClassFileImage> classes = compilation.classes();
             ClassLoader loader = compilation.loader();
 
             compilation.update(Map.of("a.sou", edited), Set.of());
@@ -129,13 +134,19 @@ final class ACompilationAnswersWithOneLoaderForItsClassesTest {
         }
     }
 
-    /** Asserts the rule at one step and answers with the classes as they now are. */
-    private static Map<String, byte[]> sameOrNot(Compilation compilation,
-                                                 Map<String, byte[]> classesBefore,
+    /**
+     * Asserts the rule at one step and answers with the classes as they now are.
+     *
+     * <p>Which classes there are is asked by what they say and not by which map they came back in. A
+     * generation that ran again and came to the same class files is the same program, and a loader
+     * replaced over it would divide the types of a program nothing about had changed.
+     */
+    private static Map<String, ClassFileImage> sameOrNot(Compilation compilation,
+                                                 Map<String, ClassFileImage> classesBefore,
                                                  ClassLoader loaderBefore, String step) {
-        Map<String, byte[]> classesNow = compilation.classes();
+        Map<String, ClassFileImage> classesNow = compilation.classes();
         ClassLoader loaderNow = compilation.loader();
-        assertEquals(classesBefore == classesNow, loaderBefore == loaderNow,
+        assertEquals(classesBefore.equals(classesNow), loaderBefore == loaderNow,
                 "the loader stands exactly while the classes do, after " + step);
         return classesNow;
     }

--- a/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
@@ -10,6 +10,7 @@ import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.Counting;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.util.List;
@@ -51,8 +52,8 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
             """;
 
     private static ModulePath published() {
-        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
-        return classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(PUBLISHED);
+        return ModulePath.of(classes);
     }
 
     private static RowOutcome onlyRowOf(String source, EvaluationPolicy policy) {
@@ -127,7 +128,7 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
      */
     @Test
     void aBehaviorBodyThatStaysInTheJarIsCountedToo() {
-        Map<String, byte[]> jar = Compiler.compile("""
+        Map<String, ClassFileImage> jar = Compiler.compile("""
                 module lib.svc exposing ( Amount, spin )
 
                 data Amount = Int
@@ -152,7 +153,7 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
 
                 example bill
                   | "reaches the dependency body": (Amount(1)) -> Receipt { total = Amount(0) }
-                """), jar::get);
+                """), ModulePath.of(jar));
         compilation.withEvaluationPolicy(EvaluationPolicy.of(50_000L));
         compilation.answerEverything();
 

--- a/souther-compiler/src/test/java/souther/compiler/AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourceContext;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -182,7 +183,7 @@ class AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest {
         return sb.toString();
     }
 
-    private void loadAll(Map<String, byte[]> classes) throws Exception {
+    private void loadAll(Map<String, ClassFileImage> classes) throws Exception {
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         for (String name : classes.keySet()) {
             // getDeclaredMethods is what forces the descriptors to be parsed; the methods

--- a/souther-compiler/src/test/java/souther/compiler/ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest.java
@@ -12,6 +12,8 @@ import souther.compiler.diag.Located;
 import souther.compiler.diag.SourceContext;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Db;
 
 import org.junit.jupiter.api.Test;
@@ -129,7 +131,7 @@ class ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest {
     @Test
     void twoClausesOfOneModuleOutOfSightAreSaidOnce() {
         Compilation c = Compilation.ofSources(List.of(CONSTRUCTING),
-                Compiler.compile(DECLARING_TWO)::get);
+                ModulePath.of(Compiler.compile(DECLARING_TWO)));
         c.answerEverything();
         Diagnostic d = theWarning(c);
 
@@ -187,14 +189,14 @@ class ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest {
     // --- the fixtures ---------------------------------------------------------------------------
 
     private static Compilation offThePath() {
-        Map<String, byte[]> path = Compiler.compile(DECLARING);
-        Compilation c = Compilation.ofSources(List.of(CONSTRUCTING), path::get);
+        Map<String, ClassFileImage> path = Compiler.compile(DECLARING);
+        Compilation c = Compilation.ofSources(List.of(CONSTRUCTING), ModulePath.of(path));
         c.answerEverything();
         return c;
     }
 
     private static Compilation inOneCompile() {
-        Compilation c = Compilation.ofSources(List.of(IN_ONE_COMPILE), Map.<String, byte[]>of()::get);
+        Compilation c = Compilation.ofSources(List.of(IN_ONE_COMPILE), ModulePath.EMPTY);
         c.answerEverything();
         return c;
     }

--- a/souther-compiler/src/test/java/souther/compiler/AModuleIsNamedByOneRuleWhicheverWayItIsNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleIsNamedByOneRuleWhicheverWayItIsNamedTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ class AModuleIsNamedByOneRuleWhicheverWayItIsNamedTest {
 
     /** The behavior lands in the package the module was named, whichever way it was named. */
     private static void emitsCalcUnder(String module) {
-        Map<String, byte[]> classes = Compiler.compile(HEADERLESS, module);
+        Map<String, ClassFileImage> classes = Compiler.compile(HEADERLESS, module);
         assertTrue(classes.containsKey(Emitted.impl(module, "calc")), classes.keySet().toString());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -17,6 +17,8 @@ import souther.compiler.query.Db;
 import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.diag.Primary;
 import souther.compiler.diag.WhereCodeIsWritten;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.ModuleReadback;
 
 import org.junit.jupiter.api.Test;
@@ -47,25 +49,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
 
     /** A module compiled against {@code path}, as its own project's build produced it. */
-    private static Map<String, byte[]> built(String source, Map<String, byte[]> path) {
-        return Compiler.compileModules(List.of(source), path::get);
+    private static Map<String, ClassFileImage> built(String source, Map<String, ClassFileImage> path) {
+        return Compiler.compileModules(List.of(source), ModulePath.of(path));
     }
 
-    private static Map<String, byte[]> and(Map<String, byte[]> one, Map<String, byte[]> other) {
-        Map<String, byte[]> both = new java.util.LinkedHashMap<>(one);
+    private static Map<String, ClassFileImage> and(Map<String, ClassFileImage> one, Map<String, ClassFileImage> other) {
+        Map<String, ClassFileImage> both = new java.util.LinkedHashMap<>(one);
         both.putAll(other);
         return both;
     }
 
-    private static Compilation reading(String source, Map<String, byte[]> path) {
-        Compilation compilation = Compilation.ofSources(List.of(source), path::get);
+    private static Compilation reading(String source, Map<String, ClassFileImage> path) {
+        Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.of(path));
         compilation.answerEverything();
         return compilation;
     }
 
     /** A module holding one thing out of another, as its own project's build produced it. */
-    private static Map<String, byte[]> holding(String name, String type, String from,
-                                               String imported, Map<String, byte[]> path) {
+    private static Map<String, ClassFileImage> holding(String name, String type, String from,
+                                               String imported, Map<String, ClassFileImage> path) {
         return built("""
                 module %s exposing ( %s )
                 import %s ( %s )
@@ -75,7 +77,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
     }
 
     /** The classes of {@code lib.deep}, which every path here leaves out. */
-    private static Map<String, byte[]> deep() {
+    private static Map<String, ClassFileImage> deep() {
         return Compiler.compile("""
                 module lib.deep exposing ( Deep )
                 data Deep = String
@@ -83,7 +85,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
     }
 
     /** The declaring project's build of {@code lib.held}, which needs {@code lib.deep}. */
-    private static Map<String, byte[]> held() {
+    private static Map<String, ClassFileImage> held() {
         return built("""
                 module lib.held exposing ( Held )
                 import lib.deep ( Deep )
@@ -142,8 +144,8 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
      */
     @Test
     void oneReachedThroughAnotherIsSaidAtTheImportThatLedThere() {
-        Map<String, byte[]> held = held();
-        Map<String, byte[]> front = built("""
+        Map<String, ClassFileImage> held = held();
+        Map<String, ClassFileImage> front = built("""
                 module lib.front exposing ( Front )
                 import lib.held ( Held )
 
@@ -230,7 +232,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 import lib.held ( Held )
 
                 data B = { held: Held }
-                """), held()::get);
+                """), ModulePath.of(held()));
         compilation.answerEverything();
 
         Map<SourceId, List<Located>> byId = compilation.diagnostics();
@@ -250,13 +252,13 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
      */
     @Test
     void aRouteFoundAfterTheModuleWasReadCountsToo() {
-        Map<String, byte[]> shared = built("""
+        Map<String, ClassFileImage> shared = built("""
                 module lib.shared exposing ( Shared )
                 import lib.deep ( Deep )
 
                 data Shared = { deep: Deep }
                 """, deep());
-        Map<String, byte[]> between = built("""
+        Map<String, ClassFileImage> between = built("""
                 module lib.between exposing ( Between )
                 import lib.shared ( Shared )
 
@@ -273,7 +275,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 import lib.between ( Between )
 
                 data B = { between: Between }
-                """), and(shared, between)::get);
+                """), ModulePath.of(and(shared, between)));
         compilation.answerEverything();
 
         Map<SourceId, List<Located>> byId = compilation.diagnostics();
@@ -292,16 +294,16 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
      */
     @Test
     void routesOfDifferentLengthsBothReachWhatTheyMeetOver() {
-        Map<String, byte[]> leaf = Compiler.compile("""
+        Map<String, ClassFileImage> leaf = Compiler.compile("""
                 module lib.leaf exposing ( Leaf )
                 data Leaf = String
                 """);
-        Map<String, byte[]> meeting = holding("lib.meeting", "Meeting", "lib.leaf", "Leaf", leaf);
-        Map<String, byte[]> shortWay = holding("lib.short", "Short", "lib.meeting", "Meeting",
+        Map<String, ClassFileImage> meeting = holding("lib.meeting", "Meeting", "lib.leaf", "Leaf", leaf);
+        Map<String, ClassFileImage> shortWay = holding("lib.short", "Short", "lib.meeting", "Meeting",
                 and(meeting, leaf));
-        Map<String, byte[]> middle = holding("lib.middle", "Middle", "lib.meeting", "Meeting",
+        Map<String, ClassFileImage> middle = holding("lib.middle", "Middle", "lib.meeting", "Meeting",
                 and(meeting, leaf));
-        Map<String, byte[]> longWay = holding("lib.long", "Long", "lib.middle", "Middle",
+        Map<String, ClassFileImage> longWay = holding("lib.long", "Long", "lib.middle", "Middle",
                 and(middle, and(meeting, leaf)));
 
         // everything but the leaf, so what is missing is under the module the two routes meet at
@@ -315,7 +317,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 import lib.long ( Long )
 
                 data B = { x: Long }
-                """), and(and(meeting, shortWay), and(middle, longWay))::get);
+                """), ModulePath.of(and(and(meeting, shortWay), and(middle, longWay))));
         compilation.answerEverything();
 
         Map<SourceId, List<Located>> byId = compilation.diagnostics();
@@ -333,8 +335,8 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
      */
     @Test
     void twoModulesNeedingTheSameAbsentOneAreTwoFindings() {
-        Map<String, byte[]> left = holding("lib.left", "Left", "lib.deep", "Deep", deep());
-        Map<String, byte[]> right = holding("lib.right", "Right", "lib.deep", "Deep", deep());
+        Map<String, ClassFileImage> left = holding("lib.left", "Left", "lib.deep", "Deep", deep());
+        Map<String, ClassFileImage> right = holding("lib.right", "Right", "lib.deep", "Deep", deep());
 
         Compilation compilation = Compilation.ofSources(List.of("""
                 module app.a exposing ( A )
@@ -346,7 +348,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 import lib.right ( Right )
 
                 data B = { x: Right }
-                """), and(left, right)::get);
+                """), ModulePath.of(and(left, right)));
         compilation.answerEverything();
 
         Set<String> saidAbout = new LinkedHashSet<>();
@@ -471,18 +473,18 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
      * A published module whose two fields name {@code first} and {@code second}, built against a
      * dependency that had them and put on the path beside one that no longer does.
      */
-    private static Map<String, byte[]> twiceNaming(String first, String second) {
-        Map<String, byte[]> withThem = Compiler.compile("""
+    private static Map<String, ClassFileImage> twiceNaming(String first, String second) {
+        Map<String, ClassFileImage> withThem = Compiler.compile("""
                 module lib.deep exposing ( Deep, Other )
                 data Deep = String
                 data Other = String
                 """);
-        Map<String, byte[]> twice = built("""
+        Map<String, ClassFileImage> twice = built("""
                 module lib.twice exposing ( Twice )
                 data Twice = { a: %s, b: %s }
                 """.formatted(first, second), withThem);
         // the dependency is rebuilt without either, so both field types fail to resolve
-        Map<String, byte[]> withoutThem = Compiler.compile("""
+        Map<String, ClassFileImage> withoutThem = Compiler.compile("""
                 module lib.deep exposing ( Gone )
                 data Gone = String
                 """);

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachingAQuantifierGetsTheFoldItBecomesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachingAQuantifierGetsTheFoldItBecomesTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -42,7 +44,7 @@ class ARuleReachingAQuantifierGetsTheFoldItBecomesTest {
             """;
 
     /** Every emitted class, loaded — which is where the JVM verifies each method it holds. */
-    private static Class<?> loadingAll(Map<String, byte[]> classes, String named) {
+    private static Class<?> loadingAll(Map<String, ClassFileImage> classes, String named) {
         BytesClassLoader loader = new BytesClassLoader(classes,
                 ARuleReachingAQuantifierGetsTheFoldItBecomesTest.class.getClassLoader());
         for (String name : classes.keySet()) {
@@ -59,7 +61,7 @@ class ARuleReachingAQuantifierGetsTheFoldItBecomesTest {
     /** And emits the fold, which is the method the expanded rule holds a call to. */
     @Test
     void andEmitsTheFoldTheRuleExpandedTo() throws Exception {
-        Map<String, byte[]> classes = Compiler.compile(ONLY_FROM_A_RULE);
+        Map<String, ClassFileImage> classes = Compiler.compile(ONLY_FROM_A_RULE);
         Class<?> fns = loadingAll(classes, "quantified.$Fns");
 
         Method fold = fns.getDeclaredMethod("List$foldFrom",

--- a/souther-compiler/src/test/java/souther/compiler/AStandardLibraryNameIsReachedQualifiedOrImportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AStandardLibraryNameIsReachedQualifiedOrImportedTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.check.StdlibLoader;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -175,12 +176,12 @@ class AStandardLibraryNameIsReachedQualifiedOrImportedTest {
         // Resolution answers what a bare name means, with the imports consulted last; every pass
         // after it reads the answer. So the two spellings of one call generate the same code —
         // except `$Module`, which records the imports as they were written for a reader of the jar.
-        Map<String, byte[]> qualified = Compiler.compile(QUALIFIED);
-        Map<String, byte[]> imported = Compiler.compile(IMPORTED);
+        Map<String, ClassFileImage> qualified = Compiler.compile(QUALIFIED);
+        Map<String, ClassFileImage> imported = Compiler.compile(IMPORTED);
 
         assertEquals(qualified.keySet(), imported.keySet());
         List<String> differing = qualified.keySet().stream()
-                .filter(name -> !java.util.Arrays.equals(qualified.get(name), imported.get(name)))
+                .filter(name -> !qualified.get(name).equals(imported.get(name)))
                 .toList();
         assertEquals(List.of(Emitted.declarations("demo")), differing,
                 "only the class that records what was written differs");

--- a/souther-compiler/src/test/java/souther/compiler/AUnionsGeneratedOrderIsTheOneAtomSpaceStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AUnionsGeneratedOrderIsTheOneAtomSpaceStatesTest.java
@@ -9,6 +9,8 @@ import java.lang.classfile.instruction.TypeCheckInstruction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,7 +83,7 @@ class AUnionsGeneratedOrderIsTheOneAtomSpaceStatesTest {
     }
 
     private static List<String> permitsOf(String behavior) throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(MODULE));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(MODULE));
         BytesClassLoader loader = new BytesClassLoader(classes,
                 AUnionsGeneratedOrderIsTheOneAtomSpaceStatesTest.class.getClassLoader());
         return Arrays.stream(loader.loadClass(Emitted.result("m", behavior)).getPermittedSubclasses())
@@ -90,8 +92,8 @@ class AUnionsGeneratedOrderIsTheOneAtomSpaceStatesTest {
 
     /** The types the union's encoder tests, in the order it tests them. */
     private static List<String> encoderDispatchOf(String behavior) {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(MODULE));
-        byte[] encoder = classes.get(Emitted.resultEncoder("m", behavior));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(MODULE));
+        byte[] encoder = classes.get(Emitted.resultEncoder("m", behavior)).bytes();
         List<String> tested = new ArrayList<>();
         for (MethodModel method : ClassFile.of().parse(encoder).methods()) {
             if (!method.methodName().stringValue().equals("encode")) {

--- a/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
@@ -10,6 +10,7 @@ import souther.compiler.meta.PublishedClasses;
 import souther.compiler.meta.ReadableModule;
 import souther.compiler.meta.Readback;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
@@ -322,13 +323,14 @@ class AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest {
      */
     @Test
     void oneWhoseDeclarationsClassCarriesMetadataThatCannotBeRead() {
-        Map<String, byte[]> built = Compiler.compile("""
+        Map<String, ClassFileImage> built = Compiler.compile("""
                 module lib.pub exposing ( Held )
                 data Held = String
                 """);
 
+        ModulePath path = ModulePath.of(built);
         bothAreSaidOnTheSource(binaryName -> binaryName.equals("lib.pub.Held")
-                ? NOT_A_CLASS_FILE : built.get(binaryName));
+                ? NOT_A_CLASS_FILE : path.bytes(binaryName));
     }
 
     /**
@@ -341,14 +343,15 @@ class AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest {
      */
     @Test
     void oneWhoseMetadataIsRefusedAfterItsClassFileParses() {
-        Map<String, byte[]> built = Compiler.compile("""
+        Map<String, ClassFileImage> built = Compiler.compile("""
                 module lib.pub exposing ( Held )
                 data Held = String
                 """);
-        byte[] lazily = readableUntilAsked(built.get("lib.pub.$Module"));
+        byte[] lazily = readableUntilAsked(built.get("lib.pub.$Module").bytes());
 
+        ModulePath path = ModulePath.of(built);
         bothAreSaidOnTheSource(binaryName -> binaryName.equals("lib.pub.$Module")
-                ? lazily : built.get(binaryName));
+                ? lazily : path.bytes(binaryName));
     }
 
     /**
@@ -514,12 +517,12 @@ class AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest {
     /** Reading one that is fine still answers a module, with its import lines read. */
     @Test
     void oneThisCompilerCanReadComesBackReady() {
-        Map<String, byte[]> built = Compiler.compile("""
+        Map<String, ClassFileImage> built = Compiler.compile("""
                 module lib.ok exposing ( Held )
                 data Held = String
                 """);
         var readback = ModuleReadback.read("lib.ok",
-                ((ModulePath) built::get).declarations(), DefaultStdlib.get().names());
+                ModulePath.of(built).declarations(), DefaultStdlib.get().names());
 
         assertEquals("lib.ok",
                 assertInstanceOf(ReadableModule.class,

--- a/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
@@ -8,6 +8,7 @@ import souther.compiler.meta.ModulePath;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import org.junit.jupiter.api.Test;
@@ -66,9 +67,9 @@ class AnEvaluationRunsTheClassesThisCompileGeneratedTest {
      * files has.
      */
     private static ModulePath leftOverClassFiles() {
-        Map<String, byte[]> built = new LinkedHashMap<>(Compiler.compile(EARLIER));
+        Map<String, ClassFileImage> built = new LinkedHashMap<>(Compiler.compile(EARLIER));
         built.keySet().remove(Emitted.declarations("example.stale"));
-        return built::get;
+        return ModulePath.of(built);
     }
 
     @Test
@@ -93,7 +94,7 @@ class AnEvaluationRunsTheClassesThisCompileGeneratedTest {
      *  into is loaded once, by whoever already has it, not defined a second time here. */
     @Test
     void anameThisCompileDidNotGenerateStillComesFromTheParent() throws Exception {
-        Map<String, byte[]> mine = Compiler.compile(EARLIER);
+        Map<String, ClassFileImage> mine = Compiler.compile(EARLIER);
         MemoryClassLoader loader =
                 new MemoryClassLoader(mine, AnEvaluationRunsTheClassesThisCompileGeneratedTest.class
                         .getClassLoader());

--- a/souther-compiler/src/test/java/souther/compiler/AnImportedNameSurvivesPublicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnImportedNameSurvivesPublicationTest.java
@@ -4,6 +4,7 @@ import souther.compiler.check.Resolve;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -51,8 +52,8 @@ class AnImportedNameSurvivesPublicationTest {
             """;
 
     private static ModulePath published(String source) {
-        Map<String, byte[]> classes = Compiler.compile(source);
-        return classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(source);
+        return ModulePath.of(classes);
     }
 
     @Test
@@ -98,20 +99,23 @@ class AnImportedNameSurvivesPublicationTest {
      *  way — a dependency of a dependency is not read under weaker rules. */
     @Test
     void aModuleReachedThroughAnotherOnThePathReadsBack() {
-        Map<String, byte[]> base = Compiler.compile(BARE);
-        Map<String, byte[]> mid = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> base = Compiler.compile(BARE);
+        Map<String, ClassFileImage> mid = Compiler.compileModules(List.of("""
                 module lib.doc exposing ( Doc )
                 import lib.text ( Title )
 
                 data Doc = { title: Title }
-                """), base::get);
+                """), ModulePath.of(base));
 
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        // The near module over the one it was built against, which is the order a path is read in.
+        Map<String, ClassFileImage> reached = new java.util.LinkedHashMap<>(base);
+        reached.putAll(mid);
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.uses
                 import lib.doc ( Doc )
 
                 data Page = { doc: Doc }
-                """), name -> mid.containsKey(name) ? mid.get(name) : base.get(name));
+                """), ModulePath.of(reached));
 
         assertTrue(app.containsKey("app.uses.Page"));
     }

--- a/souther-compiler/src/test/java/souther/compiler/BytesClassLoader.java
+++ b/souther-compiler/src/test/java/souther/compiler/BytesClassLoader.java
@@ -1,27 +1,30 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 /**
- * Loads Souther-generated classes from an in-memory byte map. Runtime classes
+ * Loads Souther-generated classes from an in-memory class-file map. Runtime classes
  * (Raw, Result, Decoder, ...) resolve through the parent, so a cast of a generated
  * value to a runtime interface is type-compatible across the two loaders.
  */
 final class BytesClassLoader extends ClassLoader {
 
-    private final Map<String, byte[]> classes;
+    private final Map<String, ClassFileImage> classes;
 
-    BytesClassLoader(Map<String, byte[]> classes, ClassLoader parent) {
+    BytesClassLoader(Map<String, ClassFileImage> classes, ClassLoader parent) {
         super(parent);
         this.classes = classes;
     }
 
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
-        byte[] bytes = classes.get(name);
-        if (bytes == null) {
+        ClassFileImage image = classes.get(name);
+        if (image == null) {
             throw new ClassNotFoundException(name);
         }
+        byte[] bytes = image.bytes();
         return defineClass(name, bytes, 0, bytes.length);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CompileBehaviorByNameTest {
 
-    private static Map<String, byte[]> classes(String source) {
+    private static Map<String, ClassFileImage> classes(String source) {
         return Compiler.compile(source);
     }
 
@@ -121,7 +122,7 @@ class CompileBehaviorByNameTest {
     /** A behavior another module declares, bound to a {@code let} in the module that imports it. */
     @Test
     void anImportedBehaviorIsBoundToALetAndHandedOver() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( twice )
 
                 behavior twice : (n: Int) -> Int
@@ -162,7 +163,8 @@ class CompileBehaviorByNameTest {
                     let f = twice
                     Out { ys = List.map(f, i.xs) }
                 }
-                """).get(Emitted.impl("demo", "go")), java.nio.charset.StandardCharsets.ISO_8859_1);
+                """).get(Emitted.impl("demo", "go")).bytes(),
+                java.nio.charset.StandardCharsets.ISO_8859_1);
 
         assertTrue(bound.contains("demo/Twice"), "the expansion does not reach `demo.Twice`");
     }
@@ -274,7 +276,8 @@ class CompileBehaviorByNameTest {
 
     /** Which behavior classes the emitted body of {@code demo.go} references. */
     private static List<String> reached(String up, String demo) {
-        String impl = new String(Compiler.compileModules(List.of(up, demo)).get(Emitted.impl("demo", "go")),
+        String impl = new String(Compiler.compileModules(List.of(up, demo))
+                .get(Emitted.impl("demo", "go")).bytes(),
                 java.nio.charset.StandardCharsets.ISO_8859_1);
         return Stream.of("demo/Twice", "up/Twice").filter(impl::contains).toList();
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileBindTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBindTest.java
@@ -1,5 +1,6 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.runtime.Behavior;
 
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class CompileBindTest {
 
     @Test
     void generatesAnAbstractBaseAndBindFactory() throws Exception {
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(MODULE));
         classes.put("demo.FindMemberImpl", compileSubclass(classes, "demo.FindMemberImpl", IMPL_SRC));
 
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -83,13 +84,14 @@ class CompileBindTest {
     }
 
     /** Compiles {@code source} against the generated classes and returns the class bytes. */
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.writeString(srcFile, source);
@@ -101,6 +103,7 @@ class CompileBindTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileClassVersionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileClassVersionTest.java
@@ -2,6 +2,8 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,16 +43,16 @@ class CompileClassVersionTest {
 
     @Test
     void everyGeneratedClassTargetsJava25() {
-        Map<String, byte[]> classes = Compiler.compile(MODULE);
-        for (Map.Entry<String, byte[]> e : classes.entrySet()) {
-            assertEquals(JAVA_25, majorVersion(e.getValue()),
+        Map<String, ClassFileImage> classes = Compiler.compile(MODULE);
+        for (Map.Entry<String, ClassFileImage> e : classes.entrySet()) {
+            assertEquals(JAVA_25, majorVersion(e.getValue().bytes()),
                     e.getKey() + " must target Java 25, not the JDK that built it");
         }
     }
 
     @Test
     void theCompilerEmitsDataDecodersAndBehaviorsAlike() {
-        Map<String, byte[]> classes = Compiler.compile(MODULE);
+        Map<String, ClassFileImage> classes = Compiler.compile(MODULE);
         // guards the test above against silently covering an empty or tiny set
         assertEquals(true, classes.size() >= 10, "expected the whole module's output, got " + classes.keySet());
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileClosureInjectedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileClosureInjectedTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import javax.tools.ToolProvider;
@@ -53,7 +55,7 @@ class CompileClosureInjectedTest {
 
     @Test
     void aClosureCapturesAndCallsAnInjectedBehavior() throws Exception {
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(MODULE));
         classes.put("demo.DepImpl", compileSubclass(classes, "demo.DepImpl", IMPL_SRC));
 
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -67,13 +69,14 @@ class CompileClosureInjectedTest {
         assertEquals("got:kawa", ((Map<?, ?>) Codecs.encode(loader, "demo.Out", r)).get("v"));
     }
 
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.writeString(srcFile, source);
@@ -84,6 +87,7 @@ class CompileClosureInjectedTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileCrossModuleFieldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileCrossModuleFieldTest.java
@@ -3,6 +3,8 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +36,7 @@ class CompileCrossModuleFieldTest {
 
     @Test
     void aBehaviorReadsAFieldOfAnImportedData() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, B));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(A, B));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
         Object req = Codecs.decoded(loader, "b.申請",
@@ -66,7 +68,7 @@ class CompileCrossModuleFieldTest {
 
     @Test
     void spreadingAnImportedDataReadsItsFieldsThroughAccessors() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(BASE, DERIVED));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(BASE, DERIVED));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
         Object base = Codecs.decoded(loader, "base_m.Base", Map.of("a", "A", "b", "B"));

--- a/souther-compiler/src/test/java/souther/compiler/CompileCrossModuleUnionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileCrossModuleUnionTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.types.TypeKey;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.TypeSymbols;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ class CompileCrossModuleUnionTest {
     @Test
     void aCaseClassCarriesOnlyItsOwnModulesUnions() throws Exception {
         // the fact the rule rests on: `implements` is settled here, when `inv` is generated
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(INVENTORY));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(INVENTORY));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Class<?> shortage = loader.loadClass("inv.Shortage");
         assertEquals(List.of(loader.loadClass(Emitted.result("inv", "allocate"))),
@@ -63,7 +64,7 @@ class CompileCrossModuleUnionTest {
                 let instruct (a) = Shipped { sku = a.sku }
                 behavior allocateAndShip = allocate >-> instruct
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, shipping));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         assertEquals(List.of(loader.loadClass("ship.Shipped"), loader.loadClass(Emitted.bridgeCase("ship", TypeSymbols.declared(new TypeKey("inv", "Shortage"))))),
                 Arrays.asList(loader.loadClass(Emitted.result("ship", "allocateAndShip")).getPermittedSubclasses()));
@@ -101,8 +102,8 @@ class CompileCrossModuleUnionTest {
                     | Allocated as a -> Shipped { sku = a.sku }
                     | Shortage as s -> s
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, shipping));
-        byte[] reader = Subclasses.compile(classes, "consumer.Reader", """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, shipping));
+        ClassFileImage reader = Subclasses.compile(classes, "consumer.Reader", """
                 package consumer;
                 import inv.Sku;
                 import ship.Ship;
@@ -117,7 +118,7 @@ class CompileCrossModuleUnionTest {
                     }
                 }
                 """);
-        Map<String, byte[]> all = new LinkedHashMap<>(classes);
+        Map<String, ClassFileImage> all = new LinkedHashMap<>(classes);
         all.put("consumer.Reader", reader);
         BytesClassLoader loader = new BytesClassLoader(all, getClass().getClassLoader());
         java.lang.reflect.Method read = loader.loadClass("consumer.Reader")
@@ -142,7 +143,7 @@ class CompileCrossModuleUnionTest {
                     | Allocated as a -> Shipped { sku = a.sku }
                     | Shortage as s -> NotShipped { sku = s.sku }
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(INVENTORY, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(INVENTORY, shipping));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Class<?> union = loader.loadClass(Emitted.result("ship", "ship"));
         assertEquals(List.of(loader.loadClass("ship.NotShipped"), loader.loadClass("ship.Shipped")),
@@ -184,7 +185,7 @@ class CompileCrossModuleUnionTest {
                     | Allocated as a -> instruct(a)
                     | Shortage as s -> NotAllocated { sku = s.sku }
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, shipping));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Class<?> union = loader.loadClass(Emitted.result("ship", "allocateAndShip"));
         assertEquals(List.of(loader.loadClass("ship.NoLabel"), loader.loadClass("ship.NotAllocated"),
@@ -243,11 +244,12 @@ class CompileCrossModuleUnionTest {
                     | Token as t -> Stamped { v = t.v }
                     | NoToken -> Unstamped
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(issuing, stamping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(issuing, stamping));
         // The call is not run here: `up.Mint` is an abstract class with a protected constructor, so a
         // stand-in cannot be made by reflection alone. What the bug produced was a descriptor naming a
         // class nothing emits, which is what is checked — the call linked to `down.MintResult` before.
-        assertEquals("()Lup/MintResult;", calleeDescriptor(classes.get(Emitted.impl("down", "stamp")), "up/Mint"));
+        assertEquals("()Lup/MintResult;",
+                calleeDescriptor(classes.get(Emitted.impl("down", "stamp")).bytes(), "up/Mint"));
         assertTrue(classes.containsKey(Emitted.result("up", "mint")), "and that class is one this compilation wrote");
     }
 
@@ -293,7 +295,7 @@ class CompileCrossModuleUnionTest {
                     | Allocated as a -> Shipped { sku = a.sku }
                     | Shortage as s -> NotAllocated { sku = s.sku }
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, shipping));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Object behavior = Emitted.behavior(loader, "ship", "ship").getConstructor().newInstance();
         Object sku = Codecs.decoded(loader, "inv.Sku", "SKU-1");

--- a/souther-compiler/src/test/java/souther/compiler/CompileExposedValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExposedValueTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
@@ -126,8 +127,8 @@ class CompileExposedValueTest {
      * the jar, and a value is substituted from that like any other. */
     @Test
     void aValueCrossesAProjectBoundary() throws Exception {
-        Map<String, byte[]> classes = Compiler.compile(UPSTREAM);
-        ModulePath path = classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(UPSTREAM);
+        ModulePath path = ModulePath.of(classes);
 
         assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
                 module app.billing exposing ( Receipt, bill )

--- a/souther-compiler/src/test/java/souther/compiler/CompileFoldSelfHostTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFoldSelfHostTest.java
@@ -3,6 +3,8 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,7 +58,7 @@ class CompileFoldSelfHostTest {
                 behavior run : (b: Bag) -> Out constructs Out
                 let run (b) = Out(List.fold((acc, x) -> acc + x, 0, b.xs))
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(a, b));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(a, b));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Object bag = Codecs.decoded(loader, "m.b.Bag", Map.of("xs", List.of(1L, 2L, 3L, 4L)));
         Object behavior = Emitted.behavior(loader, "m.b", "run").getConstructor().newInstance();

--- a/souther-compiler/src/test/java/souther/compiler/CompileFunctionValueFlowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFunctionValueFlowTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.msg.DeclarationMessage;
+import souther.compiler.jvm.ClassFileImage;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -224,7 +225,7 @@ class CompileFunctionValueFlowTest {
                 sameShape(Compiler.compile(shadowed("y"))));
     }
 
-    private static java.util.Set<String> sameShape(Map<String, byte[]> classes) {
+    private static java.util.Set<String> sameShape(Map<String, ClassFileImage> classes) {
         return classes.keySet();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileGrowingFoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileGrowingFoldTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -42,10 +44,9 @@ class CompileGrowingFoldTest {
      *  one leave one builder behind. */
     private int callsTo(String src, String method) {
         int calls = 0;
-        for (byte[] bytes : Compiler.compile(src).values().stream()
-                .map(souther.compiler.jvm.ClassFileImage::bytes).toList()) {
+        for (ClassFileImage emitted : Compiler.compile(src).values()) {
             for (java.lang.classfile.MethodModel m : java.lang.classfile.ClassFile.of()
-                    .parse(bytes).methods()) {
+                    .parse(emitted.bytes()).methods()) {
                 if (m.code().isEmpty()) {
                     continue;
                 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileGrowingFoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileGrowingFoldTest.java
@@ -42,7 +42,8 @@ class CompileGrowingFoldTest {
      *  one leave one builder behind. */
     private int callsTo(String src, String method) {
         int calls = 0;
-        for (byte[] bytes : Compiler.compile(src).values()) {
+        for (byte[] bytes : Compiler.compile(src).values().stream()
+                .map(souther.compiler.jvm.ClassFileImage::bytes).toList()) {
             for (java.lang.classfile.MethodModel m : java.lang.classfile.ClassFile.of()
                     .parse(bytes).methods()) {
                 if (m.code().isEmpty()) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileGrowingMapFoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileGrowingMapFoldTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -37,10 +39,9 @@ class CompileGrowingMapFoldTest {
     /** How many times the compiled module calls {@code method} on the runtime's map helpers. */
     private int callsTo(String src, String method) {
         int calls = 0;
-        for (byte[] bytes : Compiler.compile(src).values().stream()
-                .map(souther.compiler.jvm.ClassFileImage::bytes).toList()) {
+        for (ClassFileImage emitted : Compiler.compile(src).values()) {
             for (java.lang.classfile.MethodModel m : java.lang.classfile.ClassFile.of()
-                    .parse(bytes).methods()) {
+                    .parse(emitted.bytes()).methods()) {
                 if (m.code().isEmpty()) {
                     continue;
                 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileGrowingMapFoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileGrowingMapFoldTest.java
@@ -37,7 +37,8 @@ class CompileGrowingMapFoldTest {
     /** How many times the compiled module calls {@code method} on the runtime's map helpers. */
     private int callsTo(String src, String method) {
         int calls = 0;
-        for (byte[] bytes : Compiler.compile(src).values()) {
+        for (byte[] bytes : Compiler.compile(src).values().stream()
+                .map(souther.compiler.jvm.ClassFileImage::bytes).toList()) {
             for (java.lang.classfile.MethodModel m : java.lang.classfile.ClassFile.of()
                     .parse(bytes).methods()) {
                 if (m.code().isEmpty()) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
@@ -1,13 +1,13 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -382,11 +382,11 @@ class CompileHelperCarriesItsVariablesTest {
                 let count (xs) = List.length(xs)
                 let go (r) = Out { n = count(r.value) }
                 """;
-        Map<String, byte[]> first = Compiler.compile(src);
-        Map<String, byte[]> second = Compiler.compile(src);
+        Map<String, ClassFileImage> first = Compiler.compile(src);
+        Map<String, ClassFileImage> second = Compiler.compile(src);
         assertEquals(first.keySet(), second.keySet());
         for (String name : first.keySet()) {
-            assertArrayEquals(first.get(name), second.get(name), name + " differs between two reads");
+            assertEquals(first.get(name), second.get(name), name + " differs between two reads");
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -165,7 +166,7 @@ class CompileImplicitUnitDataTest {
      * second type of the same name, and the value would be of the wrong one. */
     @Test
     void anImportedUnitIsNotDeclaredAgainHere() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( Done )
                 data Done
                 """, """

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedBehaviorUseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedBehaviorUseTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,7 +61,7 @@ class CompileImportedBehaviorUseTest {
 
                 behavior allocateAndShip = allocate >-> instruct
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(INVENTORY, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(INVENTORY, shipping));
         assertTrue(classes.containsKey(Emitted.impl("probe.shipping", "allocateAndShip")),
                 "the pipeline is generated: " + classes.keySet());
     }
@@ -79,7 +80,7 @@ class CompileImportedBehaviorUseTest {
 
                 behavior allocateAndShip = allocate >-> instruct
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compileModules(List.of(INVENTORY, shipping)));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compileModules(List.of(INVENTORY, shipping)));
         classes.put("probe.inventory.AllocateImpl",
                 compileSubclass(classes, "probe.inventory.AllocateImpl", ALLOCATE_IMPL));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -117,7 +118,7 @@ class CompileImportedBehaviorUseTest {
                     Shipped { sku = a.sku, quantity = a.quantity }
                 }
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compileModules(List.of(INVENTORY, shipping)));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compileModules(List.of(INVENTORY, shipping)));
         classes.put("probe.inventory.AllocateImpl",
                 compileSubclass(classes, "probe.inventory.AllocateImpl", ALLOCATE_IMPL));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -158,7 +159,7 @@ class CompileImportedBehaviorUseTest {
                     Shipped { sku = a.sku }
                 }
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, shipping));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, shipping));
         assertTrue(classes.containsKey(Emitted.impl("probe.ship1", "ship")), classes.keySet().toString());
     }
 
@@ -213,7 +214,7 @@ class CompileImportedBehaviorUseTest {
                     | Shortage as s -> s
                 """;
         for (String consumer : List.of(asAStage, asADependency)) {
-            Map<String, byte[]> classes = Compiler.compileModules(List.of(inventory, consumer));
+            Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(inventory, consumer));
             String pkg = consumer == asAStage ? "probe.ship2" : "probe.ship3";
             String result = consumer == asAStage ? "AllocateAndShipResult" : "ShipResult";
             BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -225,13 +226,14 @@ class CompileImportedBehaviorUseTest {
     }
 
     /** Compiles {@code source} against the generated classes and returns the class bytes. */
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.writeString(srcFile, source);
@@ -242,6 +244,7 @@ class CompileImportedBehaviorUseTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInjectedFactoryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInjectedFactoryTest.java
@@ -7,6 +7,8 @@ import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
+import souther.compiler.jvm.ClassFileImage;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -24,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CompileInjectedFactoryTest {
 
     private Class<?> base(String moduleSrc, String baseClass) throws Exception {
-        Map<String, byte[]> classes = Compiler.compile(moduleSrc);
+        Map<String, ClassFileImage> classes = Compiler.compile(moduleSrc);
         return new BytesClassLoader(classes, getClass().getClassLoader()).loadClass(baseClass);
     }
 
@@ -94,14 +96,14 @@ class CompileInjectedFactoryTest {
     void theFieldBearingFactoryBuildsThroughConstructNotTheRawConstructor() throws Exception {
         // The factory must route through __construct (which checks the invariant) and orThrow (which
         // aborts on a violation), not the raw non-checking constructor. Verify the emitted bytecode.
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module demo
                 data OrderId = String
                     invariant String.length(value) > 0
                 data In = { x: Int }
                 behavior mk : (i: In) -> OrderId constructs OrderId
                 """);
-        Set<String> invoked = invokedIn(classes.get("demo.Mk"), "OrderId");
+        Set<String> invoked = invokedIn(classes.get("demo.Mk").bytes(), "OrderId");
         assertTrue(invoked.contains("__construct"), "the factory runs the invariant through __construct");
         assertTrue(invoked.contains("orThrow"), "a violation aborts via orThrow");
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInjectedMultiArgTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInjectedMultiArgTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.runtime.Behavior;
 
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class CompileInjectedMultiArgTest {
         // 2+ inputs → standalone abstract class, no Behavior supertype (so it cannot follow an
         // arrow), typed apply(A,B)
         String src = HEAD + "let use (a, b, send) = send(a, b)\n";
-        Map<String, byte[]> classes = Compiler.compile(src);
+        Map<String, ClassFileImage> classes = Compiler.compile(src);
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Class<?> send = loader.loadClass("demo.Send");
         assertTrue(Modifier.isAbstract(send.getModifiers()), "the injected base is abstract");
@@ -83,7 +84,7 @@ class CompileInjectedMultiArgTest {
                 data Rejected = { why: String }
                 behavior send : (a: A, b: B) -> Ok | Rejected
                 """;
-        Map<String, byte[]> classes = Compiler.compile(src);
+        Map<String, ClassFileImage> classes = Compiler.compile(src);
         assertTrue(classes.containsKey(Emitted.result("demo", "send")),
                 "the union output's sealed interface is generated: " + classes.keySet());
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -127,7 +128,7 @@ class CompileInjectedMultiArgTest {
 
                 behavior pipe = send >-> bump
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.SendImpl", Subclasses.compile(classes, "demo.SendImpl", IMPL_SRC));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
@@ -152,7 +153,7 @@ class CompileInjectedMultiArgTest {
                 data R = { z: Int }
                 behavior now : () -> R
                 """;
-        Map<String, byte[]> classes = Compiler.compile(src);
+        Map<String, ClassFileImage> classes = Compiler.compile(src);
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Class<?> now = loader.loadClass("demo.Now");
         assertTrue(Modifier.isAbstract(now.getModifiers()), "the injected base is abstract");
@@ -182,7 +183,7 @@ class CompileInjectedMultiArgTest {
                     public R apply() { return R(41); }
                 }
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.NowImpl", Subclasses.compile(classes, "demo.NowImpl", impl));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
         Object pipe = loader.loadClass("demo.Pipe").getMethod("bind", loader.loadClass("demo.Now"))
@@ -216,7 +217,7 @@ class CompileInjectedMultiArgTest {
                     public R apply() { return R(40); }
                 }
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.NowImpl", Subclasses.compile(classes, "demo.NowImpl", impl));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
@@ -278,7 +279,7 @@ class CompileInjectedMultiArgTest {
                     public R apply(A a, B b) { return R(a.x() + b.y()); }
                 }
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.SendImpl", Subclasses.compile(classes, "demo.SendImpl", impl));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
@@ -302,7 +303,7 @@ class CompileInjectedMultiArgTest {
     @Test
     void aTwoArgInjectedIsBoundAndCalledWithBothArguments() throws Exception {
         String src = HEAD + "let use (a, b, send) = send(a, b)\n";
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.SendImpl", Subclasses.compile(classes, "demo.SendImpl", IMPL_SRC));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
@@ -348,7 +349,7 @@ class CompileInjectedMultiArgTest {
                     }
                 }
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(head));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(head));
         classes.put("demo.ScaleImpl", Subclasses.compile(classes, "demo.ScaleImpl", impl));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileInlineRequiredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInlineRequiredTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import javax.tools.ToolProvider;
@@ -52,7 +54,7 @@ class CompileInlineRequiredTest {
 
     @Test
     void requiredCalledInlineInARecordLiteral() throws Exception {
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(MODULE));
         classes.put("demo.FindMemberImpl", compileSubclass(classes, "demo.FindMemberImpl", IMPL_SRC));
 
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -71,13 +73,14 @@ class CompileInlineRequiredTest {
         assertEquals("m-1", m.get("id"));
     }
 
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.writeString(srcFile, source);
@@ -89,6 +92,7 @@ class CompileInlineRequiredTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
@@ -187,8 +188,8 @@ class CompileInvariantImportedDefinitionTest {
      * its class path — and reading it there is what makes the name resolve. */
     @Test
     void anImportedValueInAnInvariantCrossesAProjectBoundary() throws Exception {
-        Map<String, byte[]> upstream = Compiler.compile(LIMITS);
-        ModulePath path = upstream::get;
+        Map<String, ClassFileImage> upstream = Compiler.compile(LIMITS);
+        ModulePath path = ModulePath.of(upstream);
 
         assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
                 module app.ids exposing ( V )

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleBehaviorTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,7 +35,7 @@ class CompileModuleBehaviorTest {
 
     @Test
     void importedBehaviorComposesInAnotherModule() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, B));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(A, B));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
         Object five = Codecs.decoded(loader, "m.a.N", 5L);

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleChainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleChainTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.types.TypeKey;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.TypeSymbols;
 
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ class CompileModuleChainTest {
 
     @Test
     void composesABehaviorTwoImportHopsAway() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, B, C));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(A, B, C));
         assertTrue(classes.containsKey("c.Quad"), "the two-hop composition generates c.Quad");
 
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -78,7 +79,7 @@ class CompileModuleChainTest {
     void aDepartedImportedCaseReachesTheCompositionsUnionThroughABridgeCase() throws Exception {
         // checkout's output is Receipt | Empty. Receipt is pb's own and is the case itself; Empty is
         // pa's, so pb emits pb.EmptyCase and permits that.
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(PA, PB));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(PA, PB));
         BytesClassLoader loader = new BytesClassLoader(classes, CompileModuleChainTest.class.getClassLoader());
         assertEquals(List.of(loader.loadClass(Emitted.bridgeCase("pb", TypeSymbols.declared(new TypeKey("pa", "Empty")))), loader.loadClass("pb.Receipt")),
                 Arrays.asList(loader.loadClass(Emitted.result("pb", "checkout")).getPermittedSubclasses()));

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleInjectedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleInjectedTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import javax.tools.ToolProvider;
@@ -46,7 +48,7 @@ class CompileModuleInjectedTest {
 
     @Test
     void importsAnInjectedBehaviorAndBindsItAcrossModules() throws Exception {
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compileModules(List.of(A, B)));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compileModules(List.of(A, B)));
         classes.put("a.ProduceImpl", compileSubclass(classes, "a.ProduceImpl", IMPL));
 
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
@@ -63,13 +65,14 @@ class CompileModuleInjectedTest {
     }
 
     /** Compiles {@code source} against the generated classes and returns the class bytes. */
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.createDirectories(srcFile.getParent());
@@ -81,6 +84,7 @@ class CompileModuleInjectedTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import net.unit8.raoh.Err;
 import net.unit8.raoh.Ok;
@@ -43,7 +44,7 @@ class CompileModuleTest {
 
     @Test
     void crossModuleTypeResolvesAndRoundTrips() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(EMPLOYEE, TRIP));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(EMPLOYEE, TRIP));
         BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
 
         // the imported 従業員ID class lives in the declaring module's package

--- a/souther-compiler/src/test/java/souther/compiler/CompileNestedSumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNestedSumTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -93,7 +95,7 @@ class CompileNestedSumTest {
      */
     @Test
     void aLeafReachesTheNestedArmOfAJavaSwitch() throws Exception {
-        Map<String, byte[]> classes = new java.util.HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new java.util.HashMap<>(Compiler.compile(MODULE));
         classes.put("demo.ReadBearer", Subclasses.compile(classes, "demo.ReadBearer", """
                 package demo;
                 public final class ReadBearer {

--- a/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.ClassFile;
@@ -38,11 +40,11 @@ class CompileNullMarkedTest {
         // class states to a consumer's compiler is the boundary, and a second annotation arriving
         // there is a decision to take rather than something to let through. The module's declarations
         // ride on `$Module` as runtime-invisible for that reason.
-        Map<String, byte[]> classes = Compiler.compile(SRC);
+        Map<String, ClassFileImage> classes = Compiler.compile(SRC);
 
         assertTrue(classes.size() > 1, "there is more than one class to mark: " + classes.keySet());
-        for (Map.Entry<String, byte[]> e : classes.entrySet()) {
-            assertEquals(List.of(NULL_MARKED), annotations(e.getValue()), e.getKey());
+        for (Map.Entry<String, ClassFileImage> e : classes.entrySet()) {
+            assertEquals(List.of(NULL_MARKED), annotations(e.getValue().bytes()), e.getKey());
         }
     }
 
@@ -58,7 +60,7 @@ class CompileNullMarkedTest {
 
     @Test
     void eachModuleOfALinkedSetMarksItsOwnClasses() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
                 """, """
@@ -67,8 +69,8 @@ class CompileNullMarkedTest {
                 data Line = { paid: Amount }
                 """));
 
-        assertEquals(List.of(NULL_MARKED), annotations(classes.get("shared.money.Amount")));
-        assertEquals(List.of(NULL_MARKED), annotations(classes.get("ordering.Line")));
+        assertEquals(List.of(NULL_MARKED), annotations(classes.get("shared.money.Amount").bytes()));
+        assertEquals(List.of(NULL_MARKED), annotations(classes.get("ordering.Line").bytes()));
     }
 
     @Test
@@ -78,7 +80,7 @@ class CompileNullMarkedTest {
         // names the clause that did not hold.
         assertEquals("(Ldemo/Amount;)Lsouther/runtime/Result<Ldemo/Receipt;"
                         + "Lsouther/runtime/InvariantFailure;>;",
-                methodSignature(Compiler.compile(SRC).get("demo.Receipt"), "__construct"));
+                methodSignature(Compiler.compile(SRC).get("demo.Receipt").bytes(), "__construct"));
     }
 
     /** The annotation types the class carries as runtime-visible — what a Kotlin compiler reads. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileObjectTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileObjectTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import net.unit8.raoh.Err;
 import net.unit8.raoh.Issue;
 import net.unit8.raoh.Ok;
@@ -33,7 +35,7 @@ class CompileObjectTest {
             """;
 
     private Class<?> compileAccount() throws Exception {
-        Map<String, byte[]> classes = Compiler.compile(ACCOUNT);
+        Map<String, ClassFileImage> classes = Compiler.compile(ACCOUNT);
         return new BytesClassLoader(classes, getClass().getClassLoader()).loadClass("demo.Account");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileOutputUnionMemberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileOutputUnionMemberTest.java
@@ -4,6 +4,7 @@ import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,7 @@ class CompileOutputUnionMemberTest {
 
     @Test
     void aPrimitiveIsAMemberAndReachesJavaWrapped() throws Exception {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module m exposing ( NoAnswer, half )
                 data NoAnswer
                 behavior half : (n: Int) -> Int | NoAnswer
@@ -46,7 +47,7 @@ class CompileOutputUnionMemberTest {
 
     @Test
     void anImportedTypeIsAMemberAndReachesJavaWrapped() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( Yen )
                 data Yen = Int
                     invariant value >= 0
@@ -141,7 +142,7 @@ class CompileOutputUnionMemberTest {
      */
     @Test
     void aValueAnsweredOpenedAndAnsweredAgainIsNotWrappedTwice() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module money exposing ( Yen )
                 data Yen = Int
                 """, """
@@ -182,7 +183,7 @@ class CompileOutputUnionMemberTest {
      * the rule a local case class already follows. */
     @Test
     void oneBridgeCaseServesEveryBehaviorThatAnswersWithTheSameImportedType() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( Yen )
                 data Yen = Int
                 """, """
@@ -247,7 +248,7 @@ class CompileOutputUnionMemberTest {
      */
     @Test
     void beingAUnionMemberLeavesTheMembersExternalRepresentationAlone() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( Yen )
                 data Yen = Int
                 """, """
@@ -277,7 +278,7 @@ class CompileOutputUnionMemberTest {
      */
     @Test
     void anInjectedBehaviorCanAnswerWithABridgedMember() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up exposing ( Yen )
                 data Yen = Int
                 """, """
@@ -287,7 +288,7 @@ class CompileOutputUnionMemberTest {
                 behavior owed : (a: Yen) -> Yen | NothingOwed
                     constructs Yen
                 """));
-        byte[] impl = Subclasses.compile(classes, "consumer.HalfOwed", """
+        ClassFileImage impl = Subclasses.compile(classes, "consumer.HalfOwed", """
                 package consumer;
                 import up.Yen;
                 import down.NothingOwed;
@@ -300,7 +301,7 @@ class CompileOutputUnionMemberTest {
                     }
                 }
                 """);
-        Map<String, byte[]> all = new LinkedHashMap<>(classes);
+        Map<String, ClassFileImage> all = new LinkedHashMap<>(classes);
         all.put("consumer.HalfOwed", impl);
         BytesClassLoader loader = new BytesClassLoader(all, getClass().getClassLoader());
         Object behavior = loader.loadClass("consumer.HalfOwed").getConstructor().newInstance();

--- a/souther-compiler/src/test/java/souther/compiler/CompilePathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePathAgreementTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import souther.compiler.diag.Primary;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -118,8 +119,8 @@ class CompilePathAgreementTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("sources")
     void bothPathsProduceTheSameClasses(String name, String source) {
-        Map<String, byte[]> alone = Compiler.compile(source);
-        Map<String, byte[]> linked = Compiler.compileModules(List.of(source));
+        Map<String, ClassFileImage> alone = Compiler.compile(source);
+        Map<String, ClassFileImage> linked = Compiler.compileModules(List.of(source));
         assertEquals(alone.keySet(), linked.keySet(),
                 "the two paths emit different classes for " + name);
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompilePipeDepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePipeDepsTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import javax.tools.ToolProvider;
@@ -58,7 +60,7 @@ class CompilePipeDepsTest {
 
     @Test
     void pipelineCollectsEveryStagesRequirements() throws Exception {
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(MODULE));
         classes.put("demo.FetchImpl", compileSubclass(classes, "demo.FetchImpl", impl("FetchImpl", "fetch", "In", "m")));
         classes.put("demo.TagImpl", compileSubclass(classes, "demo.TagImpl", impl("TagImpl", "tag", "Mid", "T")));
 
@@ -97,7 +99,7 @@ class CompilePipeDepsTest {
 
                 behavior outer = handle >-> relabel
                 """;
-        Map<String, byte[]> classes = new HashMap<>(Compiler.compile(src));
+        Map<String, ClassFileImage> classes = new HashMap<>(Compiler.compile(src));
         classes.put("demo.FetchImpl", compileSubclass(classes, "demo.FetchImpl", impl("FetchImpl", "fetch", "In", "m")));
         classes.put("demo.TagImpl", compileSubclass(classes, "demo.TagImpl", impl("TagImpl", "tag", "Mid", "T")));
 
@@ -117,13 +119,14 @@ class CompilePipeDepsTest {
         assertEquals("m", o.get("b"));
     }
 
-    private static byte[] compileSubclass(Map<String, byte[]> generated, String className, String source)
+    private static ClassFileImage compileSubclass(Map<String, ClassFileImage> generated,
+                                                  String className, String source)
             throws Exception {
         java.nio.file.Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             java.nio.file.Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         java.nio.file.Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.writeString(srcFile, source);
@@ -134,6 +137,7 @@ class CompilePipeDepsTest {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompilePublishedHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePublishedHelperTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.msg.ParseMessage;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
@@ -294,7 +295,7 @@ class CompilePublishedHelperTest {
      * declares it closed it, and the module at the end emits the method. */
     @Test
     void aRecursiveHelperTwoModulesUpArrivesThroughTheChain() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module low exposing ( summed )
 
                 partial let summed (n: Int) : Int = if n == 0 then 0 else n + summed(n - 1)
@@ -350,7 +351,7 @@ class CompilePublishedHelperTest {
      */
     @Test
     void twoModulesRecursiveHelpersOfOneNameStayTwoMethods() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module up.a exposing ( step )
 
                 partial let step (n: Int) : Int = if n == 0 then 1 else step(n - 1)
@@ -385,7 +386,7 @@ class CompilePublishedHelperTest {
      * Java-reachable entry, and a construction inside it is no more reachable than before. */
     @Test
     void aCarriedHelperIsEmittedOnThePackagePrivateFnsOfTheReader() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module maths exposing ( built )
 
                 data Wrapped = Int
@@ -416,8 +417,8 @@ class CompilePublishedHelperTest {
      * body reaches, and the importing project closes and expands it the same way. */
     @Test
     void aHelperCrossesAProjectBoundary() throws Exception {
-        Map<String, byte[]> classes = Compiler.compile(PRICING);
-        ModulePath path = classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(PRICING);
+        ModulePath path = ModulePath.of(classes);
 
         assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
                 module app.billing exposing ( Receipt, bill )
@@ -545,7 +546,7 @@ class CompilePublishedHelperTest {
      * a method has to go somewhere, not because a helper was imported. */
     @Test
     void aReaderOfANonRecursiveHelperEmitsNoFnsClass() throws Exception {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(PRICING, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(PRICING, """
                 module order exposing ( Receipt, bill )
 
                 import pricing ( Amount, taxed )
@@ -609,8 +610,8 @@ class CompilePublishedHelperTest {
      */
     @Test
     void aHelperWhoseElementIsOpenCrossesAProjectBoundary() {
-        Map<String, byte[]> library = Compiler.compile(COUNTING);
-        ModulePath path = library::get;
+        Map<String, ClassFileImage> library = Compiler.compile(COUNTING);
+        ModulePath path = ModulePath.of(library);
 
         assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
                 module app.report exposing ( Counted, tally )

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedBehaviorRefTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedBehaviorRefTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ class CompileQualifiedBehaviorRefTest {
 
     @Test
     void aStageMayNameItsBehaviorThroughItsModule() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(UP, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(UP, """
                 module d exposing ( Out, flow : Out )
                 data Out = { n: Int }
                 behavior plus : (m: up.Mid) -> Out constructs Out
@@ -76,7 +77,7 @@ class CompileQualifiedBehaviorRefTest {
     /** The injected field keeps the bare name, so the Java surface is what it was. */
     @Test
     void aRequiresMayNameItsBehaviorThroughItsModule() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(LOOKUP, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(LOOKUP, """
                 module d exposing ( Out, run )
                 data Out = { n: Int }
                 behavior run : (i: up2.In) -> Out constructs Out depends on up2.lookup

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
@@ -5,6 +5,7 @@ import souther.compiler.diag.Primary;
 import souther.compiler.diag.msg.NameMessage;
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,7 @@ class CompileQualifiedCalleeTest {
             data Amount = Int invariant value >= 0
             """;
 
-    private static Map<String, byte[]> compile(String... srcs) {
+    private static Map<String, ClassFileImage> compile(String... srcs) {
         return Compiler.compileModules(List.of(srcs));
     }
 
@@ -99,7 +100,7 @@ class CompileQualifiedCalleeTest {
      *  bound, so nothing in it is a namespace and no fold is attempted. */
     @Test
     void aChainRootedAtABindingIsReadsAllTheWayDown() throws Exception {
-        Map<String, byte[]> classes = compile("""
+        Map<String, ClassFileImage> classes = compile("""
                 module demo exposing ( In, Out, go )
                 data Inner = { n: Int }
                 data Mid = { inner: Inner }
@@ -201,7 +202,7 @@ class CompileQualifiedCalleeTest {
      *  its parts, so the pipe and the call reach the same answer for the same spelling. */
     @Test
     void aPipeToAQualifiedNameIsTheSameCallAsWritingIt() throws Exception {
-        Map<String, byte[]> classes = compile("""
+        Map<String, ClassFileImage> classes = compile("""
                 module demo exposing ( In, Out, go )
                 data In = { s: String }
                 data Out = { t: String, u: String }

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ class CompileQualifiedTypeRefTest {
 
     @Test
     void twoModulesDeclaringTheSameNameAreBothReachedQualified() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, B, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(A, B, """
                 module probe.c exposing ( Line )
                 data Line =
                     { counted: probe.a.Amount
@@ -44,7 +45,7 @@ class CompileQualifiedTypeRefTest {
     @Test
     void aNewtypeWrapsAQualifiedType() {
         // the newtype's base is written like a type anywhere else, so it reaches through a module
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(A, """
                 module probe.c exposing ( Counted )
                 data Counted = probe.a.Amount
                 """));

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecordShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecordShapeTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -98,7 +99,7 @@ class CompileRecordShapeTest {
      */
     @Test
     void anAccessorSaysEveryPositionOfItsTypeIsNonNull() {
-        ClassModel member = ClassFile.of().parse(Compiler.compile(SRC).get("demo.Member"));
+        ClassModel member = ClassFile.of().parse(Compiler.compile(SRC).get("demo.Member").bytes());
 
         assertEquals(List.of("[]"), nonNullPaths(member, "id"));
         assertEquals(List.of("[]", "[TYPE_ARGUMENT(0)]"), nonNullPaths(member, "tags"));
@@ -112,7 +113,7 @@ class CompileRecordShapeTest {
      */
     @Test
     void theRecordComponentRepeatsIt() {
-        ClassModel member = ClassFile.of().parse(Compiler.compile(SRC).get("demo.Member"));
+        ClassModel member = ClassFile.of().parse(Compiler.compile(SRC).get("demo.Member").bytes());
 
         assertEquals(List.of("[]"), componentNonNullPaths(member, "id"));
         assertEquals(List.of("[]", "[TYPE_ARGUMENT(0)]"), componentNonNullPaths(member, "tags"));
@@ -223,12 +224,12 @@ class CompileRecordShapeTest {
     }
 
     /** Writes a compiled module out as class files a javac run can read. */
-    private static Path write(Path dir, Map<String, byte[]> compiled) throws IOException {
+    private static Path write(Path dir, Map<String, ClassFileImage> compiled) throws IOException {
         Path classes = Files.createDirectories(dir.resolve("classes"));
-        for (Map.Entry<String, byte[]> e : compiled.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : compiled.entrySet()) {
             Path target = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(target.getParent());
-            Files.write(target, e.getValue());
+            Files.write(target, e.getValue().bytes());
         }
         return classes;
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileSharedInstanceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSharedInstanceTest.java
@@ -3,6 +3,8 @@ package souther.compiler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +41,7 @@ class CompileSharedInstanceTest {
             """;
 
     /** The module compiled once: the four tests only read, so they can share one loader. */
-    private static final Map<String, byte[]> CLASSES = Compiler.compile(MODULE);
+    private static final Map<String, ClassFileImage> CLASSES = Compiler.compile(MODULE);
     private static final BytesClassLoader LOADER =
             new BytesClassLoader(CLASSES, CompileSharedInstanceTest.class.getClassLoader());
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileSpecChapter23Test.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSpecChapter23Test.java
@@ -1,5 +1,6 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.DecoderKind;
 import org.junit.jupiter.api.Test;
 
@@ -105,7 +106,7 @@ class CompileSpecChapter23Test {
 
     @Test
     void theChapter23ModelCompiles() {
-        Map<String, byte[]> classes = Compiler.compile(MODULE);
+        Map<String, ClassFileImage> classes = Compiler.compile(MODULE);
         assertTrue(classes.containsKey("example.businesstrip.事前承認する"));
         assertTrue(classes.containsKey(Emitted.decoder("example.businesstrip", "出張申請", DecoderKind.VALUE)), "the state sum derives a decoder");
         assertTrue(classes.containsKey("example.businesstrip.現在時刻"), "the clock gets a Java base class");
@@ -125,7 +126,7 @@ class CompileSpecChapter23Test {
      */
     @Test
     void approvalRequiresTheApplicantsManager() throws Exception {
-        Map<String, byte[]> classes = new java.util.HashMap<>(Compiler.compile(MODULE));
+        Map<String, ClassFileImage> classes = new java.util.HashMap<>(Compiler.compile(MODULE));
         classes.put("example.businesstrip.固定時刻", Subclasses.compile(classes,
                 "example.businesstrip.固定時刻", """
                         package example.businesstrip;

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.diag.CompileException;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Compilation;
 
 
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CompileTypeVariableTest {
 
     /** Compiles a core (reserved-namespace) module, which the user-facing guard would reject. */
-    private static Map<String, byte[]> compileCore(String src) {
+    private static Map<String, ClassFileImage> compileCore(String src) {
         Compilation compilation = Compilation.ofCoreSource(src);
         compilation.answerEverything();
         CompileException failed = compilation.failure();

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueSpreadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueSpreadTest.java
@@ -115,14 +115,14 @@ class CompileValueSpreadTest {
      */
     @Test
     void aPublishedValueCarriesTheValueItSpreads() {
-        ModulePath library = Compiler.compile("""
+        ModulePath library = ModulePath.of(Compiler.compile("""
                 module shared.people exposing ( Person, listed )
 
                 data Person = { name: String, age: Int }
 
                 let base = Person { name = "A", age = 20 }
                 let listed = Person { ...base, age = 21 }
-                """)::get;
+                """));
 
         assertDoesNotThrow(() -> Compiler.compileModules(java.util.List.of("""
                 module app.roster exposing ( Entry )

--- a/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
@@ -5,6 +5,7 @@ import souther.compiler.types.TypeSymbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.meta.ModulePath;
 
+import souther.compiler.jvm.ClassFileImage;
 import souther.runtime.ConstraintViolation;
 
 import org.junit.jupiter.api.Test;
@@ -34,15 +35,15 @@ class CrossProjectImportTest {
 
     /** The library project's build: its own compile, and nothing of the consumer's. */
     private static ModulePath published(String... sources) {
-        Map<String, byte[]> classes = sources.length == 1
+        Map<String, ClassFileImage> classes = sources.length == 1
                 ? Compiler.compile(sources[0])
                 : Compiler.compileModules(List.of(sources));
-        return classes::get;
+        return ModulePath.of(classes);
     }
 
     @Test
     void aModuleOnThePathCanBeImported() {
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.order
                 import shared.money ( Amount )
                 data Order = { total: Amount }
@@ -66,7 +67,7 @@ class CrossProjectImportTest {
                 data Stock = Map<String, Int>
                 """);
 
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.catalog exposing ( Item )
                 import List ( length )
                 import shared.tagging ( Tags )
@@ -89,7 +90,7 @@ class CrossProjectImportTest {
     @Test
     void constructingAnImportedTypeRunsTheInvariantTheLibraryCompiled() throws Exception {
         ModulePath path = published(LIBRARY);
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.order exposing ( Req, place )
                 import shared.money ( Amount )
                 data Req = { n: Int }
@@ -97,9 +98,11 @@ class CrossProjectImportTest {
                 let place (r) = Amount(r.n)
                 """), path);
 
-        Map<String, byte[]> both = new LinkedHashMap<>(app);
-        both.put("shared.money.Amount", path.bytes("shared.money.Amount"));
-        both.put(Emitted.ctfe("shared.money", "Amount"), path.bytes(Emitted.ctfe("shared.money", "Amount")));
+        Map<String, ClassFileImage> both = new LinkedHashMap<>(app);
+        both.put("shared.money.Amount",
+                ClassFileImage.of(path.bytes("shared.money.Amount")));
+        both.put(Emitted.ctfe("shared.money", "Amount"),
+                ClassFileImage.of(path.bytes(Emitted.ctfe("shared.money", "Amount"))));
         BytesClassLoader loader = new BytesClassLoader(both, getClass().getClassLoader());
         Object impl = Emitted.behavior(loader, "app.order", "place").getDeclaredConstructor().newInstance();
 
@@ -168,12 +171,13 @@ class CrossProjectImportTest {
      * project does not have, so what is reported is the path, naming both modules. */
     @Test
     void aDependencyOfADependencyThatIsAbsentNamesBothModules() {
-        Map<String, byte[]> both = Compiler.compileModules(List.of(LIBRARY, """
+        Map<String, ClassFileImage> both = Compiler.compileModules(List.of(LIBRARY, """
                 module shared.billing exposing ( Invoice )
                 import shared.money ( Amount )
                 data Invoice = { total: Amount }
                 """));
-        ModulePath halfThere = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+        ModulePath halfThere = name -> name.startsWith("shared.billing") && both.containsKey(name)
+                ? both.get(name).bytes() : null;
 
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileModules(List.of("""
@@ -191,7 +195,7 @@ class CrossProjectImportTest {
      * nothing it can see mentions. */
     @Test
     void anImportOnlyAnUnpublishedLetNeededIsNotRequiredOnThePath() {
-        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> both = Compiler.compileModules(List.of("""
                 module shared.audit exposing ( Trail )
                 data Trail = String
                 """, """
@@ -200,7 +204,8 @@ class CrossProjectImportTest {
                 data Invoice = { total: Int }
                 let describe (t: Trail) = t
                 """));
-        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") && both.containsKey(name)
+                ? both.get(name).bytes() : null;
 
         Compiler.compileModules(List.of("""
                 module app.ledger
@@ -215,7 +220,7 @@ class CrossProjectImportTest {
      * declaration needs is not always one a field mentions. It is still needed on the path. */
     @Test
     void anImportOnlySpreadIntoAPublishedDataIsStillRequired() {
-        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> both = Compiler.compileModules(List.of("""
                 module shared.base exposing ( Common )
                 data Common = { id: String }
                 """, """
@@ -223,7 +228,8 @@ class CrossProjectImportTest {
                 import shared.base ( Common )
                 data Invoice = { ...Common, total: Int }
                 """));
-        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") && both.containsKey(name)
+                ? both.get(name).bytes() : null;
 
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileModules(List.of("""
@@ -240,7 +246,7 @@ class CrossProjectImportTest {
      * declarations write, so that is what says the import is needed. */
     @Test
     void anImportUsedOnlyThroughItsAliasIsStillRequired() {
-        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> both = Compiler.compileModules(List.of("""
                 module shared.audit exposing ( Trail )
                 data Trail = String
                 """, """
@@ -248,7 +254,8 @@ class CrossProjectImportTest {
                 import shared.audit as A
                 data Invoice = { trail: A.Trail }
                 """));
-        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") && both.containsKey(name)
+                ? both.get(name).bytes() : null;
 
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileModules(List.of("""
@@ -321,7 +328,7 @@ class CrossProjectImportTest {
                 data Terms = Net15 | Net30
                 """);
 
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.billing
                 import shared.terms ( Terms, Net30 )
                 data Req = { n: Int }
@@ -329,9 +336,9 @@ class CrossProjectImportTest {
                 let pick (r) = Net30
                 """), path);
 
-        Map<String, byte[]> both = new LinkedHashMap<>(app);
-        both.put("shared.terms.Terms", path.bytes("shared.terms.Terms"));
-        both.put("shared.terms.Net30", path.bytes("shared.terms.Net30"));
+        Map<String, ClassFileImage> both = new LinkedHashMap<>(app);
+        both.put("shared.terms.Terms", ClassFileImage.of(path.bytes("shared.terms.Terms")));
+        both.put("shared.terms.Net30", ClassFileImage.of(path.bytes("shared.terms.Net30")));
         BytesClassLoader loader = new BytesClassLoader(both, getClass().getClassLoader());
         Object impl = Emitted.behavior(loader, "app.billing", "pick").getDeclaredConstructor().newInstance();
 
@@ -346,7 +353,7 @@ class CrossProjectImportTest {
      */
     @Test
     void anImportedTypeIsAUnionMemberWithoutTouchingTheLibrary() throws Exception {
-        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> app = Compiler.compileModules(List.of("""
                 module app.billing exposing ( NothingOwed, owed )
                 import shared.money ( Amount )
                 data NothingOwed

--- a/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
@@ -13,6 +13,8 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
 import souther.compiler.report.AdequacyReport;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.source.SourceId;
 
 import tools.jackson.databind.JsonNode;
@@ -53,8 +55,8 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
     /** A module this compile has no file for, built as its own project's build would — and needing
      *  one this compile does not put on the path, so reading it back has something to report about a
      *  declaration written where there is no file. */
-    private static Map<String, byte[]> published() {
-        Map<String, byte[]> deep = Compiler.compile("""
+    private static Map<String, ClassFileImage> published() {
+        Map<String, ClassFileImage> deep = Compiler.compile("""
                 module lib.deep exposing ( Deep )
                 data Deep = String
                 """);
@@ -63,7 +65,7 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
                 import lib.deep ( Deep )
 
                 data Held = { deep: Deep }
-                """), deep::get);
+                """), ModulePath.of(deep));
     }
 
     /** A compile that reaches that module, so a report about it has to be said somewhere here. */
@@ -73,7 +75,7 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
                 import lib.held ( Held )
 
                 data Page = { held: Held }
-                """), published()::get);
+                """), ModulePath.of(published()));
         compilation.answerEverything();
         return compilation;
     }

--- a/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
@@ -202,9 +202,9 @@ class ImportChangesNoMeaningTest {
         return qualified.classes().entrySet().stream()
                 .filter(e -> !e.getKey().equals(Emitted.declarations("demo")))
                 .sorted(java.util.Map.Entry.comparingByKey())
-                .filter(e -> e.getValue().length != imported.classes().get(e.getKey()).length)
+                .filter(e -> e.getValue().size() != imported.classes().get(e.getKey()).size())
                 .map(e -> e.getKey() + "="
-                        + (e.getValue().length - imported.classes().get(e.getKey()).length))
+                        + (e.getValue().size() - imported.classes().get(e.getKey()).size()))
                 .collect(Collectors.joining(","));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ModuleOmissionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ModuleOmissionTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import souther.compiler.diag.CompileException;
 
 import souther.compiler.frontend.CstFrontend;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ class ModuleOmissionTest {
 
     @Test
     void compileNamesTheGeneratedClassesAfterTheDefault() {
-        Map<String, byte[]> classes = Compiler.compile(HEADERLESS, "hello");
+        Map<String, ClassFileImage> classes = Compiler.compile(HEADERLESS, "hello");
         assertTrue(classes.containsKey("hello.Greet"), classes.keySet().toString());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/Subclasses.java
+++ b/souther-compiler/src/test/java/souther/compiler/Subclasses.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import javax.tools.ToolProvider;
 import java.io.File;
 import java.nio.file.Files;
@@ -16,15 +18,15 @@ final class Subclasses {
 
     private Subclasses() {}
 
-    /** The bytes of {@code className}, compiled from {@code source} with {@code generated} on the
-     * classpath. */
-    static byte[] compile(Map<String, byte[]> generated, String className, String source)
-            throws Exception {
+    /** The class file of {@code className}, compiled from {@code source} with {@code generated} on
+     * the classpath. */
+    static ClassFileImage compile(Map<String, ClassFileImage> generated, String className,
+                                  String source) throws Exception {
         Path classesDir = Files.createTempDirectory("souther-gen");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             Path p = classesDir.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(p.getParent());
-            Files.write(p, e.getValue());
+            Files.write(p, e.getValue().bytes());
         }
         Path srcFile = classesDir.resolve(className.replace('.', '/') + ".java");
         Files.createDirectories(srcFile.getParent());
@@ -36,6 +38,7 @@ final class Subclasses {
         if (rc != 0) {
             throw new IllegalStateException("javac failed for " + className + " (rc=" + rc + ")");
         }
-        return Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class"));
+        return ClassFileImage.of(
+                Files.readAllBytes(outDir.resolve(className.replace('.', '/') + ".class")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/TwoBehaviorsOfOneNameAreTwoBehaviorsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TwoBehaviorsOfOneNameAreTwoBehaviorsTest.java
@@ -8,6 +8,7 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
 import souther.compiler.query.Output;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.ValueName;
 
 import java.lang.classfile.ClassFile;
@@ -119,9 +120,9 @@ class TwoBehaviorsOfOneNameAreTwoBehaviorsTest {
         Compilation c = compiled(THEIRS, own);
         // `app.a.f` is built where it is declared, so this composition requires nothing injected.
         assertEquals(List.of(), c.db().ask(new Bodies.Requirements("app.own")).value().get("flow"));
-        Map<String, byte[]> classes = c.db().ask(new Output.Classes("app.own")).value();
+        Map<String, ClassFileImage> classes = c.db().ask(new Output.Classes("app.own")).value();
         assertTrue(classes.containsKey("app.own.F"), classes.keySet().toString());
-        assertEquals("app.own.F", declaredBy(classes.get("app.own.F")));
+        assertEquals("app.own.F", declaredBy(classes.get("app.own.F").bytes()));
     }
 
     /** And the other way round: the module's own is built here and the one it reaches is injected
@@ -196,8 +197,8 @@ class TwoBehaviorsOfOneNameAreTwoBehaviorsTest {
                         new ValueName.Behavior("app.b", "f")),
                 dependenciesOf(c, "app.own", "flow"),
                 "one requirement each, in the order the stages name them");
-        Map<String, byte[]> classes = c.db().ask(new Output.Classes("app.own")).value();
-        List<String> fields = fieldNames(classes.get("app.own.Flow$Impl"));
+        Map<String, ClassFileImage> classes = c.db().ask(new Output.Classes("app.own")).value();
+        List<String> fields = fieldNames(classes.get("app.own.Flow$Impl").bytes());
         assertEquals(2, fields.size(), "two dependencies, two fields: " + fields);
         assertEquals(2, Set.copyOf(fields).size(),
                 "and two names — a field name is the class's own, so one name cannot answer for"
@@ -295,7 +296,7 @@ class TwoBehaviorsOfOneNameAreTwoBehaviorsTest {
      */
     @Test
     void oneDeclaredHereAndOneReadBackFromTheClassPath() {
-        Map<String, byte[]> published = Compiler.compile(THEIRS);
+        Map<String, ClassFileImage> published = Compiler.compile(THEIRS);
         String own = """
                 module app.own exposing ( Out, flow : Out )
                 data Out = { n: Int }
@@ -303,7 +304,7 @@ class TwoBehaviorsOfOneNameAreTwoBehaviorsTest {
                 let f (m) = Out { n = m.n }
                 behavior flow = app.a.f >-> f
                 """;
-        Compilation c = Compilation.ofSources(List.of(own), published::get);
+        Compilation c = Compilation.ofSources(List.of(own), ModulePath.of(published));
         c.answerEverything();
         List<String> codes = new ArrayList<>();
         for (Db.Found found : c.db().allReports()) {

--- a/souther-compiler/src/test/java/souther/compiler/WhatAFixtureMaySupplyIsItsOwnQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAFixtureMaySupplyIsItsOwnQuestionTest.java
@@ -5,6 +5,8 @@ import souther.compiler.check.Sig;
 import souther.compiler.diag.CompileException;
 import souther.compiler.query.Compilation;
 import souther.compiler.check.BoundaryInput;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.types.Type;
 
 import org.junit.jupiter.api.Test;
@@ -142,7 +144,7 @@ class WhatAFixtureMaySupplyIsItsOwnQuestionTest {
      */
     @Test
     void aTypeAnImportedModuleDeclaresBuilds() {
-        java.util.Map<String, byte[]> library = Compiler.compile("""
+        java.util.Map<String, ClassFileImage> library = Compiler.compile("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
                 """);
@@ -155,7 +157,7 @@ class WhatAFixtureMaySupplyIsItsOwnQuestionTest {
                 let place (a) = Out { n = a.value }
                 example place
                   | "an imported type in a fixture" : (Amount(5)) -> Out { n = 5 }
-                """), library::get));
+                """), ModulePath.of(library)));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhetherCodeIsOutOfSightIsSettledWhereItIsParsedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhetherCodeIsOutOfSightIsSettledWhereItIsParsedTest.java
@@ -12,6 +12,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.meta.ModuleReadback;
 import souther.compiler.meta.ReadableModule;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.Readback;
 
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ class WhetherCodeIsOutOfSightIsSettledWhereItIsParsedTest {
      */
     @Test
     void everyPositionOfAModuleReadOffThePathIsOutOfSight() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module lib.rule exposing ( Code )
 
                 data Code = Int
@@ -77,7 +78,8 @@ class WhetherCodeIsOutOfSightIsSettledWhereItIsParsedTest {
         ReadableModule read = assertInstanceOf(ReadableModule.class,
                 assertInstanceOf(Readback.Ready.class,
                         ModuleReadback.read("lib.rule",
-                                ((souther.compiler.meta.ModulePath) classes::get).declarations(), DefaultStdlib.get().names()),
+                                souther.compiler.meta.ModulePath.of(classes).declarations(),
+                                DefaultStdlib.get().names()),
                         "the module was published and is on the path").value());
 
         List<SourcePos> positions = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/WhoHoldsABehaviorToWhatItDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhoHoldsABehaviorToWhatItDeclaredTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.ClassFile;
@@ -99,28 +101,30 @@ class WhoHoldsABehaviorToWhatItDeclaredTest {
 
     @Test
     void aBodiedBehaviorChecksItselfOnceWhereItAnswers() {
-        Map<String, byte[]> classes = Compiler.compile(BODIED);
+        Map<String, ClassFileImage> classes = Compiler.compile(BODIED);
 
-        assertEquals(1, checksIn(classes.get("demo.Twice$Impl"), "apply", "demo/Twice$Ensures"),
+        assertEquals(1, checksIn(classes.get("demo.Twice$Impl").bytes(), "apply",
+                "demo/Twice$Ensures"),
                 "its own `apply` is the door every application goes through");
-        assertEquals(0, checksIn(classes.get("demo.Twice$Impl"), "apply$body", "demo/Twice$Ensures"),
+        assertEquals(0, checksIn(classes.get("demo.Twice$Impl").bytes(), "apply$body",
+                "demo/Twice$Ensures"),
                 "and the body is what is being held, not where the holding is written");
     }
 
     /** A caller emits nothing: what it calls holds itself, whatever door the caller came in by. */
     @Test
     void acallerOfABodiedBehaviorEmitsNoCheck() {
-        Map<String, byte[]> classes = Compiler.compile(BODIED);
+        Map<String, ClassFileImage> classes = Compiler.compile(BODIED);
 
-        assertEquals(0, checksOf(classes.get("demo.TwiceOver$Impl"), "demo/Twice$Ensures"),
+        assertEquals(0, checksOf(classes.get("demo.TwiceOver$Impl").bytes(), "demo/Twice$Ensures"),
                 "`twice` is checked by `twice`, in none of this class's methods");
     }
 
     @Test
     void anInjectedBehaviorIsCheckedAtTheCrossingByWhoeverCallsIt() {
-        Map<String, byte[]> classes = Compiler.compile(INJECTED);
+        Map<String, ClassFileImage> classes = Compiler.compile(INJECTED);
 
-        assertEquals(1, checksOf(classes.get("demo.Use$Impl"), "demo/Fetch$Ensures"),
+        assertEquals(1, checksOf(classes.get("demo.Use$Impl").bytes(), "demo/Fetch$Ensures"),
                 "the answer enters the domain here, so this is where it is held");
     }
 
@@ -139,7 +143,7 @@ class WhoHoldsABehaviorToWhatItDeclaredTest {
     /** A behavior stating nothing has no class and no call. */
     @Test
     void aBehaviorThatDeclaresNothingIsHeldNowhere() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module demo
 
                 data Amount = Int
@@ -149,6 +153,6 @@ class WhoHoldsABehaviorToWhatItDeclaredTest {
                 """);
 
         assertFalse(classes.containsKey("demo.Echo$Ensures"));
-        assertEquals(0, checksOf(classes.get("demo.Echo$Impl"), "demo/Echo$Ensures"));
+        assertEquals(0, checksOf(classes.get("demo.Echo$Impl").bytes(), "demo/Echo$Ensures"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
@@ -16,6 +16,7 @@ import souther.compiler.diag.Placement;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Bodies;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Compilation;
 
 import java.util.ArrayList;
@@ -158,8 +159,8 @@ class ACopiedBodyIsReadAgainstAFileThisCompileHasTest {
 
     /** The declaring module as another project built it: classes alone, no source. */
     private static ModulePath published(String source) {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(source));
-        return classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(source));
+        return ModulePath.of(classes);
     }
 
     private static List<SourcePos> positionsIn(Hir.Expr e) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
@@ -19,6 +19,7 @@ import souther.compiler.diag.DeclaringCode;
 import souther.compiler.diag.Placement;
 import souther.compiler.diag.msg.InvariantMessage;
 import souther.compiler.diag.msg.WrittenAtMessage;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import java.util.List;
@@ -217,8 +218,8 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
 
     /** The declaring module as another project built it: classes alone, no source. */
     private static ModulePath published(String source) {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(source));
-        return classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(source));
+        return ModulePath.of(classes);
     }
 
     private static Diagnostic only(Map<SourceId, List<Located>> byFile, String sourceId) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
@@ -241,7 +241,7 @@ class AWarningAboutAClauseSendsAReaderToItTest {
      */
     @Test
     void aClauseOfAPublishedModuleIsNotPointedAt() {
-        ModulePath path = Compiler.compileModules(List.of(DECLARING))::get;
+        ModulePath path = ModulePath.of(Compiler.compileModules(List.of(DECLARING)));
         List<InvariantChecker.Said> said = java.util.Collections.synchronizedList(
                 new java.util.ArrayList<>());
         List<Diagnostic> warnings;

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereADeclarationCameFromDoesNotDecideItsDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereADeclarationCameFromDoesNotDecideItsDischargeTest.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.Compiler;
 import souther.compiler.check.InvariantChecker.Said;
 import souther.compiler.check.InvariantChecker.Verdict;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
@@ -111,8 +112,8 @@ class WhereADeclarationCameFromDoesNotDecideItsDischargeTest {
     /** The library compiled on its own, and its classes handed over as the whole of what the second
      * compile knows about it. */
     private static List<Verdict> importedFromClasses(String uses) {
-        Map<String, byte[]> classes = Compiler.compile(LIBRARY);
-        ModulePath path = classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(LIBRARY);
+        ModulePath path = ModulePath.of(classes);
         return verdicts(() -> Compiler.compileModulesWithWarnings(List.of(app(uses)), path));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/codegen/AClassIsHeldUnderTheNameItDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/AClassIsHeldUnderTheNameItDeclaresTest.java
@@ -63,6 +63,6 @@ class AClassIsHeldUnderTheNameItDeclaresTest {
 
         emissions.put(held, declaring(name));
 
-        assertEquals(java.util.Set.of(name), emissions.byBinaryName().keySet());
+        assertEquals(java.util.Set.of(name), emissions.seal().keySet());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
@@ -3,6 +3,8 @@ package souther.compiler.codegen;
 import souther.compiler.Compiler;
 import souther.compiler.core.Kernel;
 
+import souther.compiler.jvm.ClassFileImage;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.ClassFile;
@@ -100,8 +102,8 @@ class DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest {
     @Test
     void noEmittedCodeRunsADecimalOperationOnBigDecimalItself() {
         Set<String> byTheBackend = new TreeSet<>();
-        for (Map.Entry<String, byte[]> emitted : Compiler.compile(MODULE).entrySet()) {
-            for (MethodModel method : ClassFile.of().parse(emitted.getValue()).methods()) {
+        for (Map.Entry<String, ClassFileImage> emitted : Compiler.compile(MODULE).entrySet()) {
+            for (MethodModel method : ClassFile.of().parse(emitted.getValue().bytes()).methods()) {
                 if (!(method.code().orElse(null) instanceof CodeModel body)) {
                     continue;
                 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/TwoClassesUnderOneNameAreNotOneClassTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/TwoClassesUnderOneNameAreNotOneClassTest.java
@@ -3,6 +3,7 @@ package souther.compiler.codegen;
 import souther.compiler.Emitted;
 import souther.compiler.EmittedBytes;
 import org.junit.jupiter.api.Test;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.jvm.DecoderKind;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.types.TypeKey;
@@ -12,7 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,10 +50,10 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
                 "the refusal names the class both wanted: " + refused.getMessage());
         assertTrue(refused.getMessage().contains("Quote") && refused.getMessage().contains("quote"),
                 "and the two identities that wanted it: " + refused.getMessage());
-        assertEquals(List.of(Emitted.value("demo", "Quote")), List.copyOf(out.byBinaryName().keySet()),
+        assertEquals(List.of(Emitted.value("demo", "Quote")), List.copyOf(out.seal().keySet()),
                 "the class already written stays the one that is written");
-        assertArrayEquals(EmittedBytes.of(QUOTE_DATA, "first"),
-                out.byBinaryName().get(Emitted.value("demo", "Quote")),
+        assertEquals(ClassFileImage.of(EmittedBytes.of(QUOTE_DATA, "first")),
+                out.seal().get(Emitted.value("demo", "Quote")),
                 "and it is not replaced on the way out");
     }
 
@@ -86,8 +86,8 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
                 () -> out.rewrite(QUOTE_BEHAVIOR, _ -> EmittedBytes.of(QUOTE_BEHAVIOR)));
         assertTrue(refused.getMessage().contains("Quote") && refused.getMessage().contains("quote"),
                 "the refusal names what was emitted and what asked: " + refused.getMessage());
-        assertArrayEquals(EmittedBytes.of(QUOTE_DATA, "first"),
-                out.byBinaryName().get(Emitted.value("demo", "Quote")),
+        assertEquals(ClassFileImage.of(EmittedBytes.of(QUOTE_DATA, "first")),
+                out.seal().get(Emitted.value("demo", "Quote")),
                 "and the class is not rewritten");
     }
 
@@ -97,12 +97,14 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
         Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, EmittedBytes.of(QUOTE_DATA, "first"));
         out.rewrite(QUOTE_DATA, _ -> EmittedBytes.of(QUOTE_DATA, "rewritten"));
-        assertArrayEquals(EmittedBytes.of(QUOTE_DATA, "rewritten"),
-                out.byBinaryName().get(Emitted.value("demo", "Quote")));
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.put(QUOTE_DATA, EmittedBytes.of(QUOTE_DATA, "third")));
         assertTrue(refused.getMessage().contains("written twice"),
                 "and a rewrite is not a second emission: " + refused.getMessage());
+        // Read last: sealing ends the writing, so what the refusal above is about has to be asked
+        // before it.
+        assertEquals(ClassFileImage.of(EmittedBytes.of(QUOTE_DATA, "rewritten")),
+                out.seal().get(Emitted.value("demo", "Quote")));
     }
 
     /** A rewrite of something nothing emitted is refused rather than becoming the emission of it. */
@@ -112,7 +114,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.rewrite(QUOTE_DATA, _ -> EmittedBytes.of(QUOTE_DATA)));
         assertTrue(refused.getMessage().contains("demo.Quote"), refused.getMessage());
-        assertEquals(List.of(), List.copyOf(out.byBinaryName().keySet()));
+        assertEquals(List.of(), List.copyOf(out.seal().keySet()));
     }
 
     /** And through the door a whole set of classes arrives by, which is how the classes compiled for
@@ -144,6 +146,6 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
         assertEquals(List.of(Emitted.value("demo", "Quote"), Emitted.encoder("demo", "Quote"),
                         Emitted.decoder("demo", "Quote", DecoderKind.JSON),
                         Emitted.behaviorInterface("demo", "price")),
-                List.copyOf(out.byBinaryName().keySet()));
+                List.copyOf(out.seal().keySet()));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/WhatIsSealedIsNoLongerWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/WhatIsSealedIsNoLongerWrittenTest.java
@@ -7,10 +7,19 @@ import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,33 +56,61 @@ class WhatIsSealedIsNoLongerWrittenTest {
                 out.seal());
     }
 
-    @Test
-    void nothingIsEmittedAfterwards() {
-        Emissions out = written();
-        out.seal();
-
-        IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> out.put(LAMBDA, EmittedBytes.of(LAMBDA)));
-        assertTrue(refused.getMessage().contains("sealed"), refused.getMessage());
+    /**
+     * Every way of writing, each asked after the sealing.
+     *
+     * <p>Named one at a time and held to covering the type, which is the point of the row below it:
+     * a way in that arrives without a line here is one nothing asked, and the guard that was
+     * forgotten on it is the guard nothing says is missing.
+     *
+     * <p><b>What is refused is asking, not a write that had something in it.</b> A set with nothing
+     * in it is here for that: {@code putAll} used to be the loop and nothing else, so a caller
+     * handing over nothing walked past the guard — and what that guard held was "one class was
+     * written after the sealing", which is not the rule.
+     */
+    private static Map<String, Consumer<Emissions>> everyWayOfWriting() {
+        Map<String, Consumer<Emissions>> ways = new LinkedHashMap<>();
+        ways.put("put", out -> out.put(LAMBDA, EmittedBytes.of(LAMBDA)));
+        ways.put("putAll", out -> out.putAll(Map.of(LAMBDA, EmittedBytes.of(LAMBDA))));
+        ways.put("putAll, of nothing", out -> out.putAll(Map.of()));
+        ways.put("rewrite", out -> out.rewrite(QUOTE, _ -> EmittedBytes.of(QUOTE, "afterwards")));
+        return ways;
     }
 
-    @Test
-    void norAWholeSetOfThem() {
-        Emissions out = written();
-        out.seal();
+    /** What this holds beside writing: what it was written for, and the sealing itself. */
+    private static final Set<String> WHICH_DO_NOT_WRITE = Set.of("implemented", "seal");
 
-        assertThrows(IllegalStateException.class,
-                () -> out.putAll(Map.of(LAMBDA, EmittedBytes.of(LAMBDA))));
+    @TestFactory
+    Stream<DynamicTest> everyWayOfWritingIsRefusedAfterwards() {
+        return everyWayOfWriting().entrySet().stream().map(way -> dynamicTest(way.getKey(), () -> {
+            Emissions out = written();
+            out.seal();
+
+            IllegalStateException refused =
+                    assertThrows(IllegalStateException.class, () -> way.getValue().accept(out));
+            assertTrue(refused.getMessage().contains("sealed"), refused.getMessage());
+        }));
     }
 
+    /**
+     * And the ways above are the ways there are.
+     *
+     * <p>The list is a list somebody wrote, so what makes it a rule is being held to what the type
+     * declares. A method arriving here fails until whoever wrote it says which of the two it is: a
+     * way of writing, which is then asked after the sealing, or one of the things that do not write.
+     */
     @Test
-    void norIsAnythingWrittenOntoWhatIsThere() {
-        Emissions out = written();
-        out.seal();
+    void andThoseAreTheWaysIn() {
+        Set<String> declared = Stream.of(Emissions.class.getDeclaredMethods())
+                .filter(m -> !m.isSynthetic() && !Modifier.isPrivate(m.getModifiers()))
+                .map(Method::getName)
+                .collect(java.util.stream.Collectors.toCollection(java.util.TreeSet::new));
+        Set<String> said = new java.util.TreeSet<>(WHICH_DO_NOT_WRITE);
+        everyWayOfWriting().keySet().forEach(way -> said.add(way.split(",")[0]));
 
-        IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> out.rewrite(QUOTE, _ -> EmittedBytes.of(QUOTE, "afterwards")));
-        assertTrue(refused.getMessage().contains("sealed"), refused.getMessage());
+        assertEquals(said, declared,
+                "every method of Emissions is a way of writing that is refused after the sealing,"
+                        + " or is written down as one that does not write");
     }
 
     /**
@@ -88,5 +125,22 @@ class WhatIsSealedIsNoLongerWrittenTest {
         Emissions out = written();
 
         assertSame(out.seal(), out.seal());
+    }
+
+    /**
+     * And what they are handed is not writable either.
+     *
+     * <p>Beside the row above rather than covered by it. One map handed to everybody is one map for
+     * a reader to write into, and every reader after it would be handed what that reader made of it
+     * — the refusals above say nothing about that, and neither does two readers getting the same
+     * object.
+     */
+    @Test
+    void norIsWhatTheyAreHandedWritable() {
+        Map<String, ClassFileImage> sealed = written().seal();
+
+        assertThrows(UnsupportedOperationException.class, sealed::clear);
+        assertThrows(UnsupportedOperationException.class,
+                () -> sealed.put(Emitted.value("demo", "Quote"), null));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/WhatIsSealedIsNoLongerWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/WhatIsSealedIsNoLongerWrittenTest.java
@@ -1,0 +1,92 @@
+package souther.compiler.codegen;
+
+import souther.compiler.Emitted;
+import souther.compiler.EmittedBytes;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.jvm.GeneratedClass;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where the classes of a module stop being writable, which is the one boundary between the thing
+ * that is built and the value it comes to.
+ *
+ * <p>A class is emitted, instrumented and written onto, and every one of those replaces an array
+ * with another. {@link Emissions#seal} is where that ends. Held to here rather than to the order
+ * statements happen to be in: a stamping step appended after the sealing would otherwise be a
+ * reader holding one thing and the next reader holding another, with nothing to say so.
+ */
+class WhatIsSealedIsNoLongerWrittenTest {
+
+    private static final GeneratedClass.Value QUOTE =
+            new GeneratedClass.Value(TypeSymbols.declared(new TypeKey("demo", "Quote")));
+    private static final GeneratedClass.Lambda LAMBDA = new GeneratedClass.Lambda("demo", 0);
+
+    private static Emissions written() {
+        Emissions out = new Emissions("demo");
+        out.put(QUOTE, EmittedBytes.of(QUOTE, "first"));
+        return out;
+    }
+
+    @Test
+    void whatIsWrittenBeforeItIsSealedIsWhatItAnswersWith() {
+        Emissions out = written();
+        out.rewrite(QUOTE, _ -> EmittedBytes.of(QUOTE, "rewritten"));
+
+        assertEquals(Map.of(Emitted.value("demo", "Quote"),
+                        ClassFileImage.of(EmittedBytes.of(QUOTE, "rewritten"))),
+                out.seal());
+    }
+
+    @Test
+    void nothingIsEmittedAfterwards() {
+        Emissions out = written();
+        out.seal();
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> out.put(LAMBDA, EmittedBytes.of(LAMBDA)));
+        assertTrue(refused.getMessage().contains("sealed"), refused.getMessage());
+    }
+
+    @Test
+    void norAWholeSetOfThem() {
+        Emissions out = written();
+        out.seal();
+
+        assertThrows(IllegalStateException.class,
+                () -> out.putAll(Map.of(LAMBDA, EmittedBytes.of(LAMBDA))));
+    }
+
+    @Test
+    void norIsAnythingWrittenOntoWhatIsThere() {
+        Emissions out = written();
+        out.seal();
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> out.rewrite(QUOTE, _ -> EmittedBytes.of(QUOTE, "afterwards")));
+        assertTrue(refused.getMessage().contains("sealed"), refused.getMessage());
+    }
+
+    /**
+     * And the second reader is handed what the first was.
+     *
+     * <p>Built once and kept, rather than read off the arrays again: an array still reachable from
+     * inside that somebody wrote into would otherwise reach the second reader and not the first,
+     * which is the fault the sealing exists to make impossible said one way further down.
+     */
+    @Test
+    void everyReaderIsHandedTheOneAnswer() {
+        Emissions out = written();
+
+        assertSame(out.seal(), out.seal());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.lang.reflect.Constructor;
@@ -66,7 +67,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         CoverageSites.Plan plan =
                 Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
         ComparisonOccurrence perElement = comparisonAt(plan, "fee", 9);
-        Map<String, byte[]> classes = probed(compilation);
+        Map<String, ClassFileImage> classes = probed(compilation);
 
         Observation mixed = new Behavior(classes, "fee").observing(20L, List.of(1L, -1L));
         Observation positives = new Behavior(classes, "fee").observing(20L, List.of(1L, 2L));
@@ -90,7 +91,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         CoverageSites.Plan plan =
                 Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
         ComparisonOccurrence named = comparisonAt(plan, "fee", 7);
-        Map<String, byte[]> classes = probed(compilation);
+        Map<String, ClassFileImage> classes = probed(compilation);
 
         assertEquals(List.of(true),
                 waysOut(new Behavior(classes, "fee").observing(20L, List.of(1L)), named));
@@ -105,7 +106,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         CoverageSites.Plan plan =
                 Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
         ComparisonOccurrence answered = comparisonAt(plan, "positive", 12);
-        Map<String, byte[]> classes = probed(compilation);
+        Map<String, ClassFileImage> classes = probed(compilation);
 
         assertEquals(List.of(true),
                 waysOut(new Behavior(classes, "positive").observing(5L), answered));
@@ -144,7 +145,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         return compilation;
     }
 
-    private static Map<String, byte[]> probed(Compilation compilation) {
+    private static Map<String, ClassFileImage> probed(Compilation compilation) {
         souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
                 .ask(new Output.Evaluated(compilation.modules().get(0),
                         ArmObservation.RECORD)).value();
@@ -158,7 +159,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         private final Object instance;
         private final Method apply;
 
-        Behavior(Map<String, byte[]> classes, String named) {
+        Behavior(Map<String, ClassFileImage> classes, String named) {
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     AComparisonIsLitWhereverItIsWrittenTest.class.getClassLoader());

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.lang.reflect.Constructor;
@@ -160,7 +161,7 @@ class AComparisonSaysWhichWayItCameOutTest {
         return compilation;
     }
 
-    private static Map<String, byte[]> probed(Compilation compilation) {
+    private static Map<String, ClassFileImage> probed(Compilation compilation) {
         souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
                 .ask(new Output.Evaluated(compilation.modules().get(0),
                         ArmObservation.RECORD)).value();
@@ -174,7 +175,7 @@ class AComparisonSaysWhichWayItCameOutTest {
         private final Object instance;
         private final Method apply;
 
-        Behavior(Map<String, byte[]> classes) {
+        Behavior(Map<String, ClassFileImage> classes) {
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     AComparisonSaysWhichWayItCameOutTest.class.getClassLoader());

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.lang.classfile.ClassFile;
@@ -59,7 +60,7 @@ class ProbedBytecodeTest {
         return compilation;
     }
 
-    private static Map<String, byte[]> probed(Compilation compilation) {
+    private static Map<String, ClassFileImage> probed(Compilation compilation) {
         souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
                 .ask(new Output.Evaluated(compilation.modules().get(0),
                         ArmObservation.RECORD)).value();
@@ -152,12 +153,12 @@ class ProbedBytecodeTest {
      */
     @Test
     void nothingThatShipsMentionsTheProbe() {
-        Map<String, byte[]> shipped = compiled().db().ask(new Output.All()).value();
+        Map<String, ClassFileImage> shipped = compiled().db().ask(new Output.All()).value();
         assertNotNull(shipped);
         assertFalse(shipped.isEmpty());
 
-        for (Map.Entry<String, byte[]> each : shipped.entrySet()) {
-            assertFalse(referencedClasses(each.getValue()).contains(PROBE),
+        for (Map.Entry<String, ClassFileImage> each : shipped.entrySet()) {
+            assertFalse(referencedClasses(each.getValue().bytes()).contains(PROBE),
                     each.getKey() + " refers to the probe");
         }
     }
@@ -165,10 +166,10 @@ class ProbedBytecodeTest {
     /** And that check is not vacuous: the measured classes do name it. */
     @Test
     void theMeasuredClassesDoMentionIt() {
-        Map<String, byte[]> classes = probed(compiled());
+        Map<String, ClassFileImage> classes = probed(compiled());
 
         assertTrue(classes.values().stream()
-                        .anyMatch(bytes -> referencedClasses(bytes).contains(PROBE)),
+                        .anyMatch(image -> referencedClasses(image.bytes()).contains(PROBE)),
                 "something in there records where a run went");
     }
 
@@ -203,23 +204,23 @@ class ProbedBytecodeTest {
     void onlyThisModulesClassesAreTheMeasuredOnes() {
         Compilation compilation = compiled();
         String module = compilation.modules().get(0);
-        Map<String, byte[]> plain = compilation.db().ask(new Output.Linked(module)).value();
-        Map<String, byte[]> measured = compilation.db()
+        Map<String, ClassFileImage> plain = compilation.db().ask(new Output.Linked(module)).value();
+        Map<String, ClassFileImage> measured = compilation.db()
                 .ask(new Output.Evaluated(module, ArmObservation.RECORD)).value().classes();
-        Map<String, byte[]> linked = compilation.db()
+        Map<String, ClassFileImage> linked = compilation.db()
                 .ask(new Output.EvaluationLinked(module, ArmObservation.RECORD)).value().classes();
         assertNotNull(plain);
         assertNotNull(linked);
 
         assertEquals(plain.keySet(), linked.keySet(), "the same classes are loadable");
-        for (Map.Entry<String, byte[]> each : linked.entrySet()) {
-            byte[] want = measured.containsKey(each.getKey())
+        for (Map.Entry<String, ClassFileImage> each : linked.entrySet()) {
+            ClassFileImage want = measured.containsKey(each.getKey())
                     ? measured.get(each.getKey()) : plain.get(each.getKey());
-            assertEquals(referencedClasses(want), referencedClasses(each.getValue()),
-                    each.getKey());
+            assertEquals(referencedClasses(want.bytes()),
+                    referencedClasses(each.getValue().bytes()), each.getKey());
         }
         assertTrue(measured.keySet().stream().anyMatch(name ->
-                        referencedClasses(linked.get(name)).contains(PROBE)),
+                        referencedClasses(linked.get(name).bytes()).contains(PROBE)),
                 "this module's own classes are the measured ones");
     }
 
@@ -231,7 +232,7 @@ class ProbedBytecodeTest {
         private final Object instance;
         private final Method apply;
 
-        Behavior(Map<String, byte[]> classes) {
+        Behavior(Map<String, ClassFileImage> classes) {
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     ProbedBytecodeTest.class.getClassLoader());

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -19,6 +19,8 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
 import souther.compiler.query.Scopes;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Shapes;
 
 import javax.tools.ToolProvider;
@@ -307,7 +309,7 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
     }
 
 
-    private static Map<String, byte[]> compiled(String model) {
+    private static Map<String, ClassFileImage> compiled(String model) {
         Compilation c = Compilation.ofSource(model, "Main");
         return c.db().ask(new Output.All()).value();
     }
@@ -364,8 +366,8 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
 
     /** What the module's rows are written for, as this compile emitted it. */
     private static java.util.function.Supplier<PublishedClasses> declarationsOf(Compilation c) {
-        Map<String, byte[]> classes = c.db().ask(new Output.All()).value();
-        return () -> new ClassFileDeclarations(classes::get);
+        Map<String, ClassFileImage> classes = c.db().ask(new Output.All()).value();
+        return () -> new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 
     /**
@@ -376,19 +378,19 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
      * its loader has, and a loader that serves classes and not resources would leave the reading with
      * nothing to read.
      */
-    private static Object builtElsewhere(Map<String, byte[]> generated, String source)
+    private static Object builtElsewhere(Map<String, ClassFileImage> generated, String source)
             throws Exception {
         return builtElsewhere(generated, source, "example/todo/FindTodoImpl.java",
                 "example.todo.FindTodoImpl");
     }
 
-    private static Object builtElsewhere(Map<String, byte[]> generated, String source,
+    private static Object builtElsewhere(Map<String, ClassFileImage> generated, String source,
                                          String written, String named) throws Exception {
         Path classes = Files.createTempDirectory("souther-bound");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve(written);
         Files.createDirectories(java.getParent());

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.generated.EvaluationArtifact;
-import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.PublishedClasses;
 import souther.compiler.observe.Applied;
 import souther.compiler.observe.Counting;
@@ -367,7 +366,7 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
     /** What the module's rows are written for, as this compile emitted it. */
     private static java.util.function.Supplier<PublishedClasses> declarationsOf(Compilation c) {
         Map<String, ClassFileImage> classes = c.db().ask(new Output.All()).value();
-        return () -> new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return () -> ModulePath.of(classes).declarations();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Scopes;
 import souther.compiler.generated.EvaluationArtifact;
-import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.PublishedClasses;
 import souther.compiler.observe.Applied;
 import souther.compiler.observe.Disposition;
@@ -329,6 +328,6 @@ class ARowIsNotHandedToAnAnswerFromAnotherBuildTest {
     private static PublishedClasses declarationsOf(String source) {
         Compilation compiled = Compilation.ofSource(source, "Main");
         Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
@@ -18,6 +18,8 @@ import souther.compiler.observe.Stage;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Shapes;
 
 import java.util.List;
@@ -326,7 +328,7 @@ class ARowIsNotHandedToAnAnswerFromAnotherBuildTest {
     /** The classes one build of {@code source} emits, read for what they were stamped with. */
     private static PublishedClasses declarationsOf(String source) {
         Compilation compiled = Compilation.ofSource(source, "Main");
-        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
-        return new ClassFileDeclarations(classes::get);
+        Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import javax.tools.ToolProvider;
@@ -109,18 +110,18 @@ class ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest {
     // --- harness ---------------------------------------------------------------------------------
 
     private static BoundExamples boundTo(String implementation) throws Exception {
-        Map<String, byte[]> generated =
+        Map<String, ClassFileImage> generated =
                 Compilation.ofSource(MODEL, "Main").db().ask(new Output.All()).value();
         return SoutherExamples.ofSource(MODEL).bind(builtElsewhere(generated, implementation));
     }
 
-    private static Object builtElsewhere(Map<String, byte[]> generated, String source)
+    private static Object builtElsewhere(Map<String, ClassFileImage> generated, String source)
             throws Exception {
         Path classes = Files.createTempDirectory("souther-optional-contract");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve("probe/opt/PickImpl.java");
         Files.createDirectories(java.getParent());

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
@@ -18,6 +18,7 @@ import souther.compiler.meta.PublishedClasses;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Shapes;
 
 import java.util.List;
@@ -230,7 +231,7 @@ class ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest {
     /** The classes one build of these sources emits, read for what they were stamped with. */
     private static PublishedClasses declarationsOf(List<String> sources) {
         Compilation compiled = Compilation.ofSources(sources, ModulePath.EMPTY);
-        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
-        return new ClassFileDeclarations(classes::get);
+        Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
@@ -12,7 +12,6 @@ import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.msg.Message;
 import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.generated.EvaluationArtifact;
-import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.PublishedClasses;
 import souther.compiler.query.Bodies;
@@ -232,6 +231,6 @@ class ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest {
     private static PublishedClasses declarationsOf(List<String> sources) {
         Compilation compiled = Compilation.ofSources(sources, ModulePath.EMPTY);
         Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/AStandInsStatementIsHeldToWhatTheImplementationAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AStandInsStatementIsHeldToWhatTheImplementationAnswersTest.java
@@ -234,7 +234,7 @@ class AStandInsStatementIsHeldToWhatTheImplementationAnswersTest {
         for (var e : souther.compiler.Compiler.compileModules(List.of(model)).entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve(pkg.replace('.', '/') + "/FindTodoImpl.java");
         Files.writeString(java, impl);

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswerIsReadIntoThisBuildAtEveryDepthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswerIsReadIntoThisBuildAtEveryDepthTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Sig;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.util.List;
@@ -91,7 +92,7 @@ class AnAnswerIsReadIntoThisBuildAtEveryDepthTest {
 
     private static Read read() {
         Compilation c = Compilation.ofSource(MODEL, "Main");
-        Map<String, byte[]> classes = c.db().ask(new Output.All()).value();
+        Map<String, ClassFileImage> classes = c.db().ask(new Output.All()).value();
         assertEquals(List.of(), c.diagnostics().values().stream().flatMap(List::stream)
                 .map(d -> String.valueOf(d.diagnostic().code())).toList());
         MemoryClassLoader loader =

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
@@ -20,6 +20,7 @@ import souther.compiler.observe.Stage;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Shapes;
 
 import java.util.ArrayList;
@@ -134,7 +135,7 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         private Class<?> hereLoaded;
         private String hereNamed;
 
-        private Answering asAnswering(Map<String, byte[]> classes, ClassLoader parent) {
+        private Answering asAnswering(Map<String, ClassFileImage> classes, ClassLoader parent) {
             return (generated, compiled) -> {
                 mine = new MemoryClassLoader(classes, parent);
                 return this;
@@ -221,7 +222,7 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         String name = c.modules().get(0);
         souther.compiler.generated.EvaluationArtifact artifact = c.db()
                 .ask(new Output.EvaluationLinked(name, ArmObservation.OMIT)).value();
-        Map<String, byte[]> classes = artifact.classes();
+        Map<String, ClassFileImage> classes = artifact.classes();
         ClassLoader parent = ExampleVerifier.class.getClassLoader();
         answerer.hereNamed = "example.crossing.倍額";
         answerer.hereLoaded = loaded(new MemoryClassLoader(classes, parent), answerer.hereNamed);

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnEntryIsHandedOverOnTheTermsARowIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnEntryIsHandedOverOnTheTermsARowIsTest.java
@@ -207,7 +207,7 @@ class AnEntryIsHandedOverOnTheTermsARowIsTest {
         for (var e : souther.compiler.Compiler.compileModules(List.of(source)).entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve("example/moved/FindTodoImpl.java");
         Files.writeString(java, impl);

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import javax.tools.ToolProvider;
@@ -314,17 +315,17 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
                 .orElseThrow(() -> new AssertionError("no row named `" + name + "`"));
     }
 
-    private static Map<String, byte[]> compiled(String model) {
+    private static Map<String, ClassFileImage> compiled(String model) {
         return Compilation.ofSource(model, "Main").db().ask(new Output.All()).value();
     }
 
-    private static Object builtElsewhere(Map<String, byte[]> generated, String source)
+    private static Object builtElsewhere(Map<String, ClassFileImage> generated, String source)
             throws Exception {
         Path classes = Files.createTempDirectory("souther-contract");
-        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+        for (Map.Entry<String, ClassFileImage> e : generated.entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve("example/todo/FindTodoImpl.java");
         Files.createDirectories(java.getParent());

--- a/souther-compiler/src/test/java/souther/compiler/examples/TheFaceReadsWhatAModelIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/TheFaceReadsWhatAModelIsWrittenAsTest.java
@@ -196,7 +196,7 @@ class TheFaceReadsWhatAModelIsWrittenAsTest {
         for (var e : souther.compiler.Compiler.compileModules(List.of(SHARED)).entrySet()) {
             Path at = published.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path model = dir.resolve("app.sou");
         Files.writeString(model, MODEL);
@@ -301,7 +301,7 @@ class TheFaceReadsWhatAModelIsWrittenAsTest {
         for (var e : souther.compiler.Compiler.compileModules(models).entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve(pkg.replace('.', '/') + "/" + named + ".java");
         Files.createDirectories(java.getParent());

--- a/souther-compiler/src/test/java/souther/compiler/examples/TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest.java
@@ -165,7 +165,7 @@ class TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest {
         for (var e : souther.compiler.Compiler.compileModules(List.of(MODEL)).entrySet()) {
             Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
             Files.createDirectories(at.getParent());
-            Files.write(at, e.getValue());
+            Files.write(at, e.getValue().bytes());
         }
         Path java = classes.resolve("example/stored/FindTodoImpl.java");
         Files.writeString(java, IMPL);

--- a/souther-compiler/src/test/java/souther/compiler/jvm/AClassFileIsWhatItsBytesSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/jvm/AClassFileIsWhatItsBytesSayTest.java
@@ -1,0 +1,76 @@
+package souther.compiler.jvm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * What a {@link ClassFileImage} is: the octets it was made of, compared by what they say.
+ *
+ * <p>The whole of what the answers holding one rest on. A store stops work by comparing an answer
+ * with the one it replaces, so two of these made from the same bytes have to be equal and two made
+ * from different bytes have to not be — and neither can turn on which array they were handed.
+ */
+class AClassFileIsWhatItsBytesSayTest {
+
+    /** Every octet there is, so nothing about the carrier turns on which values went through it. */
+    private static byte[] everyOctet() {
+        byte[] all = new byte[256];
+        for (int i = 0; i < all.length; i++) {
+            all[i] = (byte) i;
+        }
+        return all;
+    }
+
+    @Test
+    void everyByteComesBackAsItWentIn() {
+        assertArrayEquals(everyOctet(), ClassFileImage.of(everyOctet()).bytes());
+    }
+
+    @Test
+    void twoOfOneContentAreOneValue() {
+        assertEquals(ClassFileImage.of(everyOctet()), ClassFileImage.of(everyOctet()));
+        assertEquals(ClassFileImage.of(everyOctet()).hashCode(),
+                ClassFileImage.of(everyOctet()).hashCode());
+    }
+
+    @Test
+    void oneByteApartIsNotOneValue() {
+        byte[] moved = everyOctet();
+        moved[128] = (byte) (moved[128] + 1);
+        assertNotEquals(ClassFileImage.of(everyOctet()), ClassFileImage.of(moved));
+    }
+
+    @Test
+    void anEmptyOneIsAValueToo() {
+        assertEquals(ClassFileImage.of(new byte[0]), ClassFileImage.of(new byte[0]));
+        assertEquals(0, ClassFileImage.of(new byte[0]).size());
+    }
+
+    @Test
+    void sizeIsHowManyBytesThereAre() {
+        assertEquals(256, ClassFileImage.of(everyOctet()).size());
+    }
+
+    /** What was handed over is not what is held: writing into it afterwards changes nothing. */
+    @Test
+    void writingIntoTheArrayItWasMadeFromChangesNothing() {
+        byte[] handed = everyOctet();
+        ClassFileImage image = ClassFileImage.of(handed);
+        handed[0] = (byte) 0xFF;
+        assertEquals(ClassFileImage.of(everyOctet()), image);
+        assertArrayEquals(everyOctet(), image.bytes());
+    }
+
+    /** And what it hands out is not what it holds. */
+    @Test
+    void writingIntoTheArrayItHandsOutChangesNothing() {
+        ClassFileImage image = ClassFileImage.of(everyOctet());
+        byte[] taken = image.bytes();
+        taken[0] = (byte) 0xFF;
+        assertArrayEquals(everyOctet(), image.bytes());
+        assertEquals(ClassFileImage.of(everyOctet()), image);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.DefaultStdlib;
 import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.ValueName;
 
 import java.util.List;
@@ -64,8 +65,8 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
      */
     @Test
     void aModuleReachedWithoutAnImportIsRead() {
-        Map<String, byte[]> both = Compiler.compileModules(List.of(LIB, QUALIFYING));
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(both::get), DefaultStdlib.get());
+        Map<String, ClassFileImage> both = Compiler.compileModules(List.of(LIB, QUALIFYING));
+        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(both)::bytes), DefaultStdlib.get());
 
         readingOf(universe, "app.uses", "the module names a type of another and is read");
 
@@ -123,8 +124,8 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
      */
     @Test
     void aDeclarationThatReadsThroughAnotherModulesHelperIsRead() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(OFFERING, READING));
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(classes::get), DefaultStdlib.get());
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(OFFERING, READING));
+        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
 
         readingOf(universe, "example.order",
                 "its invariant calls a helper `example.money` published, which the import brings in");
@@ -149,13 +150,13 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
      */
     @Test
     void aModuleReadingThroughOneTheseClassesDoNotCarryIsNotRead() {
-        Map<String, byte[]> classes =
+        Map<String, ClassFileImage> classes =
                 new java.util.LinkedHashMap<>(Compiler.compileModules(List.of(OFFERING, NAMING)));
         int all = classes.size();
         classes.keySet().removeIf(binary -> binary.contains("money"));
         org.junit.jupiter.api.Assertions.assertTrue(classes.size() < all,
                 "the module being withheld is one this set had");
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(classes::get), DefaultStdlib.get());
+        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
 
         Readback.Failure why = refusalOf(universe, "example.line");
 
@@ -247,7 +248,7 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
     }
 
     private static PublishedUniverse universeOf(String source) {
-        Map<String, byte[]> classes = Compiler.compile(source);
-        return PublishedUniverse.of(new ClassFileDeclarations(classes::get), DefaultStdlib.get());
+        Map<String, ClassFileImage> classes = Compiler.compile(source);
+        return PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
@@ -66,7 +66,7 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
     @Test
     void aModuleReachedWithoutAnImportIsRead() {
         Map<String, ClassFileImage> both = Compiler.compileModules(List.of(LIB, QUALIFYING));
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(both)::bytes), DefaultStdlib.get());
+        PublishedUniverse universe = PublishedUniverse.of(ModulePath.of(both).declarations(), DefaultStdlib.get());
 
         readingOf(universe, "app.uses", "the module names a type of another and is read");
 
@@ -125,7 +125,7 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
     @Test
     void aDeclarationThatReadsThroughAnotherModulesHelperIsRead() {
         Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(OFFERING, READING));
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
+        PublishedUniverse universe = PublishedUniverse.of(ModulePath.of(classes).declarations(), DefaultStdlib.get());
 
         readingOf(universe, "example.order",
                 "its invariant calls a helper `example.money` published, which the import brings in");
@@ -156,7 +156,7 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
         classes.keySet().removeIf(binary -> binary.contains("money"));
         org.junit.jupiter.api.Assertions.assertTrue(classes.size() < all,
                 "the module being withheld is one this set had");
-        PublishedUniverse universe = PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
+        PublishedUniverse universe = PublishedUniverse.of(ModulePath.of(classes).declarations(), DefaultStdlib.get());
 
         Readback.Failure why = refusalOf(universe, "example.line");
 
@@ -249,6 +249,6 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
 
     private static PublishedUniverse universeOf(String source) {
         Map<String, ClassFileImage> classes = Compiler.compile(source);
-        return PublishedUniverse.of(new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get());
+        return PublishedUniverse.of(ModulePath.of(classes).declarations(), DefaultStdlib.get());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/meta/APublishedSignatureIsWrittenInNamesItsModuleHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/APublishedSignatureIsWrittenInNamesItsModuleHasTest.java
@@ -5,6 +5,7 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeReachName;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.TypeSymbols;
 
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,7 @@ class APublishedSignatureIsWrittenInNamesItsModuleHasTest {
      *  it travelled with, so its own names mean there what they meant here. */
     @Test
     void whatIsPublishedIsReadBackAsTheSameDeclaration() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(PRICING, """
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(PRICING, """
                 module shop.bare exposing ( Done, checkout : Done )
                 import shop.pricing ( Cart, Priced, quote )
                 data Done = { total: Int }
@@ -95,13 +96,13 @@ class APublishedSignatureIsWrittenInNamesItsModuleHasTest {
 
         // A second project, holding only the classes: it reads shop.bare's declarations back and
         // types a call against them, which is the round trip the published text exists for.
-        Map<String, byte[]> downstream = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> downstream = Compiler.compileModules(List.of("""
                 module app exposing ( run )
                 import shop.bare ( Done, checkout )
                 import shop.pricing ( Cart )
                 behavior run : (c: Cart) -> Done
                 let run (c) = checkout(c)
-                """), classes::get);
+                """), ModulePath.of(classes));
 
         assertTrue(downstream.containsKey("app.Run"),
                 "app typed against what shop.bare published; got " + downstream.keySet());
@@ -137,10 +138,10 @@ class APublishedSignatureIsWrittenInNamesItsModuleHasTest {
     }
 
     private static String computedSignature(List<String> modules, String binaryName) {
-        Map<String, byte[]> classes = Compiler.compileModules(modules);
-        byte[] bytes = classes.get(binaryName);
-        assertTrue(bytes != null, binaryName + " was not generated; got " + classes.keySet());
-        for (RuntimeInvisibleAnnotationsAttribute attr : ClassFile.of().parse(bytes)
+        Map<String, ClassFileImage> classes = Compiler.compileModules(modules);
+        ClassFileImage image = classes.get(binaryName);
+        assertTrue(image != null, binaryName + " was not generated; got " + classes.keySet());
+        for (RuntimeInvisibleAnnotationsAttribute attr : ClassFile.of().parse(image.bytes())
                 .findAttributes(java.lang.classfile.Attributes.runtimeInvisibleAnnotations())) {
             for (Annotation a : attr.annotations()) {
                 if (a.className().stringValue().endsWith("SoutherBehavior;")) {

--- a/souther-compiler/src/test/java/souther/compiler/meta/MetadataOfThisCompilersNameIsHeldToItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/MetadataOfThisCompilersNameIsHeldToItsShapeTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.meta;
 
 import souther.compiler.Compiler;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,17 +49,17 @@ class MetadataOfThisCompilersNameIsHeldToItsShapeTest {
     /** {@code binaryName}'s class with its annotations rewritten. */
     private static PublishedClasses withMetadata(String binaryName,
                                                  UnaryOperator<List<Annotation>> as) {
-        Map<String, byte[]> classes = new java.util.LinkedHashMap<>(Compiler.compile(SOURCE));
+        Map<String, ClassFileImage> classes = new java.util.LinkedHashMap<>(Compiler.compile(SOURCE));
         ClassFile cf = ClassFile.of();
-        ClassModel model = cf.parse(classes.get(binaryName));
+        ClassModel model = cf.parse(classes.get(binaryName).bytes());
         List<Annotation> had = new ArrayList<>();
         model.findAttribute(Attributes.runtimeInvisibleAnnotations())
                 .ifPresent(a -> had.addAll(a.annotations()));
-        classes.put(binaryName, cf.transformClass(model, ClassTransform
+        classes.put(binaryName, ClassFileImage.of(cf.transformClass(model, ClassTransform
                 .dropping(a -> a instanceof RuntimeInvisibleAnnotationsAttribute)
                 .andThen(ClassTransform.endHandler(b -> b.with(
-                        RuntimeInvisibleAnnotationsAttribute.of(as.apply(had)))))));
-        return new ClassFileDeclarations(classes::get);
+                        RuntimeInvisibleAnnotationsAttribute.of(as.apply(had))))))));
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 
     /** A member the schema declares with no default, and the writer always writes. */
@@ -251,7 +252,7 @@ class MetadataOfThisCompilersNameIsHeldToItsShapeTest {
     /** And the metadata this compiler does write is read. */
     @Test
     void whatThisCompilerWritesIsRead() {
-        PublishedClasses classes = new ClassFileDeclarations(Compiler.compile(SOURCE)::get);
+        PublishedClasses classes = new ClassFileDeclarations(ModulePath.of(Compiler.compile(SOURCE))::bytes);
 
         PublishedClasses.Carried.Declared read = assertInstanceOf(
                 PublishedClasses.Carried.Declared.class, classes.of("shared.money.Amount"));

--- a/souther-compiler/src/test/java/souther/compiler/meta/MetadataOfThisCompilersNameIsHeldToItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/MetadataOfThisCompilersNameIsHeldToItsShapeTest.java
@@ -59,7 +59,7 @@ class MetadataOfThisCompilersNameIsHeldToItsShapeTest {
                 .dropping(a -> a instanceof RuntimeInvisibleAnnotationsAttribute)
                 .andThen(ClassTransform.endHandler(b -> b.with(
                         RuntimeInvisibleAnnotationsAttribute.of(as.apply(had))))))));
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 
     /** A member the schema declares with no default, and the writer always writes. */
@@ -252,7 +252,7 @@ class MetadataOfThisCompilersNameIsHeldToItsShapeTest {
     /** And the metadata this compiler does write is read. */
     @Test
     void whatThisCompilerWritesIsRead() {
-        PublishedClasses classes = new ClassFileDeclarations(ModulePath.of(Compiler.compile(SOURCE))::bytes);
+        PublishedClasses classes = ModulePath.of(Compiler.compile(SOURCE)).declarations();
 
         PublishedClasses.Carried.Declared read = assertInstanceOf(
                 PublishedClasses.Carried.Declared.class, classes.of("shared.money.Amount"));

--- a/souther-compiler/src/test/java/souther/compiler/meta/ModuleMetadataTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/ModuleMetadataTest.java
@@ -2,6 +2,7 @@ package souther.compiler.meta;
 
 import souther.compiler.Emitted;
 import souther.compiler.Compiler;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +46,7 @@ class ModuleMetadataTest {
 
     @Test
     void aDataCarriesTheDeclarationThatDeclaredIt() {
-        Map<String, byte[]> classes = Compiler.compile(UP);
+        Map<String, ClassFileImage> classes = Compiler.compile(UP);
 
         assertEquals("""
                 // what a payment is worth
@@ -56,7 +57,7 @@ class ModuleMetadataTest {
 
     @Test
     void aBehaviorCarriesItsSignatureAndWhereItsBodyComesFrom() {
-        Map<String, byte[]> classes = Compiler.compile(UP);
+        Map<String, ClassFileImage> classes = Compiler.compile(UP);
 
         Annotation charge = annotation(classes, "shared.money.Charge", "SoutherBehavior");
         assertEquals("""
@@ -70,7 +71,7 @@ class ModuleMetadataTest {
      * worked out again from what is published, because the `let` that decides is not. */
     @Test
     void aBehaviorWithNoLetCarriesWhichOfTheTwoStatesItIsIn() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.ledger exposing ( Entry, record, audited )
                 data Entry = { amount: Int }
                 behavior record : (e: Entry) -> Entry
@@ -88,7 +89,7 @@ class ModuleMetadataTest {
 
     @Test
     void theModuleClassNamesWhatToRead() {
-        Map<String, byte[]> classes = Compiler.compile(UP);
+        Map<String, ClassFileImage> classes = Compiler.compile(UP);
 
         Annotation module = annotation(classes, Emitted.declarations("shared.money"), "SoutherModule");
         assertEquals("shared.money", string(module, "name"));
@@ -103,7 +104,7 @@ class ModuleMetadataTest {
      * invariant reaches is the module's own business and stays behind. */
     @Test
     void onlyTheHelpersAnInvariantReachesAreCarried() {
-        Map<String, byte[]> classes = Compiler.compile(UP);
+        Map<String, ClassFileImage> classes = Compiler.compile(UP);
 
         assertEquals(List.of("let withinCap (n: Int) = n <= 1000000"),
                 strings(annotation(classes, Emitted.declarations("shared.money"), "SoutherModule"),
@@ -114,7 +115,7 @@ class ModuleMetadataTest {
      *  helper it happens to be spelled like is not one this declaration needs. */
     @Test
     void aParameterSpelledLikeAHelperDoesNotCarryIt() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shadow.helper exposing ( echo )
 
                 let positive (n: Int) = n > 0
@@ -138,7 +139,7 @@ class ModuleMetadataTest {
      */
     @Test
     void aParameterSpelledLikeABehaviorDoesNotCarryItsImplementation() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shadow.impl exposing ( echo )
 
                 behavior calculate : (x: Int) -> Int
@@ -160,7 +161,7 @@ class ModuleMetadataTest {
     /** A helper a clause really calls is carried, since a reader cannot read the clause without it. */
     @Test
     void theHelperAClauseCallsIsCarried() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module carries.helper exposing ( echo )
 
                 let doubled (n: Int) = n * 2
@@ -195,7 +196,7 @@ class ModuleMetadataTest {
      */
     @Test
     void aValueOnlyAnAttachedFileDeclaresIsNotCarried() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module beside.rows exposing ( Amount, echo )
 
                 data Amount = { n: Int }
@@ -222,7 +223,7 @@ class ModuleMetadataTest {
      * the computed one is written out and the stages stay behind. */
     @Test
     void aCompositionPublishesTheSignatureItComputesTo() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module shop.pricing exposing ( Cart, Priced, quote )
                 data Cart = { n: Int }
                 data Priced = { total: Int }
@@ -243,11 +244,11 @@ class ModuleMetadataTest {
                         + " its own");
     }
 
-    private static Annotation annotation(Map<String, byte[]> classes, String binaryName,
+    private static Annotation annotation(Map<String, ClassFileImage> classes, String binaryName,
                                          String simpleAnnotationName) {
-        byte[] bytes = classes.get(binaryName);
-        assertTrue(bytes != null, binaryName + " was not generated; got " + classes.keySet());
-        for (RuntimeInvisibleAnnotationsAttribute attr : ClassFile.of().parse(bytes)
+        ClassFileImage image = classes.get(binaryName);
+        assertTrue(image != null, binaryName + " was not generated; got " + classes.keySet());
+        for (RuntimeInvisibleAnnotationsAttribute attr : ClassFile.of().parse(image.bytes())
                 .findAttributes(java.lang.classfile.Attributes.runtimeInvisibleAnnotations())) {
             for (Annotation a : attr.annotations()) {
                 if (a.className().stringValue().endsWith("/" + simpleAnnotationName + ";")) {

--- a/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.BehaviorImplementation;
 import souther.compiler.ast.Ast;
 import souther.compiler.codegen.Backend;
 import souther.compiler.frontend.CstFrontend;
+import souther.compiler.jvm.ClassFileImage;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,9 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ModuleReadbackTest {
 
-    private static ReadableModule readBack(String moduleName, Map<String, byte[]> classes) {
+    private static ReadableModule readBack(String moduleName, Map<String, ClassFileImage> classes) {
         return assertInstanceOf(ReadableModule.class, assertInstanceOf(Readback.Ready.class,
-                ModuleReadback.read(moduleName, new ClassFileDeclarations(classes::get), DefaultStdlib.get().names())).value());
+                ModuleReadback.read(moduleName, new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get().names())).value());
     }
 
     /** Why a readback would not answer, as the arm rather than as a message it was raised with. */
@@ -87,7 +88,7 @@ class ModuleReadbackTest {
      * `let` that needed the other one is not part of what was published. */
     @Test
     void onlyTheImportsTheDeclarationsNameComeBack() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
                 """, """
@@ -139,7 +140,7 @@ class ModuleReadbackTest {
      * (spec {@code [#a-published-signature-is-written-in-names-its-module-has]}). */
     @Test
     void aCompositionComesBackAsASignature() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of("""
                 module shop.pricing exposing ( Cart, Priced, quote )
                 data Cart = { n: Int }
                 data Priced = { total: Int }
@@ -197,7 +198,7 @@ class ModuleReadbackTest {
                 behavior sum : (l: Line) -> Total constructs Total, Money
                 let sum (l) = Total { amount = Money(l.item.unit.value * l.count) }
                 """;
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(base, catalog, order));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(base, catalog, order));
 
         for (String name : List.of("shop.base", "shop.catalog", "shop.order")) {
             ReadableModule read = readBack(name, classes);
@@ -234,15 +235,16 @@ class ModuleReadbackTest {
     @Test
     void aNameThatIsNotACompiledModuleReadsAsNothing() {
         assertInstanceOf(Readback.NotReady.SaysNothing.class,
-                ModuleReadback.read("shared.money", new ClassFileDeclarations(Map.<String,
-                        byte[]>of()::get), DefaultStdlib.get().names()));
+                ModuleReadback.read("shared.money",
+                        new ClassFileDeclarations(ModulePath.EMPTY::bytes),
+                        DefaultStdlib.get().names()));
     }
 
     /** A module built against a boundary this compiler does not share is refused, rather than read
      * and misunderstood. */
     @Test
     void aModuleFromADifferentBoundaryIsRefused() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
                 """);
@@ -264,7 +266,7 @@ class ModuleReadbackTest {
      */
     @Test
     void aModuleFromAnEarlierBoundaryIsRefusedToo() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.money exposing ( Amount, taxed )
                 data Amount = Int
                 let taxed (a: Amount) = Amount(a.value * 110 / 100)
@@ -284,7 +286,7 @@ class ModuleReadbackTest {
      * disagreement, rather than read and reported as an unresolved name inside a body nobody wrote. */
     @Test
     void aModuleCarryingAPublishedHelperIsRefusedAtADifferentBoundary() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.money exposing ( Amount, taxed )
                 data Amount = Int
                 let taxed (a: Amount) = Amount(a.value * 110 / 100)
@@ -318,7 +320,7 @@ class ModuleReadbackTest {
      */
     @Test
     void oneWhoseHeaderNamesAnotherModuleIsNotTheModuleThatWasAskedFor() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
                 """);
@@ -379,7 +381,7 @@ class ModuleReadbackTest {
      */
     @Test
     void aJarWritingTheOlderBehaviorMemberIsRefusedAtItsOwnBoundaryAndNotAtThisOne() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module shared.ledger exposing ( Entry, record )
                 data Entry = { amount: Int }
                 behavior record : (e: Entry) -> Entry
@@ -397,8 +399,8 @@ class ModuleReadbackTest {
 
     /** {@code classes} as a compiler that wrote {@code injected} rather than {@code implementation}
      *  published them, at {@code boundary}. */
-    private static PublishedClasses asItWasWritten(Map<String, byte[]> classes, int boundary) {
-        ClassFileDeclarations read = new ClassFileDeclarations(classes::get);
+    private static PublishedClasses asItWasWritten(Map<String, ClassFileImage> classes, int boundary) {
+        ClassFileDeclarations read = new ClassFileDeclarations(ModulePath.of(classes)::bytes);
         return binaryName -> {
             if (!(read.of(binaryName)
                     instanceof PublishedClasses.Carried.Declared(
@@ -418,9 +420,9 @@ class ModuleReadbackTest {
     }
 
     private static PublishedClasses viewing(
-            Map<String, byte[]> classes,
+            Map<String, ClassFileImage> classes,
             java.util.function.UnaryOperator<PublishedClasses.SoutherModuleView> as) {
-        ClassFileDeclarations read = new ClassFileDeclarations(classes::get);
+        ClassFileDeclarations read = new ClassFileDeclarations(ModulePath.of(classes)::bytes);
         return binaryName -> {
             if (!(read.of(binaryName)
                     instanceof PublishedClasses.Carried.Declared(

--- a/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
@@ -28,7 +28,7 @@ class ModuleReadbackTest {
 
     private static ReadableModule readBack(String moduleName, Map<String, ClassFileImage> classes) {
         return assertInstanceOf(ReadableModule.class, assertInstanceOf(Readback.Ready.class,
-                ModuleReadback.read(moduleName, new ClassFileDeclarations(ModulePath.of(classes)::bytes), DefaultStdlib.get().names())).value());
+                ModuleReadback.read(moduleName, ModulePath.of(classes).declarations(), DefaultStdlib.get().names())).value());
     }
 
     /** Why a readback would not answer, as the arm rather than as a message it was raised with. */
@@ -236,7 +236,7 @@ class ModuleReadbackTest {
     void aNameThatIsNotACompiledModuleReadsAsNothing() {
         assertInstanceOf(Readback.NotReady.SaysNothing.class,
                 ModuleReadback.read("shared.money",
-                        new ClassFileDeclarations(ModulePath.EMPTY::bytes),
+                        ModulePath.EMPTY.declarations(),
                         DefaultStdlib.get().names()));
     }
 
@@ -400,7 +400,7 @@ class ModuleReadbackTest {
     /** {@code classes} as a compiler that wrote {@code injected} rather than {@code implementation}
      *  published them, at {@code boundary}. */
     private static PublishedClasses asItWasWritten(Map<String, ClassFileImage> classes, int boundary) {
-        ClassFileDeclarations read = new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        PublishedClasses read = ModulePath.of(classes).declarations();
         return binaryName -> {
             if (!(read.of(binaryName)
                     instanceof PublishedClasses.Carried.Declared(
@@ -422,7 +422,7 @@ class ModuleReadbackTest {
     private static PublishedClasses viewing(
             Map<String, ClassFileImage> classes,
             java.util.function.UnaryOperator<PublishedClasses.SoutherModuleView> as) {
-        ClassFileDeclarations read = new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        PublishedClasses read = ModulePath.of(classes).declarations();
         return binaryName -> {
             if (!(read.of(binaryName)
                     instanceof PublishedClasses.Carried.Declared(

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.DefaultStdlib;
 import souther.compiler.query.Compilation;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.util.List;
@@ -1013,9 +1014,9 @@ class TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest {
     /** The classes one build of a model spread over several sources emits. */
     private static PublishedClasses declarationsOf(List<String> sources) {
         Compilation compiled = Compilation.ofSources(sources, ModulePath.EMPTY);
-        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
+        Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
         assertEquals(List.of(), diagnosed(compiled), "the model this is measured against compiles");
-        return new ClassFileDeclarations(classes::get);
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 
     /**
@@ -1028,9 +1029,9 @@ class TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest {
      */
     private static PublishedClasses declarationsOf(String source) {
         Compilation compiled = Compilation.ofSource(source, "Main");
-        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
+        Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
         assertEquals(List.of(), diagnosed(compiled), "the model this is measured against compiles");
-        return new ClassFileDeclarations(classes::get);
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 
     /** What a compile refused, as codes — nothing, for every model measured here.

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest.java
@@ -1016,7 +1016,7 @@ class TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest {
         Compilation compiled = Compilation.ofSources(sources, ModulePath.EMPTY);
         Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
         assertEquals(List.of(), diagnosed(compiled), "the model this is measured against compiles");
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 
     /**
@@ -1031,7 +1031,7 @@ class TheDeclarationsAnAnswerReadsByAreHeldToTheEvaluatedModuleTest {
         Compilation compiled = Compilation.ofSource(source, "Main");
         Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
         assertEquals(List.of(), diagnosed(compiled), "the model this is measured against compiles");
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 
     /** What a compile refused, as codes — nothing, for every model measured here.

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
@@ -222,6 +222,6 @@ class TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest {
                         .filter(d -> d.diagnostic().severity() == Severity.ERROR)
                         .map(d -> String.valueOf(d.diagnostic().code())).toList(),
                 "the model this is measured against compiles");
-        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
+        return ModulePath.of(classes).declarations();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
@@ -6,6 +6,7 @@ import souther.compiler.DefaultStdlib;
 import souther.compiler.Reserved;
 import souther.compiler.diag.Severity;
 import souther.compiler.query.Compilation;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
 
 import java.util.ArrayList;
@@ -216,11 +217,11 @@ class TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest {
 
     private static PublishedClasses declarationsOf(String source) {
         Compilation compiled = Compilation.ofSource(source, "Main");
-        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
+        Map<String, ClassFileImage> classes = compiled.db().ask(new Output.All()).value();
         assertEquals(List.of(), compiled.diagnostics().values().stream().flatMap(List::stream)
                         .filter(d -> d.diagnostic().severity() == Severity.ERROR)
                         .map(d -> String.valueOf(d.diagnostic().code())).toList(),
                 "the model this is measured against compiles");
-        return new ClassFileDeclarations(classes::get);
+        return new ClassFileDeclarations(ModulePath.of(classes)::bytes);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/meta/WhatABoundaryCarriesIsRecordedUnderItsNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/WhatABoundaryCarriesIsRecordedUnderItsNumberTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.Compiler;
 import souther.compiler.codegen.Backend;
+import souther.compiler.jvm.ClassFileImage;
 
 import java.io.InputStream;
 import java.lang.classfile.Annotation;
@@ -85,10 +86,10 @@ class WhatABoundaryCarriesIsRecordedUnderItsNumberTest {
     }
 
     /** The members of each annotation this compiler writes, and what kind of value each holds. */
-    private static String carried(Map<String, byte[]> classes) {
+    private static String carried(Map<String, ClassFileImage> classes) {
         Map<String, String> byAnnotation = new TreeMap<>();
-        for (byte[] bytes : classes.values()) {
-            for (Annotation annotation : annotations(bytes)) {
+        for (ClassFileImage image : classes.values()) {
+            for (Annotation annotation : annotations(image.bytes())) {
                 String type = annotation.className().stringValue();
                 if (!type.startsWith("Lsouther/runtime/meta/")) {
                     continue;

--- a/souther-compiler/src/test/java/souther/compiler/query/ALoaderStandsWhileTheClassesDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALoaderStandsWhileTheClassesDoTest.java
@@ -1,0 +1,112 @@
+package souther.compiler.query;
+
+import souther.compiler.jvm.ClassFileImage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The rule a loader is kept by, asked of it directly.
+ *
+ * <p>{@code ACompilationAnswersWithOneLoaderForItsClassesTest} drives it through edits, which is
+ * what a caller does and is what says the rule is wired to a real compile. What an edit cannot
+ * reliably produce is the case the rule exists for: two class sets that are not the same map and
+ * are the same class files. That is a generation that ran again and came to what it came to before
+ * — the whole of what holding classes as values buys — and a loader replaced over it divides every
+ * type of a program nothing about has changed.
+ *
+ * <p>So the two maps are made here. A rule that can only be reached through a scenario is a rule
+ * whose branches are covered by whatever the scenario happens to reach, and this one is not.
+ */
+class ALoaderStandsWhileTheClassesDoTest {
+
+    private static Map<String, ClassFileImage> classes(String said) {
+        Map<String, ClassFileImage> out = new LinkedHashMap<>();
+        out.put("demo.Thing", ClassFileImage.of(said.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        return out;
+    }
+
+    /** A loader nobody looks into: what is asked here is which one comes back, never what it loads. */
+    private static ClassLoader aLoader() {
+        return new ClassLoader(null) { };
+    }
+
+    @Test
+    void twoMapsOfOneProgramAreOneLoader() {
+        Map<String, ClassFileImage> first = classes("a");
+        Map<String, ClassFileImage> second = classes("a");
+        assertNotSame(first, second, "two maps");
+        assertEquals(first, second, "of one program");
+
+        LoaderOverClasses kept = new LoaderOverClasses();
+        ClassLoader over = kept.of(first, ALoaderStandsWhileTheClassesDoTest::aLoader);
+
+        assertSame(over, kept.of(second, ALoaderStandsWhileTheClassesDoTest::aLoader),
+                "a program that was built again is the program that was loaded");
+    }
+
+    /** And the map it was handed the first time is not what it holds them to. */
+    @Test
+    void andTheSameMapIsToo() {
+        Map<String, ClassFileImage> only = classes("a");
+        LoaderOverClasses kept = new LoaderOverClasses();
+        ClassLoader over = kept.of(only, ALoaderStandsWhileTheClassesDoTest::aLoader);
+
+        assertSame(over, kept.of(only, ALoaderStandsWhileTheClassesDoTest::aLoader));
+    }
+
+    @Test
+    void twoProgramsAreTwoLoaders() {
+        LoaderOverClasses kept = new LoaderOverClasses();
+        ClassLoader over = kept.of(classes("a"), ALoaderStandsWhileTheClassesDoTest::aLoader);
+
+        assertNotSame(over, kept.of(classes("b"), ALoaderStandsWhileTheClassesDoTest::aLoader),
+                "a program that came out different is a different program");
+    }
+
+    /** Nothing is built while the classes stand, which is what "kept" means and not only which
+     *  object comes back. */
+    @Test
+    void nothingIsBuiltWhileTheClassesStand() {
+        AtomicInteger built = new AtomicInteger();
+        LoaderOverClasses kept = new LoaderOverClasses();
+        kept.of(classes("a"), () -> {
+            built.incrementAndGet();
+            return aLoader();
+        });
+        kept.of(classes("a"), () -> {
+            built.incrementAndGet();
+            return aLoader();
+        });
+
+        assertEquals(1, built.get());
+    }
+
+    /**
+     * A loader that could not be built claims nothing.
+     *
+     * <p>The classes are recorded once there is a loader over them and not before, so an ask that
+     * raised is an ask that changed nothing — and the next one is not answered with the loader from
+     * before the edit, which would be a loader over a program its caller is no longer compiling.
+     */
+    @Test
+    void oneThatCouldNotBeBuiltClaimsNothing() {
+        LoaderOverClasses kept = new LoaderOverClasses();
+        ClassLoader first = kept.of(classes("a"), ALoaderStandsWhileTheClassesDoTest::aLoader);
+
+        assertThrows(IllegalStateException.class, () -> kept.of(classes("b"), () -> {
+            throw new IllegalStateException("this path cannot be read just now");
+        }));
+
+        assertNotSame(first, kept.of(classes("b"), ALoaderStandsWhileTheClassesDoTest::aLoader),
+                "the ask after it is over the classes there are");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AModuleThatCameOutTheSameLeavesItsReadersAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AModuleThatCameOutTheSameLeavesItsReadersAloneTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
@@ -60,7 +61,7 @@ class AModuleThatCameOutTheSameLeavesItsReadersAloneTest {
      *  everything. */
     @Test
     void andTwoSourcesThatSayDifferentThingsDoNot() {
-        assertNotEqualsClasses(Compiler.compile(SOURCE), Compiler.compile(OTHERWISE));
+        assertNotEquals(Compiler.compile(SOURCE), Compiler.compile(OTHERWISE));
     }
 
     /**
@@ -80,22 +81,12 @@ class AModuleThatCameOutTheSameLeavesItsReadersAloneTest {
 
         compilation.update(Map.of("a.sou", OTHERWISE), Set.of());
         Answer<Map<String, ClassFileImage>> edited = compilation.db().ask(new Output.All());
-        assertNotEqualsClasses(before.value(), edited.value(), "the edit reached the classes");
+        assertNotEquals(before.value(), edited.value(), "the edit reached the classes");
 
         compilation.update(Map.of("a.sou", SOURCE), Set.of());
         Answer<Map<String, ClassFileImage>> undone = compilation.db().ask(new Output.All());
 
         assertNotSame(before, undone, "the generation ran again");
         assertEquals(before, undone, "and came to the program that was there");
-    }
-
-    private static void assertNotEqualsClasses(Map<String, ClassFileImage> one,
-                                               Map<String, ClassFileImage> other) {
-        assertNotEqualsClasses(one, other, "two programs");
-    }
-
-    private static void assertNotEqualsClasses(Map<String, ClassFileImage> one,
-                                               Map<String, ClassFileImage> other, String said) {
-        assertFalse(one.equals(other), said);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/AModuleThatCameOutTheSameLeavesItsReadersAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AModuleThatCameOutTheSameLeavesItsReadersAloneTest.java
@@ -1,0 +1,101 @@
+package souther.compiler.query;
+
+import souther.compiler.Compiler;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/**
+ * What a module compiles to is a value, so a generation that ran again and came to the same class
+ * files leaves what read it alone.
+ *
+ * <p>The store decides what to recompute by comparing an answer with the one it replaces, and a
+ * module's classes were a map of arrays: an array is the array it is whatever it holds, so such an
+ * answer never equalled its own recomputation. Every example in the workspace reads some module's
+ * classes, so a module regenerated to the very same bytes reached all of them, on every revision,
+ * and nothing about what the compiler said could see it.
+ *
+ * <p>Asked of the classes and not of any one reader. What a reader does with an answer that came out
+ * the same is {@link AnAnswerThatCameOutTheSameLeavesItsReadersAloneTest}'s, over the store's own
+ * rule; what is here is that this answer is one the rule can act on.
+ */
+class AModuleThatCameOutTheSameLeavesItsReadersAloneTest {
+
+    private static final String SOURCE = """
+            module demo
+            data In = { n: Int }
+            data Out = { n: Int }
+            behavior twice : (i: In) -> Out
+            let twice (i) = Out { n = i.n * 2 }
+            """;
+
+    private static final String OTHERWISE = SOURCE.replace("i.n * 2", "i.n * 3");
+
+    /**
+     * Two compiles of one source come to one program.
+     *
+     * <p>Nothing of the store in it: two generations build their own arrays and always did, and what
+     * this asks is whether what holds them says the two runs came to the same thing. Everything
+     * below rests on it.
+     */
+    @Test
+    void twoCompilesOfOneSourceComeToOneProgram() {
+        Map<String, ClassFileImage> first = Compiler.compile(SOURCE);
+        Map<String, ClassFileImage> second = Compiler.compile(SOURCE);
+
+        assertFalse(first.isEmpty(), "there are classes to compare");
+        assertNotSame(first, second, "two compiles, so two maps");
+        assertEquals(first, second, "and one program");
+    }
+
+    /** And two sources that say different things do not, so the row above is not equality on
+     *  everything. */
+    @Test
+    void andTwoSourcesThatSayDifferentThingsDoNot() {
+        assertNotEqualsClasses(Compiler.compile(SOURCE), Compiler.compile(OTHERWISE));
+    }
+
+    /**
+     * A module regenerated to what it already was is the program that was already there.
+     *
+     * <p>Driven through an edit and its undo with the classes asked in between, which is what makes
+     * the generation run a second time: the store keeps the edited answer, going back differs from
+     * it, and everything from the parse down is worked out again. The map that comes back is a new
+     * map — that is what {@code assertNotSame} says — and what it holds is the program from before
+     * the edit, which is what the store compares and what lets it stop.
+     */
+    @Test
+    void aModuleRegeneratedToWhatItWasIsTheProgramThatWasThere() {
+        Compilation compilation = Compilation.ofDocuments(
+                Map.of("a.sou", SOURCE), Set.of(), ModulePath.EMPTY);
+        Answer<Map<String, ClassFileImage>> before = compilation.db().ask(new Output.All());
+
+        compilation.update(Map.of("a.sou", OTHERWISE), Set.of());
+        Answer<Map<String, ClassFileImage>> edited = compilation.db().ask(new Output.All());
+        assertNotEqualsClasses(before.value(), edited.value(), "the edit reached the classes");
+
+        compilation.update(Map.of("a.sou", SOURCE), Set.of());
+        Answer<Map<String, ClassFileImage>> undone = compilation.db().ask(new Output.All());
+
+        assertNotSame(before, undone, "the generation ran again");
+        assertEquals(before, undone, "and came to the program that was there");
+    }
+
+    private static void assertNotEqualsClasses(Map<String, ClassFileImage> one,
+                                               Map<String, ClassFileImage> other) {
+        assertNotEqualsClasses(one, other, "two programs");
+    }
+
+    private static void assertNotEqualsClasses(Map<String, ClassFileImage> one,
+                                               Map<String, ClassFileImage> other, String said) {
+        assertFalse(one.equals(other), said);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -234,18 +234,6 @@ final class AnswerClosure {
         return new Observation(Detector.TWO_ANSWERS_COMPARED, scenario);
     }
 
-    /**
-     * The classes a module compiled to, kept as the arrays they came out as.
-     *
-     * <p>What it wants is a way of holding bytes that is settled all the way down: something that
-     * says what it is by what the bytes say, holding them where nothing reading it meets an array
-     * again. Written as a value with an array inside, the array is what a walk arrives at one step
-     * further along, which is this place moved rather than struck off.
-     */
-    private static final Reading BYTES = new Reading("BYTES", MISSING_EQUALITY,
-            "what a class is is its bytes, so what lets a module whose classes came out the same "
-                    + "leave its readers alone is holding them as something that says so");
-
     /** The library this compiler ships, reached wherever a compilation holds it. */
     private static final Reading STDLIB = new Reading("STDLIB", MISSING_EQUALITY,
             "a value, and here for a reason the others are not: one is built per process and every "
@@ -370,23 +358,9 @@ final class AnswerClosure {
                 Set.of(met));
     }
 
-    private static Known bytes(String question, Locus.Step... steps) {
-        return new Known(at(question, "byte[]", steps), BYTES, BOTH_EVERYWHERE);
-    }
-
     private static final String Q = "souther.compiler.query.";
 
     private static final List<Known> KNOWN = List.of(
-            bytes(Q + "Output$All", m(ANSWER, "value"), VALUE),
-            bytes(Q + "Output$Classes", m(ANSWER, "value"), VALUE),
-            bytes(Q + "Output$Evaluated", m(ANSWER, "value"),
-                    m("souther.compiler.generated.EvaluationArtifact", "classes"), VALUE),
-            bytes(Q + "Output$EvaluationLinked", m(ANSWER, "value"),
-                    m("souther.compiler.generated.EvaluationArtifact", "classes"), VALUE),
-            // The one of the five a module on its own does not reach: nothing is linked against
-            // where there is nothing to link against.
-            new Known(at(Q + "Output$Linked", "byte[]", m(ANSWER, "value"), VALUE), BYTES,
-                    Set.of(walked(Scenario.VALID_CORPUS), compared(Scenario.VALID_CORPUS))),
             new Known(at(Q + "Names$ModuleScope", Q + "Db",
                     m(ANSWER, "value"), m("souther.compiler.check.Scoping$Scoped", "values"), m("souther.compiler.check.Resolve$Values", "elsewhere"),
                     m("souther.compiler.check.Scoping$OfTheUniverse", "universe"), m("souther.compiler.query.CompilationUniverse", "db")),
@@ -453,12 +427,6 @@ final class AnswerClosure {
     /** One arm of a sum, which a walk of types takes all of. */
     private static TypePath.Step arm(String named) {
         return new TypePath.Step.Arm(named);
-    }
-
-    /** The classes a module compiled to, held by the name each is emitted under. */
-    private static KnownDeclared classes(String question, TypePath.Step... steps) {
-        return new KnownDeclared(declared(question, "byte[]", steps), BYTES,
-                Traversal.Why.AN_ARRAY);
     }
 
     /** One way down, and then another. */
@@ -541,13 +509,6 @@ final class AnswerClosure {
 
     private static List<KnownDeclared> everyDeclaredPlace() {
         List<KnownDeclared> out = new java.util.ArrayList<>(List.of(
-            classes(Q + "Output$All", MAP_VALUE),
-            classes(Q + "Output$Classes", MAP_VALUE),
-            classes(Q + "Output$Linked", MAP_VALUE),
-            classes(Q + "Output$Evaluated",
-                    part("souther.compiler.generated.EvaluationArtifact", "classes"), MAP_VALUE),
-            classes(Q + "Output$EvaluationLinked",
-                    part("souther.compiler.generated.EvaluationArtifact", "classes"), MAP_VALUE),
             new KnownDeclared(declared(Q + "Front$Library", "souther.compiler.stdlib.Stdlib"),
                     STDLIB, Traversal.Why.SAYS_NOTHING_OF_ITSELF),
             new KnownDeclared(declared(Q + "Bodies$Expanding", "souther.compiler.stdlib.Stdlib",

--- a/souther-compiler/src/test/java/souther/compiler/query/CrossModuleContractOwnershipIsItsOwnBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/CrossModuleContractOwnershipIsItsOwnBoundaryTest.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.Compiler;
 import souther.compiler.core.EnsuresEnforcement;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -78,7 +79,7 @@ class CrossModuleContractOwnershipIsItsOwnBoundaryTest {
     /** The module that declares the clause carries it, and carries it whoever ends up calling it. */
     @Test
     void theDeclaringModuleCarriesTheCheck() {
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(DECLARING, CALLING));
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(DECLARING, CALLING));
 
         assertTrue(classes.containsKey("up.Fetch$Ensures"),
                 "the clause is `up`'s, so the class holding it is: " + classes.keySet());
@@ -115,8 +116,8 @@ class CrossModuleContractOwnershipIsItsOwnBoundaryTest {
                 decidedByDown(new ValueName.Behavior("up", "fetch")),
                 "`down` has not decided about `up.fetch`, rather than decided there is no check");
 
-        Map<String, byte[]> classes = Compiler.compileModules(List.of(DECLARING, CALLING));
-        assertEquals(0, checksOf(classes.get("down.Use$Impl"), "up/Fetch$Ensures"),
+        Map<String, ClassFileImage> classes = Compiler.compileModules(List.of(DECLARING, CALLING));
+        assertEquals(0, checksOf(classes.get("down.Use$Impl").bytes(), "up/Fetch$Ensures"),
                 "and so emits nothing for it — which follows from the decision above");
     }
 
@@ -155,7 +156,7 @@ class CrossModuleContractOwnershipIsItsOwnBoundaryTest {
      *  what says the difference above is the module boundary and not the shape of the call. */
     @Test
     void theSameCallWithinOneModuleIsCheckedAtItsCrossing() {
-        Map<String, byte[]> classes = Compiler.compile("""
+        Map<String, ClassFileImage> classes = Compiler.compile("""
                 module up
 
                 data Amount = Int
@@ -168,7 +169,7 @@ class CrossModuleContractOwnershipIsItsOwnBoundaryTest {
                 let use (a, fetch) = fetch(a)
                 """);
 
-        assertEquals(1, checksOf(classes.get("up.Use$Impl"), "up/Fetch$Ensures"),
+        assertEquals(1, checksOf(classes.get("up.Use$Impl").bytes(), "up/Fetch$Ensures"),
                 "one module, one checker, one crossing");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatACompileReadsDeclarationsOfIsWhatItCanReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatACompileReadsDeclarationsOfIsWhatItCanReachTest.java
@@ -8,6 +8,8 @@ import souther.compiler.meta.Agreement;
 import souther.compiler.meta.DeclarationAgreement;
 import souther.compiler.meta.PublishedClasses;
 import souther.compiler.meta.ModuleReadback;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.Readback;
 
 import java.util.List;
@@ -65,7 +67,7 @@ class WhatACompileReadsDeclarationsOfIsWhatItCanReachTest {
      */
     @Test
     void twoBuildsImportingOneCompiledModuleAgree() {
-        Map<String, byte[]> onThePath = Compiler.compile(SHARED);
+        Map<String, ClassFileImage> onThePath = Compiler.compile(SHARED);
 
         Agreement held = DeclarationAgreement.of("example.root", "rename",
                 declarationsOf(ROOT, onThePath), declarationsOf(ROOT, onThePath), DefaultStdlib.get());
@@ -75,8 +77,8 @@ class WhatACompileReadsDeclarationsOfIsWhatItCanReachTest {
     }
 
     /** What a compile of {@code source} against {@code path} can read declarations of. */
-    private static PublishedClasses declarationsOf(String source, Map<String, byte[]> path) {
-        Compilation compiled = Compilation.ofSources(List.of(source), path::get);
+    private static PublishedClasses declarationsOf(String source, Map<String, ClassFileImage> path) {
+        Compilation compiled = Compilation.ofSources(List.of(source), ModulePath.of(path));
         compiled.db().ask(new Output.All());
         org.junit.jupiter.api.Assertions.assertEquals(List.of(),
                 compiled.diagnostics().values().stream().flatMap(List::stream)

--- a/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -15,6 +15,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Scopes;
 
 import java.lang.reflect.Constructor;
@@ -171,7 +172,7 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
         private final Object instance;
         private final Method apply;
 
-        Behavior(Map<String, byte[]> classes, String module, String name) {
+        Behavior(Map<String, ClassFileImage> classes, String module, String name) {
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.class.getClassLoader());

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
@@ -15,6 +15,7 @@ import souther.compiler.program.DeclaredBy;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.types.TypeSymbols;
 
 import org.junit.jupiter.api.Test;
@@ -124,13 +125,13 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
      */
     @Test
     void everyIdentityAProgramReachesIsOneItAnswersFor() {
-        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
+        Map<String, ClassFileImage> classes = Compiler.compile(PUBLISHED);
         // Both programs, because the two worlds a declaration can come from besides this
         // compilation's own are one each, and a walk over either alone would hold while the other
         // went unanswered.
         CheckedProgram language = CheckedProgram.of(List.of(ROUNDS));
         CheckedProgram dependency =
-                CheckedProgram.of(List.of(IMPORTS), (ModulePath) classes::get);
+                CheckedProgram.of(List.of(IMPORTS), ModulePath.of(classes));
 
         // What each of them reaches, said out loud. A walk that quietly reached nothing would hold
         // here exactly as one that reached everything, and the second of these is a name this
@@ -232,8 +233,8 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     }
 
     private static ModulePath dependency() {
-        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
-        return classes::get;
+        Map<String, ClassFileImage> classes = Compiler.compile(PUBLISHED);
+        return ModulePath.of(classes);
     }
 
     /** The declaration whose field the behavior called {@code named} reads. */


### PR DESCRIPTION
Closes #1141.

## What was wrong

Five questions answer with the classes a module compiled to, and each held them as `Map<String, byte[]>`. An array is equal to another when it is the same array, so such an answer never equalled its own recomputation. `Db` stops work by comparing an answer with the one it replaces, and every module's examples read some module's classes — so a module that compiled to the very same bytes reached every example in the workspace, on every revision, for as long as the compilation lived. Nothing about what the compiler says changed, so no test could see it.

The cause is not that `byte[]` compares by address. It is that when "the classes a module compiled to" was needed as a value, the transport form — what `defineClass` and `Files.write` take — was written down as the answer, and nobody owns the question "are these the same classes?". So every place holding classes spelled the transport out again (285 occurrences across 101 files) and inherited array identity for free.

## What this does

**`souther.compiler.jvm.ClassFileImage`** owns the question. Two are equal when their bytes are. The octets are carried as a `String` under ISO-8859-1, which maps all 256 of them onto U+0000–U+00FF and back one for one: the language settles what such a value means, it cannot be written into, and the round trip is exact. Not a digest — what compares is every byte, so nothing rests on two different class files being unable to collide. Copied on the way in and on the way out, which a map of arrays never was.

Named `ClassFileImage` and not `ClassFile`: `java.lang.classfile.ClassFile` is the language's own, already on this compiler's classpath (`Emissions` imports it).

**`Emissions.seal()`** replaces `byBinaryName()`. A class is built, instrumented and written onto, and all of that is one array replaced by another; `seal` is where it ends, and `put` / `putAll` / `rewrite` refuse afterwards. It answers a second time with what it answered the first, and nothing hands out the map underneath — a caller holding that could write past the refusal. The boundary is a call somebody makes rather than an order of statements a later stamping step can be appended after.

**The value crosses the published boundary.** `Compilation.classes()` and `Compiler.compile*` answer with `Map<String, ClassFileImage>`. `bytes()` is called at the four places octets are handed over: `defineClass`, a file, an annotation processor's filer, and a class-file parse. A caller writing class files out opens one where it writes them; a caller asking whether a build came to what it already had can now ask.

**`Compilation.loader()` asks the classes, not the map.** A class is its binary name and the loader that defined it, so two loaders are two definitions of every type a compilation generated, and a value made under the first is not a value of the second's. Regenerating a module to what it already was is exactly the case this change makes reachable, and deciding by which map came back would have divided the types of a program nothing about had changed. Identity stays as a shortcut and never as the reason. `Db` is untouched: making its stored answer follow identity would be this same defect one level up.

**`ModulePath.of(Map<String, ClassFileImage>)`** is a path over class files in hand — a record, for the reason `ClassPath` is one: two paths over the same classes are the same path.

## What is checked

- `AClassFileIsWhatItsBytesSayTest` — all 256 octets round-trip, both defensive copies, one byte apart is not one value.
- `WhatIsSealedIsNoLongerWrittenTest` — every way of writing refuses after sealing, and a second `seal()` is the same map.
- `AModuleThatCameOutTheSameLeavesItsReadersAloneTest` — two compiles of one source come to one program, and an edit observed and then undone gives an `Answer` that is a new object and equal to the one from before.
- `ACompilationAnswersWithOneLoaderForItsClassesTest` now reads "the same classes" as equality rather than as the same map.
- `AnswerClosure` loses `BYTES` from both registers — the five places a walk of a store met and the five a walk of the declarations met — and nothing is written down in their stead.

`mvn -o test`: 11 modules, 10,773 tests, 0 failures, 0 errors.

Mutating `ClassFileImage.equals` to `this == other` turns 8 tests red across three classes, including the walk of a store — so the ten register entries were struck off because the walk stops finding those places, not because the check went quiet.

## The rule, stated

Not "`Map<String, byte[]>` is banned". A generated class-file image is held, answered and published as `ClassFileImage`; `byte[]` is produced only where octets are handed to a byte-oriented sink or read from a source, and not kept. The mutable `byte[]` inside `Emissions`, `ModulePath.bytes`, `ClassFileDeclarations`, `Recounted` and `MemoryClassLoader.define(Supplier<byte[]>)` are all inside that rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
