### PR TITLE
Read a total of a mapped sequence where the walk stands inside another closure

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ElementBindings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ElementBindings.java
@@ -24,7 +24,9 @@ import java.util.Map;
  * learns a new shape, the reading narrows with nothing saying so.
  *
  * <p>So the relation is read where it stands and carried by binding. What survives the rewrite is
- * the binding: it renames nothing, so a fact keyed this way is as true after it as before. Nothing
+ * the binding: it renames nothing, so a fact keyed this way is as true after it as before. What does
+ * mint bindings is a body being copied, and there the fact is carried across the copy's own renaming
+ * rather than surviving on its own ({@link ElementProvenance.CopyableFactKind}). Nothing
  * here is recovered by matching one tree against another, and no identity is invented for the
  * purpose — {@link BindingId} already tells one occurrence from another, which is exactly what a
  * helper expanded at two call sites needs and exactly what the construct an author wrote must not be

--- a/souther-compiler/src/main/java/souther/compiler/check/ElementProvenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ElementProvenance.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.types.BindingId;
 
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -13,7 +14,7 @@ import java.util.Map;
  * name on it — so what its answer held the elements of is a fact only the expansion had, and
  * recognising it again from the walk would read the shape a splice happens to leave.
  *
- * <p>Three relations and not one, because they license different things. Where an operation answers
+ * <p>Three facts and not one, because they license different things. Where an operation answers
  * the elements it was given — a {@code filter}, a {@code distinct} — the two bindings hold the same
  * values, so a rule about one is a rule about the other and a reading may walk through. Where it
  * answers what a closure made of them, the values came from there and are not those values: what a
