### PR TITLE
Take the snapshot bump off the pull request path

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,16 +51,22 @@ more, and both existed only because develop had been made to claim a number it w
    souther-lsp and souther-bench do not: the really-executable jar and the language server are
    distributed through GitHub Releases, and the benchmarks are not an artifact anyone depends on.
 
-6. Move develop to the next snapshot:
+6. Move develop to the next snapshot, committed to develop and pushed:
 
    ```sh
    git switch develop && git pull
    bin/set-version.sh <next version>-SNAPSHOT
+   git commit -am "Take develop to the snapshot after the release"
+   git push
    ```
 
-   on a branch of its own, as any other change to develop is. Nothing of the release goes back —
-   what this carries is that the version just released is behind develop rather than ahead of it.
-   `souther-lang/examples` names the snapshot, so it moves with this.
+   No pull request. The whole of it is what `set-version.sh` wrote, there is nothing in it to
+   review, and it is the tail of a release rather than work anyone is proposing. This is the one
+   change to develop that goes straight there; anything carrying a decision still opens one.
+
+   Nothing of the release goes back — what this carries is that the version just released is behind
+   develop rather than ahead of it. `souther-lang/examples` names the snapshot, so it moves with
+   this.
 
 ## The examples
 


### PR DESCRIPTION
The snapshot bump after a release is eleven version elements written by `bin/set-version.sh` and nothing else. `docs/releasing.md` had it opening a pull request like any other change to develop; there is nothing in it to review, and the number was decided by cutting the release.

Step 6 now commits to develop and pushes. Written as the one exception, so it does not read as a general loosening: a change to develop that carries a decision still opens a pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)