### PR TITLE
Read a comparison once and carry what it came to with its standing

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1737,9 +1737,14 @@ public final class InvariantChecker {
         for (FactSubject atom : whole.coefs().keySet()) {
             over.add(byName.get(atom).path());
         }
-        return over.isEmpty()
-                ? new Arithmetic(new UnreadComparison.Quantity.CutsNothing<>(), whole.constant())
-                : new Arithmetic(new UnreadComparison.Quantity.Over<>(over), null);
+        if (over.isEmpty()) {
+            return new Arithmetic(new UnreadComparison.Quantity.CutsNothing<>(), whole.constant());
+        }
+        if (over.size() == 1) {
+            return new Arithmetic(new UnreadComparison.Quantity.OverOne<>(over.iterator().next()),
+                    null);
+        }
+        return new Arithmetic(new UnreadComparison.Quantity.OverSeveral<>(over), null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -48,16 +48,43 @@ public final class UnreadComparison {
      */
     public sealed interface Quantity<K> {
 
-        /** The positions the quantity this comparison cuts is over. */
-        record Over<K>(Set<K> positions) implements Quantity<K> {
+        /**
+         * The quantity this comparison cuts is over several positions, so it divides none of them.
+         *
+         * <p>Several and not one, by the type. A form over one position is a line on that
+         * position as far as the arithmetic goes, and what a caller could make of it is a
+         * different question with a different answer ({@link OverOne}) — counted as one of these
+         * by the size of a set, the two were told apart by whoever held the set.
+         */
+        record OverSeveral<K>(Set<K> positions) implements Quantity<K> {
 
-            public Over {
+            public OverSeveral {
                 positions = java.util.Collections.unmodifiableSet(new LinkedHashSet<>(positions));
-                if (positions.isEmpty()) {
-                    // A quantity over no position is what {@link CutsNothing} says, and saying it
-                    // twice lets a reader answer one of them for the other.
+                if (positions.size() < 2) {
+                    // A quantity over no position is what {@link CutsNothing} says and one over a
+                    // single position is {@link OverOne}; saying either here lets a reader answer
+                    // one of them for the other.
                     throw new IllegalArgumentException(
-                            "a quantity is over something; nothing cut is CutsNothing");
+                            "a quantity over several positions is over at least two");
+                }
+            }
+        }
+
+        /**
+         * The quantity this comparison cuts is over one position: the arithmetic read a line on it.
+         *
+         * <p>A caller holding one of these and still asking what would have to change is one whose
+         * own reading of the line placed none — a reader of ends that takes a coordinate against
+         * a written constant, handed {@code x + 1 <= 10}. That reading stopped, on a form the
+         * arithmetic reads, and what it stopped on is the position and its carrier: nothing about
+         * how the sides were spelled adds to that, and asked of the sides this answered about a
+         * shape the arithmetic had already got past.
+         */
+        record OverOne<K>(K position) implements Quantity<K> {
+
+            public OverOne {
+                if (position == null) {
+                    throw new IllegalArgumentException("a quantity over one position names it");
                 }
             }
         }
@@ -122,11 +149,13 @@ public final class UnreadComparison {
      * the same division of labour {@link ValueOrigin} already has. Where the arithmetic reads
      * nothing there is no quantity to count, and the sides answer: {@code a > b} over strings
      * relates two positions on an order with no numbers, and {@code a * b > 5} names two and is
-     * stopped by neither of them.
+     * stopped by neither of them. Where it reads a line on one position, that position answers,
+     * and the sides are not consulted at all: a spelling can only disagree with a form that was
+     * read, and a reader that consulted it answered about a shape the arithmetic had got past.
      *
      * @param ordered whether a line can be drawn on what a position carries, asked of the carrier.
      *                Asked of the reader because a position is looked up there, and asked at all
-     *                only about a side that is one
+     *                only about a position the quantity is over or a side that is one
      */
     public static <K> BlockReason.RuleWithoutLineReason why(ValueOrigin<K> left, ValueOrigin<K> right,
                                                  Quantity<K> quantity, Predicate<K> ordered) {
@@ -140,12 +169,14 @@ public final class UnreadComparison {
             // Read to the end and there is no quantity. Nothing about how it was written adds to
             // that: no reading fell short, so no question about what could not be read arises.
             case Quantity.CutsNothing<K> _ -> new BlockReason.ComparisonCuttingNothing();
-            // Over one position, that one is what the rule divides however many the spelling
-            // mentions: `a + b > b` cuts `a`, and counted off the sides it was a relation the model
-            // does not state.
-            case Quantity.Over<K> over -> over.positions().size() > 1
-                    ? new BlockReason.ComparisonBetweenPositions()
-                    : whatThisSideSays(speakingSide(left, right), ordered);
+            case Quantity.OverSeveral<K> _ -> new BlockReason.ComparisonBetweenPositions();
+            // A line on one position that the caller's own reading placed nowhere: that reading
+            // stopped, and what it stopped on is the position. The carrier says which limit — a
+            // position nothing draws a line on wants the carrier, and one lines are drawn on all
+            // through the file wants a reader of the form.
+            case Quantity.OverOne<K> one -> ordered.test(one.position())
+                    ? new BlockReason.UnreadComparisonForm()
+                    : new BlockReason.UnreadComparisonDomain();
             // No quantity was read, so what the sides name is the only account there is.
             case Quantity.NotRead<K> notRead -> whatStopped(left, right, notRead, ordered);
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -147,20 +147,27 @@ public final class UnreadComparison {
                     ? new BlockReason.ComparisonBetweenPositions()
                     : whatThisSideSays(speakingSide(left, right), ordered);
             // No quantity was read, so what the sides name is the only account there is.
-            case Quantity.NotRead<K> notRead -> whatTheSidesSay(left, right, notRead, ordered);
+            case Quantity.NotRead<K> notRead -> whatStopped(left, right, notRead, ordered);
         };
     }
 
     /**
-     * What a comparison whose arithmetic went unread comes to, off what its sides name.
+     * What stopped a reading whose arithmetic read no form, off what its sides name.
      *
-     * <p>Only here. Where the canonical form was read it has already said what the rule cuts, and a
-     * spelling saying otherwise is the spelling being wrong about the rule.
+     * <p>The one arm of {@link #why} a caller holding a stopped reading may ask for on its own, and
+     * typed as a stop: every answer here is one, because the arithmetic stopped and what the sides
+     * name only says which limit it stopped on. A caller that has met a stop and wants the words
+     * for it asks this, and cannot be handed the words for a rule read to the end — those are
+     * answers about a quantity, and this is never given one.
+     *
+     * <p>Only here is the spelling consulted. Where the canonical form was read it has already said
+     * what the rule cuts, and a spelling saying otherwise is the spelling being wrong about the
+     * rule.
      */
-    private static <K> BlockReason.RuleWithoutLineReason whatTheSidesSay(ValueOrigin<K> left,
-                                                              ValueOrigin<K> right,
-                                                              Quantity.NotRead<K> notRead,
-                                                              Predicate<K> ordered) {
+    public static <K> BlockReason.RuleReadingStopped whatStopped(ValueOrigin<K> left,
+                                                               ValueOrigin<K> right,
+                                                               Quantity.NotRead<K> notRead,
+                                                               Predicate<K> ordered) {
         // What the sides name says nothing about whether anything fell short, and here something
         // did: the arithmetic stopped. A comparison naming two positions whose form was read is a
         // rule that relates them and leaves nothing missing, and one whose form was not read is a
@@ -200,9 +207,10 @@ public final class UnreadComparison {
         return left.madeFrom() != null ? left : right;
     }
 
-    /** What one side leaves to say. */
-    private static <K> BlockReason.RuleWithoutLineReason whatThisSideSays(ValueOrigin<K> side,
-                                                               Predicate<K> ordered) {
+    /** What one side leaves to say, which is always a stop: a side is asked only where no quantity
+     *  answered for the rule. */
+    private static <K> BlockReason.RuleReadingStopped whatThisSideSays(ValueOrigin<K> side,
+                                                             Predicate<K> ordered) {
         return switch (side) {
             // The position itself against something no end came out of. The carrier, asked of the
             // carrier: `at < DateTime(...)` stops because nothing draws a line on a date-time,

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
@@ -43,29 +43,48 @@ import souther.compiler.coverage.CoverageSites;
  */
 final class BoundaryPolicy {
 
-    /** What this policy says about one comparison of the body. */
+    /**
+     * What this policy says about one comparison of the body, and what the comparison came to
+     * where the policy admits it.
+     *
+     * <p>One answer per comparison. Whether a line may be drawn on it is this policy's question and
+     * what the line is, or why there is none, is the reading's ({@link ComparisonAssessment}) — and
+     * the second is asked only of a comparison the first admits, so a reason for bearing no line is
+     * never worked out from a reading that was never made. A comparison this refuses is not a rule
+     * with no line here: no row reaches its outcome, so it states nothing about any row, and a
+     * report saying nothing of it is right. Nor could it be said in the reading's words: what
+     * refuses it is where it stands, and the arithmetic has no answer to that.
+     */
     sealed interface Standing {
 
         /** The comparison this is about, whichever answer it got. */
         Core.Binary comparison();
 
-        /** A line is drawn on it. */
-        record DrawsALine(Core.Binary comparison) implements Standing {}
+        /** A line may be drawn on it, and {@code read} is what the one reading of it came to. */
+        record Admitted(Core.Binary comparison, ComparisonAssessment read) implements Standing {
 
-        /** No line is drawn on it, and this is which of the reasons it is. */
-        record DrawsNone(Core.Binary comparison, NotABoundary why) implements Standing {}
+            public Admitted {
+                if (read == null) {
+                    throw new IllegalArgumentException("a comparison this admits has been read");
+                }
+            }
+        }
+
+        /** No line may be drawn on it, and this is which of the reasons it is. */
+        record Refused(Core.Binary comparison, NotABoundary why) implements Standing {}
     }
 
     /**
-     * What {@code comparison}'s standing is, where it stands.
+     * Whether a line may be drawn on {@code comparison} where it stands, or why not.
      *
      * <p>The reason about the model is said first. A comparison the behavior's answer does not turn
      * on is not a boundary whichever way it could have been measured, and a reader told instead that
      * its outcome cannot be attributed to a row would go looking for a way to attribute it.
      *
-     * <p>Where the comparison stands and what its names point at are not arguments to this. A
-     * decision that took the reading only to hand it back was a second place holding it, and the
-     * walk that has it is {@link ComparisonReadings}.
+     * <p>Where the comparison stands and what its names point at are not arguments to this, and
+     * neither is the reading of the comparison. A decision that took the reading only to hand it
+     * back was a second place holding it, and the walk that has it is {@link ComparisonReadings},
+     * which reads what this admits.
      *
      * <p><b>How many times a run passes the comparison is not asked.</b> A recording holds that a
      * place was passed and not how many times, so two outcomes of one comparison in one run would
@@ -83,20 +102,22 @@ final class BoundaryPolicy {
      * occurrence of a position where the passes stand at different occurrences of one, and at the
      * same values where they do not — and a pass reading anything else is one no line came of.
      *
-     * @param live whether what is computed at this position is read on the way to what the behavior
-     *             answers with, which is {@link LiveFlow}'s answer carried down the walk
+     * @param live    whether what is computed at this position is read on the way to what the
+     *                behavior answers with, which is {@link LiveFlow}'s answer carried down the walk
+     * @param reading the one reading of the comparison, made only where it is admitted
      */
-    static Standing standingOf(Core.Binary comparison, CoverageSites.Plan plan, boolean live) {
+    static Standing standingOf(Core.Binary comparison, CoverageSites.Plan plan, boolean live,
+                               java.util.function.Supplier<ComparisonAssessment> reading) {
         if (!live) {
-            return new Standing.DrawsNone(comparison, NotABoundary.NOTHING_READS_IT);
+            return new Standing.Refused(comparison, NotABoundary.NOTHING_READS_IT);
         }
         // Meeting a line takes getting the comparison to answer, and whether it answered is what a
         // site records — so a comparison with no site is one no row could ever be shown to have
         // reached, and a border on it would owe a row nothing can measure.
         if (plan.comparisonAt(comparison).isEmpty()) {
-            return new Standing.DrawsNone(comparison, NotABoundary.NOTHING_RECORDS_IT);
+            return new Standing.Refused(comparison, NotABoundary.NOTHING_RECORDS_IT);
         }
-        return new Standing.DrawsALine(comparison);
+        return new Standing.Admitted(comparison, reading.get());
     }
 
     private BoundaryPolicy() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryPolicy.java
@@ -3,6 +3,8 @@ package souther.compiler.partition;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 
+import java.util.Optional;
+
 /**
  * Whether the rules of a model are read off one comparison, and why not where they are not.
  *
@@ -51,17 +53,18 @@ final class BoundaryPolicy {
      * what the line is, or why there is none, is the reading's ({@link ComparisonAssessment}) — and
      * the second is asked only of a comparison the first admits, so a reason for bearing no line is
      * never worked out from a reading that was never made. A comparison this refuses is not a rule
-     * with no line here: no row reaches its outcome, so it states nothing about any row, and a
-     * report saying nothing of it is right. Nor could it be said in the reading's words: what
-     * refuses it is where it stands, and the arithmetic has no answer to that.
+     * with no line here: its outcome is about no row ({@link NotABoundary}), so a report saying
+     * nothing of it is right. Nor could it be said in the reading's words: what refuses it is where
+     * it stands, and the arithmetic has no answer to that.
+     *
+     * <p>Which comparison it is about is not held here. The reading that holds this holds the
+     * comparison beside it ({@link ComparisonReadings.Reading}), and a second copy would be one
+     * nothing keeps equal to the first.
      */
     sealed interface Standing {
 
-        /** The comparison this is about, whichever answer it got. */
-        Core.Binary comparison();
-
         /** A line may be drawn on it, and {@code read} is what the one reading of it came to. */
-        record Admitted(Core.Binary comparison, ComparisonAssessment read) implements Standing {
+        record Admitted(ComparisonAssessment read) implements Standing {
 
             public Admitted {
                 if (read == null) {
@@ -71,7 +74,14 @@ final class BoundaryPolicy {
         }
 
         /** No line may be drawn on it, and this is which of the reasons it is. */
-        record Refused(Core.Binary comparison, NotABoundary why) implements Standing {}
+        record Refused(NotABoundary why) implements Standing {
+
+            public Refused {
+                if (why == null) {
+                    throw new IllegalArgumentException("a comparison is refused for a reason");
+                }
+            }
+        }
     }
 
     /**
@@ -102,22 +112,24 @@ final class BoundaryPolicy {
      * occurrence of a position where the passes stand at different occurrences of one, and at the
      * same values where they do not — and a pass reading anything else is one no line came of.
      *
-     * @param live    whether what is computed at this position is read on the way to what the
-     *                behavior answers with, which is {@link LiveFlow}'s answer carried down the walk
-     * @param reading the one reading of the comparison, made only where it is admitted
+     * @param live whether what is computed at this position is read on the way to what the behavior
+     *             answers with, which is {@link LiveFlow}'s answer carried down the walk
+     * @return why the comparison is refused, or empty where a line may be drawn on it. Decided from
+     *         what is passed in and nothing else: the reading of the comparison is made by the
+     *         caller, and only where this is empty
      */
-    static Standing standingOf(Core.Binary comparison, CoverageSites.Plan plan, boolean live,
-                               java.util.function.Supplier<ComparisonAssessment> reading) {
+    static Optional<NotABoundary> refuses(Core.Binary comparison, CoverageSites.Plan plan,
+                                          boolean live) {
         if (!live) {
-            return new Standing.Refused(comparison, NotABoundary.NOTHING_READS_IT);
+            return Optional.of(NotABoundary.NOTHING_READS_IT);
         }
         // Meeting a line takes getting the comparison to answer, and whether it answered is what a
-        // site records — so a comparison with no site is one no row could ever be shown to have
-        // reached, and a border on it would owe a row nothing can measure.
+        // site records — and the plan numbers no site where the expression the comparison decides
+        // never answers, so a comparison with no site is one no run answers through.
         if (plan.comparisonAt(comparison).isEmpty()) {
-            return new Standing.Refused(comparison, NotABoundary.NOTHING_RECORDS_IT);
+            return Optional.of(NotABoundary.NO_RUN_ANSWERS_THROUGH_IT);
         }
-        return new Standing.Admitted(comparison, reading.get());
+        return Optional.empty();
     }
 
     private BoundaryPolicy() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -108,12 +108,15 @@ final class ComparisonReadings {
         CoverageSites.Plan plan = in.plan();
         Symbols symbols = in.symbols();
         if (e instanceof Core.Binary comparison && plan.comparisons().at(comparison).isPresent()) {
-            // Read under the names in force here, which is the one environment the comparison is
-            // about. `answer` is null: a body has nothing that is the answer.
-            out.add(new Reading(comparison, reads, assumed,
-                    BoundaryPolicy.standingOf(comparison, plan, live, () ->
+            // Read only where the policy admits it, and under the names in force here, which is
+            // the one environment the comparison is about. `answer` is null: a body has nothing
+            // that is the answer.
+            BoundaryPolicy.Standing standing = BoundaryPolicy.refuses(comparison, plan, live)
+                    .<BoundaryPolicy.Standing>map(BoundaryPolicy.Standing.Refused::new)
+                    .orElseGet(() -> new BoundaryPolicy.Standing.Admitted(
                             ComparisonAssessment.of(in.behavior(), comparison, reads, symbols,
-                                    in.quantities(), null, false))));
+                                    in.quantities(), null, false)));
+            out.add(new Reading(comparison, reads, assumed, standing));
         }
         switch (e) {
             // The right operand runs only where the left came out the way that leaves the answer

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -11,7 +11,14 @@ import java.util.List;
 
 /**
  * One reading of a body's comparisons: where each stands, what its names point at, what a row had
- * already satisfied to get there, and whether a line is drawn on it.
+ * already satisfied to get there, whether a line may be drawn on it, and what it came to where one
+ * may.
+ *
+ * <p><b>Each comparison is read once, here, and what it came to travels with it.</b> A reader that
+ * reports why a comparison bears no line reads the answer off the standing and never reads the
+ * arithmetic again: read again downstream, the second reading answers about the form when the
+ * question was about where the comparison stands, and a form read to the end is described as one
+ * nobody could read.
  *
  * <p><b>One walk, because there is one thing being walked.</b> Three facts about a comparison are
  * settled by where it stands in the body, and each was being worked out by a walk of its own: which
@@ -63,13 +70,6 @@ final class ComparisonReadings {
         return readings;
     }
 
-    /** The comparisons a line is drawn on, in the order the source wrote them. */
-    List<Reading> drawn() {
-        return readings.stream()
-                .filter(each -> each.standing() instanceof BoundaryPolicy.Standing.DrawsALine)
-                .toList();
-    }
-
     /** What each comparison stands under, filed under the site a run through it is recorded at. */
     ReachingCuts reaching(CoverageSites.Plan plan) {
         ReachingCuts.Collected cuts = new ReachingCuts.Collected();
@@ -80,11 +80,20 @@ final class ComparisonReadings {
         return cuts.made();
     }
 
-    /** One reading of {@code body}. */
-    static ComparisonReadings of(Core body, CoverageSites.Plan plan, InputReads reads,
-                                 Symbols symbols) {
+    /**
+     * What is the same at every comparison of one body: whose body it is, what the plan numbered,
+     * the module's names, and what the input's rules leave each quantity.
+     */
+    private record Body(String behavior, CoverageSites.Plan plan, Symbols symbols,
+                        souther.compiler.inputs.Quantities quantities) {}
+
+    /** One reading of {@code body}, which is {@code behavior}'s. */
+    static ComparisonReadings of(String behavior, Core body, CoverageSites.Plan plan,
+                                 InputReads reads, Symbols symbols,
+                                 souther.compiler.inputs.Quantities quantities) {
         List<Reading> readings = new ArrayList<>();
-        walk(body, plan, reads, symbols, LiveFlow.of(body), List.of(), true, readings);
+        walk(body, new Body(behavior, plan, symbols, quantities), reads, LiveFlow.of(body),
+                List.of(), true, readings);
         return new ComparisonReadings(readings);
     }
 
@@ -94,12 +103,17 @@ final class ComparisonReadings {
      *                with. Carried down because everything inside a value nothing reads is read by
      *                nothing either
      */
-    private static void walk(Core e, CoverageSites.Plan plan, InputReads reads, Symbols symbols,
-                             LiveFlow flow, List<OnTheWay> assumed, boolean live,
-                             List<Reading> out) {
+    private static void walk(Core e, Body in, InputReads reads, LiveFlow flow,
+                             List<OnTheWay> assumed, boolean live, List<Reading> out) {
+        CoverageSites.Plan plan = in.plan();
+        Symbols symbols = in.symbols();
         if (e instanceof Core.Binary comparison && plan.comparisons().at(comparison).isPresent()) {
+            // Read under the names in force here, which is the one environment the comparison is
+            // about. `answer` is null: a body has nothing that is the answer.
             out.add(new Reading(comparison, reads, assumed,
-                    BoundaryPolicy.standingOf(comparison, plan, live)));
+                    BoundaryPolicy.standingOf(comparison, plan, live, () ->
+                            ComparisonAssessment.of(in.behavior(), comparison, reads, symbols,
+                                    in.quantities(), null, false))));
         }
         switch (e) {
             // The right operand runs only where the left came out the way that leaves the answer
@@ -107,32 +121,31 @@ final class ComparisonReadings {
             // any fork above it: there need not be one, and where there is, this is what the fork
             // would have been reading anyway.
             case Core.Binary both when both.op() == BinOp.AND -> {
-                walk(both.left(), plan, reads, symbols, flow, assumed, live, out);
-                walk(both.right(), plan, reads, symbols, flow,
+                walk(both.left(), in, reads, flow, assumed, live, out);
+                walk(both.right(), in, reads, flow,
                         taking(both.left(), true, reads, assumed, symbols), live, out);
             }
             case Core.Binary either when either.op() == BinOp.OR -> {
-                walk(either.left(), plan, reads, symbols, flow, assumed, live, out);
-                walk(either.right(), plan, reads, symbols, flow,
+                walk(either.left(), in, reads, flow, assumed, live, out);
+                walk(either.right(), in, reads, flow,
                         taking(either.left(), false, reads, assumed, symbols), live, out);
             }
             // The condition under what stood above the fork, and each arm under what that arm proves
             // of it. A comparison inside a condition is not below the fork: it runs to decide it.
             case Core.If iff -> {
-                walk(iff.cond(), plan, reads, symbols, flow, assumed, live, out);
-                walk(iff.then(), plan, reads, symbols, flow,
+                walk(iff.cond(), in, reads, flow, assumed, live, out);
+                walk(iff.then(), in, reads, flow,
                         taking(iff.cond(), true, reads, assumed, symbols), live, out);
-                walk(iff.els(), plan, reads, symbols, flow,
+                walk(iff.els(), in, reads, flow,
                         taking(iff.cond(), false, reads, assumed, symbols), live, out);
             }
             // What a `let` computes is read on the way to the answer only where the name is read;
             // everywhere else a value stands in a body it is consumed by what it stands in. And its
             // body is where the name stands for what was bound to it.
             case Core.LetIn let -> {
-                walk(let.value(), plan, reads, symbols, flow, assumed,
-                        live && flow.reads(let), out);
-                walk(let.body(), plan, reads.and(let.binder(), let.value()), symbols, flow, assumed,
-                        live, out);
+                walk(let.value(), in, reads, flow, assumed, live && flow.reads(let), out);
+                walk(let.body(), in, reads.and(let.binder(), let.value()), flow, assumed, live,
+                        out);
             }
             // And each arm under what the arm says the value it matched turned out to be. A name
             // the arm binds is the scrutinee's position narrowed to that case, so a comparison
@@ -144,14 +157,14 @@ final class ComparisonReadings {
             // inside an arm was owed a row by a walk that had been told nothing stood on the way to
             // it, and the row composed for it was written in whichever arm the values fell in.
             case Core.Match match -> {
-                walk(match.scrutinee(), plan, reads, symbols, flow, assumed, live, out);
+                walk(match.scrutinee(), in, reads, flow, assumed, live, out);
                 for (Core.Case arm : match.cases()) {
-                    walk(arm.body(), plan, reads.insideArm(match, arm, symbols), symbols, flow,
+                    walk(arm.body(), in, reads.insideArm(match, arm, symbols), flow,
                             entering(match, arm, reads, assumed, symbols), live, out);
                 }
             }
             default -> Core.forEachChild(e, child ->
-                    walk(child, plan, reads, symbols, flow, assumed, live, out));
+                    walk(child, in, reads, flow, assumed, live, out));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -109,8 +109,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             // And only here does how it was written decide anything. The arithmetic stopped, which
             // is what a date against a written date and a case of an enumeration do: the values are
             // ones it cannot count, and the comparison still states a line.
-            case AffineReading.OfAComparison.Stopped _ ->
-                    asWritten(behavior, comparison, canonical, reads, symbols, quantities);
+            case AffineReading.OfAComparison.Stopped stopped ->
+                    asWritten(behavior, comparison, stopped, reads, symbols, quantities);
         };
     }
 
@@ -173,7 +173,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * stopped, so a spelling never answers a question the canonical form has already answered.
      */
     private static Read asWritten(String behavior, Core.Binary comparison,
-                                  AffineReading.OfAComparison canonical, InputReads reads,
+                                  AffineReading.OfAComparison.Stopped canonical, InputReads reads,
                                   Symbols symbols,
                                   souther.compiler.inputs.Quantities quantities) {
         Cutting drawn = atAPosition(behavior, ComparedLine.asWritten(comparison, reads, symbols),

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -18,7 +18,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ComparisonCatalog;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.diag.Citation;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
@@ -138,105 +137,24 @@ public final class GuardThresholds {
         List<LineEvidence> found = new ArrayList<>();
         List<RuleWithoutALine> withoutALine = new ArrayList<>();
         List<LineDrawn> between = new ArrayList<>();
-        // The comparisons this reader assessed, and not the positions they were about. A position
-        // carries more than one statement and reading one of them settles nothing about the others.
-        // What each of them left the positions with is said where it was assessed, so what is left
-        // for the walk below is the comparisons that never reached this reader at all.
-        List<Core> assessed = new ArrayList<>();
-        // Every line the body draws, read where the comparison that draws it is written and under
-        // the names in force there. Which comparisons those are is
-        // {@link BoundaryPolicy}'s answer: a reader that had to find a fork before it could
-        // find a rule could not be handed a wider one without being rewritten.
         // One reading of the body, and everything below is that reading asked something. Where a
-        // comparison is written, what its names point at, what a row had satisfied to get there and
-        // whether a line is drawn on it are four questions about one position, and a walk apiece was
-        // a walk apiece to disagree about what a `let` does.
-        ComparisonReadings read = ComparisonReadings.of(body, plan, InputReads.of(inputs, elements), symbols);
-        for (ComparisonReadings.Reading each : read.drawn()) {
-            lineAt(behavior, each.comparison(), plan, each.reads(), symbols, quantities, found,
-                    between, assessed, withoutALine);
+        // comparison is written, what its names point at, what a row had satisfied to get there,
+        // whether a line may be drawn on it and what it came to are five questions about one
+        // position, and a walk apiece was a walk apiece to disagree about what a `let` does.
+        ComparisonReadings read = ComparisonReadings.of(behavior, body, plan,
+                InputReads.of(inputs, elements), symbols, quantities);
+        for (ComparisonReadings.Reading each : read.all()) {
+            switch (each.standing()) {
+                case BoundaryPolicy.Standing.Admitted admitted ->
+                        lineAt(behavior, admitted.comparison(), plan, each.reads(), symbols,
+                                admitted.read(), found, between, withoutALine);
+                // Not a rule with no line here: no row reaches its outcome, so it states nothing
+                // about any row, and there is nothing for a report to say of it. Which of the
+                // reasons it is stays with the standing, for a reader that asks the standing.
+                case BoundaryPolicy.Standing.Refused _ -> { }
+            }
         }
-        // And every comparison the model states something by that this reader never saw.
-        noticed(behavior, read, assessed, plan, symbols, withoutALine);
         return new Guards(found, withoutALine, between, read.reaching(plan));
-    }
-
-    /**
-     * Every comparison the model states something by that nothing turned into a line.
-     *
-     * <p>Asked of the comparisons and not of the positions. One position carries more than one
-     * statement, and a line read at it says nothing about the rest: kept per position, a threshold
-     * on `x` swallowed the comparison beside it that nothing could read, which is "a result exists,
-     * so the reading is complete".
-     *
-     * <p>Read off the same answer the lines came off, and not from a walk of its own. Both used to
-     * start from a fork, and a comparison written anywhere else came back neither a line nor a rule
-     * this could not read — it came back unmentioned, which is the one answer that says the model
-     * states nothing at the position. Two walks agreeing about which comparisons there are is
-     * something to keep in step; one answer read twice is not.
-     *
-     * <p>A wider set than the one that bears lines, and deliberately. What this establishes is that
-     * the model states something at a position — which is exactly what {@code not derivable} would
-     * otherwise deny — so a comparison a line could never be drawn from is still a rule the author
-     * wrote and still worth saying went unread.
-     *
-     * <p>Which is why a comparison nothing can measure is in and one nothing reads is out, and the
-     * split is the same one {@link NotABoundary} is made of. {@link NotABoundary#NOTHING_RECORDS_IT}
-     * is the author's rule, written at a position, that this could not draw a line from — the
-     * sentence {@code not read} is there to say. {@link NotABoundary#NOTHING_READS_IT} is not a rule
-     * of the model at all, and saying it went unread would put a statement into the report that the
-     * behavior does not make.
-     */
-    private static void noticed(String behavior, ComparisonReadings read, List<Core> assessed,
-                                CoverageSites.Plan plan, Symbols symbols, List<RuleWithoutALine> out) {
-        for (ComparisonReadings.Reading reading : read.all()) {
-            if (reading.standing() instanceof BoundaryPolicy.Standing.DrawsNone none
-                    && none.why() == NotABoundary.NOTHING_READS_IT) {
-                continue;
-            }
-            Core.Binary binary = reading.comparison();
-            // By the comparison it is, and not by what it was about: two comparisons at one position
-            // are two statements, and this one having been assessed is no answer about the other.
-            // What an assessed comparison leaves the positions with was said where it was assessed,
-            // in the words that reading came to — worked out again here, a comparison whose carrier
-            // stopped the reading was described as one that relates two positions, which says no
-            // measure is short of anything.
-            if (assessed.stream().anyMatch(each -> each == binary)) {
-                continue;
-            }
-            ComparisonCatalog.Comparison entry = plan.comparisons().at(binary).orElse(null);
-            if (entry == null || !writtenHere(entry)) {
-                continue;
-            }
-            InputReads reads = reading.reads();
-            List<FilingCoordinate> named = filedAt(binary, reads, symbols);
-            final BlockReason.RuleWithoutLineReason why = why(binary, reads, symbols);
-            // The rule the author wrote, read off the source. Which comparison it is is the
-            // behavior and the construct the source wrote; where a reader is sent is where it is
-            // written. Neither comes from the plan: a comparison in a fork both of whose arms can
-            // record nothing is numbered nowhere, and a model states its rules regardless.
-            RuleRef.Comparison rule = new RuleRef.Comparison(behavior, binary.origin());
-            souther.compiler.check.RuleCitation cited = citationOf(binary, plan.comparisons());
-            // A comparison naming no position of the input, whose terms came from one. Where the
-            // rule is filed and nothing else: what it says is the reading's answer, and deciding it
-            // here made the same fact about one comparison come out one way for an element and
-            // another for a number — which is not a difference between the two rules.
-            if (named.isEmpty()) {
-                List<TermPath> from = new ArrayList<>();
-                cameFrom(binary, reads, symbols, from);
-                from.forEach(each -> named.add(FilingCoordinate.at(each)));
-            }
-            for (FilingCoordinate each : named) {
-                // One per position the comparison names, and told from its neighbours by the rule as
-                // well as the place. Kept by position alone, the second comparison of one condition
-                // about one position was dropped as a repeat of the first — which is the defect this
-                // finding is about, one level in.
-                RuleWithoutALine said = new RuleWithoutALine(rule, cited, each, why);
-                if (out.stream().noneMatch(had -> had.sameAs(said))) {
-                    out.add(said);
-                }
-            }
-        }
     }
 
     /**
@@ -254,37 +172,6 @@ public final class GuardThresholds {
                 out.add(at);
             }
         }
-    }
-
-    /**
-     * Whether this comparison is written in code this compile can send a reader to.
-     *
-     * <p>A call is spliced into the body that makes it, so a comparison written in something else
-     * stands in this tree. Where that something else is out of sight — a library this compile has
-     * no file for — the comparison is not a rule anybody reading this behavior can act on:
-     * {@code Int.clamp(0, 100, n) > 70} is one comparison an author wrote and two they cannot open,
-     * and naming the second two tells them to edit a function they do not have.
-     *
-     * <p>A helper of their own is not one of these. It has a file, the report cites it where it is
-     * written, and it is theirs to rewrite — so the line is drawn at what a reader can reach and
-     * not at whether an expansion happened.
-     *
-     * <p>{@link Citation} and not the position, which cannot say this: a spliced node carries the
-     * coordinates of the code it was copied from. {@link Citation.Elsewhere} is exactly "written
-     * where this compile has no file", and it is the same answer
-     * {@link souther.compiler.check.RuleCitation} renders.
-     *
-     * <p>Read off the catalog, which holds where a comparison is written. Taken from the node again
-     * here, this was one more place deciding for itself what the catalog already answers — and the
-     * one deciding whether an author is told to edit a file they do not have.
-     *
-     * <p>Asked of the comparison and not of the fork above it. The one the author wrote sits
-     * outside an expansion whose insides they did not, so a subtree is the wrong unit — and the
-     * walk still goes through the expansion, because that is where a call's argument is bound and
-     * a comparison read without it is about nothing.
-     */
-    private static boolean writtenHere(ComparisonCatalog.Comparison comparison) {
-        return !(comparison.at() instanceof Citation.Elsewhere);
     }
 
     /**
@@ -366,83 +253,40 @@ public final class GuardThresholds {
     }
 
     /**
-     * What would have to change before this comparison could be a line.
+     * What stopped the arithmetic's reading of this comparison, told where it stopped.
      *
-     * <p>{@link UnreadComparison}'s, which is where the answer is so that an invariant's clause of
+     * <p>{@link UnreadComparison}'s answer, which is where it is so that an invariant's clause of
      * the same shape gets the same one. What is this reader's own is how a position is looked up:
      * a body's read of a parameter is what names one here, and a coordinate of a value is what
      * names one over there.
-     */
-    static BlockReason.RuleWithoutLineReason why(Core.Binary comparison, InputReads reads,
-                           Symbols symbols) {
-        return said(comparison, AffineReading.read(comparison, reads, symbols), reads, symbols);
-    }
-
-    /**
-     * The same, told what the arithmetic already came to.
      *
-     * <p>For a caller holding the reading, which is every caller that met the absence this
-     * describes. Reading it again to say why it stopped is the comparison read twice, and the
-     * second read is free to answer about a shape the first one had already got past.
+     * <p>Only for a reading that stopped, which the parameter says. A comparison the arithmetic
+     * read to the end has its answer in what it read — a line, or a quantity that is nothing — and
+     * none of that is a stop; handed the sides of such a comparison, this would describe a form
+     * that was read as one that was not. Where the reading stopped, the expression and the
+     * environment it was being read in come back together, so the sides are not read again in
+     * whatever the caller happens to hold.
      */
     static BlockReason.RuleReadingStopped whyItStopped(Core.Binary comparison,
-                                                   AffineReading.OfAComparison canonical,
+                                                   AffineReading.OfAComparison.Stopped stopped,
                                                    InputReads reads, Symbols symbols) {
-        BlockReason.RuleWithoutLineReason said = said(comparison, canonical, reads, symbols);
+        Names left = namesIn(comparison.left(), reads, symbols);
+        Names right = namesIn(comparison.right(), reads, symbols);
+        Names here = namesIn(stopped.node(), stopped.at(), symbols);
+        java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>(left.met());
+        right.met().forEach(met::putIfAbsent);
+        here.met().forEach(met::putIfAbsent);
+        BlockReason.RuleWithoutLineReason said = UnreadComparison.why(left.origin(),
+                right.origin(), new UnreadComparison.Quantity.NotRead<>(here.origin()),
+                at -> met.containsKey(at) && orderable(met.get(at), symbols));
         // What this reader is asked for is why it stopped, and the words for a rule read to the end
         // are not answers to that. Reached with one, the caller has met an absence this reading did
         // not produce — so it is refused rather than passed on as a reason nothing fell short.
-        if (said instanceof BlockReason.RuleReadingStopped stopped) {
-            return stopped;
+        if (said instanceof BlockReason.RuleReadingStopped why) {
+            return why;
         }
         throw new IllegalStateException(
                 "a reading that stopped cannot say it read the rule to the end: " + said);
-    }
-
-    /** What stopped a reading of this comparison, in whatever words its own answer comes in. */
-    private static BlockReason.RuleWithoutLineReason said(Core.Binary comparison,
-                                               AffineReading.OfAComparison canonical,
-                                               InputReads reads, Symbols symbols) {
-        Names left = namesIn(comparison.left(), reads, symbols);
-        Names right = namesIn(comparison.right(), reads, symbols);
-        java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>(left.met());
-        right.met().forEach(met::putIfAbsent);
-        return UnreadComparison.why(left.origin(), right.origin(),
-                quantityOf(canonical, reads, symbols, met),
-                at -> met.containsKey(at) && orderable(met.get(at), symbols));
-    }
-
-    /**
-     * The positions the quantity this comparison cuts is over, or null where the arithmetic read no
-     * form at all.
-     *
-     * <p>This reader's own, because the atoms are: a body names a position by what it reads of a
-     * parameter. What is done with the answer is {@link UnreadComparison}'s, so a clause of the same
-     * shape two declarations away is described in the same words.
-     */
-    private static UnreadComparison.Quantity<TermPath> quantityOf(
-            AffineReading.OfAComparison canonical, InputReads reads, Symbols symbols,
-            java.util.Map<TermPath, Type> met) {
-        // Each of the three the reading can come to, and no fourth made out of an absence. Where it
-        // stopped, the expression and the environment it was being read in come back together, so
-        // this does not read it again in whatever it happens to hold.
-        switch (canonical) {
-            case AffineReading.OfAComparison.Stopped stopped -> {
-                Names here = namesIn(stopped.node(), stopped.at(), symbols);
-                here.met().forEach(met::putIfAbsent);
-                return new UnreadComparison.Quantity.NotRead<>(here.origin());
-            }
-            case AffineReading.OfAComparison.CutsNothing _ -> {
-                return new UnreadComparison.Quantity.CutsNothing<>();
-            }
-            case AffineReading.OfAComparison.Cuts cuts -> {
-                java.util.Set<TermPath> over = new java.util.LinkedHashSet<>();
-                for (NumericTerm atom : cuts.read().form().coefs().keySet()) {
-                    over.add(atom.subjectPath());
-                }
-                return new UnreadComparison.Quantity.Over<>(over);
-            }
-        }
     }
 
     /**
@@ -519,27 +363,20 @@ public final class GuardThresholds {
      * rule's own and no other's.
      *
      * <p>Whether a line may be drawn on this comparison at all was settled before the walk got
-     * here, by {@link BoundaryPolicy}. Asked at the fork instead, this reader had to find one
-     * to find a rule.
+     * here, by {@link BoundaryPolicy}, and what the comparison comes to was read where that was
+     * settled ({@code read}). Nothing here reads the comparison again.
      */
     private static void lineAt(String behavior, Core.Binary each, CoverageSites.Plan plan,
-                               InputReads reads, Symbols symbols,
-                               souther.compiler.inputs.Quantities quantities,
+                               InputReads reads, Symbols symbols, ComparisonAssessment read,
                                List<LineEvidence> out,
                                List<LineDrawn> between,
-                               List<Core> assessed, List<RuleWithoutALine> withoutALine) {
+                               List<RuleWithoutALine> withoutALine) {
         // The plan numbered every comparison of an instrumented condition before anything read a
         // line off one, so this is here. Required rather than looked up leniently: a line whose
         // comparison has no site is this reader and the plan disagreeing about what a condition
         // is made of.
         souther.compiler.coverage.ComparisonOccurrence site =
                 plan.requireComparisonAt(each);
-        // What the comparison comes to is one question with one answer
-        // ({@link ComparisonAssessment}). What is added here is what meeting the line takes, which
-        // is a guard's own answer and no other rule's.
-        ComparisonAssessment read =
-                ComparisonAssessment.of(behavior, each, reads, symbols, quantities, null, false);
-        assessed.add(each);
         publish(behavior, each, plan, reads, symbols, read, withoutALine);
         switch (read) {
             case ComparisonAssessment.AtAPosition at -> {

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -140,17 +140,17 @@ public final class GuardThresholds {
         // One reading of the body, and everything below is that reading asked something. Where a
         // comparison is written, what its names point at, what a row had satisfied to get there,
         // whether a line may be drawn on it and what it came to are five questions about one
-        // position, and a walk apiece was a walk apiece to disagree about what a `let` does.
+        // position, and one walk answers them about one position.
         ComparisonReadings read = ComparisonReadings.of(behavior, body, plan,
                 InputReads.of(inputs, elements), symbols, quantities);
         for (ComparisonReadings.Reading each : read.all()) {
             switch (each.standing()) {
                 case BoundaryPolicy.Standing.Admitted admitted ->
-                        lineAt(behavior, admitted.comparison(), plan, each.reads(), symbols,
+                        lineAt(behavior, each.comparison(), plan, each.reads(), symbols,
                                 admitted.read(), found, between, withoutALine);
-                // Not a rule with no line here: no row reaches its outcome, so it states nothing
-                // about any row, and there is nothing for a report to say of it. Which of the
-                // reasons it is stays with the standing, for a reader that asks the standing.
+                // Not a rule with no line here: its outcome is about no row, whichever of the
+                // reasons refused it ({@link NotABoundary}), so there is nothing for a report to
+                // say of it.
                 case BoundaryPolicy.Standing.Refused _ -> { }
             }
         }
@@ -276,17 +276,9 @@ public final class GuardThresholds {
         java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>(left.met());
         right.met().forEach(met::putIfAbsent);
         here.met().forEach(met::putIfAbsent);
-        BlockReason.RuleWithoutLineReason said = UnreadComparison.why(left.origin(),
-                right.origin(), new UnreadComparison.Quantity.NotRead<>(here.origin()),
+        return UnreadComparison.whatStopped(left.origin(), right.origin(),
+                new UnreadComparison.Quantity.NotRead<>(here.origin()),
                 at -> met.containsKey(at) && orderable(met.get(at), symbols));
-        // What this reader is asked for is why it stopped, and the words for a rule read to the end
-        // are not answers to that. Reached with one, the caller has met an absence this reading did
-        // not produce — so it is refused rather than passed on as a reason nothing fell short.
-        if (said instanceof BlockReason.RuleReadingStopped why) {
-            return why;
-        }
-        throw new IllegalStateException(
-                "a reading that stopped cannot say it read the rule to the end: " + said);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/NotABoundary.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/NotABoundary.java
@@ -1,22 +1,25 @@
 package souther.compiler.partition;
 
 /**
- * Why a comparison of a body bears no line.
+ * Why {@link BoundaryPolicy} refuses a comparison of a body.
  *
- * <p>An answer and never an absence. What these are told apart for is that a reader has to do
- * opposite things about them: one says the behavior draws no boundary here and a report saying
- * nothing is right, and the other says it may well draw one that this could not be shown a row
- * against. Folded into one {@code false}, the second arrives downstream as the same silence as the
- * first — and whoever widens the measurement later has to work out again why anything was left out.
+ * <p>The two gates the policy asks, in the order it asks them, and an answer rather than an
+ * absence: which gate refused a comparison is a fact the policy has in hand when it refuses, and
+ * folded into one {@code false} it would have to be worked out again by anyone who needed it.
+ *
+ * <p><b>Neither is a rule without a line, and no report says either.</b> A comparison nothing reads
+ * decides nothing the behavior answers by; a comparison no run can be recorded through decides
+ * nothing any row reaches. In both the comparison's outcome is about no row, so there is nothing
+ * for a finding about a position to say — and nothing that could be said in the reading's words
+ * ({@link souther.compiler.inputs.BlockReason}), which are about what the arithmetic did with a
+ * form: what refuses the comparison is where it stands, and the arithmetic is never asked. A
+ * reason in those words for a refused comparison would be one made up from material that cannot
+ * answer the question, and it is the type of {@link BoundaryPolicy.Standing.Refused} that makes
+ * such a reason unsayable.
  *
  * <p>The first is said where both hold, because it is the one about the model. A reader told that a
  * comparison's outcome cannot be attributed to a row would go looking for a way to attribute it,
  * when the behavior's answer does not turn on the comparison at all.
- *
- * <p>Nothing here is about what a rule was written in. Whether a comparison this policy admits comes
- * to a line is the reading's answer and is said in the reading's words
- * ({@link souther.compiler.inputs.BlockReason}); the two vocabularies stay apart, and a comparison
- * this admits and no arithmetic reads is reported by that one rather than by a third word here.
  */
 public enum NotABoundary {
 
@@ -35,11 +38,18 @@ public enum NotABoundary {
     NOTHING_READS_IT,
 
     /**
-     * No run through the comparison can be recorded, so no row could be shown to have reached it.
+     * No run answers a value through the comparison, so its outcome is about no row.
      *
-     * <p>What the plan numbering already answers. A comparison behind something that aborts, or in an
-     * arm a condition never comes out the way of, is one no run gets to — and meeting a line takes
-     * getting the comparison to answer, so a border there would owe a row nothing can measure.
+     * <p>What the plan numbering already answers, and exactly that. The plan numbers a site for a
+     * comparison only where the expression the comparison decides can answer a value
+     * ({@link souther.compiler.coverage.NormalReturn}); a comparison behind something that aborts,
+     * or deciding between arms that both abort, gets none. So a comparison named this is not one a
+     * row may reach and this cannot measure — it is one whose truth no answer of the behavior turns
+     * on, for the same reason the first is, arrived at by a different reading.
+     *
+     * <p>Which is why it is not a shortfall of the measurement and no report says it. Where such a
+     * comparison stands is a case the model rules out, and that is what the report says of the
+     * case; a line the comparison would have drawn is not something the model is missing.
      */
-    NOTHING_RECORDS_IT
+    NO_RUN_ANSWERS_THROUGH_IT
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonNoRunReachesIsNotARuleWithoutALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonNoRunReachesIsNotARuleWithoutALineTest.java
@@ -12,18 +12,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A comparison no run through can be recorded is not a rule the model has no line for.
+ * A comparison no run answers through is not a rule the model has no line for.
  *
- * <p>Its outcome decides nothing about any row, because no row gets past it — so there is nothing
- * for a report to say of it, and in particular nothing in the words a reading of the arithmetic
- * answers in. Those words are about what the arithmetic could do with the form, and the form is not
- * what refuses the comparison: where it stands is. Given a reason in those words all the same, a
- * comparison the arithmetic reads to the end is reported as one whose form went unread, and the
- * measurement is marked short of something no reader fell short of.
+ * <p>Its outcome is about no row, because the expression it decides never answers a value — so
+ * there is nothing for a report to say of it, and in particular nothing in the words a reading of
+ * the arithmetic answers in. Those words are about what the arithmetic could do with the form, and
+ * the form is not what refuses the comparison: where it stands is. Given a reason in those words all
+ * the same, a comparison the arithmetic reads to the end is reported as one whose form went unread,
+ * and the measurement is marked short of something no reader fell short of.
  *
  * <p>What refuses it is asked of the standing, so the claim is made at both levels: that this
  * comparison is one the policy refuses for that reason, and that the report says nothing of it.
- * Without the first, the second would hold of a model whose comparison was simply a line.
+ * Without the first, the second would hold of a model whose comparison was simply a line. And the
+ * silence is shown to be the right answer rather than a missing one: the case the comparison stands
+ * in is reported as one the model rules out, and everything the model does answer by is measured
+ * whole.
  */
 class AComparisonNoRunReachesIsNotARuleWithoutALineTest {
 
@@ -60,26 +63,24 @@ class AComparisonNoRunReachesIsNotARuleWithoutALineTest {
     /** A form the arithmetic stops on: the product of a position with itself. */
     private static final String STOPPED = "n * n >= 100000";
 
-    private static String report(String condition) {
-        Compilation compilation = Compilation.ofSource(model(condition), "Main");
+    private static String report(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
         return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
     }
 
     @Test
-    void theComparisonIsOneNoRunRecords() {
-        BoundaryPolicy.Standing standing =
-                ReadComparisons.of(model(READ), "pick").only().standing();
-        assertEquals(new BoundaryPolicy.Standing.Refused(standing.comparison(),
-                NotABoundary.NOTHING_RECORDS_IT), standing);
+    void theComparisonIsOneNoRunAnswersThrough() {
+        assertEquals(new BoundaryPolicy.Standing.Refused(NotABoundary.NO_RUN_ANSWERS_THROUGH_IT),
+                ReadComparisons.of(model(READ), "pick").only().standing());
     }
 
     @Test
     void aFormReadToTheEndIsNotReportedAsOneNobodyRead() {
-        String human = report(READ);
+        String human = report(model(READ));
         assertFalse(human.contains("not read: comparison"), human);
-        assertFalse(human.contains("measurement: partial"), human);
+        assertTrue(human.contains("measurement: complete"), human);
     }
 
     /**
@@ -89,16 +90,31 @@ class AComparisonNoRunReachesIsNotARuleWithoutALineTest {
      */
     @Test
     void aFormTheArithmeticWouldStopOnIsNotReportedEither() {
-        String human = report(STOPPED);
+        String human = report(model(STOPPED));
         assertFalse(human.contains("not read: comparison"), human);
-        assertFalse(human.contains("measurement: partial"), human);
+        assertTrue(human.contains("measurement: complete"), human);
     }
 
-    /** The half that makes the other half worth reading: the same rule where a run reaches it is
-     *  a line, and the report carries it. */
+    /**
+     * The silence is the right answer and not a gap. What the model does answer by is measured
+     * whole, and the case the comparison stands in is said to be one the model rules out.
+     */
     @Test
-    void theSameRuleWhereARunReachesItIsALine() {
-        Compilation compilation = Compilation.ofSource("""
+    void whatTheModelAnswersByIsMeasuredWholeAndTheCaseIsSaidToBeRuledOut() {
+        String human = report(model(READ));
+        assertTrue(human.contains("branch      1/1"), human);
+        assertTrue(human.contains("`Off` is declared unreachable on every path"), human);
+        // The position the refused comparison names is one the model draws no line through, which
+        // is what is true of it, said in the words for that and not in a reading's.
+        assertTrue(human.contains("not derivable: n"), human);
+        assertTrue(human.contains("border      not applicable"), human);
+    }
+
+    /** The half that makes the other half worth reading: the same rule where a run answers through
+     *  it is a line, and the report carries the border. */
+    @Test
+    void theSameRuleWhereARunAnswersThroughItIsALine() {
+        String human = report("""
                 module example.probe
 
                 data Answer = Int
@@ -108,10 +124,8 @@ class AComparisonNoRunReachesIsNotARuleWithoutALineTest {
 
                 example pick
                     | "low" : (3) -> Answer(0)
-                """, "Main");
-        compilation.measure(Adequacy.Asked.fullReport());
-        compilation.answerEverything();
-        String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
-        assertTrue(human.contains("100000"), human);
+                """);
+        assertTrue(human.contains("borders 1"), human);
+        assertTrue(human.contains("the ON point pick/n = 100000 (comparison@6:21)"), human);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonNoRunReachesIsNotARuleWithoutALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonNoRunReachesIsNotARuleWithoutALineTest.java
@@ -1,0 +1,117 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A comparison no run through can be recorded is not a rule the model has no line for.
+ *
+ * <p>Its outcome decides nothing about any row, because no row gets past it — so there is nothing
+ * for a report to say of it, and in particular nothing in the words a reading of the arithmetic
+ * answers in. Those words are about what the arithmetic could do with the form, and the form is not
+ * what refuses the comparison: where it stands is. Given a reason in those words all the same, a
+ * comparison the arithmetic reads to the end is reported as one whose form went unread, and the
+ * measurement is marked short of something no reader fell short of.
+ *
+ * <p>What refuses it is asked of the standing, so the claim is made at both levels: that this
+ * comparison is one the policy refuses for that reason, and that the report says nothing of it.
+ * Without the first, the second would hold of a model whose comparison was simply a line.
+ */
+class AComparisonNoRunReachesIsNotARuleWithoutALineTest {
+
+    /**
+     * A comparison whose every continuation aborts, with the rule written in {@code condition}.
+     *
+     * <p>{@code Off} is a case the model rules out, so the {@code unreachable}s are claims the rules
+     * bear out (E1326 otherwise) — and the comparison deciding between the two of them is one no
+     * run answers past, whichever way it comes out.
+     */
+    private static String model(String condition) {
+        return """
+                module example.probe
+
+                data On
+                data Off
+                data Flag = On | Off
+                data Active = Flag invariant value /= Off
+                data Answer = Int
+
+                behavior pick : (f: Active, n: Int) -> Answer
+                let pick (f, n) = match f.value with
+                    | On  -> Answer(1)
+                    | Off -> if %s then unreachable "a" else unreachable "b"
+
+                example pick
+                    | "on" : (Active(On), 3) -> Answer(1)
+                """.formatted(condition);
+    }
+
+    /** A form the arithmetic reads to the end: one line, cutting one position at one value. */
+    private static final String READ = "n >= 100000";
+
+    /** A form the arithmetic stops on: the product of a position with itself. */
+    private static final String STOPPED = "n * n >= 100000";
+
+    private static String report(String condition) {
+        Compilation compilation = Compilation.ofSource(model(condition), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+
+    @Test
+    void theComparisonIsOneNoRunRecords() {
+        BoundaryPolicy.Standing standing =
+                ReadComparisons.of(model(READ), "pick").only().standing();
+        assertEquals(new BoundaryPolicy.Standing.Refused(standing.comparison(),
+                NotABoundary.NOTHING_RECORDS_IT), standing);
+    }
+
+    @Test
+    void aFormReadToTheEndIsNotReportedAsOneNobodyRead() {
+        String human = report(READ);
+        assertFalse(human.contains("not read: comparison"), human);
+        assertFalse(human.contains("measurement: partial"), human);
+    }
+
+    /**
+     * And a form the arithmetic would have stopped on says nothing either. The standing is decided
+     * before the arithmetic is asked, so what the arithmetic would have made of the form is not a
+     * fact anybody holds.
+     */
+    @Test
+    void aFormTheArithmeticWouldStopOnIsNotReportedEither() {
+        String human = report(STOPPED);
+        assertFalse(human.contains("not read: comparison"), human);
+        assertFalse(human.contains("measurement: partial"), human);
+    }
+
+    /** The half that makes the other half worth reading: the same rule where a run reaches it is
+     *  a line, and the report carries it. */
+    @Test
+    void theSameRuleWhereARunReachesItIsALine() {
+        Compilation compilation = Compilation.ofSource("""
+                module example.probe
+
+                data Answer = Int
+
+                behavior pick : (n: Int) -> Answer
+                let pick (n) = if n >= 100000 then Answer(1) else Answer(0)
+
+                example pick
+                    | "low" : (3) -> Answer(0)
+                """, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+        assertTrue(human.contains("100000"), human);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
@@ -35,13 +35,14 @@ record ReadComparisons(List<ComparisonReadings.Reading> comparisons, Symbols sym
         String module = compilation.modules().get(0);
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
-        return new ReadComparisons(ComparisonReadings.of(
+        souther.compiler.inputs.InputDomain inputs =
+                compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
+        return new ReadComparisons(ComparisonReadings.of(behavior,
                 checked.behaviorBodies().get(behavior),
                 CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
                         checked.supplied()),
-                InputReads.of(compilation.db().ask(new Adequacy.Inputs(module)).value()
-                        .get(behavior), checked.elementBindings().get(behavior)),
-                symbols).all(), symbols);
+                InputReads.of(inputs, checked.elementBindings().get(behavior)),
+                symbols, inputs.quantities(symbols)).all(), symbols);
     }
 
     /** The one comparison the body writes. A body writing two would leave a caller picking one of

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
@@ -73,9 +73,9 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
 
         Map<Integer, BoundaryPolicy.Standing> byLine = new LinkedHashMap<>();
         for (ComparisonReadings.Reading each
-                : ComparisonReadings.of(body, plan,
+                : ComparisonReadings.of("read", body, plan,
                         InputReads.of(inputs, checked.elementBindings().get("read")),
-                        symbols).all()) {
+                        symbols, inputs.quantities(symbols)).all()) {
             byLine.put(each.comparison().pos().line(), each.standing());
         }
         return byLine;
@@ -84,7 +84,7 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
     /** A truth a fork below reads is a line. */
     @Test
     void aTruthSomethingReadsBearsALine() {
-        assertEquals(BoundaryPolicy.Standing.DrawsALine.class,
+        assertEquals(BoundaryPolicy.Standing.Admitted.class,
                 standingAt(8).getClass());
     }
 
@@ -97,7 +97,7 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
     /** A truth one run reaches once per element of an input bears a line at that element. */
     @Test
     void aTruthReachedOncePerElementOfAnInputBearsALine() {
-        assertEquals(BoundaryPolicy.Standing.DrawsALine.class,
+        assertEquals(BoundaryPolicy.Standing.Admitted.class,
                 standingAt(10).getClass(),
                 "each pass is one occurrence of a position, so a row can be read at it");
     }
@@ -115,10 +115,10 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
      */
     @Test
     void aTruthOneRunReachesMoreThanOnceIsStillOneThisPolicyAdmits() {
-        assertEquals(BoundaryPolicy.Standing.DrawsALine.class, standingAt(11).getClass());
+        assertEquals(BoundaryPolicy.Standing.Admitted.class, standingAt(11).getClass());
     }
 
     private static NotABoundary whyOf(BoundaryPolicy.Standing standing) {
-        return standing instanceof BoundaryPolicy.Standing.DrawsNone none ? none.why() : null;
+        return standing instanceof BoundaryPolicy.Standing.Refused none ? none.why() : null;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
@@ -18,10 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * A comparison that bears no line says which of the reasons it is.
  *
- * <p>They are not one answer. A truth nothing reads is one the behavior draws no boundary on at all,
- * and a report that stayed silent about it is right. A comparison no run through can be recorded is
- * one the behavior may well draw a boundary on and this cannot show a row to have met. Folded into
- * one {@code false}, the second becomes silence that reads like the first.
+ * <p>They are not one answer. A truth nothing reads is one the behavior draws no boundary on at all;
+ * a comparison no run answers through is one whose outcome is about no row, arrived at from where
+ * it stands rather than from what reads it. Neither is reported, and which of the two refused a
+ * comparison is a fact the policy has when it refuses — folded into one {@code false}, whoever
+ * needs it next works it out again.
  *
  * <p>What a comparison is written inside is no part of this. A step a combinator applies once per
  * element is passed as many times as there are elements, and the two written here stand together to


### PR DESCRIPTION
Closes #1172.

## What was wrong

A comparison the plan numbers no site for was published as a rule without a line, with a reason derived from reading its arithmetic a second time. That reading answers about the form; what refuses the comparison is where it stands. So a form read to the end (`n >= 100000`) was reported as *written in a form this compiler does not read*, and the measurement went `partial`. The issue found no model reaching it; this one does, and on `develop` prints exactly that for both the readable and the stopped form:

```souther
data Active = Flag invariant value /= Off
behavior pick : (f: Active, n: Int) -> Answer
let pick (f, n) = match f.value with
    | On  -> Answer(1)
    | Off -> if n >= 100000 then unreachable "a" else unreachable "b"
```

## Root cause

`NotABoundary.NOTHING_RECORDS_IT` claimed the comparison "may well draw a boundary this cannot show a row against". The mechanism says less: `CoverageSites.number` skips a site exactly where `reachable && answers(e)` is false, i.e. where the expression the comparison decides never answers a value. Such a comparison's outcome is about no row. The over-claim is what made the reporting path (`noticed`) exist, and it is what a report-level "not recordable" reason would re-encode.

## What changes

- `BoundaryPolicy.refuses(comparison, plan, live)` answers `Optional<NotABoundary>` from its own inputs. `ComparisonReadings.walk` reads a comparison (`ComparisonAssessment.of`) only where that is empty, and `Standing` is `Admitted(read)` or `Refused(why)` — the comparison lives on the `Reading` beside it, once.
- `NOTHING_RECORDS_IT` becomes `NO_RUN_ANSWERS_THROUGH_IT`, documented as what the plan's numbering guarantees. Neither refusal is reported: the case such a comparison stands in is reported as ruled out, and the position as one the model draws no line through.
- `GuardThresholds.of` is one loop over the readings; an admitted comparison's geometry and rule-without-a-line come off its own assessment. `noticed`, `why`, `said`, `quantityOf`, the `assessed` list and `writtenHere` are deleted. `AffineReading.read` is called in `Cutting.read` and nowhere else in the package.
- `UnreadComparison.Quantity.Over` is `OverOne(position)` or `OverSeveral(positions)`. `why` answers the first from the position's carrier and never from the sides, so the side-reading helpers are reached from the stopped path only and their `RuleReadingStopped` type holds on every path.
- `UnreadComparison.whatStopped` is the stop-typed entry for a caller holding a stopped reading; `whyItStopped` takes `AffineReading.OfAComparison.Stopped` and has no runtime guard.

## Verification

- `AComparisonNoRunReachesIsNotARuleWithoutALineTest`: the witness is `Refused(NO_RUN_ANSWERS_THROUGH_IT)`; the report says nothing of it, is `measurement: complete`, says `Off` is declared unreachable, `not derivable: n`, and `border not applicable`; the same holds for `n * n >= 100000`; the positive control asserts the border line at `pick/n = 100000`. A mutant publishing `UnreadComparisonForm` for refused comparisons turns the report tests red.
- `mvn -o test` green across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)