### PR TITLE
Own the terms a run is held to where every run reads them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -208,14 +208,17 @@ public final class Compiler {
                                                java.time.Duration exampleBudget, Deadline deadline,
                                                EvaluationPolicy policy, ModulePath path) {
         Compilation compilation = Compilation.ofSource(source, defaultModuleName, path);
+        // The terms first and the wait after, because the wait is one of them: said the other way
+        // round, a caller that asked for both would have the policy put the default wait back over
+        // the one it asked for, and nothing would say so.
+        if (policy != null) {
+            compilation.withEvaluationPolicy(policy);
+        }
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);
         }
         if (deadline != null) {
             compilation.withDeadline(deadline);
-        }
-        if (policy != null) {
-            compilation.withEvaluationPolicy(policy);
         }
         compilation.measure(measure);
 
@@ -380,14 +383,15 @@ public final class Compiler {
                                               java.time.Duration exampleBudget, Deadline deadline,
                                               EvaluationPolicy policy) {
         Compilation compilation = Compilation.ofSources(sources, path);
+        // The terms first and the wait after, for the reason compilingSource gives.
+        if (policy != null) {
+            compilation.withEvaluationPolicy(policy);
+        }
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);
         }
         if (deadline != null) {
             compilation.withDeadline(deadline);
-        }
-        if (policy != null) {
-            compilation.withEvaluationPolicy(policy);
         }
         compilation.measure(measure);
 

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -9,7 +9,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.DeclarationMessage;
 import souther.compiler.diag.Located;
 import souther.compiler.examples.Deadline;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Acceptance;
 import souther.compiler.query.Adequacy;

--- a/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
@@ -36,11 +36,20 @@ public interface Deadline {
      */
     long DEFAULT_WORKER_STACK_BYTES = 64L * 1024 * 1024;
 
-    /** The stack this JVM's settings ask a worker to be given, read the way {@link
-     *  EvaluationPolicy#fromSettings} reads the terms. */
+    /** The stack this JVM's settings ask a worker to be given, on the terms
+     *  {@link EvaluationPolicy#fromSettings} states: a setting that is missing, unreadable or not
+     *  positive leaves the default in place. */
     static long workerStackFromSettings() {
-        return EvaluationPolicy.positiveLong("souther.example.worker.stack.bytes",
-                DEFAULT_WORKER_STACK_BYTES);
+        String written = System.getProperty("souther.example.worker.stack.bytes");
+        if (written == null) {
+            return DEFAULT_WORKER_STACK_BYTES;
+        }
+        try {
+            long asked = Long.parseLong(written.trim());
+            return asked > 0 ? asked : DEFAULT_WORKER_STACK_BYTES;
+        } catch (NumberFormatException _) {
+            return DEFAULT_WORKER_STACK_BYTES;
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.RowIdentity;
 
 import java.util.concurrent.Callable;
@@ -19,6 +20,28 @@ import java.util.concurrent.Callable;
  * come back" is stated rather than raced for.
  */
 public interface Deadline {
+
+    /**
+     * The stack a worker is given.
+     *
+     * <p>Large, and said here rather than inherited, so that how deep a recursion gets before the
+     * stack runs out is not something the surrounding JVM decides. What is meant to stop a recursion
+     * is {@link EvaluationPolicy#recursionDepthLimit}, which is counted and is the same on every
+     * machine; this is what makes room for that count to be reached first, and how much room it makes
+     * is what that limit was measured against.
+     *
+     * <p>A number of bytes of a thread's stack is this arrangement's and no other's. An execution
+     * that runs a row some other way bounds its recursion its own way and has nothing to do with
+     * this, which is why it is not among the terms a run is held to.
+     */
+    long DEFAULT_WORKER_STACK_BYTES = 64L * 1024 * 1024;
+
+    /** The stack this JVM's settings ask a worker to be given, read the way {@link
+     *  EvaluationPolicy#fromSettings} reads the terms. */
+    static long workerStackFromSettings() {
+        return EvaluationPolicy.positiveLong("souther.example.worker.stack.bytes",
+                DEFAULT_WORKER_STACK_BYTES);
+    }
 
     /**
      * One piece of work, said as what it is rather than as a sentence about it.
@@ -90,7 +113,7 @@ public interface Deadline {
      * <p>For a run whose answers come from outside the compile. Two things have to hold at once and
      * they look like they conflict. A row is one thread's from beginning to end — what it spends is
      * counted there, and how deep it may recurse is decided by the stack that thread was made with,
-     * which is why {@link EvaluationPolicy#workerStackBytes} is said outright rather than inherited
+     * which is why {@link #DEFAULT_WORKER_STACK_BYTES} is said outright rather than inherited
      * from whatever {@code -Xss} the surrounding JVM has. And a supplied implementation answers out
      * of the caller's world, of which a thread is part — a transaction bound to one, a security or
      * request context, an MDC, a scoped value — so it has to run where the caller called from.

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.WrittenStatements.Disagreement;
 import souther.compiler.observe.WrittenStatements.Readings;
 import souther.compiler.observe.WrittenStatements.Statement;

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.MemoryClassLoader;

--- a/souther-compiler/src/main/java/souther/compiler/examples/Handoff.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Handoff.java
@@ -9,7 +9,7 @@ import java.util.concurrent.SynchronousQueue;
  * <p>A row is one thread's from beginning to end and has to be: what it spends is counted on that
  * thread ({@code EvaluationContext}), what it went through is collected there ({@code Probe}), and
  * how deep it may recurse is decided by the stack that thread was made with
- * ({@link EvaluationPolicy#workerStackBytes}). Splitting a row across two threads would take the
+ * ({@link Deadline#DEFAULT_WORKER_STACK_BYTES}). Splitting a row across two threads would take the
  * counting apart, and running it on whatever thread called would put a model's recursion limit at
  * the mercy of the surrounding {@code -Xss}.
  *

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.execute.RowTrials;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.BoundaryInput;

--- a/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
@@ -202,7 +202,7 @@ public final class SoutherExamples {
         }
         return new BoundExamples(module, asked.rows(),
                 JvmExampleRuns.evaluating(compilation.jvmProgramImages(), asked,
-                        Output.deadlineOf(compilation.db()),
+                        compilation.jvmExampleDeadlines().forThisCompile(),
                         Answering.bound(implementation, Set.copyOf(bound), sigs.get(module))),
                 bound);
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
@@ -140,8 +140,8 @@ public final class SoutherExamples {
         // A row runs on a worker of this compile's own, so what it spends is counted on one thread
         // and how deep it may recurse is this compile's answer; what it hands outside runs on
         // whoever called, because that is the world a supplied implementation answers out of.
-        compiled.withDeadline(Deadline.crossingBackToTheCaller(
-                EvaluationPolicy.DEFAULT.workerStackBytes()));
+        compiled.withDeadline(
+                Deadline.crossingBackToTheCaller(Deadline.DEFAULT_WORKER_STACK_BYTES));
         return new SoutherExamples(compiled);
     }
 
@@ -202,6 +202,7 @@ public final class SoutherExamples {
         }
         return new BoundExamples(module, asked.rows(),
                 JvmExampleRuns.evaluating(compilation.jvmProgramImages(), asked,
+                        Output.deadlineOf(compilation.db()),
                         Answering.bound(implementation, Set.copyOf(bound), sigs.get(module))),
                 bound);
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
@@ -202,7 +202,8 @@ public final class SoutherExamples {
         }
         return new BoundExamples(module, asked.rows(),
                 JvmExampleRuns.evaluating(compilation.jvmProgramImages(), asked,
-                        compilation.jvmExampleDeadlines().forThisCompile(),
+                        compilation.jvmExampleDeadlines()
+                                .forThisCompile(asked.policy().outerTimeout()),
                         Answering.bound(implementation, Set.copyOf(bound), sigs.get(module))),
                 bound);
     }

--- a/souther-compiler/src/main/java/souther/compiler/execute/EvaluationPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/EvaluationPolicy.java
@@ -1,9 +1,15 @@
-package souther.compiler.examples;
+package souther.compiler.execute;
 
 import java.time.Duration;
 
 /**
- * What a compile allows one row's evaluation, and what it allows the machinery running it.
+ * What a compile holds one row's evaluation to, whoever runs it.
+ *
+ * <p>Terms and not a way of meeting them. Each of the three is a condition on the answer — how much
+ * the evaluated code may spend, how deep it may go, and how long the caller may be made to wait —
+ * and none of them says how an execution arranges to keep it. That is why they are here rather than
+ * beside the JVM's arrangement: an execution that is not this one honours the same three by its own
+ * means, and reads them without naming the subsystem that happens to run them today.
  *
  * <p>The first two are what decide a row. {@code stepLimit} is how many times the evaluated code may
  * pass a point the emitter counts, and {@code recursionDepthLimit} is how deep a recursive helper may
@@ -11,21 +17,22 @@ import java.time.Duration;
  * neither is a measure of time. Two compiles of the same model under the same policy therefore say
  * the same thing about it, however fast the host is and however loaded.
  *
- * <p>The last two are not about the model at all. {@code outerTimeout} is the wait after which the
- * evaluation is given up on, and it exists for what a counter cannot reach — a call into code this
- * compile did not generate, so has no counted points in. Losing to it is the compiler failing to
- * answer, not the model failing to terminate, and the two are reported as the different things they
- * are. {@code workerStackBytes} is the stack an evaluation runs on, said outright so that the depth a
- * recursion reaches is this compile's answer rather than whatever {@code -Xss} the JVM happens to
- * have been started with.
+ * <p>{@code outerTimeout} is not about the model at all. It exists for what a counter cannot reach —
+ * a call into code this compile did not generate, so has no counted points in. Losing to it is the
+ * compiler failing to answer, not the model failing to terminate, and the two are reported as the
+ * different things they are.
  *
- * <p>The relation between the two pairs is one-directional and cannot be made exact: the depth limit
- * is set to be reached before the stack runs out, and the outer timeout to be reached long after any
- * budget a row could spend. Neither can be proven — a frame's size depends on the helper it is for,
- * and a step's cost depends on what the step does — so both are set with room rather than derived.
+ * <p>What it obliges an execution to is elapsed time: past this, the caller is not still waiting.
+ * A limit on how much work is done is not the same promise and does not discharge it — an
+ * implementation counting fuel, instructions or reductions has bounded the work and not the wait, and
+ * still owes a clock of its own. What that clock is belongs to the implementation; that there is one
+ * is what reading this means.
+ *
+ * <p>The relation between the counted pair and the wait is one-directional and cannot be made exact:
+ * the outer timeout is set to be reached long after any budget a row could spend. It cannot be
+ * proven — a step's cost depends on what the step does — so it is set with room rather than derived.
  */
-public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration outerTimeout,
-                               long workerStackBytes) {
+public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration outerTimeout) {
 
     /**
      * Steps enough for anything a model states as an example, and far short of what code that does
@@ -42,16 +49,19 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
      *
      * <p>Which of the two happens first cannot be settled by reasoning about it: a frame's size is
      * decided by the helper's parameters and locals, so the depth a given stack holds differs between
-     * helpers. It was settled by measuring instead. On {@link #DEFAULT_WORKER_STACK_BYTES}, a plain
-     * recursion and one carrying eight extra parameters both reach a counted limit of a hundred
-     * thousand before the stack; at two hundred thousand the wide one runs the stack out first, at
-     * about a hundred and fifty thousand frames.
+     * helpers. It was settled by measuring instead, against the stack a worker of this compile's own
+     * is given. On sixty-four megabytes of it, a plain recursion and one carrying eight extra
+     * parameters both reach a counted limit of a hundred thousand before the stack; at two hundred
+     * thousand the wide one runs the stack out first, at about a hundred and fifty thousand frames.
      *
      * <p>Set below that rather than at it, and set higher than the depth any model here reaches. The
      * two ways this can be wrong are not equally bad: too low reports a legitimate deep walk as a
      * recursion that does not terminate, which is a wrong answer about the model, while too high
      * reports that the stack ran out first — which says the settings are wrong for this model and
      * what to do about it.
+     *
+     * <p>How much stack the execution actually gives a worker is that execution's own, and stating
+     * it is how it makes room for this count to be reached first.
      */
     public static final int DEFAULT_RECURSION_DEPTH_LIMIT = 50_000;
 
@@ -65,19 +75,9 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
      */
     public static final Duration DEFAULT_OUTER_TIMEOUT = Duration.ofSeconds(60);
 
-    /**
-     * The stack an evaluation is given.
-     *
-     * <p>Large, and said here rather than inherited, so that how deep a recursion gets before the
-     * stack runs out is not something the surrounding JVM decides. The depth limit is what is meant to
-     * stop a recursion; this is what makes room for it to, and how much room it makes is what
-     * {@link #DEFAULT_RECURSION_DEPTH_LIMIT} was measured against.
-     */
-    public static final long DEFAULT_WORKER_STACK_BYTES = 64L * 1024 * 1024;
-
     /** What a compile that says nothing is held to. */
     public static final EvaluationPolicy DEFAULT = new EvaluationPolicy(DEFAULT_STEP_LIMIT,
-            DEFAULT_RECURSION_DEPTH_LIMIT, DEFAULT_OUTER_TIMEOUT, DEFAULT_WORKER_STACK_BYTES);
+            DEFAULT_RECURSION_DEPTH_LIMIT, DEFAULT_OUTER_TIMEOUT);
 
     public EvaluationPolicy {
         if (stepLimit <= 0) {
@@ -89,10 +89,6 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
         }
         if (outerTimeout == null || outerTimeout.isNegative() || outerTimeout.isZero()) {
             throw new IllegalArgumentException("an outer timeout has to be positive: " + outerTimeout);
-        }
-        if (workerStackBytes <= 0) {
-            throw new IllegalArgumentException(
-                    "a worker stack size has to be positive: " + workerStackBytes);
         }
     }
 
@@ -116,11 +112,14 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
                         positiveLong("souther.example.recursion.depth",
                                 DEFAULT_RECURSION_DEPTH_LIMIT)),
                 Duration.ofMillis(positiveLong("souther.example.outer.timeout.ms",
-                        DEFAULT_OUTER_TIMEOUT.toMillis())),
-                positiveLong("souther.example.worker.stack.bytes", DEFAULT_WORKER_STACK_BYTES));
+                        DEFAULT_OUTER_TIMEOUT.toMillis())));
     }
 
