### PR TITLE
Owe a name at an end to the difference the clauses made

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/EndNarrowing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EndNarrowing.java
@@ -1,0 +1,173 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which of the declarations relating a coordinate to something else account for where it stops.
+ *
+ * <p>A declaration reaches here for having written such a relation, which is not the same as having
+ * decided anything: a clause reaching a value another clause has already passed moves the end
+ * nowhere. So the first question is whether the candidates between them left the coordinate
+ * anywhere other than where it would be without every one of them, and only where they did is there
+ * a difference for any of them to answer for. Naming them all where there is none does not add a
+ * name beside the type's — a line a declaration took in is that declaration's to answer for and no
+ * longer the type's ({@code AuthoredLine.obligationOwners}) — it moves the row to an author who can
+ * rewrite their clause with the line staying where it is.
+ *
+ * <p>That first answer is what an instance of this is. It is reached by {@link #read} and by nothing
+ * else, so a reader asking which declarations account for an end holds a difference to attribute
+ * before the question can be put. The end without the candidates answers whether there is one and
+ * answers nothing after: every question below compares a reading against the end the coordinate
+ * actually stops at, and a baseline still in reach is a baseline the next comparison can be written
+ * against.
+ */
+final class EndNarrowing {
+
+    /**
+     * Where a coordinate stops with the clauses of some declarations taken away.
+     *
+     * <p>A set, because that is what a counterfactual reading is asked: a declaration named twice is
+     * named once, and which order they arrive in is no part of what the reading comes to.
+     *
+     * <p>An end that is not there is a {@code null}, which is a wider reading and not a missing
+     * answer — taking clauses away is what widens one.
+     */
+    interface Ends {
+        Endpoint without(Set<TypeSymbol.AtModule> removed);
+    }
+
+    /**
+     * Which declarations account for the end, and by which of the questions asked here.
+     *
+     * <p>The rules are tried in the order they are written below and the first that names anybody is
+     * the answer, so what an arm says is which evidence the names came from rather than which of
+     * them a world is in. A declaration whose removal moves the end is holding it whatever else is
+     * true of it, and there is no reason to go on and ask whether it could hold the end alone.
+     */
+    sealed interface Answer {
+
+        /** The declarations these names are, or none where there are none to name. */
+        List<TypeSymbol.AtModule> names();
+
+        /**
+         * The candidates leave the coordinate where it stops without any of them.
+         *
+         * <p>Not that nothing was written about it. Their clauses were read and reached a value
+         * something else had already stopped it at, and an author sent here would be sent to a
+         * clause they can rewrite with the end staying put.
+         */
+        record NoNarrowing() implements Answer {
+
+            @Override
+            public List<TypeSymbol.AtModule> names() {
+                return List.of();
+            }
+        }
+
+        /**
+         * Each of these moves the end when it alone is taken away, the rest left as they are.
+         *
+         * @param names in declaration order
+         */
+        record Indispensable(List<TypeSymbol.AtModule> names) implements Answer {}
+
+        /**
+         * None of them is missed on its own and each of these leaves the end where it is with the
+         * rest of the candidates gone.
+         *
+         * <p>Two or more saying what the edge says, which is not a reason to name one of them over
+         * the others and not a reason to name a candidate that says something short of it.
+         *
+         * @param names in declaration order
+         */
+        record AloneSufficient(List<TypeSymbol.AtModule> names) implements Answer {}
+
+        /**
+         * The candidates moved the end and neither question told any of them apart.
+         *
+         * <p>What is known is that the set as a whole accounts for the end, and this is that and not
+         * an answer that every one of them does. A bound can arrive along a path through the
+         * differences where clauses reach an end only together, and the set is handed over as what
+         * these counterfactuals came to rather than as a finding about each declaration in it.
+         *
+         * @param names in declaration order
+         */
+        record Undifferentiated(List<TypeSymbol.AtModule> names) implements Answer {}
+    }
+
+    private final Endpoint end;
+
+    private final List<TypeSymbol.AtModule> candidates;
+
+    private final Ends ends;
+
+    private EndNarrowing(Endpoint end, List<TypeSymbol.AtModule> candidates, Ends ends) {
+        this.end = end;
+        this.candidates = candidates;
+        this.ends = ends;
+    }
+
+    /**
+     * What the candidates account for at {@code end}, which is nothing unless they moved it there.
+     *
+     * @param end        where the coordinate stops with every clause read, which is an end that is
+     *                   there: a coordinate nothing stops on this side has no end for a declaration
+     *                   to have moved anywhere, and a caller with none has its answer already
+     * @param candidates the declarations that wrote a relation about it, in the order they were
+     *                   found
+     * @param ends       the same coordinate read again with clauses taken away
+     */
+    static Answer read(Endpoint end, List<TypeSymbol.AtModule> candidates, Ends ends) {
+        return end.sameAs(ends.without(Set.copyOf(candidates)))
+                ? new Answer.NoNarrowing()
+                : new EndNarrowing(end, candidates, ends).attribute();
+    }
+
+    private Answer attribute() {
+        List<TypeSymbol.AtModule> indispensable = new ArrayList<>();
+        for (TypeSymbol.AtModule each : candidates) {
+            if (!end.sameAs(ends.without(Set.of(each)))) {
+                indispensable.add(each);
+            }
+        }
+        if (!indispensable.isEmpty()) {
+            return new Answer.Indispensable(inDeclarationOrder(indispensable));
+        }
+        List<TypeSymbol.AtModule> alone = new ArrayList<>();
+        for (TypeSymbol.AtModule each : candidates) {
+            if (end.sameAs(ends.without(allBut(each)))) {
+                alone.add(each);
+            }
+        }
+        if (!alone.isEmpty()) {
+            return new Answer.AloneSufficient(inDeclarationOrder(alone));
+        }
+        return new Answer.Undifferentiated(inDeclarationOrder(candidates));
+    }
+
+    private Set<TypeSymbol.AtModule> allBut(TypeSymbol.AtModule kept) {
+        Set<TypeSymbol.AtModule> removed = new LinkedHashSet<>(candidates);
+        removed.remove(kept);
+        return removed;
+    }
+
+    /**
+     * In one order, whoever found them. Several of these are one answer and the answer is what a
+     * line is told apart by, so an order read off the walk that collected them would make two
+     * readings of one edge into two lines.
+     *
+     * <p>The declaration's own order and not its name alone. Two declarations holding one end can be
+     * written in two modules — an inner record's clause and an outer record's reaching the same
+     * coordinate at the same value — and two modules may each declare a {@code Span}, so a name is
+     * not what tells those two apart.
+     */
+    private static List<TypeSymbol.AtModule> inDeclarationOrder(List<TypeSymbol.AtModule> found) {
+        return found.stream().sorted().toList();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -454,8 +454,8 @@ public final class FieldDomains {
     }
 
     /**
-     * The declaration whose clause could have moved where the coordinate at {@code path} stops, or
-     * null where none did.
+     * The declarations that moved where the coordinate at {@code path} stops, and none where the
+     * ones relating it to something else left it where it would be without them.
      *
      * <p>Which declaration wrote the relation, and not which value the position sits in. The same
      * relation can be written on the record, on a record inside it, or on a name wrapped round
@@ -464,8 +464,9 @@ public final class FieldDomains {
      *
      * <p>Several where several hold it, in one order whoever found them. Which of them settled the
      * number is not always a question this can answer — a bound arrives along a path through the
-     * differences and clauses can reach an end only together — and where it cannot, the set is what
-     * is known and is handed over as it is.
+     * differences and clauses can reach an end only together — and {@link EndNarrowing} says which
+     * of its questions an answer came out of, including the one where none of them told the
+     * candidates apart.
      */
     private List<TypeSymbol.AtModule> narrowedBy(String path, boolean lower) {
         List<TypeSymbol.AtModule> candidates = narrowers.get(path);
@@ -477,71 +478,21 @@ public final class FieldDomains {
         if (end == null) {
             return List.of();
         }
-        // Which of them is holding this end, asked by taking each away. A candidate is a declaration
-        // that wrote a relation about this coordinate, which is not the same as one that decided
-        // where it stops: a second relation reaching a value the first has already passed changes
-        // nothing, and naming it would make an edge's identity turn on a clause that moved it
-        // nowhere.
-        List<TypeSymbol.AtModule> held = new ArrayList<>();
-        for (TypeSymbol.AtModule each : candidates) {
-            if (!ends(end, without(each::equals), path, lower)) {
-                held.add(each);
-            }
-        }
-        if (!held.isEmpty()) {
-            return inDeclarationOrder(held);
-        }
-        // None on its own: two or more of them say what the edge says, and taking away any one
-        // leaves the others saying it. Which is not a reason to name one — each is as much the
-        // answer as the others — and not a reason to name all of them either. A candidate that
-        // moves this end nowhere when it is the only one left moved it nowhere here, and it is out
-        // whatever the rest of them are doing.
-        Endpoint bare = endOf(without(candidates::contains), path, lower);
-        List<TypeSymbol.AtModule> saying = new ArrayList<>();
-        for (TypeSymbol.AtModule each : candidates) {
-            if (!ends(bare, without(name -> candidates.contains(name) && !name.equals(each)),
-                    path, lower)) {
-                saying.add(each);
-            }
-        }
-        return inDeclarationOrder(saying.isEmpty() ? candidates : saying);
-    }
-
-    /** In one order, whoever found them. Several of these are one answer and the answer is what a
-     * line is told apart by, so an order read off the walk that collected them would make two
-     * readings of one edge into two lines.
-     *
-     * <p>The declaration's own order and not its name alone. Two declarations holding one end can be
-     * written in two modules — an inner record's clause and an outer record's reaching the same
-     * coordinate at the same value — and two modules may each declare a {@code Span}, so a name is
-     * not what tells those two apart. */
-    private static List<TypeSymbol.AtModule> inDeclarationOrder(List<TypeSymbol.AtModule> found) {
-        return found.stream().sorted().toList();
-    }
-
-    private Endpoint endOf(FieldDomains read, String path, boolean lower) {
-        NumericDomain.Bounds bounds = read.byField.get(path);
-        return bounds == null ? null : lower ? bounds.min() : bounds.max();
+        return EndNarrowing.read(end, candidates,
+                removed -> endWithout(removed, path, lower)).names();
     }
 
     /**
-     * Whether {@code end} is where {@code other} leaves this coordinate on the side asked for.
+     * Where the coordinate at {@code path} stops on the side asked for, read again without the
+     * clauses of the declarations {@code removed} names.
      *
-     * <p>Whether the end moved, which is a question about where the coordinate stops and not about
-     * what the two readings hold: {@link Endpoint#sameAs} and not a derived equality. The two are
-     * different questions here and not two spellings of one — a decimal's scale says which grid a
-     * quantity was rounded onto, so the layer these ends come from keeps representations apart where
-     * they carry something, and {@code 5} and {@code 5.00} are one place held two ways.
-     *
-     * <p>So this does not rest on every end arriving here already written the one way. Nothing
-     * states that, and the reading below is under no obligation to make it true.
-     *
-     * <p>An end neither reading has is the same absence, which is why a null on both sides is true
-     * here and is not {@link Endpoint#sameAs}'s answer: that one is asked of an end that is there.
+     * <p>The one way a counterfactual reading is asked for here. Which reading an end is compared
+     * against is the whole of what {@link EndNarrowing} means by an answer, and a second way of
+     * standing one up is a second place for that comparison to be written a different way round.
      */
-    private boolean ends(Endpoint end, FieldDomains other, String path, boolean lower) {
-        Endpoint theirs = endOf(other, path, lower);
-        return end == null ? theirs == null : end.sameAs(theirs);
+    private Endpoint endWithout(Set<TypeSymbol.AtModule> removed, String path, boolean lower) {
+        NumericDomain.Bounds bounds = without(removed::contains).byField.get(path);
+        return bounds == null ? null : lower ? bounds.min() : bounds.max();
     }
 
     /** This value read again without the clauses of the declarations {@code skip} names. */
@@ -1096,7 +1047,8 @@ public final class FieldDomains {
     public NarrowedBounds at(String path) {
         NumericDomain.Bounds here = byField.get(path);
         // The ends now and the names when they are asked for. Answering who holds an end reads this
-        // declaration again once per candidate that wrote a relation about the coordinate, and the
+        // declaration again without the clauses of every declaration that wrote a relation about
+        // the coordinate, and again per candidate where taking them away moved the end, and the
         // callers standing a fixture in a field's range ask a field at a time and read only the
         // ends.
         return here == null ? NarrowedBounds.NOTHING

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
@@ -1,0 +1,149 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Which readings a declaration is named by, asked of the readings alone.
+ *
+ * <p>The counterfactuals are given here rather than read out of a model, so that each question can
+ * be put to a set of ends the questions beside it cannot reach. Two of these answers are what the
+ * compiler's own models come to; the other two are what the rules say and no model reaches, and a
+ * rule nothing observes is a rule the next reader is free to write a different way.
+ *
+ * <p>Every reading asked for is one this states, so a question put to a set of declarations that is
+ * not the set the rule names fails here rather than answering.
+ */
+class WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest {
+
+    private static final TypeSymbol.AtModule A = named("A");
+
+    private static final TypeSymbol.AtModule B = named("B");
+
+    private static final TypeSymbol.AtModule C = named("C");
+
+    private static final Endpoint TWENTY = Endpoint.inclusive(Count.of(20));
+
+    private static final Endpoint THIRTY = Endpoint.inclusive(Count.of(30));
+
+    private static final Endpoint FIFTY = Endpoint.inclusive(Count.of(50));
+
+    /**
+     * Where the end is where it is without any of them, none of them is named.
+     *
+     * <p>And no further reading is asked for. What each of them would do on its own is a question
+     * about a difference, and there is none here to divide up.
+     */
+    @Test
+    void whereTheyLeaveTheEndWhereItIsNobodyIsNamed() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B),
+                reading(Map.of(Set.of(A, B), TWENTY)));
+
+        assertInstanceOf(EndNarrowing.Answer.NoNarrowing.class, answer,
+                "the clauses reached a value something else had already stopped it at");
+        assertEquals(List.of(), answer.names());
+    }
+
+    /** The one the end moves without is named, and the one it does not is left out. */
+    @Test
+    void theOneTheEndMovesWithoutIsNamed() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B),
+                reading(Map.of(
+                        Set.of(A, B), FIFTY,
+                        Set.of(A), FIFTY,
+                        Set.of(B), TWENTY)));
+
+        assertEquals(new EndNarrowing.Answer.Indispensable(List.of(A)), answer,
+                "taking A away moves the end and taking B away leaves it");
+    }
+
+    /**
+     * Where neither is missed on its own, the ones that reach the end alone are named.
+     *
+     * <p>Both of them here, which is what two declarations saying what the edge says comes to. One
+     * of them is no more the answer than the other.
+     */
+    @Test
+    void whereNeitherIsMissedTheOnesReachingTheEndAloneAreNamed() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B),
+                reading(Map.of(
+                        Set.of(A, B), FIFTY,
+                        Set.of(A), TWENTY,
+                        Set.of(B), TWENTY)));
+
+        assertEquals(new EndNarrowing.Answer.AloneSufficient(List.of(A, B)), answer,
+                "each of them leaves the end where it is with the other gone");
+    }
+
+    /**
+     * Reaching the end and moving it are not the same question.
+     *
+     * <p>{@code C} left alone leaves the end at thirty, which is neither where the three of them put
+     * it nor where none of them does. It moved something and it does not say what the edge says, and
+     * an author sent to it would be sent to a clause that cannot put the end at twenty.
+     */
+    @Test
+    void oneThatMovesTheEndWithoutReachingItIsNotNamed() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B, C),
+                reading(Map.of(
+                        Set.of(A, B, C), FIFTY,
+                        Set.of(A), TWENTY,
+                        Set.of(B), TWENTY,
+                        Set.of(C), TWENTY,
+                        Set.of(B, C), TWENTY,
+                        Set.of(A, C), TWENTY,
+                        Set.of(A, B), THIRTY)));
+
+        assertEquals(new EndNarrowing.Answer.AloneSufficient(List.of(A, B)), answer,
+                "C alone stops short of the end, and stopping short is not saying it");
+    }
+
+    /**
+     * Where neither question tells them apart, the set is the answer.
+     *
+     * <p>Any two of these reach the end and no one of them does, so what is known is that the three
+     * of them account for it. That is what this says, and it is not that each of them moved it.
+     */
+    @Test
+    void whereNeitherQuestionTellsThemApartTheSetIsTheAnswer() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B, C),
+                reading(Map.of(
+                        Set.of(A, B, C), FIFTY,
+                        Set.of(A), TWENTY,
+                        Set.of(B), TWENTY,
+                        Set.of(C), TWENTY,
+                        Set.of(B, C), THIRTY,
+                        Set.of(A, C), THIRTY,
+                        Set.of(A, B), THIRTY)));
+
+        assertEquals(new EndNarrowing.Answer.Undifferentiated(List.of(A, B, C)), answer,
+                "any two of them reach it and no one of them does");
+    }
+
+    /** The ends these readings come to, and an error for a reading nothing here states. */
+    private static EndNarrowing.Ends reading(Map<Set<TypeSymbol.AtModule>, Endpoint> ends) {
+        return removed -> {
+            Endpoint found = ends.get(removed);
+            if (found == null) {
+                throw new AssertionError("no reading stated for a walk without " + removed);
+            }
+            return found;
+        };
+    }
+
+    private static TypeSymbol.AtModule named(String name) {
+        return TypeSymbols.declared(new TypeKey("example.narrowing", name));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
@@ -18,10 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 /**
  * Which readings a declaration is named by, asked of the readings alone.
  *
- * <p>The counterfactuals are given here rather than read out of a model, so that each question can
- * be put to a set of ends the questions beside it cannot reach. Two of these answers are what the
- * compiler's own models come to; the other two are what the rules say and no model reaches, and a
- * rule nothing observes is a rule the next reader is free to write a different way.
+ * <p>The counterfactuals are stated here rather than read out of a model, so that every answer, and
+ * every rule that tells two of them apart, stays observable where the compiler's own models do not
+ * reach it. A rule nothing observes is a rule the next reader is free to write a different way.
  *
  * <p>Every reading asked for is one this states, so a question put to a set of declarations that is
  * not the set the rule names fails here rather than answering.

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest.java
@@ -132,6 +132,22 @@ class WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest {
                 "any two of them reach it and no one of them does");
     }
 
+    /**
+     * Where nothing stops the coordinate without them, that absence is the difference.
+     *
+     * <p>A reading with no end on the side is a wider one and not a missing answer, and the
+     * candidates are the whole of why the coordinate stops anywhere at all. Read as an end that
+     * could not be worked out, it would say they left it where it was.
+     */
+    @Test
+    void whereNothingStopsItWithoutThemThatAbsenceIsTheDifference() {
+        EndNarrowing.Answer answer = EndNarrowing.read(TWENTY, List.of(A, B),
+                removed -> removed.equals(Set.of(A, B)) ? null : TWENTY);
+
+        assertEquals(new EndNarrowing.Answer.AloneSufficient(List.of(A, B)), answer,
+                "with neither of them the coordinate stops nowhere, and it stops at twenty");
+    }
+
     /** The ends these readings come to, and an error for a reading nothing here states. */
     private static EndNarrowing.Ends reading(Map<Set<TypeSymbol.AtModule>, Endpoint> ends) {
         return removed -> {

--- a/souther-compiler/src/test/java/souther/compiler/query/ANameBesideAnEndIsOwedToTheDifferenceItMadeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ANameBesideAnEndIsOwedToTheDifferenceItMadeTest.java
@@ -1,0 +1,138 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.PointRole;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A declaration is named beside an end only where the clauses relating the position to something
+ * else left it anywhere other than where it stops without them.
+ *
+ * <p>Writing a relation about a position is not deciding where it stops. A clause reaching a value
+ * the position's own type has already stopped it at moves nothing, and a name written down there
+ * does not stand beside the type's: a line a declaration took in is that declaration's to answer for
+ * and no longer the type's ({@code AuthoredLine.obligationOwners}), so the row moves to an author
+ * who can rewrite their clause with the run staying exactly where it is.
+ *
+ * <p>Read here rather than at a cut. {@code LocalInspection}'s {@code moved} asks whether a cut owes
+ * anything to a name that is about the end it stands at, which is a question a run between two ends
+ * does not have to ask — so what the names themselves say shows up here as it was worked out.
+ */
+class ANameBesideAnEndIsOwedToTheDifferenceItMadeTest {
+
+    /**
+     * {@code Held} holds both ends it arrived at and moved one of them.
+     *
+     * <p>{@code c} stops at twenty because {@code Cap} says so, and {@code tight} taken away leaves
+     * it there. {@code l} has no floor of its own, and the same clause is the whole of why it has
+     * one — so one clause is a reason to name {@code Held} at one of the two and no reason at all at
+     * the other.
+     */
+    private static final String ONE_CLAUSE_MOVING_ONE_END = """
+            module example.tight
+
+            data Cap = Int
+                invariant floor = value >= 0
+                invariant capped = value <= 20
+
+            data Lim = Int
+                invariant capped = value <= 50
+
+            data Held = { c: Cap, l: Lim }
+                invariant tight = c.value <= l.value
+
+            behavior take : (h: Held) -> Int
+            let take (h) = 1
+
+            example take
+                | "x" : (Held { c = Cap(1), l = Lim(2) }) -> 1
+            """;
+
+    /**
+     * Two declarations reaching one end, neither of them missed on its own.
+     *
+     * <p>{@code Inner} stops {@code c} at thirty through its own {@code Lim}, and {@code Outer} says
+     * the same of the same position through another. Take either away and the other still says it,
+     * so neither is holding the end by itself and both of them say what the edge says.
+     */
+    private static final String TWO_SAYING_THE_SAME = """
+            module example.both
+
+            data Cap = Int
+                invariant floor = value >= 0
+                invariant capped = value <= 50
+
+            data Lim = Int
+                invariant floor = value >= 0
+                invariant capped = value <= 30
+
+            data Inner = { c: Cap, l: Lim }
+                invariant tight = c.value <= l.value
+
+            data Outer = { i: Inner, m: Lim }
+                invariant also = i.c.value <= m.value
+
+            behavior take : (o: Outer) -> Int
+            let take (o) = 1
+
+            example take
+                | "x" : (Outer { i = Inner { c = Cap(1), l = Lim(2) }, m = Lim(2) }) -> 1
+            """;
+
+    /** Where the record moved the end, the run beside it is the record's to answer for as well. */
+    @Test
+    void aDeclarationThatMovedAnEndIsNamedBesideIt() {
+        assertEquals("Lim or Held",
+                ownersOf(ONE_CLAUSE_MOVING_ONE_END, "example.tight", PointRole.IN,
+                        "value in 0 <= value < 50"),
+                "nothing but the record's clause gives this field a floor, so the record holds it");
+    }
+
+    /** And where it moved none, the run stays the type's alone. */
+    @Test
+    void aDeclarationThatMovedNoEndIsNotNamedBesideIt() {
+        assertEquals("Cap",
+                ownersOf(ONE_CLAUSE_MOVING_ONE_END, "example.tight", PointRole.IN,
+                        "value in 0 < value <= 20"),
+                "the type stops the field at twenty on its own, so the run there is the type's");
+    }
+
+    /**
+     * Neither of two reaching one end is the answer over the other, and both are named.
+     *
+     * <p>Naming nobody here would be as wrong as naming everybody where nobody moved it: the end is
+     * thirty because these two say so, and an author of either is looking at a clause they can move
+     * it with.
+     */
+    @Test
+    void twoDeclarationsSayingWhatTheEdgeSaysAreBothNamed() {
+        assertEquals("Inner or Outer",
+                ownersOf(TWO_SAYING_THE_SAME, "example.both", PointRole.ON, "value = 30"),
+                "each of them says the edge and neither is missed on its own");
+    }
+
+    /** Who a report says owes one row of a module's account. */
+    private static String ownersOf(String source, String module, PointRole role, String said) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Adequacy.DeclaredBoundaries account =
+                compilation.db().ask(new Adequacy.DeclaredBorders(module)).value();
+        assertNotNull(account, "the model under test compiles");
+        List<Adequacy.DeclaredDebt> debts = account.owed();
+        return debts.stream()
+                .filter(each -> each.debt().role() == role && each.debt().said().equals(said))
+                .map(each -> each.subject().named())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no " + role + " debt asking " + said + ": "
+                        + debts.stream()
+                                .map(each -> each.debt().role() + " " + each.debt().said()
+                                        + " -> " + each.subject().named())
+                                .toList()));
+    }
+}


