### PR TITLE
Take develop to the snapshot after the release

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,9 @@
 # Releasing
 
-develop never carries a release version. It is `0.1.0-SNAPSHOT` from one release to the next, and
-the number a release is cut at is set on `main`. That is what keeps a release to one pull request:
-bumping develop to the release version and taking it back off afterwards were two more, and both
-existed only because develop had been made to claim a number it was not.
+develop never carries a release version. It carries the snapshot of the version after the last one
+released, and the number a release is cut at is set on `main`. That is what keeps a release to one
+pull request: bumping develop to the release version and taking it back off afterwards were two
+more, and both existed only because develop had been made to claim a number it was not.
 
 ## Cutting one
 
@@ -51,7 +51,16 @@ existed only because develop had been made to claim a number it was not.
    souther-lsp and souther-bench do not: the really-executable jar and the language server are
    distributed through GitHub Releases, and the benchmarks are not an artifact anyone depends on.
 
-Nothing goes back to develop afterwards. It is on the snapshot already.
+6. Move develop to the next snapshot:
+
+   ```sh
+   git switch develop && git pull
+   bin/set-version.sh <next version>-SNAPSHOT
+   ```
+
+   on a branch of its own, as any other change to develop is. Nothing of the release goes back —
+   what this carries is that the version just released is behind develop rather than ahead of it.
+   `souther-lang/examples` names the snapshot, so it moves with this.
 
 ## The examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.souther-lang</groupId>
     <artifactId>souther-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Souther</name>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-bench</artifactId>

--- a/souther-build-driver/pom.xml
+++ b/souther-build-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-build-driver</artifactId>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-cli</artifactId>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-compiler</artifactId>

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-fmt</artifactId>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-lsp</artifactId>

--- a/souther-program-api-test/pom.xml
+++ b/souther-program-api-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-program-api-test</artifactId>

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-runtime</artifactId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-syntax</artifactId>

--- a/souther-test-support/pom.xml
+++ b/souther-test-support/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-test-support</artifactId>


### PR DESCRIPTION
`0.1.0` is released, so `0.1.0-SNAPSHOT` on develop names a version behind develop rather than ahead of it. The reactor moves to `0.1.1-SNAPSHOT`.

`docs/releasing.md` moves with it: develop still carries a snapshot and still never carries a release version, and moving that snapshot is now written down as the last step of cutting a release. `souther-lang/examples` names the snapshot, so it moves too — that is called out in the same place.

`mvn -o -B verify` green: 11013 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)