@@ -28,32 +29,92 @@ import java.util.Map;
  * {@link #projectedFrom} is that, and the operation it was proved of is gone by the time anything
  * reads the tree — so it is proved where the operation stands and carried by binding.
  *
+ * <p><b>Asked one fact at a time, and never as a table.</b> The three are kept in one place because
+ * they obey one law where a body is copied ({@link CopyableFactKind}), and that is a reason for the
+ * shape inside and for nothing outside: a reader wants to know what one binding's elements came
+ * from, and the question it asks is that. Nothing here hands out the table, so no reader can come to
+ * depend on this being a table — which is what would make a fact obeying a different law hard to add
+ * beside these, exactly the thing the kinds were named narrowly to keep possible.
+ *
  * <p>Bindings and not expressions. A binding tells one occurrence from another, which is what two
- * calls of one operation need, and it survives everything between here and the tree that runs —
- * where an expression does not survive being copied, renamed or rewritten.
+ * calls of one operation need, where an expression does not survive being copied, renamed or
+ * rewritten. What a binding survives is two different things, and they are not both free:
+ *
+ * <p><b>A rewrite keeps the binding.</b> A fold that only grows a collection becomes a walk over a
+ * builder, and two such walks in a row become one; none of it mints a binding or renames one, so a
+ * fact keyed this way is as true after it as before and nothing has to be done.
+ *
+ * <p><b>A copy makes new bindings, and the facts are carried across it.</b> Splicing a body in gives
+ * every binding the body introduces one of the copy's own, so a fact left keyed on the original is
+ * about bindings the copied tree does not have. The copy holds the whole renaming at the one moment
+ * it is made, and {@link CopyableFactKind} is the law that says what to do with it there.
+ *
+ * <p>A value, compared by what it holds. It is part of an answer the query database keeps, and an
+ * identity that differed between two readings of one source would make every edit look like a change
+ * to everything downstream ({@link BindingId}).
  */
-public record ElementProvenance(Map<BindingId, BindingId> holding,
-                                Map<BindingId, BindingId> deriving,
-                                Map<BindingId, BindingId> projectedFrom) {
+public final class ElementProvenance {
+
+    /**
+     * A kind of fact this holds, and the law every one of them obeys where a body is copied.
+     *
+     * <p>Each is one binding said of another, both written by an expansion, and the two are moved
+     * together or not at all. So where a copy gives a body's bindings new ones under a renaming
+     * {@code m}, the copy has the same fact of the bindings it made: {@code a R b} with both ends in
+     * {@code m} induces {@code m(a) R m(b)}.
+     *
+     * <p>Named for what the facts have in common rather than for their being relations between
+     * bindings. A fact from one binding to several, or one a copy moves only one end of, obeys
+     * nothing said here and does not belong among these however much it reads like one — put here,
+     * it would be carried by a law it does not keep.
+     */
+    enum CopyableFactKind {
+        /** The two bindings hold the same values. */
+        HOLDS_THE_SAME_AS,
+        /** The first binding's elements were made from the second's. */
+        DERIVES_FROM,
+        /** The first binding is the closure parameter of a walk answering one per element of the
+         *  second. */
+        PROJECTS_EACH_ELEMENT_OF
+    }
 
     /** Nothing was expanded, which is what a body calling no such operation comes to. */
-    public static final ElementProvenance NONE =
-            new ElementProvenance(Map.of(), Map.of(), Map.of());
+    public static final ElementProvenance NONE = new ElementProvenance(Map.of());
 
-    public ElementProvenance {
-        holding = Map.copyOf(holding);
-        deriving = Map.copyOf(deriving);
-        projectedFrom = Map.copyOf(projectedFrom);
+    private final Map<CopyableFactKind, Map<BindingId, BindingId>> byKind;
+
+    /** Every kind is present, so a reader of one never meets an absence standing for an empty
+     *  table, and the tables are this value's rather than any caller's. */
+    private ElementProvenance(Map<CopyableFactKind, Map<BindingId, BindingId>> facts) {
+        Map<CopyableFactKind, Map<BindingId, BindingId>> held =
+                new EnumMap<>(CopyableFactKind.class);
+        for (CopyableFactKind kind : CopyableFactKind.values()) {
+            held.put(kind, Map.copyOf(facts.getOrDefault(kind, Map.of())));
+        }
+        this.byKind = Map.copyOf(held);
+    }
+
+    /** What one kind of fact this holds, as the bindings it is said of against the bindings it says
+     *  them of. Here for what is written beside it and for what holds the law; a reader asks about
+     *  one binding. */
+    Map<BindingId, BindingId> of(CopyableFactKind kind) {
+        return byKind.get(kind);
+    }
+
+    /** Every closure parameter of a one-per-element walk, against the container walked. The one
+     *  kind a reader beside this asks about as a whole, to say how many such walks a body has. */
+    Map<BindingId, BindingId> projectedFrom() {
+        return of(CopyableFactKind.PROJECTS_EACH_ELEMENT_OF);
     }
 
     /** The binding whose elements {@code binding} holds too, or null where none does. */
     public BindingId sameElementsAs(BindingId binding) {
-        return binding == null ? null : holding.get(binding);
+        return binding == null ? null : of(CopyableFactKind.HOLDS_THE_SAME_AS).get(binding);
     }
 
     /** The binding whose elements {@code binding}'s were made from, or null where none was. */
     public BindingId madeFrom(BindingId binding) {
-        return binding == null ? null : deriving.get(binding);
+        return binding == null ? null : of(CopyableFactKind.DERIVES_FROM).get(binding);
     }
 
     /**
@@ -66,37 +127,118 @@ public record ElementProvenance(Map<BindingId, BindingId> holding,
      * about this.
      */
     public BindingId projectedFrom(BindingId parameter) {
-        return parameter == null ? null : projectedFrom.get(parameter);
+        return parameter == null ? null
+                : of(CopyableFactKind.PROJECTS_EACH_ELEMENT_OF).get(parameter);
     }
 
     public boolean isEmpty() {
-        return holding.isEmpty() && deriving.isEmpty() && projectedFrom.isEmpty();
+        return byKind.values().stream().allMatch(Map::isEmpty);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof ElementProvenance that && byKind.equals(that.byKind);
+    }
+
+    @Override
+    public int hashCode() {
+        return byKind.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ElementProvenance" + byKind;
     }
 
     /** What an expansion writes down as it goes. */
     static final class Builder {
 
-        private final Map<BindingId, BindingId> holding = new LinkedHashMap<>();
-        private final Map<BindingId, BindingId> deriving = new LinkedHashMap<>();
-        private final Map<BindingId, BindingId> projectedFrom = new LinkedHashMap<>();
+        private final Map<CopyableFactKind, Map<BindingId, BindingId>> byKind =
+                new EnumMap<>(CopyableFactKind.class);
+
+        Builder() {
+            for (CopyableFactKind kind : CopyableFactKind.values()) {
+                byKind.put(kind, new LinkedHashMap<>());
+            }
+        }
 
         void holdsTheSameAs(BindingId binding, BindingId container) {
-            holding.putIfAbsent(binding, container);
+            byKind.get(CopyableFactKind.HOLDS_THE_SAME_AS).putIfAbsent(binding, container);
         }
 
         void derivesFrom(BindingId binding, BindingId container) {
-            deriving.putIfAbsent(binding, container);
+            byKind.get(CopyableFactKind.DERIVES_FROM).putIfAbsent(binding, container);
         }
 
         /** {@code parameter} is the closure parameter of a walk answering one per element of
          *  {@code container}. */
         void projectsEachElementOf(BindingId parameter, BindingId container) {
-            projectedFrom.putIfAbsent(parameter, container);
+            byKind.get(CopyableFactKind.PROJECTS_EACH_ELEMENT_OF).putIfAbsent(parameter, container);
+        }
+
+        /**
+         * Every fact said again of the bindings a copy made, under the renaming that copy is.
+         *
+         * <p>Induced and not moved. The body a copy was taken from is a body too — a lambda applied
+         * at two places is copied twice, and what was proved of the original is still what it was —
+         * so what this writes is a second fact beside the first rather than in place of it.
+         *
+         * <p>Both ends or neither, which is {@link CopyableFactKind}'s law. A fact one end of which
+         * this renaming does not move is not this copy's fact, and half of it renamed would say of
+         * one body's binding what was proved about another's.
+         *
+         * <p>The renaming and not whatever holds it. What is obeyed here is a law about facts and a
+         * map from bindings to bindings, and nothing about how the map came to exist — so this is
+         * held to on its own, by the map alone, rather than through the pass that copies bodies.
+         *
+         * <p><b>No two facts of one kind land on one binding.</b> A binding a copy minted is one
+         * nothing has said anything of, so meeting one already answered is not a fact arriving twice
+         * — it is two bindings given one name, whether the other came from this copy or from a copy
+         * before it. Asked once against both, because it is one thing that must not happen and a
+         * question asked of the table alone would let a renaming carrying two names for one binding
+         * through.
+         *
+         * <p>Refused where it would be written and not by walking the whole renaming, which would
+         * be a claim about renamings this does not need and does not make: what must not happen is
+         * two facts on one binding, and a renaming naming one binding twice with no fact on either
+         * writes nothing here.
+         *
+         * <p>Walked from the renaming rather than from the table, so what this costs is the size of
+         * the copy and not the size of what has been proved so far. Read the other way round, a body
+         * with many walks in it would have every one of them looked at again at every copy, which is
+         * a second reading of the whole table for work that is about one copy's bindings.
+         *
+         * <p>Gathered before any of it is written, since what is read is the table being added to.
+         */
+        void carriedAcross(Map<BindingId, BindingId> renaming) {
+            if (renaming.isEmpty()) {
+                return;
+            }
+            for (Map<BindingId, BindingId> facts : byKind.values()) {
+                Map<BindingId, BindingId> induced = new LinkedHashMap<>();
+                renaming.forEach((of, here) -> {
+                    BindingId from = facts.get(of);
+                    BindingId there = from == null ? null : renaming.get(from);
+                    if (there == null) {
+                        return;
+                    }
+                    BindingId already =
+                            induced.containsKey(here) ? induced.get(here) : facts.get(here);
+                    if (already != null) {
+                        throw new IllegalStateException(
+                                "two facts landed on one binding: " + here + " was said of "
+                                        + already + " before this copy said " + there);
+                    }
+                    induced.put(here, there);
+                });
+                facts.putAll(induced);
+            }
         }
 
         ElementProvenance built() {
-            return holding.isEmpty() && deriving.isEmpty() && projectedFrom.isEmpty() ? NONE
-                    : new ElementProvenance(holding, deriving, projectedFrom);
+            ElementProvenance built = new ElementProvenance(byKind);
+            return built.isEmpty() ? NONE : built;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1330,7 +1330,15 @@ public final class HelperInliner {
         // stamp says that is what it is doing, so nothing downstream reads the call as the place the
         // code is written.
         DeclaringCode declaring = whereTheBodyIs(call, helper);
-        Renaming renaming = new Renaming(arguments.subst(), new Copy(helper.writtenBody(), ours),
+        Copy copy = new Copy(helper.writtenBody(), ours);
+        // What was proved of the bindings this body has, said again of the ones the copy gives them.
+        // The body being copied is one already expanded — a lambda registered here is registered
+        // with its calls spliced in — so the operation that proved anything of it is gone from what
+        // is copied, and nothing downstream proves it again of the bindings the copy makes. Said
+        // here because this is where the whole renaming is in hand and nothing has been written from
+        // it yet.
+        provenance.carriedAcross(copy.renaming());
+        Renaming renaming = new Renaming(arguments.subst(), copy,
                 declaring == null ? null : call.pos().standingInFor(declaring),
                 declaring == null ? null : standingIn(call.region(), declaring));
         Hir.Expr body = inline(rename(helper.writtenBody(), renaming));   // expand nested helpers too
@@ -1849,6 +1857,12 @@ public final class HelperInliner {
         private Copy(Hir.Expr body, Hir.Binders binders) {
             eachBinder(body, binder ->
                     mine.put(binder.id(), binders.binder(binder.name(), binder.pos()).id()));
+        }
+
+        /** Which of the body's bindings became which of this copy's, for a reader whose question is
+         *  about the renaming itself rather than about any one name in it. */
+        Map<BindingId, BindingId> renaming() {
+            return mine;
         }
 
         /** This copy's binder for one the body has. The copy is this pass's writing, however much

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -77,7 +77,10 @@ public final class InputNumber {
      * with it, so what is read of the walk afterwards is read where the walk stands.
      *
      * <p>Null wherever any of the three is missing, which is a rule this compiler did not read
-     * rather than a rule the model does not state — and is reported as one.
+     * rather than a rule the model does not state — and is reported as one. Null too where the three
+     * are in hand and what they come to is not one run
+     * ({@link RunSource#overTheOccurrencesAt}), which is the same answer for the same reason: a
+     * reading short rather than a line somewhere it does not go.
      */
     private static NumericTerm overARun(NumericMeasures.Measured measured, InputReads reads,
                                         Symbols symbols) {
@@ -106,10 +109,17 @@ public final class InputNumber {
             return null;
         }
         TermPath under = answered.from(at);
+        // Whether what is read from there is one run is the run's own question, and it is asked
+        // rather than assumed: a walk over a sequence inside another sequence is over some of the
+        // occurrences of its path, and a term made of it would state of every one of them what the
+        // model says of those.
+        RunSource over = RunSource.overTheOccurrencesAt(under);
+        if (over == null) {
+            return null;
+        }
         Type stands = where.read().typeAt(under, symbols);
         return stands == null ? null
-                : NumericTerm.TakenOver.of(measured.operation(),
-                        new RunSource.ProjectedOccurrences(under), stands, symbols);
+                : NumericTerm.TakenOver.of(measured.operation(), over, stands, symbols);
     }
 
     /** The number a comparison is about, from whichever side names one. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RunSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RunSource.java
@@ -26,6 +26,37 @@ public sealed interface RunSource {
     TermPath subjectPath();
 
     /**
+     * The values a walk over {@code where} was taken of, or null where what is read from there is
+     * not one run.
+     *
+     * <p>The one place that decides it, so a reader asking for a run either gets one that means what
+     * this promises or gets nothing. Asked as a question first and refused in the constructor after,
+     * because a reader that has to catch a refusal is a reader that will one day not.
+     */
+    static RunSource overTheOccurrencesAt(TermPath where) {
+        return where != null && namesOneRun(where) ? new ProjectedOccurrences(where) : null;
+    }
+
+    /**
+     * Whether every occurrence of {@code where} is in one run, which is what
+     * {@link ProjectedOccurrences} says of the path it holds.
+     *
+     * <p>One sequence, and the two ways of not being one are one question. None of them is a run at
+     * all — a position holding one value is one value. Two of them is a run this cannot name:
+     * {@code groups[*].lines[*].amount} says every line of every group, a walk over one group's
+     * lines is over some of them, and the path is the whole of what a {@link ProjectedOccurrences}
+     * holds, so it cannot tell those two apart. Asked as one question because it is one invariant,
+     * and a reader who has a third thing to say about a path says it here rather than beside it.
+     *
+     * <p>What would lift the second is a run that names which occurrences it is over, and that is a
+     * thing this representation does not have rather than a shape nothing writes. Refused until it
+     * does, so the gap is one reading short and never a line drawn wrong.
+     */
+    private static boolean namesOneRun(TermPath where) {
+        return where.sequencesContainingIt().size() == 1;
+    }
+
+    /**
      * The values standing at one position, each element of the walk being one of them.
      *
      * <p>What has to be shown before one of these is made: as many values as the position has, and
@@ -33,14 +64,25 @@ public sealed interface RunSource {
      * it was given, or that answers one element for two, is not this — the numbers added up would
      * be a subset or a multiset of what the row holds, and a rule about the total would be measured
      * against something the model does not state.
+     *
+     * <p>And every occurrence of the path is in the run, which is what the path being the whole of
+     * what this holds comes to. {@link #namesOneRun} is that, asked of every one of these however it
+     * was reached.
      */
     record ProjectedOccurrences(TermPath subjectPath) implements RunSource {
 
         public ProjectedOccurrences {
             java.util.Objects.requireNonNull(subjectPath, "a run is read from somewhere");
-            if (!subjectPath.insideASequence()) {
-                throw new IllegalArgumentException(
-                        "a run stands inside a sequence, and `" + subjectPath + "` is one position"
+            // One invariant, and the two ways of failing it are two sentences about it rather than
+            // two guards: a reader with a third thing to say about the path says it in the question.
+            if (!namesOneRun(subjectPath)) {
+                throw new IllegalArgumentException(subjectPath.insideASequence()
+                        ? "a run is over every occurrence of the path it is read from, and `"
+                                + subjectPath + "` stands inside "
+                                + subjectPath.sequencesContainingIt().size()
+                                + " sequences, so which of its occurrences a walk was over is not"
+                                + " said by it"
+                        : "a run stands inside a sequence, and `" + subjectPath + "` is one position"
                                 + " holding one value");
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasProvedOfABodyIsSaidAgainOfEveryCopyOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasProvedOfABodyIsSaidAgainOfEveryCopyOfItTest.java
@@ -1,0 +1,225 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import souther.compiler.check.ElementProvenance.CopyableFactKind;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What was proved of a body's bindings is said again of the bindings a copy of that body was given.
+ *
+ * <p>Two things are held here, and they are not the same thing. The law is about facts and a
+ * renaming: both ends moved or nothing induced, and the fact already written left where it is. What
+ * the models hold is that the law is applied where a body is copied at all, which is what a walk
+ * standing inside another walk's closure needs and what no law about a map can say.
+ *
+ * <p>The law is held by the map and not through a model, because no source reaches its edges. Every
+ * fact here is one binding of an expansion said of another the same expansion wrote, so a renaming
+ * that moved one end and not the other is not a state a body compiles into. What can be asked of the
+ * primitive is the law itself, over bindings made by hand.
+ */
+class WhatWasProvedOfABodyIsSaidAgainOfEveryCopyOfItTest {
+
+    private static final BindingOwner WRITTEN = new BindingOwner.OfValue("example.claims", "f");
+    private static final BindingOwner COPIED = new BindingOwner.OfValue("example.claims", "g");
+
+    private static final BindingId OF = new BindingId(WRITTEN, 0);
+    private static final BindingId FROM = new BindingId(WRITTEN, 1);
+    private static final BindingId OF_HERE = new BindingId(COPIED, 0);
+    private static final BindingId FROM_HERE = new BindingId(COPIED, 1);
+
+    /**
+     * Both ends moved: the copy has the same fact of the bindings it was given, and the body it was
+     * taken from keeps its own.
+     *
+     * <p>Asked of every kind, so a fourth added to the table is carried by the same law or fails
+     * here. What records it is chosen by a switch over the kinds with no default, so a kind added
+     * and not recorded does not reach this test at all.
+     */
+    @ParameterizedTest
+    @EnumSource(CopyableFactKind.class)
+    void bothEndsMovedInducesTheFactOfTheCopy(CopyableFactKind kind) {
+        assertEquals(Map.of(OF, FROM, OF_HERE, FROM_HERE),
+                carried(kind, Map.of(OF, OF_HERE, FROM, FROM_HERE)).of(kind),
+                "the copy's bindings have between them what the body's had, and the body it was"
+                        + " copied from is a body too, so its own fact stays as it was");
+    }
+
+    /**
+     * One end moved is not this copy's fact, and half of it renamed would say of one body's binding
+     * what was proved about another's.
+     *
+     * <p>The whole table either way round. What a half-renamed fact does is either put one under a
+     * binding the copy made or rewrite the end of the one already there, and only reading all of it
+     * says neither happened — asked of the moved binding alone, the second goes unseen.
+     */
+    @ParameterizedTest
+    @EnumSource(CopyableFactKind.class)
+    void oneEndMovedInducesNothing(CopyableFactKind kind) {
+        assertEquals(Map.of(OF, FROM), carried(kind, Map.of(OF, OF_HERE)).of(kind),
+                "the binding a fact is said of moved and the one it is said of did not");
+        assertEquals(Map.of(OF, FROM), carried(kind, Map.of(FROM, FROM_HERE)).of(kind),
+                "and the other way round: the end this fact is said of is where it was");
+    }
+
+    /** A renaming that moves neither end moves nothing. */
+    @ParameterizedTest
+    @EnumSource(CopyableFactKind.class)
+    void aRenamingOfOtherBindingsInducesNothing(CopyableFactKind kind) {
+        assertEquals(Map.of(OF, FROM),
+                carried(kind, Map.of(new BindingId(WRITTEN, 9), OF_HERE)).of(kind),
+                "a copy of some other part of the body says nothing about this fact");
+    }
+
+    /**
+     * A binding a copy just minted is one nothing has spoken of, so meeting it already answered is
+     * two bindings given one name rather than a fact arriving twice.
+     *
+     * <p>Two ways it can be met and one thing that must not happen. The binding is already spoken
+     * for in the table, which is a copy before this one having minted it; or twice within this
+     * copy, which is this renaming naming two of the body's bindings alike. Asked of the table
+     * alone, the second goes through and one of the two facts is quietly the other.
+     */
+    @Test
+    void aBindingAlreadySpokenForInTheTableIsRefused() {
+        ElementProvenance.Builder builder = new ElementProvenance.Builder();
+        record(builder, CopyableFactKind.PROJECTS_EACH_ELEMENT_OF, OF, FROM);
+        record(builder, CopyableFactKind.PROJECTS_EACH_ELEMENT_OF, OF_HERE, FROM_HERE);
+
+        assertThrows(IllegalStateException.class,
+                () -> builder.carriedAcross(Map.of(OF, OF_HERE, FROM, FROM_HERE)),
+                "the binding this copy would write under is one the table already answers");
+    }
+
+    /** And a renaming naming two of the body's bindings alike is refused for the same reason. */
+    @Test
+    void twoOfTheBodysBindingsGivenOneNameAreRefused() {
+        BindingId alsoOf = new BindingId(WRITTEN, 2);
+        BindingId alsoFrom = new BindingId(WRITTEN, 3);
+        ElementProvenance.Builder builder = new ElementProvenance.Builder();
+        record(builder, CopyableFactKind.PROJECTS_EACH_ELEMENT_OF, OF, FROM);
+        record(builder, CopyableFactKind.PROJECTS_EACH_ELEMENT_OF, alsoOf, alsoFrom);
+
+        assertThrows(IllegalStateException.class,
+                () -> builder.carriedAcross(Map.of(OF, OF_HERE, FROM, FROM_HERE,
+                        alsoOf, OF_HERE, alsoFrom, new BindingId(COPIED, 3))),
+                "both facts would be written under the one binding, and one of them would be the"
+                        + " other with nothing saying so");
+    }
+
+    /** Nothing recorded stays nothing, whatever a copy renames. */
+    @Test
+    void aBodyWithNothingProvedOfItCarriesNothing() {
+        ElementProvenance.Builder builder = new ElementProvenance.Builder();
+        builder.carriedAcross(Map.of(OF, OF_HERE, FROM, FROM_HERE));
+        assertTrue(builder.built().isEmpty(), "a copy induces facts and does not invent them");
+    }
+
+    /**
+     * The lifetime, which the law alone does not give: a walk inside another walk's closure is read
+     * as the run it is read as in a body.
+     *
+     * <p>The closure is applied where the operation that hands it its elements was spliced in, so
+     * its body — already expanded, the walk inside it already proved of — is copied there, and every
+     * binding the reading looks for is one that copy made.
+     */
+    @Test
+    void aWalkInsideAnothersClosureIsRead() {
+        ElementBindings elements = elements("insideAClosure");
+        assertFalse(elements.projected().isEmpty(),
+                "the walk answers a place of its element, and the licence is on that element");
+        assertEquals("amount",
+                elements.projectionAt(elements.projected().keySet().iterator().next()).toString());
+    }
+
+    /**
+     * And a second closure between the walk and the body changes nothing.
+     *
+     * <p>Not a second copy: what the outer closure's body holds by the time it is copied is the
+     * inner walk already expanded, so one renaming carries both. What this holds is that a shape an
+     * author writes — a walk reached through two closures rather than one — reads like the shape
+     * above, and it says nothing about when the carrying happens.
+     */
+    @Test
+    void aWalkReachedThroughTwoClosuresIsRead() {
+        ElementBindings elements = elements("twoClosuresDeep");
+        assertFalse(elements.projected().isEmpty(),
+                "the licence is on the element however many closures stand between the walk and"
+                        + " the body");
+    }
+
+    private static ElementProvenance carried(CopyableFactKind kind,
+                                             Map<BindingId, BindingId> renaming) {
+        ElementProvenance.Builder builder = new ElementProvenance.Builder();
+        record(builder, kind, OF, FROM);
+        builder.carriedAcross(renaming);
+        return builder.built();
+    }
+
+    /** One fact of the given kind, written down. A switch over the kinds and no default, so a kind
+     *  added to the table is a kind this test does not compile without. */
+    private static void record(ElementProvenance.Builder builder, CopyableFactKind kind,
+                               BindingId of, BindingId from) {
+        BiConsumer<BindingId, BindingId> into = switch (kind) {
+            case HOLDS_THE_SAME_AS -> builder::holdsTheSameAs;
+            case DERIVES_FROM -> builder::derivesFrom;
+            case PROJECTS_EACH_ELEMENT_OF -> builder::projectsEachElementOf;
+        };
+        into.accept(of, from);
+    }
+
+    private static final String MODEL = """
+            module example.claims
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Item = { amount: Amount, free: Bool }
+
+            data Big = { threshold: Int }
+            data Small
+            data Kind = Big | Small
+
+            data Needed
+            data NotNeeded
+            data Verdict = Needed | NotNeeded
+
+            let matches (lines: List<Item>, k: Kind): Bool =
+                match k with
+                    | Big { threshold } ->
+                        List.sum(List.map(line -> line.amount.value, lines)) >= threshold
+                    | Small -> false
+
+            behavior insideAClosure : (lines: List<Item>, kinds: List<Kind>) -> Verdict
+            let insideAClosure (lines, kinds) =
+                if List.length(List.filter(k -> matches(lines, k), kinds)) >= 1
+                    then Needed else NotNeeded
+
+            behavior twoClosuresDeep : (lines: List<Item>, kinds: List<Kind>, tags: List<Int>)
+                    -> Verdict
+            let twoClosuresDeep (lines, kinds, tags) =
+                if List.length(List.filter(t -> List.any(k -> matches(lines, k), kinds), tags))
+                        >= 1 then Needed else NotNeeded
+            """;
+
+    private static ElementBindings elements(String behavior) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        Bodies.CheckedBody checked = compilation.db().ask(new Bodies.CheckedBehavior(
+                compilation.modules().get(0), behavior)).value();
+        return checked.elements();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunIsOverEveryOccurrenceOfThePathItIsReadFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunIsOverEveryOccurrenceOfThePathItIsReadFromTest.java
@@ -1,0 +1,163 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.inputs.RunSource;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A run holds a path and nothing else, so it is only over the walks every occurrence of that path is
+ * in.
+ *
+ * <p>The pair of shapes is the whole of it. A walk over a sequence captured from outside the closure
+ * it stands in is over every occurrence of its path, and the rule about its total is a line. A walk
+ * over a sequence belonging to the closure's own parameter is over the occurrences under one element
+ * of the walk outside it, and its path — inside two sequences — names every occurrence under every
+ * one of them. The second is not a reading this can have until a run says which occurrences it is
+ * over, and what it must not be is the first.
+ *
+ * <p>Held at the reading and at the representation both. The reading asks before it builds one; the
+ * representation refuses one built anyway, which is what says the promise is the type's and not one
+ * caller's care.
+ */
+class ARunIsOverEveryOccurrenceOfThePathItIsReadFromTest {
+
+    private static final String MODULE = "example.claims";
+
+    private static final String MODEL = """
+            module example.claims
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Item = { amount: Amount, free: Bool }
+            data Group = { lines: List<Item> }
+
+            data Big = { threshold: Int }
+            data Small
+            data Kind = Big | Small
+
+            data Needed
+            data NotNeeded
+            data Verdict = Needed | NotNeeded
+
+            let matches (lines: List<Item>, k: Kind): Bool =
+                match k with
+                    | Big { threshold } ->
+                        List.sum(List.map(line -> line.amount.value, lines)) >= threshold
+                    | Small -> false
+
+            behavior overASequenceFromOutsideTheClosure
+                    : (lines: List<Item>, kinds: List<Kind>) -> Verdict
+            let overASequenceFromOutsideTheClosure (lines, kinds) =
+                if List.length(List.filter(k -> matches(lines, k), kinds)) >= 1
+                    then Needed else NotNeeded
+
+            behavior overTheClosuresOwnSequence : (groups: List<Group>) -> Verdict
+            let overTheClosuresOwnSequence (groups) =
+                if List.length(List.filter(g ->
+                        List.sum(List.map(line -> line.amount.value, g.lines)) >= 100000,
+                        groups)) >= 1
+                    then Needed else NotNeeded
+            """;
+
+    /**
+     * The walk whose sequence came from outside the closure is read, and its rule is a line on the
+     * total.
+     *
+     * <p>The shape a claim's central rule is written in: the closure decides one thing about a
+     * candidate and the total it decides it by is of a list the behavior was given.
+     */
+    @Test
+    void aWalkOverASequenceFromOutsideTheClosureIsReadAsARun() {
+        assertTrue(reasonsOf("overASequenceFromOutsideTheClosure")
+                        .contains(UndividedPosition.Reason.RULE_ABOUT_A_RUN),
+                "the rule is about what the values at the place come to, which is a run and not a"
+                        + " class of any of them");
+        String report = report();
+        for (String point : List.of("ON", "OFF", "IN", "OUT")) {
+            assertTrue(report.contains("the " + point + " point overASequenceFromOutsideTheClosure/"
+                            + "List.sum(lines[*].amount)"),
+                    () -> "a " + point + " point is owed against the total: " + report);
+        }
+    }
+
+    /**
+     * The walk over the closure's own sequence is not, and no line is drawn anywhere near it.
+     *
+     * <p>What it must not come out as is a rule about `groups[*].lines[*].amount`, which is every
+     * line of every group: the walk is over one group's lines, and a total of all of them is a
+     * number no rule in this model is written about. Reported as a rule about a value that came
+     * from the position, which is what it is — the reading followed the value to where it came from
+     * and could not say what the rule says about the values there.
+     */
+    @Test
+    void aWalkOverTheClosuresOwnSequenceIsNotReadAsARunOverAllOfThem() {
+        assertFalse(report().contains("List.sum(groups[*].lines[*].amount)"),
+                () -> "a total of every line of every group is a number this model does not"
+                        + " compare: " + report());
+        assertFalse(reasonsOf("overTheClosuresOwnSequence")
+                        .contains(UndividedPosition.Reason.RULE_ABOUT_A_RUN),
+                "and it is not said to be a rule about a run, which promises a border was drawn");
+        assertTrue(reasonsOf("overTheClosuresOwnSequence")
+                        .contains(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
+                "the rule is one about a value made from what stands there, which is a reading"
+                        + " this did not have rather than one the model does not state");
+    }
+
+    /** The reading asks the question rather than building one and hoping. */
+    @Test
+    void theReadingAsksBeforeItBuildsOne() {
+        assertNotNull(RunSource.overTheOccurrencesAt(
+                        TermPath.of("lines").element().then("amount")),
+                "a place inside one sequence is a place every occurrence of which is in the run");
+        assertNull(RunSource.overTheOccurrencesAt(
+                        TermPath.of("groups").element().then("lines").element().then("amount")),
+                "a place inside two is not, and the run says which of them it is over by holding a"
+                        + " path — which says neither");
+    }
+
+    /** And one built anyway is refused, so the promise is the type's. */
+    @Test
+    void oneBuiltAnywayIsRefused() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new RunSource.ProjectedOccurrences(
+                        TermPath.of("groups").element().then("lines").element().then("amount")),
+                "every occurrence of the path is in the run, and a path inside two sequences has"
+                        + " occurrences under each element of the outer one");
+    }
+
+    private static List<UndividedPosition.Reason> reasonsOf(String behavior) {
+        return evidence().get(behavior).notRead().stream()
+                .map(PartitionEvidence.NotRead::reason).toList();
+    }
+
+    private static Map<String, PartitionEvidence> evidence() {
+        return measured().db().ask(new Adequacy.Coverage(MODULE)).value();
+    }
+
+    private static String report() {
+        return AdequacyReport.of(measured()).human(SourceNameResolver.identity());
+    }
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+}


### PR DESCRIPTION
A total of a mapped sequence drew no line where the walk stood inside another walk's closure, and
drawing it there turned out to need a second thing said about what a run is over. Two commits, one
each.

## Say what was proved of a body again of every copy of it

What a walk answers per element is proved where the operation stands and kept by binding, on the
ground that nothing between there and the tree that runs renames a binding. A rewrite does not. A
copy does — splicing a body in gives every binding the body introduces one of the copy's own, and a
lambda handed to an operation is applied inside that operation's own body, so a walk inside the
closure is copied there with its bindings minted afresh. Measured on the shape the issue is about:

```text
projectedFrom = {$f#3.0 = List.map#2.1}   the bindings the copy abandoned
tree          = ... $keep#5.5 / $keep#5.8 / $keep#5.9
projected     = {}
```

The copy holds the whole renaming at the one moment it is made, so the facts are carried across it
there: both ends moved or nothing induced, and the fact already written left where it is — the body
a copy was taken from is a body too.

The table is now keyed by what its facts have in common rather than held as three fields beside each
other, so the law is one law over the kinds and a fourth kind is carried by it or does not belong in
the table. The law is held by the map, over bindings made by hand, because no source reaches a
renaming that moves one end of a fact and not the other. What the models hold is that the law is
applied where a body is copied at all.

The carrying is walked from the renaming and not from the table, so it costs the size of the copy.
Read the other way round it is quadratic in one body's walks — 32 nested walks came to 6577 entries
visited against 2310 — and the corpora, where the table is nearly empty, would not have shown it.

## Hold a run to the occurrences the path it holds names

With the fact carried, a walk one nesting further out is reached too, and it read wrong:
`List.sum(List.map(f, g.lines))` inside a walk over `groups` came out as
`List.sum(groups[*].lines[*].amount)` with a border drawn on it. That is a total of every line of
every group; the walk is over one group's lines.

A run holds a path and nothing else, which is what cannot tell the two apart. So what the type
already promises — every occurrence of the path is in the run — is made a condition of being one:
the path stands inside one sequence and no more. The reading asks before it builds one and the
constructor refuses one built anyway, so the promise is the type's rather than one caller's care.

The refused shape is reported as a rule about a value that came from the position, which is what it
is. No word is added for it: naming which occurrences a run is over is what would lift it, and until
a run can say that, a reading short is the answer.

## What this does not reach

`#1153`'s businesstrip criterion — `高額か` a line at a hundred thousand — is **not met by this pull
request**, and the issue stays open. What stops it is #1157: a number reached through a value the
body constructs is not read at all. Measured on this branch, businesstrip still reports

```text
notRead[事前承認要否を判定する] = [予定費用[*].費目.金額:UNSUPPORTED_SYNTAX, 予定費用:UNSUPPORTED_SYNTAX]
```

and the same word comes out of a module with one `Int` input and four lines, with no sequence,
closure or walk anywhere near it. That is why it is `Refs #1153` and not `Fixes`.

## Evidence

All 10861 tests green. Both commits' claims were checked by mutation: without the carrying, the two
models that read a walk inside a closure fail; with half a fact renamed, the law fails for all three
kinds; with the run's condition weakened to what it was, the border on `groups[*].lines[*].amount`
comes back.

One claim was written and then withdrawn. The carrying was documented as having to happen before the
copied body is walked, so that a copy of a copy would be taken from a table already carried into.
Moving the call after the walk failed no test: a walk two closures deep is one copy of a body that
already holds the inner walk expanded, not a copy of a copy. The ordering is not something the
mechanism guarantees, so nothing says it does.

Refs #1153
