### PR TITLE
Say where a line was read with the whole of what it was drawn at

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -190,11 +190,18 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, PointA
     }
 
     /**
-     * The position this line is on, as a report names it.
+     * The left of the line, qualified by the behavior it is an input of, as a report indexes by.
      *
-     * <p>Asked of the shape of the line rather than of a field every shape was assumed to have. A
-     * line between two positions is on neither of them, and answering with one of the two would name
-     * a border after half of itself.
+     * <p>Asked of the shape of the line rather than of a field every shape was assumed to have,
+     * because what a line is drawn on is not always a position: a line between two positions is on
+     * neither of them and a line over a form is on none of them, and each shape says how it is
+     * named.
+     *
+     * <p><b>Not what tells one line from another.</b> A quantity over more than one position is
+     * named after the left of it, so every line from one position to a field of a sum has this same
+     * word — a heading a reader groups under, and half of a line where there are two. What says
+     * which line it is, is the whole of what it was drawn at ({@link #cut}); what a report writes to
+     * be read is {@link #label}, and what a document publishes beside this is the other end.
      */
     public String axis() {
         return cut.named();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -186,7 +186,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, PointA
     /** Where the line is, as a report names it. Not what any one of its points asks for: that is
      *  {@link #label(PointRole)}, and the two differ at three of the four. */
     public String label() {
-        return cut.left() + " = " + cut.right();
+        return cut.label();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryTarget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryTarget.java
@@ -12,6 +12,13 @@ package souther.compiler.partition;
  *
  * <p>The sentence a line is named by is {@code left = right} whatever it is on, so both are asked
  * here rather than assembled by each reader out of whichever fields it knows about.
+ *
+ * <p><b>This value is what tells one place a line was read from another.</b> Two of these are equal
+ * when they are the same quantity cut at the same place, and nothing about how either was found or
+ * printed is in here — which is what lets a reader hold the whole value as an identity instead of
+ * keying on a word it can spell. Anything added to it that is not part of what is cut or where —
+ * where the reading came from, what a diagnostic wants to say — would start telling two readings of
+ * one place apart.
  */
 public record BoundaryTarget(BorderQuantity of, QuantityCut cut) {
 
@@ -54,15 +61,28 @@ public record BoundaryTarget(BorderQuantity of, QuantityCut cut) {
         return of.named();
     }
 
-    /** The left of the {@code left = right} a report names this by. */
+    /**
+     * The left of the {@code left = right} a report names this by.
+     *
+     * <p>A word for a reader, and not what tells two of these apart. A quantity runs over as many
+     * positions as it runs over and this names one of them, so two lines from one position to two
+     * different ones are both written {@code today} here — a map keyed on it holds one of the two.
+     * What tells them apart is the whole value; a reader wanting the sentence takes {@link #label}.
+     */
     public String left() {
         return of.left();
     }
 
     /** The right of it, which is where the rule cut, written the way the quantity writes its own
-     *  levels. */
+     *  levels. The same caution as {@link #left()}: a word, and not half of a key. */
     public String right() {
         return of.writtenAt(at());
+    }
+
+    /** The whole sentence a report names this line by. The one spelling of it, so that a reader
+     *  meeting it in two places meets one wording. */
+    public String label() {
+        return left() + " = " + right();
     }
 
     /** Which shape a line has, for a reader that has to tell them apart without holding either. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
@@ -137,8 +137,7 @@ public final class LinesRead {
 
     private static String said(List<Line> lines) {
         return lines.stream()
-                .map(each -> each.at().left() + " = " + each.at().right()
-                        + " (" + each.by().named() + ")")
+                .map(each -> each.at().label() + " (" + each.by().named() + ")")
                 .collect(java.util.stream.Collectors.joining(", "));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAccount.java
@@ -416,7 +416,7 @@ public record BorderAccount(String module, GenerationScope scope,
         return new GenerationOutcome.CannotGenerate(said.isEmpty()
                 ? List.of(new Generator.UnresolvedCombination(
                         coverage.came().keySet().stream()
-                                .map(BorderObligationPointAssessment.Reading::at).toList(),
+                                .map(each -> each.target().label()).toList(),
                         Generator.UnresolvedCombination.Reason
                                 .NO_READING_OF_THE_LINE_COULD_BE_SEARCHED))
                 : List.copyOf(said));

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -50,46 +50,50 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                                                       met) {
 
     /**
-     * One reading of the line: which behavior met it, and at which of that behavior's positions.
+     * One reading of the line: which behavior met it, and where in that behavior it was met.
      *
-     * <p><b>The position and not the behavior alone.</b> One behavior can carry the type at more
-     * than one position — {@code { a: Code, b: Code }} is two readings of {@code Code}'s line in
-     * whichever behavior takes that record — and what a search of one of them comes to is a fact
-     * about that position: the rules reaching it, and the values its decoder took. Told apart by
-     * the behavior alone, the second position's answer was dropped and which one survived was
-     * whichever the search walked first.
+     * <p><b>The place and not the behavior alone.</b> One behavior can carry the type at more than
+     * one place — {@code { a: Code, b: Code }} is two readings of {@code Code}'s line in whichever
+     * behavior takes that record — and what a search of one of them comes to is a fact about that
+     * place: the rules reaching it, and the values its decoder took. Told apart by the behavior
+     * alone, the second answer was dropped and which one survived was whichever the search walked
+     * first.
      *
-     * <p>{@code at} is the bare term a row at the position is labelled with — {@code
-     * String.length(x.a)} — and two readings of one line in one behavior are two positions, so it
-     * tells them apart. The behavior-qualified spelling is not used here because it would say the
-     * behavior twice; where the pair would not tell two readings apart, {@link #across} refuses
-     * rather than keeping one of them.
+     * <p><b>The whole target, because that is what says where a line was read.</b> A quantity runs
+     * over as many positions as it runs over: a rule relating {@code today} to a field of a sum is
+     * read once under each case, and both readings write {@code today} on the left. A word off the
+     * target — the left of it, the sentence a report prints — names one of the positions or spells
+     * the pair, and neither is what tells two of them apart; keyed on one, two readings of one line
+     * arrived as one and {@link #across} refused a model the compiler can read.
+     *
+     * <p><b>So a point and a reading of it are a line and where it was read.</b> A point carries
+     * the authored line ({@link souther.compiler.partition.BorderObligationId#line}), this carries
+     * the target, and the two together are the {@link souther.compiler.partition.BoundaryLine} the
+     * readings of one behavior were folded under ({@code Coverages.merged}). That is why the fold
+     * and this cannot come apart: they are one equivalence written once, rather than two that agree
+     * while every quantity has one position.
      */
-    public record Reading(String behavior, String at) {
+    public record Reading(String behavior, souther.compiler.partition.BoundaryTarget target) {
 
         public Reading {
-            if (behavior == null || at == null) {
+            if (behavior == null || target == null) {
                 throw new IllegalArgumentException("a reading is some behavior's, somewhere in it");
             }
         }
 
-        /**
-         * The reading a behavior made where it met {@code line}.
-         *
-         * <p>The one spelling of it, because it is compared. A reader asking whether a row was
-         * composed at its own position holds a border and a behavior and works out the pair; so
-         * does the gathering that keyed the readings in the first place, and two of them spelling
-         * the position differently is a comparison that answers no every time. It fails as a row
-         * that quietly stops being offered — nothing is thrown and no answer is wrong on its face —
-         * so the pair is made here and nowhere else.
-         */
+        /** The reading a behavior made where it met {@code line}. */
         public static Reading of(String behavior, souther.compiler.partition.Border line) {
-            return new Reading(behavior, line.cut().left());
+            return new Reading(behavior, line.cut());
         }
 
+        /**
+         * How a message names this reading. For a person to read, and never a key: what tells two
+         * readings apart is the value, and a caller comparing these words is asking a question the
+         * pair already answers.
+         */
         @Override
         public String toString() {
-            return behavior + "/" + at;
+            return behavior + "/" + target.label();
         }
     }
 
@@ -123,6 +127,14 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
      * account reads {@link #owedToTheReading}. Asked before the grouping instead, one of the two
      * kinds is gathered and the other is not — and the one that is not has no value naming its
      * readings, so whatever offers it a row has only one of them to offer from.
+     *
+     * <p><b>Of lines already folded, one per line a behavior read.</b> A point and a {@link Reading}
+     * are the authored line and where it was read, which is the
+     * {@link souther.compiler.partition.BoundaryLine} {@code Coverages.merged} folds on — so after
+     * merging, one point of one behavior has one reading at one target, and two of them under one
+     * key say the caller handed lines that were never merged. That is what the refusal below is
+     * about; it is not a fold, and joining two such entries would put the order of a walk into what
+     * a row is offered for.
      */
     public static List<BorderObligationPointAssessment> across(
             Map<String, List<BorderAssessment>> byBehavior) {
@@ -147,12 +159,16 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                     BorderAssessment already = byPoint
                             .computeIfAbsent(owed, _ -> new LinkedHashMap<>()).put(where, reading);
                     if (already != null) {
-                        // Two readings this cannot tell apart, which is not two readings: what a
-                        // search of one of them came to would stand for the other, chosen by the
-                        // order the walk took. Refused rather than kept, for the reason `owedAt`
-                        // refuses one behavior's lines holding one line twice.
-                        throw new IllegalStateException("one behavior reads " + owed + " twice at "
-                                + where + ", so the two readings of it are one");
+                        // One line, one behavior, one place, twice — which the lines handed in were
+                        // folded on and so cannot be. What is wrong is upstream: these are the
+                        // readings a behavior's lines came to after Coverages merged them, and two
+                        // entries under one key say the list was never merged. Refused rather than
+                        // kept, because keeping one of them means
+                        // what a search of it came to stands for the other, chosen by the order the
+                        // walk took.
+                        throw new IllegalStateException("two of one behavior's lines are the same"
+                                + " line read at the same place, so they were never merged: " + owed
+                                + " at " + where);
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -122,10 +122,15 @@ public final class PointResolver {
                         // quantity: a clause names what it is about and a comparison in a body
                         // names nothing, so a subject taken from the point would be a word the
                         // model does not have wherever the line is a body's.
+                        //
+                        // Put into words here and nowhere earlier. Which reading this is is settled
+                        // by the value the walk is keyed on, and what goes into the outcome is a
+                        // sentence for whoever reads it — the whole of the line, because half of it
+                        // is a word two readings of one line can share.
                         case ItemAssessment.Attempt.Unavailable _ -> walked.put(reading,
                                 new SearchCoverage.ReadingSearch.Attempted(
                                         new Generator.UnresolvedCombination(
-                                                List.of(reading.at()),
+                                                List.of(reading.target().label()),
                                                 Generator.UnresolvedCombination.Reason
                                                         .NOTHING_TO_BUILD_AGAINST)));
                     }

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -360,11 +360,14 @@ class EveryFindingHasAGenerationDispositionTest {
 
         assertFalse(coverage.isEmpty(), "the model under test composes nothing at the line");
         for (SearchCoverage each : coverage) {
-            assertEquals(List.of(
-                            new BorderObligationPointAssessment.Reading("one", "String.length(x.a)"),
-                            new BorderObligationPointAssessment.Reading("one", "String.length(x.b)")),
-                    each.readings(),
-                    "both positions the behavior meets the line at, at every point of it");
+            assertEquals(List.of("one", "one"), each.readings().stream()
+                            .map(BorderObligationPointAssessment.Reading::behavior).toList(),
+                    "one behavior, at every point of the line");
+            assertEquals(List.of("String.length(x.a)", "String.length(x.b)"),
+                    each.readings().stream().map(r -> r.target().left()).toList(),
+                    "both positions it meets the line at");
+            assertEquals(2, java.util.Set.copyOf(each.readings()).size(),
+                    "and they are two readings, which is what a walk of them has to see");
         }
         // Both points of the line, each searched at both positions. The line and the run beside it
         // are two rows to write and neither is composable here, so each of them is answered from

--- a/souther-compiler/src/test/java/souther/compiler/query/ALineReadUnderEachCaseIsOneRowToWriteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALineReadUnderEachCaseIsOneRowToWriteTest.java
@@ -68,8 +68,8 @@ class ALineReadUnderEachCaseIsOneRowToWriteTest {
                 guarded.stream().map(BorderObligationPointAssessment::role).toList(),
                 () -> "the four points of one line: " + said(guarded));
         for (BorderObligationPointAssessment each : guarded) {
-            assertEquals(List.of("check/r@P.deadline", "check/r@T.deadline"),
-                    each.met().keySet().stream().map(Object::toString).toList(),
+            assertEquals(List.of("r@P.deadline", "r@T.deadline"),
+                    each.met().keySet().stream().map(where -> where.target().left()).toList(),
                     () -> "read under each case: " + each.point());
         }
     }
@@ -92,8 +92,8 @@ class ALineReadUnderEachCaseIsOneRowToWriteTest {
                 () -> "so nothing is looked for at it: " + on.owed());
         Map<String, Boolean> byReading = new LinkedHashMap<>();
         on.met().forEach((where, at) ->
-                byReading.put(where.toString(), at.owedAt(PointRole.ON).hasRowWitness()));
-        assertEquals(Map.of("check/r@P.deadline", true, "check/r@T.deadline", false), byReading,
+                byReading.put(where.target().left(), at.owedAt(PointRole.ON).hasRowWitness()));
+        assertEquals(Map.of("r@P.deadline", true, "r@T.deadline", false), byReading,
                 () -> "and which case a row stands under is still said: " + byReading);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/TwoReadingsAreOnePointOnlyWhereOneRowAnswersBothTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/TwoReadingsAreOnePointOnlyWhereOneRowAnswersBothTest.java
@@ -77,7 +77,7 @@ class TwoReadingsAreOnePointOnlyWhereOneRowAnswersBothTest {
     void aPointIsReadUnderEveryCaseThatSharesIt() {
         Map<PointRole, List<BorderObligationPointAssessment>> byRole = theGuardsPoints();
 
-        assertEquals(List.of("check/r@P.deadline", "check/r@T.deadline"),
+        assertEquals(List.of("r@P.deadline", "r@T.deadline"),
                 readings(byRole.get(PointRole.ON).get(0)),
                 "the line is read under each case");
         for (BorderObligationPointAssessment each : byRole.get(PointRole.IN)) {
@@ -91,7 +91,9 @@ class TwoReadingsAreOnePointOnlyWhereOneRowAnswersBothTest {
      *
      * <p>What a search of one of them came to would stand for the other, chosen by the order the
      * walk took — so two readings this cannot tell apart are not two readings, and saying so is the
-     * only answer that does not depend on which arrived first.
+     * only answer that does not depend on which arrived first. What it says is about the caller:
+     * these are lines already folded on where each was read, so one line at one place twice is a
+     * list that was never merged.
      */
     @Test
     void aReadingOfferedTwiceIsRefused() {
@@ -101,11 +103,11 @@ class TwoReadingsAreOnePointOnlyWhereOneRowAnswersBothTest {
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> BorderObligationPointAssessment.across(Map.of("check", twice)));
-        assertTrue(refused.getMessage().contains("twice"), refused::getMessage);
+        assertTrue(refused.getMessage().contains("never merged"), refused::getMessage);
     }
 
     private static List<String> readings(BorderObligationPointAssessment point) {
-        return point.met().keySet().stream().map(Object::toString).toList();
+        return point.met().keySet().stream().map(where -> where.target().left()).toList();
     }
 
     /** The points the guard's own line is owed a row at, by which of the four each is. */

--- a/souther-compiler/src/test/java/souther/compiler/query/WhereALineWasReadIsTheWholeTargetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhereALineWasReadIsTheWholeTargetTest.java
@@ -1,0 +1,115 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.BoundaryLine;
+import souther.compiler.partition.PointRole;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Where a behavior read a line is the whole of what the line was drawn at, and not a word off it.
+ *
+ * <p>A quantity runs over as many positions as it runs over. A rule relating one position to a
+ * field of a sum is read once under each case of the sum, and every one of those readings writes
+ * the same thing on the left — so two readings of one line share the left and are told apart by
+ * what stands on the right. Named by the left alone, they arrive as one reading, and the gathering
+ * of what a point came to refuses a model this compiler can otherwise read whole.
+ *
+ * <p>The two halves are held apart here on purpose. Two readings sharing a word are two readings;
+ * two readings at one target are not two, and that is what a merge already settled.
+ */
+class WhereALineWasReadIsTheWholeTargetTest {
+
+    /**
+     * Two cases of one sum, each spreading the record that carries the date, and one comparison
+     * against it. The walk reaches the field once under each case.
+     */
+    private static final String TWO_CASES = """
+            module probe.twice
+
+            data Base = { due: Date }
+            data First = { ...Base }
+            data Second = { ...Base }
+            data Request = First | Second
+
+            data Expired
+            data Listable
+
+            behavior check : (r: Request, today: Date) -> Listable | Expired
+            let check (r, today) = {
+                guard Date.daysBetween(today, r.due) >= 0 else Expired
+                Listable
+            }
+
+            example check
+                | "listable" : (First { due = Date("2026-08-10") }, Date("2026-08-03")) -> Listable
+            """;
+
+    /**
+     * One line, read under each case of the sum, is one debt with two readings.
+     *
+     * <p>The left of both is {@code today}, which is what a reading named by the left could not
+     * tell apart. What differs is the position the line runs to, and it is a difference the readings
+     * are kept apart by: a search of one of them is about that position's own rules and values.
+     */
+    @Test
+    void twoReadingsSharingTheLeftAreStillTwoReadings() {
+        BorderObligationPointAssessment point = onePointOf(TWO_CASES);
+
+        List<BorderObligationPointAssessment.Reading> readings =
+                List.copyOf(point.met().keySet());
+        assertEquals(2, readings.size(),
+                () -> "the field is reached once under each case: " + readings);
+        assertEquals(readings.get(0).target().left(), readings.get(1).target().left(),
+                "both readings are of the same position on the left");
+        assertNotEquals(readings.get(0).target(), readings.get(1).target(),
+                "and they run to two different positions, which is what they are told apart by");
+        assertNotEquals(readings.get(0), readings.get(1));
+    }
+
+    /**
+     * A point and one of its readings are the authored line and where it was read, which is the line
+     * the readings of a behavior were folded under.
+     *
+     * <p>What makes the fold and the gathering one equivalence rather than two that agree. The
+     * point carries the authored line and the reading carries the target, so putting them back
+     * together has to come out as the key the merge used — and if it did not, a reading would be
+     * told apart by less than the merge folded on, whatever either half looked like on its own.
+     */
+    @Test
+    void aPointAndAReadingOfItAreTheLineTheMergeFoldedOn() {
+        for (BorderObligationPointAssessment point : pointsOf(TWO_CASES)) {
+            point.met().forEach((reading, assessment) -> assertEquals(
+                    BoundaryLine.of(assessment.border()),
+                    new BoundaryLine(reading.target(), point.id().line()),
+                    () -> "the point holds the authored line and the reading holds where it was"
+                            + " read: " + point.point() + " at " + reading));
+        }
+    }
+
+    /** Every point the module's lines are owed a row at. */
+    private static List<BorderObligationPointAssessment> pointsOf(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        List<BorderObligationPointAssessment> points = compilation.db()
+                .ask(new Adequacy.Obligations("probe.twice", new GenerationScope.Module())).value();
+        assertNotNull(points, "the model under test is read to the end");
+        return points;
+    }
+
+    /** The point at the line itself, which is the one both readings meet. */
+    private static BorderObligationPointAssessment onePointOf(String model) {
+        List<BorderObligationPointAssessment> at = pointsOf(model).stream()
+                .filter(each -> each.role() == PointRole.ON).toList();
+        assertEquals(1, at.size(),
+                () -> "one comparison draws one line: " + at.stream()
+                        .map(each -> each.point().toString()).toList());
+        return at.get(0);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -2,6 +2,14 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.partition.AxisId;
+import souther.compiler.partition.BorderQuantity;
+import souther.compiler.partition.BoundaryTarget;
 import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.Level;
@@ -34,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WhichReadingComposesTheRowALineIsOwedTest {
 
     private static final String SAID = "String.length(value) = 1";
+
+    private static final Carrier WHOLE = new Carrier.Whole();
 
     /**
      * A walk stops at the first reading that composed a row.
@@ -142,8 +152,8 @@ class WhichReadingComposesTheRowALineIsOwedTest {
      */
     @Test
     void twoReadingsInOneBehaviorAreTwoReadings() {
-        Reading first = new Reading("one", "String.length(x.a)");
-        Reading second = new Reading("one", "String.length(x.b)");
+        Reading first = new Reading("one", aLineAt("one", "x.a"));
+        Reading second = new Reading("one", aLineAt("one", "x.b"));
         SearchCoverage coverage = coverageOf(Map.of(
                         first, new SearchCoverage.ReadingSearch.Attempted(nothingThere()),
                         second, new SearchCoverage.ReadingSearch.Attempted(refused())),
@@ -256,7 +266,15 @@ class WhichReadingComposesTheRowALineIsOwedTest {
 
     /** A reading of the line: one behavior at its one position carrying the type. */
     private static Reading at(String behavior) {
-        return new Reading(behavior, behavior + ".value");
+        return new Reading(behavior, aLineAt(behavior, behavior + ".value"));
+    }
+
+    /** Where a line was read: one position of one behavior, cut at one value. */
+    private static BoundaryTarget aLineAt(String behavior, String path) {
+        return BoundaryTarget.at(
+                new BorderQuantity.OfACoordinate(new AxisId(behavior, path),
+                        new NumericTerm.ValueOf(TermPath.of(path)), TermOrders.itself(WHOLE)),
+                new Level.OnACarrier(WHOLE, Count.of(1)));
     }
 
     /** A point a row is owed at, measured and missed, so a search of it would tell somebody


### PR DESCRIPTION
Closes #1164.

## What was wrong

A reading of a line was identified by `BoundaryTarget.left()` — the word a generated row is
labelled with. For a line between two positions that word names one of them, so
`today = r@First.due` and `today = r@Second.due` are two readings that spell the same key. Gathering
what a point came to put them under one key and refused, and `souther examples` ended in an internal
compiler error instead of a report.

`Apart` is where it showed, but the defect is not `Apart`'s. `left()` was injective while every
quantity had one position, and that passing property was being used as the contract for an identity.
The quantity became a product over one, two or many positions; this reader kept the scalar-position
assumption in the shape of a word.

Two answers to "which readings are one line" also existed in two places: `Coverages.merged` folds on
`BoundaryLine`, and the gathering split on a word off the target. They agreed only for as long as
the word was injective.

## What it is now

A reading holds the target: `Reading(String behavior, BoundaryTarget target)`. A point carries the
authored line and a reading carries the target, so `(point, reading)` is the `BoundaryLine` the
merge folded on, without loss. The fold and the split are one equivalence written once, and a
quantity shape added later inherits the identity rather than needing a label to stay injective.

Four contracts are fixed in the code:

- `BoundaryTarget` as a value is the identity of where a line was read; `left()` and `right()` are
  projections and say so.
- A point determines its authored line, which is what makes `(point, reading)` and
  `(behavior, BoundaryLine)` the same thing.
- After merging, `(point, behavior, target)` is unique. The refusal in `across` watches that
  invariant and now says what it means: a list that was never merged.
- The words a report uses are written after the identity work, not in place of it. The
  `left = right` sentence has one spelling, on the target, and `PointResolver` and `BorderAccount`
  take it from there.

## Measurement

- `mvn -o test` from the reactor root: 7522 + 36 + 48 green.
- Mutation: with `Reading` given back its old equality (behavior and `left()` only), the two new
  tests go red with the issue's exact error. `EveryFindingHasAGenerationDisposition` stays green
  under that mutation, which is why it is not the test that carries this.
- Over `souther-examples`, every module's report is byte-identical to `develop`'s except `joboffer`,
  which goes from the internal compiler error to a report of 60 gaps.
- The issue's 62 is from `f0fd133cc`. Nine of the fifteen example modules already report differently
  between `f0fd133cc` and `c3dba0cbe`, and this branch changes nothing outside `joboffer`, so the
  62 → 60 difference is in that range and not here. 60 is what the current revision measures.

## Tests

`WhereALineWasReadIsTheWholeTargetTest` holds the two halves apart: two readings sharing the left are
two readings, and `(point, reading.target())` reconstructs the line the merge folded on.
`TwoReadingsAreOnePointOnlyWhereOneRowAnswersBoth.aReadingOfferedTwiceIsRefused` already held the
other side and keeps it.

The tests that pinned `Reading.toString()` now read the position off the target. The spelling is a
sentence for a person and is not a contract anything compares.

## The same premise, one file over

`Border.axis()` said that a line between two positions is on neither of them, and that answering
with one of the two would name a border after half of itself. The quantity answers with one of the
two: all nine of `joboffer`'s lines from `今日` are `応募期限を検査する/今日`. A reader taking that
sentence at face value concludes the word identifies a line, which is the belief that produced this
issue one file over, so the sentence now says what the word is — a heading to group under, and half
of a line where there are two.

The published document is whole: `axis`, `origin` and `value` together name each of the nine, and
`kind: between_positions` says how to read the pair. Measured on `joboffer`. So this is the sentence
and not the mechanism.

