### PR TITLE
Read a number out of the construction a body wrote it in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -21,8 +21,9 @@ import java.util.Map;
  * first, and a rule the check enforced was one the measure reported as unread.
  *
  * <p><b>The grammar and the walk belong here.</b> Which nodes compose — a literal, a negation,
- * {@code +}, {@code -}, a scalar multiply, a binding, a newtype's value read off something that is
- * not a place — is a fact about the language. A caller supplies only the answers that depend on its
+ * {@code +}, {@code -}, a scalar multiply, a binding, a construction of a newtype, and an
+ * elimination standing against the introduction that wrote what it reads — is a fact about the
+ * language. A caller supplies only the answers that depend on its
  * environment: what an otherwise-uncomposed value is called, what environment lies inside a binding,
  * and which source value a name denotes transparently.
  *
@@ -90,7 +91,14 @@ public final class AffineForms {
          * <p>What it wraps is what it is, so such a read is the target itself. Whether the target is
          * a place is asked of what it denotes and not of how it is spelled: a name given a computed
          * value is no more a place than the call it was given, and asked by the spelling it came out
-         * one — so a guard over the name settled nothing about a construction over the value (#676).
+         * one — so a guard over the name settled nothing about a construction over the value.
+         *
+         * <p><b>The second proof a projection has, and asked second.</b> Where the value read from
+         * was written down, this walk takes the field off the construction that gave it and never
+         * asks here. What is left for this is a projection with no construction in sight — a name a
+         * call was given — which is a different piece of evidence and not a weaker copy of the
+         * first. Asked first, it would answer a projection the grammar reads, and the grammar's
+         * rule could be taken away without anything saying so.
          */
         boolean readsThrough(Core.FieldAccess fa, E at);
     }
@@ -314,17 +322,10 @@ public final class AffineForms {
             case Core.LetIn li -> {
                 return standing(li.body(), reading.inside(li, at), reading, following);
             }
-            case Core.FieldAccess fa -> {
-                Standing<E> target = standing(fa.target(), at, reading, following);
-                Core given = fieldOf(target.value(), fa.field());
-                return given == null ? new Standing<>(e, at)
-                        : standing(given, target.at(), reading, following);
-            }
-            case Core.TupleGet get -> {
-                Standing<E> tuple = standing(get.tuple(), at, reading, following);
-                Core element = elementOf(tuple.value(), get.index());
-                return element == null ? new Standing<>(e, at)
-                        : standing(element, tuple.at(), reading, following);
+            case Core.FieldAccess _, Core.TupleGet _ -> {
+                Standing<E> written = eliminated(e, at, reading, following);
+                return written == null ? new Standing<>(e, at)
+                        : standing(written.value(), written.at(), reading, following);
             }
             default -> {
                 return new Standing<>(e, at);
@@ -333,29 +334,49 @@ public final class AffineForms {
     }
 
     /**
-     * The value {@code standing} gives {@code field}, or null where it gives it none.
+     * What this elimination stands against, or null where nothing written stands against it.
      *
-     * <p>Null rather than a missing construction, because the two are one question here: whether
-     * the elimination has an introduction to stand against. Asked as "is this a construction" and
-     * answered separately, a construction without the field asked for would count as a successor
-     * this walk never produced.
+     * <p><b>One question with one answer, asked by the two readings that have it.</b> Resolving an
+     * occurrence needs to know what an elimination came to so it can go on, and reading a form
+     * needs to know it so it can compose — and where it comes to nothing, the second has another
+     * proof to try. Written out at each of them, one copy would come to read a shape the other did
+     * not, and which shapes a rule about eliminations covers would depend on which reader met it.
+     *
+     * <p><b>Null is the rule not applying, and never the kind of node.</b> A construction that does
+     * not give the field asked for has nothing written to stand against, exactly as an expression
+     * that is no construction has not — so a caller asking whether the structural reading produced
+     * a successor is asking one thing. Read off the node instead, a construction missing the field
+     * would count as a reduction this never made.
+     *
+     * <p>The target resolves before the field is taken, which is what closes this under itself: the
+     * value a construction gives a field is reached whether the construction was written where the
+     * projection is or stands behind a name and another projection.
      */
-    private static Core fieldOf(Core standing, String field) {
-        if (!(standing instanceof Core.Construct nd)) {
-            return null;
-        }
-        for (Core.FieldValue each : nd.values()) {
-            if (each.field().equals(field)) {
-                return each.value();
+    private static <A, E> Standing<E> eliminated(Core e, E at, Reading<A, E> reading,
+                                                 java.util.Set<BindingId> following) {
+        switch (e) {
+            case Core.FieldAccess fa -> {
+                Standing<E> target = standing(fa.target(), at, reading, following);
+                if (!(target.value() instanceof Core.Construct nd)) {
+                    return null;
+                }
+                for (Core.FieldValue each : nd.values()) {
+                    if (each.field().equals(fa.field())) {
+                        return new Standing<>(each.value(), target.at());
+                    }
+                }
+                return null;
+            }
+            case Core.TupleGet get -> {
+                Standing<E> tuple = standing(get.tuple(), at, reading, following);
+                return tuple.value() instanceof Core.Tuple written && get.index() >= 0
+                        && get.index() < written.elements().size()
+                        ? new Standing<>(written.elements().get(get.index()), tuple.at()) : null;
+            }
+            default -> {
+                return null;
             }
         }
-        return null;
-    }
-
-    /** The value {@code standing} writes at {@code index}, or null where it writes none there. */
-    private static Core elementOf(Core standing, int index) {
-        return standing instanceof Core.Tuple written && index >= 0
-                && index < written.elements().size() ? written.elements().get(index) : null;
     }
 
     /** {@code e} read as arithmetic over what its parts answer, or null where this has no rule for
@@ -395,6 +416,10 @@ public final class AffineForms {
             // and never the shape, which is what `isSingleValueNewtype` is asked — a data of one
             // field that is not a newtype wraps its value rather than being it, and its
             // construction is a value of its own.
+            // A carrier takes the same names off to find a value written down, and answers above
+            // for `Yen(100)` before this is reached. The two agree where they overlap and are not
+            // one rule: that one asks what a written value counts as and stops where nothing is
+            // written, and this one asks what the arithmetic under the name comes to.
             case Core.Construct nd when !nd.values().isEmpty()
                     && TypeOps.isSingleValueNewtype(Type.ref(nd.typeName()), reading.symbols()) ->
                     formOf(nd.values().get(0).value(), at, reading, following, stopped);
@@ -406,10 +431,9 @@ public final class AffineForms {
             // eliminate, the reading's own evidence that the projection keeps what it reads —
             // which is how a name a call was given is read through with no construction in sight.
             case Core.FieldAccess fa -> {
-                Standing<E> target = standing(fa.target(), at, reading, following);
-                Core given = fieldOf(target.value(), fa.field());
-                if (given != null) {
-                    yield formOf(given, target.at(), reading, following, stopped);
+                Standing<E> eliminated = eliminated(fa, at, reading, following);
+                if (eliminated != null) {
+                    yield formOf(eliminated.value(), eliminated.at(), reading, following, stopped);
                 }
                 yield reading.readsThrough(fa, at)
                         ? formOf(fa.target(), at, reading, following, stopped) : null;
@@ -420,10 +444,9 @@ public final class AffineForms {
             // fall back on, because nothing declares a tuple transparent the way a newtype's
             // declaration does.
             case Core.TupleGet get -> {
-                Standing<E> tuple = standing(get.tuple(), at, reading, following);
-                Core element = elementOf(tuple.value(), get.index());
-                yield element == null ? null
-                        : formOf(element, tuple.at(), reading, following, stopped);
+                Standing<E> eliminated = eliminated(get, at, reading, following);
+                yield eliminated == null ? null
+                        : formOf(eliminated.value(), eliminated.at(), reading, following, stopped);
             }
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what a helper
             // becomes, so reading through it is reading what the author wrote at the call. Whether

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -6,6 +6,7 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.Place;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -258,6 +259,105 @@ public final class AffineForms {
         return form;
     }
 
+    /**
+     * An occurrence resolved as far as one value can be followed, and what to read it in.
+     *
+     * <p>The environment travels with the value for the reason {@link ReadThrough} gives: what a
+     * name was given is written in the environment the binding was made in, and a projection out of
+     * it is read in that one rather than in the one the projection was written in.
+     */
+    private record Standing<E>(Core value, E at) {}
+
+    /**
+     * {@code e} under the reductions this reading licenses, as far as they go.
+     *
+     * <p><b>A normal form and never a failure.</b> What comes back is where the reductions run out:
+     * a written construction where the occurrence resolves to one, and the occurrence itself where
+     * nothing licensed applies. Reaching a {@code Core.If} is such a result and not an absence —
+     * what stands there is known perfectly well, and it is a choice rather than a value — so a
+     * caller reads what it was handed and never treats getting its own expression back as an answer
+     * about this walk.
+     *
+     * <p><b>Nothing here chooses.</b> The reductions are the ones with a single successor: a name
+     * the reading says denotes one value, a binding's body, and an elimination standing against the
+     * introduction that wrote it. An alternative and an element of a list have more than one value
+     * that can stand at them, and there is no rule for either — which is what keeps a rule about
+     * {@code Big { threshold = 100000 }} from being answered for a position where a second
+     * construction can stand as well. That boundary is the absence of a rule and not a refusal, so
+     * nothing has to be kept in step with it.
+     *
+     * <p><b>Closed under its own eliminations.</b> A projection resolves through whatever the target
+     * resolves to, so a construction inside a construction is reached the same way a construction
+     * behind a name is. Left at one step, this would cross a single introduction and no more, and
+     * which spellings that admits is nothing either the language or a reader states.
+     *
+     * <p><b>The authority is the reading's and none is added here.</b> A name is followed only
+     * where {@link Reading#readThrough} licenses that occurrence, and a binding is entered only
+     * through {@link Reading#inside}. What is derived is how far those answers reach, which is not
+     * the same kind of thing as the answers — so this is not the place to ask what an environment
+     * happens to hold. {@code Terms.given} is that question and peels every name a binding gave a
+     * value to; a name it would peel is one this leaves alone unless the reading says the two are
+     * one value.
+     */
+    private static <A, E> Standing<E> standing(Core e, E at, Reading<A, E> reading,
+                                               java.util.Set<BindingId> following) {
+        switch (e) {
+            case Core.Read r -> {
+                ReadThrough<E> through = reading.readThrough(r, at);
+                if (through == null || through.value() == e || !following.add(r.binding())) {
+                    return new Standing<>(e, at);
+                }
+                Standing<E> denoted = standing(through.value(), through.at(), reading, following);
+                following.remove(r.binding());
+                return denoted;
+            }
+            case Core.LetIn li -> {
+                return standing(li.body(), reading.inside(li, at), reading, following);
+            }
+            case Core.FieldAccess fa -> {
+                Standing<E> target = standing(fa.target(), at, reading, following);
+                Core given = fieldOf(target.value(), fa.field());
+                return given == null ? new Standing<>(e, at)
+                        : standing(given, target.at(), reading, following);
+            }
+            case Core.TupleGet get -> {
+                Standing<E> tuple = standing(get.tuple(), at, reading, following);
+                Core element = elementOf(tuple.value(), get.index());
+                return element == null ? new Standing<>(e, at)
+                        : standing(element, tuple.at(), reading, following);
+            }
+            default -> {
+                return new Standing<>(e, at);
+            }
+        }
+    }
+
+    /**
+     * The value {@code standing} gives {@code field}, or null where it gives it none.
+     *
+     * <p>Null rather than a missing construction, because the two are one question here: whether
+     * the elimination has an introduction to stand against. Asked as "is this a construction" and
+     * answered separately, a construction without the field asked for would count as a successor
+     * this walk never produced.
+     */
+    private static Core fieldOf(Core standing, String field) {
+        if (!(standing instanceof Core.Construct nd)) {
+            return null;
+        }
+        for (Core.FieldValue each : nd.values()) {
+            if (each.field().equals(field)) {
+                return each.value();
+            }
+        }
+        return null;
+    }
+
+    /** The value {@code standing} writes at {@code index}, or null where it writes none there. */
+    private static Core elementOf(Core standing, int index) {
+        return standing instanceof Core.Tuple written && index >= 0
+                && index < written.elements().size() ? written.elements().get(index) : null;
+    }
+
     /** {@code e} read as arithmetic over what its parts answer, or null where this has no rule for
      *  it or the rule it has does not compose. */
     private static <A, E> LinearForm<A> composed(Core e, E at, Reading<A, E> reading,
@@ -291,8 +391,40 @@ public final class AffineForms {
                     answered(e, at, reading, following, stopped);
             case Core.Call _ when formSaidOf(e) != null ->
                     answered(e, at, reading, following, stopped);
-            case Core.FieldAccess fa when reading.readsThrough(fa, at) ->
-                    formOf(fa.target(), at, reading, following, stopped);
+            // A newtype's construction is the value it wraps. What makes it one is the declaration
+            // and never the shape, which is what `isSingleValueNewtype` is asked — a data of one
+            // field that is not a newtype wraps its value rather than being it, and its
+            // construction is a value of its own.
+            case Core.Construct nd when !nd.values().isEmpty()
+                    && TypeOps.isSingleValueNewtype(Type.ref(nd.typeName()), reading.symbols()) ->
+                    formOf(nd.values().get(0).value(), at, reading, following, stopped);
+            // One arm, holding two proofs that this projection is the value it reads. The
+            // structural one is asked first and is asked as whether it produced a successor rather
+            // than as what kind of node was standing there: a construction without the field asked
+            // for has proved nothing, and read as a node kind it would take the answer away from
+            // the proof that can still be made. Second, and only where nothing was written to
+            // eliminate, the reading's own evidence that the projection keeps what it reads —
+            // which is how a name a call was given is read through with no construction in sight.
+            case Core.FieldAccess fa -> {
+                Standing<E> target = standing(fa.target(), at, reading, following);
+                Core given = fieldOf(target.value(), fa.field());
+                if (given != null) {
+                    yield formOf(given, target.at(), reading, following, stopped);
+                }
+                yield reading.readsThrough(fa, at)
+                        ? formOf(fa.target(), at, reading, following, stopped) : null;
+            }
+            // The same elimination against the introduction beside it. A tuple's element is reached
+            // this way and no other — the language writes no projection of one, so what comes here
+            // is what a binding over a tuple was taken apart into — and there is no second proof to
+            // fall back on, because nothing declares a tuple transparent the way a newtype's
+            // declaration does.
+            case Core.TupleGet get -> {
+                Standing<E> tuple = standing(get.tuple(), at, reading, following);
+                Core element = elementOf(tuple.value(), get.index());
+                yield element == null ? null
+                        : formOf(element, tuple.at(), reading, following, stopped);
+            }
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what a helper
             // becomes, so reading through it is reading what the author wrote at the call. Whether
             // what it holds is a number is not asked: a binding denotes what it was given whatever

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -612,15 +612,9 @@ final class Terms {
         return b.coefs().isEmpty() ? a.times(b.constant()) : null;
     }
 
-    /** A node the affine walk composes nothing out of, as a form: a numeric atom, a newtype
-     * construct's wrapped value, what a name was given, or {@code null}. */
+    /** A node the affine walk composes nothing out of, as a form: a numeric atom, what a name was
+     * given, or {@code null}. */
     private LinearForm<FactSubject> leafOf(Core n, Denotations at) {
-        // A newtype built around a number is that number here. What makes it one is the
-        // declaration, which the carrier reads through; a construction of it has the one field the
-        // declaration gives it.
-        if (n instanceof Core.Construct nd && carriesANumber(Type.ref(nd.typeName()))) {
-            return affineOf(nd.values().get(0).value(), at);
-        }
         Core written = writtenValue(n, at);
         if (written != null && written != n) {
             return affineOf(written, at);
@@ -700,6 +694,13 @@ final class Terms {
      * a container read through its name and not through a binding, a closure's answer read through
      * neither. What is left to the reader is what is genuinely about the value — the fields a
      * construction is built from, the arithmetic a number is — and never how it was written down.
+     *
+     * <p><b>This is what the environment holds and not what a reading is licensed to follow.</b>
+     * Every name a binding gives a value to is peeled here, which is the question a reader asking
+     * what was built wants answered. What one occurrence may be read as another is a narrower
+     * answer with an owner of its own ({@link AffineForms.Reading#readThrough}), and the walk that
+     * resolves an occurrence under it is held to that owner rather than to this one — so the two
+     * are not made one, however alike the shapes they peel look.
      */
     Given given(Core e, Denotations at) {
         if (e instanceof Core.Read r) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatThisGrammarReadsIsReadWithoutACallersLeafTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatThisGrammarReadsIsReadWithoutACallersLeafTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.ast.Ast;
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A construction the grammar takes apart is read without either caller being asked to name it.
+ *
+ * <p><b>Who owns a rule, and not whether two callers agree about it.</b> Two readers walk this
+ * grammar with leaves of their own, and a rule one of them keeps is a rule the other is free not to
+ * have: a newtype's construction was a number to the check that discharges a clause and an
+ * expression nobody could read to the measure beside it, over the same construction and for no
+ * reason the model states. A pair of fixtures showing the two now agreeing would say they agree
+ * today; what says it cannot come apart again is that the reading needs no leaf at all.
+ *
+ * <p>So the leaf here fails when it is called. What is left composing the form is the grammar,
+ * which is the thing being claimed to own these two eliminations — a construction of a newtype, and
+ * a field read off a construction.
+ *
+ * <p>The values wrapped are written as arithmetic rather than as numbers. A number written out is a
+ * constant of this grammar wherever it stands, and a carrier reads one through a newtype's
+ * construction to find it, so a test over {@code Yen(100)} would pass with no rule for a
+ * construction anywhere — and go on passing after the rule it is meant to hold was taken away.
+ */
+class WhatThisGrammarReadsIsReadWithoutACallersLeafTest {
+
+    private static final SourcePos SOMEWHERE = new SourcePos(1, 1);
+
+    private static final String MODULE = """
+            module demo
+
+            data Yen = Int
+            data Big = { threshold: Int }
+            """;
+
+    private static final Symbols SYMBOLS = symbols();
+
+    private static final TypeSymbol.AtModule YEN = TypeSymbols.declared(new TypeKey("demo", "Yen"));
+
+    private static final TypeSymbol.AtModule BIG = TypeSymbols.declared(new TypeKey("demo", "Big"));
+
+    /** {@code 99 + 1}, which no carrier reads as a written value. */
+    private static Core computed() {
+        return new Core.Binary(souther.compiler.types.BinOp.ADD,
+                new Core.Int(99, Type.INT, SOMEWHERE), new Core.Int(1, Type.INT, SOMEWHERE),
+                souther.compiler.types.CoverageOrigin.unwritten(), Type.INT, SOMEWHERE);
+    }
+
+    /** A newtype's construction is the value it wraps, and the grammar says so. */
+    @Test
+    void aNewtypesConstructionIsWhatItWraps() {
+        Core wrapped = new Core.Construct(YEN,
+                List.of(new Core.FieldValue("value", computed(), SOMEWHERE)),
+                Type.ref(YEN), SOMEWHERE);
+
+        assertEquals(BigDecimal.valueOf(100), constantOf(wrapped));
+    }
+
+    /** And a field read off a construction is what that construction gives the field. */
+    @Test
+    void aFieldReadOffAConstructionIsWhatItWasGiven() {
+        Core built = new Core.Construct(BIG,
+                List.of(new Core.FieldValue("threshold", computed(), SOMEWHERE)),
+                Type.ref(BIG), SOMEWHERE);
+
+        assertEquals(BigDecimal.valueOf(100),
+                constantOf(new Core.FieldAccess(built, "threshold", Type.INT, SOMEWHERE)));
+    }
+
+    /** The constant {@code e} reads as, through a walk that can name nothing. */
+    private static BigDecimal constantOf(Core e) {
+        LinearForm<String> form = AffineForms.of(e, "nowhere", refusingToName());
+        if (form == null) {
+            throw new AssertionError("the grammar composed no form for " + e);
+        }
+        assertEquals(java.util.Map.of(), form.coefs(), "a written value stands over no position");
+        return form.constant();
+    }
+
+    /**
+     * A reading that answers only what depends on an environment, and has no leaf.
+     *
+     * <p>{@code readsThrough} is false throughout. It is the second proof a projection has, and
+     * left on it would answer {@code Yen(...).value} whether or not the elimination this test is
+     * about reads anything.
+     */
+    private static AffineForms.Reading<String, String> refusingToName() {
+        return new AffineForms.Reading<>() {
+
+            @Override
+            public Symbols symbols() {
+                return SYMBOLS;
+            }
+
+            @Override
+            public LinearForm<String> leafOf(Core e, String at) {
+                fail("the grammar owns this reading and asked a caller's leaf about " + e);
+                return null;
+            }
+
+            @Override
+            public String inside(Core.LetIn li, String at) {
+                return at;
+            }
+
+            @Override
+            public AffineForms.ReadThrough<String> readThrough(Core.Read read, String at) {
+                return null;
+            }
+
+            @Override
+            public boolean readsThrough(Core.FieldAccess fa, String at) {
+                return false;
+            }
+        };
+    }
+
+    private static Symbols symbols() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        Hir.Module resolved = Resolve.module(parsed, SyntaxSymbols.of(parsed, DefaultStdlib.get()));
+        return Symbols.of(resolved, DefaultStdlib.get());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionIsFollowedWhereverTheValueItBuiltStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionIsFollowedWhereverTheValueItBuiltStandsTest.java
@@ -6,7 +6,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static souther.compiler.partition.ARuleReachedThroughAConstructedValueIsReadTest.reading;
 
 /**
  * A value written in a body is followed to wherever the number a rule compares against was written.
@@ -14,8 +13,8 @@ import static souther.compiler.partition.ARuleReachedThroughAConstructedValueIsR
  * <p>The seven spellings a rule can be written in are one line to a reader and one witness to this
  * compiler. What reads them is a relation rather than a list: an occurrence resolves through the
  * names the reading licenses and through the eliminations written against what those names hold,
- * and it does so as far as the writing goes. Crossing one construction and stopping would read all
- * seven of them, so nothing in the seven says which of the two was built.
+ * and it does so as far as the writing goes. Crossing one construction and stopping reads all seven
+ * of them, so nothing in the seven says which of the two was built.
  *
  * <p>These say it. A construction inside a construction and a name given the value halfway are two
  * spellings a single crossing does not reach; a helper's parameter is what says the value is
@@ -45,6 +44,11 @@ class AConstructionIsFollowedWhereverTheValueItBuiltStandsTest {
                         let big = outer.big
                         if n >= big.threshold then Yes else No
                     }"""));
+        read.put("aFieldGivenAName", reading("""
+                {
+                        let inner = Big { threshold = 100000 }
+                        if n >= Outer { big = inner }.big.threshold then Yes else No
+                    }"""));
         read.put("aHelpersParameter", reading("if n >= bigOf(100000).threshold then Yes else No"));
         read.put("aHelpersParameterInsideAConstruction",
                 reading("if n >= outerOf(100000).big.threshold then Yes else No"));
@@ -73,5 +77,26 @@ class AConstructionIsFollowedWhereverTheValueItBuiltStandsTest {
         Map<String, String> oneLineEach = new LinkedHashMap<>();
         read.keySet().forEach(spelling -> oneLineEach.put(spelling, LINE));
         assertEquals(oneLineEach, read);
+    }
+
+    private static String reading(String body) {
+        return MeasuredBehavior.reading("""
+                module g
+
+                data Big = { threshold: Int }
+                data Outer = { big: Big }
+                data Yen = Int
+                data Yes
+                data No
+
+                let bigOf (t: Int) = Big { threshold = t }
+                let outerOf (t: Int) = Outer { big = Big { threshold = t } }
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body), "classify");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionIsFollowedWhereverTheValueItBuiltStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionIsFollowedWhereverTheValueItBuiltStandsTest.java
@@ -1,0 +1,77 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static souther.compiler.partition.ARuleReachedThroughAConstructedValueIsReadTest.reading;
+
+/**
+ * A value written in a body is followed to wherever the number a rule compares against was written.
+ *
+ * <p>The seven spellings a rule can be written in are one line to a reader and one witness to this
+ * compiler. What reads them is a relation rather than a list: an occurrence resolves through the
+ * names the reading licenses and through the eliminations written against what those names hold,
+ * and it does so as far as the writing goes. Crossing one construction and stopping would read all
+ * seven of them, so nothing in the seven says which of the two was built.
+ *
+ * <p>These say it. A construction inside a construction and a name given the value halfway are two
+ * spellings a single crossing does not reach; a helper's parameter is what says the value is
+ * followed under the environment the construction was written in and not under the one the
+ * projection was; a number wrapped in arithmetic is what says the wrapping is taken off by this
+ * grammar rather than recognised by a carrier as a value written out.
+ *
+ * <p>A tuple is here for the same reason and not as a second feature. This language writes no
+ * projection of one — a {@code let (a, b) = t} is where {@code Core.TupleGet} comes from — and
+ * taking the element a tuple was written with is the elimination a construction's field already is.
+ * Read one and not the other, the relation would hold of whichever constructor a reader happened to
+ * meet.
+ */
+class AConstructionIsFollowedWhereverTheValueItBuiltStandsTest {
+
+    private static final String LINE = "[n/x < 100000, n/100000 <= x] unread []";
+
+    @Test
+    void aValueIsFollowedThroughEveryProjectionWrittenAgainstIt() {
+        Map<String, String> read = new LinkedHashMap<>();
+        read.put("aConstructionInsideAConstruction", reading(
+                "if n >= Outer { big = Big { threshold = 100000 } }.big.threshold"
+                        + " then Yes else No"));
+        read.put("aNameGivenTheValueHalfway", reading("""
+                {
+                        let outer = Outer { big = Big { threshold = 100000 } }
+                        let big = outer.big
+                        if n >= big.threshold then Yes else No
+                    }"""));
+        read.put("aHelpersParameter", reading("if n >= bigOf(100000).threshold then Yes else No"));
+        read.put("aHelpersParameterInsideAConstruction",
+                reading("if n >= outerOf(100000).big.threshold then Yes else No"));
+        read.put("aNewtypeOverArithmetic", reading("""
+                {
+                        let y = Yen(99999 + 1)
+                        if n >= y.value then Yes else No
+                    }"""));
+        read.put("aTuplesElement", reading("""
+                {
+                        let (a, b) = (100000, 1)
+                        if n >= a then Yes else No
+                    }"""));
+        read.put("aTupleGivenAName", reading("""
+                {
+                        let t = (100000, 1)
+                        let (a, b) = t
+                        if n >= a then Yes else No
+                    }"""));
+        read.put("aConstructionInsideATuple", reading("""
+                {
+                        let (a, b) = (Big { threshold = 100000 }, 1)
+                        if n >= a.threshold then Yes else No
+                    }"""));
+
+        Map<String, String> oneLineEach = new LinkedHashMap<>();
+        read.keySet().forEach(spelling -> oneLineEach.put(spelling, LINE));
+        assertEquals(oneLineEach, read);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
@@ -6,7 +6,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static souther.compiler.partition.ARuleReachedThroughAConstructedValueIsReadTest.reading;
 
 /**
  * Where more than one value can stand at a position, no rule is read off any of them.
@@ -96,5 +95,33 @@ class ARuleIsNotReadWhereMoreThanOneValueCanStandTest {
                         let ks = [ AtMost { threshold = 100000 }, Whatever ]
                         if List.any((k) -> reaches(n, k), ks) then Yes else No
                     }"""));
+    }
+
+    private static String reading(String body) {
+        return MeasuredBehavior.reading("""
+                module g
+
+                data Big = { threshold: Int }
+                data Yes
+                data No
+
+                data AtMost = { threshold: Int }
+                data Whatever
+                data Reason = AtMost | Whatever
+
+                let chooseBig (c: Bool) =
+                    if c then Big { threshold = 100000 } else Big { threshold = 200000 }
+
+                let reaches (n: Int, reason: Reason): Bool =
+                    match reason with
+                        | AtMost { threshold } -> n >= threshold
+                        | Whatever             -> true
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body), "classify");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static souther.compiler.partition.ARuleReachedThroughAConstructedValueIsReadTest.reading;
+
+/**
+ * Where more than one value can stand at a position, no rule is read off any of them.
+ *
+ * <p>What a measure answers is what the model states about every value that can stand where the
+ * rule is written. A body that chooses between two constructions states no number at the position
+ * the choice stands at, and a reading that followed one arm would answer a hundred thousand for a
+ * model that says a hundred thousand or two hundred thousand — a rule about a value, reported as a
+ * rule about the model.
+ *
+ * <p>Nothing here refuses anything. What holds these open is that the relation which follows a
+ * value has no rule for a choice and none for an element: it takes an elimination against the
+ * introduction written for it, and neither an arm nor a list element is one. So there is no list of
+ * shapes to keep in step with the shapes that do read, and a construction that becomes readable
+ * does not quietly make these readable with it.
+ *
+ * <p>The helper is the stronger of the two alternatives. The name it was given is read through, so
+ * the reading is inside the helper's body when it meets the choice — which is where a relation that
+ * stopped at names rather than at what they hold would already have answered.
+ *
+ * <p>Each of these is reported as a rule written in a form this compiler does not read, which is
+ * the word such a position already had. A position holding a choice is not a new kind of thing to
+ * tell a reader about.
+ */
+class ARuleIsNotReadWhereMoreThanOneValueCanStandTest {
+
+    /** The `n > 0` the choice is made on is a line of its own, and it is the only one. */
+    private static final String ONLY_THE_CHOICE =
+            "[n/x <= 0, n/0 < x] unread [n UNSUPPORTED_SYNTAX]";
+
+    @Test
+    void neitherArmAnswersForThePositionTheChoiceStandsAt() {
+        Map<String, String> read = new LinkedHashMap<>();
+        read.put("betweenTwoConstructions", reading("""
+                {
+                        let k = if n > 0 then Big { threshold = 100000 }
+                                else Big { threshold = 200000 }
+                        if n >= k.threshold then Yes else No
+                    }"""));
+        read.put("fromAHelperThatChooses",
+                reading("if n >= chooseBig(n > 0).threshold then Yes else No"));
+        read.put("betweenTwoTuples", reading("""
+                {
+                        let (a, b) = if n > 0 then (100000, 1) else (200000, 1)
+                        if n >= a then Yes else No
+                    }"""));
+
+        Map<String, String> nothingButTheChoice = new LinkedHashMap<>();
+        read.keySet().forEach(spelling -> nothingButTheChoice.put(spelling, ONLY_THE_CHOICE));
+        assertEquals(nothingButTheChoice, read);
+    }
+
+    /**
+     * And an element of a written list answers for none of them either.
+     *
+     * <p>Its own claim beside the three above. A choice is written where the value stands and a
+     * list element is not: what names the element is a binding an operation handed it, and what
+     * holds this open is that such a name is not one the reading says stands for a single value.
+     * The two boundaries are kept by different answers and are stated apart.
+     */
+    @Test
+    void anElementOfAWrittenListAnswersForNoneOfThem() {
+        assertEquals("[] unread [n UNSUPPORTED_SYNTAX]", reading("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And a case bound off one is still an element, however narrowly the arm names it.
+     *
+     * <p>An arm that admits one case looks as though it says which element is standing there, and
+     * it does not: a list may be written with two of the same case, and each of them would satisfy
+     * the arm with a different number under it. So the number a rule compares against is reached
+     * here through a name whose value the reading does not single out, and the arm is no part of
+     * whether it does.
+     *
+     * <p>This is the shape a model reaches it by, which is why it is written out rather than left
+     * to the two above. Narrowing an element to a case is where a reader would expect the value to
+     * become one, and it is exactly where nothing has said so.
+     */
+    @Test
+    void andACaseBoundOffAnElementIsStillOne() {
+        assertEquals("[] unread [n UNSUPPORTED_SYNTAX]", reading("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, Whatever ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleReachedThroughAConstructedValueIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleReachedThroughAConstructedValueIsReadTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A number a rule compares against is read where it is reached through a value the body constructs.
+ *
+ * <p>One line at a hundred thousand, written seven ways. A number written out was read and the same
+ * number reached through a construction was not, and the position it divides got no axis at all —
+ * so a model stating where its values part was reported as stating nothing there, over a difference
+ * in how the number was spelled.
+ *
+ * <p>A name in the middle is no part of it either way, which is why the two spellings that already
+ * read are held here beside the five that did not. What stops a reading is what the number came
+ * through and not the binding it was given, and a change that gains the five by losing either of
+ * those two has not read one rule seven ways.
+ */
+class ARuleReachedThroughAConstructedValueIsReadTest {
+
+    private static final String LINE = "[n/x < 100000, n/100000 <= x] unread []";
+
+    @Test
+    void oneLineIsReadHoweverTheNumberIsReached() {
+        Map<String, String> read = new LinkedHashMap<>();
+        read.put("written", reading("if n >= 100000 then Yes else No"));
+        read.put("namedNumber", reading("""
+                {
+                        let t = 100000
+                        if n >= t then Yes else No
+                    }"""));
+        read.put("constructionInPlace",
+                reading("if n >= Big { threshold = 100000 }.threshold then Yes else No"));
+        read.put("namedConstruction", reading("""
+                {
+                        let k = Big { threshold = 100000 }
+                        if n >= k.threshold then Yes else No
+                    }"""));
+        read.put("namedField", reading("""
+                {
+                        let t = Big { threshold = 100000 }.threshold
+                        if n >= t then Yes else No
+                    }"""));
+        read.put("newtypeProjection", reading("""
+                {
+                        let y = Yen(100000)
+                        if n >= y.value then Yes else No
+                    }"""));
+        read.put("throughAHelper", reading("if n >= bigOne(n).threshold then Yes else No"));
+
+        Map<String, String> oneLineEach = new LinkedHashMap<>();
+        read.keySet().forEach(spelling -> oneLineEach.put(spelling, LINE));
+        assertEquals(oneLineEach, read);
+    }
+
+    /** What the measure made of a behavior whose body is {@code body}: its classes, and what it
+     *  could not read. */
+    static String reading(String body) {
+        String source = """
+                module g
+
+                data Big = { threshold: Int }
+                data Outer = { big: Big }
+                data Yen = Int
+                data Yes
+                data No
+
+                data AtMost = { threshold: Int }
+                data Whatever
+                data Reason = AtMost | Whatever
+
+                let reaches (n: Int, reason: Reason): Bool =
+                    match reason with
+                        | AtMost { threshold } -> n >= threshold
+                        | Whatever             -> true
+
+                let bigOne (n: Int) = Big { threshold = 100000 }
+                let bigOf (t: Int) = Big { threshold = t }
+                let outerOf (t: Int) = Outer { big = Big { threshold = t } }
+                let chooseBig (c: Bool) =
+                    if c then Big { threshold = 100000 } else Big { threshold = 200000 }
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport.BehaviorReport behavior = AdequacyReport.of(compilation)
+                .modules().get(0).behaviors().stream()
+                .filter(each -> each.name().equals("classify")).findFirst().orElseThrow();
+        return "[" + behavior.partition().axes().stream()
+                .flatMap(axis -> axis.classes().stream())
+                .collect(Collectors.joining(", "))
+                + "] unread [" + behavior.partition().notRead().stream()
+                .map(each -> each.at() + " " + each.reason())
+                .collect(Collectors.joining(", ")) + "]";
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleReachedThroughAConstructedValueIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleReachedThroughAConstructedValueIsReadTest.java
@@ -2,13 +2,8 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Adequacy;
-import souther.compiler.query.Compilation;
-import souther.compiler.report.AdequacyReport;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -62,50 +57,22 @@ class ARuleReachedThroughAConstructedValueIsReadTest {
         assertEquals(oneLineEach, read);
     }
 
-    /** What the measure made of a behavior whose body is {@code body}: its classes, and what it
-     *  could not read. */
-    static String reading(String body) {
-        String source = """
+    private static String reading(String body) {
+        return MeasuredBehavior.reading("""
                 module g
 
                 data Big = { threshold: Int }
-                data Outer = { big: Big }
                 data Yen = Int
                 data Yes
                 data No
 
-                data AtMost = { threshold: Int }
-                data Whatever
-                data Reason = AtMost | Whatever
-
-                let reaches (n: Int, reason: Reason): Bool =
-                    match reason with
-                        | AtMost { threshold } -> n >= threshold
-                        | Whatever             -> true
-
                 let bigOne (n: Int) = Big { threshold = 100000 }
-                let bigOf (t: Int) = Big { threshold = t }
-                let outerOf (t: Int) = Outer { big = Big { threshold = t } }
-                let chooseBig (c: Bool) =
-                    if c then Big { threshold = 100000 } else Big { threshold = 200000 }
 
                 behavior classify : (n: Int) -> Yes | No
                 let classify (n) = %s
 
                 example classify
                     | "one" : (1) -> No
-                """.formatted(body);
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.measure(Adequacy.Asked.fullReport());
-        compilation.answerEverything();
-        AdequacyReport.BehaviorReport behavior = AdequacyReport.of(compilation)
-                .modules().get(0).behaviors().stream()
-                .filter(each -> each.name().equals("classify")).findFirst().orElseThrow();
-        return "[" + behavior.partition().axes().stream()
-                .flatMap(axis -> axis.classes().stream())
-                .collect(Collectors.joining(", "))
-                + "] unread [" + behavior.partition().notRead().stream()
-                .map(each -> each.at() + " " + each.reason())
-                .collect(Collectors.joining(", ")) + "]";
+                """.formatted(body), "classify");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/MeasuredBehavior.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/MeasuredBehavior.java
@@ -1,0 +1,40 @@
+package souther.compiler.partition;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.stream.Collectors;
+
+/**
+ * What the measure made of one behavior of a module, written out for a test to compare.
+ *
+ * <p>The classes a rule parts a position into and what no reading took in, in one string. A
+ * reading that gained a line by losing what it could not read is as wrong as one that read
+ * nothing, and a test holding the two apart can assert one and forget the other.
+ *
+ * <p>The source is the caller's whole module. Which declarations a claim needs is part of the
+ * claim, and a fixture shared between claims grows the declarations of each of them — after which
+ * what a test compiles is no longer what it is about.
+ */
+final class MeasuredBehavior {
+
+    /** The classes and the unread reasons of {@code behavior}, as {@code [classes] unread
+     *  [reasons]}. */
+    static String reading(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport.BehaviorReport read = AdequacyReport.of(compilation)
+                .modules().get(0).behaviors().stream()
+                .filter(each -> each.name().equals(behavior)).findFirst().orElseThrow();
+        return "[" + read.partition().axes().stream()
+                .flatMap(axis -> axis.classes().stream())
+                .collect(Collectors.joining(", "))
+                + "] unread [" + read.partition().notRead().stream()
+                .map(each -> each.at() + " " + each.reason())
+                .collect(Collectors.joining(", ")) + "]";
+    }
+
+    private MeasuredBehavior() {}
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneConstructionReadsAlikeForBothItsReadersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneConstructionReadsAlikeForBothItsReadersTest.java
@@ -8,6 +8,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.report.AdequacyReport;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,12 +77,12 @@ class OneConstructionReadsAlikeForBothItsReadersTest {
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
 
-        assertEquals(List.of("throughARecord: n/x < 100, n/100 <= x",
-                        "throughANewtype: n/x < 100, n/100 <= x"),
+        assertEquals(Map.of("throughARecord", "n/x < 100, n/100 <= x",
+                        "throughANewtype", "n/x < 100, n/100 <= x"),
                 AdequacyReport.of(compilation).modules().get(0).behaviors().stream()
-                        .map(behavior -> behavior.name() + ": " + behavior.partition().axes()
-                                .stream().flatMap(axis -> axis.classes().stream())
-                                .collect(Collectors.joining(", ")))
-                        .toList());
+                        .collect(Collectors.toMap(AdequacyReport.BehaviorReport::name,
+                                behavior -> behavior.partition().axes().stream()
+                                        .flatMap(axis -> axis.classes().stream())
+                                        .collect(Collectors.joining(", ")))));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneConstructionReadsAlikeForBothItsReadersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneConstructionReadsAlikeForBothItsReadersTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The check that discharges a clause and the measure that finds a line read one construction alike.
+ *
+ * <p>Two readers walk one grammar with leaves of their own, and what each of them keeps in its leaf
+ * is what the other is free not to have. A newtype's construction was a number to the check and an
+ * expression nobody could read to the measure, so a threshold this compiler was willing to reason
+ * with was reported as one it could not read — one model, measured against two accounts of what a
+ * construction is.
+ *
+ * <p>Held on one source rather than two. The claim is not that both readers are correct about their
+ * own fixture; it is that the same four lines say the same thing to both of them, which two
+ * fixtures written apart cannot say however carefully they are kept alike.
+ *
+ * <p>What owns the reading is held elsewhere and separately
+ * ({@code WhatThisGrammarReadsIsReadWithoutACallersLeafTest}): this pair would go on passing if the
+ * rule were copied into both leaves, which is the shape it is here to keep from coming back.
+ */
+class OneConstructionReadsAlikeForBothItsReadersTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Yen = Int
+            data Big = { threshold: Int }
+            data Amount = Int
+                invariant atLeastAHundred = value >= 100
+
+            behavior throughARecord : (n: Int) -> Amount
+                constructs Amount, Big
+            let throughARecord (n) =
+                if n >= Big { threshold = 99 + 1 }.threshold then Amount(n) else Amount(100)
+
+            behavior throughANewtype : (n: Int) -> Amount
+                constructs Amount, Yen
+            let throughANewtype (n) =
+                if n >= Yen(99 + 1).value then Amount(n) else Amount(100)
+
+            example throughARecord
+                | "under" : (1) -> Amount(100)
+
+            example throughANewtype
+                | "under" : (1) -> Amount(100)
+            """;
+
+    /**
+     * The check has what it needs to discharge the invariant on the side the rule keeps.
+     *
+     * <p>{@code Amount(n)} stands where {@code n} is at least a hundred, and the only thing that
+     * says so is the comparison beside it having been read. A reader that stopped at the
+     * construction knows nothing there and says so.
+     */
+    @Test
+    void theCheckReadsTheThresholdItWasComparedAgainst() {
+        assertEquals(List.of(), Compiler.compileWithWarnings(MODULE).warnings().stream()
+                .map(each -> each.code() + " " + each.primary()).toList());
+    }
+
+    /** And the measure draws the line the same comparison states, at the same number. */
+    @Test
+    void theMeasureDrawsTheLineTheSameComparisonStates() {
+        Compilation compilation = Compilation.ofSource(MODULE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+
+        assertEquals(List.of("throughARecord: n/x < 100, n/100 <= x",
+                        "throughANewtype: n/x < 100, n/100 <= x"),
+                AdequacyReport.of(compilation).modules().get(0).behaviors().stream()
+                        .map(behavior -> behavior.name() + ": " + behavior.partition().axes()
+                                .stream().flatMap(axis -> axis.classes().stream())
+                                .collect(Collectors.joining(", ")))
+                        .toList());
+    }
+}


### PR DESCRIPTION
A number a rule compares against was read where it was written out and not where it was
reached through a value the body constructs, and the position the rule divides got no
axis at all. #1157.

## What was stopping it

`AffineForms` had rules for building a value and none for taking one apart. A field read
off a construction had no rule at all, so the walk stopped at the projection without ever
looking at what it was written against; a construction had none either, so the walk
stopped again where `readsThrough` did make it look. Measured on `0779d928d`, with the
node each reading stopped at:

| written | stopped at |
| --- | --- |
| `n >= Big { threshold = 100000 }.threshold` | `FieldAccess(Construct, threshold)` |
| `let k = Big { … }` … `k.threshold` | `FieldAccess(Read k, threshold)` |
| `let t = Big { … }.threshold` … `t` | `FieldAccess(Construct, threshold)` |
| `bigOne(n).threshold` | `FieldAccess(Call, threshold)` |

A name in the middle made no difference either way, which is what said the construction
and not the binding was what stopped it.

Two of the issue's seven spellings already read on `develop`, and a third — `Yen(100000)`
given a name and projected — started reading with #1165: `Carrier.literalOf` takes a
newtype's construction off a value written out. That one is a trap for the acceptance
rather than a case less to do, and the tests here are written so it cannot stand in for the
rule (below).

## What changed

**One law, written as a relation.** An occurrence resolves through the names the reading
licenses, through the bindings it enters, and through the eliminations written against
what those hold — as far as the writing goes. So a construction inside a construction is
reached the way one behind a name is, and a tuple's element is reached the way a
construction's field is: `Core.TupleGet` is where a `let (a, b) = t` arrives, and taking
the element a tuple was written with is the elimination a field already is.

Crossing one construction and stopping reads all seven spellings the issue lists. Taking
the closure out leaves those seven green and drops four others, which is why the two are
held in separate tests.

**What has no rule is what holds the boundary.** A choice and an element have none, so a
body choosing between two constructions states no number where the choice stands and
nothing follows an arm. Four shapes are held against that, including a helper that returns
the choice — stronger than a written `if`, since the reading is already inside the helper's
body when it meets it.

**The projection keeps the proof it already had, and asks for it second.** Where a
construction was written, the writing answers; where none was, `readsThrough` still reads a
name a call was given. Asked the other way round, `Yen(100000).value` would go on being
answered by the second proof after the first was taken away. The two are one arm rather
than two, since a guarded case cannot follow an unguarded one over the same type.

**The newtype rule the check kept in its leaf goes.** `Terms.leafOf` read a newtype's
construction as the number it wraps and the measure's leaf did not, so `Yen(99 + 1).value`
was a threshold the discharge check reasoned with and one the measure reported as unread.
The rule is the grammar's now, and the leaf's copy is removed rather than copied to the
other side.

`Terms.given` is left alone and told why: it answers what an environment holds and peels
every name a binding gave a value to, where this walk follows a name only where the reading
says the two are one value. Both sides now say which of the two they are.

## What holds it

Beside the seven spellings, nine mechanism cases (a construction inside a construction, an
alias halfway, a field given a name, a helper's parameter, the two together, a newtype over
arithmetic, three tuples), five boundaries, and two contracts:

- **Ownership.** A reading whose leaf fails when it is called, asserting the form still
  composes. What is left composing it is the grammar. The wrapped values are written as
  arithmetic — a number written out is a constant wherever it stands, so the same test over
  `Yen(100)` would pass with no rule for a construction anywhere.
- **Both readers, one source.** The discharge check raises nothing and the measure draws the
  line, over the same four lines rather than two fixtures kept alike by hand.

Six mutations, each dropping what it should and nothing else:

| taken out | falls |
| --- | --- |
| the eliminations from the resolution | 4 of 9 mechanism cases; the seven stay green |
| resolving the value an elimination came to | the case whose field is given a name |
| the newtype construction rule | the ownership test — and 12 existing tests, reactor-wide |
| the structural projection | acceptance, mechanism, ownership, both readers |
| the tuple element rule | the two cases where the element is the number |
| letting the resolution take an `if` arm | all three alternative boundaries |

The second of those was written after the first: every case that read a nested projection
also read it with one crossing, since a field given a written construction needs no further
step. The reading whose field is given a name is what the closure is held by.

## businesstrip

Byte-identical before and after. `高額か`'s comparison is still not read: it reaches its
threshold through `基準金額` bound by a `match` arm over an element of the written candidate
list, and an element is one of the two shapes this deliberately has no rule for. By the
issue's own criterion that makes it a separate capability rather than something this
absorbs — and what it would need is not this relation extended but the one above it: whether
every element that can stand at an arm supports the same form. An arm admitting one case
does not single out an element, since a list may be written with two of that case.

That shape is kept as a boundary here rather than left to the integration measurement.

## Verification

`mvn -o verify` from the reactor root, green. `souther-compiler` recompiled all 771 main and
1217 test sources, so Error Prone ran over every one of them: 7561 tests, `souther-cli` 422,
`souther-bench` 36, `souther-program-api-test` 48.

businesstrip was measured by running the CLI from this worktree's classes, so nothing was
written to the shared repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