### PR DESCRIPTION
Closes #1122.

`FieldDomains.narrowedBy` asked which of the declarations relating a coordinate to something
else is holding one of its ends, and never asked whether any of them is. A candidate reaches
that question for having written such a relation, which is not the same as having decided
where the position stops, so the question had an unstated precondition and the terminal
default — every candidate — supplied it. That is the direction that adds obligation: a line a
declaration took in is that declaration's to answer for and no longer the type's, so the row
moved to an author who can rewrite their clause with the run staying exactly where it is.

## What is here

`EndNarrowing` owns both halves and only hands the second one out through the first. The end
read without every candidate decides whether there is a difference to attribute; where there
is none the answer names nobody, and where there is one the value carrying it is the only way
to reach the questions that divide it up. That value does not carry the baseline: it answered
whether there is a difference and answers nothing after, and a baseline still in reach is a
baseline the next comparison gets written against — which is how the second question came to
be asked the way it was.

Both questions now compare against the end the position actually stops at:

- which candidates the end moves without,
- and where none of them is missed on its own, which of them reach the end alone.

The second used to be compared with the end without any of them, so a candidate that moved
the end part of the way was named as saying what the edge says. Where neither question tells
the candidates apart the set is the answer, and it is said as that rather than as a finding
about each declaration in it.