-    private static long positiveLong(String setting, long fallback) {
+    /**
+     * One setting read as a positive number of something, or {@code fallback} where it does not say
+     * one. What "does not say one" covers is in {@link #fromSettings}.
+     */
+    public static long positiveLong(String setting, long fallback) {
         String written = System.getProperty(setting);
         if (written == null) {
             return fallback;
@@ -135,23 +134,18 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
 
     /** The default, holding a row to {@code stepLimit} steps. */
     public static EvaluationPolicy of(long stepLimit) {
-        return new EvaluationPolicy(stepLimit, DEFAULT_RECURSION_DEPTH_LIMIT, DEFAULT_OUTER_TIMEOUT,
-                DEFAULT_WORKER_STACK_BYTES);
+        return new EvaluationPolicy(stepLimit, DEFAULT_RECURSION_DEPTH_LIMIT, DEFAULT_OUTER_TIMEOUT);
     }
 
     public EvaluationPolicy withStepLimit(long steps) {
-        return new EvaluationPolicy(steps, recursionDepthLimit, outerTimeout, workerStackBytes);
+        return new EvaluationPolicy(steps, recursionDepthLimit, outerTimeout);
     }
 
     public EvaluationPolicy withRecursionDepthLimit(int depth) {
-        return new EvaluationPolicy(stepLimit, depth, outerTimeout, workerStackBytes);
+        return new EvaluationPolicy(stepLimit, depth, outerTimeout);
     }
 
     public EvaluationPolicy withOuterTimeout(Duration timeout) {
-        return new EvaluationPolicy(stepLimit, recursionDepthLimit, timeout, workerStackBytes);
-    }
-
-    public EvaluationPolicy withWorkerStackBytes(long bytes) {
-        return new EvaluationPolicy(stepLimit, recursionDepthLimit, outerTimeout, bytes);
+        return new EvaluationPolicy(stepLimit, recursionDepthLimit, timeout);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/execute/EvaluationPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/EvaluationPolicy.java
@@ -115,11 +115,7 @@ public record EvaluationPolicy(long stepLimit, int recursionDepthLimit, Duration
                         DEFAULT_OUTER_TIMEOUT.toMillis())));
     }
 
-    /**
-     * One setting read as a positive number of something, or {@code fallback} where it does not say
-     * one. What "does not say one" covers is in {@link #fromSettings}.
-     */
-    public static long positiveLong(String setting, long fallback) {
+    private static long positiveLong(String setting, long fallback) {
         String written = System.getProperty(setting);
         if (written == null) {
             return fallback;

--- a/souther-compiler/src/main/java/souther/compiler/execute/ExampleExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/ExampleExecution.java
@@ -6,8 +6,6 @@ import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
-import souther.compiler.examples.Deadline;
-import souther.compiler.examples.EvaluationPolicy;
 import souther.compiler.source.SourceId;
 import souther.compiler.types.ValueName;
 
@@ -46,7 +44,6 @@ public final class ExampleExecution {
     private final Map<String, List<BehaviorRequirement>> requirements;
     private final Map<String, Hir.FnDef> definitions;
     private final Map<ValueName.Behavior, Contract> contracts;
-    private final Deadline deadline;
     private final EvaluationPolicy policy;
     private final Map<String, ExampleExecution> declaring;
 
@@ -55,7 +52,7 @@ public final class ExampleExecution {
                             Map<String, List<BehaviorRequirement>> requirements,
                             Map<String, Hir.FnDef> definitions,
                             Map<ValueName.Behavior, Contract> contracts,
-                            Deadline deadline, EvaluationPolicy policy,
+                            EvaluationPolicy policy,
                             Map<String, ExampleExecution> declaring) {
         this.prepared = prepared;
         this.symbols = symbols;
@@ -68,7 +65,6 @@ public final class ExampleExecution {
         this.requirements = requirements;
         this.definitions = definitions;
         this.contracts = contracts;
-        this.deadline = deadline;
         this.policy = policy;
     }
 
@@ -139,12 +135,13 @@ public final class ExampleExecution {
         return contracts;
     }
 
-    /** How long a reading may take before it is stopped. */
-    public Deadline deadline() {
-        return deadline;
-    }
-
-    /** What a run is counted against. */
+    /**
+     * What a run of these rows is held to.
+     *
+     * <p>The terms and not a way of keeping them. How an execution arranges to stop a row that has
+     * spent them is its own — a worker and a wall clock here, something else elsewhere — and saying
+     * it here would put one implementation's arrangement in what every implementation is asked.
+     */
     public EvaluationPolicy policy() {
         return policy;
     }

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleDeadlines.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleDeadlines.java
@@ -1,0 +1,22 @@
+package souther.compiler.execute.jvm;
+
+import souther.compiler.examples.Deadline;
+
+/**
+ * Where the JVM implementation gets the deadline it runs a row under.
+ *
+ * <p>Beside {@link JvmProgramImages} and for the same reason. What a run is held to — the steps, the
+ * depth, the wait — is the compile's and crosses {@code ProgramExecution} as terms; how those terms
+ * are kept is the implementation's, and here it is a worker of this compile's own and a wall clock.
+ * A {@link Deadline} is that arrangement, not a term: it takes the work and runs it. So it does not
+ * cross the boundary, and the implementation that needs one is handed this instead.
+ *
+ * <p>Asked per compile rather than given once. What a build uses is built from what the compilation
+ * settled; a test says one outright, and says it after the implementation was named. Reading it at
+ * the question is what lets the second of those work at all.
+ */
+public interface JvmExampleDeadlines {
+
+    /** The deadline this compile's rows and readings are run under. */
+    Deadline forThisCompile();
+}

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleDeadlines.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleDeadlines.java
@@ -2,6 +2,8 @@ package souther.compiler.execute.jvm;
 
 import souther.compiler.examples.Deadline;
 
+import java.time.Duration;
+
 /**
  * Where the JVM implementation gets the deadline it runs a row under.
  *
@@ -11,12 +13,23 @@ import souther.compiler.examples.Deadline;
  * A {@link Deadline} is that arrangement, not a term: it takes the work and runs it. So it does not
  * cross the boundary, and the implementation that needs one is handed this instead.
  *
- * <p>Asked per compile rather than given once. What a build uses is built from what the compilation
- * settled; a test says one outright, and says it after the implementation was named. Reading it at
- * the question is what lets the second of those work at all.
+ * <p>The wait is passed in rather than fetched, and that is the whole point of the signature. An
+ * implementation that reached back into the compile for the term it was already told would have two
+ * ways to learn one thing, and two ways to learn one thing is how the boundary came to state a
+ * minute while the run was given up on after five milliseconds. Asked this way, what the JVM keeps
+ * is what the language said it would be held to, because it is the same value.
+ *
+ * <p>Asked per compile rather than given once. What a build uses is built from the term; a test says
+ * the arrangement outright, and says it after the implementation was named. Reading that at the
+ * question is what lets the second of those work at all.
  */
 public interface JvmExampleDeadlines {
 
-    /** The deadline this compile's rows and readings are run under. */
-    Deadline forThisCompile();
+    /**
+     * The arrangement this compile's rows and readings are run under, keeping {@code outerTimeout}.
+     *
+     * <p>An arrangement a caller said outright answers for the wait itself and this is then what it
+     * already decided, which is what saying one outright is for.
+     */
+    Deadline forThisCompile(Duration outerTimeout);
 }

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleRuns.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleRuns.java
@@ -1,6 +1,7 @@
 package souther.compiler.execute.jvm;
 
 import souther.compiler.examples.Answering;
+import souther.compiler.examples.Deadline;
 import souther.compiler.examples.ExampleVerifier;
 import souther.compiler.execute.ExampleExecution;
 import souther.compiler.observe.ArmObservation;
@@ -31,10 +32,15 @@ public final class JvmExampleRuns {
      * the module as this reading of the source has it, which is the whole reason the source is read
      * at the time the run happens.
      *
+     * <p>{@code deadline} is asked for beside the reading rather than taken out of it. What a row is
+     * held to crosses as terms; the arrangement that keeps them is this implementation's, and here
+     * it is the caller's own — a row driven one at a time from Java hands its applications back to
+     * the thread that asked.
+     *
      * @throws IllegalStateException where this compile emitted nothing to run the rows against
      */
     public static ExampleVerifier evaluating(JvmProgramImages images, ExampleExecution asked,
-                                             Answering answering) {
+                                             Deadline deadline, Answering answering) {
         JvmProgramImage image = images.evaluating(asked.module(), ArmObservation.OMIT);
         if (image == null) {
             throw new IllegalStateException("`" + asked.module() + "` emitted nothing to run its"
@@ -42,7 +48,7 @@ public final class JvmExampleRuns {
         }
         return ExampleVerifier.evaluating(asked.rows(), asked.symbols(), asked.signatures(),
                 image.program(), image.published(), asked.requirements(), image.around(),
-                asked.definitions(), asked.deadline(), asked.policy(), answering,
+                asked.definitions(), deadline, asked.policy(), answering,
                 asked.contracts());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
@@ -41,12 +41,18 @@ import java.util.Optional;
 public final class JvmProgramExecution implements ProgramExecution {
 
     private final JvmProgramImages images;
+    private final JvmExampleDeadlines deadlines;
 
-    public JvmProgramExecution(JvmProgramImages images) {
+    public JvmProgramExecution(JvmProgramImages images, JvmExampleDeadlines deadlines) {
         if (images == null) {
             throw new IllegalArgumentException("a run of the JVM program needs its classes");
         }
+        if (deadlines == null) {
+            throw new IllegalArgumentException(
+                    "a run of the JVM program needs the deadline it runs under");
+        }
         this.images = images;
+        this.deadlines = deadlines;
     }
 
     @Override
@@ -57,7 +63,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         }
         Observations observed = ExampleVerifier.check(asked.rowsWrittenIn(source), asked.symbols(),
                 asked.signatures(), image.program(), image.published(), asked.requirements(),
-                image.around(), asked.definitions(), asked.deadline(), asked.policy(),
+                image.around(), asked.definitions(), deadlines.forThisCompile(), asked.policy(),
                 // What applies a behavior here is what this compile emitted. A compile has nothing
                 // else to run a row against; something supplied from outside one arrives through
                 // the same seam and brings its own classes.
@@ -83,7 +89,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         // a question this asks.
         return new TableBuild.Built(ExampleStatements.fakeTables(asked.rows(), asked.symbols(),
                 asked.signatures(), image.program().classes(), image.around(), asked.definitions(),
-                source, asked.deadline(), asked.policy(), asked.contracts()));
+                source, deadlines.forThisCompile(), asked.policy(), asked.contracts()));
     }
 
     @Override
@@ -102,7 +108,7 @@ public final class JvmProgramExecution implements ProgramExecution {
                         reading.definitions())));
         return new StatementReading.Read(ExampleStatements.disagreements(asked.rows(),
                 asked.symbols(), asked.signatures(), image.program().classes(), image.around(),
-                asked.definitions(), asked.deadline(), asked.policy(), asked.contracts(),
+                asked.definitions(), deadlines.forThisCompile(), asked.policy(), asked.contracts(),
                 declaring));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
@@ -55,6 +55,17 @@ public final class JvmProgramExecution implements ProgramExecution {
         this.deadlines = deadlines;
     }
 
+    /**
+     * The arrangement this run keeps the wait it was told with.
+     *
+     * <p>Told and not looked up. The wait is one of the terms in {@code asked}, so this is where it
+     * is turned into something that keeps it, and there is no other way for a run here to learn it —
+     * which is what stops the boundary saying one wait while the run is given up on at another.
+     */
+    private souther.compiler.examples.Deadline keeping(ExampleExecution asked) {
+        return deadlines.forThisCompile(asked.policy().outerTimeout());
+    }
+
     @Override
     public RowRun run(ExampleExecution asked, SourceId source, ArmObservation arms) {
         JvmProgramImage image = images.evaluating(asked.module(), arms);
@@ -63,7 +74,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         }
         Observations observed = ExampleVerifier.check(asked.rowsWrittenIn(source), asked.symbols(),
                 asked.signatures(), image.program(), image.published(), asked.requirements(),
-                image.around(), asked.definitions(), deadlines.forThisCompile(), asked.policy(),
+                image.around(), asked.definitions(), keeping(asked), asked.policy(),
                 // What applies a behavior here is what this compile emitted. A compile has nothing
                 // else to run a row against; something supplied from outside one arrives through
                 // the same seam and brings its own classes.
@@ -89,7 +100,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         // a question this asks.
         return new TableBuild.Built(ExampleStatements.fakeTables(asked.rows(), asked.symbols(),
                 asked.signatures(), image.program().classes(), image.around(), asked.definitions(),
-                source, deadlines.forThisCompile(), asked.policy(), asked.contracts()));
+                source, keeping(asked), asked.policy(), asked.contracts()));
     }
 
     @Override
@@ -108,7 +119,7 @@ public final class JvmProgramExecution implements ProgramExecution {
                         reading.definitions())));
         return new StatementReading.Read(ExampleStatements.disagreements(asked.rows(),
                 asked.symbols(), asked.signatures(), image.program().classes(), image.around(),
-                asked.definitions(), deadlines.forThisCompile(), asked.policy(), asked.contracts(),
+                asked.definitions(), keeping(asked), asked.policy(), asked.contracts(),
                 declaring));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
@@ -7,7 +7,7 @@ package souther.compiler.partition;
  * a caller — which is the absence issue #969 opened on, and it was never only about the one limit
  * that issue removed. A limit is an input the query graph hands to the analysis (rule 4 of this
  * package's documentation), the way {@link souther.compiler.check.ReadingPolicy} and
- * {@link souther.compiler.examples.EvaluationPolicy} already are.
+ * {@link souther.compiler.execute.EvaluationPolicy} already are.
  *
  * <p><b>Grouped by which result each weakens, and not by being numbers.</b> A budget is only ever
  * read beside the answer it makes partial, and the two halves here are not interchangeable: the

--- a/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
@@ -45,7 +45,7 @@
  *
  * <p><b>4. Resource policy belongs to the compilation.</b> A limit is an input the query graph hands
  * to the analysis, the way {@link souther.compiler.check.ReadingPolicy} and
- * {@link souther.compiler.examples.EvaluationPolicy} already are, rather than a private constant or
+ * {@link souther.compiler.execute.EvaluationPolicy} already are, rather than a private constant or
  * a system property read wherever the work happens. {@link
  * souther.compiler.partition.AdequacyPolicy} is where the three are written, grouped by which
  * result each weakens — a caller raising one to lift a partial measurement should not as readily

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -64,7 +64,11 @@ public final class Compilation {
         // Read now, so this compilation is held to what the settings said when it started rather than
         // to what the first compile in this JVM happened to read. A caller with a reason of its own
         // says so with withEvaluationPolicy.
-        db.set(new Front.Policy(), souther.compiler.examples.EvaluationPolicy.fromSettings());
+        db.set(new Front.Policy(), souther.compiler.execute.EvaluationPolicy.fromSettings());
+        // And the stack a worker of this compilation's own is made with, read now for the same
+        // reason. Not one of the terms above: what a recursion is held to is counted, and this is
+        // what the arrangement running it on a JVM thread gives that count room to be reached in.
+        db.set(new Front.WorkerStack(), souther.compiler.examples.Deadline.workerStackFromSettings());
         // The one place a reading policy is made. Everything that reads a declaration is handed
         // this one, so a declaration read twice in one compilation is read the same way both times.
         db.set(new Front.Reading(), Front.Reading.STANDARD);
@@ -81,7 +85,10 @@ public final class Compilation {
         // program, and ADR-0032 settles that it is run as the program that will ship. Which
         // implementation that is belongs here, so that nothing deciding whether the language
         // accepts a program names one.
-        db.running(new souther.compiler.execute.jvm.JvmProgramExecution(jvmProgramImages));
+        // Its classes, and the deadline it runs them under. The second is read at the question and
+        // not handed over now, because a test says one after this line has run.
+        db.running(new souther.compiler.execute.jvm.JvmProgramExecution(jvmProgramImages,
+                () -> Output.deadlineOf(db)));
     }
 
     /**
@@ -402,7 +409,7 @@ public final class Compilation {
      * What a caller says here is said about this compilation alone, so a test holding a row to a few
      * steps does not hold every other compile in the same JVM to them.
      */
-    public Compilation withEvaluationPolicy(souther.compiler.examples.EvaluationPolicy policy) {
+    public Compilation withEvaluationPolicy(souther.compiler.execute.EvaluationPolicy policy) {
         db.set(new Front.Policy(), policy);
         return this;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -383,15 +383,20 @@ public final class Compilation {
      * is reported when one does not come back — gets that without holding every other compile in the
      * same JVM to the same wait.
      *
+     * <p>The wait among the terms and not a second one beside them. Said as its own input it would be
+     * a wait the JVM kept and the boundary did not know about, so an execution asked what it was held
+     * to would answer the default while the run it was answering for was already being given up on.
+     * Which is why {@link #withEvaluationPolicy} said afterwards replaces this along with the rest of
+     * them: it states the terms, and this states one of them.
+     *
      * @throws IllegalArgumentException if {@code budget} is not positive; a row that is given no time
      *     at all would report every behavior as one that does not terminate.
      */
     public Compilation withExampleBudget(java.time.Duration budget) {
-        long ms = budget.toMillis();
-        if (ms <= 0) {
+        if (budget.toMillis() <= 0) {
             throw new IllegalArgumentException("an example budget has to be positive: " + budget);
         }
-        db.set(new Front.ExampleBudget(), ms);
+        db.set(new Front.Policy(), Output.policyOf(db).withOuterTimeout(budget));
         return this;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.execute.jvm.JvmExampleDeadlines;
 import souther.compiler.execute.jvm.JvmProgramImages;
 import souther.compiler.DefaultStdlib;
 import souther.compiler.source.SourceId;
@@ -52,6 +53,9 @@ public final class Compilation {
      * shape of holding something for a backend, and a second one would want the name.
      */
     private final JvmProgramImages jvmProgramImages = new QueryJvmProgramImages(db);
+    /** And what it runs them under, one of it for the same reason: the run that decides whether the
+     *  rows hold and the run a Java binding drives are held to one compilation's answer. */
+    private final JvmExampleDeadlines jvmExampleDeadlines = new QueryJvmExampleDeadlines(db);
     /** Which source each id was, for a caller that identifies sources by index. */
     private final Map<SourceId, Integer> indexOfId = new LinkedHashMap<>();
     /** The sources this compilation currently has, so one that goes away can be forgotten. */
@@ -85,10 +89,8 @@ public final class Compilation {
         // program, and ADR-0032 settles that it is run as the program that will ship. Which
         // implementation that is belongs here, so that nothing deciding whether the language
         // accepts a program names one.
-        // Its classes, and the deadline it runs them under. The second is read at the question and
-        // not handed over now, because a test says one after this line has run.
         db.running(new souther.compiler.execute.jvm.JvmProgramExecution(jvmProgramImages,
-                () -> Output.deadlineOf(db)));
+                jvmExampleDeadlines));
     }
 
     /**
@@ -101,6 +103,13 @@ public final class Compilation {
      */
     public JvmProgramImages jvmProgramImages() {
         return jvmProgramImages;
+    }
+
+    /** What the JVM runs this compilation's rows under, for the same caller. Reached the same way
+     *  and for the same reason: a binding that ran the rows under a deadline of its own making
+     *  would not be running them the way this compilation says. */
+    public JvmExampleDeadlines jvmExampleDeadlines() {
+        return jvmExampleDeadlines;
     }
 
     /** A compile of several sources identified by their position, the way a build hands them over.

--- a/souther-compiler/src/main/java/souther/compiler/query/ExampleExecutions.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ExampleExecutions.java
@@ -90,7 +90,7 @@ public final class ExampleExecutions {
         Map<String, Hir.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
         return new ExampleExecution(prepared.value(), scope.value(), sigs.value(),
                 requirements, values == null ? Map.of() : values, contracts,
-                Output.deadlineOf(db), Output.policyOf(db),
+                Output.policyOf(db),
                 withDeclaring ? declaringOf(db, prepared.value()) : Map.of());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -95,11 +95,11 @@ public final class Front {
      * row evaluated, or one written statement read to compare it against another.
      *
      * <p>Not what decides a row. What a row is held to is counted
-     * ({@link souther.compiler.examples.EvaluationPolicy#stepLimit}), and this is the wait after which an
+     * ({@link souther.compiler.execute.EvaluationPolicy#stepLimit}), and this is the wait after which an
      * evaluation that has stopped answering is given up on — which is reported as the compiler
      * failing to decide, not as the model failing to terminate.
      *
-     * <p>Absent means {@link souther.compiler.examples.EvaluationPolicy#outerTimeout}. Nothing but a caller
+     * <p>Absent means {@link souther.compiler.execute.EvaluationPolicy#outerTimeout}. Nothing but a caller
      * with a reason to differ has to know this exists.
      */
     public record ExampleBudget() implements Input<Long> {}
@@ -118,8 +118,21 @@ public final class Front {
     public record ExampleDeadline() implements Input<souther.compiler.examples.Deadline> {}
 
     /**
+     * How much stack a worker of this compilation's own is made with, in bytes.
+     *
+     * <p>Not a term a row is held to. What holds a recursion is counted
+     * ({@link souther.compiler.execute.EvaluationPolicy#recursionDepthLimit}) and reads the same on
+     * every machine; this is how much room the arrangement that runs a row on a JVM thread makes for
+     * that count to be reached before the stack runs out, and it means nothing to a way of running a
+     * row that is not that one.
+     *
+     * <p>Absent means {@link souther.compiler.examples.Deadline#DEFAULT_WORKER_STACK_BYTES}.
+     */
+    public record WorkerStack() implements Input<Long> {}
+
+    /**
      * What this compilation allows one row's evaluation: the steps and the depth that decide it, and
-     * the wait and the stack the machinery running it is given.
+     * the wait after which it is given up on.
      *
      * <p>Read once, here, rather than out of a system property wherever a row happens to be evaluated.
      * A property read at class initialization is fixed for the life of the JVM, which is the wrong
@@ -127,9 +140,9 @@ public final class Front {
      * a setting was written for is not the one that reads it. Held as an input, it belongs to the
      * compilation, and two of them in one JVM may differ.
      *
-     * <p>Absent means {@link souther.compiler.examples.EvaluationPolicy#DEFAULT}.
+     * <p>Absent means {@link souther.compiler.execute.EvaluationPolicy#DEFAULT}.
      */
-    public record Policy() implements Input<souther.compiler.examples.EvaluationPolicy> {}
+    public record Policy() implements Input<souther.compiler.execute.EvaluationPolicy> {}
 
     /**
      * The standard library this compilation reads names against.

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -91,20 +91,6 @@ public final class Front {
     public record Core() implements Input<Boolean> {}
 
     /**
-     * How long one thing built and run on a worker of its own is given, in milliseconds: an example
-     * row evaluated, or one written statement read to compare it against another.
-     *
-     * <p>Not what decides a row. What a row is held to is counted
-     * ({@link souther.compiler.execute.EvaluationPolicy#stepLimit}), and this is the wait after which an
-     * evaluation that has stopped answering is given up on — which is reported as the compiler
-     * failing to decide, not as the model failing to terminate.
-     *
-     * <p>Absent means {@link souther.compiler.execute.EvaluationPolicy#outerTimeout}. Nothing but a caller
-     * with a reason to differ has to know this exists.
-     */
-    public record ExampleBudget() implements Input<Long> {}
-
-    /**
      * What one row or one reading is given to finish within, set outright rather than as a number of
      * milliseconds.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -560,9 +560,9 @@ public final class Output {
      * compiles in one JVM may differ and so that a long-lived one — a build daemon, an editor's
      * language server — is not held for its whole life to whatever the first compile in it read.
      */
-    public static souther.compiler.examples.EvaluationPolicy policyOf(Db db) {
-        souther.compiler.examples.EvaluationPolicy said = db.ask(new Front.Policy()).value();
-        return said == null ? souther.compiler.examples.EvaluationPolicy.DEFAULT : said;
+    public static souther.compiler.execute.EvaluationPolicy policyOf(Db db) {
+        souther.compiler.execute.EvaluationPolicy said = db.ask(new Front.Policy()).value();
+        return said == null ? souther.compiler.execute.EvaluationPolicy.DEFAULT : said;
     }
 
     /**
@@ -575,8 +575,13 @@ public final class Output {
     public static souther.compiler.examples.Deadline deadlineOf(Db db) {
         souther.compiler.examples.Deadline said = db.ask(new Front.ExampleDeadline()).value();
         return said != null ? said
-                : souther.compiler.examples.Deadline.ofMillis(exampleBudgetMs(db),
-                        policyOf(db).workerStackBytes());
+                : souther.compiler.examples.Deadline.ofMillis(exampleBudgetMs(db), workerStack(db));
+    }
+
+    /** How much stack this compilation makes a worker with. */
+    private static long workerStack(Db db) {
+        Long asked = db.ask(new Front.WorkerStack()).value();
+        return asked == null ? souther.compiler.examples.Deadline.DEFAULT_WORKER_STACK_BYTES : asked;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -545,14 +545,6 @@ public final class Output {
         };
     }
 
-    /** How long this compilation gives one row or one reading, in milliseconds. A compilation that
-     * says nothing is given the default, which is what a build wants; the input exists for a caller
-     * whose reason to differ is its own (see {@link Front.ExampleBudget}). */
-    static long exampleBudgetMs(Db db) {
-        Long asked = db.ask(new Front.ExampleBudget()).value();
-        return asked == null ? policyOf(db).outerTimeout().toMillis() : asked;
-    }
-
     /**
      * What this compilation allows one row's evaluation.
      *
@@ -566,16 +558,24 @@ public final class Output {
     }
 
     /**
-     * What this compilation gives one row or one reading to finish within.
+     * The arrangement this compilation keeps {@code outerTimeout} with.
      *
-     * <p>A deadline set outright wins over a budget in milliseconds, and only a test sets one: what
-     * it is for is stating that a particular row does not come back, rather than writing a model
-     * that does not come back and racing a clock to observe it.
+     * <p>The wait is a parameter and not something read here. It is a term, so it reaches the
+     * implementation the way every term does — across the boundary, in what the language asked —
+     * and a second reading of it out of this store is how the two came to say different things
+     * before. What is read here is the part that is not a term: the stack a worker is made with,
+     * and whether a caller said the arrangement outright.
+     *
+     * <p>A deadline set outright wins, and only a test sets one: what it is for is stating that a
+     * particular row does not come back, rather than writing a model that does not come back and
+     * racing a clock to observe it. It answers for the wait as it answers for everything else,
+     * which is why it takes no argument from here.
      */
-    public static souther.compiler.examples.Deadline deadlineOf(Db db) {
+    static souther.compiler.examples.Deadline deadlineOf(Db db, java.time.Duration outerTimeout) {
         souther.compiler.examples.Deadline said = db.ask(new Front.ExampleDeadline()).value();
         return said != null ? said
-                : souther.compiler.examples.Deadline.ofMillis(exampleBudgetMs(db), workerStack(db));
+                : souther.compiler.examples.Deadline.ofMillis(outerTimeout.toMillis(),
+                        workerStack(db));
     }
 
     /** How much stack this compilation makes a worker with. */

--- a/souther-compiler/src/main/java/souther/compiler/query/QueryJvmExampleDeadlines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/QueryJvmExampleDeadlines.java
@@ -3,14 +3,16 @@ package souther.compiler.query;
 import souther.compiler.examples.Deadline;
 import souther.compiler.execute.jvm.JvmExampleDeadlines;
 
+import java.time.Duration;
+
 /**
  * How this compiler answers what the JVM implementation runs a row under.
  *
  * <p>The arrangement beside {@link QueryJvmProgramImages}, for the other thing that implementation
- * needs and the language does not hand it. A deadline is built from what this compilation settled —
- * a budget in milliseconds, a stack in bytes — or said outright by a caller with a reason to; both
- * are inputs of this store, and turning them into the arrangement that keeps them is this
- * compiler's side of the seam rather than the implementation's.
+ * needs and the language does not hand it. A deadline is built from the wait the language handed
+ * over and the stack this compilation makes a worker with, or said outright by a caller with a
+ * reason to; turning those into the arrangement that keeps them is this compiler's side of the seam
+ * rather than the implementation's.
  *
  * <p>Asked, not held. A caller says a deadline after the implementation has been named, so one read
  * at construction would be the one it replaced.
@@ -24,7 +26,7 @@ final class QueryJvmExampleDeadlines implements JvmExampleDeadlines {
     }
 
     @Override
-    public Deadline forThisCompile() {
-        return Output.deadlineOf(db);
+    public Deadline forThisCompile(Duration outerTimeout) {
+        return Output.deadlineOf(db, outerTimeout);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/QueryJvmExampleDeadlines.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/QueryJvmExampleDeadlines.java
@@ -1,0 +1,30 @@
+package souther.compiler.query;
+
+import souther.compiler.examples.Deadline;
+import souther.compiler.execute.jvm.JvmExampleDeadlines;
+
+/**
+ * How this compiler answers what the JVM implementation runs a row under.
+ *
+ * <p>The arrangement beside {@link QueryJvmProgramImages}, for the other thing that implementation
+ * needs and the language does not hand it. A deadline is built from what this compilation settled —
+ * a budget in milliseconds, a stack in bytes — or said outright by a caller with a reason to; both
+ * are inputs of this store, and turning them into the arrangement that keeps them is this
+ * compiler's side of the seam rather than the implementation's.
+ *
+ * <p>Asked, not held. A caller says a deadline after the implementation has been named, so one read
+ * at construction would be the one it replaced.
+ */
+final class QueryJvmExampleDeadlines implements JvmExampleDeadlines {
+
+    private final Db db;
+
+    QueryJvmExampleDeadlines(Db db) {
+        this.db = db;
+    }
+
+    @Override
+    public Deadline forThisCompile() {
+        return Output.deadlineOf(db);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ACompilationAnswersWithOneLoaderForItsClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACompilationAnswersWithOneLoaderForItsClassesTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.generated.GeneratedBehavior;
 import souther.compiler.generated.JsonBoundary;
 import souther.compiler.meta.ModulePath;
@@ -70,8 +70,7 @@ final class ACompilationAnswersWithOneLoaderForItsClassesTest {
         compilation.withExampleBudget(Duration.ofMillis(12_345));
         compilation.withEvaluationPolicy(new EvaluationPolicy(999_999L,
                 EvaluationPolicy.DEFAULT_RECURSION_DEPTH_LIMIT,
-                EvaluationPolicy.DEFAULT_OUTER_TIMEOUT,
-                EvaluationPolicy.DEFAULT_WORKER_STACK_BYTES));
+                EvaluationPolicy.DEFAULT_OUTER_TIMEOUT));
         compilation.measure(Adequacy.Asked.warningsAt(Adequacy.Level.ALL));
 
         assertSame(before, compilation.loader(), "the loader after an input the classes do not read");

--- a/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import souther.compiler.observe.ArmObservation;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;

--- a/souther-compiler/src/test/java/souther/compiler/ARecursionIsHeldToItsDepthAndNotToTheStackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARecursionIsHeldToItsDepthAndNotToTheStackTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import souther.compiler.observe.ArmObservation;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsEvaluatedOncePerCompileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsEvaluatedOncePerCompileTest.java
@@ -1,7 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.examples.Deadline;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsHeldToStepsAndNotToTheClockTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsHeldToStepsAndNotToTheClockTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import souther.compiler.observe.ArmObservation;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.diag.CompileException;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;

--- a/souther-compiler/src/test/java/souther/compiler/ASettingBelongsToTheCompileThatReadItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ASettingBelongsToTheCompileThatReadItTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import souther.compiler.observe.ArmObservation;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.query.Compilation;

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -8,7 +8,7 @@ import souther.compiler.source.SourceId;
 import souther.compiler.diag.QuotedFrom;
 
 import souther.compiler.examples.Deadline;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.examples.ExampleStatements;
 import souther.compiler.examples.ExampleVerifier;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -4,7 +4,7 @@ import souther.compiler.diag.Primary;
 
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.diag.msg.ExampleMessage;
 import org.junit.jupiter.api.Test;
 

--- a/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
+++ b/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
@@ -2,7 +2,7 @@ package souther.compiler;
 
 import souther.compiler.examples.Deadline;
 import souther.compiler.observe.RowIdentity;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import java.time.Duration;
 import java.util.function.Predicate;
 

--- a/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
@@ -3,7 +3,7 @@ package souther.compiler;
 import souther.compiler.observe.ArmObservation;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.Counting;
 import souther.compiler.observe.RowOutcome;

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import net.unit8.raoh.Ok;

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.examples;
 
 import souther.compiler.check.CheckedEnsures;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.observe.Observations;
 import souther.compiler.observe.ArmObservation;
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
@@ -8,6 +8,7 @@ import souther.compiler.query.ExampleExecutions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -144,6 +145,37 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
                         .toList());
     }
 
+    /**
+     * And the wait it is told is the wait this compilation is run on.
+     *
+     * <p>A budget in milliseconds is what a caller says when it wants a row given up on sooner than
+     * a build would. Said as an input of its own it was kept by the JVM and unknown to the boundary,
+     * so an execution asked what it was held to answered the default minute while the run it was
+     * answering for was already being abandoned at five milliseconds — the boundary stating one
+     * thing and the implementation doing another, which is the whole of what this file is about.
+     *
+     * <p>So it is not an input of its own. It is the wait among the terms, and this reads it back
+     * where every execution reads it.
+     */
+    @Test
+    void andTheWaitItIsToldIsTheWaitTheCompilationRunsOn() {
+        RecordingExecution execution = new RecordingExecution();
+
+        execution.statements(readingHeldTo(EvaluationPolicy.DEFAULT, Duration.ofMillis(1_234)));
+
+        assertEquals(List.of("given up on after 1234ms"),
+                execution.asked().stream().map(AnExecutionThatIsNotTheJvmsCanBeWrittenTest::waited)
+                        .toList());
+    }
+
+    private static final Pattern GIVEN_UP_AFTER = Pattern.compile("given up on after \\d+ms");
+
+    /** What one sentence says the wait is, or the sentence itself where it says nothing. */
+    private static String waited(String said) {
+        Matcher matched = GIVEN_UP_AFTER.matcher(said);
+        return matched.find() ? matched.group() : said;
+    }
+
     private static final Pattern STEPS_EACH = Pattern.compile("\\d+ steps an example");
 
     /** What one sentence says an example is allowed, or the sentence itself where it says nothing —
@@ -155,8 +187,16 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
 
     /** {@link #TWO_EXAMPLES} as this compiler reads it, under {@code terms}. */
     private static ExampleExecution readingHeldTo(EvaluationPolicy terms) {
+        return readingHeldTo(terms, null);
+    }
+
+    /** The same, {@code budget} saying the wait the way a caller with a reason to differ says it. */
+    private static ExampleExecution readingHeldTo(EvaluationPolicy terms, Duration budget) {
         Compilation compilation = Compilation.ofSource(TWO_EXAMPLES, "Main");
         compilation.withEvaluationPolicy(terms);
+        if (budget != null) {
+            compilation.withExampleBudget(budget);
+        }
         compilation.answerEverything();
         ExampleExecution reading = ExampleExecutions.of(compilation.db(), "example.terms");
         assertTrue(reading != null, "the module has to check for there to be a reading of it");

--- a/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
@@ -2,11 +2,16 @@ package souther.compiler.execute;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ExampleExecutions;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,23 +28,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * question added to {@link ProgramExecution} that cannot be answered from there stops the build. What
  * is left for this to hold is what an import would let through quietly.
  *
- * <p>What is refused is what #971 refuses: how this compiler answers its own questions, what it
- * emits with, and what it emits. Not {@code souther.compiler.examples} — a {@code Deadline} and an
- * {@code EvaluationPolicy} are declared there and neither is a word of the machine, so refusing the
- * package would be this test making a claim the issue does not, and the stand-in would pass it by
- * not reading the budget rather than by not needing the machine. Whether those two are still owned
- * by the package the JVM implementation runs out of is a question about ownership, and it is not
- * settled by what a test finds convenient.
+ * <p>What is refused is how this compiler answers its own questions, what it emits with, what it
+ * emits, and the subsystem that runs a row on a JVM worker. The last of those is refused because
+ * what a run is held to and how a run is held to it are two things: the terms are the compile's and
+ * cross as {@link EvaluationPolicy}, while the arrangement that keeps them — a thread, a stack, a
+ * wall clock, work handed back to the caller — is one implementation's and does not cross at all.
+ *
+ * <p>Which is why the stand-in reads the terms rather than holding them. A file that took the
+ * budget and printed it would satisfy a rule about imports while showing nothing: what the rule is
+ * for is an execution that can be held to what the compile decided, and being held to a number
+ * means computing with it.
  */
 class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
 
-    /** How this compiler answers its own questions, what it emits with, and what one execution of a
-     *  program runs it as. */
+    /** How this compiler answers its own questions, what it emits with, what one execution of a
+     *  program runs it as, and the arrangement that runs a row on a worker of this compile's own. */
     private static final List<String> THE_MACHINES = List.of(
             "souther.compiler.query",
             "souther.compiler.codegen",
             "souther.compiler.generated",
             "souther.compiler.jvm",
+            "souther.compiler.examples",
             "ClassLoader");
 
     private static final Path STAND_IN =
@@ -91,5 +100,65 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
         assertEquals(List.of("constant 金額 written in example.money at null, of null,"
                         + " over 0 clauses, of Whole[value=500]"),
                 execution.asked());
+    }
+
+    /** Two behaviors with rows of their own, so a budget split over what the reading holds is a
+     *  different number from the budget. */
+    private static final String TWO_ROWS = """
+            module example.terms
+            data N = Int
+            data Out = Int
+            behavior twice : (n: N) -> Out constructs Out
+            let twice (n) = Out(n.value * 2)
+            example twice
+              | "twice one": (N(1)) -> Out(2)
+            behavior thrice : (n: N) -> Out constructs Out
+            let thrice (n) = Out(n.value * 3)
+            example thrice
+              | "thrice one": (N(1)) -> Out(3)
+            """;
+
+    /**
+     * And what it answers is decided by the terms it was handed.
+     *
+     * <p>The other tests here say the boundary can be declared and taken without the machine. This
+     * says the one part of it that is a term rather than a fact — what the compile holds a run to —
+     * arrives as a number an execution can be held to. A stand-in that only carried it would pass
+     * every other test in this file, so what this asks is that the answer moves when the terms do:
+     * two thousand steps over two rows is a thousand a row, and four thousand is two thousand.
+     *
+     * <p>Which is also why the arrangement that keeps the terms is not here to be read. Whether a
+     * budget is kept by a worker and a clock or by something else is the implementation's, and this
+     * execution keeps it by dividing it, which is an arrangement too.
+     */
+    @Test
+    void andWhatItAnswersFollowsTheTermsItWasGiven() {
+        RecordingExecution execution = new RecordingExecution();
+
+        execution.statements(readingHeldTo(EvaluationPolicy.of(2_000L)));
+        execution.statements(readingHeldTo(EvaluationPolicy.of(4_000L)));
+
+        assertEquals(List.of("1000 steps a row", "2000 steps a row"),
+                execution.asked().stream().map(AnExecutionThatIsNotTheJvmsCanBeWrittenTest::steps)
+                        .toList());
+    }
+
+    private static final Pattern STEPS_A_ROW = Pattern.compile("\\d+ steps a row");
+
+    /** What one sentence says a row is allowed, or the sentence itself where it says nothing —
+     *  which is what a stand-in that stopped reading the terms would leave to compare. */
+    private static String steps(String said) {
+        Matcher matched = STEPS_A_ROW.matcher(said);
+        return matched.find() ? matched.group() : said;
+    }
+
+    /** {@link #TWO_ROWS} as this compiler reads it, under {@code terms}. */
+    private static ExampleExecution readingHeldTo(EvaluationPolicy terms) {
+        Compilation compilation = Compilation.ofSource(TWO_ROWS, "Main");
+        compilation.withEvaluationPolicy(terms);
+        compilation.answerEverything();
+        ExampleExecution reading = ExampleExecutions.of(compilation.db(), "example.terms");
+        assertTrue(reading != null, "the module has to check for there to be a reading of it");
+        return reading;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/AnExecutionThatIsNotTheJvmsCanBeWrittenTest.java
@@ -102,9 +102,10 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
                 execution.asked());
     }
 
-    /** Two behaviors with rows of their own, so a budget split over what the reading holds is a
-     *  different number from the budget. */
-    private static final String TWO_ROWS = """
+    /** Two behaviors with an {@code example} of their own, so a budget split over what the reading
+     *  holds is a different number from the budget. What the reading counts is the blocks and not
+     *  the lines in them, which is why one row each is enough and two under one block would not be. */
+    private static final String TWO_EXAMPLES = """
             module example.terms
             data N = Int
             data Out = Int
@@ -125,7 +126,7 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
      * says the one part of it that is a term rather than a fact — what the compile holds a run to —
      * arrives as a number an execution can be held to. A stand-in that only carried it would pass
      * every other test in this file, so what this asks is that the answer moves when the terms do:
-     * two thousand steps over two rows is a thousand a row, and four thousand is two thousand.
+     * two thousand steps over two examples is a thousand each, and four thousand is two thousand.
      *
      * <p>Which is also why the arrangement that keeps the terms is not here to be read. Whether a
      * budget is kept by a worker and a clock or by something else is the implementation's, and this
@@ -138,23 +139,23 @@ class AnExecutionThatIsNotTheJvmsCanBeWrittenTest {
         execution.statements(readingHeldTo(EvaluationPolicy.of(2_000L)));
         execution.statements(readingHeldTo(EvaluationPolicy.of(4_000L)));
 
-        assertEquals(List.of("1000 steps a row", "2000 steps a row"),
+        assertEquals(List.of("1000 steps an example", "2000 steps an example"),
                 execution.asked().stream().map(AnExecutionThatIsNotTheJvmsCanBeWrittenTest::steps)
                         .toList());
     }
 
-    private static final Pattern STEPS_A_ROW = Pattern.compile("\\d+ steps a row");
+    private static final Pattern STEPS_EACH = Pattern.compile("\\d+ steps an example");
 
-    /** What one sentence says a row is allowed, or the sentence itself where it says nothing —
+    /** What one sentence says an example is allowed, or the sentence itself where it says nothing —
      *  which is what a stand-in that stopped reading the terms would leave to compare. */
     private static String steps(String said) {
-        Matcher matched = STEPS_A_ROW.matcher(said);
+        Matcher matched = STEPS_EACH.matcher(said);
         return matched.find() ? matched.group() : said;
     }
 
-    /** {@link #TWO_ROWS} as this compiler reads it, under {@code terms}. */
+    /** {@link #TWO_EXAMPLES} as this compiler reads it, under {@code terms}. */
     private static ExampleExecution readingHeldTo(EvaluationPolicy terms) {
-        Compilation compilation = Compilation.ofSource(TWO_ROWS, "Main");
+        Compilation compilation = Compilation.ofSource(TWO_EXAMPLES, "Main");
         compilation.withEvaluationPolicy(terms);
         compilation.answerEverything();
         ExampleExecution reading = ExampleExecutions.of(compilation.db(), "example.terms");

--- a/souther-compiler/src/test/java/souther/compiler/execute/NothingCrossingTheExecutionBoundaryIsTheMachinesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/NothingCrossingTheExecutionBoundaryIsTheMachinesTest.java
@@ -33,6 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * That is the difference between this walk and the one over a checked program, which does refuse
  * them, because what reads a checked program is an output standing outside this compiler.
  *
+ * <p>The subsystem that runs a row on a worker of this compile's own is refused for the same reason
+ * the emitted classes are. What a run is held to is the compile's and crosses as a term; the
+ * arrangement that keeps it — a thread of a stated size, a wall clock, work handed back to the
+ * caller — is one implementation's answer to how, and an execution that answers how differently
+ * would have to name it to be asked at all.
+ *
  * <p>Reachability and not the declared surface of one interface. A type is reached through the
  * methods of the types before it and through the arms of a sealed one, so a machine word four hops
  * out is one that crossed.
@@ -46,6 +52,7 @@ class NothingCrossingTheExecutionBoundaryIsTheMachinesTest {
             "souther.compiler.generated.",
             "souther.compiler.jvm.",
             "souther.compiler.execute.jvm.",
+            "souther.compiler.examples.",
             "java.lang.ClassLoader",
             "java.lang.Object");
 

--- a/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
@@ -51,8 +51,16 @@ final class RecordingExecution implements ProgramExecution {
      * can be declared without the machine and not that it can be met: the imports it does not need
      * are the ones for the parts it never opened. So this reads all of them, and what it makes of
      * them is a sentence, because what it is showing is that they can be read at all.
+     *
+     * <p>The terms are worked with and not quoted. A getter called for the object that comes back
+     * would compile against a term whose type this cannot name, and print it — which says the ask
+     * carries something, not that an execution can be held to it. Splitting the budget over the rows
+     * is this stand-in's own arrangement, and it is what makes the number in the sentence the terms'
+     * and not the sentence's.
      */
     private static String read(ExampleExecution about) {
+        EvaluationPolicy held = about.policy();
+        long rows = Math.max(1, about.rows().rows().size());
         return about.module()
                 + " (" + about.rows().rows().size() + " rows"
                 + ", " + about.signatures().size() + " behaviors"
@@ -60,8 +68,9 @@ final class RecordingExecution implements ProgramExecution {
                 + ", " + about.definitions().size() + " definitions"
                 + ", " + about.contracts().size() + " contracts"
                 + ", names " + (Objects.requireNonNull(about.symbols()) != null)
-                + ", within " + Objects.requireNonNull(about.deadline())
-                + " and " + Objects.requireNonNull(about.policy()) + ")";
+                + ", " + held.stepLimit() / rows + " steps a row"
+                + ", " + held.recursionDepthLimit() + " deep"
+                + ", given up on after " + held.outerTimeout().toMillis() + "ms)";
     }
 
     @Override

--- a/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
@@ -54,21 +54,22 @@ final class RecordingExecution implements ProgramExecution {
      *
      * <p>The terms are worked with and not quoted. A getter called for the object that comes back
      * would compile against a term whose type this cannot name, and print it — which says the ask
-     * carries something, not that an execution can be held to it. Splitting the budget over the rows
-     * is this stand-in's own arrangement, and it is what makes the number in the sentence the terms'
-     * and not the sentence's.
+     * carries something, not that an execution can be held to it. Splitting the budget over what
+     * was written is this stand-in's own arrangement, and it is what makes the number in the
+     * sentence the terms' and not the sentence's. A module that wrote none is given the whole of it
+     * rather than divided by nothing.
      */
     private static String read(ExampleExecution about) {
         EvaluationPolicy held = about.policy();
-        long rows = Math.max(1, about.rows().rows().size());
+        long written = Math.max(1, about.rows().rows().size());
         return about.module()
-                + " (" + about.rows().rows().size() + " rows"
+                + " (" + about.rows().rows().size() + " examples"
                 + ", " + about.signatures().size() + " behaviors"
                 + ", " + about.requirements().size() + " requirement tables"
                 + ", " + about.definitions().size() + " definitions"
                 + ", " + about.contracts().size() + " contracts"
                 + ", names " + (Objects.requireNonNull(about.symbols()) != null)
-                + ", " + held.stepLimit() / rows + " steps a row"
+                + ", " + held.stepLimit() / written + " steps an example"
                 + ", " + held.recursionDepthLimit() + " deep"
                 + ", given up on after " + held.outerTimeout().toMillis() + "ms)";
     }
@@ -76,7 +77,7 @@ final class RecordingExecution implements ProgramExecution {
     @Override
     public TableBuild fakeTables(ExampleExecution about, SourceId source) {
         asked.add("fakes of " + read(about) + " written in " + source
-                + ", " + about.rowsWrittenIn(source).rows().size() + " of its rows here");
+                + ", " + about.rowsWrittenIn(source).rows().size() + " of them here");
         return new TableBuild.NotBuiltHere();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/report/AMeasureWeakerThanCompleteSaysWhatMadeItSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AMeasureWeakerThanCompleteSaysWhatMadeItSoTest.java
@@ -5,7 +5,7 @@ import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.SourceNameResolver;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Measure;

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
@@ -1,7 +1,7 @@
 package souther.compiler.report;
 
 import org.junit.jupiter.api.Test;
-import souther.compiler.examples.EvaluationPolicy;
+import souther.compiler.execute.EvaluationPolicy;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.InputCaseEvidence;


### PR DESCRIPTION
Closes #1067.

## The decision

`ExampleExecution` carried two things declared in `souther.compiler.examples`, so an execution that is not the JVM's had to name the example subsystem to be held to a budget. The two are not the same kind of thing, and they get different owners.

- **`EvaluationPolicy` → `souther.compiler.execute`.** Terms: `stepLimit`, `recursionDepthLimit`, `outerTimeout`. What a run is held to, whoever runs it. Not `observe` — `Limits` there is about what an observation keeps of an answer, which is the other side of the run.
- **`Deadline` stays in `souther.compiler.examples`, whole.** Not split into an interface and its implementations. `given(Work, Callable)` is a way of running work, and `Work` is the example subsystem's vocabulary (`Row`, `Fixtures`, `Table`, `With`). That `crossingBackToTheCaller` needs the package-private `Handoff` is the evidence: a design that made `Handoff` public would be lifting an examples-specific mechanism into a general abstraction.
- **`workerStackBytes` leaves the terms.** Measured: its only two readers both built a `Deadline` with it, and `withWorkerStackBytes` had no callers. A number of bytes of a thread's stack means nothing to a way of running a row that has no threads. It is now `Deadline.DEFAULT_WORKER_STACK_BYTES`, held per compilation as `Front.WorkerStack`.

`outerTimeout` stays among the terms even though today's only reader builds a deadline from it. Its javadoc now says what reading it obliges an execution to: elapsed time, not work done — bounding fuel or instructions bounds the work and still owes a clock.

## How the JVM execution gets its deadline

Not off the ask. `JvmExampleDeadlines` sits beside `JvmProgramImages` in `execute.jvm`, and `Compilation` implements it. It is asked at the question rather than handed over once, because `withDeadline` is called after the implementation has been named.

`execute.jvm` naming `examples` is not a violation — package hierarchy is not the abstraction boundary. What must not name it is the portable half, and that is what is checked.

## What closes it

`NothingCrossingTheExecutionBoundaryIsTheMachinesTest` refuses `souther.compiler.examples.` on the boundary. Verified by mutation: putting `deadline()` back on `ExampleExecution` fails it with the ten types and the path each crossed on.

`AnExecutionThatIsNotTheJvmsCanBeWrittenTest` lists the package in `THE_MACHINES`, and `RecordingExecution` now divides the step budget over the reading instead of printing the object it got — so the rule is met by a stand-in that can be held to a budget, not by one that never opened it. Both mutations were run red.

`mvn -o test` green across the reactor (7440 in the compiler, 422, 330, 2271, …).