### PR TITLE
Read a total's elements on the order its answer is measured on

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -331,7 +331,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
                 }
             }
             return switch (takenAs()) {
-                case TakenAs.TheSumOfWhatItHolds _ -> addedUp(values, on.answered());
+                case TakenAs.TheSumOfWhatItHolds _ -> addedUp(values, on);
                 case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ ->
                         new Reading.NotNumber();
             };
@@ -502,7 +502,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
         }
         return switch (term) {
             case ValueOf _ -> asItStands(at, observed);
-            case TakenOf taken -> taken(taken.takenAs(), at, observed);
+            case TakenOf taken -> taken(taken.takenAs(), at, on);
         };
     }
 
@@ -523,13 +523,20 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
      * from being read as whichever arm was written first — the state {@code SizeOf} left the reader
      * in, where a term standing for anything but a size would have been read as the observation
      * itself (#1027).
+     *
+     * <p>The pair and not one end of it, because which end an account reads its values on is the
+     * account's own answer. A part of a time is a number of the value as it is written; what a
+     * container adds up to is a number of the values it holds, and those are places of the order the
+     * total is measured on. Handed one carrier for every arm, the arms that want the other end have
+     * nothing to say so with — and a container is written on no order at all, so the one that adds
+     * its elements up is handed nothing.
      */
-    private static Reading taken(TakenAs how, ObservedValue at, Carrier observed) {
+    private static Reading taken(TakenAs how, ObservedValue at, TermOrders on) {
         return switch (how) {
             case TakenAs.HowManyItHolds _ -> howMany(at);
-            case TakenAs.TheSumOfWhatItHolds _ -> addedUp(at, observed);
-            case TakenAs.PartOfTime taken -> partOfTime(taken.part(), at, observed);
-            case TakenAs.PartOfDate taken -> partOfDate(taken.part(), at, observed);
+            case TakenAs.TheSumOfWhatItHolds _ -> addedUp(at, on);
+            case TakenAs.PartOfTime taken -> partOfTime(taken.part(), at, on.observed());
+            case TakenAs.PartOfDate taken -> partOfDate(taken.part(), at, on.observed());
         };
     }
 
@@ -568,14 +575,22 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
      * value the model may write, and answering that it holds no number would put a row the author
      * can write outside every class of the number a rule is about.
      */
-    private static Reading addedUp(ObservedValue at, Carrier observed) {
+    private static Reading addedUp(ObservedValue at, TermOrders on) {
         return at instanceof ObservedValue.Sequence held
-                ? addedUp(held.elements(), observed) : new Reading.NotNumber();
+                ? addedUp(held.elements(), on) : new Reading.NotNumber();
     }
 
-    /** The same, over values a caller gathered rather than over a container standing somewhere. */
-    private static Reading addedUp(java.util.List<ObservedValue> values, Carrier observed) {
-        if (observed == null) {
+    /**
+     * The same, over values a caller gathered rather than over a container standing somewhere.
+     *
+     * <p>Where the end is taken, for both readers at once. A total of what a place holds and a total
+     * over the values of a run are one account of one operation, so which order their elements are
+     * places of is one answer. Taken apiece, the two are free to add the same values up on different
+     * orders.
+     */
+    private static Reading addedUp(java.util.List<ObservedValue> values, TermOrders on) {
+        Carrier elements = on.answered();
+        if (elements == null) {
             return new Reading.NotNumber();
         }
         java.math.BigDecimal total = java.math.BigDecimal.ZERO;
@@ -589,7 +604,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
             // number each carries is one inside.
             ObservedValue value = each instanceof ObservedValue.Constructed c
                     && c.field("value") != null ? c.field("value") : each;
-            Place read = observed.placeOf(value);
+            Place read = elements.placeOf(value);
             if (!(read instanceof Count count)) {
                 return new Reading.NotNumber();
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
@@ -1,0 +1,107 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.Symbols;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.RunSource;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A total of a container is added up over its elements, and the elements are read the same way
+ * wherever the total is.
+ *
+ * <p>The values a total is taken of are places of the order the answer is measured on: a walk
+ * carries what it has so far in the type it answers, so an element is a place of the same carrier
+ * the sum is. The other end is the order the value at the term's own path is written on, and a
+ * container is written on none — so a reader taking that end of the pair has nothing to add its
+ * elements up with, and the total it answers is no number. Every class of the axis measuring that
+ * total then says it does not hold the value, which is the partition's own contract broken: a class
+ * holds every value of the position it is a class of.
+ *
+ * <p>Which is why a row is written here. Measuring the reading alone leaves this unexercised — an
+ * axis is made and a border is drawn without any row falling into a class.
+ */
+class ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest {
+
+    private static final String MODEL = """
+            module example.totals
+
+            data Yes
+            data No
+
+            behavior overAListAtAPosition : (planned: List<Int>) -> Yes | No
+            let overAListAtAPosition (planned) =
+                if List.sum(planned) >= 3 then Yes else No
+
+            example overAListAtAPosition
+                | "under" : ([ 1 ]) -> No
+                | "over"  : ([ 1, 5 ]) -> Yes
+            """;
+
+    /** A row written against a total of a list at a position is classified, like any other. */
+    @Test
+    void aRowAgainstATotalOfAListAtAPositionFallsInAClass() {
+        String report = report();
+        assertTrue(report.contains("equivalence partitions 2/2"),
+                () -> "both rows fell in a class of the total: " + report);
+    }
+
+    /**
+     * The two readers of one account add the same values up to the same number.
+     *
+     * <p>The orders they are given are the ones a container stands on: none of its own, and the
+     * total measured by whole numbers. A reader taking the first end has nothing to read the
+     * elements on, and the number it answers of a list of ones and fives is no number at all.
+     */
+    @Test
+    void aTotalOfAContainerAndATotalOverARunReadOneOrder() {
+        List<ObservedValue> elements = List.of(new ObservedValue.Integer(1),
+                new ObservedValue.Integer(5));
+        assertEquals(Count.of(6), numberOf(AT_A_POSITION.read(new ObservedValue.Sequence(elements),
+                        A_CONTAINERS_ORDERS)),
+                "the total of what the place holds");
+        assertEquals(Count.of(6), numberOf(OVER_A_RUN.readOver(elements, A_CONTAINERS_ORDERS)),
+                "and the total over the values of a run, which are the same values");
+    }
+
+    /** {@code List.sum} of what a place holds. */
+    private static final NumericTerm.FromOnePosition AT_A_POSITION = NumericTerm.TakenOf.of(
+            ValueName.Stdlib.operation("List", "sum"), TermPath.of("ns"),
+            new Type.ListOf(Type.INT), Symbols.none(souther.compiler.DefaultStdlib.get()));
+
+    /** And of the values a walk answered, which is the same operation over a run. */
+    private static final NumericTerm.TakenOver OVER_A_RUN = NumericTerm.TakenOver.of(
+            ValueName.Stdlib.operation("List", "sum"),
+            RunSource.overTheOccurrencesAt(TermPath.of("ns").element()), Type.INT,
+            Symbols.none(souther.compiler.DefaultStdlib.get()));
+
+    /** A container is on no order of its own, and the total it answers is counted by one. */
+    private static final TermOrders A_CONTAINERS_ORDERS = new TermOrders(null, Carrier.WHOLE);
+
+    private static Count numberOf(NumericTerm.Reading read) {
+        return (Count) ((NumericTerm.Reading.Number) read).value();
+    }
+
+    private static String report() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}


### PR DESCRIPTION
Closes #1183.

`souther examples` stops the compiler on a twelve-line model: a rule that is a total of a list the behavior takes, with one `example` row written against it.

```
internal compiler error: IllegalStateException: no class of judge/List.sum(planned) holds a value
it read: Sequence[elements=[Integer[value=1], Integer[value=5]]]
```

A term reads a value through the pair of orders it stands on — the one the value at its path is written on, and the one the number it answers is measured on — and which end an account takes is the account's own answer. The arm for a total was handed the first for every account. A container is written on no order, so the elements had nothing to be places of and the total came back as no number; every class of the axis then said it does not hold the value, and `InputClassifications` threw over the contract that says a class holds every value of the position it is a class of.

The same operation read over the values of a run took the other end already, which is why the projection shape (`List.sum(List.map(...))`) has always measured. The two now go through one place that takes the end, so one account cannot be added up two ways.

Measured: `businesstrip` is unchanged at 16 gaps, and the model above reports, with its row falling in a class and standing at the IN point of the line. That nothing composes a row for such a point is #1184 and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)