### PR TITLE
Hash a term from what it is made of, and not from what an identity was drawn as

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -18,18 +18,17 @@ import souther.compiler.diag.SourcePos;
  *
  * <p>The position it carries is for a reader and takes no part in telling two apart.
  *
- * <p>Hashed by what it is and not by which object it is, which is a different question from
- * equality. A hash has to agree with equality one way only — two that are one hash alike — so a
- * subject told apart by identity may still be hashed by something a reading can say, and it has to
- * be: {@code Object}'s hash is drawn afresh each run, and a term carrying one of these is filed
- * under it.
+ * <p>What a term carrying one of these is hashed from is not which object it is. {@code Object}'s
+ * hash is drawn afresh each run, and a term filed under one would be filed somewhere else the next
+ * time — so the term algebra reads what was written and which occurrence of the reading this is
+ * ({@code Term.STANDS_FOR}), which agrees with equality the one way a hash has to: two that are one
+ * hash alike.
  *
- * <p>What it is taken from is a string and a number, and nothing that holds anything further. A hash
- * a type states for itself is taken at its word by the walk that proves a term is hashed from values
- * ({@link Term#ruleFor}), so what such a hash reads is exactly what nothing else checks — which is a
- * reason to read as little as possible. The position is not among it: it is what a reader is shown
- * and it stands on a {@link souther.compiler.diag.Placement}, whose own hash reads a tree this has
- * no way to answer for.
+ * <p>Named there rather than answered here. A type answering with a hash of its own is where the
+ * walk that proves a term is hashed from values has to stop, and what that hash reads is then the
+ * one thing nothing checks; a type naming what stands for it is walked through like everything
+ * else. Which is why the position is not among what is named: it stands on a {@link
+ * souther.compiler.diag.Placement}, and what that reads is a tree, not a value this can answer for.
  */
 final class EvaluationId {
 
@@ -45,9 +44,14 @@ final class EvaluationId {
         this.occurrence = occurrence;
     }
 
-    @Override
-    public int hashCode() {
-        return what.hashCode() * 31 + occurrence;
+    /** What was written where this stands. */
+    String what() {
+        return what;
+    }
+
+    /** Which one this is of the evaluations its reading has named. */
+    int occurrence() {
+        return occurrence;
     }
 
     SourcePos where() {

--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -22,8 +22,14 @@ import souther.compiler.diag.SourcePos;
  * equality. A hash has to agree with equality one way only — two that are one hash alike — so a
  * subject told apart by identity may still be hashed by something a reading can say, and it has to
  * be: {@code Object}'s hash is drawn afresh each run, and a term carrying one of these is filed
- * under it. What is taken is where the evaluation is written and which occurrence there it is, so
- * two evaluations at one position are two hashes and the whole of it is a function of the program.
+ * under it.
+ *
+ * <p>What it is taken from is a string and a number, and nothing that holds anything further. A hash
+ * a type states for itself is taken at its word by the walk that proves a term is hashed from values
+ * ({@link Term#ruleFor}), so what such a hash reads is exactly what nothing else checks — which is a
+ * reason to read as little as possible. The position is not among it: it is what a reader is shown
+ * and it stands on a {@link souther.compiler.diag.Placement}, whose own hash reads a tree this has
+ * no way to answer for.
  */
 final class EvaluationId {
 
@@ -41,7 +47,7 @@ final class EvaluationId {
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(what, where, occurrence);
+        return what.hashCode() * 31 + occurrence;
     }
 
     SourcePos where() {

--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -17,15 +17,31 @@ import souther.compiler.diag.SourcePos;
  * subject that moves when the walk does, and a fact filed under the old one is then about nothing.
  *
  * <p>The position it carries is for a reader and takes no part in telling two apart.
+ *
+ * <p>Hashed by what it is and not by which object it is, which is a different question from
+ * equality. A hash has to agree with equality one way only — two that are one hash alike — so a
+ * subject told apart by identity may still be hashed by something a reading can say, and it has to
+ * be: {@code Object}'s hash is drawn afresh each run, and a term carrying one of these is filed
+ * under it. What is taken is where the evaluation is written and which occurrence there it is, so
+ * two evaluations at one position are two hashes and the whole of it is a function of the program.
  */
 final class EvaluationId {
 
     private final SourcePos where;
     private final String what;
 
-    EvaluationId(String what, SourcePos where) {
+    /** Which one this is of the evaluations its reading has named, in the order it named them. */
+    private final int occurrence;
+
+    EvaluationId(String what, SourcePos where, int occurrence) {
         this.what = what;
         this.where = where;
+        this.occurrence = occurrence;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(what, where, occurrence);
     }
 
     SourcePos where() {

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -38,36 +38,41 @@ import java.util.Map;
 final class Term {
 
     /** How a term is built. What a shape means is what {@link Terms} builds it for; this says only
-     * which shapes are told apart. */
+     * which shapes are told apart, and what each carries beside its parts ({@link Payload}). */
     enum Shape {
         /** A place: a binding and the fields read from it. */
-        AT,
+        AT(Payload.of(Location.class)),
         /** A parameter of a closure, named by where it is bound rather than by which binding it is. */
-        BOUND,
+        BOUND(Payload.of(At.class)),
         /** Fields read off a term that is not a place. */
-        ON,
-        INT, DECIMAL, STRING, BOOL, UNIT,
+        ON(Payload.listOf(Payload.of(String.class))),
+        INT(Payload.of(Long.class)),
+        DECIMAL(Payload.of(BigDecimal.class)),
+        STRING(Payload.of(String.class)),
+        BOOL(Payload.of(Boolean.class)),
+        UNIT(Payload.of(TypeSymbol.class)),
         /** Arithmetic negation. */
-        NEG,
+        NEG(Payload.none()),
         /** The denial of a condition. */
-        NOT,
+        NOT(Payload.none()),
         /** An {@code ==}, whose two parts are unordered. */
-        EQ,
+        EQ(Payload.none()),
         /** Any other operator, over its two operands in the order written. */
-        OP,
-        LIST, TUPLE,
+        OP(Payload.of(BinOp.class)),
+        LIST(Payload.none()),
+        TUPLE(Payload.none()),
         /** One element of a tuple, by index. */
-        PART,
+        PART(Payload.of(Integer.class)),
         /** A conditional, over its condition and its two branches. */
-        CHOICE,
+        CHOICE(Payload.none()),
         /** A closure, over the number of parameters it binds and its body. */
-        CLOSURE,
+        CLOSURE(Payload.of(Integer.class)),
         /** A value bound and a body read under it. */
-        LET,
+        LET(Payload.none()),
         /** A construction, over the values its fields are given in declaration order. */
-        BUILT,
+        BUILT(Payload.of(Built.class)),
         /** A call, over its arguments. */
-        CALLED,
+        CALLED(Payload.of(ValueName.class)),
         /**
          * One evaluation, told apart from every other by the { EvaluationId} it holds and not by
          * anything about its shape.
@@ -78,9 +83,9 @@ final class Term {
          * built over it composes. { length(E)} written twice is one term because { CALLED}
          * interns over its children and the child is the one atom both times.
          */
-        EVALUATION,
+        EVALUATION(Payload.of(EvaluationId.class)),
         /** A value given to an optional position. */
-        SOME,
+        SOME(Payload.none()),
         /**
          * What a present optional holds, read where an arm has opened one.
          *
@@ -89,9 +94,9 @@ final class Term {
          * read out of, so this is that one case and nothing more general. Everything else a
          * {@code match} opens binds the value it was given.
          */
-        HELD,
+        HELD(Payload.none()),
         /** The empty optional, at the type of the position it fills. */
-        NONE,
+        NONE(Payload.of(souther.compiler.types.Type.class)),
         /**
          * The value one case of a union carries, over the value that union is.
          *
@@ -107,7 +112,7 @@ final class Term {
          * is {@code a / b} and is one term with the written divide (spec
          * §invariant-discharge-arithmetic).
          */
-        OPENED,
+        OPENED(Payload.of(souther.compiler.types.Type.class)),
         /**
          * A value a walk hands its step, read where that walk is being proved about.
          *
@@ -120,11 +125,58 @@ final class Term {
          * <p>And by the walk, not only by the position: two walks in one body each hand their step an
          * accumulator, and they are two values.
          */
-        HANDED,
+        HANDED(Payload.of(Integer.class)),
         /** A value opened, over the scrutinee and each arm's body. */
-        MATCHED,
+        MATCHED(Payload.listOf(Payload.listOf(Payload.of(TypeSymbol.class)))),
         /** An attempted construction, over what it builds and what each of its departures answers. */
-        ATTEMPTED
+        ATTEMPTED(Payload.listOf(Payload.of(String.class)));
+
+        private final Payload payload;
+
+        Shape(Payload payload) {
+            this.payload = payload;
+        }
+
+        /** What a term of this shape carries beside its parts. */
+        Payload payload() {
+            return payload;
+        }
+    }
+
+    /**
+     * What a shape carries beside its parts, said as something a walk can read.
+     *
+     * <p>Written here because {@link #of} is an {@code Object} and an {@code Object} states nothing:
+     * a hash taken of one is taken of whatever that value's own class does, and the values a term is
+     * made of have to be values for the hash to be one. So the shapes say what they carry, and
+     * {@link #hashOf} says how each kind of thing is taken — the two together are what makes the
+     * whole of a term's hash a function of the term.
+     *
+     * <p>A list says what its elements are rather than being one class, since a class does not carry
+     * its element type and an element is where the walk would otherwise stop.
+     */
+    sealed interface Payload {
+
+        /** A shape whose parts are the whole of it. */
+        record Nothing() implements Payload {}
+
+        /** A value of {@code type}, or of one of the types {@code type} permits. */
+        record OfType(Class<?> type) implements Payload {}
+
+        /** A list of {@code element}. */
+        record OfList(Payload element) implements Payload {}
+
+        static Payload none() {
+            return new Nothing();
+        }
+
+        static Payload of(Class<?> type) {
+            return new OfType(type);
+        }
+
+        static Payload listOf(Payload element) {
+            return new OfList(element);
+        }
     }
 
     /** What a shape holds beside its parts: a location, a written value, an operator, the name of an
@@ -147,11 +199,164 @@ final class Term {
      */
     private static final int MIX = 0x9E3779B1;
 
+    /**
+     * How the value under a payload is taken into a term's hash.
+     *
+     * <p>Asked of a class rather than written into one switch body, so that the walk which proves the
+     * payload types are all taken by value reads the same answer the hash reads. A rule stated in a
+     * place a test cannot ask is a rule a test can only copy.
+     */
+    enum Rule {
+        /** Its own hash, which for such a class is a function of the value. */
+        ITS_OWN_HASH,
+        /** Its name: an enum constant's own hash is its identity and is drawn afresh each run. */
+        AN_ENUM_BY_NAME,
+        /** Each of its record components, in the order they are declared. */
+        ITS_COMPONENTS,
+        /** Each of its elements, in order. */
+        ITS_ELEMENTS,
+        /** Nothing here takes a value of this class. */
+        NONE_HERE
+    }
+
+    /** A class the platform hashes by what the value is. */
+    private static final java.util.Set<Class<?>> SCALARS = java.util.Set.of(
+            String.class, Long.class, Integer.class, Boolean.class, BigDecimal.class,
+            Short.class, Byte.class, Character.class, Double.class, Float.class);
+
+    private static final ClassValue<Rule> RULES = new ClassValue<>() {
+
+        @Override
+        protected Rule computeValue(Class<?> type) {
+            return ruleOf(type);
+        }
+    };
+
+    /** How a value of {@code type} is taken. */
+    static Rule ruleFor(Class<?> type) {
+        return RULES.get(type);
+    }
+
+    private static Rule ruleOf(Class<?> type) {
+        if (Enum.class.isAssignableFrom(type)) {
+            return Rule.AN_ENUM_BY_NAME;
+        }
+        if (SCALARS.contains(type)) {
+            return Rule.ITS_OWN_HASH;
+        }
+        if (List.class.isAssignableFrom(type)) {
+            return Rule.ITS_ELEMENTS;
+        }
+        if (type.isRecord()) {
+            // A record given its equality holds it over everything it carries, so its components are
+            // what it is. One stating an equality of its own holds it over some of what it carries,
+            // and taking the rest in would give two equal values two hashes.
+            return statesAnEqualityOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.ITS_COMPONENTS;
+        }
+        return statesAnEqualityOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.NONE_HERE;
+    }
+
+    /**
+     * Whether {@code type} answers which two of it are one, rather than leaving the answer to what
+     * it is made of or to which object it is.
+     *
+     * <p>Read off the modifier, since the equality a record is given is final and one written by
+     * hand is not. What it decides is who is taken at their word: a type stating an equality states
+     * a hash to go with it, and this hash algebra takes that hash. A type stating none is either a
+     * record, and is what it holds, or is told apart by which object it is — which is drawn afresh
+     * each run and is what nothing here may be hashed from.
+     */
+    private static boolean statesAnEqualityOfItsOwn(Class<?> type) {
+        for (java.lang.reflect.Method method : type.getDeclaredMethods()) {
+            if (method.getName().equals("hashCode") && method.getParameterCount() == 0) {
+                return !java.lang.reflect.Modifier.isFinal(method.getModifiers());
+            }
+        }
+        return false;
+    }
+
+    /** How each of a record's components is read, worked out once for the class. */
+    private static final ClassValue<java.lang.invoke.MethodHandle[]> ACCESSORS = new ClassValue<>() {
+
+        @Override
+        protected java.lang.invoke.MethodHandle[] computeValue(Class<?> type) {
+            java.lang.reflect.RecordComponent[] components = type.getRecordComponents();
+            java.lang.invoke.MethodHandle[] accessors =
+                    new java.lang.invoke.MethodHandle[components.length];
+            java.lang.invoke.MethodHandles.Lookup lookup = java.lang.invoke.MethodHandles.lookup();
+            for (int i = 0; i < components.length; i++) {
+                java.lang.reflect.Method accessor = components[i].getAccessor();
+                accessor.setAccessible(true);
+                try {
+                    accessors[i] = lookup.unreflect(accessor)
+                            .asType(java.lang.invoke.MethodType.methodType(
+                                    Object.class, Object.class));
+                } catch (IllegalAccessException e) {
+                    throw new IllegalStateException("a " + type.getName() + " does not answer "
+                            + accessor.getName(), e);
+                }
+            }
+            return accessors;
+        }
+    };
+
+    /**
+     * The hash of a value a shape carries, which is a function of that value and of nothing else.
+     *
+     * <p>The one place a term's hash meets something that is not a term. What is wanted of it is not
+     * a good hash but a hash of the value: {@code Object.hashCode} tells an object from every other
+     * and says nothing about what it holds, and on HotSpot the number it answers is drawn from a
+     * sequence held per thread — so a term hashed through one is hashed by when its class was first
+     * asked, which is a fact about the run and not about the program. An enum is that case wearing a
+     * value's clothes, since {@code Enum.hashCode} is {@code Object}'s and cannot be replaced.
+     *
+     * <p>What is refused is refused here rather than left to answer wrongly. A payload nothing above
+     * knows how to take is a shape carrying something this algebra was never extended to, and the
+     * only thing it could do quietly is hash it by its identity.
+     */
+    static int hashOf(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        Class<?> type = value.getClass();
+        return switch (ruleFor(type)) {
+            case ITS_OWN_HASH -> value.hashCode();
+            case AN_ENUM_BY_NAME -> ((Enum<?>) value).name().hashCode();
+            case ITS_COMPONENTS -> componentsOf(value, type);
+            case ITS_ELEMENTS -> elementsOf((List<?>) value);
+            case NONE_HERE -> throw new IllegalStateException(
+                    "nothing says what a term hashed from a " + type.getName() + " is hashed from");
+        };
+    }
+
+    /** Which record it is and what it holds. The class is taken in because two records holding alike
+     *  are two values, and a term carrying either is told apart by nothing else here. */
+    private static int componentsOf(Object value, Class<?> type) {
+        int h = type.getName().hashCode();
+        for (java.lang.invoke.MethodHandle accessor : ACCESSORS.get(type)) {
+            try {
+                h = h * MIX + hashOf((Object) accessor.invokeExact(value));
+            } catch (Throwable e) {
+                throw new IllegalStateException("a " + type.getName() + " does not answer one of"
+                        + " what it holds", e);
+            }
+        }
+        return h;
+    }
+
+    private static int elementsOf(List<?> values) {
+        int h = values.size();
+        for (Object value : values) {
+            h = h * MIX + hashOf(value);
+        }
+        return h;
+    }
+
     private Term(Shape shape, Object of, List<Term> parts) {
         this.shape = shape;
         this.of = of;
         this.parts = List.copyOf(parts);
-        int h = shape.hashCode() * MIX + (of == null ? 0 : of.hashCode());
+        int h = hashOf(shape) * MIX + hashOf(of);
         h = h * MIX + this.parts.size();
         if (shape == Shape.EQ) {
             // an equality is between two values and not from one to the other

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -244,7 +244,8 @@ final class Term {
      * place a test cannot ask is a rule a test can only copy.
      */
     enum Rule {
-        /** Its own hash, which for such a class is a function of the value. */
+        /** Its own hash. The platform's own scalars and nothing else: every other class is taken
+         *  apart, so that what a hash of it reads is walked rather than trusted. */
         ITS_OWN_HASH,
         /** Its name: an enum constant's own hash is its identity and is drawn afresh each run. */
         AN_ENUM_BY_NAME,
@@ -252,6 +253,10 @@ final class Term {
         ITS_COMPONENTS,
         /** Each of its elements, in order. */
         ITS_ELEMENTS,
+        /** Each of its elements, in no order — what a set's own equality reads. */
+        ITS_UNORDERED_ELEMENTS,
+        /** The parts it says stand for it ({@link #STANDS_FOR}). */
+        THE_PARTS_IT_NAMES,
         /** Nothing here takes a value of this class. */
         NONE_HERE
     }
@@ -274,6 +279,24 @@ final class Term {
         return RULES.get(type);
     }
 
+    /**
+     * What stands for a value of a class that is neither a scalar nor a record given its equality.
+     *
+     * <p>Named parts and not a hash. A class answering "here is my hash" is a place the walk that
+     * proves a term is hashed from values has to stop, and what such a hash reads is then the one
+     * thing nothing checks — which is how a set of type symbols came to be hashed by the identity of
+     * an enum two levels under it. A class answering "here is what stands for me" is one the walk
+     * goes through, so what it reads is proved like everything else.
+     *
+     * <p>Both of these are told apart by less than what they hold. A type symbol is its address, and
+     * an evaluation is told apart from every other by which object it is — so what is named here is
+     * what may be hashed without giving two equal values two hashes, which for the second is
+     * anything that is a function of the value.
+     */
+    private static final Map<Class<?>, List<String>> STANDS_FOR = Map.of(
+            TypeSymbol.AtModule.class, List.of("key"),
+            EvaluationId.class, List.of("what", "occurrence"));
+
     private static Rule ruleOf(Class<?> type) {
         if (Enum.class.isAssignableFrom(type)) {
             return Rule.AN_ENUM_BY_NAME;
@@ -284,13 +307,20 @@ final class Term {
         if (List.class.isAssignableFrom(type)) {
             return Rule.ITS_ELEMENTS;
         }
-        if (type.isRecord()) {
-            // A record given its equality holds it over everything it carries, so its components are
-            // what it is. One stating an equality of its own holds it over some of what it carries,
-            // and taking the rest in would give two equal values two hashes.
-            return statesAHashOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.ITS_COMPONENTS;
+        if (java.util.Set.class.isAssignableFrom(type)) {
+            return Rule.ITS_UNORDERED_ELEMENTS;
         }
-        return statesAHashOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.NONE_HERE;
+        if (STANDS_FOR.containsKey(type)) {
+            return Rule.THE_PARTS_IT_NAMES;
+        }
+        // A record given its equality holds it over everything it carries, so its components are
+        // what it is. One stating an equality of its own holds it over some of what it carries, and
+        // taking the rest in would give two equal values two hashes — so it says which parts stand
+        // for it or nothing here takes it.
+        if (type.isRecord() && !statesAHashOfItsOwn(type)) {
+            return Rule.ITS_COMPONENTS;
+        }
+        return Rule.NONE_HERE;
     }
 
     /**
@@ -321,12 +351,12 @@ final class Term {
 
         @Override
         protected java.lang.invoke.MethodHandle[] computeValue(Class<?> type) {
-            java.lang.reflect.RecordComponent[] components = type.getRecordComponents();
+            List<java.lang.reflect.Method> read = readersOf(type);
             java.lang.invoke.MethodHandle[] accessors =
-                    new java.lang.invoke.MethodHandle[components.length];
+                    new java.lang.invoke.MethodHandle[read.size()];
             java.lang.invoke.MethodHandles.Lookup lookup = java.lang.invoke.MethodHandles.lookup();
-            for (int i = 0; i < components.length; i++) {
-                java.lang.reflect.Method accessor = components[i].getAccessor();
+            for (int i = 0; i < read.size(); i++) {
+                java.lang.reflect.Method accessor = read.get(i);
                 accessor.setAccessible(true);
                 try {
                     accessors[i] = lookup.unreflect(accessor)
@@ -340,6 +370,28 @@ final class Term {
             return accessors;
         }
     };
+
+    /** How each of what stands for a value of {@code type} is read: the parts it names, or its
+     *  record components where it names none. */
+    static List<java.lang.reflect.Method> readersOf(Class<?> type) {
+        List<String> named = STANDS_FOR.get(type);
+        List<java.lang.reflect.Method> read = new ArrayList<>();
+        try {
+            if (named != null) {
+                for (String part : named) {
+                    read.add(type.getDeclaredMethod(part));
+                }
+                return read;
+            }
+            for (java.lang.reflect.RecordComponent component : type.getRecordComponents()) {
+                read.add(component.getAccessor());
+            }
+            return read;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(type.getName() + " does not answer what it says stands"
+                    + " for it", e);
+        }
+    }
 
     /**
      * The hash of a value a shape carries, which is a function of that value and of nothing else.
@@ -363,11 +415,24 @@ final class Term {
         return switch (ruleFor(type)) {
             case ITS_OWN_HASH -> value.hashCode();
             case AN_ENUM_BY_NAME -> ((Enum<?>) value).name().hashCode();
-            case ITS_COMPONENTS -> componentsOf(value, type);
+            case ITS_COMPONENTS, THE_PARTS_IT_NAMES -> componentsOf(value, type);
             case ITS_ELEMENTS -> elementsOf((List<?>) value);
+            case ITS_UNORDERED_ELEMENTS -> unorderedOf((java.util.Set<?>) value);
             case NONE_HERE -> throw new IllegalStateException(
                     "nothing says what a term hashed from a " + type.getName() + " is hashed from");
         };
+    }
+
+    /** What a set holds, taken so that the answer does not depend on the order it hands them over
+     *  in — which is what its own equality reads, and a hash that read more would give two equal
+     *  sets two hashes. */
+    private static int unorderedOf(java.util.Set<?> values) {
+        int h = values.size();
+        for (Object value : values) {
+            int each = hashOf(value);
+            h += each ^ (each >>> 16);
+        }
+        return h;
     }
 
     /** Which record it is and what it holds. The class is taken in because two records holding alike

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -157,14 +157,51 @@ final class Term {
      */
     sealed interface Payload {
 
+        /**
+         * Whether {@code value} is what this says a shape carries.
+         *
+         * <p>Asked of every term as it is built, under assertions. What a shape carries is written
+         * down so that a walk can prove nothing a term is hashed from is hashed by its identity, and
+         * a walk over what was written proves that of the shapes as written — so if the writing and
+         * the building come apart, what is proved is a set of types nothing builds. The building is
+         * what settles it, and this is where the two meet.
+         */
+        boolean holds(Object value);
+
         /** A shape whose parts are the whole of it. */
-        record Nothing() implements Payload {}
+        record Nothing() implements Payload {
+
+            @Override
+            public boolean holds(Object value) {
+                return value == null;
+            }
+        }
 
         /** A value of {@code type}, or of one of the types {@code type} permits. */
-        record OfType(Class<?> type) implements Payload {}
+        record OfType(Class<?> type) implements Payload {
+
+            @Override
+            public boolean holds(Object value) {
+                return type.isInstance(value);
+            }
+        }
 
         /** A list of {@code element}. */
-        record OfList(Payload element) implements Payload {}
+        record OfList(Payload element) implements Payload {
+
+            @Override
+            public boolean holds(Object value) {
+                if (!(value instanceof List<?> values)) {
+                    return false;
+                }
+                for (Object each : values) {
+                    if (!element.holds(each)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
 
         static Payload none() {
             return new Nothing();
@@ -251,22 +288,26 @@ final class Term {
             // A record given its equality holds it over everything it carries, so its components are
             // what it is. One stating an equality of its own holds it over some of what it carries,
             // and taking the rest in would give two equal values two hashes.
-            return statesAnEqualityOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.ITS_COMPONENTS;
+            return statesAHashOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.ITS_COMPONENTS;
         }
-        return statesAnEqualityOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.NONE_HERE;
+        return statesAHashOfItsOwn(type) ? Rule.ITS_OWN_HASH : Rule.NONE_HERE;
     }
 
     /**
-     * Whether {@code type} answers which two of it are one, rather than leaving the answer to what
-     * it is made of or to which object it is.
+     * Whether {@code type} says what a value of it hashes to, rather than leaving it to what the
+     * value is made of or to which object it is.
      *
-     * <p>Read off the modifier, since the equality a record is given is final and one written by
-     * hand is not. What it decides is who is taken at their word: a type stating an equality states
-     * a hash to go with it, and this hash algebra takes that hash. A type stating none is either a
-     * record, and is what it holds, or is told apart by which object it is — which is drawn afresh
-     * each run and is what nothing here may be hashed from.
+     * <p>Read off the modifier, since the hash a record is given is final and one written by hand is
+     * not. What it decides is who is taken at their word. A record stating none is what it holds, and
+     * following its components is following its hash; a record stating one states it over some of
+     * what it holds, so following the rest would give two equal values two hashes.
+     *
+     * <p>Taken at their word and no further: what such a hash is itself taken from is not walked, so
+     * a type saying what it hashes to answers for the whole of what it reads. Which is why what is
+     * said here is about the hash and not about the equality — {@link EvaluationId} tells two apart
+     * by which object each is and still says what it hashes to, and it is the hash this asks about.
      */
-    private static boolean statesAnEqualityOfItsOwn(Class<?> type) {
+    private static boolean statesAHashOfItsOwn(Class<?> type) {
         for (java.lang.reflect.Method method : type.getDeclaredMethods()) {
             if (method.getName().equals("hashCode") && method.getParameterCount() == 0) {
                 return !java.lang.reflect.Modifier.isFinal(method.getModifiers());
@@ -353,6 +394,8 @@ final class Term {
     }
 
     private Term(Shape shape, Object of, List<Term> parts) {
+        assert shape.payload().holds(of) : shape + " is written as carrying " + shape.payload()
+                + " and was built with " + (of == null ? "nothing" : of.getClass().getName());
         this.shape = shape;
         this.of = of;
         this.parts = List.copyOf(parts);

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1876,7 +1876,7 @@ final class Terms {
             return null;
         }
         return evaluations.computeIfAbsent(asWritten(e),
-                node -> new EvaluationId(shapeOf(node), node.pos()));
+                node -> new EvaluationId(shapeOf(node), node.pos(), evaluations.size()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
@@ -122,6 +122,24 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
         assertNotEquals(four, five, "and two shapes are two");
     }
 
+    /** How many places a table holding a thousand and one of these has, and how it reads a hash into
+     *  one: what {@link java.util.HashMap} does, since it is the table this is held for. */
+    private static final int PLACES = 2048;
+
+    /** How many of the chain's terms fall in the fullest place of that table. */
+    private static int longestBucket(List<Term> along) {
+        int[] held = new int[PLACES];
+        for (Term term : along) {
+            int hash = term.hashCode();
+            held[(hash ^ (hash >>> 16)) & (PLACES - 1)]++;
+        }
+        int longest = 0;
+        for (int count : held) {
+            longest = Math.max(longest, count);
+        }
+        return longest;
+    }
+
     /**
      * This chain does not hash into one bucket.
      *
@@ -134,8 +152,14 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
      * distinct, and only the table holding them turns into a list. A thousand links took 8.7 seconds
      * where a hundred took 20 milliseconds.
      *
-     * <p>Held as a spread and not as a time, since a time is a fact about the machine. A mixing that
-     * ties a few of these together is not this defect; one that ties most of them together is.
+     * <p>Held on the fullest place of the table rather than on how many hashes there are. What made
+     * the lookup a walk is a place holding the family, and the two are not the same measurement:
+     * that collapse put 997 of the thousand in one place, while a family spread over 84% of its
+     * hashes still fills its fullest place seven deep, which is what an evenly spread thousand into
+     * two thousand places does anyway. Counting hashes both passes a hash whose low bits agree and
+     * fails one that is perfectly good.
+     *
+     * <p>Held as places and not as a time, since a time is a fact about the machine.
      */
     @Test
     void theChainDoesNotHashIntoOneBucket() {
@@ -145,8 +169,12 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
         along.forEach(term -> hashes.add(term.hashCode()));
 
         assertEquals(1001, terms.size(), "a thousand links are a thousand terms");
-        assertTrue(hashes.size() > terms.size() * 0.9,
-                "and they are spread over hashes: " + hashes.size() + " of " + terms.size());
+        // Sixteen: the collapse filled a place 997 deep and this family fills one 6 deep, which is
+        // what a thousand spread evenly over two thousand places comes to. A bound between them
+        // holds the difference and lets the hash change without saying so.
+        assertTrue(longestBucket(along) <= 16, "and no place of the table holds many of them: "
+                + longestBucket(along) + " at the fullest, over " + hashes.size() + " of "
+                + terms.size() + " distinct hashes");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -149,6 +149,24 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                 "every shape is built here, so that what each carries is checked as it is built");
     }
 
+    /**
+     * Two sets holding the same things are one hash, whichever order they hand them over in.
+     *
+     * <p>What a set's equality reads is what it holds and not the order it walks it, so a hash
+     * taken by folding the elements up in the order they arrive gives two equal values two hashes —
+     * and a term carrying either is then two terms to the table and one term to the comparison.
+     */
+    @Test
+    void twoSetsHoldingAlikeAreOneHashWhateverOrderTheyWalkIn() {
+        TypeSymbol one = TypeSymbols.declared(new TypeKey("m", "A"));
+        TypeSymbol other = TypeSymbols.declared(new TypeKey("m", "B"));
+        Type forwards = new Type.Union(new LinkedHashSet<>(List.of(one, other)));
+        Type backwards = new Type.Union(new LinkedHashSet<>(List.of(other, one)));
+
+        assertEquals(forwards, backwards, "the two are one value");
+        assertEquals(Term.hashOf(forwards), Term.hashOf(backwards), "so they are one hash");
+    }
+
     private void walkPayload(Term.Payload payload, Path path) {
         switch (payload) {
             case Term.Payload.Nothing ignored -> { }
@@ -163,10 +181,20 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
             return;
         }
         switch (type) {
+            // The container is asked about before what it holds. A walk that went straight to the
+            // arguments would prove the elements of a collection nothing says how to hash, which is
+            // what a set of type symbols was: its elements were walked and the set itself fell
+            // through to its own hash, which is the sum of theirs.
             case ParameterizedType parameterized -> {
-                for (java.lang.reflect.Type argument : parameterized.getActualTypeArguments()) {
-                    walkType(argument, path.then("each " + shown(parameterized.getRawType())));
+                Class<?> raw = (Class<?>) parameterized.getRawType();
+                Term.Rule holds = Term.ruleFor(raw);
+                if (holds != Term.Rule.ITS_ELEMENTS && holds != Term.Rule.ITS_UNORDERED_ELEMENTS) {
+                    findings.add(shown(raw) + " holds what a term is hashed from and nothing says"
+                            + " how it is taken (" + holds + "), under\n       " + path);
+                    return;
                 }
+                walkType(parameterized.getActualTypeArguments()[0],
+                        path.then("each " + shown(raw)));
             }
             case Class<?> raw -> walkClass(raw, path);
             default -> findings.add("no rule reaches " + shown(type) + ", under\n       " + path);
@@ -210,8 +238,15 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                     walkComponents(type, path);
                 }
             }
-            case ITS_ELEMENTS -> findings.add(shown(type)
-                    + " is taken by its elements, which a class does not say, under\n       " + path);
+            case THE_PARTS_IT_NAMES -> {
+                for (java.lang.reflect.Method part : Term.readersOf(type)) {
+                    walkType(part.getGenericReturnType(),
+                            path.then(shown(type) + " stands for its " + part.getName()));
+                }
+            }
+            case ITS_ELEMENTS, ITS_UNORDERED_ELEMENTS -> findings.add(shown(type)
+                    + " is taken by its elements, and what it holds is not written down here,"
+                    + " under\n       " + path);
             case NONE_HERE -> findings.add("nothing takes " + shown(type) + ", under\n       " + path);
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -1,13 +1,23 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,11 +47,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
 
-    /** A class whose hash is a function of its value and is written in the platform. */
-    private static final Set<Class<?>> SCALARS = Set.of(
-            String.class, Long.class, Integer.class, Boolean.class, BigDecimal.class,
-            int.class, long.class, boolean.class, char.class, double.class, float.class,
-            short.class, byte.class);
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final Hir.Binders BINDERS =
+            new Hir.Binders(new BindingOwner.OfValue("demo", "test"));
+
+    /** What a component declared as a primitive arrives as, since a hash is taken of the value and a
+     *  value handed over as an {@code Object} is the box. */
+    private static final Map<Class<?>, Class<?>> BOXED = Map.of(
+            int.class, Integer.class, long.class, Long.class, boolean.class, Boolean.class,
+            char.class, Character.class, double.class, Double.class, float.class, Float.class,
+            short.class, Short.class, byte.class, Byte.class);
 
     /** What reached a type, so that a finding names the payload it is under and not only itself. */
     private record Path(List<String> steps) {
@@ -75,6 +90,65 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                 + String.join("\n\n", findings) + "\n");
     }
 
+    /**
+     * What the shapes say they carry is what the interner builds them with.
+     *
+     * <p>The other test walks from what the shapes say. Said and built are two things, and a walk
+     * over what was said proves what was said: writing {@code OP} down as carrying a string leaves
+     * the whole suite green and takes {@code BinOp} out of the walk without a word. So the interner
+     * is asked to build one term of every shape, and the check that a shape carries what it says it
+     * carries is in the constructor, where every term goes through — under assertions, which is
+     * every run of this suite.
+     *
+     * <p>Every shape and not the ones that came to mind: a shape nothing here builds is a shape the
+     * constructor's check never sees, and the two tests together would then be proving something
+     * about a smaller set than there is.
+     */
+    @Test
+    void everyShapeIsBuiltWithWhatItSaysItCarries() {
+        Term.Interner interned = new Term.Interner();
+        BindingId x = BINDERS.binder("x", POS).id();
+        TypeSymbol data = TypeSymbols.declared(new TypeKey("m", "D"));
+        Term one = interned.written(1L);
+        Term evaluated = interned.evaluated(new EvaluationId("an answer", POS, 0));
+
+        Set<Term.Shape> built = new LinkedHashSet<>();
+        for (Term term : List.of(
+                interned.at(Location.of(x)),
+                interned.bound(0, 0),
+                interned.on(evaluated, List.of("a")),
+                one,
+                interned.written(java.math.BigDecimal.ONE),
+                interned.written("s"),
+                interned.written(true),
+                interned.unit(data),
+                interned.negated(one),
+                interned.not(interned.written(true)),
+                interned.operator(BinOp.EQ, one, one),
+                interned.operator(BinOp.ADD, one, one),
+                interned.list(List.of(one)),
+                interned.tuple(List.of(one)),
+                interned.part(one, 0),
+                interned.choice(one, one, one),
+                interned.closure(1, one),
+                interned.let(one, one),
+                interned.built(data, List.of("f"), List.of(one)),
+                interned.called(new ValueName.Helper("m", "f"), List.of(one)),
+                evaluated,
+                interned.some(one),
+                interned.held(evaluated),
+                interned.handed(one, 0),
+                interned.none(Type.INT),
+                interned.opened(one, Type.INT),
+                interned.matched(one, List.of(List.of(data)), List.of(one)),
+                interned.attempted(one, List.of("c"), List.of(one)))) {
+            built.add(term.shape());
+        }
+
+        assertEquals(Set.of(Term.Shape.values()), built,
+                "every shape is built here, so that what each carries is checked as it is built");
+    }
+
     private void walkPayload(Term.Payload payload, Path path) {
         switch (payload) {
             case Term.Payload.Nothing ignored -> { }
@@ -99,10 +173,8 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
         }
     }
 
-    private void walkClass(Class<?> type, Path path) {
-        if (SCALARS.contains(type)) {
-            return;
-        }
+    private void walkClass(Class<?> raw, Path path) {
+        Class<?> type = BOXED.getOrDefault(raw, raw);
         if (type.isInterface() || java.lang.reflect.Modifier.isAbstract(type.getModifiers())) {
             Class<?>[] permitted = type.getPermittedSubclasses();
             if (permitted == null || permitted.length == 0) {

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -1,0 +1,168 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Everything a term's hash is taken from is a value.
+ *
+ * <p>A term's hash has to be a function of the term. The interner files a term under it, {@link
+ * Term#equals} reads it before anything else, and the cost of a chain of terms is what the table
+ * holding them does with it — none of which is a statement about a term at all if the number moves
+ * between runs of one program.
+ *
+ * <p>What can move it is an identity hash. {@code Enum.hashCode()} is {@code Object}'s, and on
+ * HotSpot the default implementation draws from a sequence held per thread, so which number an enum
+ * constant gets depends on when in that thread it was first hashed. Nothing about the program
+ * decides that: under Surefire it is decided by which fork a class landed in and what ran before it.
+ *
+ * <p>So the walk here is over types and not over values. It starts at what the shapes say they carry
+ * ({@link Term.Payload}), follows a record into its components and a sealed type into what it
+ * permits, and asks at every node how {@link Term#ruleFor} takes a value of it. A node taken by its
+ * own hash whose own hash is an identity is a finding, and the finding carries the path that reached
+ * it — the type on its own says nothing about why a term's hash depends on it.
+ *
+ * <p>Following the components matters as much as following the payload. A record's generated hash
+ * is its components' hashes, so a payload that is a record of a record of a sealed type of a record
+ * of an enum is hashed by that enum's identity with no enum in sight.
+ */
+class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
+
+    /** A class whose hash is a function of its value and is written in the platform. */
+    private static final Set<Class<?>> SCALARS = Set.of(
+            String.class, Long.class, Integer.class, Boolean.class, BigDecimal.class,
+            int.class, long.class, boolean.class, char.class, double.class, float.class,
+            short.class, byte.class);
+
+    /** What reached a type, so that a finding names the payload it is under and not only itself. */
+    private record Path(List<String> steps) {
+
+        Path then(String step) {
+            List<String> next = new ArrayList<>(steps);
+            next.add(step);
+            return new Path(next);
+        }
+
+        @Override
+        public String toString() {
+            return String.join("\n       → ", steps);
+        }
+    }
+
+    private final List<String> findings = new ArrayList<>();
+    private final Set<java.lang.reflect.Type> walked = new LinkedHashSet<>();
+
+    @Test
+    void nothingATermIsHashedFromIsHashedByItsIdentity() {
+        walkType(Term.Shape.class, new Path(List.of("Term.hashOf(shape)")));
+        for (Term.Shape shape : Term.Shape.values()) {
+            walkPayload(shape.payload(), new Path(List.of("Shape." + shape + " carries")));
+        }
+
+        // The count says what was looked at. A walk that stopped early reports nothing and reads
+        // exactly like one that reached everything.
+        assertEquals(List.of(), findings, "a term's hash is taken from values, over the "
+                + walked.size() + " types the payloads reach:\n\n"
+                + String.join("\n\n", findings) + "\n");
+    }
+
+    private void walkPayload(Term.Payload payload, Path path) {
+        switch (payload) {
+            case Term.Payload.Nothing ignored -> { }
+            case Term.Payload.OfType(Class<?> type) -> walkType(type, path.then(type.getSimpleName()));
+            case Term.Payload.OfList(Term.Payload element) ->
+                    walkPayload(element, path.then("each element"));
+        }
+    }
+
+    private void walkType(java.lang.reflect.Type type, Path path) {
+        if (!walked.add(type)) {
+            return;
+        }
+        switch (type) {
+            case ParameterizedType parameterized -> {
+                for (java.lang.reflect.Type argument : parameterized.getActualTypeArguments()) {
+                    walkType(argument, path.then("each " + shown(parameterized.getRawType())));
+                }
+            }
+            case Class<?> raw -> walkClass(raw, path);
+            default -> findings.add("no rule reaches " + shown(type) + ", under\n       " + path);
+        }
+    }
+
+    private void walkClass(Class<?> type, Path path) {
+        if (SCALARS.contains(type)) {
+            return;
+        }
+        if (type.isInterface() || java.lang.reflect.Modifier.isAbstract(type.getModifiers())) {
+            Class<?>[] permitted = type.getPermittedSubclasses();
+            if (permitted == null || permitted.length == 0) {
+                findings.add(shown(type) + " is open, so what a term is hashed from is not known,"
+                        + " under\n       " + path);
+                return;
+            }
+            for (Class<?> subtype : permitted) {
+                walkType(subtype, path.then(shown(subtype)));
+            }
+            return;
+        }
+        switch (Term.ruleFor(type)) {
+            case AN_ENUM_BY_NAME -> {
+                if (!type.isEnum()) {
+                    findings.add(shown(type) + " is taken as an enum and is none, under\n       "
+                            + path);
+                }
+            }
+            case ITS_OWN_HASH -> {
+                // Taken at its word, and the word is what is checked: a type answering which two of
+                // it are one by which object it is answers a different question every run.
+                if (hashesByItsIdentity(type)) {
+                    findings.add(shown(type) + " is taken by its own hash, and its own hash is its"
+                            + " identity, under\n       " + path);
+                }
+            }
+            case ITS_COMPONENTS -> {
+                if (!type.isRecord()) {
+                    findings.add(shown(type) + " is taken by its components and has none, under\n"
+                            + "       " + path);
+                } else {
+                    walkComponents(type, path);
+                }
+            }
+            case ITS_ELEMENTS -> findings.add(shown(type)
+                    + " is taken by its elements, which a class does not say, under\n       " + path);
+            case NONE_HERE -> findings.add("nothing takes " + shown(type) + ", under\n       " + path);
+        }
+    }
+
+    private void walkComponents(Class<?> type, Path path) {
+        for (RecordComponent component : type.getRecordComponents()) {
+            walkType(component.getGenericType(), path.then(shown(type) + "." + component.getName()));
+        }
+    }
+
+    /** Whether a value of {@code type} is hashed by which object it is rather than by what it is. */
+    private static boolean hashesByItsIdentity(Class<?> type) {
+        if (Enum.class.isAssignableFrom(type)) {
+            return true;
+        }
+        try {
+            return type.getMethod("hashCode").getDeclaringClass() == Object.class;
+        } catch (NoSuchMethodException e) {
+            return true;
+        }
+    }
+
+    private static String shown(java.lang.reflect.Type type) {
+        return type instanceof Class<?> c ? c.getSimpleName() : type.getTypeName();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ReadingAFieldDoesNotDecideWhichValueItIsReadFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ReadingAFieldDoesNotDecideWhichValueItIsReadFromTest.java
@@ -52,7 +52,7 @@ class ReadingAFieldDoesNotDecideWhichValueItIsReadFromTest {
 
     @Test
     void theSameHoldsOfAValueThatIsNowhere() {
-        Term evaluated = interned.evaluated(new EvaluationId("an answer", POS));
+        Term evaluated = interned.evaluated(new EvaluationId("an answer", POS, 0));
 
         assertEquals(interned.on(evaluated, List.of("a", "b")),
                 interned.on(interned.on(evaluated, List.of("a")), List.of("b")));
@@ -62,7 +62,7 @@ class ReadingAFieldDoesNotDecideWhichValueItIsReadFromTest {
     void extendingAPathKeepsWhatItIsRootedAt() {
         BindingId x = BINDERS.binder("x", POS).id();
         BindingId y = BINDERS.binder("y", POS).id();
-        Term evaluated = interned.evaluated(new EvaluationId("an answer", POS));
+        Term evaluated = interned.evaluated(new EvaluationId("an answer", POS, 0));
 
         assertNotEquals(interned.on(interned.at(Location.of(x)), List.of("a")),
                 interned.on(interned.at(Location.of(y)), List.of("a")),


### PR DESCRIPTION
Closes #1135.

## What was wrong

`ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.theChainDoesNotHashIntoOneBucket` failed once in a full run and never on its own. The mechanism is that `Term`'s hash was not a function of the term.

`Term`'s hash started from `shape.hashCode()`, and `Enum.hashCode()` is `Object`'s. `of` is declared `Object`, so any payload brought its own class's answer in. On HotSpot the default identity hash is drawn from a sequence held per thread, so the number an enum constant gets depends on when in that thread it was first hashed — with `forkCount=0.5C`, `reuseForks=true` and `runOrder=balanced`, on which fork a class landed in and what ran before it. Running the test alone fixes that position, which is why it is green alone every time.

Measured, on the same test with only the selection changed:

    -Dtest=ATermThat…Test                   OP=334593716   INT=1660325375  ADD=487416600
    -Dtest='souther.compiler.check.*Test'   OP=1961129028  INT=1274247563  ADD=1678623942

The chain's hashes are the iterates of one map whose constant is built from those, so whether 1001 links stay distinct depends only on that constant. Over 20,000 random constants, 7 fall below the 90% the assertion asked for.

## What reached the hash

A walk over the payload types found six, five of them through records and sealed types with no enum in sight:

    Shape             ← Term.hashOf(shape)
    Prim              ← Shape.AT carries → Location → Location.root → BindingId.owner
                         → Expansion → Expansion.expanded → InScope → OfType → OfType.type
                         → OfLanguage → Primitive → Primitive.primitive
    LanguageCaseId    ← the same, → LanguageCase → LanguageCase.id
    Pass              ← Shape.AT carries → Location → Location.root → BindingId.owner
                         → Synthesized → Synthesized.pass
    BinOp             ← Shape.OP carries → BinOp
    EvaluationId      ← Shape.EVALUATION carries → EvaluationId

`Shape.AT` is the commonest shape in the check, so this was not confined to the family the test builds. It also decided the iteration order of `LinearForm.coefs`, which is a `HashMap` keyed by `FactSubject`, and so the order atoms reach the solver.

## What this does

`Shape` says what it carries (`Term.Payload`). `Term.hashOf` is the one place a term's hash meets something that is not a term, and `Term.ruleFor` says how each kind of thing is taken: an enum by its name, a record by what it holds unless it states an equality of its own, a list by its elements, and anything no rule reaches stops the compile rather than being hashed by which object it is.

`EvaluationId` keeps identity for equality and is hashed by where it is written and which occurrence there it is. A hash has to agree with equality one way only.

`ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest` walks the 61 types the payloads reach and reports a finding with the path that got there. Putting enums back on their own hash turns it red on five of the six.

## The assertion

The 90% spread is not what the test was protecting. Paired against the fullest place of the table:

    distinct=853 → 7      distinct=809 → 8      distinct=315 → 346
    distinct=879 → 7      distinct=221 → 31     distinct=223 → 12

An evenly spread thousand over two thousand places fills its fullest place five or six deep, so `853/1001` was a healthy table failing the assertion. The collapse the javadoc names measures `distinct=6, maxBucket=997`. So the assertion is now on the fullest place, bounded at 16, and the distinct count stays in the failure message.

Measured here: `longest=6 distinct=1001`, and the same under both selections above, where before the fix the seeds moved.

## Cost

The corpus wall time cannot see this — the delegating control ran 4.4–10.3s against 3.8–4.6s for the change. In one JVM, `Term.hashOf(location)` against `location.hashCode()` was 8× at first and is 1.8× with `MethodHandle.invokeExact` (142ns against 76ns; 192ns against 107ns through a `Synthesized` owner).

## Left out

The per-link map multiplies by `MIX + 1`, which is even, and rotating each part by its position before folding takes seeds that collide within 1001 links from 63/200,000 to 13/200,000. That is a hash-quality change and not this defect, so it is not here.

## What the walk proves, and what settles it

A first pass wrote the payloads down and walked from what was written. Writing `OP` down as carrying a `String` instead of `BinOp` left all 1138 tests of the package green: the walk proved a set of types nothing builds, and `BinOp` left it without a word.

So the constructor asks the shape whether the payload is what it says, under assertions, where every term goes through — and the interner is asked for one term of every shape, held against `Shape.values()`, since a shape nothing builds is one that check never sees. The same false declaration now fails:

    OP is written as carrying OfType[type=class java.lang.String] and was built with souther.compiler.types.BinOp

`EvaluationId` is hashed by what was written and which occurrence of the reading it is, and no longer by where. A hash a type states for itself is taken at its word by the walk, so what it reads is what nothing else checks — and a position stands on a `Placement`, whose own hash reads a tree this cannot answer for.

## Review: a set reached the hash by an enum's identity

Found in review, and live rather than latent. `Type.Union` holds a `Set<TypeSymbol>`, and `Shape.NONE`/`Shape.OPENED` carry a `Type`.

Two exits let it through, and neither was a decision about a value. The walk met the set as a parameterized type and followed the argument without asking what the container was, so `TypeSymbol` was walked and the set was not. At run time the set fell to `ITS_OWN_HASH` — a concrete set states a hash — and a set's hash is the sum of its elements', which reaches `Type.Prim` through `TypeSymbol.Primitive` and takes its identity. One exit hid it from the proof; the other gave it a wrong answer.

So neither exit is left:

- A container is asked about before what it holds. A parameterized type whose raw class has no element rule is a finding, not a walk of its arguments. `Map` and arrays are findings today rather than silence tomorrow.
- A set is taken by its elements with no order among them, since that is what `Set.equals` reads. An ordered fold would give two equal sets two hashes.
- A class no longer answers with a hash of its own. `ITS_OWN_HASH` is the platform's scalars and nothing else; a type told apart by less than what it holds names the parts that stand for it (`Term.STANDS_FOR`), and the walk goes through those. Two do: `TypeSymbol.AtModule` is its address, and `EvaluationId` is told apart by which object it is and hashed from what was written and which occurrence of the reading it is.

Taking `Set` back out turns the walk red on the path the review names:

    Set holds what a term is hashed from and nothing says how it is taken (NONE_HERE), under
           Shape.NONE carries -> Type -> Leaf -> Union -> Union.members

`twoSetsHoldingAlikeAreOneHashWhateverOrderTheyWalkIn` holds the unordered part against `Type.Union`.

## Where the occurrence numbers come from

`Terms.evaluations` and `Terms.builtFrom` are `IdentityHashMap`s reached only through `computeIfAbsent`, `get` and `put` — neither is iterated anywhere, so no unordered traversal orders the numbering. The order is the order the Core walk asks in, which is a function of the program.

## Known limits

- Generated and hand-written `hashCode` are told apart by the `final` modifier, which decides whether a record is taken by its components. A hand-written `public final int hashCode()` would read as generated. Nothing in the closure has that shape today.
- `Term.STANDS_FOR` names what may be read of the two types told apart by less than they hold. A name too many there would give two equal values two hashes; the walk follows what is named but cannot read what equality reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
