### PR TITLE
Read a rule about an element of a written list

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -293,8 +293,12 @@ public final class AffineForms {
      *
      * <p>And a name the reading names every value of is read as what those values agree on. The same
      * step as the one above with the count changed: one value is what the name comes to, and several
-     * come to whatever all of them come to. Where they come to different forms this answers nothing,
-     * and the name is where the reading stopped — which is the list an author would have to change.
+     * come to whatever all of them come to.
+     *
+     * <p>Where a member stopped, that is where the reading stopped — as it is for the one value a
+     * name denotes, since a member of a written list is an expression an author wrote and is the one
+     * they would have to change. Where every member was read and they came to different forms,
+     * nothing stopped and this answers nothing, and the stop is reported at the name.
      */
     private static <A, E> Outcome<A, E> read(Core e, E at, Reading<A, E> reading,
                                              java.util.Set<BindingId> following) {
@@ -316,9 +320,13 @@ public final class AffineForms {
         }
         java.util.List<Standing<E>> each = new java.util.ArrayList<>();
         alternatives.forEach(one -> each.add(new Standing<>(one.value(), one.at())));
-        LinearForm<A> agreed = commonForm(each, reading, following, new Stop<>());
+        Stop<A, E> stopped = new Stop<>();
+        LinearForm<A> agreed = commonForm(each, reading, following, stopped);
         following.remove(r.binding());
-        return agreed == null ? null : new Outcome.Composed<>(agreed);
+        if (agreed != null) {
+            return new Outcome.Composed<>(agreed);
+        }
+        return stopped.at;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -318,10 +318,8 @@ public final class AffineForms {
         if (alternatives == null || alternatives.isEmpty() || !following.add(r.binding())) {
             return null;
         }
-        java.util.List<Standing<E>> each = new java.util.ArrayList<>();
-        alternatives.forEach(one -> each.add(new Standing<>(one.value(), one.at())));
         Stop<A, E> stopped = new Stop<>();
-        LinearForm<A> agreed = commonForm(each, reading, following, stopped);
+        LinearForm<A> agreed = commonForm(membersOf(alternatives, reading), following, stopped);
         following.remove(r.binding());
         if (agreed != null) {
             return new Outcome.Composed<>(agreed);
@@ -330,13 +328,77 @@ public final class AffineForms {
     }
 
     /**
-     * An occurrence resolved as far as one value can be followed, and what to read it in.
+     * An occurrence resolved as far as one value can be followed, what to read it in, and what to
+     * read it with.
      *
      * <p>The environment travels with the value for the reason {@link ReadThrough} gives: what a
      * name was given is written in the environment the binding was made in, and a projection out of
      * it is read in that one rather than in the one the projection was written in.
+     *
+     * <p>And the reading travels with it for the same kind of reason. A value reached by taking one
+     * of several is read with less than the value the walk started from: the plurality it came out
+     * of is the one this walk reads, and a second one inside it is not read at all
+     * ({@link #membersOf}). Left behind, the restriction would hold over the step that produced the
+     * members and be gone by the time their parts were read — which is the whole of what it is for.
      */
-    private record Standing<E>(Core value, E at) {}
+    private record Standing<A, E>(Core value, E at, Reading<A, E> reading) {}
+
+    /**
+     * The values a name stands for, each to be read without a plurality of its own.
+     *
+     * <p><b>One plurality per rule, said here and nowhere else.</b> What this walk answers about a
+     * position several values stand at is what all of them support, and reading a member that is
+     * itself several means asking that of every pairing: two members whose members have two each is
+     * four readings, and a rule written down a chain of them is two to the power of its depth. That
+     * is a capability with a cost, and it is not the one this rule is: a container written out in
+     * the source is what a model states its numbers in.
+     *
+     * <p>Said as what the members are read with rather than as a count or a depth. A reading with no
+     * plurality in it cannot expand one however far down a member the walk goes, so the boundary
+     * holds over the parts of a member as well as over the member — which a guard at the point of
+     * expansion would not, since the parts are read after it.
+     */
+    private static <A, E> java.util.List<Standing<A, E>> membersOf(
+            java.util.List<ReadThrough<E>> alternatives, Reading<A, E> reading) {
+        java.util.List<Standing<A, E>> out = new java.util.ArrayList<>();
+        Reading<A, E> once = new OneAtATime<>(reading);
+        alternatives.forEach(each -> out.add(new Standing<>(each.value(), each.at(), once)));
+        return out;
+    }
+
+    /** {@code of} with no plurality in it, which is what the members of one are read with. */
+    private record OneAtATime<A, E>(Reading<A, E> of) implements Reading<A, E> {
+
+        @Override
+        public Symbols symbols() {
+            return of.symbols();
+        }
+
+        @Override
+        public LinearForm<A> leafOf(Core e, E at) {
+            return of.leafOf(e, at);
+        }
+
+        @Override
+        public E inside(Core.LetIn li, E at) {
+            return of.inside(li, at);
+        }
+
+        @Override
+        public ReadThrough<E> readThrough(Core.Read read, E at) {
+            return of.readThrough(read, at);
+        }
+
+        @Override
+        public java.util.List<ReadThrough<E>> alternativesOf(Core.Read read, E at) {
+            return null;
+        }
+
+        @Override
+        public boolean readsThrough(Core.FieldAccess fa, E at) {
+            return of.readsThrough(fa, at);
+        }
+    }
 
     /**
      * {@code e} under the reductions this reading licenses, as far as they go.
@@ -371,16 +433,16 @@ public final class AffineForms {
      * value to; a name it would peel is one this leaves alone unless the reading says the two are
      * one value.
      */
-    private static <A, E> java.util.List<Standing<E>> standing(Core e, E at, Reading<A, E> reading,
-                                                               java.util.Set<BindingId> following) {
+    private static <A, E> java.util.List<Standing<A, E>> standing(
+            Core e, E at, Reading<A, E> reading, java.util.Set<BindingId> following) {
         switch (e) {
             case Core.Read r -> {
                 ReadThrough<E> through = reading.readThrough(r, at);
                 if (through != null) {
                     if (through.value() == e || !following.add(r.binding())) {
-                        return java.util.List.of(new Standing<>(e, at));
+                        return java.util.List.of(new Standing<>(e, at, reading));
                     }
-                    java.util.List<Standing<E>> denoted =
+                    java.util.List<Standing<A, E>> denoted =
                             standing(through.value(), through.at(), reading, following);
                     following.remove(r.binding());
                     return denoted;
@@ -388,11 +450,11 @@ public final class AffineForms {
                 java.util.List<ReadThrough<E>> alternatives = reading.alternativesOf(r, at);
                 if (alternatives == null || alternatives.isEmpty()
                         || !following.add(r.binding())) {
-                    return java.util.List.of(new Standing<>(e, at));
+                    return java.util.List.of(new Standing<>(e, at, reading));
                 }
-                java.util.List<Standing<E>> each = new java.util.ArrayList<>();
-                for (ReadThrough<E> one : alternatives) {
-                    each.addAll(standing(one.value(), one.at(), reading, following));
+                java.util.List<Standing<A, E>> each = new java.util.ArrayList<>();
+                for (Standing<A, E> one : membersOf(alternatives, reading)) {
+                    each.addAll(standing(one.value(), one.at(), one.reading(), following));
                 }
                 following.remove(r.binding());
                 return each;
@@ -401,18 +463,18 @@ public final class AffineForms {
                 return standing(li.body(), reading.inside(li, at), reading, following);
             }
             case Core.FieldAccess _, Core.TupleGet _ -> {
-                java.util.List<Standing<E>> written = eliminated(e, at, reading, following);
+                java.util.List<Standing<A, E>> written = eliminated(e, at, reading, following);
                 if (written == null) {
-                    return java.util.List.of(new Standing<>(e, at));
+                    return java.util.List.of(new Standing<>(e, at, reading));
                 }
-                java.util.List<Standing<E>> each = new java.util.ArrayList<>();
-                for (Standing<E> one : written) {
-                    each.addAll(standing(one.value(), one.at(), reading, following));
+                java.util.List<Standing<A, E>> each = new java.util.ArrayList<>();
+                for (Standing<A, E> one : written) {
+                    each.addAll(standing(one.value(), one.at(), one.reading(), following));
                 }
                 return each;
             }
             default -> {
-                return java.util.List.of(new Standing<>(e, at));
+                return java.util.List.of(new Standing<>(e, at, reading));
             }
         }
     }
@@ -442,20 +504,21 @@ public final class AffineForms {
      * to state is what the members agree on, and a member this could not eliminate is one it has
      * nothing to compare.
      */
-    private static <A, E> java.util.List<Standing<E>> eliminated(Core e, E at,
-                                                                 Reading<A, E> reading,
-                                                                 java.util.Set<BindingId> following) {
+    private static <A, E> java.util.List<Standing<A, E>> eliminated(
+            Core e, E at, Reading<A, E> reading, java.util.Set<BindingId> following) {
         switch (e) {
             case Core.FieldAccess fa -> {
-                java.util.List<Standing<E>> out = new java.util.ArrayList<>();
-                for (Standing<E> target : standing(fa.target(), at, reading, following)) {
+                java.util.List<Standing<A, E>> out = new java.util.ArrayList<>();
+                for (Standing<A, E> target : standing(fa.target(), at, reading, following)) {
                     if (!(target.value() instanceof Core.Construct nd)) {
                         return null;
                     }
-                    Standing<E> given = null;
+                    Standing<A, E> given = null;
                     for (Core.FieldValue each : nd.values()) {
                         if (each.field().equals(fa.field())) {
-                            given = new Standing<>(each.value(), target.at());
+                            // What a member gives a field is read with what the member is read
+                            // with, which is how one plurality stays one over the parts of it.
+                            given = new Standing<>(each.value(), target.at(), target.reading());
                             break;
                         }
                     }
@@ -467,13 +530,14 @@ public final class AffineForms {
                 return out;
             }
             case Core.TupleGet get -> {
-                java.util.List<Standing<E>> out = new java.util.ArrayList<>();
-                for (Standing<E> tuple : standing(get.tuple(), at, reading, following)) {
+                java.util.List<Standing<A, E>> out = new java.util.ArrayList<>();
+                for (Standing<A, E> tuple : standing(get.tuple(), at, reading, following)) {
                     if (!(tuple.value() instanceof Core.Tuple written) || get.index() < 0
                             || get.index() >= written.elements().size()) {
                         return null;
                     }
-                    out.add(new Standing<>(written.elements().get(get.index()), tuple.at()));
+                    out.add(new Standing<>(written.elements().get(get.index()), tuple.at(),
+                            tuple.reading()));
                 }
                 return out;
             }
@@ -496,13 +560,13 @@ public final class AffineForms {
      * <p>Not a meet. There is no order being descended here and no weaker answer to fall back on:
      * the values agree or this walk has nothing to say about the position.
      */
-    private static <A, E> LinearForm<A> commonForm(java.util.List<Standing<E>> these,
-                                                   Reading<A, E> reading,
+    private static <A, E> LinearForm<A> commonForm(java.util.List<Standing<A, E>> these,
                                                    java.util.Set<BindingId> following,
                                                    Stop<A, E> stopped) {
         LinearForm<A> agreed = null;
-        for (Standing<E> each : these) {
-            LinearForm<A> here = formOf(each.value(), each.at(), reading, following, stopped);
+        for (Standing<A, E> each : these) {
+            LinearForm<A> here =
+                    formOf(each.value(), each.at(), each.reading(), following, stopped);
             if (here == null) {
                 return null;
             }
@@ -567,9 +631,10 @@ public final class AffineForms {
             // eliminate, the reading's own evidence that the projection keeps what it reads —
             // which is how a name a call was given is read through with no construction in sight.
             case Core.FieldAccess fa -> {
-                java.util.List<Standing<E>> eliminated = eliminated(fa, at, reading, following);
+                java.util.List<Standing<A, E>> eliminated =
+                        eliminated(fa, at, reading, following);
                 if (eliminated != null) {
-                    yield commonForm(eliminated, reading, following, stopped);
+                    yield commonForm(eliminated, following, stopped);
                 }
                 yield reading.readsThrough(fa, at)
                         ? formOf(fa.target(), at, reading, following, stopped) : null;
@@ -580,9 +645,9 @@ public final class AffineForms {
             // fall back on, because nothing declares a tuple transparent the way a newtype's
             // declaration does.
             case Core.TupleGet get -> {
-                java.util.List<Standing<E>> eliminated = eliminated(get, at, reading, following);
-                yield eliminated == null ? null
-                        : commonForm(eliminated, reading, following, stopped);
+                java.util.List<Standing<A, E>> eliminated =
+                        eliminated(get, at, reading, following);
+                yield eliminated == null ? null : commonForm(eliminated, following, stopped);
             }
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what a helper
             // becomes, so reading through it is reading what the author wrote at the call. Whether

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -86,6 +86,23 @@ public final class AffineForms {
         ReadThrough<E> readThrough(Core.Read read, E at);
 
         /**
+         * Every value {@code read}'s name can stand for, where the environment has all of them — or
+         * null where it has not.
+         *
+         * <p>Beside {@link #readThrough} and answering the other half of one question. That one says
+         * the name and one value are one value; this says the name is one of these and names them
+         * all. A name has at most one of the two answers, and which it is is the environment's to
+         * say: a reader that took a plurality for a denotation would state of one value what the
+         * model says of several, and one that took a denotation for a plurality would be asking what
+         * a single value agrees with.
+         *
+         * <p><b>Exhaustive, or null.</b> What this walk does with the answer is keep what every
+         * member comes to, and a member left out makes that a statement about a value the name can
+         * take with nothing said. So an environment that can write out some of them answers none.
+         */
+        java.util.List<ReadThrough<E>> alternativesOf(Core.Read read, E at);
+
+        /**
          * Whether a field access is a newtype's value read off something that is not a place.
          *
          * <p>What it wraps is what it is, so such a read is the target itself. Whether the target is
@@ -101,6 +118,27 @@ public final class AffineForms {
          * rule could be taken away without anything saying so.
          */
         boolean readsThrough(Core.FieldAccess fa, E at);
+    }
+
+    /**
+     * Whether two readings came to the same form.
+     *
+     * <p>On the numbers and not on the records' own equality. A form is a constant and a coefficient
+     * apiece, and {@code 0.10} and {@code 0.1} are one number — two readings differing in nothing
+     * but a scale are not two answers, and compared by {@code equals} they would be.
+     *
+     * <p><b>Equal and never near.</b> What this decides is whether several values state one thing,
+     * which is either so or not: a rule that answered with whatever two forms have in common would
+     * be reading a weaker rule than the model states and reporting it as the model's. So there is no
+     * order here for a caller to relax into, and a form that is not this one is no answer at all.
+     */
+    public static <A> boolean sameForm(LinearForm<A> a, LinearForm<A> b) {
+        if (a.constant().compareTo(b.constant()) != 0
+                || !a.coefs().keySet().equals(b.coefs().keySet())) {
+            return false;
+        }
+        return a.coefs().entrySet().stream()
+                .allMatch(one -> one.getValue().compareTo(b.coefs().get(one.getKey())) == 0);
     }
 
     /**
@@ -252,6 +290,11 @@ public final class AffineForms {
      * so, and this is what says the walk stops rather than a comment claiming it cannot go round.
      * Lifted again once the name is behind the walk, so a form adding one name to itself still reads
      * both of them.
+     *
+     * <p>And a name the reading names every value of is read as what those values agree on. The same
+     * step as the one above with the count changed: one value is what the name comes to, and several
+     * come to whatever all of them come to. Where they come to different forms this answers nothing,
+     * and the name is where the reading stopped — which is the list an author would have to change.
      */
     private static <A, E> Outcome<A, E> read(Core e, E at, Reading<A, E> reading,
                                              java.util.Set<BindingId> following) {
@@ -259,12 +302,23 @@ public final class AffineForms {
             return null;
         }
         ReadThrough<E> through = reading.readThrough(r, at);
-        if (through == null || through.value() == e || !following.add(r.binding())) {
+        if (through != null) {
+            if (through.value() == e || !following.add(r.binding())) {
+                return null;
+            }
+            Outcome<A, E> form = of(through.value(), through.at(), reading, following);
+            following.remove(r.binding());
+            return form;
+        }
+        java.util.List<ReadThrough<E>> alternatives = reading.alternativesOf(r, at);
+        if (alternatives == null || alternatives.isEmpty() || !following.add(r.binding())) {
             return null;
         }
-        Outcome<A, E> form = of(through.value(), through.at(), reading, following);
+        java.util.List<Standing<E>> each = new java.util.ArrayList<>();
+        alternatives.forEach(one -> each.add(new Standing<>(one.value(), one.at())));
+        LinearForm<A> agreed = commonForm(each, reading, following, new Stop<>());
         following.remove(r.binding());
-        return form;
+        return agreed == null ? null : new Outcome.Composed<>(agreed);
     }
 
     /**
@@ -286,10 +340,12 @@ public final class AffineForms {
      * caller reads what it was handed and never treats getting its own expression back as an answer
      * about this walk.
      *
-     * <p><b>Nothing here chooses.</b> The reductions are the ones with a single successor: a name
-     * the reading says denotes one value, a binding's body, and an elimination standing against the
-     * introduction that wrote it. An alternative and an element of a list have more than one value
-     * that can stand at them, and there is no rule for either — which is what keeps a rule about
+     * <p><b>Nothing here chooses.</b> The reductions that leave one value are the ones with a single
+     * successor: a name the reading says denotes one value, a binding's body, and an elimination
+     * standing against the introduction that wrote it. Where the reading names every value a name
+     * can stand for, all of them come back — none of them is picked, and what a caller may do with
+     * several is state what they agree on. An arm of a choice is neither: the reading gives it no
+     * plurality and there is no rule here for one, which is what keeps a rule about
      * {@code Big { threshold = 100000 }} from being answered for a position where a second
      * construction can stand as well. That boundary is the absence of a rule and not a refusal, so
      * nothing has to be kept in step with it.
@@ -307,28 +363,48 @@ public final class AffineForms {
      * value to; a name it would peel is one this leaves alone unless the reading says the two are
      * one value.
      */
-    private static <A, E> Standing<E> standing(Core e, E at, Reading<A, E> reading,
-                                               java.util.Set<BindingId> following) {
+    private static <A, E> java.util.List<Standing<E>> standing(Core e, E at, Reading<A, E> reading,
+                                                               java.util.Set<BindingId> following) {
         switch (e) {
             case Core.Read r -> {
                 ReadThrough<E> through = reading.readThrough(r, at);
-                if (through == null || through.value() == e || !following.add(r.binding())) {
-                    return new Standing<>(e, at);
+                if (through != null) {
+                    if (through.value() == e || !following.add(r.binding())) {
+                        return java.util.List.of(new Standing<>(e, at));
+                    }
+                    java.util.List<Standing<E>> denoted =
+                            standing(through.value(), through.at(), reading, following);
+                    following.remove(r.binding());
+                    return denoted;
                 }
-                Standing<E> denoted = standing(through.value(), through.at(), reading, following);
+                java.util.List<ReadThrough<E>> alternatives = reading.alternativesOf(r, at);
+                if (alternatives == null || alternatives.isEmpty()
+                        || !following.add(r.binding())) {
+                    return java.util.List.of(new Standing<>(e, at));
+                }
+                java.util.List<Standing<E>> each = new java.util.ArrayList<>();
+                for (ReadThrough<E> one : alternatives) {
+                    each.addAll(standing(one.value(), one.at(), reading, following));
+                }
                 following.remove(r.binding());
-                return denoted;
+                return each;
             }
             case Core.LetIn li -> {
                 return standing(li.body(), reading.inside(li, at), reading, following);
             }
             case Core.FieldAccess _, Core.TupleGet _ -> {
-                Standing<E> written = eliminated(e, at, reading, following);
-                return written == null ? new Standing<>(e, at)
-                        : standing(written.value(), written.at(), reading, following);
+                java.util.List<Standing<E>> written = eliminated(e, at, reading, following);
+                if (written == null) {
+                    return java.util.List.of(new Standing<>(e, at));
+                }
+                java.util.List<Standing<E>> each = new java.util.ArrayList<>();
+                for (Standing<E> one : written) {
+                    each.addAll(standing(one.value(), one.at(), reading, following));
+                }
+                return each;
             }
             default -> {
-                return new Standing<>(e, at);
+                return java.util.List.of(new Standing<>(e, at));
             }
         }
     }
@@ -351,32 +427,84 @@ public final class AffineForms {
      * <p>The target resolves before the field is taken, which is what closes this under itself: the
      * value a construction gives a field is reached whether the construction was written where the
      * projection is or stands behind a name and another projection.
+     *
+     * <p><b>Taken of every value the target can stand at, or of none of them.</b> A projection out
+     * of a name that stands for several is that projection out of each of them, and one member with
+     * nothing written to stand against takes the answer away for all of them: what a caller is going
+     * to state is what the members agree on, and a member this could not eliminate is one it has
+     * nothing to compare.
      */
-    private static <A, E> Standing<E> eliminated(Core e, E at, Reading<A, E> reading,
-                                                 java.util.Set<BindingId> following) {
+    private static <A, E> java.util.List<Standing<E>> eliminated(Core e, E at,
+                                                                 Reading<A, E> reading,
+                                                                 java.util.Set<BindingId> following) {
         switch (e) {
             case Core.FieldAccess fa -> {
-                Standing<E> target = standing(fa.target(), at, reading, following);
-                if (!(target.value() instanceof Core.Construct nd)) {
-                    return null;
-                }
-                for (Core.FieldValue each : nd.values()) {
-                    if (each.field().equals(fa.field())) {
-                        return new Standing<>(each.value(), target.at());
+                java.util.List<Standing<E>> out = new java.util.ArrayList<>();
+                for (Standing<E> target : standing(fa.target(), at, reading, following)) {
+                    if (!(target.value() instanceof Core.Construct nd)) {
+                        return null;
                     }
+                    Standing<E> given = null;
+                    for (Core.FieldValue each : nd.values()) {
+                        if (each.field().equals(fa.field())) {
+                            given = new Standing<>(each.value(), target.at());
+                            break;
+                        }
+                    }
+                    if (given == null) {
+                        return null;
+                    }
+                    out.add(given);
                 }
-                return null;
+                return out;
             }
             case Core.TupleGet get -> {
-                Standing<E> tuple = standing(get.tuple(), at, reading, following);
-                return tuple.value() instanceof Core.Tuple written && get.index() >= 0
-                        && get.index() < written.elements().size()
-                        ? new Standing<>(written.elements().get(get.index()), tuple.at()) : null;
+                java.util.List<Standing<E>> out = new java.util.ArrayList<>();
+                for (Standing<E> tuple : standing(get.tuple(), at, reading, following)) {
+                    if (!(tuple.value() instanceof Core.Tuple written) || get.index() < 0
+                            || get.index() >= written.elements().size()) {
+                        return null;
+                    }
+                    out.add(new Standing<>(written.elements().get(get.index()), tuple.at()));
+                }
+                return out;
             }
             default -> {
                 return null;
             }
         }
+    }
+
+    /**
+     * The one form every one of {@code these} comes to, or null where they do not all come to one.
+     *
+     * <p>What a rule about a position several values can stand at is entitled to say. Every value is
+     * read, and what comes back is the form they support between them — which is a form they all
+     * have or nothing. A reading that answered with one of them would state a hundred thousand for a
+     * model that says a hundred thousand or two hundred thousand, and one that answered with what
+     * two forms have in common would state a rule weaker than the model's and report it as the
+     * model's.
+     *
+     * <p>Not a meet. There is no order being descended here and no weaker answer to fall back on:
+     * the values agree or this walk has nothing to say about the position.
+     */
+    private static <A, E> LinearForm<A> commonForm(java.util.List<Standing<E>> these,
+                                                   Reading<A, E> reading,
+                                                   java.util.Set<BindingId> following,
+                                                   Stop<A, E> stopped) {
+        LinearForm<A> agreed = null;
+        for (Standing<E> each : these) {
+            LinearForm<A> here = formOf(each.value(), each.at(), reading, following, stopped);
+            if (here == null) {
+                return null;
+            }
+            if (agreed == null) {
+                agreed = here;
+            } else if (!sameForm(agreed, here)) {
+                return null;
+            }
+        }
+        return agreed;
     }
 
     /** {@code e} read as arithmetic over what its parts answer, or null where this has no rule for
@@ -431,9 +559,9 @@ public final class AffineForms {
             // eliminate, the reading's own evidence that the projection keeps what it reads —
             // which is how a name a call was given is read through with no construction in sight.
             case Core.FieldAccess fa -> {
-                Standing<E> eliminated = eliminated(fa, at, reading, following);
+                java.util.List<Standing<E>> eliminated = eliminated(fa, at, reading, following);
                 if (eliminated != null) {
-                    yield formOf(eliminated.value(), eliminated.at(), reading, following, stopped);
+                    yield commonForm(eliminated, reading, following, stopped);
                 }
                 yield reading.readsThrough(fa, at)
                         ? formOf(fa.target(), at, reading, following, stopped) : null;
@@ -444,9 +572,9 @@ public final class AffineForms {
             // fall back on, because nothing declares a tuple transparent the way a newtype's
             // declaration does.
             case Core.TupleGet get -> {
-                Standing<E> eliminated = eliminated(get, at, reading, following);
+                java.util.List<Standing<E>> eliminated = eliminated(get, at, reading, following);
                 yield eliminated == null ? null
-                        : formOf(eliminated.value(), eliminated.at(), reading, following, stopped);
+                        : commonForm(eliminated, reading, following, stopped);
             }
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what a helper
             // becomes, so reading through it is reading what the author wrote at the call. Whether

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1557,14 +1557,6 @@ public final class InvariantChecker {
                 return terms.readThrough(name, where);
             }
 
-            /** No name here stands for several values: a clause is read once for the value in
-             *  front of it, and nothing in one hands a closure the elements of a container. */
-            @Override
-            public java.util.List<AffineForms.ReadThrough<Denotations>> alternativesOf(
-                    Core.Read name, Denotations where) {
-                return null;
-            }
-
             @Override
             public Denotations inside(Core.LetIn li, Denotations where) {
                 return terms.inside(li, where);

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1557,6 +1557,14 @@ public final class InvariantChecker {
                 return terms.readThrough(name, where);
             }
 
+            /** No name here stands for several values: a clause is read once for the value in
+             *  front of it, and nothing in one hands a closure the elements of a container. */
+            @Override
+            public java.util.List<AffineForms.ReadThrough<Denotations>> alternativesOf(
+                    Core.Read name, Denotations where) {
+                return null;
+            }
+
             @Override
             public Denotations inside(Core.LetIn li, Denotations where) {
                 return terms.inside(li, where);

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -494,6 +494,12 @@ final class Terms {
             }
 
             @Override
+            public java.util.List<AffineForms.ReadThrough<Denotations>> alternativesOf(
+                    Core.Read read, Denotations where) {
+                return affineReading.alternativesOf(read, where);
+            }
+
+            @Override
             public boolean readsThrough(Core.FieldAccess fa, Denotations where) {
                 return affineReading.readsThrough(fa, where);
             }
@@ -531,6 +537,21 @@ final class Terms {
                 public AffineForms.ReadThrough<Denotations> readThrough(Core.Read read,
                                                                         Denotations at) {
                     return Terms.this.readThrough(read, at);
+                }
+
+                /**
+                 * No name here stands for several values.
+                 *
+                 * <p>What this reads is a clause a declaration wrote, whose names are the fields of
+                 * the declaration and the bindings a body gave values to. An operation that hands a
+                 * closure the elements of a container is what puts several values under one name,
+                 * and the elements a rule of a declaration is written over are not bound by one:
+                 * such a clause is read once for the value in front of it.
+                 */
+                @Override
+                public java.util.List<AffineForms.ReadThrough<Denotations>> alternativesOf(
+                        Core.Read read, Denotations at) {
+                    return null;
                 }
 
                 @Override
@@ -1486,12 +1507,10 @@ final class Terms {
         return a.inclusive() == b.inclusive() && a.at().sameAs(b.at());
     }
 
+    /** Asked of the walk that reads forms, which is where what counts as one answer is decided for
+     *  every reader of one. */
     private static boolean sameForm(LinearForm<FactSubject> a, LinearForm<FactSubject> b) {
-        if (a.constant().compareTo(b.constant()) != 0 || !a.coefs().keySet().equals(b.coefs().keySet())) {
-            return false;
-        }
-        return a.coefs().entrySet().stream()
-                .allMatch(one -> one.getValue().compareTo(b.coefs().get(one.getKey())) == 0);
+        return AffineForms.sameForm(a, b);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1470,7 +1470,8 @@ final class Terms {
             return false;
         }
         for (int i = 0; i < a.size(); i++) {
-            if (a.get(i).rel() != b.get(i).rel() || !sameForm(a.get(i).form(), b.get(i).form())) {
+            if (a.get(i).rel() != b.get(i).rel()
+                    || !AffineForms.sameForm(a.get(i).form(), b.get(i).form())) {
                 return false;
             }
         }
@@ -1484,7 +1485,7 @@ final class Terms {
 
         @Override
         public boolean forms(LinearForm<FactSubject> a, LinearForm<FactSubject> b) {
-            return sameForm(a, b);
+            return AffineForms.sameForm(a, b);
         }
 
         @Override
@@ -1505,12 +1506,6 @@ final class Terms {
             return a == b;
         }
         return a.inclusive() == b.inclusive() && a.at().sameAs(b.at());
-    }
-
-    /** Asked of the walk that reads forms, which is where what counts as one answer is decided for
-     *  every reader of one. */
-    private static boolean sameForm(LinearForm<FactSubject> a, LinearForm<FactSubject> b) {
-        return AffineForms.sameForm(a, b);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -189,6 +189,18 @@ public sealed interface ValueOrigin<K> {
          *  stands for something of its own. */
         AffineForms.ReadThrough<E> readThrough(Core.Read read, E at);
 
+        /**
+         * Every value {@code read}'s name can stand for, or null where the environment has not got
+         * all of them.
+         *
+         * <p>The same answer the arithmetic beside this one is given
+         * ({@link AffineForms.Reading#alternativesOf}), and asked here for the reason it is asked
+         * there: a name a plurality stands behind is one both walks meet, and a walk that could not
+         * read it answered that the rule was about nothing — while the other drew the rule's line.
+         * A position divided by a line, reported as one the model divides no way.
+         */
+        java.util.List<AffineForms.ReadThrough<E>> alternativesOf(Core.Read read, E at);
+
         /** What {@code li}'s body is read in. */
         E inside(Core.LetIn li, E at);
     }
@@ -212,7 +224,8 @@ public sealed interface ValueOrigin<K> {
                 following.remove(read.binding());
                 return inside;
             }
-            return leafOf(e, at, reading);
+            ValueOrigin<K> agreed = through != null ? null : ofEach(read, at, reading, following);
+            return agreed != null ? agreed : leafOf(e, at, reading);
         }
         // The operation a call reaches, asked of {@link Terms} so that what counts as one is
         // settled where the arithmetic already settles it. A two-argument call the language has an
@@ -240,6 +253,38 @@ public sealed interface ValueOrigin<K> {
             return leafOf(e, at, reading);
         }
         return new Composed<>(partsOf(children, at, reading, following));
+    }
+
+    /**
+     * What every value {@code read}'s name can stand for is made of, where they are all made of the
+     * same thing — or null.
+     *
+     * <p>The same discipline the arithmetic keeps over such a name: what may be said of a position
+     * several values stand at is what holds of every one of them. Members made of different things
+     * leave nothing to say, and the name falls back to what it is on its own.
+     *
+     * <p>Compared by what the origins are and not by which member answered. Two members that are
+     * the same position are one answer about that position, however many of them a container was
+     * written with.
+     */
+    private static <K, E> ValueOrigin<K> ofEach(Core.Read read, E at, Reading<K, E> reading,
+                                                Set<souther.compiler.types.BindingId> following) {
+        List<AffineForms.ReadThrough<E>> alternatives = reading.alternativesOf(read, at);
+        if (alternatives == null || alternatives.isEmpty() || !following.add(read.binding())) {
+            return null;
+        }
+        ValueOrigin<K> agreed = null;
+        for (AffineForms.ReadThrough<E> each : alternatives) {
+            ValueOrigin<K> one = of(each.value(), each.at(), reading, following);
+            if (agreed == null) {
+                agreed = one;
+            } else if (!agreed.equals(one)) {
+                agreed = null;
+                break;
+            }
+        }
+        following.remove(read.binding());
+        return agreed;
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueOrigin.java
@@ -189,18 +189,6 @@ public sealed interface ValueOrigin<K> {
          *  stands for something of its own. */
         AffineForms.ReadThrough<E> readThrough(Core.Read read, E at);
 
-        /**
-         * Every value {@code read}'s name can stand for, or null where the environment has not got
-         * all of them.
-         *
-         * <p>The same answer the arithmetic beside this one is given
-         * ({@link AffineForms.Reading#alternativesOf}), and asked here for the reason it is asked
-         * there: a name a plurality stands behind is one both walks meet, and a walk that could not
-         * read it answered that the rule was about nothing — while the other drew the rule's line.
-         * A position divided by a line, reported as one the model divides no way.
-         */
-        java.util.List<AffineForms.ReadThrough<E>> alternativesOf(Core.Read read, E at);
-
         /** What {@code li}'s body is read in. */
         E inside(Core.LetIn li, E at);
     }
@@ -224,8 +212,13 @@ public sealed interface ValueOrigin<K> {
                 following.remove(read.binding());
                 return inside;
             }
-            ValueOrigin<K> agreed = through != null ? null : ofEach(read, at, reading, following);
-            return agreed != null ? agreed : leafOf(e, at, reading);
+            // A name standing for several values is not one this walk reads through. What may be
+            // said of such a name is what all of its values support, and that is one law with one
+            // owner — the arithmetic, which is asked before this walk is
+            // ({@link souther.compiler.partition.ComparisonAssessment}). Answered here as well, it
+            // would be a second account of it: two values agree as arithmetic and are made of
+            // different things, so the two would differ about a name and the stricter would win.
+            return leafOf(e, at, reading);
         }
         // The operation a call reaches, asked of {@link Terms} so that what counts as one is
         // settled where the arithmetic already settles it. A two-argument call the language has an
@@ -253,38 +246,6 @@ public sealed interface ValueOrigin<K> {
             return leafOf(e, at, reading);
         }
         return new Composed<>(partsOf(children, at, reading, following));
-    }
-
-    /**
-     * What every value {@code read}'s name can stand for is made of, where they are all made of the
-     * same thing — or null.
-     *
-     * <p>The same discipline the arithmetic keeps over such a name: what may be said of a position
-     * several values stand at is what holds of every one of them. Members made of different things
-     * leave nothing to say, and the name falls back to what it is on its own.
-     *
-     * <p>Compared by what the origins are and not by which member answered. Two members that are
-     * the same position are one answer about that position, however many of them a container was
-     * written with.
-     */
-    private static <K, E> ValueOrigin<K> ofEach(Core.Read read, E at, Reading<K, E> reading,
-                                                Set<souther.compiler.types.BindingId> following) {
-        List<AffineForms.ReadThrough<E>> alternatives = reading.alternativesOf(read, at);
-        if (alternatives == null || alternatives.isEmpty() || !following.add(read.binding())) {
-            return null;
-        }
-        ValueOrigin<K> agreed = null;
-        for (AffineForms.ReadThrough<E> each : alternatives) {
-            ValueOrigin<K> one = of(each.value(), each.at(), reading, following);
-            if (agreed == null) {
-                agreed = one;
-            } else if (!agreed.equals(one)) {
-                agreed = null;
-                break;
-            }
-        }
-        following.remove(read.binding());
-        return agreed;
     }
 
     private static <K, E> List<ValueOrigin<K>> partsOf(List<Core> of, E at, Reading<K, E> reading,

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Denotation.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Denotation.java
@@ -1,0 +1,29 @@
+package souther.compiler.inputs;
+
+import souther.compiler.core.Core;
+
+/**
+ * A value a name stands for, and what that value is read in.
+ *
+ * <p>The two travel together because they are one answer. A value stands for the name in the
+ * environment the binding was made in, which is not always the one the name was read in; handed the
+ * expression alone, each reader supplies an environment of its own, and two readers that supply
+ * different ones are two accounts of what the name means.
+ *
+ * <p>One type rather than a pair written out at each place that needs it. A name standing for one
+ * value and a name standing for one of several are the same kind of answer differing in how many
+ * there are ({@link ReadMeaning.Through}, {@link ReadMeaning.OneOf}), and a plurality that dropped
+ * the environment would be the pairing holding for one value and not for several — which is the
+ * distinction being made by how many there happen to be.
+ *
+ * <p>Today the two environments cannot be told apart and a caller hands back the one it was given.
+ * What makes that one fact rather than a coincidence repeated at each caller is that it is carried
+ * here.
+ */
+public record Denotation(Core value, InputReads at) {
+
+    public Denotation {
+        java.util.Objects.requireNonNull(value, "a name stands for a value");
+        java.util.Objects.requireNonNull(at, "and the value is read in something");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -95,8 +95,8 @@ public final class InputNumber {
                     || !(where.meaningOf(read, symbols) instanceof ReadMeaning.Through through)) {
                 return null;
             }
-            walk = through.value();
-            where = through.at();
+            walk = through.denotes().value();
+            where = through.denotes().at();
         }
         souther.compiler.types.BindingId element =
                 souther.compiler.core.GrowingFold.elementBindingOf(walk);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -29,28 +29,37 @@ import java.util.Map;
  * finds every comparison about nothing.
  *
  * <p>And a name stands for more than a position or nothing. It is a position, or the expression it
- * was given, or an element an operation handed out, or something this knows nothing about
- * ({@link ReadMeaning}). Answered as a position and nothing, the last three were one answer, and a
- * rule written over a name given arithmetic over positions was read as no rule at all.
+ * was given, or one of several values this can write out, or an element an operation handed out, or
+ * something this knows nothing about ({@link ReadMeaning}). Answered as a position and nothing, the
+ * last four were one answer, and a rule written over a name given arithmetic over positions was read
+ * as no rule at all.
  *
  * <p>Nothing here decides what a position holds; that is the reading of the declarations
  * ({@link InputDomain}), and this only says what a name is pointing at.
  *
- * @param roots      which bindings name which parameter, in the tree being walked
- * @param callsStand whether an operation the language defines the meaning of is left standing in
- *                   this tree. It is in the representation a declaration's own rules are read in
- *                   and it is not in the one that runs, and the difference is not a detail of the
- *                   walk: a call left standing names no location, which is an answer where such a
- *                   tree is what was handed over and a bug in the caller where it is not
+ * @param roots        which bindings name which parameter, in the tree being walked
+ * @param alternatives which bindings stand for one of several values, and which values those are.
+ *                     Written where an arm narrows what it was handed and read nowhere else: an
+ *                     element's own alternatives are worked out from the container it came from, and
+ *                     what an arm leaves of them is a fact about this walk's position in the tree
+ *                     that nothing under the arm could recover
+ * @param callsStand   whether an operation the language defines the meaning of is left standing in
+ *                     this tree. It is in the representation a declaration's own rules are read in
+ *                     and it is not in the one that runs, and the difference is not a detail of the
+ *                     walk: a call left standing names no location, which is an answer where such a
+ *                     tree is what was handed over and a bug in the caller where it is not
  */
 public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
                          Map<BindingId, Core> bound,
-                         souther.compiler.check.ElementBindings elements, boolean callsStand)
+                         souther.compiler.check.ElementBindings elements,
+                         Map<BindingId, java.util.List<Denotation>> alternatives,
+                         boolean callsStand)
         implements InputPaths {
 
     public InputReads {
         roots = Map.copyOf(roots);
         bound = Map.copyOf(bound);
+        alternatives = Map.copyOf(alternatives);
     }
 
     /** At the top of a body, where nothing has been bound yet and no element has been handed out. */
@@ -73,7 +82,7 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      */
     public static InputReads ofParameters(Map<BindingId, String> parameters,
                                           souther.compiler.check.ElementBindings elements) {
-        return new InputReads(null, rooted(parameters), Map.of(), elements, false);
+        return new InputReads(null, rooted(parameters), Map.of(), elements, Map.of(), false);
     }
 
     /**
@@ -99,7 +108,8 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * position, which is what it did before there was anything to give.
      */
     public static InputReads of(InputDomain read, souther.compiler.check.ElementBindings elements) {
-        return new InputReads(read, rooted(read.parameterReads()), Map.of(), elements, false);
+        return new InputReads(read, rooted(read.parameterReads()), Map.of(), elements,
+                Map.of(), false);
     }
 
     /** The parameters as positions, which is what a name in a tree stands for. */
@@ -118,7 +128,7 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      */
     public static InputReads ofWhatIsDeclared(InputDomain read, Map<BindingId, String> roots) {
         return new InputReads(read, rooted(roots), Map.of(),
-                souther.compiler.check.ElementBindings.NONE, true);
+                souther.compiler.check.ElementBindings.NONE, Map.of(), true);
     }
 
     /**
@@ -136,13 +146,13 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      */
     public static InputReads ofADeclaredClause(InputDomain read, Map<BindingId, TermPath> roots) {
         return new InputReads(read, roots, Map.of(),
-                souther.compiler.check.ElementBindings.NONE, true);
+                souther.compiler.check.ElementBindings.NONE, Map.of(), true);
     }
 
     /** The same, before there is a reading to hold beside it ({@link #ofParameters}). */
     public static InputReads ofWhatIsDeclared(Map<BindingId, String> roots) {
         return new InputReads(null, rooted(roots), Map.of(),
-                souther.compiler.check.ElementBindings.NONE, true);
+                souther.compiler.check.ElementBindings.NONE, Map.of(), true);
     }
 
     /**
@@ -157,16 +167,26 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * <p>Only where the arm selects one case. An arm answering for several narrows to none of them
      * in particular, and a name that stands for no position is what a reader is given for it —
      * which is what it was given before there was anything to say.
+     *
+     * <p><b>And where the scrutinee stands for one of several written values, the arm narrows that
+     * set.</b> Which is a different answer from the one above and not a weaker copy of it: a
+     * position is one place a row writes at, and a set is every value the name can take. An arm
+     * admitting one case takes out the members that are not of it and leaves the rest — however
+     * many that is. A container written with two members of the admitted case leaves two, and an
+     * arm is no evidence that the name is one of them: what would make it one is there being one
+     * left, which is what the set says and the arm does not.
      */
     @Override
     public InputReads insideArm(Core.Match match, Core.Case arm, Symbols symbols) {
-        if (arm.binder() == null || arm.binder().binding() == null
-                || arm.caseTypes().size() != 1) {
+        if (arm.binder() == null || arm.binder().binding() == null) {
             return this;
+        }
+        if (arm.caseTypes().size() != 1) {
+            return admitting(match, arm, symbols);
         }
         TermPath scrutinee = pathOf(match.scrutinee(), symbols);
         if (scrutinee == null) {
-            return this;
+            return admitting(match, arm, symbols);
         }
         TermPath narrowed = scrutinee.refine(Refinement.sumCase(arm.caseTypes().get(0)));
         // And nothing is asked of the reading. What this answers is which location the arm's name
@@ -181,7 +201,83 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
         // that stands for a place no row reaches — which the reading refuses when it is asked.
         Map<BindingId, TermPath> wider = new LinkedHashMap<>(roots);
         wider.put(arm.binder().binding(), narrowed);
-        return new InputReads(read, wider, bound, elements, callsStand);
+        return new InputReads(read, wider, bound, elements, alternatives, callsStand);
+    }
+
+    /**
+     * The same, where what the arm binds is one of the values the scrutinee's set holds.
+     *
+     * <p>Only where the arm's carriers are the values themselves. A case that binds what an optional
+     * holds binds something under the value that was matched rather than the value, so the members
+     * of the set are not what the name stands for — and a set narrowed as though they were would
+     * name every member one step too high.
+     *
+     * <p>Nothing is narrowed where a member cannot be told which case it is. What makes the set an
+     * answer is that it holds every value the name can take, and a filter that let through what it
+     * could not classify would be keeping a member the arm excludes, while one that dropped it would
+     * be losing a member the arm admits. Neither is the set, so the name is left with none.
+     */
+    private InputReads admitting(Core.Match match, Core.Case arm, Symbols symbols) {
+        ReadMeaning.OneOf one = pluralityOf(match.scrutinee(), symbols,
+                new java.util.HashSet<>());
+        if (one == null) {
+            return this;
+        }
+        for (souther.compiler.types.CaseSelector selector : arm.pattern().selectors()) {
+            if (!(selector.refinement() instanceof souther.compiler.types.Refinement.Direct)) {
+                return this;
+            }
+        }
+        java.util.List<Denotation> left = new java.util.ArrayList<>();
+        for (Denotation each : one.alternatives()) {
+            souther.compiler.types.TypeSymbol written = caseWritten(each.value());
+            if (written == null) {
+                return this;
+            }
+            if (arm.caseTypes().contains(written)) {
+                left.add(each);
+            }
+        }
+        if (left.isEmpty()) {
+            return this;
+        }
+        Map<BindingId, java.util.List<Denotation>> wider = new LinkedHashMap<>(alternatives);
+        wider.put(arm.binder().binding(), left);
+        return new InputReads(read, roots, bound, elements, wider, callsStand);
+    }
+
+    /**
+     * The values {@code e} can stand for, or null where they are not written out.
+     *
+     * <p>Through the names that stand for one value, which is what a scrutinee usually is: a body
+     * naming what it matches, and a helper expanded into one binding the call's argument to its own
+     * parameter, leave a run of names between the {@code match} and the element. Read one step, an
+     * arm inside such a helper would narrow nothing and the reading would stop at the first name.
+     *
+     * <p>Following is this reader's own and is not written into {@link #meaningOf}. That answers
+     * what a name is, one step, for every reader; whether a reader may go on through a name that
+     * stands for one value is what the answer licenses rather than something it does.
+     */
+    private ReadMeaning.OneOf pluralityOf(Core e, Symbols symbols,
+                                          java.util.Set<BindingId> met) {
+        if (!(e instanceof Core.Read name) || !met.add(name.binding())) {
+            return null;
+        }
+        return switch (meaningOf(name, symbols)) {
+            case ReadMeaning.OneOf one -> one;
+            case ReadMeaning.Through through ->
+                    through.denotes().at().pluralityOf(through.denotes().value(), symbols, met);
+            default -> null;
+        };
+    }
+
+    /** Which case {@code e} is written as, or null where it is not written as one. */
+    private static souther.compiler.types.TypeSymbol caseWritten(Core e) {
+        return switch (e) {
+            case Core.Construct nd -> nd.typeName();
+            case Core.UnitValue unit -> unit.data();
+            default -> null;
+        };
     }
 
     /** The same, inside what {@code binder} binds. */
@@ -193,7 +289,7 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
         Map<BindingId, Core> wider = new LinkedHashMap<>(bound);
         // The nearest binding wins, which is what being inside it means.
         wider.put(binder.binding(), value);
-        return new InputReads(read, roots, wider, elements, callsStand);
+        return new InputReads(read, roots, wider, elements, alternatives, callsStand);
     }
 
     /** The position {@code e} names here, or null where it names none. */
@@ -219,14 +315,24 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * stand where the name does is the caller's question, asked of the fact rather than of a
      * permission recorded here: an arithmetic reader substitutes it, and a reader collecting
      * positions walks into it, and neither is the other's rule.
+     *
+     * <p>A set the arms already narrowed stands before an element's own, which is the same order as
+     * everywhere else: what is in force where the name is read wins over what was true of it
+     * further out.
      */
     public ReadMeaning meaningOf(Core.Read read, Symbols symbols) {
         TermPath path = pathOf(read, symbols);
         if (path != null) {
             return new ReadMeaning.Position(path);
         }
-        if (elements.containerOf(read.binding()) != null) {
-            return new ReadMeaning.Element();
+        java.util.List<Denotation> narrowed = alternatives.get(read.binding());
+        if (narrowed != null) {
+            return new ReadMeaning.OneOf(narrowed);
+        }
+        Core container = elements.containerOf(read.binding());
+        if (container != null) {
+            java.util.List<Denotation> written = writtenElementsOf(new Denotation(container, this));
+            return written == null ? new ReadMeaning.Element() : new ReadMeaning.OneOf(written);
         }
         Core held = bound.get(read.binding());
         // Read in this environment. Bindings are added on the way down and each tells itself from
@@ -234,7 +340,69 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
         // is why the environment at the binder and the one at the read cannot be told apart yet.
         // Said once here rather than by each reader, so the day they can be, one place changes.
         return held == null || held == read ? new ReadMeaning.Unknown()
-                : new ReadMeaning.Through(held, this);
+                : new ReadMeaning.Through(new Denotation(held, this));
+    }
+
+    /**
+     * The elements {@code container} was written with, or null where it was not written out.
+     *
+     * <p>What makes this an answer about every element and not about some of them is that the
+     * container is followed only through steps with one successor — a name this environment bound,
+     * and the body of a binding — until a list written in the source is standing there. An operation
+     * that builds a container answers elements this walk cannot enumerate, and the walk stops rather
+     * than reading what went in: {@code List.append(xs, ys)} holds the elements of both, and a
+     * reading that took either would have written out a set missing the other half.
+     *
+     * <p><b>Followed with this environment and never with the body's.</b> What a binding holds is
+     * also recorded over the whole body ({@link souther.compiler.check.ElementBindings#boundTo}), and
+     * reading a container out of that would give a value with no environment to read it in — after
+     * which the environment each element is read in would be whichever one the caller had in hand.
+     * Where the way to the list runs through a binding this walk has not passed, the elements are
+     * not written out, and that is a capability short of what a reader could have rather than a set
+     * put together out of two readings.
+     *
+     * <p>Null for a list written empty. No value stands at an element of it, so there is nothing for
+     * a statement about every member to be about, and a statement quantified over no members holds
+     * whatever it says.
+     */
+    private static java.util.List<Denotation> writtenElementsOf(Denotation container) {
+        Denotation standing = standing(container, new java.util.HashSet<>());
+        if (!(standing.value() instanceof Core.ListLit written) || written.elements().isEmpty()) {
+            return null;
+        }
+        java.util.List<Denotation> out = new java.util.ArrayList<>();
+        written.elements().forEach(each -> out.add(new Denotation(each, standing.at())));
+        return out;
+    }
+
+    /**
+     * {@code from} followed through the steps that have one successor, as far as they go.
+     *
+     * <p>The names this environment bound and the bodies of the bindings inside it, and nothing
+     * else. A normal form and never a failure: what comes back where nothing applies is what went
+     * in, which a caller reads rather than treating as an absence.
+     *
+     * <p>By the bindings met, which is what makes it stop. Each tells itself from every other, so a
+     * name that came round to itself is one already answered for.
+     */
+    private static Denotation standing(Denotation from, java.util.Set<BindingId> met) {
+        Denotation at = from;
+        while (true) {
+            switch (at.value()) {
+                case Core.Read name -> {
+                    Core held = at.at().bound.get(name.binding());
+                    if (held == null || held == name || !met.add(name.binding())) {
+                        return at;
+                    }
+                    at = new Denotation(held, at.at());
+                }
+                case Core.LetIn let ->
+                        at = new Denotation(let.body(), at.at().and(let.binder(), let.value()));
+                default -> {
+                    return at;
+                }
+            }
+        }
     }
 
     /** The position an element handed to {@code binding} stands at, or null where it stands at

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -217,6 +217,13 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * could not classify would be keeping a member the arm excludes, while one that dropped it would
      * be losing a member the arm admits. Neither is the set, so the name is left with none.
      *
+     * <p>Which a member is is read off the construction or the case written where it stands, and the
+     * arm's own carriers reach further than that: a case may name a primitive, and a value written
+     * as a number is not a construction. No model gets here that way — a declared sum's cases are
+     * declared data, and the union that can name a primitive is anonymous and may not be written in
+     * a narrow type position, so no container's element type has one. A language that let one be
+     * written would arrive at the guard above rather than at a set with a member misfiled.
+     *
      * <p>And nothing is narrowed to no members. An arm admitting none of what the container holds is
      * an arm no value reaches, so the name inside it stands for nothing — which is what a name with
      * no meaning here already says, and is not a set of no members.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -216,10 +216,13 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * answer is that it holds every value the name can take, and a filter that let through what it
      * could not classify would be keeping a member the arm excludes, while one that dropped it would
      * be losing a member the arm admits. Neither is the set, so the name is left with none.
+     *
+     * <p>And nothing is narrowed to no members. An arm admitting none of what the container holds is
+     * an arm no value reaches, so the name inside it stands for nothing — which is what a name with
+     * no meaning here already says, and is not a set of no members.
      */
     private InputReads admitting(Core.Match match, Core.Case arm, Symbols symbols) {
-        ReadMeaning.OneOf one = pluralityOf(match.scrutinee(), symbols,
-                new java.util.HashSet<>());
+        ReadMeaning.OneOf one = pluralityOf(match.scrutinee(), symbols);
         if (one == null) {
             return this;
         }
@@ -257,18 +260,18 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * <p>Following is this reader's own and is not written into {@link #meaningOf}. That answers
      * what a name is, one step, for every reader; whether a reader may go on through a name that
      * stands for one value is what the answer licenses rather than something it does.
+     *
+     * <p>The same walk a container is found by ({@link #standing}), asked for what is standing at
+     * the end of it rather than for a list written there. Two walks over the run of names between a
+     * {@code match} and what it matches would be two answers about which names may be gone through,
+     * and the day they differed the arm would narrow a set the arithmetic never met.
      */
-    private ReadMeaning.OneOf pluralityOf(Core e, Symbols symbols,
-                                          java.util.Set<BindingId> met) {
-        if (!(e instanceof Core.Read name) || !met.add(name.binding())) {
-            return null;
-        }
-        return switch (meaningOf(name, symbols)) {
-            case ReadMeaning.OneOf one -> one;
-            case ReadMeaning.Through through ->
-                    through.denotes().at().pluralityOf(through.denotes().value(), symbols, met);
-            default -> null;
-        };
+    private ReadMeaning.OneOf pluralityOf(Core e, Symbols symbols) {
+        Denotation standing = standing(new Denotation(e, this), symbols,
+                new java.util.HashSet<>());
+        return standing.value() instanceof Core.Read name
+                && standing.at().meaningOf(name, symbols) instanceof ReadMeaning.OneOf one
+                ? one : null;
     }
 
     /** Which case {@code e} is written as, or null where it is not written as one. */
@@ -321,6 +324,19 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * further out.
      */
     public ReadMeaning meaningOf(Core.Read read, Symbols symbols) {
+        return meaningOf(read, symbols, new java.util.HashSet<>());
+    }
+
+    /**
+     * The same, through the bindings a walk into a container has already met.
+     *
+     * <p>One set for the whole answer, because the answer reaches back into this: a name an
+     * operation handed an element on is answered by walking to the container it came from, and that
+     * walk meets names this has to answer about. Threaded rather than started afresh at each step,
+     * so what stops the walk is the bindings met and not a depth anybody chose.
+     */
+    private ReadMeaning meaningOf(Core.Read read, Symbols symbols,
+                                  java.util.Set<BindingId> met) {
         TermPath path = pathOf(read, symbols);
         if (path != null) {
             return new ReadMeaning.Position(path);
@@ -331,7 +347,8 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
         }
         Core container = elements.containerOf(read.binding());
         if (container != null) {
-            java.util.List<Denotation> written = writtenElementsOf(new Denotation(container, this));
+            java.util.List<Denotation> written =
+                    writtenElementsOf(new Denotation(container, this), symbols, met);
             return written == null ? new ReadMeaning.Element() : new ReadMeaning.OneOf(written);
         }
         Core held = bound.get(read.binding());
@@ -365,8 +382,10 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
      * a statement about every member to be about, and a statement quantified over no members holds
      * whatever it says.
      */
-    private static java.util.List<Denotation> writtenElementsOf(Denotation container) {
-        Denotation standing = standing(container, new java.util.HashSet<>());
+    private static java.util.List<Denotation> writtenElementsOf(Denotation container,
+                                                                Symbols symbols,
+                                                                java.util.Set<BindingId> met) {
+        Denotation standing = standing(container, symbols, met);
         if (!(standing.value() instanceof Core.ListLit written) || written.elements().isEmpty()) {
             return null;
         }
@@ -378,23 +397,33 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
     /**
      * {@code from} followed through the steps that have one successor, as far as they go.
      *
-     * <p>The names this environment bound and the bodies of the bindings inside it, and nothing
-     * else. A normal form and never a failure: what comes back where nothing applies is what went
-     * in, which a caller reads rather than treating as an absence.
+     * <p>A name standing for one value and the body of a binding, and nothing else. A normal form
+     * and never a failure: what comes back where nothing applies is what went in, which a caller
+     * reads rather than treating as an absence.
+     *
+     * <p><b>Which names those are is {@link #meaningOf}'s answer and is not read off the bindings
+     * here.</b> A name is a position, or one of several values, or an element, before it is what it
+     * was bound to, and reading {@code bound} would be this walk deciding that order for itself —
+     * beside the one place that decides it, and free to differ. No model here comes out differently
+     * for it: what would tell them apart is a binding that both holds a value and is what an
+     * operation handed an element on, which is a shape a fused pair of walks can leave
+     * ({@link InputPath}) and which none of these tests writes.
      *
      * <p>By the bindings met, which is what makes it stop. Each tells itself from every other, so a
      * name that came round to itself is one already answered for.
      */
-    private static Denotation standing(Denotation from, java.util.Set<BindingId> met) {
+    private static Denotation standing(Denotation from, Symbols symbols,
+                                       java.util.Set<BindingId> met) {
         Denotation at = from;
         while (true) {
             switch (at.value()) {
                 case Core.Read name -> {
-                    Core held = at.at().bound.get(name.binding());
-                    if (held == null || held == name || !met.add(name.binding())) {
+                    if (!met.add(name.binding())
+                            || !(at.at().meaningOf(name, symbols, met)
+                                    instanceof ReadMeaning.Through through)) {
                         return at;
                     }
-                    at = new Denotation(held, at.at());
+                    at = through.denotes();
                 }
                 case Core.LetIn let ->
                         at = new Denotation(let.body(), at.at().and(let.binder(), let.value()));

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadMeaning.java
@@ -1,19 +1,25 @@
 package souther.compiler.inputs;
 
-import souther.compiler.core.Core;
-
 /**
  * What a name a body reads stands for, said in terms of the behavior's input.
  *
- * <p>Four answers rather than two. A reader that asks only which position a name is gets a position
- * or nothing, and that nothing holds three different names at once: one given arithmetic over
- * positions, one an operation handed an element on, and one this reading knows nothing about. Told
- * apart nowhere, they were read the same way — so a rule written over a name given arithmetic drew
- * no line, and nothing said why.
+ * <p>Five answers rather than two. A reader that asks only which position a name is gets a position
+ * or nothing, and that nothing holds four different names at once: one given arithmetic over
+ * positions, one an operation handed an element of a container this reading can write out, one it
+ * handed an element of a container it cannot, and one this reading knows nothing about. Told apart
+ * nowhere, they were read the same way — so a rule written over a name given arithmetic drew no
+ * line, and nothing said why.
  *
  * <p>Facts about the name and not permissions. Whether a reader may put {@link Through}'s expression
  * where the name stands is that reader's to settle from the fact; what is answered here is what the
  * reading of the input knows, which is the same knowledge whoever asks.
+ *
+ * <p><b>How many values, and never which one.</b> {@link Through} says the name and one value are
+ * one value; {@link OneOf} says the name stands for one of several and names all of them;
+ * {@link Element} says several stand there and this reading cannot write them out. What a reader
+ * does with a plurality is that reader's rule — the arithmetic reads every one of them and keeps
+ * what they agree on — and choosing one of them here would be this reading answering a question
+ * about a value with a fact about a set.
  */
 public sealed interface ReadMeaning {
 
@@ -21,31 +27,64 @@ public sealed interface ReadMeaning {
     record Position(TermPath path) implements ReadMeaning {}
 
     /**
-     * The name and {@code value} are one value, which is what the name was given, and {@code at} is
-     * what that value is read in.
+     * The name and {@code denotes} are one value, which is what the name was given.
      *
      * <p>What is held is the expression rather than anything read off it. Which of the readings of a
      * value this expression carries — an affine form, the positions it mentions — is each reader's
      * own question, and answering one of them here would be this reading keeping an account of a
      * name that only one reader could use.
-     *
-     * <p>The environment comes with it because it is part of the answer. A value stands for the name
-     * in the environment the binding was made in, which is not always the one the name was read in;
-     * left out, each reader supplies one, and two readers that supply different ones are two
-     * accounts of what the name means — which is the shape this whole reading exists to remove.
-     * Today they cannot be told apart, and what makes that one fact rather than two is that it is
-     * settled here.
      */
-    record Through(Core value, InputReads at) implements ReadMeaning {}
+    record Through(Denotation denotes) implements ReadMeaning {
+
+        public Through {
+            java.util.Objects.requireNonNull(denotes, "a name read through denotes something");
+        }
+    }
 
     /**
-     * An operation of the language handed the name an element of a container, and no position of the
-     * input holds those elements.
+     * The name stands for one of {@code alternatives} and for no other value.
+     *
+     * <p><b>Exhaustive, or this is not the answer.</b> What a reader may do with a plurality is
+     * state what holds of every member, and one member left out makes that statement about a value
+     * the name can take and nothing said. So this is produced only where every value the name can
+     * stand for was written down and reached — a container written out as a list, narrowed by the
+     * arms passed on the way — and a container built by an operation stays {@link Element}, which
+     * says the plurality is there and its members are not in hand. A reading that cannot write them
+     * out is one capability short; a reading that writes out some of them is wrong.
+     *
+     * <p>Never empty. A name stands for something wherever it can be read, so no members is not a
+     * name that can take no value — it is this reading having lost them, and a statement quantified
+     * over nothing holds vacuously, which would make the emptiest answer the strongest one.
+     *
+     * <p>A list and not a set. Two members that are written alike are two elements of the container,
+     * and what tells occurrences apart is not this reading's to decide: a reader that only wants to
+     * know what they agree on may ignore how many there are, and one that identified them here
+     * would have taken that decision for every reader.
+     */
+    record OneOf(java.util.List<Denotation> alternatives) implements ReadMeaning {
+
+        public OneOf {
+            if (alternatives == null || alternatives.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a name stands for something, so its alternatives are not none");
+            }
+            alternatives = java.util.List.copyOf(alternatives);
+        }
+    }
+
+    /**
+     * An operation of the language handed the name an element of a container, no position of the
+     * input holds those elements, and this reading cannot write out which values they are.
      *
      * <p>Which is not the same as knowing nothing. The name holds something, and what it holds is
      * one element of what an operation answered rather than the value the name has at a read — an
      * expression built from a closure's parameter, standing for every element at once. A reader that
      * put it where the name stands would state of one value what was written about all of them.
+     *
+     * <p>Beside {@link OneOf} and short of it by exactly what a reader would need: that one names
+     * every value the position admits, and this one says there are several and stops. Held apart
+     * because the two license different work and the difference is not a matter of degree — a
+     * statement about all of them can be made from the first and cannot be made from the second.
      */
     record Element() implements ReadMeaning {}
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadMeaning.java
@@ -14,12 +14,12 @@ package souther.compiler.inputs;
  * where the name stands is that reader's to settle from the fact; what is answered here is what the
  * reading of the input knows, which is the same knowledge whoever asks.
  *
- * <p><b>How many values, and never which one.</b> {@link Through} says the name and one value are
- * one value; {@link OneOf} says the name stands for one of several and names all of them;
- * {@link Element} says several stand there and this reading cannot write them out. What a reader
- * does with a plurality is that reader's rule — the arithmetic reads every one of them and keeps
- * what they agree on — and choosing one of them here would be this reading answering a question
- * about a value with a fact about a set.
+ * <p><b>Which values, and never which one of them.</b> {@link Through} says the name and one value
+ * are one value; {@link OneOf} names every value the name can take, however many that is;
+ * {@link Element} says there are values and this reading cannot write them out. What a reader does
+ * with a set is that reader's rule — the arithmetic reads every member and keeps what they agree on
+ * — and choosing a member here would be this reading answering a question about a value with a fact
+ * about a set.
  */
 public sealed interface ReadMeaning {
 
@@ -43,6 +43,12 @@ public sealed interface ReadMeaning {
 
     /**
      * The name stands for one of {@code alternatives} and for no other value.
+     *
+     * <p>How many there are says nothing. A container written with one member, and an arm that left
+     * one of several standing, both answer with one — and that is this answer with one member rather
+     * than a name that denotes it: what a reader may do is state what every member supports, which
+     * is the same rule at any count. A singleton read as a denotation would be a name given the
+     * value of an element, which is what an arm is not evidence for.
      *
      * <p><b>Exhaustive, or this is not the answer.</b> What a reader may do with a plurality is
      * state what holds of every member, and one member left out makes that statement about a value

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -68,9 +68,23 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             }
         }
 
-        /** Read to the end, and the quantity it cuts is nothing: a comparison of constants, or one
-         *  whose positions cancel. Nothing is missing here. */
-        record CutsNothing() implements OfAComparison {}
+        /**
+         * Read to the end, and the quantity it cuts is nothing: a comparison of constants, or one
+         * whose positions cancel. Nothing is missing here.
+         *
+         * <p>{@code read} is every number of the input this reading named on the way, whether or not
+         * it survived the cancellation. What the rule is about is not what is left of it: {@code a -
+         * a <= 0} states something about {@code a} and holds of every row, and a reader told only
+         * that the quantity is empty would have to go back to the operands to find out where to say
+         * so — which is a second account of what the rule names, beside the reading that has just
+         * read it. A comparison of constants named nothing and comes back with nothing.
+         */
+        record CutsNothing(java.util.Set<NumericTerm> read) implements OfAComparison {
+
+            public CutsNothing {
+                read = java.util.Set.copyOf(read);
+            }
+        }
 
         /** The reading stopped, at this expression and in the environment it was being read in. */
         record Stopped(Core node, InputReads at) implements OfAComparison {
@@ -85,13 +99,16 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
     /** The same, saying which of the three it is. */
     static OfAComparison read(Core.Binary comparison, InputReads reads, Symbols symbols) {
         if (!comparison.op().compares()) {
-            return new OfAComparison.CutsNothing();
+            return new OfAComparison.CutsNothing(java.util.Set.of());
         }
+        // What this reading names as it goes, kept so that a reading which ran to the end can say
+        // what it was about without anybody reading the comparison again.
+        java.util.Set<NumericTerm> named = new java.util.LinkedHashSet<>();
         // The left first where both stop, which is the side a threshold would be read off.
         LinearForm<NumericTerm> left = null;
         for (Core side : java.util.List.of(comparison.left(), comparison.right())) {
             AffineForms.Outcome<NumericTerm, InputReads> read =
-                    AffineForms.outcome(side, reads, reading(symbols));
+                    AffineForms.outcome(side, reads, reading(symbols, named));
             if (read instanceof AffineForms.Outcome.StoppedAt<NumericTerm, InputReads> stopped) {
                 return new OfAComparison.Stopped(stopped.node(), stopped.at());
             }
@@ -101,7 +118,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
                 LinearForm<NumericTerm> whole = left.minus(
                         ((AffineForms.Outcome.Composed<NumericTerm, InputReads>) read).form());
                 if (whole.coefs().isEmpty()) {
-                    return new OfAComparison.CutsNothing();
+                    return new OfAComparison.CutsNothing(named);
                 }
                 AffineReading here = new AffineReading(
                         new LinearForm<>(BigDecimal.ZERO, whole.coefs()),
@@ -134,12 +151,20 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
 
     /** {@code e} as an affine form over the behavior's positions, or null where it is not one. */
     static LinearForm<NumericTerm> affine(Core e, InputReads reads, Symbols symbols) {
-        return AffineForms.of(e, reads, reading(symbols));
+        return AffineForms.of(e, reads, reading(symbols, new java.util.LinkedHashSet<>()));
     }
 
-    /** What this reader answers about its own environment, which is what tells its atoms from
-     *  another reader's. */
-    private static AffineForms.Reading<NumericTerm, InputReads> reading(Symbols symbols) {
+    /**
+     * What this reader answers about its own environment, which is what tells its atoms from
+     * another reader's.
+     *
+     * <p>{@code named} takes every number this names, which is the one place a node of the tree
+     * becomes a term of the input. Collected here rather than recovered afterwards: what a rule is
+     * about is what the reading of it named, and a reader working that out again from the operands
+     * is a second account of it.
+     */
+    private static AffineForms.Reading<NumericTerm, InputReads> reading(
+            Symbols symbols, java.util.Set<NumericTerm> named) {
         return new AffineForms.Reading<NumericTerm, InputReads>() {
 
             @Override
@@ -150,7 +175,11 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             @Override
             public LinearForm<NumericTerm> leafOf(Core node, InputReads at) {
                 NumericTerm term = InputNumber.of(node, at, symbols);
-                return term == null ? null : LinearForm.atom(term);
+                if (term == null) {
+                    return null;
+                }
+                named.add(term);
+                return LinearForm.atom(term);
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -177,6 +177,27 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
                                 through.denotes().at()) : null;
             }
 
+            /**
+             * A name an operation handed an element on, where the container was written out.
+             *
+             * <p>The same one answer as the one above ({@link InputReads#meaningOf}), read for the
+             * count it comes back with. A container an operation built answers no plurality here,
+             * and a rule about an element of one is a rule about no position — which is what it was
+             * before there was anything to write out.
+             */
+            @Override
+            public java.util.List<AffineForms.ReadThrough<InputReads>> alternativesOf(
+                    Core.Read read, InputReads at) {
+                if (!(at.meaningOf(read, symbols) instanceof ReadMeaning.OneOf one)) {
+                    return null;
+                }
+                java.util.List<AffineForms.ReadThrough<InputReads>> each =
+                        new java.util.ArrayList<>();
+                one.alternatives().forEach(stands ->
+                        each.add(new AffineForms.ReadThrough<>(stands.value(), stands.at())));
+                return each;
+            }
+
             @Override
             public boolean readsThrough(Core.FieldAccess fa, InputReads at) {
                 return at.pathOf(fa.target(), symbols) == null

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -8,7 +8,6 @@ import souther.compiler.core.Core;
 import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.inputs.ReadMeaning;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 
 import java.math.BigDecimal;
@@ -172,30 +171,18 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
              */
             @Override
             public AffineForms.ReadThrough<InputReads> readThrough(Core.Read read, InputReads at) {
-                return at.meaningOf(read, symbols) instanceof ReadMeaning.Through through
-                        ? new AffineForms.ReadThrough<>(through.denotes().value(),
-                                through.denotes().at()) : null;
+                return NameAnswers.denoting(read, at, symbols);
             }
 
             /**
-             * A name an operation handed an element on, where the container was written out.
-             *
-             * <p>The same one answer as the one above ({@link InputReads#meaningOf}), read for the
-             * count it comes back with. A container an operation built answers no plurality here,
-             * and a rule about an element of one is a rule about no position — which is what it was
-             * before there was anything to write out.
+             * A name an operation handed an element on, where the container was written out. Read
+             * for the count the one answer comes back with, beside the walk that says which
+             * positions a rule is about, so the two meet a plurality with the same knowledge.
              */
             @Override
             public java.util.List<AffineForms.ReadThrough<InputReads>> alternativesOf(
                     Core.Read read, InputReads at) {
-                if (!(at.meaningOf(read, symbols) instanceof ReadMeaning.OneOf one)) {
-                    return null;
-                }
-                java.util.List<AffineForms.ReadThrough<InputReads>> each =
-                        new java.util.ArrayList<>();
-                one.alternatives().forEach(stands ->
-                        each.add(new AffineForms.ReadThrough<>(stands.value(), stands.at())));
-                return each;
+                return NameAnswers.alternativesOf(read, at, symbols);
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -78,6 +78,11 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
          * that the quantity is empty would have to go back to the operands to find out where to say
          * so — which is a second account of what the rule names, beside the reading that has just
          * read it. A comparison of constants named nothing and comes back with nothing.
+         *
+         * <p>A set, because naming one number twice is naming it once. Which order a document lists
+         * them in is not carried here and is not the order they were met in: that is how the rule
+         * was spelled, and it is settled where the coordinates are made
+         * ({@link AffineReading#filedAt}).
          */
         record CutsNothing(java.util.Set<NumericTerm> read) implements OfAComparison {
 
@@ -147,6 +152,30 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             LinearForm<NumericTerm> form) {
         return form.coefs().entrySet().stream()
                 .sorted(java.util.Comparator.comparing(each -> each.getKey().toString())).toList();
+    }
+
+    /**
+     * Where a reading that reached the numbers files what it found, in the order a document names
+     * them.
+     *
+     * <p><b>The numbers and not the places they sit at.</b> A reader that got as far as the terms
+     * has the operation each number is taken by, and two operations over one path are two rules a
+     * report has to tell apart ({@link souther.compiler.inputs.FilingCoordinate}); the coordinate
+     * that names only the place is for a reader that did not get that far. Written out again at a
+     * second reader, the weaker of the two is the one that would be reached for, since a path is
+     * what every term can be asked for.
+     *
+     * <p>By the term's own name, for the reason {@link #ordered} gives: how a rule was spelled is
+     * not what a document is keyed on, and a report is compared against the one written last time.
+     * So the order the reading happened to meet them in is not carried, and neither is a set's.
+     */
+    static java.util.List<souther.compiler.inputs.FilingCoordinate> filedAt(
+            java.util.Collection<NumericTerm> terms) {
+        return terms.stream()
+                .sorted(java.util.Comparator.comparing(NumericTerm::toString))
+                .<souther.compiler.inputs.FilingCoordinate>map(
+                        souther.compiler.inputs.FilingCoordinate::of)
+                .distinct().toList();
     }
 
     /** {@code e} as an affine form over the behavior's positions, or null where it is not one. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -173,7 +173,8 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             @Override
             public AffineForms.ReadThrough<InputReads> readThrough(Core.Read read, InputReads at) {
                 return at.meaningOf(read, symbols) instanceof ReadMeaning.Through through
-                        ? new AffineForms.ReadThrough<>(through.value(), through.at()) : null;
+                        ? new AffineForms.ReadThrough<>(through.denotes().value(),
+                                through.denotes().at()) : null;
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
@@ -70,11 +70,18 @@ final class BoundaryPolicy {
      * <p><b>How many times a run passes the comparison is not asked.</b> A recording holds that a
      * place was passed and not how many times, so two outcomes of one comparison in one run would
      * have to be told from two rows' outcomes — and what settles that is the reading of the
-     * comparison rather than anything about the construct it stands in. A reading comes to a line
-     * over positions of the input and no other atom, so every pass of a comparison that bears one
-     * reads what the row holds: at one occurrence of a position where the passes stand at different
-     * occurrences of one, and at the same values where they do not. A pass reading a value the row
-     * does not settle is one the arithmetic has no atom for and no line comes of it.
+     * comparison rather than anything about the construct it stands in.
+     *
+     * <p>What the reading settles is this: <b>every atom of a form it composed is a term the row
+     * decides.</b> A value at a position of the input is one, a number taken of one is one, and a
+     * number taken over the occurrences of one path in a single run is one — that last names no
+     * single position, and what makes the row decide it is the run naming exactly one sequence
+     * ({@link souther.compiler.inputs.RunSource}). What a row does not decide is not an atom at all:
+     * it enters a form only where it was written out and every value of it came to the same form
+     * ({@link souther.compiler.check.AffineForms}), after which it is a number and no longer an
+     * uncertainty. So every pass of a comparison that bears a line reads what the row holds — at one
+     * occurrence of a position where the passes stand at different occurrences of one, and at the
+     * same values where they do not — and a pass reading anything else is one no line came of.
      *
      * @param live whether what is computed at this position is read on the way to what the behavior
      *             answers with, which is {@link LiveFlow}'s answer carried down the walk

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
@@ -67,15 +67,19 @@ final class BoundaryPolicy {
      * decision that took the reading only to hand it back was a second place holding it, and the
      * walk that has it is {@link ComparisonReadings}.
      *
+     * <p><b>How many times a run passes the comparison is not asked.</b> A recording holds that a
+     * place was passed and not how many times, so two outcomes of one comparison in one run would
+     * have to be told from two rows' outcomes — and what settles that is the reading of the
+     * comparison rather than anything about the construct it stands in. A reading comes to a line
+     * over positions of the input and no other atom, so every pass of a comparison that bears one
+     * reads what the row holds: at one occurrence of a position where the passes stand at different
+     * occurrences of one, and at the same values where they do not. A pass reading a value the row
+     * does not settle is one the arithmetic has no atom for and no line comes of it.
+     *
      * @param live whether what is computed at this position is read on the way to what the behavior
      *             answers with, which is {@link LiveFlow}'s answer carried down the walk
-     * @param eachPassIsAnOccurrence whether every pass of this position in one run is one occurrence
-     *                               of a position of the input, which is
-     *                               {@link souther.compiler.check.ElementBindings}'s answer carried
-     *                               down the walk beside {@code live}
      */
-    static Standing standingOf(Core.Binary comparison, CoverageSites.Plan plan, boolean live,
-                               boolean eachPassIsAnOccurrence) {
+    static Standing standingOf(Core.Binary comparison, CoverageSites.Plan plan, boolean live) {
         if (!live) {
             return new Standing.DrawsNone(comparison, NotABoundary.NOTHING_READS_IT);
         }
@@ -84,15 +88,6 @@ final class BoundaryPolicy {
         // reached, and a border on it would owe a row nothing can measure.
         if (plan.comparisonAt(comparison).isEmpty()) {
             return new Standing.DrawsNone(comparison, NotABoundary.NOTHING_RECORDS_IT);
-        }
-        // A recording holds that a place was passed and not how many times, so two outcomes of one
-        // comparison in one run cannot be told from two rows' outcomes — unless something else tells
-        // the passes apart. Where the closure that repeats this one is applied to the elements of a
-        // container the input walk has a position for, each pass is one occurrence of that position,
-        // and the row's own values there say which pass came out which way. The comparison is one
-        // rule about the element and not several about the container.
-        if (plan.mayRepeat(comparison) && !eachPassIsAnOccurrence) {
-            return new Standing.DrawsNone(comparison, NotABoundary.REPEATED_IN_ONE_RUN);
         }
         return new Standing.DrawsALine(comparison);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -115,8 +115,20 @@ sealed interface ComparisonAssessment {
     /** The comparison names no position of the behavior's input. */
     record NoInput() implements ComparisonAssessment {}
 
-    /** Read to the end, and the quantity it cuts is nothing: the positions cancel. */
-    record CutsNothing() implements ComparisonAssessment {}
+    /**
+     * Read to the end, and the quantity it cuts is nothing: the positions cancel.
+     *
+     * <p>{@code filedAt} is where the rule is said to have cut nothing, and it comes off the
+     * reading rather than off a second walk over the operands. What is left of the quantity is not
+     * what the rule is about — {@code a - a <= 0} is about {@code a} and cuts nothing — so the
+     * coordinates are the numbers the reading named, whether or not they survived.
+     */
+    record CutsNothing(List<FilingCoordinate> filedAt) implements ComparisonAssessment {
+
+        public CutsNothing {
+            filedAt = List.copyOf(filedAt);
+        }
+    }
 
     /** Read in full, and the quantity does not run as far as the line the rule draws. */
     record OutsideTheDomain(Cutting cutting) implements ComparisonAssessment {
@@ -186,10 +198,10 @@ sealed interface ComparisonAssessment {
      * ({@link souther.compiler.inputs.InputNumber}), so a comparison that came to a line is about
      * the positions of that line and there is nothing left to look up. What the walk over the
      * expression says a side is made of is the answer for a rule that came to no line — where it is
-     * the only account there is — and asked first it is a second reading standing in front of the
-     * first, able to veto it and never to add to it. It did: two members of a written list holding
-     * one form written two ways agree as arithmetic and are made of different things, and the rule
-     * they state came back as one about no input at all.
+     * the only account there is — and asked first it would be a second reading standing in front of
+     * the first, able to veto it and never to add to it: two members of a written list holding one
+     * form written two ways agree as arithmetic and are made of different things, so the rule they
+     * state would come back as one about no input at all.
      */
     static ComparisonAssessment of(String behavior, Core.Binary comparison, InputReads reads,
                                    Symbols symbols, Quantities quantities, BindingId answer,
@@ -208,9 +220,11 @@ sealed interface ComparisonAssessment {
             // of this compiler: `a <= a` holds of every row. Where the comparison names no position
             // either, there is no rule about a position to say it of — `2 > 1` is a comparison of
             // constants and states nothing anywhere.
-            case Cutting.Read.CutsNothing _ ->
-                    namesAPosition(comparison, reads, symbols)
-                            ? new CutsNothing() : aboutNoPosition(comparison, reads, symbols);
+            case Cutting.Read.CutsNothing over -> over.read().isEmpty()
+                    ? aboutNoPosition(comparison, reads, symbols)
+                    : new CutsNothing(over.read().stream()
+                            .map(NumericTerm::subjectPath).distinct()
+                            .map(FilingCoordinate::at).toList());
             // And where the reading stopped, its own answer for having stopped — decided where it
             // stopped rather than worked out again from the comparison afterwards. Here the walk
             // over the expression is the only account of what the rule is about, which is what it
@@ -222,12 +236,6 @@ sealed interface ComparisonAssessment {
                         : new Unread(stopped.why(), filedAt);
             }
         };
-    }
-
-    /** Whether the walk over the expression names a position of the input in it. */
-    private static boolean namesAPosition(Core.Binary comparison, InputReads reads,
-                                          Symbols symbols) {
-        return !GuardThresholds.filedAt(comparison, reads, symbols).isEmpty();
     }
 
     /**
@@ -329,7 +337,7 @@ sealed interface ComparisonAssessment {
             // the input empty says nothing about which positions this rule is about.
             case NoFeasibleInput none -> none.cutting().over();
             case Unread unread -> unread.filedAt();
-            case CutsNothing _ -> GuardThresholds.filedAt(comparison, reads, symbols);
+            case CutsNothing cuts -> cuts.filedAt();
             case AtAPosition _, AnswerDependent _, NoInput _ -> List.of();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -121,7 +121,8 @@ sealed interface ComparisonAssessment {
      * <p>{@code filedAt} is where the rule is said to have cut nothing, and it comes off the
      * reading rather than off a second walk over the operands. What is left of the quantity is not
      * what the rule is about — {@code a - a <= 0} is about {@code a} and cuts nothing — so the
-     * coordinates are the numbers the reading named, whether or not they survived.
+     * coordinates are the numbers the reading named, whether or not they survived, and they are the
+     * numbers rather than the places they sit at ({@link AffineReading#filedAt}).
      */
     record CutsNothing(List<FilingCoordinate> filedAt) implements ComparisonAssessment {
 
@@ -222,9 +223,7 @@ sealed interface ComparisonAssessment {
             // constants and states nothing anywhere.
             case Cutting.Read.CutsNothing over -> over.read().isEmpty()
                     ? aboutNoPosition(comparison, reads, symbols)
-                    : new CutsNothing(over.read().stream()
-                            .map(NumericTerm::subjectPath).distinct()
-                            .map(FilingCoordinate::at).toList());
+                    : new CutsNothing(AffineReading.filedAt(over.read()));
             // And where the reading stopped, its own answer for having stopped — decided where it
             // stopped rather than worked out again from the comparison afterwards. Here the walk
             // over the expression is the only account of what the rule is about, which is what it

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -180,6 +180,16 @@ sealed interface ComparisonAssessment {
      *
      * <p>The one way in. {@code answer} is the binding a clause calls what the behavior answers, or
      * null where the comparison is written in a body and there is nothing to be the answer.
+     *
+     * <p><b>The arithmetic answers before anything else is asked.</b> Which positions a rule is
+     * about is what the quantity it cuts is over: every atom of a form is a number of a location
+     * ({@link souther.compiler.inputs.InputNumber}), so a comparison that came to a line is about
+     * the positions of that line and there is nothing left to look up. What the walk over the
+     * expression says a side is made of is the answer for a rule that came to no line — where it is
+     * the only account there is — and asked first it is a second reading standing in front of the
+     * first, able to veto it and never to add to it. It did: two members of a written list holding
+     * one form written two ways agree as arithmetic and are made of different things, and the rule
+     * they state came back as one about no input at all.
      */
     static ComparisonAssessment of(String behavior, Core.Binary comparison, InputReads reads,
                                    Symbols symbols, Quantities quantities, BindingId answer,
@@ -191,20 +201,33 @@ sealed interface ComparisonAssessment {
         if (readsAnswer(comparison, answer)) {
             return new AnswerDependent();
         }
-        List<FilingCoordinate> filedAt = GuardThresholds.filedAt(comparison, reads, symbols);
-        if (filedAt.isEmpty()) {
-            return aboutNoPosition(comparison, reads, symbols);
-        }
         return switch (Cutting.read(behavior, comparison, reads, symbols, quantities)) {
             case Cutting.Read.Cuts cuts ->
                     onTheQuantity(comparison, cuts.cutting(), quantities, drawnByAnInvariant);
             // Read to the end and cutting nothing, which is a fact about the rule and not a limit
-            // of this compiler: `a <= a` holds of every row.
-            case Cutting.Read.CutsNothing _ -> new CutsNothing();
+            // of this compiler: `a <= a` holds of every row. Where the comparison names no position
+            // either, there is no rule about a position to say it of — `2 > 1` is a comparison of
+            // constants and states nothing anywhere.
+            case Cutting.Read.CutsNothing _ ->
+                    namesAPosition(comparison, reads, symbols)
+                            ? new CutsNothing() : aboutNoPosition(comparison, reads, symbols);
             // And where the reading stopped, its own answer for having stopped — decided where it
-            // stopped rather than worked out again from the comparison afterwards.
-            case Cutting.Read.Stopped stopped -> new Unread(stopped.why(), filedAt);
+            // stopped rather than worked out again from the comparison afterwards. Here the walk
+            // over the expression is the only account of what the rule is about, which is what it
+            // is for.
+            case Cutting.Read.Stopped stopped -> {
+                List<FilingCoordinate> filedAt =
+                        GuardThresholds.filedAt(comparison, reads, symbols);
+                yield filedAt.isEmpty() ? aboutNoPosition(comparison, reads, symbols)
+                        : new Unread(stopped.why(), filedAt);
+            }
         };
+    }
+
+    /** Whether the walk over the expression names a position of the input in it. */
+    private static boolean namesAPosition(Core.Binary comparison, InputReads reads,
+                                          Symbols symbols) {
+        return !GuardThresholds.filedAt(comparison, reads, symbols).isEmpty();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -84,7 +84,7 @@ final class ComparisonReadings {
     static ComparisonReadings of(Core body, CoverageSites.Plan plan, InputReads reads,
                                  Symbols symbols) {
         List<Reading> readings = new ArrayList<>();
-        walk(body, plan, reads, symbols, LiveFlow.of(body), List.of(), true, true, readings);
+        walk(body, plan, reads, symbols, LiveFlow.of(body), List.of(), true, readings);
         return new ComparisonReadings(readings);
     }
 
@@ -93,17 +93,13 @@ final class ComparisonReadings {
      * @param live    whether what is computed here is read on the way to what the behavior answers
      *                with. Carried down because everything inside a value nothing reads is read by
      *                nothing either
-     * @param each    whether every pass of this position in one run is one occurrence of a position
-     *                of the input. Carried down for the same reason: a closure applied once per
-     *                element stands inside whatever applies the closure above it, and one that
-     *                nothing says the applications of settles it for everything under it
      */
     private static void walk(Core e, CoverageSites.Plan plan, InputReads reads, Symbols symbols,
                              LiveFlow flow, List<OnTheWay> assumed, boolean live,
-                             boolean each, List<Reading> out) {
+                             List<Reading> out) {
         if (e instanceof Core.Binary comparison && plan.comparisons().at(comparison).isPresent()) {
             out.add(new Reading(comparison, reads, assumed,
-                    BoundaryPolicy.standingOf(comparison, plan, live, each)));
+                    BoundaryPolicy.standingOf(comparison, plan, live)));
         }
         switch (e) {
             // The right operand runs only where the left came out the way that leaves the answer
@@ -111,39 +107,33 @@ final class ComparisonReadings {
             // any fork above it: there need not be one, and where there is, this is what the fork
             // would have been reading anyway.
             case Core.Binary both when both.op() == BinOp.AND -> {
-                walk(both.left(), plan, reads, symbols, flow, assumed, live, each, out);
+                walk(both.left(), plan, reads, symbols, flow, assumed, live, out);
                 walk(both.right(), plan, reads, symbols, flow,
-                        taking(both.left(), true, reads, assumed, symbols), live, each, out);
+                        taking(both.left(), true, reads, assumed, symbols), live, out);
             }
             case Core.Binary either when either.op() == BinOp.OR -> {
-                walk(either.left(), plan, reads, symbols, flow, assumed, live, each, out);
+                walk(either.left(), plan, reads, symbols, flow, assumed, live, out);
                 walk(either.right(), plan, reads, symbols, flow,
-                        taking(either.left(), false, reads, assumed, symbols), live, each, out);
+                        taking(either.left(), false, reads, assumed, symbols), live, out);
             }
             // The condition under what stood above the fork, and each arm under what that arm proves
             // of it. A comparison inside a condition is not below the fork: it runs to decide it.
             case Core.If iff -> {
-                walk(iff.cond(), plan, reads, symbols, flow, assumed, live, each, out);
+                walk(iff.cond(), plan, reads, symbols, flow, assumed, live, out);
                 walk(iff.then(), plan, reads, symbols, flow,
-                        taking(iff.cond(), true, reads, assumed, symbols), live, each, out);
+                        taking(iff.cond(), true, reads, assumed, symbols), live, out);
                 walk(iff.els(), plan, reads, symbols, flow,
-                        taking(iff.cond(), false, reads, assumed, symbols), live, each, out);
+                        taking(iff.cond(), false, reads, assumed, symbols), live, out);
             }
             // What a `let` computes is read on the way to the answer only where the name is read;
             // everywhere else a value stands in a body it is consumed by what it stands in. And its
             // body is where the name stands for what was bound to it.
             case Core.LetIn let -> {
                 walk(let.value(), plan, reads, symbols, flow, assumed,
-                        live && flow.reads(let), each, out);
+                        live && flow.reads(let), out);
                 walk(let.body(), plan, reads.and(let.binder(), let.value()), symbols, flow, assumed,
-                        live, each, out);
+                        live, out);
             }
-            // What runs inside a function value runs once per application, and how many applications
-            // there are is the caller's to say. Where the caller is an operation over a container and
-            // this is the step it applies per element, the elements are what it applies it to and the
-            // input walk has a position for one of them.
-            case Core.Block step -> walk(step.body(), plan, reads, symbols, flow, assumed, live,
-                    each && perElement(step, reads, symbols), out);
             // And each arm under what the arm says the value it matched turned out to be. A name
             // the arm binds is the scrutinee's position narrowed to that case, so a comparison
             // written inside an arm draws its line on a position the reading of the input has —
@@ -154,37 +144,15 @@ final class ComparisonReadings {
             // inside an arm was owed a row by a walk that had been told nothing stood on the way to
             // it, and the row composed for it was written in whichever arm the values fell in.
             case Core.Match match -> {
-                walk(match.scrutinee(), plan, reads, symbols, flow, assumed, live, each, out);
+                walk(match.scrutinee(), plan, reads, symbols, flow, assumed, live, out);
                 for (Core.Case arm : match.cases()) {
                     walk(arm.body(), plan, reads.insideArm(match, arm, symbols), symbols, flow,
-                            entering(match, arm, reads, assumed, symbols), live, each, out);
+                            entering(match, arm, reads, assumed, symbols), live, out);
                 }
             }
             default -> Core.forEachChild(e, child ->
-                    walk(child, plan, reads, symbols, flow, assumed, live, each, out));
+                    walk(child, plan, reads, symbols, flow, assumed, live, out));
         }
-    }
-
-    /**
-     * Whether {@code step} is applied once per element of a container, which is what makes its
-     * applications occurrences of one position rather than an unknown number of passes.
-     *
-     * <p>Read off the binding of the parameter the elements arrive at, which is what
-     * {@link souther.compiler.check.ElementBindings} recorded where the operation is written. Not
-     * read off the shape of the call here: after the rewrite that fuses the walks there is no call
-     * left to match, and a reading that matched one would narrow with nothing saying so.
-     */
-    private static boolean perElement(Core.Block step, InputReads reads, Symbols symbols) {
-        // Applied once per element of the container the parameter is handed elements of, and each
-        // of those elements at a position the input walk names. A container the walk names nothing
-        // at is one no row can be read at, so what repeats there is still a number of passes and not
-        // a number of occurrences, and a line drawn on it would be owed by nothing.
-        for (Core.Binder param : step.params()) {
-            if (param.binding() != null && reads.elementAt(param.binding(), symbols) != null) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -62,8 +62,16 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             }
         }
 
-        /** Read to the end, and the quantity it cuts is nothing. */
-        record CutsNothing() implements Read {}
+        /** Read to the end, and the quantity it cuts is nothing. {@code read} is what the reading
+         *  named on the way, which is what the rule is about however much of it cancelled
+         *  ({@link AffineReading.OfAComparison.CutsNothing}). */
+        record CutsNothing(java.util.Set<souther.compiler.inputs.NumericTerm> read)
+                implements Read {
+
+            public CutsNothing {
+                read = java.util.Set.copyOf(read);
+            }
+        }
 
         /** The reading stopped, and this is what it stopped on. */
         record Stopped(souther.compiler.inputs.BlockReason.RuleReadingStopped why) implements Read {
@@ -91,7 +99,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             // `a <= a` names one position on either side and the arithmetic has already said the
             // two are one, so a reading of the operands finding a distance there is that reading
             // being wrong about the rule.
-            case AffineReading.OfAComparison.CutsNothing _ -> new Read.CutsNothing();
+            case AffineReading.OfAComparison.CutsNothing over ->
+                    new Read.CutsNothing(over.read());
             // The quantity is what the arithmetic says it is, and the realization is the only thing
             // left to try. Read the other way round, a spelling that produced a line took the
             // comparison before the canonical form was consulted at all.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -418,15 +418,11 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * position it does not mention.
      */
     java.util.List<souther.compiler.inputs.FilingCoordinate> over() {
-        // By the position's own name, which is the one thing about a form that does not depend on
-        // how it was written — the same order {@link AffineReading#ordered} puts a form's
-        // coefficients in. Read off the map instead, the entries come back in an order salted once
-        // per run, and a report is a document compared against the one written last time.
-        return AffineReading.ordered(direction(of)).stream()
-                .map(java.util.Map.Entry::getKey)
-                .<souther.compiler.inputs.FilingCoordinate>map(
-                        souther.compiler.inputs.FilingCoordinate::of)
-                .distinct().toList();
+        // Where a reading that reached the numbers files them, which is one answer for every such
+        // reading ({@link AffineReading#filedAt}): the terms themselves, in the order a document
+        // names them. Written out here, a reader that reached the numbers by another way would
+        // write it out again, and the two would file one rule at two coordinates.
+        return AffineReading.filedAt(direction(of).coefs().keySet());
     }
 
     /** Whether the rule singles a value out rather than ordering the values around it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -182,10 +182,10 @@ public final class GuardThresholds {
      *
      * <p>Which is why a comparison nothing can measure is in and one nothing reads is out, and the
      * split is the same one {@link NotABoundary} is made of. {@link NotABoundary#NOTHING_RECORDS_IT}
-     * and {@link NotABoundary#REPEATED_IN_ONE_RUN} are the author's rules, written at a position,
-     * that this could not draw a line from — the sentence {@code not read} is there to say.
-     * {@link NotABoundary#NOTHING_READS_IT} is not a rule of the model at all, and saying it went
-     * unread would put a statement into the report that the behavior does not make.
+     * is the author's rule, written at a position, that this could not draw a line from — the
+     * sentence {@code not read} is there to say. {@link NotABoundary#NOTHING_READS_IT} is not a rule
+     * of the model at all, and saying it went unread would put a statement into the report that the
+     * behavior does not make.
      */
     private static void noticed(String behavior, ComparisonReadings read, List<Core> assessed,
                                 CoverageSites.Plan plan, Symbols symbols, List<RuleWithoutALine> out) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -358,17 +358,6 @@ public final class GuardThresholds {
                 return NameAnswers.denoting(read, at, symbols);
             }
 
-            /**
-             * A name an operation handed an element on, where the container was written out. The
-             * same one answer the arithmetic is given, so the two walks meet a plurality with the
-             * same knowledge rather than one of them naming nothing where the other draws a line.
-             */
-            @Override
-            public java.util.List<souther.compiler.check.AffineForms.ReadThrough<InputReads>>
-                    alternativesOf(Core.Read read, InputReads at) {
-                return NameAnswers.alternativesOf(read, at, symbols);
-            }
-
             @Override
             public InputReads inside(Core.LetIn li, InputReads at) {
                 return at.and(li.binder(), li.value());

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -357,7 +357,7 @@ public final class GuardThresholds {
                     Core.Read read, InputReads at) {
                 return at.meaningOf(read, symbols) instanceof ReadMeaning.Through through
                         ? new souther.compiler.check.AffineForms.ReadThrough<>(
-                                through.value(), through.at())
+                                through.denotes().value(), through.denotes().at())
                         : null;
             }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -355,10 +355,7 @@ public final class GuardThresholds {
             @Override
             public souther.compiler.check.AffineForms.ReadThrough<InputReads> readThrough(
                     Core.Read read, InputReads at) {
-                return at.meaningOf(read, symbols) instanceof ReadMeaning.Through through
-                        ? new souther.compiler.check.AffineForms.ReadThrough<>(
-                                through.denotes().value(), through.denotes().at())
-                        : null;
+                return NameAnswers.denoting(read, at, symbols);
             }
 
             /**
@@ -369,15 +366,7 @@ public final class GuardThresholds {
             @Override
             public java.util.List<souther.compiler.check.AffineForms.ReadThrough<InputReads>>
                     alternativesOf(Core.Read read, InputReads at) {
-                if (!(at.meaningOf(read, symbols) instanceof ReadMeaning.OneOf one)) {
-                    return null;
-                }
-                java.util.List<souther.compiler.check.AffineForms.ReadThrough<InputReads>> each =
-                        new java.util.ArrayList<>();
-                one.alternatives().forEach(stands ->
-                        each.add(new souther.compiler.check.AffineForms.ReadThrough<>(
-                                stands.value(), stands.at())));
-                return each;
+                return NameAnswers.alternativesOf(read, at, symbols);
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -361,6 +361,25 @@ public final class GuardThresholds {
                         : null;
             }
 
+            /**
+             * A name an operation handed an element on, where the container was written out. The
+             * same one answer the arithmetic is given, so the two walks meet a plurality with the
+             * same knowledge rather than one of them naming nothing where the other draws a line.
+             */
+            @Override
+            public java.util.List<souther.compiler.check.AffineForms.ReadThrough<InputReads>>
+                    alternativesOf(Core.Read read, InputReads at) {
+                if (!(at.meaningOf(read, symbols) instanceof ReadMeaning.OneOf one)) {
+                    return null;
+                }
+                java.util.List<souther.compiler.check.AffineForms.ReadThrough<InputReads>> each =
+                        new java.util.ArrayList<>();
+                one.alternatives().forEach(stands ->
+                        each.add(new souther.compiler.check.AffineForms.ReadThrough<>(
+                                stands.value(), stands.at())));
+                return each;
+            }
+
             @Override
             public InputReads inside(Core.LetIn li, InputReads at) {
                 return at.and(li.binder(), li.value());

--- a/souther-compiler/src/main/java/souther/compiler/partition/NameAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/NameAnswers.java
@@ -1,0 +1,57 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.AffineForms;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.inputs.Denotation;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.ReadMeaning;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What the reading of a body's names comes to, in the shape the walks over a body ask for.
+ *
+ * <p>Two walks meet every name of a body — the arithmetic that finds the line a rule draws, and the
+ * one that says which positions a rule is about — and each asks its own interface for the same two
+ * facts. What a name means is {@link InputReads#meaningOf}'s single answer; what is here is the
+ * projection of that answer onto the pair those interfaces are written in.
+ *
+ * <p>Written once because the two walks disagreeing about a name is not a difference of opinion but
+ * a defect with a shape: one of them reads a rule and draws its line while the other cannot name the
+ * position the line divides, after which the position is reported as one the model divides no way.
+ * Kept as two copies, that is one edit away at all times.
+ */
+final class NameAnswers {
+
+    /** The one value {@code read}'s name denotes, or null where it denotes none. */
+    static AffineForms.ReadThrough<InputReads> denoting(Core.Read read, InputReads at,
+                                                        Symbols symbols) {
+        return at.meaningOf(read, symbols) instanceof ReadMeaning.Through through
+                ? asked(through.denotes()) : null;
+    }
+
+    /**
+     * Every value {@code read}'s name can stand for, or null where the reading has not got them all.
+     *
+     * <p>A container an operation built answers nothing here, which is what it answered before there
+     * was anything to write out.
+     */
+    static List<AffineForms.ReadThrough<InputReads>> alternativesOf(Core.Read read, InputReads at,
+                                                                    Symbols symbols) {
+        if (!(at.meaningOf(read, symbols) instanceof ReadMeaning.OneOf one)) {
+            return null;
+        }
+        List<AffineForms.ReadThrough<InputReads>> each = new ArrayList<>();
+        one.alternatives().forEach(stands -> each.add(asked(stands)));
+        return each;
+    }
+
+    /** A value and what to read it in, as the walks spell that pair. */
+    private static AffineForms.ReadThrough<InputReads> asked(Denotation stands) {
+        return new AffineForms.ReadThrough<>(stands.value(), stands.at());
+    }
+
+    private NameAnswers() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/NotABoundary.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/NotABoundary.java
@@ -5,14 +5,18 @@ package souther.compiler.partition;
  *
  * <p>An answer and never an absence. What these are told apart for is that a reader has to do
  * opposite things about them: one says the behavior draws no boundary here and a report saying
- * nothing is right, and the other two say it may well draw one that this could not be shown a row
- * against. Folded into one {@code false}, the second and third arrive downstream as the same silence
- * as the first — and whoever widens the measurement later has to work out again why anything was
- * left out.
+ * nothing is right, and the other says it may well draw one that this could not be shown a row
+ * against. Folded into one {@code false}, the second arrives downstream as the same silence as the
+ * first — and whoever widens the measurement later has to work out again why anything was left out.
  *
- * <p>One is said where more than one holds, and it is the one about the model. A reader told that a
+ * <p>The first is said where both hold, because it is the one about the model. A reader told that a
  * comparison's outcome cannot be attributed to a row would go looking for a way to attribute it,
  * when the behavior's answer does not turn on the comparison at all.
+ *
+ * <p>Nothing here is about what a rule was written in. Whether a comparison this policy admits comes
+ * to a line is the reading's answer and is said in the reading's words
+ * ({@link souther.compiler.inputs.BlockReason}); the two vocabularies stay apart, and a comparison
+ * this admits and no arithmetic reads is reported by that one rather than by a third word here.
  */
 public enum NotABoundary {
 
@@ -37,21 +41,5 @@ public enum NotABoundary {
      * arm a condition never comes out the way of, is one no run gets to — and meeting a line takes
      * getting the comparison to answer, so a border there would owe a row nothing can measure.
      */
-    NOTHING_RECORDS_IT,
-
-    /**
-     * One run passes the comparison more than once, so an outcome recorded at it belongs to no one
-     * row.
-     *
-     * <p>A boundary the behavior may well draw. What stops it is the shape of the recording rather
-     * than anything about the model: a recording holds that a place was passed and not how many
-     * times, so a comparison inside a function value a combinator applies per element leaves two
-     * outcomes in one run that cannot be told from two rows' outcomes. {@code Plan.mayRepeat} is
-     * what says so.
-     *
-     * <p>Kept apart from the others for the day the measurement grows. A reading that could attribute
-     * an outcome to the element it came from would make these lines, and nothing else about the
-     * policy would have to change.
-     */
-    REPEATED_IN_ONE_RUN
+    NOTHING_RECORDS_IT
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatThisGrammarReadsIsReadWithoutACallersLeafTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatThisGrammarReadsIsReadWithoutACallersLeafTest.java
@@ -125,6 +125,14 @@ class WhatThisGrammarReadsIsReadWithoutACallersLeafTest {
                 return null;
             }
 
+            /** No name here stands for several values either: what is being shown is that the
+             *  grammar reads these shapes with an environment that answers nothing. */
+            @Override
+            public java.util.List<AffineForms.ReadThrough<String>> alternativesOf(Core.Read read,
+                                                                                  String at) {
+                return null;
+            }
+
             @Override
             public boolean readsThrough(Core.FieldAccess fa, String at) {
                 return false;

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingStoppedComesBackWithWhatItWasReadInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAReadingStoppedComesBackWithWhatItWasReadInTest.java
@@ -100,6 +100,14 @@ class WhereAReadingStoppedComesBackWithWhatItWasReadInTest {
                         : null;
             }
 
+            /** One name denotes one value here, and no name stands for several: what this test is
+             *  about is the environment a stop comes back with, which a plurality would not add to. */
+            @Override
+            public java.util.List<AffineForms.ReadThrough<String>> alternativesOf(Core.Read read,
+                                                                                  String at) {
+                return null;
+            }
+
             @Override
             public boolean readsThrough(Core.FieldAccess fa, String at) {
                 return false;

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
@@ -1,0 +1,215 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.ReadMeaning;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a name an operation handed an element on stands for, where the container was written out.
+ *
+ * <p>A plurality this reading can write out and one it cannot are different answers. An element of a
+ * list written in the source stands for those values and no others, and that is what lets a reader
+ * state what holds of every one of them; an element of a container an operation built stands for
+ * values this reading has not got, and a statement about all of them cannot be made from it. Read as
+ * one answer, the second would be the first with members missing, which is worse than either.
+ *
+ * <p>None of this says what a rule about such a name comes to. Which of the values a name may be
+ * read as, and what an arithmetic makes of them, are the readers' own questions asked of the answer
+ * here.
+ */
+class ANameStandsForEveryValueItsContainerWasWrittenWithTest {
+
+    /** The values a list was written with are what its element stands for. */
+    @Test
+    void aWrittenListNamesEveryValueItsElementCanTake() {
+        assertEquals("OneOf[g.Big, g.Big]", standingOn("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /** And a helper that writes one out is the same list a name further away. */
+    @Test
+    void aHelperThatWritesTheListOutNamesThemToo() {
+        assertEquals("OneOf[g.Big, g.Big]", standingOn(
+                "if List.any((k) -> n >= k.threshold, twoBigs(n)) then Yes else No"));
+    }
+
+    /**
+     * A container an operation built names none of them.
+     *
+     * <p>Both halves were written out here and the operation holds the elements of both, so a
+     * reading that took either would have written out a set missing the other. It is answered as the
+     * plurality it is and left there.
+     */
+    @Test
+    void aContainerAnOperationBuiltNamesNoneOfThem() {
+        assertEquals("Element", standingOn("""
+                {
+                        let ks = List.append([ Big { threshold = 100000 } ],
+                                             [ Big { threshold = 200000 } ])
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * An arm narrows the set to the members it admits.
+     *
+     * <p>Which is the whole of what an arm settles. It takes out what it does not admit; what is
+     * left is what the name can stand for, and how many that is is the container's answer.
+     */
+    @Test
+    void anArmTakesOutTheMembersItDoesNotAdmit() {
+        assertEquals("OneOf[g.AtMost]", standingOn("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, Whatever ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And leaves two where two are of the case it admits.
+     *
+     * <p>The claim the arm is most likely to be read as making, and does not make. A list may be
+     * written with two members of one case, and an arm admitting that case has told them apart in no
+     * way at all — so what stands under the arm's name is still both of them.
+     */
+    @Test
+    void anArmAdmittingOneCaseLeavesBothMembersOfIt() {
+        assertEquals("OneOf[g.AtMost, g.AtMost]", standingOn("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, AtMost { threshold = 200000 } ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * A list written empty names no value, which is not a set of none.
+     *
+     * <p>A statement about every member of nothing holds whatever it says, so an empty set would be
+     * the strongest answer this could give and the one least entitled to be believed.
+     */
+    @Test
+    void aListWrittenEmptyNamesNoValueRatherThanNoneOfThem() {
+        assertEquals("Element", standingOn("""
+                {
+                        let ks: List<Big> = []
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * What the name the threshold side is read off stands for.
+     *
+     * <p>Followed through the names that denote one value, which is what puts the reading inside the
+     * arm and behind the field: the answer wanted is about the name the values arrive under, and
+     * every name between here and it stands for one thing.
+     */
+    private static String standingOn(String body) {
+        String source = """
+                module g
+
+                data Big = { threshold: Int }
+                data Yes
+                data No
+
+                data AtMost = { threshold: Int }
+                data Whatever
+                data Reason = AtMost | Whatever
+
+                let twoBigs (c: Int): List<Big> =
+                    [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
+
+                let reaches (n: Int, reason: Reason): Bool =
+                    match reason with
+                        | AtMost { threshold } -> n >= threshold
+                        | Whatever             -> false
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body);
+
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(java.util.List.of(), compilation.errors().stream()
+                .map(each -> each.diagnostic().code() + " "
+                        + each.diagnostic().primary()).toList(),
+                "the model under test compiles");
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        ComparisonReadings.Reading only = ComparisonReadings.of(
+                        checked.behaviorBodies().get("classify"),
+                        CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                                checked.supplied()),
+                        InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
+                                .get("classify"), checked.elementBindings().get("classify")),
+                        symbols)
+                .all().stream().findFirst().orElseThrow();
+
+        Core side = only.comparison().right();
+        InputReads at = only.reads();
+        while (true) {
+            if (side instanceof Core.FieldAccess field) {
+                side = field.target();
+                continue;
+            }
+            if (!(side instanceof Core.Read name)) {
+                return "not a name: " + side.getClass().getSimpleName();
+            }
+            ReadMeaning meaning = at.meaningOf(name, symbols);
+            if (!(meaning instanceof ReadMeaning.Through through)) {
+                return said(meaning);
+            }
+            side = through.denotes().value();
+            at = through.denotes().at();
+        }
+    }
+
+    /** The answer, by which of the five it is and which values a plurality holds. */
+    private static String said(ReadMeaning meaning) {
+        return switch (meaning) {
+            case ReadMeaning.OneOf one -> "OneOf" + one.alternatives().stream()
+                    .map(each -> switch (each.value()) {
+                        case Core.Construct made -> made.typeName().toString();
+                        case Core.UnitValue unit -> unit.data().toString();
+                        default -> each.value().getClass().getSimpleName();
+                    })
+                    .toList();
+            case ReadMeaning.Position position -> "Position[" + position.path() + "]";
+            case ReadMeaning.Element _ -> "Element";
+            case ReadMeaning.Unknown _ -> "Unknown";
+            case ReadMeaning.Through _ -> throw new IllegalStateException("followed already");
+        };
+    }
+
+    /** Every answer this test can get, so a case added to the reading arrives here rather than
+     *  under a word one of these tests already expects. */
+    @Test
+    void theFiveAnswersAreTheOnesThisTestKnows() {
+        Map<String, String> byName = new LinkedHashMap<>();
+        for (Class<?> each : ReadMeaning.class.getPermittedSubclasses()) {
+            byName.put(each.getSimpleName(), each.getSimpleName());
+        }
+        assertEquals(Map.of("Position", "Position", "Through", "Through", "OneOf", "OneOf",
+                "Element", "Element", "Unknown", "Unknown"), byName);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
@@ -3,19 +3,13 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.ReadMeaning;
-import souther.compiler.query.Adequacy;
-import souther.compiler.query.Bodies;
-import souther.compiler.query.Compilation;
-import souther.compiler.query.Scopes;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * What a name an operation handed an element on stands for, where the container was written out.
@@ -146,24 +140,9 @@ class ANameStandsForEveryValueItsContainerWasWrittenWithTest {
                     | "one" : (1) -> No
                 """.formatted(body);
 
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
-        assertEquals(java.util.List.of(), compilation.errors().stream()
-                .map(each -> each.diagnostic().code() + " "
-                        + each.diagnostic().primary()).toList(),
-                "the model under test compiles");
-        String module = compilation.modules().get(0);
-        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
-        assertNotNull(checked, "the model under test compiles");
-        Symbols symbols = Scopes.derived(compilation.db(), module).value();
-        ComparisonReadings.Reading only = ComparisonReadings.of(
-                        checked.behaviorBodies().get("classify"),
-                        CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
-                                checked.supplied()),
-                        InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
-                                .get("classify"), checked.elementBindings().get("classify")),
-                        symbols)
-                .all().stream().findFirst().orElseThrow();
+        ReadComparisons read = ReadComparisons.of(source, "classify");
+        ComparisonReadings.Reading only = read.only();
+        Symbols symbols = read.symbols();
 
         Core side = only.comparison().right();
         InputReads at = only.reads();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
@@ -128,6 +128,29 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
     }
 
     /**
+     * A container a member of another container holds states nothing.
+     *
+     * <p>Where the way to a written list runs through a name standing for several, the list is not
+     * one this reading arrives at: what a member holds is followed through the steps with one
+     * successor, and a member is not one of those. Every number written here is the same and it is
+     * still no answer.
+     *
+     * <p>Which is also what keeps the reading of one rule linear in the members of one container. A
+     * plurality inside a plurality would be read once per member of the outer, and a reader that
+     * gained the inner one would want the cost of it measured before it did.
+     */
+    @Test
+    void aContainerAMemberHoldsStatesNoNumber() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ Holder { items = [ Big { threshold = 100000 } ] }
+                                 , Holder { items = [ Big { threshold = 100000 } ] } ]
+                        if List.any((k) -> List.any((j) -> n >= j.threshold, k.items), ks)
+                            then Yes else No
+                    }"""));
+    }
+
+    /**
      * A choice between two constructions still states nothing, even between two alike.
      *
      * <p>Which is the boundary as it was. The reading names no values for what stands at a choice,
@@ -151,6 +174,7 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
                 module g
 
                 data Big = { threshold: Int }
+                data Holder = { items: List<Big> }
                 data Yes
                 data No
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
@@ -148,16 +148,34 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
     }
 
     /**
-     * A container a member of another container holds states nothing.
+     * A plurality standing inside a plurality is not read.
      *
-     * <p>Where the way to a written list runs through a name standing for several, the list is not
-     * one this reading arrives at: what a member holds is followed through the steps with one
-     * successor, and a member is not one of those. Every number written here is the same and it is
-     * still no answer.
+     * <p>The inner list is written out and every one of its members is a name standing for two
+     * values, so a reading that went on would be asking what every pairing of them agrees on: two
+     * members holding two each is four readings, and a rule written down a chain of these is two to
+     * the power of its depth. What a rule about a written container is is one container, and the
+     * members of it are read with no plurality in them.
      *
-     * <p>Which is also what keeps the reading of one rule linear in the members of one container. A
-     * plurality inside a plurality would be read once per member of the outer, and a reader that
-     * gained the inner one would want the cost of it measured before it did.
+     * <p>Every number written here is the same, which is what makes it worth writing out: what
+     * refuses this is the rule and not a disagreement between the members.
+     */
+    @Test
+    void aPluralityStandingInsideOneIsNotRead() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 100000 } ]
+                        if List.any((k) -> List.any((j) -> n >= j.threshold, [k, k]), ks)
+                            then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And a container a member holds is not one this reading arrives at either.
+     *
+     * <p>Beside the one above and refused before it rather than by it: the way to a written list is
+     * followed through the steps with one successor, and a member of a container is not one of
+     * those, so there is no second plurality here for the rule above to refuse. The two are written
+     * out apart because a reader gaining either would still meet the other.
      */
     @Test
     void aContainerAMemberHoldsStatesNoNumber() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
@@ -1,0 +1,209 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.Symbols;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a rule written over an element of a written container comes to.
+ *
+ * <p>A position several values can stand at supports what all of them support and nothing else. So a
+ * container written with one number under the field a rule compares against states that number, and
+ * one written with two states neither — and which of those it is turns on the numbers rather than on
+ * how many elements were written or which cases they are.
+ *
+ * <p>Read at the arithmetic and not at the report. What a comparison inside a repeated closure is
+ * then worth to a measure is a second question with an owner of its own; this one is about the
+ * number a rule cuts, which is what a reader of the model would have to be able to state before any
+ * of that arises.
+ */
+class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
+
+    /** The number is stated where the elements agree on it. */
+    @Test
+    void elementsThatAgreeOnTheNumberStateIt() {
+        assertEquals("n cut 100000", cut("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 100000 } ]
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /** And no number is stated where they do not. */
+    @Test
+    void elementsThatDisagreeStateNoNumber() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * An arm narrows the set the number is taken over.
+     *
+     * <p>The shape a model reaches this by. What the arm settles is which members are still standing
+     * where the rule is written, and the number comes from those and not from the arm.
+     */
+    @Test
+    void anArmLeavesTheNumberToWhatItStillAdmits() {
+        assertEquals("n cut 100000", cut("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, Whatever ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And an arm admitting a case two elements are of states no number where they differ.
+     *
+     * <p>The claim an arm looks as though it makes. A list written with two members of one case
+     * satisfies the arm at either of them with a different number underneath, so what the arm leaves
+     * is both — and two numbers are no number.
+     */
+    @Test
+    void anArmAdmittingBothOfThemStatesNeitherNumber() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, AtMost { threshold = 200000 } ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /** And states it where they do not differ, however many of them there are. */
+    @Test
+    void anArmAdmittingBothOfThemStatesTheNumberTheyShare() {
+        assertEquals("n cut 100000", cut("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, AtMost { threshold = 100000 } ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * A container an operation built states nothing, whatever went into it.
+     *
+     * <p>Both halves are written out here and each holds one number. What the operation answers is
+     * the elements of both, and a reading that wrote out either would be stating of every element
+     * what half of them satisfy.
+     */
+    @Test
+    void aContainerAnOperationBuiltStatesNoNumber() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = List.append([ Big { threshold = 100000 } ],
+                                             [ Big { threshold = 100000 } ])
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * One member this cannot read takes the answer away from the members it can.
+     *
+     * <p>The number the readable member states is the one the answer would be, which is what makes
+     * this worth writing out: what is being asked is what every value standing there supports, and a
+     * member with nothing read off it supports nothing — so the agreement is not there to be had,
+     * however plainly the rest of the list agrees.
+     */
+    @Test
+    void oneMemberWithNothingReadOffItStatesNoNumberForAnyOfThem() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ Big { threshold = 100000 }
+                                 , if n > 0 then Big { threshold = 100000 }
+                                   else Big { threshold = 100000 } ]
+                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * A choice between two constructions still states nothing, even between two alike.
+     *
+     * <p>Which is the boundary as it was. The reading names no values for what stands at a choice,
+     * so there is no set here for the numbers to be taken over — and it is that absence rather than
+     * a rule about choices, so nothing here has to be kept in step with what a container states.
+     */
+    @Test
+    void aChoiceBetweenTwoConstructionsStatesNoNumber() {
+        assertEquals("stopped", cut("""
+                {
+                        let k = if n > 0 then Big { threshold = 100000 }
+                                else Big { threshold = 100000 }
+                        if n >= k.threshold then Yes else No
+                    }"""));
+    }
+
+    /** The number a comparison cuts, or that the reading stopped. The last comparison of the body,
+     *  which is the one these fixtures are about. */
+    private static String cut(String body) {
+        String source = """
+                module g
+
+                data Big = { threshold: Int }
+                data Yes
+                data No
+
+                data AtMost = { threshold: Int }
+                data Whatever
+                data Reason = AtMost | Whatever
+
+                let reaches (n: Int, reason: Reason): Bool =
+                    match reason with
+                        | AtMost { threshold } -> n >= threshold
+                        | Whatever             -> false
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body);
+
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(java.util.List.of(), compilation.errors().stream()
+                .map(each -> each.diagnostic().code() + " "
+                        + each.diagnostic().primary()).toList(),
+                "the model under test compiles");
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        ComparisonReadings.Reading against = ComparisonReadings.of(
+                        checked.behaviorBodies().get("classify"),
+                        CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                                checked.supplied()),
+                        InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
+                                .get("classify"), checked.elementBindings().get("classify")),
+                        symbols)
+                .all().stream().reduce((first, last) -> last).orElseThrow();
+
+        return switch (AffineReading.read(against.comparison(), against.reads(), symbols)) {
+            case AffineReading.OfAComparison.Stopped _ -> "stopped";
+            case AffineReading.OfAComparison.CutsNothing _ -> "cuts nothing";
+            case AffineReading.OfAComparison.Cuts cuts -> said(cuts);
+        };
+    }
+
+    /** The quantity and where it is cut, in the order the positions are named in. */
+    private static String said(AffineReading.OfAComparison.Cuts cuts) {
+        Map<String, BigDecimal> over = new LinkedHashMap<>();
+        AffineReading.ordered(cuts.read().form())
+                .forEach(each -> over.put(each.getKey().toString(), each.getValue()));
+        return over.entrySet().stream()
+                .map(each -> each.getValue().compareTo(BigDecimal.ONE) == 0 ? each.getKey()
+                        : each.getValue() + "*" + each.getKey())
+                .reduce((a, b) -> a + " + " + b).orElseThrow()
+                + " cut " + cuts.read().cut().stripTrailingZeros().toPlainString();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest.java
@@ -1,13 +1,6 @@
 package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
-import souther.compiler.check.Symbols;
-import souther.compiler.coverage.CoverageSites;
-import souther.compiler.inputs.InputReads;
-import souther.compiler.query.Adequacy;
-import souther.compiler.query.Bodies;
-import souther.compiler.query.Compilation;
-import souther.compiler.query.Scopes;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -47,6 +40,33 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
                 {
                         let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
                         if List.any((k) -> n >= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And the member need not be taken apart to be read.
+     *
+     * <p>Beside the two above and reaching the agreement by the other way in. There a projection out
+     * of the name is what the members answer for; here the name is the number, and what a rule
+     * compares against is what the members are. A reading that only agreed under an elimination
+     * would have this one back as a rule about nothing.
+     */
+    @Test
+    void membersThatAreTheNumberStateItToo() {
+        assertEquals("n cut 100000", cut("""
+                {
+                        let ks = [ 100000, 100000 ]
+                        if List.any((k) -> n >= k, ks) then Yes else No
+                    }"""));
+    }
+
+    /** And state none where they differ, by the same rule. */
+    @Test
+    void membersThatAreTwoNumbersStateNeither() {
+        assertEquals("stopped", cut("""
+                {
+                        let ks = [ 100000, 200000 ]
+                        if List.any((k) -> n >= k, ks) then Yes else No
                     }"""));
     }
 
@@ -121,7 +141,7 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
         assertEquals("stopped", cut("""
                 {
                         let ks = [ Big { threshold = 100000 }
-                                 , if n > 0 then Big { threshold = 100000 }
+                                 , if c then Big { threshold = 100000 }
                                    else Big { threshold = 100000 } ]
                         if List.any((k) -> n >= k.threshold, ks) then Yes else No
                     }"""));
@@ -161,14 +181,19 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
     void aChoiceBetweenTwoConstructionsStatesNoNumber() {
         assertEquals("stopped", cut("""
                 {
-                        let k = if n > 0 then Big { threshold = 100000 }
+                        let k = if c then Big { threshold = 100000 }
                                 else Big { threshold = 100000 }
                         if n >= k.threshold then Yes else No
                     }"""));
     }
 
-    /** The number a comparison cuts, or that the reading stopped. The last comparison of the body,
-     *  which is the one these fixtures are about. */
+    /**
+     * The number the body's comparison cuts, or that the reading stopped.
+     *
+     * <p>Each of these bodies writes one comparison, which is why the choice they are told apart by
+     * is made on a parameter rather than on a number: a second comparison would leave this picking
+     * one of them by where it stands, after which a fixture could be about a rule nobody meant.
+     */
     private static String cut(String body) {
         String source = """
                 module g
@@ -187,32 +212,16 @@ class ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest {
                         | AtMost { threshold } -> n >= threshold
                         | Whatever             -> false
 
-                behavior classify : (n: Int) -> Yes | No
-                let classify (n) = %s
+                behavior classify : (n: Int, c: Bool) -> Yes | No
+                let classify (n, c) = %s
 
                 example classify
-                    | "one" : (1) -> No
+                    | "one" : (1, true) -> No
                 """.formatted(body);
 
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
-        assertEquals(java.util.List.of(), compilation.errors().stream()
-                .map(each -> each.diagnostic().code() + " "
-                        + each.diagnostic().primary()).toList(),
-                "the model under test compiles");
-        String module = compilation.modules().get(0);
-        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
-        Symbols symbols = Scopes.derived(compilation.db(), module).value();
-        ComparisonReadings.Reading against = ComparisonReadings.of(
-                        checked.behaviorBodies().get("classify"),
-                        CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
-                                checked.supplied()),
-                        InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
-                                .get("classify"), checked.elementBindings().get("classify")),
-                        symbols)
-                .all().stream().reduce((first, last) -> last).orElseThrow();
-
-        return switch (AffineReading.read(against.comparison(), against.reads(), symbols)) {
+        ReadComparisons read = ReadComparisons.of(source, "classify");
+        ComparisonReadings.Reading against = read.only();
+        return switch (AffineReading.read(against.comparison(), against.reads(), read.symbols())) {
             case AffineReading.OfAComparison.Stopped _ -> "stopped";
             case AffineReading.OfAComparison.CutsNothing _ -> "cuts nothing";
             case AffineReading.OfAComparison.Cuts cuts -> said(cuts);

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
@@ -1,0 +1,128 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.OwedBoundaryPoint;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A rule written inside a step a combinator applies per element is a line, with the points a row has
+ * to meet it at.
+ *
+ * <p>How many times a run passes a comparison used to settle this, and what it settles now is the
+ * arithmetic. A line is over positions of the input and nothing else, so a run through a comparison
+ * that bears one reads what the row holds however many times it passes: at one occurrence of a
+ * position where the passes stand at different occurrences of one, and at the same values where they
+ * do not.
+ *
+ * <p>Which is why the first of these is here. Nothing about an element enters its rule at all, and
+ * it was refused for standing where an element's rule stands — so it is the case that says what the
+ * refusal was costing, with none of the reading of elements in it.
+ */
+class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
+
+    /**
+     * The line and the four points a row is owed at it.
+     *
+     * <p>The rule is {@code n >= 100000} over an {@code Int}, so a row stands on the line at a
+     * hundred thousand, off it at the value next to that one, and inside and outside it anywhere
+     * past each of those.
+     */
+    private static final String AT_A_HUNDRED_THOUSAND =
+            "[n/x < 100000, n/100000 <= x] unread [] points ["
+                    + "classify/n ON 100000, classify/n OFF 99999, "
+                    + "classify/n IN 100000 < n, classify/n OUT n < 99999]";
+
+    /** A rule no element enters, written inside a step applied per element of a written list. */
+    @Test
+    void aRuleNoElementEntersIsALine() {
+        assertEquals(AT_A_HUNDRED_THOUSAND, reading("""
+                {
+                        let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
+                        if List.any((k) -> n >= 100000, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And so is a rule that compares against a number every element of the list states.
+     *
+     * <p>The shape a model reaches this by, and the whole of what it takes: the arm leaves one
+     * member standing, that member writes a hundred thousand under the field, and the rule is a line
+     * there. The list holds a member of another case, which is what makes the arm do work.
+     */
+    @Test
+    void aRuleAgainstANumberEveryElementStatesIsTheSameLine() {
+        assertEquals(AT_A_HUNDRED_THOUSAND, reading("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, Whatever ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And a list whose members state two numbers is a rule with no line, as it was.
+     *
+     * <p>Beside the one above and differing in one number. What tells them apart is what the members
+     * state and not how many there are, which case they are, or what the arm admits.
+     */
+    @Test
+    void aRuleAgainstTwoNumbersIsNoLine() {
+        assertEquals("[] unread [n UNSUPPORTED_SYNTAX] points []", reading("""
+                {
+                        let ks = [ AtMost { threshold = 100000 }, AtMost { threshold = 200000 } ]
+                        if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /** The classes, what went unread, and the points a row is owed, of {@code classify}. */
+    private static String reading(String body) {
+        String source = """
+                module g
+
+                data Big = { threshold: Int }
+                data Yes
+                data No
+
+                data AtMost = { threshold: Int }
+                data Whatever
+                data Reason = AtMost | Whatever
+
+                let reaches (n: Int, reason: Reason): Bool =
+                    match reason with
+                        | AtMost { threshold } -> n >= threshold
+                        | Whatever             -> false
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> No
+                """.formatted(body);
+
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport.BehaviorReport read = AdequacyReport.of(compilation)
+                .modules().get(0).behaviors().stream()
+                .filter(each -> each.name().equals("classify")).findFirst().orElseThrow();
+        return "[" + read.partition().axes().stream()
+                .flatMap(axis -> axis.classes().stream())
+                .collect(Collectors.joining(", "))
+                + "] unread [" + read.partition().notRead().stream()
+                .map(each -> each.at() + " " + each.reason())
+                .collect(Collectors.joining(", "))
+                + "] points [" + read.partition().owedPoints().stream()
+                .map(ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest::said)
+                .collect(Collectors.joining(", ")) + "]";
+    }
+
+    /** One point a row is owed, as the position, which of the four it is, and the value. */
+    private static String said(OwedBoundaryPoint point) {
+        return point.axis() + " " + point.role() + " " + point.against();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
@@ -79,6 +79,63 @@ class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
                     }"""));
     }
 
+    /**
+     * The model this is about, written the way a model of this size writes it.
+     *
+     * <p>The candidates come back from a helper, one of them wraps its number in a value type, the
+     * arm that admits it is one of three, and the comparison is inside a second helper the first
+     * one calls. None of that is a case of its own: it is one reading through the names a model puts
+     * between a rule and the value it is written about, and a fixture with the names taken out would
+     * be testing a shape nobody writes.
+     *
+     * <p>Two lines come of it, and the second is why the first is not the whole claim. The arm that
+     * admits the candidate holding a value type states a hundred thousand, and the arm that admits
+     * the one holding a parameter states that parameter — so what a member contributes is whatever
+     * it wrote, and a reading that only ever answered with written numbers would pass the first and
+     * fail the second.
+     */
+    @Test
+    void aModelReachesItsThresholdThroughACandidateListAndAnArm() {
+        assertEquals("[予定費用/x < 100000, 予定費用/100000 <= x, 役職/x <= 3, 役職/3 < x] "
+                        + "unread [] points ["
+                        + "判定する/予定費用 ON 100000, 判定する/予定費用 OFF 99999, "
+                        + "判定する/予定費用 IN 100000 < 予定費用, 判定する/予定費用 OUT 予定費用 < 99999, "
+                        + "判定する/役職 ON 4, 判定する/役職 OFF 3, "
+                        + "判定する/役職 IN 4 < 役職, 判定する/役職 OUT 役職 < 3]",
+                readingOf("""
+                module g
+
+                data 金額 = Int
+                data 高額出張 = { 基準金額: 金額 }
+                data 権限不足 = { 役職: Int }
+                data 先方費用負担
+                data 事前承認理由 = 高額出張 | 権限不足 | 先方費用負担
+                data Yes
+                data No
+
+                let 事前承認理由の候補 (役職: Int): List<事前承認理由> =
+                    [ 高額出張 { 基準金額 = 金額(100000) }
+                    , 権限不足 { 役職 = 役職 }
+                    , 先方費用負担 ]
+
+                let 高額か (予定費用: Int, 基準金額: 金額): Bool = 予定費用 >= 基準金額.value
+
+                let 該当するか (予定費用: Int, 理由: 事前承認理由): Bool =
+                    match 理由 with
+                        | 高額出張 { 基準金額 } -> 高額か(予定費用, 基準金額)
+                        | 権限不足 { 役職 }     -> 役職 > 3
+                        | 先方費用負担          -> false
+
+                behavior 判定する : (予定費用: Int, 役職: Int) -> Yes | No
+                let 判定する (予定費用, 役職) =
+                    if List.any((理由) -> 該当するか(予定費用, 理由), 事前承認理由の候補(役職))
+                        then Yes else No
+
+                example 判定する
+                    | "one" : (1, 1) -> No
+                """, "判定する"));
+    }
+
     /** The classes, what went unread, and the points a row is owed, of {@code classify}. */
     private static String reading(String body) {
         String source = """
@@ -103,13 +160,21 @@ class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
                 example classify
                     | "one" : (1) -> No
                 """.formatted(body);
+        return readingOf(source, "classify");
+    }
 
+    /** The same, of whichever behavior {@code source} is about. */
+    private static String readingOf(String source, String behavior) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
+        assertEquals(java.util.List.of(), compilation.errors().stream()
+                .map(each -> each.diagnostic().code() + " "
+                        + each.diagnostic().primary()).toList(),
+                "the model under test compiles");
         AdequacyReport.BehaviorReport read = AdequacyReport.of(compilation)
                 .modules().get(0).behaviors().stream()
-                .filter(each -> each.name().equals("classify")).findFirst().orElseThrow();
+                .filter(each -> each.name().equals(behavior)).findFirst().orElseThrow();
         return "[" + read.partition().axes().stream()
                 .flatMap(axis -> axis.classes().stream())
                 .collect(Collectors.joining(", "))

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest.java
@@ -14,11 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * A rule written inside a step a combinator applies per element is a line, with the points a row has
  * to meet it at.
  *
- * <p>How many times a run passes a comparison used to settle this, and what it settles now is the
- * arithmetic. A line is over positions of the input and nothing else, so a run through a comparison
- * that bears one reads what the row holds however many times it passes: at one occurrence of a
- * position where the passes stand at different occurrences of one, and at the same values where they
- * do not.
+ * <p>How many times a run passes a comparison used to settle this, and what settles it now is the
+ * arithmetic. Every atom of a line is a term the row decides — a value at a position, a number taken
+ * of one, or a number taken over the occurrences of one path in a single run — so a run through a
+ * comparison that bears a line reads what the row holds however many times it passes: at one
+ * occurrence of a position where the passes stand at different occurrences of one, and at the same
+ * values where they do not.
  *
  * <p>Which is why the first of these is here. Nothing about an element enters its rule at all, and
  * it was refused for standing where an element's rule stands — so it is the case that says what the
@@ -61,6 +62,26 @@ class ARuleInsideAWalkOverAWrittenListIsALineWithPointsTest {
                 {
                         let ks = [ AtMost { threshold = 100000 }, Whatever ]
                         if List.any((k) -> reaches(n, k), ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And so is a rule whose members write one form two ways.
+     *
+     * <p>What the members agree on is the arithmetic's answer, and it is the only one asked. Two
+     * ways of writing one form are made of different things — a sum of a position with itself, and a
+     * position scaled — so a walk over the expressions disagrees about them where the arithmetic
+     * does not. Asked which positions the rule is about, that walk would answer none, and the rule
+     * would go out as one about no input at all: neither a line nor a rule anything fell short on.
+     */
+    @Test
+    void membersWritingOneFormTwoWaysAreStillTheSameLine() {
+        assertEquals("[n/x <= 49999, n/49999 < x] unread [] points ["
+                        + "classify/n ON 50000, classify/n OFF 49999, "
+                        + "classify/n IN 50000 < n, classify/n OUT n < 49999]", reading("""
+                {
+                        let ks = [ Big { threshold = n + n }, Big { threshold = 2 * n } ]
+                        if List.any((k) -> k.threshold >= 100000, ks) then Yes else No
                     }"""));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleIsNotReadWhereMoreThanOneValueCanStandTest.java
@@ -16,11 +16,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * model that says a hundred thousand or two hundred thousand — a rule about a value, reported as a
  * rule about the model.
  *
- * <p>Nothing here refuses anything. What holds these open is that the relation which follows a
- * value has no rule for a choice and none for an element: it takes an elimination against the
- * introduction written for it, and neither an arm nor a list element is one. So there is no list of
- * shapes to keep in step with the shapes that do read, and a construction that becomes readable
- * does not quietly make these readable with it.
+ * <p>Nothing here refuses anything. What holds these open is that the reading names no values for
+ * what stands at a choice: the relation which follows a value takes an elimination against the
+ * introduction written for it and a name the reading answers for, and an arm of a choice is
+ * neither. So there is no list of shapes to keep in step with the shapes that do read, and a
+ * construction that becomes readable does not quietly make these readable with it.
+ *
+ * <p>Which is a different boundary from the one a container has, and it is why an element of a
+ * written list is not here. That one is a name the reading can write out every value of, and what a
+ * rule over it comes to is what those values agree on
+ * ({@link ARuleAboutAnElementIsReadWhereTheyAllSupportOneFormTest}). A choice has no such answer
+ * and gets none from anywhere.
  *
  * <p>The helper is the stronger of the two alternatives. The name it was given is read through, so
  * the reading is inside the helper's body when it meets the choice — which is where a relation that
@@ -58,45 +64,6 @@ class ARuleIsNotReadWhereMoreThanOneValueCanStandTest {
         assertEquals(nothingButTheChoice, read);
     }
 
-    /**
-     * And an element of a written list answers for none of them either.
-     *
-     * <p>Its own claim beside the three above. A choice is written where the value stands and a
-     * list element is not: what names the element is a binding an operation handed it, and what
-     * holds this open is that such a name is not one the reading says stands for a single value.
-     * The two boundaries are kept by different answers and are stated apart.
-     */
-    @Test
-    void anElementOfAWrittenListAnswersForNoneOfThem() {
-        assertEquals("[] unread [n UNSUPPORTED_SYNTAX]", reading("""
-                {
-                        let ks = [ Big { threshold = 100000 }, Big { threshold = 200000 } ]
-                        if List.any((k) -> n >= k.threshold, ks) then Yes else No
-                    }"""));
-    }
-
-    /**
-     * And a case bound off one is still an element, however narrowly the arm names it.
-     *
-     * <p>An arm that admits one case looks as though it says which element is standing there, and
-     * it does not: a list may be written with two of the same case, and each of them would satisfy
-     * the arm with a different number under it. So the number a rule compares against is reached
-     * here through a name whose value the reading does not single out, and the arm is no part of
-     * whether it does.
-     *
-     * <p>This is the shape a model reaches it by, which is why it is written out rather than left
-     * to the two above. Narrowing an element to a case is where a reader would expect the value to
-     * become one, and it is exactly where nothing has said so.
-     */
-    @Test
-    void andACaseBoundOffAnElementIsStillOne() {
-        assertEquals("[] unread [n UNSUPPORTED_SYNTAX]", reading("""
-                {
-                        let ks = [ AtMost { threshold = 100000 }, Whatever ]
-                        if List.any((k) -> reaches(n, k), ks) then Yes else No
-                    }"""));
-    }
-
     private static String reading(String body) {
         return MeasuredBehavior.reading("""
                 module g
@@ -105,17 +72,8 @@ class ARuleIsNotReadWhereMoreThanOneValueCanStandTest {
                 data Yes
                 data No
 
-                data AtMost = { threshold: Int }
-                data Whatever
-                data Reason = AtMost | Whatever
-
                 let chooseBig (c: Bool) =
                     if c then Big { threshold = 100000 } else Big { threshold = 200000 }
-
-                let reaches (n: Int, reason: Reason): Bool =
-                    match reason with
-                        | AtMost { threshold } -> n >= threshold
-                        | Whatever             -> true
 
                 behavior classify : (n: Int) -> Yes | No
                 let classify (n) = %s

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleReadToTheEndSaysWhatItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleReadToTheEndSaysWhatItIsAboutTest.java
@@ -61,6 +61,20 @@ class ARuleReadToTheEndSaysWhatItIsAboutTest {
     }
 
     /**
+     * A number taken of a position is filed as that number and not as the position.
+     *
+     * <p>What the reading named is the length, and a rule about the length is not a rule about the
+     * string: two operations over one place are two rules, and a report that filed both at the place
+     * would have them as one. The reading reached the number, so the number is what it says — a
+     * coordinate that names only the place is for a reader that did not get that far.
+     */
+    @Test
+    void aNumberTakenOfAPositionIsFiledAsThatNumber() {
+        assertEquals("[] unread [String.length(s) RULE_CUTS_NOTHING]", reading(
+                "if String.length(s) - String.length(s) <= 0 then Yes else No"));
+    }
+
+    /**
      * A comparison of constants names nothing, and nothing is recorded.
      *
      * <p>The other side of the same rule. It is read from end to end and cuts nothing, and there is
@@ -80,11 +94,11 @@ class ARuleReadToTheEndSaysWhatItIsAboutTest {
                 data Yes
                 data No
 
-                behavior classify : (n: Int) -> Yes | No
-                let classify (n) = %s
+                behavior classify : (n: Int, s: String) -> Yes | No
+                let classify (n, s) = %s
 
                 example classify
-                    | "one" : (1) -> Yes
+                    | "one" : (1, "") -> Yes
                 """.formatted(body), "classify");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleReadToTheEndSaysWhatItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleReadToTheEndSaysWhatItIsAboutTest.java
@@ -1,0 +1,90 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comparison read from end to end says which positions it is about, and says it itself.
+ *
+ * <p>A rule whose quantity cancels is read in full and divides nothing: {@code a - a <= 0} holds of
+ * every row, and a report that stayed silent about it would leave the position looking like one the
+ * model states nothing at. What it is about is therefore said — and what it is about is what the
+ * reading named on the way, not what is left of the quantity, since what is left is nothing.
+ *
+ * <p>Which is why the walk over the operands is not asked. That walk is what a rule the reading could
+ * not finish is described by; asked about one the reading finished, it is a second account of the
+ * same thing and a stricter one — two values that are one form written two ways are made of
+ * different things — so a rule read in full would go out as one about no input at all, which is
+ * neither a line nor a shortfall.
+ */
+class ARuleReadToTheEndSaysWhatItIsAboutTest {
+
+    /** The rule is recorded at the position it names, and its quantity is empty. */
+    private static final String CUTS_NOTHING_AT_N = "[] unread [n RULE_CUTS_NOTHING]";
+
+    /** Members that write one form two ways cancel against each other and name the position. */
+    @Test
+    void membersWritingOneFormTwoWaysStillNameThePosition() {
+        assertEquals(CUTS_NOTHING_AT_N, reading("""
+                {
+                        let ks = [ Big { threshold = n + n }, Big { threshold = 2 * n } ]
+                        if List.any((k) -> k.threshold <= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * And so do members that write it one way.
+     *
+     * <p>Beside the one above and differing in nothing the model states. Two spellings of one form
+     * are one rule, and a reader that told them apart would be reporting how a list was written.
+     */
+    @Test
+    void membersWritingItOneWayNameTheSamePosition() {
+        assertEquals(CUTS_NOTHING_AT_N, reading("""
+                {
+                        let ks = [ Big { threshold = n + n }, Big { threshold = n + n } ]
+                        if List.any((k) -> k.threshold <= k.threshold, ks) then Yes else No
+                    }"""));
+    }
+
+    /**
+     * A quantity that cancels inside one side names its position too.
+     *
+     * <p>No plurality anywhere here, and it is what says the coordinates cannot come off the form
+     * the reading ended with: that form has no atom in it, and the rule is about {@code n} all the
+     * same.
+     */
+    @Test
+    void aQuantityCancellingInsideOneSideNamesItsPosition() {
+        assertEquals(CUTS_NOTHING_AT_N, reading("if n - n <= 0 then Yes else No"));
+    }
+
+    /**
+     * A comparison of constants names nothing, and nothing is recorded.
+     *
+     * <p>The other side of the same rule. It is read from end to end and cuts nothing, and there is
+     * no position for a sentence about one to be about — so what tells this from the three above is
+     * that the reading named no number, and not that its quantity is empty.
+     */
+    @Test
+    void aComparisonOfConstantsIsAboutNoPosition() {
+        assertEquals("[] unread []", reading("if 2 > 1 then Yes else No"));
+    }
+
+    private static String reading(String body) {
+        return MeasuredBehavior.reading("""
+                module g
+
+                data Big = { threshold: Int }
+                data Yes
+                data No
+
+                behavior classify : (n: Int) -> Yes | No
+                let classify (n) = %s
+
+                example classify
+                    | "one" : (1) -> Yes
+                """.formatted(body), "classify");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
@@ -1,0 +1,54 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The comparisons one behavior's body writes, read where each of them stands.
+ *
+ * <p>The mechanical part of getting there and nothing else: compile the caller's module, find the
+ * behavior, and walk it once. What a test claims about a comparison, and which declarations its
+ * claim needs, stay the test's — a fixture shared between claims grows the declarations of each of
+ * them, after which what a test compiles is no longer what it is about.
+ *
+ * <p>The source is asserted to compile here, because a model that does not is a test that measured
+ * nothing and every claim below would be about an empty list.
+ */
+record ReadComparisons(List<ComparisonReadings.Reading> comparisons, Symbols symbols) {
+
+    static ReadComparisons of(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.errors().stream()
+                        .map(each -> each.diagnostic().code() + " "
+                                + each.diagnostic().primary()).toList(),
+                "the model under test compiles");
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        return new ReadComparisons(ComparisonReadings.of(
+                checked.behaviorBodies().get(behavior),
+                CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                        checked.supplied()),
+                InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
+                        .get(behavior), checked.elementBindings().get(behavior)),
+                symbols).all(), symbols);
+    }
+
+    /** The one comparison the body writes. A body writing two would leave a caller picking one of
+     *  them by where it stands, after which a fixture could be about a rule nobody meant. */
+    ComparisonReadings.Reading only() {
+        assertEquals(1, comparisons.size(), () -> "the body under test writes one comparison: "
+                + comparisons.stream().map(each -> each.comparison().pos().toString()).toList());
+        return comparisons.get(0);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
@@ -19,17 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * A comparison that bears no line says which of the reasons it is.
  *
  * <p>They are not one answer. A truth nothing reads is one the behavior draws no boundary on at all,
- * and a report that stayed silent about it is right. A comparison one run passes more than once is
- * one the behavior may well draw a boundary on and this cannot show a row to have met: a recording
- * holds that a place was passed and not how many times, so two outcomes of one comparison in one run
- * cannot be told from two rows' outcomes. Folded into one {@code false}, the second becomes silence
- * that reads like the first.
+ * and a report that stayed silent about it is right. A comparison no run through can be recorded is
+ * one the behavior may well draw a boundary on and this cannot show a row to have met. Folded into
+ * one {@code false}, the second becomes silence that reads like the first.
  *
- * <p>What tells the passes apart is a position for what is passed. A step applied once per element
- * of a container the input walk names is passed once per element of that container, and the row's
- * own values there say which pass came out which way — so that one is a line, and it is the same
- * comparison, written the same way, as the one below it whose container the walk names nothing at.
- * The two stand together here because the difference between them is the whole of the reason.
+ * <p>What a comparison is written inside is no part of this. A step a combinator applies once per
+ * element is passed as many times as there are elements, and the two written here stand together to
+ * say that the policy admits both: what each of them comes to is settled by the arithmetic, over
+ * the container the input walk names and over the one written in the body alike.
  */
 class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
 
@@ -106,12 +103,19 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
     }
 
     /**
-     * The same comparison over a container the input walk names nothing at is a boundary nothing can
-     * measure a row against.
+     * The same comparison over a container the input walk names nothing at is a boundary all the
+     * same, and what it comes to is the reading's answer.
+     *
+     * <p>How many times a run passes it is not one of these reasons. A comparison this admits bears
+     * a line where the arithmetic reads one, and a reading comes to a line over positions of the
+     * input and nothing else — so every pass of a comparison that bears one reads what the row
+     * holds. This one is read over the elements of a list written {@code [1, 2, 3]}, which state
+     * three different numbers and therefore state none; that is said where a rule that could not be
+     * read is said, and not here.
      */
     @Test
-    void aTruthOneRunReachesMoreThanOnceIsOneNothingCanMeasure() {
-        assertEquals(NotABoundary.REPEATED_IN_ONE_RUN, whyOf(standingAt(11)));
+    void aTruthOneRunReachesMoreThanOnceIsStillOneThisPolicyAdmits() {
+        assertEquals(BoundaryPolicy.Standing.DrawsALine.class, standingAt(11).getClass());
     }
 
     private static NotABoundary whyOf(BoundaryPolicy.Standing standing) {


### PR DESCRIPTION
Closes #1170.

A rule comparing against a number reached through an element of a list the model
writes out was reported as written in a form this compiler does not read.
`businesstrip` reaches its threshold that way.

Two things were holding it, and the issue names one.

## What a name standing for several values means

The reading of a body's names gave a name four answers, and the one for an
element said only that there were several. A list written in the source and a
container an operation built came back alike, so a reader could state nothing
about either.

`ReadMeaning.OneOf` writes the values out where they were all written, and
`Element` stays for where they were not. Exhaustive is the contract: the
container is followed only through the steps with one successor — a name this
environment bound, and the body of a binding — until a written list is standing
there, and anything else answers the plurality without its members. A list
written empty answers no plurality, since a statement about every member of
nothing is one nothing has to satisfy.

The pair of a value and the environment to read it in becomes `Denotation`.
`Through` held one already; a plurality that dropped the environment would be
the pairing holding for one value and not for several.

A `match` arm narrows the set — and only that. A container with two members of
the case an arm admits leaves two, and the arm has told them apart in no way.
What would make the name one value is there being one member left.

## What a rule over such a position comes to

The relation that resolves an occurrence now answers with every value the
reading names, and the eliminations distribute over it: a projection out of a
name standing for several is that projection out of each of them. The
arithmetic keeps the form they agree on, or nothing.

Agreement is equality of the form and not an order to descend. Two forms have
plenty in common and none of it is what the model states. It is compared on the
numbers, since a scale is not a second form — the rule the check that reads
recipes already used, moved to the walk that reads forms.

One member with nothing read off it takes the answer away from the members that
have one.

A choice is unchanged. The reading names no values for what stands at one.

## The second gate

A comparison a run may pass more than once was refused before its arithmetic was
consulted, unless the step that repeats it was applied to the elements of a
container the input walk names a position at. Measured before any of this: a
rule no element enters at all — `n >= 100000` inside a step applied per element
of a list the body wrote — read to the end, cut one position, and was reported
as written in a form this compiler does not read.

The reading already settles what that refusal was for, and settles it for every
comparison rather than for the ones written in one construct. Every atom of a
form is a term the row decides — a value at a position, a number taken of one, or
a number taken over the occurrences of one path in a single run — and finite
uncertainty enters a form only where every value of it was written out and came
to the same form. So a run through a comparison that bears a line reads what the
row holds: at one occurrence of a position where the passes stand at different
occurrences of one, and at the same values where they do not.

So `NotABoundary.REPEATED_IN_ONE_RUN` goes, with the fact the walk carried down
for it. Adding a second way past the refusal was the other way to do this, and it
would have put the proof in two places to be kept in step. Neither reason was
ever reported: the words a document promises are the reading's.

## The walk that names positions

Found by writing the integration acceptance. A model reaching its threshold
through a candidate list has two rules in it, and the second compares against a
parameter a member wrote. Its line was drawn and the position it divides was
named nowhere, so the rule was filed at no position and the position was reported
as one the model divides no way at all — a worse answer than the one before this
work.

The plurality is one answer with two readers. `ValueOrigin` reads it under the
same discipline: a name standing for several is made of what all of them are made
of, and of nothing where they are made of different things. The question is on
the interface both walks ask, so a reader that meets a plurality answers it or
does not compile.

## Found in review

The assessment of a comparison asked which positions a rule is about of the walk
over its expressions, before reading the arithmetic. That walk exists to say what
a rule is about where no line was read; in front of the reading it can only veto
it, and it did — two members writing one form two ways (`n + n` and `2 * n`)
agree as arithmetic and are made of different things, so the rule came back as
one about no input at all: neither a line nor a rule anything fell short on. The
reading answers first now, and the walk is asked where the reading stopped.

And the members of a plurality were read with the reading the walk already had,
so a member that is itself a plural name expanded again. It is a rule now,
carried by the members, so it holds over the parts of a member too.

## What this does not do

`Core.If`, a general reading of choices, the enumeration of a container an
operation built, and the reason `noticed` gives for a comparison it read to the
end (#1172). The last was reachable through the repeat refusal and reached the
report; removing that reason took the witness away and left the derivation, which
is why it is filed rather than fixed here.

## Measured

Nine cases at the arithmetic, four at the report, seven on what a name stands
for. Told apart by what the members state and not by how many there are or which
cases they are: two members of one case stating one number read, the same two
stating two numbers not.

Eight mutations, each killing the tests it should and no others — the arm's
filter both ways, the empty-list guard, `commonForm` taking the first member,
either walk blind to a plurality, a member skipped rather than refused, and the
repeat refusal put back.

Cost: 17ms at two members to 24ms at 128. A plurality standing inside a
plurality is refused by a rule, which is what bounds it — the members of one are
read with a reading that has no plurality in it.

An earlier revision of this text claimed the nesting was already not read and
that the cost was flat with depth. Both were wrong: the shape measured was a
container held by a member, which stops for an unrelated reason, and `[k, k]`
was read and exponential. On the pathological shape that remains — nested
`List.any` over `[j, j]` at every level — the compiler is exponential on
`develop` too (260ms, 960ms, 3987ms at depths 12, 14, 16), and this branch adds a
constant factor of about three on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


