### PR TITLE
Decide a branch by every clause, and answer for a rule by its own

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ChoiceId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ChoiceId.java
@@ -1,0 +1,13 @@
+package souther.compiler.check;
+
+/**
+ * One written choice, told apart from every other by being this object.
+ *
+ * <p>Made once, where the {@code ||} is read, and copied wherever a conjunction distributes over
+ * the choice — so however many places a branch of it turns up in the met-together reading, every
+ * one of them answers for the same thing an author wrote. Identity and nothing else: two choices
+ * spelled the same way are two decisions, which is the same reason the parts of a clause are filed
+ * by the node and not by what a node is equal to.
+ */
+final class ChoiceId {
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -672,14 +672,6 @@ public final class InvariantChecker {
             // value is the walk's answer and is given to both readings; what each of them makes of a
             // clause is its own, so neither can widen the other's idea of what it was handed.
             Map<FactSubject, Type> positions = positions(atoms, keys, typeAt);
-            // One reading in two languages and not two readings: the connectives belong to the clause,
-            // so an alternative nothing can satisfy is dropped by asking the whole of what is known
-            // about it.
-            //
-            // Read before the ends are, because the reading of ends asks what this one made of each part
-            // it meets. Nothing here depends on that order otherwise — both are given the same clauses
-            // and neither takes anything from the other.
-            StatedByClauses stated = StatedByClauses.top();
             // How a choice holds what it leaves, settled over the whole declaration before any of
             // it is read. Its clauses are met, so what they come to together is the product of what
             // each comes to, and a bound on that bounds every step of the fold — which is why the
@@ -701,11 +693,11 @@ public final class InvariantChecker {
             StatedByClauses.Reading reader = StatedByClauses
                     .readingOf(c.terms, at, positions, symbols, alternatives, allowed);
             // What each clause said and what each part of it said, kept as they were read and
-            // asked afterwards. Which branch of a choice anybody can take turns on machines nobody
-            // has made at this point, and every one of these questions has a different answer for a
-            // branch that survives and one that does not — a clause's adoption included. Asked
-            // here, a reading answered from what it happened to hold, and an account named a rule
-            // of a branch nothing satisfies.
+            // asked afterwards. Which branch of a choice anybody can take turns on clauses not yet
+            // read and on machines nobody has made at this point, and every one of these questions
+            // has a different answer for a branch that survives and one that does not — a clause's
+            // adoption included. Asked here, a reading answered from what it happened to hold, and
+            // an account named a rule of a branch nothing satisfies.
             //
             // Kept in the order they were read and not in a map keyed by what a node happens to be,
             // because the order these are worked out in is the order the allowance is spent in: a
@@ -713,7 +705,7 @@ public final class InvariantChecker {
             // where its clauses landed in a table.
             StatedByClauses.Asked<Written> asked = new StatedByClauses.Asked<>();
             for (Written each : written) {
-                stated = stated.meet(asked.read(reader, each, each.clause()));
+                asked.read(reader, each, each.clause());
             }
             // And now that every rule about this value has been said, what its positions admit is
             // worked out — and with it what each clause and each part of it took in, since a branch
@@ -721,7 +713,7 @@ public final class InvariantChecker {
             // met out of every clause that reached it, so anything built before the last of them
             // arrived would be built out of less than the rules say — and which of two ways of
             // writing the same rules was affordable would be a fact about the writing.
-            StatedByClauses.Answered<Written> answered = asked.resolve(reader, stated, allowed);
+            StatedByClauses.Answered<Written> answered = asked.resolve(reader, allowed);
             // What the answer has left, before a word of the account is read.
             Map<FactSubject, Integer> unspent = leftOf(allowed, positions.keySet());
             AdmissibleValues<FactSubject> values = answered.whole().values();

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -34,10 +34,11 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
     /**
      * What one part of one clause came to, once every branch of the value is decided.
      *
-     * <p>A projection of the whole and not a reading of its own. The branch a part is in is dropped
-     * or kept by the rules of every clause together, so a part read again on its own answers about a
-     * branch this declaration has already dropped — and pays for machines the whole answer never
-     * needed to find out.
+     * <p>Answered over the part's own rule's tree, with the branches decided by the fates the
+     * settlement handed back ({@code Settlement}). The branch a part is in is dropped or kept by
+     * the rules of every clause together, so a part deciding that for itself would answer about a
+     * branch this declaration has already dropped — and would pay for machines the whole answer
+     * never needed to find out.
      *
      * @param aboutARule what a rule of this part is answerable for, per position
      */

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -25,8 +25,9 @@ import java.util.Set;
  * inside the left of {@code A} is refined by {@code A}'s left, and the same branch inside the right
  * by {@code A}'s right. What the written branch's author can act on is the whole declaration's
  * answer: nobody can be in it only if nobody can be in it anywhere it stands. So the sides join over
- * occurrences by {@link Emptiness#joined}, which is associative, commutative and idempotent — the
- * order the copies are met in, and how the conjunctions were bracketed, cannot reach the answer.
+ * occurrences by {@link Emptiness#joined}, which is associative, commutative and idempotent — and
+ * so is every other component of a side ({@link Sided#alsoSeen}), so the order the copies are met
+ * in, and how the conjunctions were bracketed, cannot reach the answer.
  *
  * @param made     the whole reading worked out, with what could not be built beside it
  * @param ordered  where every position stops, settled by the same work
@@ -62,12 +63,22 @@ record Settlement(Realized<FactSubject> made, OrderedIntervals<FactSubject> orde
             return new Sided(emptiness, Map.of(), Set.of());
         }
 
-        /** The same branch with one more occurrence of it taken in. */
+        /**
+         * The same branch with one more occurrence of it taken in.
+         *
+         * <p>Associative, commutative and idempotent in every component, which is what lets the
+         * class doc promise that the order the copies are met in cannot reach the answer:
+         * {@link Emptiness#joined} is, a set union is, and the reasons are joined as a set and then
+         * said in the vocabulary's declared order — kept in the order the occurrences were met,
+         * they would be said in a neighbouring clause's order.
+         */
         Sided alsoSeen(Sided other) {
             Set<FactSubject> gaveUp = new java.util.LinkedHashSet<>(unbuilt);
             gaveUp.addAll(other.unbuilt());
-            return new Sided(emptiness.joined(other.emptiness()),
-                    ReadByClauses.alsoSaying(standing, other.standing()), gaveUp);
+            Map<FactSubject, List<UnreadReason>> why = new java.util.LinkedHashMap<>();
+            ReadByClauses.alsoSaying(standing, other.standing()).forEach((position, reasons) ->
+                    why.put(position, reasons.stream().sorted().toList()));
+            return new Sided(emptiness.joined(other.emptiness()), why, gaveUp);
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -1,0 +1,73 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.Emptiness;
+import souther.compiler.values.Realized;
+import souther.compiler.values.UnreadReason;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What settling the met-together reading came to: the values, and the fate of every branch.
+ *
+ * <p>One computation and two projections of its result. Working {@link StatedTogether} out under an
+ * allowance is what decides which values every position admits, and the same work is the only thing
+ * that can say whether anybody can be in a branch of a choice — so both come back from it together,
+ * as a value, and nothing recomputes either. The account of what each rule took in
+ * ({@link StatedByClauses.Reading#accountOf}) consumes the fates; it holds no machinery to decide
+ * one.
+ *
+ * <p><b>A fate is an aggregate over every place distribution put the branch, not an attribute of
+ * one place.</b> The same written choice stands inside each branch of every choice met with it, and
+ * one copy's branch can admit something where another copy's admits nothing — a branch of {@code B}
+ * inside the left of {@code A} is refined by {@code A}'s left, and the same branch inside the right
+ * by {@code A}'s right. What the written branch's author can act on is the whole declaration's
+ * answer: nobody can be in it only if nobody can be in it anywhere it stands. So the sides join over
+ * occurrences by {@link Emptiness#joined}, which is associative, commutative and idempotent — the
+ * order the copies are met in, and how the conjunctions were bracketed, cannot reach the answer.
+ *
+ * @param made     the whole reading worked out, with what could not be built beside it
+ * @param ordered  where every position stops, settled by the same work
+ * @param outcomes the fate of both branches of every written choice, by its id
+ */
+record Settlement(Realized<FactSubject> made, OrderedIntervals<FactSubject> ordered,
+                  Map<ChoiceId, OfAChoice> outcomes) {
+
+    /** Both branches of one written choice, each aggregated over its occurrences. */
+    record OfAChoice(Sided left, Sided right) {
+
+        /** This choice with one more occurrence of it taken in, side by side. */
+        OfAChoice alsoSeen(OfAChoice occurrence) {
+            return new OfAChoice(left.alsoSeen(occurrence.left()),
+                    right.alsoSeen(occurrence.right()));
+        }
+    }
+
+    /**
+     * One branch's fate, over every occurrence taken in so far.
+     *
+     * <p>{@code standing} and {@code unbuilt} carry what probing the occurrences could not build,
+     * for the one case the account needs it: a branch kept without being shown live is kept with
+     * the reason nobody knows, or the account would call a position open where the truth is that
+     * nothing looked. Read only where the aggregate stays {@link Emptiness#UNDECIDED}; a branch
+     * shown live somewhere needs no excuse, and a branch dead everywhere takes its reasons with it.
+     */
+    record Sided(Emptiness emptiness, Map<FactSubject, List<UnreadReason>> standing,
+                 Set<FactSubject> unbuilt) {
+
+        /** A branch nobody has probed yet, which everything joins onto. */
+        static Sided settledAs(Emptiness emptiness) {
+            return new Sided(emptiness, Map.of(), Set.of());
+        }
+
+        /** The same branch with one more occurrence of it taken in. */
+        Sided alsoSeen(Sided other) {
+            Set<FactSubject> gaveUp = new java.util.LinkedHashSet<>(unbuilt);
+            gaveUp.addAll(other.unbuilt());
+            return new Sided(emptiness.joined(other.emptiness()),
+                    ReadByClauses.alsoSaying(standing, other.standing()), gaveUp);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -24,8 +24,9 @@ import java.util.Set;
  * the conjunction across rules is not written over this type at all: the value derivation is a
  * projection ({@link #together()}) onto {@link StatedTogether}, which is where clauses meet, and
  * the one thing this tree takes back from there is the fate of its own choices
- * ({@link Settlement}). The conjunction inside one clause is this type's ({@link #meet}), reached
- * only through the fold that reads the clause.
+ * ({@link Settlement}). The conjunction inside one clause exists only inside the fold that reads
+ * the clause ({@code Reading}), so there is no operation on this type by which a neighbouring
+ * rule's reading could arrive.
  *
  * <p><b>The connectives are over this and not over either of them.</b> A choice between two
  * alternatives is a choice between two readings of the whole value, so an alternative that cannot be
@@ -110,19 +111,17 @@ sealed interface StatedByClauses {
         Part either(Part other) {
             Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
                     ReadByClauses.alsoSaying(standing, other.standing());
-            // Spoiled by there having been an alternative this could not read, which is the rule
-            // the values join by ({@code PlannedValues}), said of the part: a value satisfying the
-            // branch nothing read is under no obligation from this one, so what this side's copy
-            // reached is left open. Not what it settled — a position a dead branch settled is an
-            // answer, and an unread alternative widens a constraint, not an answer ({@link
-            // Adoption#either} makes the same distinction). Only where nothing has spoiled the
-            // position already: a reason recorded there is a rule that named it, which is nearer
-            // than a branch that widened it from outside.
+            // What an unread alternative does to the reasons is the vocabulary's rule, stated once
+            // ({@code UnreadReason.leftOpen}); which positions it happens to is this carrier's.
+            // What this side's copy reached — not what it settled: a position a dead branch
+            // settled is an answer, and an unread alternative widens a constraint, not an answer
+            // ({@link Adoption#either} makes the same distinction).
             if (other.byValues().dropped()) {
-                why = leftOpen(why, reachedBy(byValues()));
+                why = souther.compiler.values.UnreadReason.leftOpen(why, reachedBy(byValues()));
             }
             if (byValues().dropped()) {
-                why = leftOpen(why, reachedBy(other.byValues()));
+                why = souther.compiler.values.UnreadReason.leftOpen(why,
+                        reachedBy(other.byValues()));
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
                     why);
@@ -136,18 +135,6 @@ sealed interface StatedByClauses {
             return out;
         }
 
-        private static Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>>
-                leftOpen(Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> had,
-                         java.util.Set<FactSubject> these) {
-            if (these.isEmpty()) {
-                return had;
-            }
-            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> out =
-                    new java.util.LinkedHashMap<>(had);
-            these.forEach(each -> out.putIfAbsent(each, java.util.List.of(
-                    souther.compiler.values.UnreadReason.ALTERNATIVE_NOT_READ)));
-            return out;
-        }
     }
 
     /**
@@ -213,29 +200,6 @@ sealed interface StatedByClauses {
      * it gave before anybody knew.
      */
     StatedByClauses from(Core e);
-
-    /**
-     * Both holding at once, distributed over a choice this could not settle.
-     *
-     * <p>A conjunction of a choice is the choice between the conjunctions. Merged into one first,
-     * the reading would be answering about a branch that may not be there.
-     */
-    default StatedByClauses meet(StatedByClauses other) {
-        if (this instanceof Choice it) {
-            return new Choice(it.id(), it.left().meet(other), it.right().meet(other));
-        }
-        if (other instanceof Choice it) {
-            return new Choice(it.id(), meet(it.left()), meet(it.right()));
-        }
-        Said here = (Said) this;
-        Said there = (Said) other;
-        return new Said(here.values().meet(there.values()),
-                here.ordered().meet(there.ordered()),
-                here.byValues().both(there.byValues()), here.byOrder().both(there.byOrder()),
-                // The parts of both, since a conjunction is every clause of it holding at once and
-                // each of them is still the part it was.
-                bothParts(here.parts(), there.parts()));
-    }
 
     /**
      * The same clauses with the account left behind, which is what the rules of a declaration are
@@ -329,7 +293,34 @@ sealed interface StatedByClauses {
 
         @Override
         public StatedByClauses both(StatedByClauses one, StatedByClauses other) {
-            return one.meet(other);
+            return met(one, other);
+        }
+
+        /**
+         * Both holding at once, distributed over a choice this could not settle.
+         *
+         * <p>A conjunction of a choice is the choice between the conjunctions. Merged into one
+         * first, the reading would be answering about a branch that may not be there.
+         *
+         * <p>Reachable only through the fold that reads one clause, which is what keeps this tree
+         * one rule's: the conjunction across rules has no operation here to arrive by, and is
+         * written where the rules of a declaration meet ({@link StatedTogether#meet}).
+         */
+        private static StatedByClauses met(StatedByClauses one, StatedByClauses other) {
+            if (one instanceof Choice it) {
+                return new Choice(it.id(), met(it.left(), other), met(it.right(), other));
+            }
+            if (other instanceof Choice it) {
+                return new Choice(it.id(), met(one, it.left()), met(one, it.right()));
+            }
+            Said here = (Said) one;
+            Said there = (Said) other;
+            return new Said(here.values().meet(there.values()),
+                    here.ordered().meet(there.ordered()),
+                    here.byValues().both(there.byValues()), here.byOrder().both(there.byOrder()),
+                    // The parts of both, since a conjunction is every clause of it holding at once
+                    // and each of them is still the part it was.
+                    bothParts(here.parts(), there.parts()));
         }
 
         /**
@@ -373,16 +364,15 @@ sealed interface StatedByClauses {
          */
         @Override
         public StatedByClauses either(StatedByClauses one, StatedByClauses other) {
-            // Held apart, every choice is held open past the clause: whether anybody can be in a
-            // branch is settled by the rules of every clause together, and a clause written later
-            // can be the one that shows a branch here impossible. Decided now instead, the branch
-            // structure is gone by the time that clause arrives, and its refinement has nothing to
-            // reach. The expansion this defers was counted over the whole declaration before any
-            // clause was read, which is what admitted the declaration as APART at all.
-            if (alternatives == Alternatives.MERGED
-                    && one instanceof Said here && other instanceof Said there) {
+            if (one instanceof Said here && other instanceof Said there) {
                 Emptiness a = here.emptiness();
                 Emptiness b = there.emptiness();
+                // A branch the descriptions already show empty is decided here whichever way the
+                // declaration holds its choices. The answer is definitive — a description empty
+                // before anything is built admits nothing however the other clauses refine it —
+                // and a clause written later can only show more branches impossible, never fewer,
+                // so nothing a deferral waits for can reach a different decision. Deferred anyway,
+                // the dead branch would widen the met-together tree for nothing.
                 if (a == Emptiness.EMPTY && b == Emptiness.EMPTY) {
                     return bothDead(here, there);
                 }
@@ -392,7 +382,14 @@ sealed interface StatedByClauses {
                 if (b == Emptiness.EMPTY) {
                     return beside(here, there);
                 }
-                if (a == Emptiness.NONEMPTY && b == Emptiness.NONEMPTY) {
+                // Two live branches are another matter: merging them is the one decision a clause
+                // written later can be too late for, since it is the branch structure the later
+                // clause's conjunction would have refined. Held apart, the choice is held open past
+                // the clause and settled by the rules of every clause together; the expansion the
+                // deferral costs was counted over the whole declaration before any clause was
+                // read, which is what admitted the declaration as APART at all.
+                if (alternatives == Alternatives.MERGED
+                        && a == Emptiness.NONEMPTY && b == Emptiness.NONEMPTY) {
                     return live(here, there);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -11,12 +11,21 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * What the clauses of one value say, in each of the languages a clause is read in.
+ * What the clauses of one rule say, in each of the languages a clause is read in.
  *
  * <p>Two languages and one reading. Which values a position may take is a set, and where a position
  * stops is a range, and neither says what the other says — an ordering names no finite set, and a
  * set of values has no word for what lies between two of them. So a clause reaches whichever of them
  * has a word for it, and some clauses reach both.
+ *
+ * <p><b>One rule's, and never met with another rule's.</b> This tree answers what one rule's own
+ * clauses took in, and that answer must come from those clauses alone — a constraint a neighbouring
+ * rule states does not change what this one read, however much it changes what the value admits. So
+ * the conjunction across rules is not written over this type at all: the value derivation is a
+ * projection ({@link #together()}) onto {@link StatedTogether}, which is where clauses meet, and
+ * the one thing this tree takes back from there is the fate of its own choices
+ * ({@link Settlement}). The conjunction inside one clause is this type's ({@link #meet}), reached
+ * only through the fold that reads the clause.
  *
  * <p><b>The connectives are over this and not over either of them.</b> A choice between two
  * alternatives is a choice between two readings of the whole value, so an alternative that cannot be
@@ -99,8 +108,35 @@ sealed interface StatedByClauses {
 
         /** The same part of two branches somebody can be in. */
         Part either(Part other) {
+            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
+                    ReadByClauses.alsoSaying(standing, other.standing());
+            // Spoiled by there having been an alternative this could not read, which is the rule
+            // the values join by ({@code PlannedValues}), said of the part: a value satisfying the
+            // branch nothing read is under no obligation from this one, so what this side's copy
+            // reached is left open. Only where nothing has spoiled the position already — a reason
+            // recorded there is a rule that named it, which is nearer than a branch that widened
+            // it from outside.
+            if (other.byValues().dropped()) {
+                why = leftOpen(why, byValues().mentions());
+            }
+            if (byValues().dropped()) {
+                why = leftOpen(why, other.byValues().mentions());
+            }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
-                    ReadByClauses.alsoSaying(standing, other.standing()));
+                    why);
+        }
+
+        private static Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>>
+                leftOpen(Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> had,
+                         java.util.Set<FactSubject> these) {
+            if (these.isEmpty()) {
+                return had;
+            }
+            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> out =
+                    new java.util.LinkedHashMap<>(had);
+            these.forEach(each -> out.putIfAbsent(each, java.util.List.of(
+                    souther.compiler.values.UnreadReason.ALTERNATIVE_NOT_READ)));
+            return out;
         }
     }
 
@@ -108,8 +144,11 @@ sealed interface StatedByClauses {
      * A choice whose branches this cannot tell apart yet.
      *
      * <p>An interpreted connective and not an unread one: the clause said {@code ||} and this is
-     * what {@code ||} means, held open only because whether either branch admits anything turns on
-     * machines nobody has made.
+     * what {@code ||} means, held open because whether anybody can be in a branch is settled by the
+     * rules of every clause together — a clause written later can be the one that shows a branch
+     * here impossible, and where the choice was decided over what this clause happened to hold,
+     * that clause's refinement had nothing to reach. It carries the id of the written {@code ||},
+     * which is how the fate settled over the whole declaration finds its way back to this tree.
      *
      * <p><b>The whole of what was read, and not its values alone.</b> A branch is dropped, kept, or
      * kept beside a dead one, and every part of a reading is answered differently by each of those
@@ -118,18 +157,19 @@ sealed interface StatedByClauses {
      * behind: the account said a rule of a branch nothing satisfies had gone unread, and there was
      * no branch for an author to go and look at.
      */
-    record Choice(StatedByClauses left, StatedByClauses right) implements StatedByClauses {
+    record Choice(ChoiceId id, StatedByClauses left, StatedByClauses right)
+            implements StatedByClauses {
 
         public Choice {
-            if (left == null || right == null) {
-                throw new IllegalArgumentException("a choice is between two readings");
+            if (id == null || left == null || right == null) {
+                throw new IllegalArgumentException("a choice is between two named readings");
             }
         }
 
         /** Into both branches, since which of them survives is not known yet. */
         @Override
         public StatedByClauses from(Core e) {
-            return new Choice(left.from(e), right.from(e));
+            return new Choice(id, left.from(e), right.from(e));
         }
     }
 
@@ -172,10 +212,10 @@ sealed interface StatedByClauses {
      */
     default StatedByClauses meet(StatedByClauses other) {
         if (this instanceof Choice it) {
-            return new Choice(it.left().meet(other), it.right().meet(other));
+            return new Choice(it.id(), it.left().meet(other), it.right().meet(other));
         }
         if (other instanceof Choice it) {
-            return new Choice(meet(it.left()), meet(it.right()));
+            return new Choice(it.id(), meet(it.left()), meet(it.right()));
         }
         Said here = (Said) this;
         Said there = (Said) other;
@@ -187,13 +227,28 @@ sealed interface StatedByClauses {
                 bothParts(here.parts(), there.parts()));
     }
 
+    /**
+     * The same clauses with the account left behind, which is what the rules of a declaration are
+     * met over.
+     *
+     * <p>A projection and not a second reading: the values and the ranges are the ones this holds,
+     * and the choices keep their ids, so a fate settled over there names a choice here.
+     */
+    default StatedTogether together() {
+        return switch (this) {
+            case Said it -> new StatedTogether.Said(it.values(), it.ordered());
+            case Choice it -> new StatedTogether.Choice(it.id(),
+                    it.left().together(), it.right().together());
+        };
+    }
+
     /** The reading of one value's positions, made once and used over however many clauses reach it.
      *  Built per clause, this walk paid for a pair of readers at every clause of every value. */
     static Reading readingOf(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                              Symbols symbols, Alternatives alternatives,
                              souther.compiler.values.Allowance<FactSubject> allowed) {
         return new Reading(AdmissibleReading.of(terms, at, byName, symbols, alternatives, allowed),
-                OrderedReading.of(terms, at, byName, symbols), terms, at, byName);
+                OrderedReading.of(terms, at, byName, symbols), terms, at, byName, alternatives);
     }
 
 
@@ -210,7 +265,7 @@ sealed interface StatedByClauses {
      * its own to avoid, and the one this accounting was written against.
      */
     record Reading(AdmissibleReading values, OrderedReading ordered, Terms terms, Denotations at,
-                   Map<FactSubject, Type> byName)
+                   Map<FactSubject, Type> byName, Alternatives alternatives)
             implements ClauseReading<StatedByClauses> {
 
         @Override
@@ -308,7 +363,14 @@ sealed interface StatedByClauses {
          */
         @Override
         public StatedByClauses either(StatedByClauses one, StatedByClauses other) {
-            if (one instanceof Said here && other instanceof Said there) {
+            // Held apart, every choice is held open past the clause: whether anybody can be in a
+            // branch is settled by the rules of every clause together, and a clause written later
+            // can be the one that shows a branch here impossible. Decided now instead, the branch
+            // structure is gone by the time that clause arrives, and its refinement has nothing to
+            // reach. The expansion this defers was counted over the whole declaration before any
+            // clause was read, which is what admitted the declaration as APART at all.
+            if (alternatives == Alternatives.MERGED
+                    && one instanceof Said here && other instanceof Said there) {
                 Emptiness a = here.emptiness();
                 Emptiness b = there.emptiness();
                 if (a == Emptiness.EMPTY && b == Emptiness.EMPTY) {
@@ -329,33 +391,203 @@ sealed interface StatedByClauses {
             // what the positions admit, where they stop, and what each language is recorded as
             // having taken in; settled for some of those and held open for the rest, a branch that
             // turned out dead would have left an account of what it adopted behind it.
-            return new Choice(one, other);
+            return new Choice(new ChoiceId(), one, other);
         }
 
         /**
-         * What the choice comes to, with every branch of it worked out.
+         * The met-together reading worked out, with the fate of every branch beside it.
          *
-         * <p>Where the question waited, this is where it is answered — once, by the rules above,
-         * on branches that are readings rather than descriptions of them. Nothing downstream is
-         * left holding a decision: what comes back has a set at every position, an account of what
-         * each language took in, and no branch anybody still has to choose between.
+         * <p>Once, and this is where every choice is answered — over branches that are readings
+         * rather than descriptions of them, by the same four rules a settled reading always used.
+         * What comes back is a value: nothing downstream is left holding a decision, and nothing
+         * recomputes one — the accounts ({@link #accountOf}) read the fates out of it.
+         *
+         * <p>A fate is aggregated over every place distribution put the branch — the reasoning is
+         * {@link Settlement}'s. What is decided here per place is the emptiness of that occurrence,
+         * and the join over occurrences is associative, commutative and idempotent, so the answer
+         * cannot turn on the order the clauses were met in.
          */
-        ReadByClauses resolve(StatedByClauses read,
-                              souther.compiler.values.Allowance<FactSubject> by) {
-            Said said = settled(read, by);
-            souther.compiler.values.Realized<FactSubject> made = said.values().resolve(by);
+        Settlement settle(StatedTogether read,
+                          souther.compiler.values.Allowance<FactSubject> by) {
+            Map<ChoiceId, Settlement.OfAChoice> outcomes = new java.util.LinkedHashMap<>();
+            StatedTogether.Said said = settling(read, by, outcomes);
+            return new Settlement(said.values().resolve(by), said.ordered(), outcomes);
+        }
+
+        /** The same reading with every choice in it decided, each occurrence noting its fate. */
+        private StatedTogether.Said settling(StatedTogether read,
+                                             souther.compiler.values.Allowance<FactSubject> by,
+                                             Map<ChoiceId, Settlement.OfAChoice> outcomes) {
+            return switch (read) {
+                case StatedTogether.Said it -> it;
+                case StatedTogether.Choice it -> {
+                    StatedTogether.Said one = settling(it.left(), by, outcomes);
+                    StatedTogether.Said other = settling(it.right(), by, outcomes);
+                    Settlement.Sided here = probed(one, by);
+                    Settlement.Sided there = probed(other, by);
+                    outcomes.merge(it.id(), new Settlement.OfAChoice(here, there),
+                            Settlement.OfAChoice::alsoSeen);
+                    yield decided(one, here, other, there);
+                }
+            };
+        }
+
+        /**
+         * What one occurrence of a choice leaves the values, by the rule its two fates pick.
+         *
+         * <p>The four rules of a settled reading, over the values and the ranges alone: what each
+         * language recorded as taken in is the account's, answered over the rule's own tree with
+         * the aggregated fates, and is not here to be answered per occurrence.
+         */
+        private StatedTogether.Said decided(StatedTogether.Said one, Settlement.Sided here,
+                                            StatedTogether.Said other, Settlement.Sided there) {
+            if (here.emptiness() == Emptiness.EMPTY && there.emptiness() == Emptiness.EMPTY) {
+                // The rule for a choice nobody can take, named rather than arrived at: a join is
+                // what two branches somebody can take come to, and neither of these is one.
+                return new StatedTogether.Said(
+                        one.values().leavingNothing().bothDead(other.values().leavingNothing()),
+                        ordered.either(one.ordered().leavingNothing(),
+                                other.ordered().leavingNothing()));
+            }
+            if (here.emptiness() == Emptiness.EMPTY) {
+                return keptTogether(other, there);
+            }
+            if (there.emptiness() == Emptiness.EMPTY) {
+                return keptTogether(one, here);
+            }
+            StatedTogether.Said left = keptTogether(one, here);
+            StatedTogether.Said right = keptTogether(other, there);
+            return new StatedTogether.Said(values.either(left.values(), right.values()),
+                    ordered.either(left.ordered(), right.ordered()));
+        }
+
+        /**
+         * A branch that is being kept, holding what working it out could not build.
+         *
+         * <p>A branch shown to admit something is kept and there is nothing more to say; a branch
+         * nothing could work out is kept for the same reason nothing was dropped — nobody showed it
+         * empty — and that is not the same fact. Kept without saying so, the reading would call a
+         * position open where the truth is that nobody looked.
+         */
+        private StatedTogether.Said keptTogether(StatedTogether.Said read,
+                                                 Settlement.Sided known) {
+            if (known.emptiness() != Emptiness.UNDECIDED) {
+                return read;
+            }
+            return new StatedTogether.Said(read.values().alsoStanding(known.standing()),
+                    read.ordered());
+        }
+
+        /**
+         * Whether anything satisfies a branch, asked of this occurrence of it worked out.
+         *
+         * <p>Three answers. A branch whose ordering admits nothing, or whose values came out empty,
+         * is one nobody can be in here; a branch every position of which was worked out and which
+         * admits something is one somebody can be in; and a branch with a position this compiler
+         * could not build is neither, whatever the widened set it came back with says — and what
+         * could not be built comes back with the answer, so a branch kept on it is kept saying so.
+         *
+         * <p>What the descriptions settle is settled before anything is built: a branch shown to
+         * admit nothing, or to admit something, is decided without a machine, and only where the
+         * descriptions leave the question open is the branch worked out to answer it.
+         */
+        private Settlement.Sided probed(StatedTogether.Said read,
+                                        souther.compiler.values.Allowance<FactSubject> by) {
+            if (read.ordered().isBottom()) {
+                return Settlement.Sided.settledAs(Emptiness.EMPTY);
+            }
+            Emptiness said = read.values().emptiness();
+            if (said != Emptiness.UNDECIDED) {
+                return Settlement.Sided.settledAs(said);
+            }
+            souther.compiler.values.Realized<FactSubject> made = read.values().resolve(by);
+            if (made.emptiness() != Emptiness.UNDECIDED) {
+                return Settlement.Sided.settledAs(made.emptiness());
+            }
+            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
+                    new java.util.LinkedHashMap<>(made.aboutARule());
+            made.aboutTheAnswer().forEach(why::putIfAbsent);
+            return new Settlement.Sided(Emptiness.UNDECIDED, why, made.unbuilt());
+        }
+
+        /**
+         * What one rule's clauses took in, answered over that rule's own tree.
+         *
+         * <p>The one thing taken from outside the rule is the fate of its choices, which is the
+         * whole declaration's to say and arrives settled ({@link Settlement}). Everything else —
+         * what each part adopted, what stopped this reading of it — was recorded as the rule was
+         * read, so nothing here builds a machine and nothing here can be widened by a constraint a
+         * neighbouring rule stated: no neighbouring rule is in the tree.
+         */
+        Map<Core, ReadByClauses.OfAPart> accountOf(StatedByClauses rule, Settlement made) {
+            Said said = accounted(rule, made.outcomes());
+            Set<FactSubject> unbuilt = made.made().unbuilt();
             // And what could not be built is given up on here too. What a leaf said it adopted was
-            // said before any machine was made, so a position whose answer this did not work out is
-            // one the account still calls taken in — while the values beside it say it holds every
-            // value because nobody worked it out.
+            // said before any machine was made, so a position whose answer the whole reading did
+            // not work out is one the account still calls taken in — while the values beside it
+            // say it holds every value because nobody worked it out.
             Map<Core, ReadByClauses.OfAPart> parts = new java.util.IdentityHashMap<>();
             said.parts().forEach((each, part) -> parts.put(each, new ReadByClauses.OfAPart(
-                    part.byValues().unbuiltAt(made.unbuilt()),
-                    part.byOrder().unbuiltAt(made.unbuilt()),
-                    aRuleIsAnswerableFor(part, made))));
-            return new ReadByClauses(made.values(), said.ordered(),
-                    said.byValues().unbuiltAt(made.unbuilt()),
-                    said.byOrder().unbuiltAt(made.unbuilt()), parts);
+                    part.byValues().unbuiltAt(unbuilt),
+                    part.byOrder().unbuiltAt(unbuilt),
+                    aRuleIsAnswerableFor(part, made.made()))));
+            return parts;
+        }
+
+        /** The same rule's reading with every choice in it decided, by the fates alone. */
+        private Said accounted(StatedByClauses read,
+                               Map<ChoiceId, Settlement.OfAChoice> outcomes) {
+            return switch (read) {
+                case Said it -> it;
+                case Choice it -> {
+                    Said one = accounted(it.left(), outcomes);
+                    Said other = accounted(it.right(), outcomes);
+                    Settlement.OfAChoice fate = outcomes.get(it.id());
+                    if (fate == null) {
+                        // Every choice of a rule stands somewhere in the met-together reading, so
+                        // a fate nobody settled is this compiler's arithmetic gone wrong and not a
+                        // fact about any model.
+                        throw new IllegalStateException(
+                                "a choice of a rule was never met in the settled reading");
+                    }
+                    Emptiness here = fate.left().emptiness();
+                    Emptiness there = fate.right().emptiness();
+                    if (here == Emptiness.EMPTY && there == Emptiness.EMPTY) {
+                        yield bothDead(one, other);
+                    }
+                    if (here == Emptiness.EMPTY) {
+                        yield beside(keptAs(other, fate.right()), one);
+                    }
+                    if (there == Emptiness.EMPTY) {
+                        yield beside(keptAs(one, fate.left()), other);
+                    }
+                    yield live(keptAs(one, fate.left()), keptAs(other, fate.right()));
+                }
+            };
+        }
+
+        /**
+         * A branch of the rule that is being kept, holding what the settlement could not build in
+         * it.
+         *
+         * <p>{@link #keptTogether} for the account: the reasons and the given-up positions were
+         * settled where the branch's occurrences were probed, and are applied to what this rule's
+         * parts said — a part about a position nobody worked out is one the account still calls
+         * taken in until this is applied.
+         */
+        private Said keptAs(Said read, Settlement.Sided known) {
+            if (known.emptiness() != Emptiness.UNDECIDED) {
+                return read;
+            }
+            Map<Core, Part> parts = new java.util.IdentityHashMap<>();
+            read.parts().forEach((each, part) -> parts.put(each, new Part(
+                    part.byValues().unbuiltAt(known.unbuilt()),
+                    part.byOrder().unbuiltAt(known.unbuilt()),
+                    ReadByClauses.alsoSaying(part.standing(), known.standing()))));
+            return new Said(read.values().alsoStanding(known.standing()), read.ordered(),
+                    read.byValues().unbuiltAt(known.unbuilt()),
+                    read.byOrder().unbuiltAt(known.unbuilt()),
+                    parts);
         }
 
         /**
@@ -388,96 +620,6 @@ sealed interface StatedByClauses {
                 }
             });
             return out;
-        }
-
-        /**
-         * The same reading with every choice in it decided, which is one reading.
-         *
-         * <p>The branches are worked out to decide, and then the decision is made over the
-         * descriptions rather than over what they came to: the four rules are the ones a settled
-         * reading always used, and what they are applied to is the same two branches. Joined as the
-         * worked-out readings instead, every position of the choice would be a machine made out of
-         * sets that were already machines, which is work nobody described.
-         */
-        private Said settled(StatedByClauses read,
-                             souther.compiler.values.Allowance<FactSubject> by) {
-            return switch (read) {
-                case Said it -> it;
-                case Choice it -> {
-                    Said one = settled(it.left(), by);
-                    Said other = settled(it.right(), by);
-                    souther.compiler.values.Emptiness here = emptinessOf(one, by);
-                    souther.compiler.values.Emptiness there = emptinessOf(other, by);
-                    if (here == Emptiness.EMPTY && there == Emptiness.EMPTY) {
-                        yield bothDead(one, other);
-                    }
-                    if (here == Emptiness.EMPTY) {
-                        yield beside(kept(other, there, by), one);
-                    }
-                    if (there == Emptiness.EMPTY) {
-                        yield beside(kept(one, here, by), other);
-                    }
-                    yield live(kept(one, here, by), kept(other, there, by));
-                }
-            };
-        }
-
-        /**
-         * Whether anything satisfies a branch, asked of the branch worked out.
-         *
-         * <p>Three answers. A branch whose ordering admits nothing, or whose values came out
-         * empty, is one nobody can be in; a branch every position of which was worked out and which
-         * admits something is one somebody can be in; and a branch with a position this compiler
-         * could not build is neither, whatever the widened set it came back with says.
-         */
-        private Emptiness emptinessOf(Said read,
-                                      souther.compiler.values.Allowance<FactSubject> by) {
-            if (read.ordered().isBottom()) {
-                return Emptiness.EMPTY;
-            }
-            // What the descriptions settle, before anything is built. A branch shown to admit
-            // nothing, or shown to admit something, is decided without a machine — and only where
-            // the descriptions leave the question open is the branch worked out to answer it.
-            Emptiness said = read.values().emptiness();
-            return said == Emptiness.UNDECIDED ? read.values().resolve(by).emptiness() : said;
-        }
-
-        /**
-         * A branch that is being kept, holding what working it out could not build.
-         *
-         * <p>Which is the whole of what the third answer means. A branch shown to admit something
-         * is kept and there is nothing more to say; a branch nothing could work out is kept for the
-         * same reason nothing was dropped — nobody showed it empty — and that is not the same fact.
-         * Kept without saying so, the branch beside it would be answered as though this one had
-         * been read, and the account would call a position open where the truth is that nobody
-         * looked.
-         *
-         * <p>Said here rather than left to the plan built afterwards. That plan need not hold the
-         * part that was refused: a choice whose branches speak about different positions joins to
-         * one the expensive part is not in, and the reason would go with it.
-         */
-        private Said kept(Said read, Emptiness known,
-                          souther.compiler.values.Allowance<FactSubject> by) {
-            if (known != Emptiness.UNDECIDED) {
-                return read;
-            }
-            souther.compiler.values.Realized<FactSubject> made = read.values().resolve(by);
-            java.util.Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
-                    new java.util.LinkedHashMap<>(made.aboutARule());
-            made.aboutTheAnswer().forEach(why::putIfAbsent);
-            // The parts of it too, and for the same reason. What a part said it adopted was said
-            // before any machine was made, so a part about a position this branch could not work
-            // out is one the account still calls taken in — and the plan the whole answer builds
-            // afterwards need not reach that position at all.
-            Map<Core, Part> parts = new java.util.IdentityHashMap<>();
-            read.parts().forEach((each, part) -> parts.put(each, new Part(
-                    part.byValues().unbuiltAt(made.unbuilt()),
-                    part.byOrder().unbuiltAt(made.unbuilt()),
-                    ReadByClauses.alsoSaying(part.standing(), why))));
-            return new Said(read.values().alsoStanding(why), read.ordered(),
-                    read.byValues().unbuiltAt(made.unbuilt()),
-                    read.byOrder().unbuiltAt(made.unbuilt()),
-                    parts);
         }
 
         /**
@@ -590,6 +732,7 @@ sealed interface StatedByClauses {
 
         private final Map<K, Core> byClause = new java.util.LinkedHashMap<>();
         private final Map<K, java.util.List<Core>> byPart = new java.util.LinkedHashMap<>();
+        private final Map<K, StatedByClauses> trees = new java.util.LinkedHashMap<>();
 
         /** One clause read, with the parts of it noted in the order the reading reached them. */
         StatedByClauses read(Reading reader, K key, Core clause) {
@@ -597,37 +740,56 @@ sealed interface StatedByClauses {
             StatedByClauses one = reader.read(clause, true, (part, _) -> parts.add(part));
             byClause.put(key, clause);
             byPart.put(key, parts);
+            trees.put(key, one);
             return one;
         }
 
         /**
-         * All of it worked out, once, and every part of it looked up in that.
+         * All of it worked out, once, and every rule of it answered over its own tree.
          *
-         * <p>One traversal because there is one answer. A clause worked out on its own is worked
-         * out against a tree the other clauses never reached: its branches are decided by its own
-         * rules alone, so a branch another clause makes impossible is still standing in it, and the
-         * account it gives names rules of a branch nobody can be in. And it pays for that —
-         * building machines the whole answer had no use for, out of what the whole answer has left.
+         * <p>One settlement because there is one value: the clauses are met over
+         * {@link StatedTogether}, in the order they were read, and everything that has to be built
+         * is built there, under the one allowance, with the fate of every branch coming back as
+         * part of the result. Each rule's account is then its own tree with those fates applied —
+         * its own tree, because what a rule took in is a fact about its clauses and not about the
+         * constraints its neighbours distributed beside them; and the fates, because a branch of it
+         * nobody anywhere can be in is not a branch whose rules went unread. Nothing in the second
+         * step builds a machine.
          */
-        Answered<K> resolve(Reading reader, StatedByClauses whole,
-                            souther.compiler.values.Allowance<FactSubject> by) {
-            ReadByClauses said = reader.resolve(whole, by);
+        Answered<K> resolve(Reading reader, souther.compiler.values.Allowance<FactSubject> by) {
+            StatedTogether whole = StatedTogether.top();
+            for (StatedByClauses each : trees.values()) {
+                whole = whole.meet(each.together());
+            }
+            Settlement made = reader.settle(whole, by);
+            Map<Core, ReadByClauses.OfAPart> said = new java.util.IdentityHashMap<>();
+            Adoption<FactSubject> byValues = Adoption.nothing();
+            Adoption<FactSubject> byOrder = Adoption.nothing();
+            for (Map.Entry<K, StatedByClauses> each : trees.entrySet()) {
+                Map<Core, ReadByClauses.OfAPart> mine = reader.accountOf(each.getValue(), made);
+                said.putAll(mine);
+                ReadByClauses.OfAPart clause = mine.get(byClause.get(each.getKey()));
+                byValues = byValues.both(clause.byValues());
+                byOrder = byOrder.both(clause.byOrder());
+            }
+            ReadByClauses read = new ReadByClauses(made.made().values(), made.ordered(),
+                    byValues, byOrder, said);
             Map<K, ReadByClauses.OfAPart> clauses = new java.util.LinkedHashMap<>();
-            byClause.forEach((key, clause) -> clauses.put(key, said.parts().get(clause)));
+            byClause.forEach((key, clause) -> clauses.put(key, said.get(clause)));
             Map<K, java.util.List<Map.Entry<Core, ReadByClauses.OfAPart>>> parts =
                     new java.util.LinkedHashMap<>();
             byPart.forEach((key, these) -> {
                 java.util.List<Map.Entry<Core, ReadByClauses.OfAPart>> out =
                         new java.util.ArrayList<>();
                 these.forEach(each -> {
-                    ReadByClauses.OfAPart one = said.parts().get(each);
+                    ReadByClauses.OfAPart one = said.get(each);
                     if (one != null) {
                         out.add(Map.entry(each, one));
                     }
                 });
                 parts.put(key, out);
             });
-            return new Answered<>(said, clauses, parts);
+            return new Answered<>(read, clauses, parts);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -113,17 +113,27 @@ sealed interface StatedByClauses {
             // Spoiled by there having been an alternative this could not read, which is the rule
             // the values join by ({@code PlannedValues}), said of the part: a value satisfying the
             // branch nothing read is under no obligation from this one, so what this side's copy
-            // reached is left open. Only where nothing has spoiled the position already — a reason
-            // recorded there is a rule that named it, which is nearer than a branch that widened
-            // it from outside.
+            // reached is left open. Not what it settled — a position a dead branch settled is an
+            // answer, and an unread alternative widens a constraint, not an answer ({@link
+            // Adoption#either} makes the same distinction). Only where nothing has spoiled the
+            // position already: a reason recorded there is a rule that named it, which is nearer
+            // than a branch that widened it from outside.
             if (other.byValues().dropped()) {
-                why = leftOpen(why, byValues().mentions());
+                why = leftOpen(why, reachedBy(byValues()));
             }
             if (byValues().dropped()) {
-                why = leftOpen(why, other.byValues().mentions());
+                why = leftOpen(why, reachedBy(other.byValues()));
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
                     why);
+        }
+
+        /** The positions a rule of this copy reached and did not merely settle: what it
+         *  constrained, and what it was about and could not manage. */
+        private static java.util.Set<FactSubject> reachedBy(Adoption<FactSubject> of) {
+            java.util.Set<FactSubject> out = new java.util.LinkedHashSet<>(of.read());
+            out.addAll(of.missed());
+            return out;
         }
 
         private static Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>>

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedTogether.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedTogether.java
@@ -1,0 +1,67 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.PlannedValues;
+
+/**
+ * What every clause of one value says between them, with the choices still open.
+ *
+ * <p>One of two trees over the same clauses, and the one that derives values. Which values a
+ * position may take is settled by every rule of the declaration together, so a conjunction here
+ * distributes over a choice ({@link #meet}) and a branch is refined by clauses its author wrote
+ * elsewhere. Which rules each clause took in is not here at all: that is a question about one
+ * rule's own clauses, answered over {@link StatedByClauses}, and a constraint distributed in from a
+ * neighbouring rule must not answer it. This type has no account to contaminate, and the account's
+ * type has no way to take another rule's reading in — the separation is the two types.
+ *
+ * <p>What the two share is the choices. A {@link Choice} here carries the {@link ChoiceId} of the
+ * written {@code ||} it came from, and settling this tree is what decides, for every id, whether
+ * anybody can be in each of its branches ({@link Settlement}). The account reads that decision; it
+ * never makes one.
+ */
+sealed interface StatedTogether {
+
+    /** What the clauses reaching here leave, in both languages. */
+    record Said(PlannedValues<FactSubject> values, OrderedIntervals<FactSubject> ordered)
+            implements StatedTogether {
+    }
+
+    /**
+     * A choice whose branches are not settled yet, standing for the written {@code ||} named by
+     * {@code id} — one of however many places distribution put it.
+     */
+    record Choice(ChoiceId id, StatedTogether left, StatedTogether right)
+            implements StatedTogether {
+
+        public Choice {
+            if (id == null || left == null || right == null) {
+                throw new IllegalArgumentException("a choice is between two named readings");
+            }
+        }
+    }
+
+    /** Nothing read, so nothing ruled out — the identity of {@link #meet}. */
+    static StatedTogether top() {
+        return new Said(PlannedValues.top(), OrderedIntervals.top());
+    }
+
+    /**
+     * Both holding at once, distributed over every choice still open.
+     *
+     * <p>A conjunction of a choice is the choice between the conjunctions, and the id goes with
+     * each copy: what is multiplied is where the branch stands, never which written choice it is a
+     * branch of.
+     */
+    default StatedTogether meet(StatedTogether other) {
+        if (this instanceof Choice it) {
+            return new Choice(it.id(), it.left().meet(other), it.right().meet(other));
+        }
+        if (other instanceof Choice it) {
+            return new Choice(it.id(), meet(it.left()), meet(it.right()));
+        }
+        Said here = (Said) this;
+        Said there = (Said) other;
+        return new Said(here.values().meet(there.values()),
+                here.ordered().meet(there.ordered()));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -914,10 +914,10 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         // the unread rule was about — a rule relating two other positions relates this one to
         // nothing, and lending its reason here would say that it did.
         if (other.dropped) {
-            spoiled = spoiling(spoiled, promisedAt());
+            spoiled = UnreadReason.leftOpen(spoiled, promisedAt());
         }
         if (dropped) {
-            spoiled = spoiling(spoiled, other.promisedAt());
+            spoiled = UnreadReason.leftOpen(spoiled, other.promisedAt());
         }
         // What each rule left standing is kept whole. Whether a position is answerable for it is
         // read off the two ends where the question is asked ({@link #speaksFor}) rather than
@@ -1089,27 +1089,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     private Set<A> promisedAt() {
         return guaranteed.keySet();
-    }
-
-    /**
-     * The same, with {@code these} left open by an alternative — where nothing has spoiled them
-     * already. A reason already recorded for a position is a rule that named it, which is nearer
-     * than a branch that widened it from outside.
-     *
-     * <p>The one place a reason is not added beside the reasons already there. What this says is
-     * that the choice offered an alternative nothing could read, which is one fact about the choice
-     * however many positions it reaches — a position whose own rules already stopped this reading
-     * is not stopped a second time by it.
-     */
-    private static <A> Map<A, List<UnreadReason>> spoiling(Map<A, List<UnreadReason>> had,
-                                                           Set<A> these) {
-        if (these.isEmpty()) {
-            return had;
-        }
-        Map<A, List<UnreadReason>> out = new LinkedHashMap<>(had);
-        these.forEach(each ->
-                out.putIfAbsent(each, List.of(UnreadReason.ALTERNATIVE_NOT_READ)));
-        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -329,10 +329,10 @@ public sealed interface PlannedValues<A> {
                 List.of(here.defaultGuaranteed(), there.defaultGuaranteed()));
         Map<A, List<UnreadReason>> spoiled = union(here.standing(), there.standing());
         if (there.dropped()) {
-            spoiled = spoiling(spoiled, promisedAt(here));
+            spoiled = UnreadReason.leftOpen(spoiled, promisedAt(here));
         }
         if (here.dropped()) {
-            spoiled = spoiling(spoiled, promisedAt(there));
+            spoiled = UnreadReason.leftOpen(spoiled, promisedAt(there));
         }
         Set<A> shapedBy = new LinkedHashSet<>(promisedAt(here));
         shapedBy.addAll(promisedAt(there));
@@ -384,14 +384,6 @@ public sealed interface PlannedValues<A> {
      *  {@link AdmissibleValues}. */
     private static <A> Set<A> promisedAt(Settled<A> of) {
         return of.guaranteed().keySet();
-    }
-
-    /** The same reasons, and one more at each position an unread alternative stood beside. */
-    private static <A> Map<A, List<UnreadReason>> spoiling(Map<A, List<UnreadReason>> standing,
-                                                           Set<A> named) {
-        Map<A, List<UnreadReason>> out = new LinkedHashMap<>(standing);
-        named.forEach(each -> out.putIfAbsent(each, List.of(UnreadReason.ALTERNATIVE_NOT_READ)));
-        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
@@ -134,6 +134,29 @@ public enum UnreadReason {
         NEITHER
     }
 
+    /**
+     * The same reasons, with {@code these} left open by an alternative nothing could read — where
+     * nothing has spoiled them already.
+     *
+     * <p>The one rule for what an unread alternative does to the account beside it, stated once for
+     * every carrier that joins a choice: a value satisfying the branch nothing read is under no
+     * obligation from the branch that was read, so the positions that branch reached are left open.
+     * The one place a reason is not added beside the reasons already there — what this says is that
+     * the choice offered an alternative nothing could read, which is one fact about the choice
+     * however many positions it reaches, and a position whose own rules already stopped a reading
+     * is not stopped a second time by it. A reason recorded there is a rule that named the
+     * position, which is nearer than a branch that widened it from outside.
+     */
+    public static <A> java.util.Map<A, java.util.List<UnreadReason>> leftOpen(
+            java.util.Map<A, java.util.List<UnreadReason>> had, java.util.Set<A> these) {
+        if (these.isEmpty()) {
+            return had;
+        }
+        java.util.Map<A, java.util.List<UnreadReason>> out = new java.util.LinkedHashMap<>(had);
+        these.forEach(each -> out.putIfAbsent(each, java.util.List.of(ALTERNATIVE_NOT_READ)));
+        return out;
+    }
+
     /** What this reason is a fact about — see {@link About}. */
     public About about() {
         return switch (this) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -153,6 +153,38 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 byQuestion(read(THE_OTHER_CLAUSE_ORDER, "M")));
     }
 
+    private static final Term.Interner NAMES = new Term.Interner();
+    private static final FactSubject CONSTRAINED = FactSubject.of(NAMES.written("constrained"));
+    private static final FactSubject SETTLED = FactSubject.of(NAMES.written("settled"));
+    private static final FactSubject UNREAD = FactSubject.of(NAMES.written("unread"));
+
+    /**
+     * An unread alternative widens what a branch constrained, and not what a dead branch inside it
+     * settled.
+     *
+     * <p>The account's copy of the rule the values join by: a position a dead branch settled holds
+     * an answer — the choice imposes nothing there — and a further alternative, read or not,
+     * imposes nothing extra either ({@code Adoption.either} draws the same line). Written over the
+     * copy's mentions instead, the account held a reason at a settled position that no output
+     * happens to show today, which is a lie waiting for its first reader.
+     */
+    @Test
+    void anUnreadAlternativeWidensAConstraintAndNotAnAnswer() {
+        StatedByClauses.Part read = new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
+                        java.util.Set.of(), false),
+                Adoption.nothing(), Map.of());
+        StatedByClauses.Part unread = new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
+                        true),
+                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)));
+
+        assertEquals(Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ),
+                        CONSTRAINED, List.of(UnreadReason.ALTERNATIVE_NOT_READ)),
+                read.either(unread).standing(),
+                "the constraint is left open and the answer stands");
+    }
+
     /** Every question of every rule that nothing answered, and what stopped this reading of it. */
     private static Map<String, List<UnreadReason>> byQuestion(FieldDomains read) {
         Map<String, List<UnreadReason>> out = new LinkedHashMap<>();

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -1,0 +1,184 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.UnreadReason;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which branches of a choice anybody can be in is the whole declaration's answer, and what a rule
+ * left unread is that rule's own.
+ *
+ * <p>The two pull the reading in different directions and both hold at once. A branch live on its
+ * own clause can be impossible under a clause written later, so the decision waits for every clause
+ * — and a branch nobody anywhere can be in takes its unread rules with it, since there is no branch
+ * for an author to look at. But a clause a neighbour wrote does not read this rule's alternatives
+ * for it: whether an alternative of this rule went unread is answered over this rule's clauses
+ * alone, or the gap is hidden by a constraint that happens to stand beside it
+ * ({@code EveryPartAReadingStoppedOnSaysWhyTest} holds that end).
+ *
+ * <p>And a branch's fate is aggregated over every place distribution put it. The same written
+ * choice stands inside each branch of every choice met with it, live in one place and dead in
+ * another — dead is only dead everywhere, and the aggregate cannot depend on the order the clauses
+ * were written in.
+ */
+class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
+
+    /**
+     * A branch live on its own clause and impossible under the next one.
+     *
+     * <p>Reading {@code one} alone, both alternatives admit something, and the rule this reading
+     * has no word for stands only in the left one. {@code two} then leaves nobody able to be in
+     * that branch.
+     */
+    private static final String A_LATER_CLAUSE_KILLS_A_BRANCH = """
+            module demo
+
+            data Pair = { code: String, tag: String }
+                invariant one =
+                    (code == "a" && String.startsWith("q", tag))
+                    || code == "c"
+                invariant two = code == "c"
+            """;
+
+    /**
+     * One written choice standing in both branches of another, live in one and dead in the other.
+     *
+     * <p>Distribution puts each alternative of {@code b} beside each alternative of {@code a}:
+     * {@code x == 0} is impossible beside {@code x == 1} and possible beside {@code x == 0}. Both
+     * of {@code b}'s branches are live somewhere, so neither is dead.
+     */
+    private static final String LIVE_SOMEWHERE_IS_LIVE = """
+            module demo
+
+            data N = { x: Int, s: String }
+                invariant a = x == 0 || x == 1
+                invariant b =
+                    (x == 0 && String.startsWith("q", s))
+                    || x == 1
+            """;
+
+    /**
+     * A branch dead in every place it stands.
+     *
+     * <p>{@code x == 2} is impossible beside {@code x == 0} and beside {@code x == 1}, so the
+     * branch carrying the rule nothing reads is dead everywhere — and only then do its unread
+     * rules go with it.
+     */
+    private static final String DEAD_EVERYWHERE_IS_DEAD = """
+            module demo
+
+            data M = { x: Int, s: String }
+                invariant a = x == 0 || x == 1
+                invariant b =
+                    (x == 2 && String.startsWith("q", s))
+                    || x == 0 || x == 1
+            """;
+
+    /** The same two rules with the clauses the other way round. */
+    private static final String THE_OTHER_CLAUSE_ORDER = """
+            module demo
+
+            data M = { x: Int, s: String }
+                invariant b =
+                    (x == 2 && String.startsWith("q", s))
+                    || x == 0 || x == 1
+                invariant a = x == 0 || x == 1
+            """;
+
+    /**
+     * A question a rule of a dead branch raised is settled, not left standing.
+     *
+     * <p>The branch is live on its own clause — this is what waiting for every clause buys. Left
+     * standing, an author is sent to a rule of a branch their own next clause already forbids.
+     */
+    @Test
+    void aBranchALaterClauseForbidsTakesItsUnreadRulesWithIt() {
+        Map<String, List<UnreadReason>> standing =
+                byQuestion(read(A_LATER_CLAUSE_KILLS_A_BRANCH, "Pair"));
+        assertFalse(standing.containsKey("invariant Pair (one) at tag"),
+                "nothing satisfies the branch the pattern is in, so there is no branch to look at");
+    }
+
+    /**
+     * A branch live beside one alternative of a neighbour is live, however dead it is beside
+     * another.
+     *
+     * <p>Live, so the rule this reading has no word for inside it is still a rule somebody wrote
+     * about a branch somebody can be in — the question at {@code s} stands. What would fail here is
+     * a fate recorded per place rather than aggregated: whichever copy was settled last would win,
+     * the branch would be reported dead, and the question would be settled with it.
+     */
+    @Test
+    void aBranchLiveAnywhereIsLive() {
+        Map<String, List<UnreadReason>> standing =
+                byQuestion(read(LIVE_SOMEWHERE_IS_LIVE, "N"));
+        assertTrue(standing.containsKey("invariant N (b) at s"),
+                "somebody can be in the branch, so its unread rule is theirs to look at: "
+                        + standing);
+    }
+
+    /** Dead is only dead everywhere — and then the unread rule goes with the branch. */
+    @Test
+    void aBranchDeadEverywhereIsDead() {
+        Map<String, List<UnreadReason>> standing =
+                byQuestion(read(DEAD_EVERYWHERE_IS_DEAD, "M"));
+        assertFalse(standing.containsKey("invariant M (b) at s"),
+                "no alternative of `a` admits the branch, so there is no branch to look at");
+    }
+
+    /**
+     * The aggregate reads the same whichever clause is written first.
+     *
+     * <p>Written the other way round, the same written choice is distributed into different
+     * places in a different order. A fate that depended on either would answer the same model two
+     * ways.
+     */
+    @Test
+    void aFateDoesNotTurnOnTheOrderTheClausesWereWritten() {
+        assertEquals(byQuestion(read(DEAD_EVERYWHERE_IS_DEAD, "M")),
+                byQuestion(read(THE_OTHER_CLAUSE_ORDER, "M")));
+    }
+
+    /** Every question of every rule that nothing answered, and what stopped this reading of it. */
+    private static Map<String, List<UnreadReason>> byQuestion(FieldDomains read) {
+        Map<String, List<UnreadReason>> out = new LinkedHashMap<>();
+        read.accounting().values().forEach(accounting ->
+                accounting.answers().forEach((owed, outcome) -> {
+                    if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted
+                            && unaccounted.why()
+                                    instanceof RuleAccounting.Why.TheValueReadingSays says) {
+                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                                says.why());
+                    }
+                }));
+        return out;
+    }
+
+    private static FieldDomains read(String source, String name) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(symbols.module(), name));
+        return FieldDomains.of(at,
+                (Hir.Data) symbols.declarations().declaration(at.key()), symbols,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -185,6 +185,29 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                 "the constraint is left open and the answer stands");
     }
 
+    /**
+     * A fate aggregates the same whichever occurrence comes first — the reasons included.
+     *
+     * <p>{@code Emptiness.joined} alone being commutative is not enough: the reasons probing two
+     * occurrences left behind travel with the fate, and two occurrences of one branch can be
+     * stopped by two limits. Kept in the order the occurrences were met, the same model written
+     * with its clauses the other way round would say the same reasons in a different order — a
+     * neighbouring clause's order, which is no order of this rule's.
+     */
+    @Test
+    void aFateAggregatesTheSameWhicheverOccurrenceComesFirst() {
+        Settlement.Sided one = new Settlement.Sided(
+                souther.compiler.values.Emptiness.UNDECIDED,
+                Map.of(UNREAD, List.of(UnreadReason.PATTERN_TOO_COSTLY)), java.util.Set.of());
+        Settlement.Sided other = new Settlement.Sided(
+                souther.compiler.values.Emptiness.UNDECIDED,
+                Map.of(UNREAD, List.of(UnreadReason.EXACT_VALUES_TOO_COSTLY)),
+                java.util.Set.of());
+
+        assertEquals(one.alsoSeen(other), other.alsoSeen(one),
+                "one branch, one aggregate, whichever copy was settled first");
+    }
+
     /** Every question of every rule that nothing answered, and what stopped this reading of it. */
     private static Map<String, List<UnreadReason>> byQuestion(FieldDomains read) {
         Map<String, List<UnreadReason>> out = new LinkedHashMap<>();


### PR DESCRIPTION
Closes #1173.

## What was wrong

A choice was decided where its own clause was read (`StatedByClauses.Reading.either`): two branches alive on that clause merged on the spot, so a clause written later had no branch structure left to refine. The unread `startsWith` in the issue's first example stayed on the declaration as a question about a branch `two` forbids.

And the fix could not be a deferral alone, because one tree served two questions. Distributing later clauses into the branches makes the values right and the account wrong: what a rule read is a fact about its own clauses, and a neighbouring rule's constraint met into the branch would hide the gap — the issue's second example, whose expectation `EveryPartAReadingStoppedOnSaysWhyTest` already pins and which stays green here.

## The shape

Two questions, two types, one settlement.

- `StatedTogether` is where the clauses of a declaration meet — values and ranges only, distributed over every open choice. The conjunction across rules exists only on this type; the account's type has no operation that could take a neighbouring rule in.
- `settle` works the met-together tree out once and returns a `Settlement`: the resolved values and the fate of both branches of every written choice, as one value of one computation. Nothing recomputes a decision.
- `StatedByClauses` stays one rule's own reading. Its account (`accountOf`) folds the rule's own tree with the fates looked up by `ChoiceId`; it builds no machine, so the corpus-wide assert that reading the account spends no allowance keeps holding.
- A fate is an aggregate over every place distribution put the branch, not an attribute of one place: `Emptiness.joined` over occurrences (associative, commutative, idempotent), because the same written choice stands inside each branch of every choice met with it, live in one place and dead in another. Dead is only dead everywhere, and the answer cannot turn on clause order or bracketing — `AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest` holds the duplicated-choice and the order-metamorphic cases.
- Whether a declaration's choices are held open past the clause is the existing per-declaration gate: `ExpansionCost` already counts the product of all clauses before any is read. APART declarations decide a branch the descriptions already prove empty at the clause, and defer only the merge of two live branches — the one decision a later clause can be too late for; MERGED ones decide everything at the clause as before. No second budget decision exists inside the fold, which is the bracketing-independence `ReadingPolicy` already promises.

`Part.either` now states the same spoiling rule the values join by (a part standing in both branches of a live choice is left open at the positions its copy reached where the branch beside it dropped a rule). The account used to take that from the values it was filed with, which the deferral takes away. This also makes the account of a choice settled late agree with one settled at the clause — previously a spanning part of an UNDECIDED choice was never spoiled while the same part of a decidable one was.

## Verified

- Full suite green: compiler 7643, bench, program-api, all modules. No existing expectation moved.
- Both acceptance counterexamples from the issue: the dead branch's question is settled (`aBranchALaterClauseForbidsTakesItsUnreadRulesWithIt`), and `ALTERNATIVE_NOT_READ at a` in the second example stays (existing test).
- Mutations killed: restoring the clause-boundary decision fails the two deferral tests; replacing the fate aggregation with last-occurrence-wins fails `aBranchLiveAnywhereIsLive`; removing the `Part.either` spoiling fails `EveryPartAReadingStoppedOnSaysWhyTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