`FieldDomains.endWithout(Set, ...)` is the one way a counterfactual reading is asked for. The
set is the point: a declaration named twice is named once and the order they were found in is
no part of what the reading comes to.

## Not in scope

`LocalInspection.moved` stays. `narrowedBy` answers whether and which relation declarations
account for the end the record reading leaves; `moved` separately asks whether that end moved
the cut from the position type's own end. They are different questions at the same number, and
the measurement below says the second still decides 20 cuts once the first stops answering
wrongly.

## Measured

Over the compiler's own test suite, throwaway instrumentation, of the 321 calls asking who
holds an end:

```text
                        before   after
the end moves without      145     145
reaches the end alone        5       5
nobody                       0     171   named every candidate before
neither tells them apart     0       0
```

```text
a candidate that moves the end without reaching it       0   not reachable from a model
a removal that moves an end no removal of all of them does   0
declarations named where the cut did not move          190      20
```

Nothing in the suite reaches the undifferentiated answer and nothing in it can tell the two
readings of the second question apart, which is why both are put to stated readings in
`WhatNamesADeclarationAtAnEndIsTheDifferenceItMadeTest` rather than to a model. Dropping the
difference gate turns two tests red — the stated-reading one and the account of
`example.tight` — and leaves `ADeclarationThatCannotMoveACutIsNotNamedAtItTest` green, which
is the cut's own question and not this one.

`mvn -o test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)