### PR TITLE
Ask what stopped a reading at the place the answer is filed, not at a side

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -66,7 +66,7 @@ public final class FieldDomains {
      */
     public static final FieldDomains NONE =
             new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), Set.of(), List.of(), List.of(), Map.of(),
-                    Map.of(), new ReadingEvidence(), Map.of(), Set.of(THE_VALUE), Set.of(),
+                    Map.of(), Map.of(), new ReadingEvidence(), Map.of(), Set.of(THE_VALUE), Set.of(),
                     NO_POSITIONS,
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(), Set.of(THE_VALUE),
                     Map.of(), Map.of(), Map.of(), Map.of());
@@ -83,6 +83,9 @@ public final class FieldDomains {
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
      *  conjunct is about, and not what the conjunct written beside it raised. */
     private final Map<RuleRef, Map<Core, Required>> raisedByPart;
+
+    /** What the reading answered for each boundary question it raised and left standing. */
+    private final Map<BoundaryQuestion, BoundaryStanding> standing;
     /** Which readings took each clause in, as each of them said so. */
     private final ReadingEvidence took;
     /** The accounting, worked out once. Every position of a value asks the same question of it. */
@@ -152,7 +155,8 @@ public final class FieldDomains {
                          Set<String> notSeparatedByField,
                          List<InvariantChecker.Direct> directs, List<NoLine> noLines,
                          Map<RuleRef, Required> raised,
-                         Map<RuleRef, Map<Core, Required>> raisedByPart, ReadingEvidence took,
+                         Map<RuleRef, Map<Core, Required>> raisedByPart,
+                         Map<BoundaryQuestion, BoundaryStanding> standing, ReadingEvidence took,
                          Map<String, List<TypeSymbol.AtModule>> narrowers,
                          Set<String> notGathered, Set<String> handedOn,
                          SequencedMap<FactSubject, String> positions,
@@ -172,6 +176,7 @@ public final class FieldDomains {
         this.noLines = noLines;
         this.raised = raised;
         this.raisedByPart = raisedByPart;
+        this.standing = standing;
         this.took = took;
         this.narrowers = narrowers;
         this.notGathered = notGathered;
@@ -396,7 +401,8 @@ public final class FieldDomains {
                 named(seeded, field).forEach(term -> placeOf.putIfAbsent(term, field)));
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
                 Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().noLines(),
-                seeded.reading().raised(), seeded.reading().raisedByPart(), seeded.took(),
+                seeded.reading().raised(), seeded.reading().raisedByPart(),
+                seeded.reading().standing(), seeded.took(),
                 seeded.reading().narrowers(),
                 seeded.notGathered(), seeded.handedOn(), placeOf,
                 seeded.constraints(), named, data, symbols, policy, settled,
@@ -471,6 +477,55 @@ public final class FieldDomains {
         /** Where in the value the end was to have been placed. */
         public String path() {
             return at.path();
+        }
+    }
+
+    /**
+     * One rule, one coordinate: the question of where the values there stop.
+     *
+     * <p>What a reader of an accounting asks about, and the key its answer is held under. A rule is
+     * read a conjunct at a time and any number of them may draw the same line, so the parts are not
+     * this — held under them, an answer had to be put back together from whatever rows a finer key
+     * happened to hold.
+     */
+    public record BoundaryQuestion(RuleRef.Invariant from, Coordinate at) {}
+
+    /**
+     * A boundary question the reading of ends did not answer, and everything behind it.
+     *
+     * <p><b>One reason and several conjuncts, which are two different multiplicities.</b> Which
+     * limit stopped the reading is read off the coordinate — a carrier lines are drawn on wants a
+     * reader for the form, and one nothing draws a line on wants the carrier
+     * ({@link UnreadComparison#whereALineWouldFall}) — so every part of the rule that raises this
+     * question comes to the same word. How many parts are standing behind it is what an author has
+     * left to lift, and that is its own count.
+     *
+     * <p>Made where the question is raised and not gathered from the findings afterwards. Gathered,
+     * the answer was whatever the rows filed under a finer key came to, and the day two of them
+     * differed a reader would have been handed both with nothing saying which the question's is.
+     *
+     * @param conjuncts the parts of the rule still standing behind it, in the order they are
+     *                  written
+     */
+    public record BoundaryStanding(
+            souther.compiler.inputs.BlockReason.RuleReadingStopped why, List<Integer> conjuncts) {
+
+        public BoundaryStanding {
+            if (why == null) {
+                throw new IllegalArgumentException("a question left standing says why");
+            }
+            if (conjuncts.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "and says which part of the rule is standing behind it");
+            }
+            conjuncts = List.copyOf(conjuncts);
+        }
+
+        /** The same, with {@code one} standing behind it too. */
+        BoundaryStanding and(BoundaryStanding one) {
+            List<Integer> both = new ArrayList<>(conjuncts);
+            one.conjuncts().stream().filter(each -> !both.contains(each)).forEach(both::add);
+            return new BoundaryStanding(why, both);
         }
     }
 
@@ -744,73 +799,21 @@ public final class FieldDomains {
      * <p>Asked per rule and per position, as the admission question is. A bound on a field's own
      * type and a clause of the record about the same field are two rules, and an end read for one
      * says nothing about the other.
+     *
+     * <p><b>Looked up and not worked out.</b> The reading made this answer where it raised the
+     * question, so what is here is a lookup under the question's own key. Put together from the
+     * findings instead, an answer keyed at {@code (rule, coordinate)} was rebuilt out of rows keyed
+     * at {@code (rule, conjunct, coordinate)} and came to whatever those rows held — which made a
+     * question's word depend on a table nobody had asked it of, and left every reader downstream
+     * looking at a list where the model has one answer.
      */
     private RuleAccounting.Outcome boundaryAnswered(RuleRef rule, Coordinate where) {
-        // Every conjunct that asked, and not whichever one happened to be read. A rule is read a
-        // conjunct at a time and files one question about its line, so the two ways of reading the
-        // record are both wrong: asked of what went unread alone, `value >= 1 && Int.abs(value) >= 2`
-        // left its own line unanswered by the half that draws none, and asked of the ends alone,
-        // `value >= 1 && value <= 10 * 2` reported the half nothing could read as answered by the
-        // half beside it. The parts each say what they raised, and an end says which part placed it.
-        //
-        // And every conjunct that was stopped, not the first of them. One question is answered when
-        // every part that asked it has been read, so a part still standing behind another is a
-        // second thing an author has to lift — and stopping at the first said one of them while the
-        // rest went out under an answer that was true of their neighbour.
-        List<souther.compiler.inputs.BlockReason.RuleReadingStopped> stopped = new ArrayList<>();
-        for (Map.Entry<Core, Required> part : raisedByPart
-                .getOrDefault(rule, Map.of()).entrySet()) {
-            // One arm each, so that a question added later is decided about rather than answered
-            // "not this one" by a test it also fails.
-            boolean asked = part.getValue().obligations().stream()
-                    .anyMatch(owed -> switch (owed) {
-                        case Owed.Boundary line -> line.on().equals(where);
-                        case Owed.AdmittedValues _ -> false;
-                    });
-            if (!asked) {
-                continue;
-            }
-            if (directs.stream().noneMatch(d -> d.from().equals(rule) && d.part() == part.getKey()
-                    && d.at().equals(where))) {
-                whatStopped(rule, part.getKey(), where).forEach(each -> {
-                    if (!stopped.contains(each)) {
-                        stopped.add(each);
-                    }
-                });
-            }
-        }
-        return stopped.isEmpty()
+        BoundaryStanding said = rule instanceof RuleRef.Invariant invariant
+                ? standing.get(new BoundaryQuestion(invariant, where)) : null;
+        return said == null
                 ? new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_END_READING)
                 : new RuleAccounting.Outcome.Unaccounted(
-                        new RuleAccounting.Why.TheEndReadingSays(stopped));
-    }
-
-    /**
-     * What the reading of ends was stopped by at this position, of one part of the rule.
-     *
-     * <p>Empty where that reading was not stopped. A rule it read from end to end and drew no line
-     * from has answered the question that reading answers: the rule places no line, so there is
-     * none to be owed at, and a reader sent after it would be looking for a limit of this compiler
-     * that is not there.
-     *
-     * <p>Which is the second of two places that has to hold. A rule read to the end raises no such
-     * question in the first place ({@link ClauseStates.NoRestriction},
-     * {@link ClauseStates.ARelation}), so nothing reaches here to be answered this way — and the
-     * question being unaskable is what makes the answer unreachable rather than the other way
-     * about. Both are written, because the day one of them slips the other is what is left.
-     */
-    private List<souther.compiler.inputs.BlockReason.RuleReadingStopped> whatStopped(
-            RuleRef rule, Core part, Coordinate where) {
-        List<souther.compiler.inputs.BlockReason.RuleReadingStopped> out = new ArrayList<>();
-        for (NoLine said : noLines) {
-            if (said.from().equals(rule) && said.part() == part
-                    && said.at().equals(where)
-                    && said.why() instanceof souther.compiler.inputs.BlockReason
-                            .RuleReadingStopped stopped) {
-                out.add(stopped);
-            }
-        }
-        return out;
+                        new RuleAccounting.Why.TheEndReadingSays(said));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -504,6 +504,13 @@ public final class FieldDomains {
      * the answer was whatever the rows filed under a finer key came to, and the day two of them
      * differed a reader would have been handed both with nothing saying which the question's is.
      *
+     * <p><b>A part met afterwards adds itself and cannot bring a reason.</b> {@link #and} takes the
+     * part and nothing else, so there is never a second word to reconcile — and no place where one
+     * could be dropped for being second. Written the other way, with each part making a whole
+     * answer and the two merged, the merge had to choose, and choosing quietly is a worse version
+     * of the gathering this replaced: it turns a producer that has come apart into one word decided
+     * by the order the conjuncts are written in.
+     *
      * @param conjuncts the parts of the rule still standing behind it, in the order they are
      *                  written
      */
@@ -521,10 +528,13 @@ public final class FieldDomains {
             conjuncts = List.copyOf(conjuncts);
         }
 
-        /** The same, with {@code one} standing behind it too. */
-        BoundaryStanding and(BoundaryStanding one) {
+        /** The same answer, with the part written at {@code conjunct} standing behind it too. */
+        BoundaryStanding and(int conjunct) {
+            if (conjuncts.contains(conjunct)) {
+                return this;
+            }
             List<Integer> both = new ArrayList<>(conjuncts);
-            one.conjuncts().stream().filter(each -> !both.contains(each)).forEach(both::add);
+            both.add(conjunct);
             return new BoundaryStanding(why, both);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -450,7 +450,7 @@ public final class InvariantChecker {
          *  every position, since nothing here knows which of them the rules were about. */
         static Seeded nothingRead() {
             return new Seeded(ConstraintState.<FactSubject>top(), Map.of(), Map.of(), Map.of(),
-                    new Reading(List.of(), List.of(), Map.of(), Map.of(), Map.of()),
+                    new Reading(List.of(), List.of(), Map.of(), Map.of(), Map.of(), Map.of()),
                     new ReadingEvidence(),
                     false, Set.of(FieldDomains.THE_VALUE), Set.of(FieldDomains.THE_VALUE),
                     Set.of(), Map.of(), Map.of());
@@ -1210,7 +1210,8 @@ public final class InvariantChecker {
     record Reading(List<Direct> directs, List<FieldDomains.NoLine> noLines,
                    Map<String, List<TypeSymbol.AtModule>> narrowers,
                    Map<RuleRef, Required> raised,
-                   Map<RuleRef, Map<Core, Required>> raisedByPart) {}
+                   Map<RuleRef, Map<Core, Required>> raisedByPart,
+                   Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
     private Reading directsIn(List<Written> stated, Denotations at,
                                    Map<String, FactSubject> atoms, Map<String, FactSubject> keys,
@@ -1238,14 +1239,17 @@ public final class InvariantChecker {
         Map<String, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
+        Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
+                new LinkedHashMap<>();
         stated.forEach(each ->
                 direct(each.clause(), each.from(), new int[1], at, byName, out, noLines, narrowers, raised,
-                        took, typeAt, parts, raisedByPart));
+                        took, typeAt, parts, raisedByPart, standing));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines), Map.copyOf(narrowers),
                 java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raised)),
-                java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raisedByPart)));
+                java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raisedByPart)),
+                java.util.Collections.unmodifiableMap(new LinkedHashMap<>(standing)));
     }
 
     /** What {@code clause} raises, taken together with whatever its other conjuncts raised. */
@@ -1344,7 +1348,9 @@ public final class InvariantChecker {
                         Map<RuleRef, Required> raised, ReadingEvidence took,
                         Map<String, Type> typeAt,
                         PartsRead parts,
-                        Map<RuleRef, Map<Core, Required>> raisedByPart) {
+                        Map<RuleRef, Map<Core, Required>> raisedByPart,
+                        Map<FieldDomains.BoundaryQuestion,
+                                FieldDomains.BoundaryStanding> standing) {
         if (clause instanceof Core.Binary and && and.op() == BinOp.AND) {
             // One rule the author wrote, so what it raises is what its conjuncts raise together.
             // Left before right, which is the order the clause was written in and the order
@@ -1352,9 +1358,9 @@ public final class InvariantChecker {
             // its conjuncts alike, which is what lets a line drawn here be recognised as the line
             // the declaration's own reading drew (issue #1062).
             direct(and.left(), from, conjunct, at, byName, out, noLines, narrowers, raised, took,
-                    typeAt, parts, raisedByPart);
+                    typeAt, parts, raisedByPart, standing);
             direct(and.right(), from, conjunct, at, byName, out, noLines, narrowers, raised, took,
-                    typeAt, parts, raisedByPart);
+                    typeAt, parts, raisedByPart, standing);
             return;
         }
         // Which conjunct of the clause this is, taken here so that every one of them is numbered —
@@ -1420,6 +1426,19 @@ public final class InvariantChecker {
             // rebuilt from the path: which of a position's numbers a line is on is what the operation
             // beside it says, and a reader handed the path alone has to go and ask something else.
             shape = new ClauseStates.ABound(about.at(), positions);
+        }
+        // And where this part raises the question of where the values there stop and no end came of
+        // it, the answer to that question, made here. Which limit it is is read off the coordinate
+        // and not off this part — every part raising this question comes to the same word — so what
+        // each part adds is itself, standing behind an answer that is already whole. Put together
+        // afterwards from the findings, the answer was whatever rows a finer key happened to hold.
+        if (shape instanceof ClauseStates.ABound stated
+                && end instanceof InvariantBound.Read.NoEnd) {
+            standing.merge(new FieldDomains.BoundaryQuestion(from, stated.line()),
+                    new FieldDomains.BoundaryStanding(
+                            UnreadComparison.whereALineWouldFall(about.carrier() != null),
+                            List.of(part)),
+                    FieldDomains.BoundaryStanding::and);
         }
         settle(bin, from, shape, end, at, byName, raised, took, typeAt, parts, raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1623,6 +1623,12 @@ public final class InvariantChecker {
      * <p>Which limit stopped it is {@link UnreadComparison}'s, so a {@code guard} of this shape
      * cannot come to a different answer. What is read here is only what each side of the comparison
      * came to, which is this reader's own way of looking a coordinate up.
+     *
+     * <p><b>And which positions there are findings for is the quantity's where there is one.</b>
+     * The walk says what each place the comparison mentions is called and which came first; the
+     * quantity says which of them the rule is about. Taken from the walk, {@code x + y - y <= 20}
+     * left a finding at {@code y} of a rule its own canonical form had cancelled — and the word
+     * left there was the word for {@code x}.
      */
     private void noLineDrawn(Core.Binary comparison, RuleRef.Invariant from, int conjunct,
                             Denotations at,
@@ -1633,15 +1639,63 @@ public final class InvariantChecker {
         }
         Places left = placesIn(comparison.left(), at, byName);
         Places right = placesIn(comparison.right(), at, byName);
-        BlockReason.RuleWithoutLineReason why = UnreadComparison.why(left.origin(), right.origin(),
-                read.quantity(),
-                place -> carrierAt(place, left, right) != null);
+        Predicate<String> ordered = place -> carrierAt(place, left, right) != null;
+        Map<String, Coordinate> met = new LinkedHashMap<>();
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
-            FieldDomains.NoLine said =
-                    new FieldDomains.NoLine(each.at(), from, comparison, conjunct, why);
-            if (!out.contains(said)) {
-                out.add(said);
+            met.putIfAbsent(each.path(), each);
+        }
+        switch (read.quantity()) {
+            case UnreadComparison.Quantity.Read<String> quantity -> {
+                BlockReason.RuleWithoutLineReason why =
+                        UnreadComparison.ofTheQuantity(quantity, ordered);
+                for (String path : UnreadComparison.filedAt(quantity, List.copyOf(met.keySet()))) {
+                    file(met.get(path), from, comparison, conjunct, why, out);
+                }
             }
+            // Where the reading stopped there is no quantity to be a subject, so every place the
+            // walk met is asked, and asked for itself.
+            case UnreadComparison.Quantity.NotRead<String> notRead -> {
+                for (Coordinate each : met.values()) {
+                    file(each, from, comparison, conjunct,
+                            UnreadComparison.whereItStopped(ruleAt(each, left, right), notRead,
+                                    ordered),
+                            out);
+                }
+            }
+        }
+    }
+
+    /**
+     * What a rule filed at {@code where} is about, as this reader knows it.
+     *
+     * <p>The values at the position where a whole side of the comparison is that position and
+     * nothing else, and where the coordinate met there is the position's own value rather than a
+     * number an operation answered of it. Everything else the walk meets it met on the way through
+     * an expression — inside a call read through to its body, or under a field access this reading
+     * does not take apart — and what the rule says about the values at such a place is exactly the
+     * part that went unread.
+     */
+    private static RuleAt<String> ruleAt(Coordinate where, Places left, Places right) {
+        boolean ownValue = where.at().kind() instanceof FieldDomains.CoordinateKind.OfItsOwnValue;
+        boolean aWholeSide = isExactly(left.origin(), where.path())
+                || isExactly(right.origin(), where.path());
+        return ownValue && aWholeSide ? new RuleAt.AboutOwnValues<>(where.path())
+                : new RuleAt.NotAboutOwnValues<>(where.path());
+    }
+
+    /** Whether a whole side of the comparison is the position at {@code path} and nothing else. */
+    private static boolean isExactly(ValueOrigin<String> side, String path) {
+        return side instanceof ValueOrigin.IsAPosition<String> one && one.at().equals(path);
+    }
+
+    /** One finding, kept once. A coordinate reached twice is one place with one thing to say. */
+    private static void file(Coordinate where, RuleRef.Invariant from, Core.Binary comparison,
+                             int conjunct, BlockReason.RuleWithoutLineReason why,
+                             List<FieldDomains.NoLine> out) {
+        FieldDomains.NoLine said =
+                new FieldDomains.NoLine(where.at(), from, comparison, conjunct, why);
+        if (!out.contains(said)) {
+            out.add(said);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1428,17 +1428,19 @@ public final class InvariantChecker {
             shape = new ClauseStates.ABound(about.at(), positions);
         }
         // And where this part raises the question of where the values there stop and no end came of
-        // it, the answer to that question, made here. Which limit it is is read off the coordinate
-        // and not off this part — every part raising this question comes to the same word — so what
-        // each part adds is itself, standing behind an answer that is already whole. Put together
-        // afterwards from the findings, the answer was whatever rows a finer key happened to hold.
+        // it, the answer to that question. Made once, when the question is first met: which limit
+        // it is is read off the coordinate the question is keyed by, and the coordinate is what
+        // carries the carrier — so the same reading of the same carrier is what any part raising
+        // this question would come to, and it is done once rather than done again and reconciled.
+        // What a part met afterwards adds is itself.
         if (shape instanceof ClauseStates.ABound stated
                 && end instanceof InvariantBound.Read.NoEnd) {
-            standing.merge(new FieldDomains.BoundaryQuestion(from, stated.line()),
-                    new FieldDomains.BoundaryStanding(
-                            UnreadComparison.whereALineWouldFall(about.carrier() != null),
-                            List.of(part)),
-                    FieldDomains.BoundaryStanding::and);
+            standing.compute(new FieldDomains.BoundaryQuestion(from, stated.line()),
+                    (question, had) -> had == null
+                            ? new FieldDomains.BoundaryStanding(
+                                    UnreadComparison.whereALineWouldFall(about.carrier() != null),
+                                    List.of(part))
+                            : had.and(part));
         }
         settle(bin, from, shape, end, at, byName, raised, took, typeAt, parts, raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1668,24 +1668,12 @@ public final class InvariantChecker {
     /**
      * What a rule filed at {@code where} is about, as this reader knows it.
      *
-     * <p>The values at the position where a whole side of the comparison is that position and
-     * nothing else, and where the coordinate met there is the position's own value rather than a
-     * number an operation answered of it. Everything else the walk meets it met on the way through
-     * an expression — inside a call read through to its body, or under a field access this reading
-     * does not take apart — and what the rule says about the values at such a place is exactly the
-     * part that went unread.
+     * <p>What this reader supplies is what it calls the place. Whether the rule states anything
+     * about the values standing there is the same question a body's comparison is held to, and is
+     * answered where both readers meet it.
      */
     private static RuleAt<String> ruleAt(Coordinate where, Places left, Places right) {
-        boolean ownValue = where.at().kind() instanceof FieldDomains.CoordinateKind.OfItsOwnValue;
-        boolean aWholeSide = isExactly(left.origin(), where.path())
-                || isExactly(right.origin(), where.path());
-        return ownValue && aWholeSide ? new RuleAt.AboutOwnValues<>(where.path())
-                : new RuleAt.NotAboutOwnValues<>(where.path());
-    }
-
-    /** Whether a whole side of the comparison is the position at {@code path} and nothing else. */
-    private static boolean isExactly(ValueOrigin<String> side, String path) {
-        return side instanceof ValueOrigin.IsAPosition<String> one && one.at().equals(path);
+        return UnreadComparison.subjectAt(where.path(), left.origin(), right.origin());
     }
 
     /** One finding, kept once. A coordinate reached twice is one place with one thing to say. */

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -239,7 +239,7 @@ public final class RuleAccounting {
                 case TheValueReadingSays it -> it.why().stream()
                         .map(souther.compiler.inputs.BlockReason::ofARuleTheValueReadingLeft)
                         .toList();
-                case TheEndReadingSays it -> it.why();
+                case TheEndReadingSays it -> List.of(it.why());
                 case NothingTookItIn _ ->
                         List.of(new souther.compiler.inputs.BlockReason.NoReadingTookItIn());
             }) {
@@ -283,15 +283,17 @@ public final class RuleAccounting {
          * every one of them has been read — so a part still standing behind another is a second
          * thing to lift and not a repeat of the first.
          */
-        record TheEndReadingSays(
-                List<souther.compiler.inputs.BlockReason.RuleReadingStopped> why)
-                implements Why {
+        record TheEndReadingSays(FieldDomains.BoundaryStanding standing) implements Why {
 
             public TheEndReadingSays {
-                if (why == null || why.isEmpty()) {
+                if (standing == null) {
                     throw new IllegalArgumentException("a reading that stopped says why");
                 }
-                why = List.copyOf(why);
+            }
+
+            /** Which limit stopped it, which is one word however many parts are behind it. */
+            public souther.compiler.inputs.BlockReason.RuleReadingStopped why() {
+                return standing.why();
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAt.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAt.java
@@ -1,0 +1,61 @@
+package souther.compiler.check;
+
+/**
+ * What a rule filed at one place is about, said by the reader that filed it there.
+ *
+ * <p>Asked only where a reading stopped. A comparison the arithmetic read to the end has a subject
+ * already — the quantity it cuts — and nothing here would add to it; where it stopped there is no
+ * subject, and this is what stands in its place.
+ *
+ * <p>The one question a classifier of comparisons cannot answer for itself. Whether a rule
+ * constrains the values at a position, or something taken from them, is not readable off the
+ * expression: {@link ValueOrigin} reads a call through to its body, so {@code describe(a) > 0}
+ * arrives as arithmetic holding the position and carries no operation to recognise. What settles it
+ * is what the reader knew when it chose the place to file at.
+ *
+ * <p>Two cases, and the second is named for what it denies because there is nothing the members of
+ * it hold in common besides that. A length taken of a string, a value a call answered of a field,
+ * and a position met inside an expression the reader did not take apart are one case only in that
+ * none of them says anything about the order the position's own values carry. Called a quantity of
+ * the position, two of the three are not one; called something of it, the one thing this is for
+ * disappears from the name.
+ *
+ * @param <K> what the reader calls a position
+ */
+public sealed interface RuleAt<K> {
+
+    /** The position this stands for, in the reader's own names. */
+    K position();
+
+    /**
+     * The rule constrains the values that stand at the position.
+     *
+     * <p>So what the position carries is the rule's own subject, and whether a line can be drawn on
+     * it is a question about this rule.
+     */
+    record AboutOwnValues<K>(K position) implements RuleAt<K> {
+
+        public AboutOwnValues {
+            if (position == null) {
+                throw new IllegalArgumentException("a rule about a position's values names it");
+            }
+        }
+    }
+
+    /**
+     * The rule is filed here and states nothing about the values that stand here.
+     *
+     * <p>The carrier is not this rule's subject, so asking whether a line can be drawn on it
+     * answers about something the author did not write. A rule about {@code String.length(s)} told
+     * that no line is drawn on a string sends its author to the values of {@code s}, which the rule
+     * never mentions.
+     */
+    record NotAboutOwnValues<K>(K position) implements RuleAt<K> {
+
+        public NotAboutOwnValues {
+            if (position == null) {
+                throw new IllegalArgumentException("a rule filed at a position names it");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAt.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAt.java
@@ -1,17 +1,18 @@
 package souther.compiler.check;
 
 /**
- * What a rule filed at one place is about, said by the reader that filed it there.
+ * What a rule filed at one place is about.
  *
  * <p>Asked only where a reading stopped. A comparison the arithmetic read to the end has a subject
  * already — the quantity it cuts — and nothing here would add to it; where it stopped there is no
  * subject, and this is what stands in its place.
  *
- * <p>The one question a classifier of comparisons cannot answer for itself. Whether a rule
- * constrains the values at a position, or something taken from them, is not readable off the
- * expression: {@link ValueOrigin} reads a call through to its body, so {@code describe(a) > 0}
- * arrives as arithmetic holding the position and carries no operation to recognise. What settles it
- * is what the reader knew when it chose the place to file at.
+ * <p>Made by {@link UnreadComparison#subjectAt}, so the law is one. Which side of a comparison a
+ * position stands as is the same question for a clause of a declaration and for a body's
+ * comparison, and each reader answering it in its own names is how the two came to disagree about
+ * one shape of rule in the first place. What a reader is asked for is the part only it knows: what
+ * the place it chose is called, and whether that place is the position's own value or a number
+ * taken of it.
  *
  * <p>Two cases, and the second is named for what it denies because there is nothing the members of
  * it hold in common besides that. A length taken of a string, a value a call answered of a field,
@@ -24,14 +25,11 @@ package souther.compiler.check;
  */
 public sealed interface RuleAt<K> {
 
-    /** The position this stands for, in the reader's own names. */
-    K position();
-
     /**
      * The rule constrains the values that stand at the position.
      *
      * <p>So what the position carries is the rule's own subject, and whether a line can be drawn on
-     * it is a question about this rule.
+     * it is a question about this rule. The position is here because that question is asked of it.
      */
     record AboutOwnValues<K>(K position) implements RuleAt<K> {
 
@@ -49,13 +47,10 @@ public sealed interface RuleAt<K> {
      * answers about something the author did not write. A rule about {@code String.length(s)} told
      * that no line is drawn on a string sends its author to the values of {@code s}, which the rule
      * never mentions.
+     *
+     * <p>Carrying nothing, because there is nothing to ask of the position here. Held with the
+     * place it was filed at, this would be a position beside an answer that is not about it, which
+     * is the reading the whole type exists to stop.
      */
-    record NotAboutOwnValues<K>(K position) implements RuleAt<K> {
-
-        public NotAboutOwnValues {
-            if (position == null) {
-                throw new IllegalArgumentException("a rule filed at a position names it");
-            }
-        }
-    }
+    record NotAboutOwnValues<K>() implements RuleAt<K> {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -64,11 +64,7 @@ public final class UnreadComparison {
          * - b + c <= 10} is {@code a + c <= 10}, and a note at {@code b} would say the rule relates
          * a position it does not mention.
          */
-        sealed interface Read<K> extends Quantity<K> {
-
-            /** The positions the quantity runs over, which may be none. */
-            Set<K> support();
-        }
+        sealed interface Read<K> extends Quantity<K> {}
 
         /**
          * The quantity this comparison cuts is over several positions, so it divides none of them.
@@ -90,11 +86,6 @@ public final class UnreadComparison {
                             "a quantity over several positions is over at least two");
                 }
             }
-
-            @Override
-            public Set<K> support() {
-                return positions;
-            }
         }
 
         /**
@@ -114,11 +105,6 @@ public final class UnreadComparison {
                     throw new IllegalArgumentException("a quantity over one position names it");
                 }
             }
-
-            @Override
-            public Set<K> support() {
-                return Set.of(position);
-            }
         }
 
         /**
@@ -134,13 +120,7 @@ public final class UnreadComparison {
          * file at, and what makes the rule worth saying at all is that the model names a position
          * there and cuts nothing — so this alone is filed where the comparison names.
          */
-        record CutsNothing<K>() implements Read<K> {
-
-            @Override
-            public Set<K> support() {
-                return Set.of();
-            }
-        }
+        record CutsNothing<K>() implements Read<K> {}
 
         /**
          * The arithmetic read no form here, and what it was looking at when it stopped.
@@ -178,16 +158,53 @@ public final class UnreadComparison {
      * states something at the positions it names and cuts none of them.
      */
     public static <K> List<K> filedAt(Quantity.Read<K> read, List<K> met) {
-        if (read instanceof Quantity.CutsNothing<K>) {
-            return List.copyOf(met);
-        }
+        return switch (read) {
+            case Quantity.CutsNothing<K> _ -> List.copyOf(met);
+            case Quantity.OverOne<K> one -> over(met, one.position()::equals);
+            case Quantity.OverSeveral<K> several -> over(met, several.positions()::contains);
+        };
+    }
+
+    /** The places of {@code met} the quantity runs over, in the order the walk met them. */
+    private static <K> List<K> over(List<K> met, Predicate<K> runsOver) {
         List<K> out = new ArrayList<>();
         for (K each : met) {
-            if (read.support().contains(each)) {
+            if (runsOver.test(each)) {
                 out.add(each);
             }
         }
         return out;
+    }
+
+    /**
+     * What a rule filed at {@code position} is about, for the reader that chose to file it there.
+     *
+     * <p><b>The law both readers are held to.</b> Whether the rule states something about the
+     * values standing at a place is settled by the comparison — a whole side of it is that position
+     * and nothing else — and a reader answering that for itself is how a clause and a body's
+     * comparison of one shape came to different words. What a reader supplies is what it calls the
+     * place, which is the part only it knows.
+     *
+     * <p>{@code s < Won} is about the values of {@code s} whatever the reading made of the other
+     * side. {@code n < l1.l2.leaf.x} says nothing about the values of {@code l1.l2.leaf}, which is
+     * where a walk met a position on its way through an expression it could not take apart.
+     *
+     * <p>A number taken of the position needs nothing here. Where a reader files at one, the
+     * carrier it goes on to ask about is that number's and not the position's underneath —
+     * {@code String.length(s)} is asked what lengths are counted on — so the two answers this could
+     * give come to the same word. Written as a case of its own, it would be a branch nothing can
+     * make a difference to.
+     */
+    public static <K> RuleAt<K> subjectAt(K position, ValueOrigin<K> left, ValueOrigin<K> right) {
+        return isExactly(left, position) || isExactly(right, position)
+                ? new RuleAt.AboutOwnValues<>(position)
+                : new RuleAt.NotAboutOwnValues<>();
+    }
+
+    /** Whether a whole side of the comparison is the position at {@code position}, and nothing
+     *  else. */
+    private static <K> boolean isExactly(ValueOrigin<K> side, K position) {
+        return side instanceof ValueOrigin.IsAPosition<K> one && one.at().equals(position);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -2,7 +2,9 @@ package souther.compiler.check;
 
 import souther.compiler.inputs.BlockReason;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -21,11 +23,17 @@ import java.util.function.Predicate;
  * called; neither is the other's business. What is here is what the answers come to, which is the
  * part that has to agree.
  *
- * <p><b>Every answer is read off what the comparison is, and none off what a reader could not
- * do.</b> The arithmetic says whether it read a quantity and what that quantity is over; it does
- * not say so by declining to answer. An expression that stopped one reader is described by what it
- * is made of ({@link ValueOrigin}) — an operation's answer is not a syntax nobody reads, and told
- * that, an author goes looking for a spelling that was never the difficulty.
+ * <p><b>Two questions, and which of them is asked turns on whether there is a quantity.</b> Where
+ * the arithmetic reached one, the quantity is what the rule is about: it says what the rule leaves
+ * and, through {@link #filedAt}, which of the places the walk met are the rule's at all. Where the
+ * arithmetic stopped there is no quantity to be about, so each place is asked for itself and the
+ * reader says what filing there means ({@link RuleAt}).
+ *
+ * <p>So no answer here is read off a side of the comparison. One was: the reason was worked out
+ * once from whichever side named a position, and every place the comparison mentioned was handed
+ * the result — after which a rule about {@code n} told {@code l1.l2.leaf} what {@code n}'s carrier
+ * carries, and a position the canonical form had cancelled was told a form nobody could read
+ * stopped at it.
  *
  * <p>What a position is called travels with the answers and is never read here, only compared with
  * another of its own. So the readers may hold a position under whatever name each of them uses and
@@ -36,10 +44,10 @@ public final class UnreadComparison {
     /**
      * What the arithmetic made of the comparison.
      *
-     * <p>Three cases and not a set that may be absent. That the arithmetic read no form at all is an
-     * answer about the comparison, and holding it as a missing set made it an answer about the
-     * reader — after which the word a report printed turned on which side of the affine fragment an
-     * operation happened to fall, which is no fact about the rule.
+     * <p>Two cases at the top and not four, because the two questions below divide here. A reading
+     * that reached a quantity has a subject; one that stopped has none, and the difference decides
+     * which of them a caller may ask. Flat, a caller with a stopped reading could ask for the
+     * quantity's answer and be given one about a subject that was never established.
      *
      * <p><b>Each of them carries what it stands for.</b> A quantity over nothing is not a quantity,
      * and a reading that stopped is not one without somewhere it stopped — held as cases that can be
@@ -49,6 +57,20 @@ public final class UnreadComparison {
     public sealed interface Quantity<K> {
 
         /**
+         * The arithmetic read the comparison to the end, and this is the quantity it cuts.
+         *
+         * <p>Which positions that quantity runs over is what the rule is about. A position the
+         * canonical form cancelled is named by the comparison and is no subject of it: {@code a + b
+         * - b + c <= 10} is {@code a + c <= 10}, and a note at {@code b} would say the rule relates
+         * a position it does not mention.
+         */
+        sealed interface Read<K> extends Quantity<K> {
+
+            /** The positions the quantity runs over, which may be none. */
+            Set<K> support();
+        }
+
+        /**
          * The quantity this comparison cuts is over several positions, so it divides none of them.
          *
          * <p>Several and not one, by the type. A form over one position is a line on that
@@ -56,7 +78,7 @@ public final class UnreadComparison {
          * different question with a different answer ({@link OverOne}) — counted as one of these
          * by the size of a set, the two were told apart by whoever held the set.
          */
-        record OverSeveral<K>(Set<K> positions) implements Quantity<K> {
+        record OverSeveral<K>(Set<K> positions) implements Read<K> {
 
             public OverSeveral {
                 positions = java.util.Collections.unmodifiableSet(new LinkedHashSet<>(positions));
@@ -67,6 +89,11 @@ public final class UnreadComparison {
                     throw new IllegalArgumentException(
                             "a quantity over several positions is over at least two");
                 }
+            }
+
+            @Override
+            public Set<K> support() {
+                return positions;
             }
         }
 
@@ -80,12 +107,17 @@ public final class UnreadComparison {
          * how the sides were spelled adds to that, and asked of the sides this answered about a
          * shape the arithmetic had already got past.
          */
-        record OverOne<K>(K position) implements Quantity<K> {
+        record OverOne<K>(K position) implements Read<K> {
 
             public OverOne {
                 if (position == null) {
                     throw new IllegalArgumentException("a quantity over one position names it");
                 }
+            }
+
+            @Override
+            public Set<K> support() {
+                return Set.of(position);
             }
         }
 
@@ -97,8 +129,18 @@ public final class UnreadComparison {
          * no position, which is a fact about the rule; folded together with a reading that stopped,
          * it was reported as a rule written in a form this compiler cannot read — of a form this
          * compiler read completely.
+         *
+         * <p>The one quantity whose places are not its support. There is nothing in the support to
+         * file at, and what makes the rule worth saying at all is that the model names a position
+         * there and cuts nothing — so this alone is filed where the comparison names.
          */
-        record CutsNothing<K>() implements Quantity<K> {}
+        record CutsNothing<K>() implements Read<K> {
+
+            @Override
+            public Set<K> support() {
+                return Set.of();
+            }
+        }
 
         /**
          * The arithmetic read no form here, and what it was looking at when it stopped.
@@ -124,48 +166,44 @@ public final class UnreadComparison {
     }
 
     /**
-     * What would have to change before this comparison could be a line.
+     * Which of the places a walk met a read comparison is filed at, in the order it met them.
      *
-     * <p>Four different things, and a reader told one sentence for all of them cannot tell which
-     * limit is theirs to wait on. A comparison between two positions asks for a class that is about
-     * both, which a partition of one position is not. One on a carrier nothing draws a line on asks
-     * for that carrier. One written about what an operation answered asks for a statement about
-     * that operation. What is left is a form this does not read — the position inside arithmetic the
-     * terms do not take apart, or a threshold written as something other than a constant.
+     * <p>The quantity decides, and the walk only says what each place is called and which came
+     * first. Membership taken from the walk instead, a rule was filed at positions its own
+     * canonical form had cancelled — and the word it left there was the word for the position the
+     * quantity does cut.
      *
-     * <p>Two positions is asked of what the sides <em>name</em>, however deeply, and not of what
-     * they are. That is as true of {@code x < y + 1} as of {@code x < y}: reading it off whether a
-     * side is a position loses the second position entirely and answers with the form.
+     * <p>{@link Quantity.CutsNothing} is the exception, and a deliberate one: its support is empty
+     * and there would be nothing to file, while what the rule is worth saying for is that the model
+     * states something at the positions it names and cuts none of them.
+     */
+    public static <K> List<K> filedAt(Quantity.Read<K> read, List<K> met) {
+        if (read instanceof Quantity.CutsNothing<K>) {
+            return List.copyOf(met);
+        }
+        List<K> out = new ArrayList<>();
+        for (K each : met) {
+            if (read.support().contains(each)) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * What a comparison the arithmetic read to the end leaves, at the places it is filed at.
      *
-     * <p>And of <em>another</em> position, not of a position on each side ({@link Relates}).
-     * {@code x < x + 1} has a position on both sides and one position, so there is no second one
-     * for a class to be about — what a reader would have to be given is a reading of the form, and
-     * being sent after a relation sends them looking for a position the model never wrote.
-     *
-     * <p><b>Asked of what the rule cuts, and of the sides only where that is unreadable.</b> Which
-     * side a position is written on is no part of whether a rule relates two of them: {@code 3 * a +
-     * 6 * b <= 48} puts both on one side and divides neither. What says so is the quantity the
-     * canonical form cuts, which each reader works out with its own atoms and its own environment —
-     * the same division of labour {@link ValueOrigin} already has. Where the arithmetic reads
-     * nothing there is no quantity to count, and the sides answer: {@code a > b} over strings
-     * relates two positions on an order with no numbers, and {@code a * b > 5} names two and is
-     * stopped by neither of them. Where it reads a line on one position, that position answers,
-     * and the sides are not consulted at all: a spelling can only disagree with a form that was
-     * read, and a reader that consulted it answered about a shape the arithmetic had got past.
+     * <p>One answer for all of them, because the quantity is one subject. Which places those are is
+     * {@link #filedAt}'s, and every one of them is a position this quantity runs over — or, for a
+     * quantity that runs over none, a position the rule names and cuts nothing of.
      *
      * @param ordered whether a line can be drawn on what a position carries, asked of the carrier.
      *                Asked of the reader because a position is looked up there, and asked at all
-     *                only about a position the quantity is over or a side that is one
+     *                only about the one position a quantity over one is on
      */
-    public static <K> BlockReason.RuleWithoutLineReason why(ValueOrigin<K> left, ValueOrigin<K> right,
-                                                 Quantity<K> quantity, Predicate<K> ordered) {
-        // What the rule cuts, where the arithmetic could be read at all. A quantity over
-        // more than one position divides none of them — which values of one are on which
-        // side depends on the others — and that is as true of `3a + 6b <= 48`, whose two
-        // sit on one side, as of `a < b`. Counted off the sides instead, the first came
-        // back as a form nobody could read; counted off how many positions the comparison
-        // names, `a * b > 5` came back as a relation when what stops it is the product.
-        return switch (quantity) {
+    public static <K> BlockReason.RuleWithoutLineReason ofTheQuantity(Quantity.Read<K> read,
+                                                                     Predicate<K> ordered) {
+        return switch (read) {
             // Read to the end and there is no quantity. Nothing about how it was written adds to
             // that: no reading fell short, so no question about what could not be read arises.
             case Quantity.CutsNothing<K> _ -> new BlockReason.ComparisonCuttingNothing();
@@ -177,98 +215,66 @@ public final class UnreadComparison {
             case Quantity.OverOne<K> one -> ordered.test(one.position())
                     ? new BlockReason.UnreadComparisonForm()
                     : new BlockReason.UnreadComparisonDomain();
-            // No quantity was read, so what the sides name is the only account there is.
-            case Quantity.NotRead<K> notRead -> whatStopped(left, right, notRead, ordered);
         };
     }
 
     /**
-     * What stopped a reading whose arithmetic read no form, off what its sides name.
+     * What a reading that stopped leaves at one place it was filed at.
      *
-     * <p>The one arm of {@link #why} a caller holding a stopped reading may ask for on its own, and
-     * typed as a stop: every answer here is one, because the arithmetic stopped and what the sides
-     * name only says which limit it stopped on. A caller that has met a stop and wants the words
-     * for it asks this, and cannot be handed the words for a rule read to the end — those are
-     * answers about a quantity, and this is never given one.
+     * <p>Typed as a stop, because that is what every answer here is: the arithmetic stopped, and
+     * what is left to decide is which limit it stopped on. A caller that has met a stop and wants
+     * the words for it asks this, and cannot be handed the words for a rule read to the end —
+     * those are answers about a quantity, and this is never given one.
      *
-     * <p>Only here is the spelling consulted. Where the canonical form was read it has already said
-     * what the rule cuts, and a spelling saying otherwise is the spelling being wrong about the
-     * rule.
+     * <p><b>What the reading stopped at first, and the carrier only after.</b> Where the value the
+     * rule speaks of was made by an operation, following the rule back through that operation is
+     * the capability that is missing, and it is missing whatever the position carries. Asked the
+     * other way round, a rule about what a call answered of a field with no order of its own was
+     * reported as a rule this could draw no line on — sending its author to values the rule never
+     * mentions.
+     *
+     * <p>And the carrier is asked only where the rule is about the values at the place it is filed
+     * at, which the reader says. Asked at every place, a rule about {@code n} answered about what
+     * {@code l1.l2.leaf} carries, because that is where the walk met a position on its way through
+     * an expression it could not take apart.
      */
-    public static <K> BlockReason.RuleReadingStopped whatStopped(ValueOrigin<K> left,
-                                                               ValueOrigin<K> right,
-                                                               Quantity.NotRead<K> notRead,
-                                                               Predicate<K> ordered) {
-        // What the sides name says nothing about whether anything fell short, and here something
-        // did: the arithmetic stopped. A comparison naming two positions whose form was read is a
-        // rule that relates them and leaves nothing missing, and one whose form was not read is a
-        // rule nobody here has taken in — said alike, the second went out under a word that means
-        // no measure is short of anything, and a model missing a border came back complete.
-        // The carrier, asked of the position and before the reading. Whether a line can be drawn on
-        // what a position holds is settled by the position, and no reader of any form would change
-        // it — so `s < Won` over a type with one value says that, wherever the reading stopped.
-        ValueOrigin<K> side = speakingSide(left, right);
-        if (side instanceof ValueOrigin.IsAPosition<K> one && !ordered.test(one.at())) {
-            return new BlockReason.UnreadComparisonDomain();
+    public static <K> BlockReason.RuleReadingStopped whereItStopped(RuleAt<K> at,
+                                                                   Quantity.NotRead<K> notRead,
+                                                                   Predicate<K> ordered) {
+        // A value an operation made of what stands at a position, and a rule written about that
+        // value. Where it came from is known; what the rule says about the values there is not,
+        // and working it out means following the rule back through the operation. One answer for
+        // an operation over a position and for an element an operation handed out alike: a rule
+        // about a sequence's elements is not a different kind of thing from a rule about a number.
+        if (madeByAnOperation(notRead.stoppedAt())) {
+            return new BlockReason.RuleAboutADerivedValue();
         }
-        // And what the reading stopped at, where it stopped. Which expression that was is the
-        // walk's answer and not something recovered from the sides: `String.length(s) > n * n`
-        // stops at the product, and read off the sides it came back as a rule about the length —
-        // an operation this reads, named for the one it does not.
-        return whatThisSideSays(notRead.stoppedAt(), ordered);
-    }
-
-    /**
-     * The side the reason is about.
-     *
-     * <p>The one that names a position, and the left where both do — which is the side a threshold
-     * would be read off, and what is left over there is then what the coordinate was compared
-     * against. Where neither names one, the side whose value came from a position: an author who
-     * compared what a {@code map} answered wrote the rule about that side, and answering about the
-     * literal beside it says the comparison was a form nobody could read when the form was never
-     * the difficulty.
-     */
-    private static <K> ValueOrigin<K> speakingSide(ValueOrigin<K> left, ValueOrigin<K> right) {
-        if (!left.positions().isEmpty()) {
-            return left;
-        }
-        if (!right.positions().isEmpty()) {
-            return right;
-        }
-        return left.madeFrom() != null ? left : right;
-    }
-
-    /** What one side leaves to say, which is always a stop: a side is asked only where no quantity
-     *  answered for the rule. */
-    private static <K> BlockReason.RuleReadingStopped whatThisSideSays(ValueOrigin<K> side,
-                                                             Predicate<K> ordered) {
-        return switch (side) {
-            // The position itself against something no end came out of. The carrier, asked of the
-            // carrier: `at < DateTime(...)` stops because nothing draws a line on a date-time,
-            // while `p.x < 1 + 2` stops because the other side is not a form a threshold is read
-            // out of and `p.x` is an `Int` — a carrier lines are drawn on all through the file.
-            case ValueOrigin.IsAPosition<K> one -> ordered.test(one.at())
+        return switch (at) {
+            // The values here are what the rule speaks of, so what they are carried on says which
+            // limit stopped the reading: `at < DateTime(...)` stops because nothing draws a line on
+            // a date-time, while `p.x < 1 + 2` stops because the other side is not a form a
+            // threshold is read out of and `p.x` is an `Int` — a carrier lines are drawn on all
+            // through the file.
+            case RuleAt.AboutOwnValues<K> own -> ordered.test(own.position())
                     ? new BlockReason.UnreadComparisonForm()
                     : new BlockReason.UnreadComparisonDomain();
-            // A value an operation made of what stands at a position, and a rule written about that
-            // value. Where it came from is known; what the rule says about the values there is not,
-            // and working it out means following the rule back through the operation. One answer
-            // for an operation over a position and for an element an operation handed out alike: a
-            // rule about a sequence's elements is not a different kind of thing from a rule about a
-            // number.
-            case ValueOrigin.Applied<K> _, ValueOrigin.MadeFromAPosition<K> _ ->
-                    new BlockReason.RuleAboutADerivedValue();
+            // And where they are not, there is no question about this carrier to answer. What is
+            // left is the form: something is written here that this did not read, and which of the
+            // position's numbers it was about is the part that went unread.
+            case RuleAt.NotAboutOwnValues<K> _ -> new BlockReason.UnreadComparisonForm();
+        };
+    }
+
+    /** Whether what a reading stopped at is a value an operation made of a position. */
+    private static <K> boolean madeByAnOperation(ValueOrigin<K> stoppedAt) {
+        return switch (stoppedAt) {
+            case ValueOrigin.Applied<K> _, ValueOrigin.MadeFromAPosition<K> _ -> true;
             // Arithmetic the terms do not take apart — unless what is under it came from a
             // position, which is the same rule about a value made from one with a layer of
             // arithmetic over it.
-            case ValueOrigin.Composed<K> composed -> composed.madeFrom() != null
-                    ? new BlockReason.RuleAboutADerivedValue()
-                    : new BlockReason.UnreadComparisonForm();
-            // A side that names nothing at all. Nothing is filed under this — a reason is said at
-            // the positions the comparison names, and it names none — so what is answered is only
-            // that no capability is owed on its account.
-            case ValueOrigin.Written<K> _, ValueOrigin.Unnameable<K> _ ->
-                    new BlockReason.UnreadComparisonForm();
+            case ValueOrigin.Composed<K> composed -> composed.madeFrom() != null;
+            case ValueOrigin.IsAPosition<K> _, ValueOrigin.Written<K> _,
+                 ValueOrigin.Unnameable<K> _ -> false;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -148,10 +148,13 @@ public final class UnreadComparison {
     /**
      * Which of the places a walk met a read comparison is filed at, in the order it met them.
      *
-     * <p>The quantity decides, and the walk only says what each place is called and which came
-     * first. Membership taken from the walk instead, a rule was filed at positions its own
-     * canonical form had cancelled — and the word it left there was the word for the position the
-     * quantity does cut.
+     * <p><b>The quantity says which, and the walk says only which came first.</b> Membership taken
+     * from the walk, a rule was filed at positions its own canonical form had cancelled — and the
+     * word it left there was the word for the position the quantity does cut. Taken as an
+     * intersection, the walk keeps a veto it is not entitled to: a place the quantity runs over
+     * that the walk did not name would go quietly missing, and the answer would be a filing the
+     * rule is short of with nothing saying so. So a quantity running over a place the walk never
+     * met is a disagreement between two readings of one comparison, and it is refused here.
      *
      * <p>{@link Quantity.CutsNothing} is the exception, and a deliberate one: its support is empty
      * and there would be nothing to file, while what the rule is worth saying for is that the model
@@ -160,18 +163,26 @@ public final class UnreadComparison {
     public static <K> List<K> filedAt(Quantity.Read<K> read, List<K> met) {
         return switch (read) {
             case Quantity.CutsNothing<K> _ -> List.copyOf(met);
-            case Quantity.OverOne<K> one -> over(met, one.position()::equals);
-            case Quantity.OverSeveral<K> several -> over(met, several.positions()::contains);
+            case Quantity.OverOne<K> one -> over(met, Set.of(one.position()));
+            case Quantity.OverSeveral<K> several -> over(met, several.positions());
         };
     }
 
-    /** The places of {@code met} the quantity runs over, in the order the walk met them. */
-    private static <K> List<K> over(List<K> met, Predicate<K> runsOver) {
+    /** The places {@code runsOver} names, in the order the walk met them. */
+    private static <K> List<K> over(List<K> met, Set<K> runsOver) {
         List<K> out = new ArrayList<>();
         for (K each : met) {
-            if (runsOver.test(each)) {
+            if (runsOver.contains(each)) {
                 out.add(each);
             }
+        }
+        if (out.size() != runsOver.size()) {
+            // The walk names the places and the quantity says which of them the rule is about, so
+            // one of them holding a place the other has never heard of is two readings of one
+            // comparison disagreeing. Filed as whatever they have in common, the rule would go out
+            // short of a place with nothing to say it was ever expected.
+            throw new IllegalStateException(
+                    "the quantity runs over " + runsOver + ", which the walk met as " + met);
         }
         return out;
     }
@@ -229,10 +240,23 @@ public final class UnreadComparison {
             // stopped, and what it stopped on is the position. The carrier says which limit — a
             // position nothing draws a line on wants the carrier, and one lines are drawn on all
             // through the file wants a reader of the form.
-            case Quantity.OverOne<K> one -> ordered.test(one.position())
-                    ? new BlockReason.UnreadComparisonForm()
-                    : new BlockReason.UnreadComparisonDomain();
+            case Quantity.OverOne<K> one -> whereALineWouldFall(ordered.test(one.position()));
         };
+    }
+
+    /**
+     * What a rule stating where the values at one place stop is left with, where no line came of
+     * it.
+     *
+     * <p>The carrier and nothing else. A position nothing draws a line on wants that carrier read;
+     * one lines are drawn on all through the file wants a reader for the form the rule is written
+     * in. Which of the two it is turns on the place and on nothing about the comparison, so a
+     * question raised at one coordinate has one answer however many parts of a rule raise it — and
+     * that is what lets such a question be answered rather than gathered.
+     */
+    public static BlockReason.RuleReadingStopped whereALineWouldFall(boolean ordered) {
+        return ordered ? new BlockReason.UnreadComparisonForm()
+                : new BlockReason.UnreadComparisonDomain();
     }
 
     /**
@@ -243,42 +267,41 @@ public final class UnreadComparison {
      * the words for it asks this, and cannot be handed the words for a rule read to the end —
      * those are answers about a quantity, and this is never given one.
      *
-     * <p><b>What the reading stopped at first, and the carrier only after.</b> Where the value the
-     * rule speaks of was made by an operation, following the rule back through that operation is
-     * the capability that is missing, and it is missing whatever the position carries. Asked the
-     * other way round, a rule about what a call answered of a field with no order of its own was
-     * reported as a rule this could draw no line on — sending its author to values the rule never
-     * mentions.
+     * <p><b>Every answer is about the place, and none about the expression as a whole.</b> The
+     * carrier is asked only where the rule states something about the values standing there, which
+     * the reader says: asked at every place, a rule about {@code n} answered about what
+     * {@code l1.l2.leaf} carries, because that is where a walk met a position on its way through an
+     * expression it could not take apart.
      *
-     * <p>And the carrier is asked only where the rule is about the values at the place it is filed
-     * at, which the reader says. Asked at every place, a rule about {@code n} answered about what
-     * {@code l1.l2.leaf} carries, because that is where the walk met a position on its way through
-     * an expression it could not take apart.
+     * <p>And whether an operation made the value the rule speaks of is asked only where the rule is
+     * not about the values standing here. Asked first, of the stopped expression, it answered over
+     * a place whose own values the rule plainly states something about: {@code s < Won} would be a
+     * rule about a value an operation made the day an operation appeared beside it.
+     *
+     * <p><b>So the answer at a place a rule is about the values of is a function of that place.</b>
+     * Both of the words such a place can be left with are read off the carrier, and the carrier is
+     * the position's. Which is what lets a question raised at one coordinate be answered once
+     * rather than gathered from the conjuncts that asked it.
      */
     public static <K> BlockReason.RuleReadingStopped whereItStopped(RuleAt<K> at,
                                                                    Quantity.NotRead<K> notRead,
                                                                    Predicate<K> ordered) {
-        // A value an operation made of what stands at a position, and a rule written about that
-        // value. Where it came from is known; what the rule says about the values there is not,
-        // and working it out means following the rule back through the operation. One answer for
-        // an operation over a position and for an element an operation handed out alike: a rule
-        // about a sequence's elements is not a different kind of thing from a rule about a number.
-        if (madeByAnOperation(notRead.stoppedAt())) {
-            return new BlockReason.RuleAboutADerivedValue();
-        }
         return switch (at) {
             // The values here are what the rule speaks of, so what they are carried on says which
             // limit stopped the reading: `at < DateTime(...)` stops because nothing draws a line on
             // a date-time, while `p.x < 1 + 2` stops because the other side is not a form a
             // threshold is read out of and `p.x` is an `Int` — a carrier lines are drawn on all
             // through the file.
-            case RuleAt.AboutOwnValues<K> own -> ordered.test(own.position())
-                    ? new BlockReason.UnreadComparisonForm()
-                    : new BlockReason.UnreadComparisonDomain();
-            // And where they are not, there is no question about this carrier to answer. What is
-            // left is the form: something is written here that this did not read, and which of the
-            // position's numbers it was about is the part that went unread.
-            case RuleAt.NotAboutOwnValues<K> _ -> new BlockReason.UnreadComparisonForm();
+            case RuleAt.AboutOwnValues<K> own ->
+                    whereALineWouldFall(ordered.test(own.position()));
+            // And where they are not, what is left is which of two ways they are not. A value an
+            // operation made of what stands here is a rule to be followed back through that
+            // operation; anything else is a form this did not read, and which number of the
+            // position it was about is the part that went unread.
+            case RuleAt.NotAboutOwnValues<K> _ ->
+                    madeByAnOperation(notRead.stoppedAt())
+                            ? new BlockReason.RuleAboutADerivedValue()
+                            : new BlockReason.UnreadComparisonForm();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -266,7 +266,28 @@ sealed interface ComparisonAssessment {
             case Cutting.Read.Stopped stopped -> stopped.why().isEmpty()
                     ? aboutNoPosition(comparison, reads, symbols)
                     : new Unread(stopped.why());
+            // And where the quantity was read and no line could be built on it, the carrier is
+            // what a reader is owed — at the quantity's own coordinates, because the quantity is
+            // what such a rule is about.
+            case Cutting.Read.NoLineOnTheQuantity over -> over.over().isEmpty()
+                    ? aboutNoPosition(comparison, reads, symbols)
+                    : new Unread(atEachOf(over.over(),
+                            new BlockReason.UnreadComparisonDomain()));
         };
+    }
+
+    /**
+     * One answer at every one of {@code places}, kept in the order they were given.
+     *
+     * <p>Sound where the places are one subject: the coordinates of one quantity, or the places a
+     * statement nothing read at all names. A reading that stopped has no such subject, and its
+     * places are answered one at a time where it stopped.
+     */
+    static <R extends BlockReason.RuleWithoutLineReason> java.util.SequencedMap<FilingCoordinate, R>
+            atEachOf(List<FilingCoordinate> places, R why) {
+        java.util.SequencedMap<FilingCoordinate, R> out = new java.util.LinkedHashMap<>();
+        places.forEach(each -> out.putIfAbsent(each, why));
+        return out;
     }
 
     /**
@@ -465,19 +486,10 @@ sealed interface ComparisonAssessment {
         };
     }
 
-    /**
-     * The same answer at every place this is filed at.
-     *
-     * <p>Sound here and nowhere else: these are the coordinates of one quantity, and the quantity
-     * is what the rule is about. A reading that stopped has no such subject, and its places are
-     * answered one at a time where it stopped.
-     */
+    /** The same answer at every place this is filed at, which are one quantity's coordinates. */
     private java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason>
             sameAtEachPlace(BlockReason.RuleWithoutLineReason why) {
-        java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason> out =
-                new java.util.LinkedHashMap<>();
-        filedAt().forEach(each -> out.putIfAbsent(each, why));
-        return out;
+        return atEachOf(filedAt(), why);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -12,7 +12,6 @@ import souther.compiler.numeric.Place;
 import souther.compiler.types.BindingId;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * What one comparison comes to on the input space: one reading, and everything read off it.
@@ -200,17 +199,24 @@ sealed interface ComparisonAssessment {
      * fell short — handed to this one, a comparison whose carrier could not be read was described
      * as relating two positions, and a model short of a border came back complete.
      *
-     * @param filedAt where the reading was looking, which is a diagnostic position and never the
-     *                subject of a question. What such a rule is about is the part that was not read
+     * <p>One reason per place and not one for the comparison. Where a reading stopped there is no
+     * quantity for the places to be one subject of, so each of them says what stopped it there — a
+     * position met inside an expression this did not take apart is told nothing about what it
+     * carries, and one asked about for itself is.
+     *
+     * @param why where the reading was looking and what it left there. The places are diagnostic
+     *            positions and never the subject of a question: what such a rule is about is the
+     *            part that was not read
      */
-    record Unread(BlockReason.RuleReadingStopped why, List<FilingCoordinate> filedAt)
-            implements ComparisonAssessment {
+    record Unread(java.util.SequencedMap<FilingCoordinate,
+            BlockReason.RuleReadingStopped> why) implements ComparisonAssessment {
 
         public Unread {
-            if (why == null) {
-                throw new IllegalArgumentException("a reading that stopped says why");
+            if (why == null || why.isEmpty()) {
+                throw new IllegalArgumentException("a reading that stopped says where and why");
             }
-            filedAt = List.copyOf(filedAt);
+            why = java.util.Collections.unmodifiableSequencedMap(
+                    new java.util.LinkedHashMap<>(why));
         }
     }
 
@@ -257,12 +263,9 @@ sealed interface ComparisonAssessment {
             // stopped rather than worked out again from the comparison afterwards. Here the walk
             // over the expression is the only account of what the rule is about, which is what it
             // is for.
-            case Cutting.Read.Stopped stopped -> {
-                List<FilingCoordinate> filedAt =
-                        GuardThresholds.filedAt(comparison, inputs, reads, symbols);
-                yield filedAt.isEmpty() ? aboutNoPosition(comparison, reads, symbols)
-                        : new Unread(stopped.why(), filedAt);
-            }
+            case Cutting.Read.Stopped stopped -> stopped.why().isEmpty()
+                    ? aboutNoPosition(comparison, reads, symbols)
+                    : new Unread(stopped.why());
         };
     }
 
@@ -283,8 +286,11 @@ sealed interface ComparisonAssessment {
         if (from.isEmpty()) {
             return new NoInput();
         }
-        return new Unread(new BlockReason.RuleAboutADerivedValue(),
-                from.stream().map(FilingCoordinate::at).toList());
+        java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> why =
+                new java.util.LinkedHashMap<>();
+        from.forEach(each -> why.putIfAbsent(FilingCoordinate.at(each),
+                new BlockReason.RuleAboutADerivedValue()));
+        return new Unread(why);
     }
 
     /** What a line comes to on the input space, from the quantity it is on. */
@@ -388,14 +394,15 @@ sealed interface ComparisonAssessment {
             // The positions its quantity is over, as every read rule's are. That the rules leave
             // the input empty says nothing about which positions this rule is about.
             case NoFeasibleInput none -> none.cutting().over();
-            case Unread unread -> unread.filedAt();
+            case Unread unread -> List.copyOf(unread.why().keySet());
             case CutsNothing cuts -> cuts.filedAt();
             case AtAPosition _, AnswerDependent _, NoInput _ -> List.of();
         };
     }
 
     /**
-     * Why the reading of lines drew none from this comparison, or empty where it drew one.
+     * What the reading of lines leaves at each place this comparison is filed at, and empty where
+     * it leaves nothing.
      *
      * <p><b>Named for the reading it is the answer of, and not for the assessment it is read
      * off.</b> What a comparison comes to is one decision; what a reading makes of it is that
@@ -404,6 +411,13 @@ sealed interface ComparisonAssessment {
      * into sets of values gets nothing it can hold from the same rule. A name saying only that a
      * reason was read off an assessment would be reached for by that reader too, and the answer it
      * would take is the one that says nothing fell short.
+     *
+     * <p><b>Per place, and the same at every place only where the places are one subject.</b> A
+     * comparison whose arithmetic reached a quantity is about that quantity, so its places are the
+     * quantity's coordinates and one answer holds at all of them. A reading that stopped has no
+     * quantity to be about, and each place it was left at says what stopped it there — handed one
+     * answer, a position met inside an expression this did not take apart was told what another
+     * position's carrier carries.
      *
      * <p>Answered once, here. Both producers of this evidence — a clause of an {@code ensures} and a
      * {@code guard}'s comparison — worked the same table out separately, so a case added to
@@ -417,37 +431,53 @@ sealed interface ComparisonAssessment {
      * method and in the value reading's own beside it, which is the point of neither having a
      * default.
      */
-    default Optional<BlockReason.RuleWithoutLineReason> whyTheLineReadingDrewNone() {
+    default java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason>
+            whatEachPlaceIsLeftWith() {
         return switch (this) {
             // Which of the two a form that divides nothing is: a line over a run is one number and
             // one line with no position under it, and a line over several positions is a relation
             // between them. Answered from what the quantity is over rather than by the count of its
             // terms, since a form of one term is either.
-            case AcrossPositions across -> Optional.of(across.overARun()
+            case AcrossPositions across -> sameAtEachPlace(across.overARun()
                     ? new BlockReason.ComparisonOverARun()
                     : new BlockReason.ComparisonBetweenPositions());
-            case CutsNothing _ -> Optional.of(new BlockReason.ComparisonCuttingNothing());
+            case CutsNothing _ -> sameAtEachPlace(new BlockReason.ComparisonCuttingNothing());
             case OutsideTheDomain _ ->
-                    Optional.of(new BlockReason.ComparisonCuttingOutsideDomain());
+                    sameAtEachPlace(new BlockReason.ComparisonCuttingOutsideDomain());
             // Not the reason above: there the declarations never run as far as the line, and here
             // they do — what stops short of it is the values that arrive at the comparison, ruled
             // out by the guards on the way. An author reading the first would look at one rule for
             // a contradiction with their declarations that is not in it.
             case NothingArrivesAtItsLine _ ->
-                    Optional.of(new BlockReason.ComparisonNothingArrivesAtItsLine());
+                    sameAtEachPlace(new BlockReason.ComparisonNothingArrivesAtItsLine());
+            // Its own answer for having stopped, decided where it stopped and at each place it was
+            // left at. Worked out again from the comparison afterwards, one whose carrier stopped
+            // the reading came back as a rule that relates two positions — a sentence saying no
+            // measure is short of anything, over a model missing a border.
+            case Unread unread -> new java.util.LinkedHashMap<>(unread.why());
             // Nothing about this rule fell short, and nothing about this rule is what happened. The
             // rules of the input admit no value between them, which is one fact about the behavior
             // and not one per rule at each position it names — said here, a model with two clauses
             // and four positions would be told eight times, and each time about a rule that is not
             // the one at fault.
-            case NoFeasibleInput _ -> Optional.empty();
-            // Its own answer for having stopped, decided where it stopped. Worked out again from
-            // the comparison afterwards, one whose carrier stopped the reading came back as a rule
-            // that relates two positions — a sentence saying no measure is short of anything, over
-            // a model missing a border.
-            case Unread unread -> Optional.of(unread.why());
-            case AtAPosition _, NoInput _, AnswerDependent _ -> Optional.empty();
+            case NoFeasibleInput _, AtAPosition _, NoInput _, AnswerDependent _ ->
+                    new java.util.LinkedHashMap<>();
         };
+    }
+
+    /**
+     * The same answer at every place this is filed at.
+     *
+     * <p>Sound here and nowhere else: these are the coordinates of one quantity, and the quantity
+     * is what the rule is about. A reading that stopped has no such subject, and its places are
+     * answered one at a time where it stopped.
+     */
+    private java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason>
+            sameAtEachPlace(BlockReason.RuleWithoutLineReason why) {
+        java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason> out =
+                new java.util.LinkedHashMap<>();
+        filedAt().forEach(each -> out.putIfAbsent(each, why));
+        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -74,7 +74,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         }
 
         /**
-         * The reading drew no line, and this is what it leaves at each place it is filed at.
+         * The arithmetic stopped, and this is what it leaves at each place it is filed at.
          *
          * <p>A map and not one reason, because the places are not one subject. Where the arithmetic
          * stopped, each place the walk met is a separate question — a position met inside an
@@ -87,6 +87,26 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             public Stopped {
                 why = java.util.Collections.unmodifiableSequencedMap(
                         new java.util.LinkedHashMap<>(why));
+            }
+        }
+
+        /**
+         * The quantity was read and no line could be built on it: a position with no order to be
+         * counted on, or an order whose values this draws no line against.
+         *
+         * <p>Its own answer and not {@link Stopped}. Nothing about the form fell short — it is
+         * right here, and it is the carrier that stopped this — so the quantity is the subject and
+         * the places are its own, which is what every read comparison's are. Said as a reading that
+         * stopped, the places would come from a walk over the operands, and which of two authorities
+         * a comparison's places came from would turn on which producer built the answer.
+         *
+         * @param over the coordinates of the quantity, which is where a reader is sent
+         */
+        record NoLineOnTheQuantity(
+                java.util.List<souther.compiler.inputs.FilingCoordinate> over) implements Read {
+
+            public NoLineOnTheQuantity {
+                over = java.util.List.copyOf(over);
             }
         }
     }
@@ -170,28 +190,10 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         if (form != null) {
             return new Read.Cuts(form);
         }
-        // The quantity was read and no line could be built on it: a position with no order to be
-        // counted on, or an order whose values this draws no line against. Its own answer and not
-        // the form's — the form is right here, and it is the carrier that stopped this.
-        //
-        // Filed at the quantity, because the quantity is what the rule is about. One answer for all
-        // of them for the same reason: they are one subject, and what stopped this is a fact about
-        // the order that subject is on.
-        return new Read.Stopped(sameAt(
-                AffineReading.filedAt(read.form().coefs().keySet()),
-                new souther.compiler.inputs.BlockReason.UnreadComparisonDomain()));
-    }
-
-    /** One answer at every one of {@code places}, for a reading whose subject is one quantity. */
-    private static java.util.SequencedMap<souther.compiler.inputs.FilingCoordinate,
-            souther.compiler.inputs.BlockReason.RuleReadingStopped> sameAt(
-            java.util.List<souther.compiler.inputs.FilingCoordinate> places,
-            souther.compiler.inputs.BlockReason.RuleReadingStopped why) {
-        java.util.SequencedMap<souther.compiler.inputs.FilingCoordinate,
-                souther.compiler.inputs.BlockReason.RuleReadingStopped> out =
-                new java.util.LinkedHashMap<>();
-        places.forEach(each -> out.putIfAbsent(each, why));
-        return out;
+        // The quantity was read and no line could be built on it. Filed at the quantity, because
+        // the quantity is what the rule is about.
+        return new Read.NoLineOnTheQuantity(
+                AffineReading.filedAt(read.form().coefs().keySet()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -73,11 +73,20 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             }
         }
 
-        /** The reading stopped, and this is what it stopped on. */
-        record Stopped(souther.compiler.inputs.BlockReason.RuleReadingStopped why) implements Read {
+        /**
+         * The reading drew no line, and this is what it leaves at each place it is filed at.
+         *
+         * <p>A map and not one reason, because the places are not one subject. Where the arithmetic
+         * stopped, each place the walk met is a separate question — a position met inside an
+         * expression this did not take apart says nothing about what that position carries — and
+         * one answer handed to all of them told a position about the carrier of another.
+         */
+        record Stopped(java.util.SequencedMap<souther.compiler.inputs.FilingCoordinate,
+                souther.compiler.inputs.BlockReason.RuleReadingStopped> why) implements Read {
 
             public Stopped {
-                java.util.Objects.requireNonNull(why, "a reading that stopped says why");
+                why = java.util.Collections.unmodifiableSequencedMap(
+                        new java.util.LinkedHashMap<>(why));
             }
         }
     }
@@ -164,7 +173,25 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         // The quantity was read and no line could be built on it: a position with no order to be
         // counted on, or an order whose values this draws no line against. Its own answer and not
         // the form's — the form is right here, and it is the carrier that stopped this.
-        return new Read.Stopped(new souther.compiler.inputs.BlockReason.UnreadComparisonDomain());
+        //
+        // Filed at the quantity, because the quantity is what the rule is about. One answer for all
+        // of them for the same reason: they are one subject, and what stopped this is a fact about
+        // the order that subject is on.
+        return new Read.Stopped(sameAt(
+                AffineReading.filedAt(read.form().coefs().keySet()),
+                new souther.compiler.inputs.BlockReason.UnreadComparisonDomain()));
+    }
+
+    /** One answer at every one of {@code places}, for a reading whose subject is one quantity. */
+    private static java.util.SequencedMap<souther.compiler.inputs.FilingCoordinate,
+            souther.compiler.inputs.BlockReason.RuleReadingStopped> sameAt(
+            java.util.List<souther.compiler.inputs.FilingCoordinate> places,
+            souther.compiler.inputs.BlockReason.RuleReadingStopped why) {
+        java.util.SequencedMap<souther.compiler.inputs.FilingCoordinate,
+                souther.compiler.inputs.BlockReason.RuleReadingStopped> out =
+                new java.util.LinkedHashMap<>();
+        places.forEach(each -> out.putIfAbsent(each, why));
+        return out;
     }
 
     /**
@@ -189,7 +216,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
             return new Read.Cuts(drawn);
         }
         return new Read.Stopped(
-                GuardThresholds.whyItStopped(comparison, canonical, reads, symbols));
+                GuardThresholds.whatEachPlaceIsLeftWith(comparison, canonical, inputs, reads,
+                        symbols));
     }
 
     /** One position's own values, cut where the reading found the line, or null where that reading

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -200,12 +200,11 @@ public final class EnsuresThresholds {
             // One answer at every one of them, and not a copy of a decision made elsewhere: nothing
             // here was read, so no place is one the rule is known to be about the values at, and
             // the form is what each of them is left with.
-            java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason> left =
-                    new java.util.LinkedHashMap<>();
-            GuardThresholds.mentionedIn(e, reads, symbols).forEach(each ->
-                    left.putIfAbsent(FilingCoordinate.at(each),
-                            new BlockReason.UnreadComparisonForm()));
-            reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), e, rule.value(), left,
+            reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), e, rule.value(),
+                    ComparisonAssessment.atEachOf(
+                            GuardThresholds.mentionedIn(e, reads, symbols).stream()
+                                    .map(FilingCoordinate::at).toList(),
+                            new BlockReason.UnreadComparisonForm()),
                     out.rulesWithoutALine());
             return line + 1;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -197,10 +197,15 @@ public final class EnsuresThresholds {
             // A statement that is not a comparison was not assessed as one, so what stopped this
             // is the form it is written in — the one of the reasons that does not turn on what two
             // sides name — and the positions the walk met are all there is to file it at.
-            reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), e, rule.value(),
-                    new BlockReason.UnreadComparisonForm(),
-                    GuardThresholds.mentionedIn(e, reads, symbols).stream()
-                            .map(FilingCoordinate::at).toList(),
+            // One answer at every one of them, and not a copy of a decision made elsewhere: nothing
+            // here was read, so no place is one the rule is known to be about the values at, and
+            // the form is what each of them is left with.
+            java.util.SequencedMap<FilingCoordinate, BlockReason.RuleWithoutLineReason> left =
+                    new java.util.LinkedHashMap<>();
+            GuardThresholds.mentionedIn(e, reads, symbols).forEach(each ->
+                    left.putIfAbsent(FilingCoordinate.at(each),
+                            new BlockReason.UnreadComparisonForm()));
+            reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), e, rule.value(), left,
                     out.rulesWithoutALine());
             return line + 1;
         }
@@ -216,9 +221,8 @@ public final class EnsuresThresholds {
         // What the positions this names are left with, where the reading of lines drew none. Asked
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.
-        assessed.whyTheLineReadingDrewNone().ifPresent(why ->
-                reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), why,
-                        assessed.filedAt(), out.rulesWithoutALine()));
+        reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(),
+                assessed.whatEachPlaceIsLeftWith(), out.rulesWithoutALine());
         // And the geometry, which is this reader's own. Only the two arms that draw something have
         // anything to add here.
         switch (assessed) {
@@ -302,20 +306,20 @@ public final class EnsuresThresholds {
      * form is what stopped it: the one reason that does not turn on what two sides name.
      */
     private static void reportRuleWithoutLine(RuleRef.Ensures rule, Core statement, BindingId answer,
-                                     BlockReason.RuleWithoutLineReason why,
-                                     List<FilingCoordinate> at,
+                                     java.util.SequencedMap<FilingCoordinate,
+                                             BlockReason.RuleWithoutLineReason> left,
                                      List<RuleWithoutALine> withoutALine) {
         if (ComparisonAssessment.readsAnswer(statement, answer)) {
             return;
         }
         souther.compiler.check.RuleCitation cited =
                 souther.compiler.check.RuleCitation.named(rule);
-        for (FilingCoordinate named : at) {
+        left.forEach((named, why) -> {
             RuleWithoutALine here = new RuleWithoutALine(rule, cited, named, why);
             if (withoutALine.stream().noneMatch(had -> had.sameAs(here))) {
                 withoutALine.add(here);
             }
-        }
+        });
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -301,31 +301,15 @@ public final class GuardThresholds {
     /**
      * What a rule filed at {@code at} is about, as this reader knows it.
      *
-     * <p>The values at a position where a whole side of the comparison is that position and nothing
-     * else. {@code s < Won} states something about the values of {@code s}, whatever the reading
-     * made of the other side; {@code n < l1.l2.leaf.x} states nothing about the values of
-     * {@code l1.l2.leaf}, which is where the walk happened to meet a position on its way through an
-     * expression it could not take apart.
-     *
-     * <p>And of the position's own value, not of a number taken of it. A rule about a length is
-     * filed at the length, and what strings are ordered on is no part of what it says.
-     *
-     * <p>Which is the same question the reading of clauses answers of its own coordinates, put in
-     * this reader's names. Answered from the coordinate alone, {@code s < Won} came out as a rule
-     * about something other than {@code s}: the coordinate says the reading named no number there,
-     * and there is no number to name — the values of a case of a sum are not counted.
+     * <p>What this reader supplies is where the coordinate sits. Whether the rule states anything
+     * about the values standing there is the same question the reading of clauses is held to, and
+     * is answered where both readers meet it. Answered from the coordinate alone, {@code s < Won}
+     * came out as a rule about something other than {@code s}: the coordinate says the reading
+     * named no number there, and there was no number to name — the values of a case of a sum are
+     * not counted.
      */
     private static RuleAt<TermPath> ruleAt(FilingCoordinate at, Names left, Names right) {
-        TermPath here = at instanceof FilingCoordinate.OfTerm it
-                && !(it.term() instanceof NumericTerm.ValueOf) ? null : at.path();
-        return here != null && (isExactly(left.origin(), here) || isExactly(right.origin(), here))
-                ? new RuleAt.AboutOwnValues<>(at.path())
-                : new RuleAt.NotAboutOwnValues<>(at.path());
-    }
-
-    /** Whether a whole side of the comparison is the position at {@code path} and nothing else. */
-    private static boolean isExactly(ValueOrigin<TermPath> side, TermPath path) {
-        return side instanceof ValueOrigin.IsAPosition<TermPath> one && one.at().equals(path);
+        return UnreadComparison.subjectAt(at.path(), left.origin(), right.origin());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
+import souther.compiler.check.RuleAt;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.UnreadComparison;
 import souther.compiler.check.ValueOrigin;
@@ -274,18 +275,57 @@ public final class GuardThresholds {
      * environment it was being read in come back together, so the sides are not read again in
      * whatever the caller happens to hold.
      */
-    static BlockReason.RuleReadingStopped whyItStopped(Core.Binary comparison,
-                                                   AffineReading.OfAComparison.Stopped stopped,
-                                                   InputReads reads, Symbols symbols) {
+    static java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped>
+            whatEachPlaceIsLeftWith(Core.Binary comparison,
+                                    AffineReading.OfAComparison.Stopped stopped,
+                                    InputDomain inputs, InputReads reads, Symbols symbols) {
         Names left = namesIn(comparison.left(), reads, symbols);
         Names right = namesIn(comparison.right(), reads, symbols);
         Names here = namesIn(stopped.node(), stopped.at(), symbols);
         java.util.Map<TermPath, Type> met = new java.util.LinkedHashMap<>(left.met());
         right.met().forEach(met::putIfAbsent);
         here.met().forEach(met::putIfAbsent);
-        return UnreadComparison.whatStopped(left.origin(), right.origin(),
-                new UnreadComparison.Quantity.NotRead<>(here.origin()),
-                at -> met.containsKey(at) && orderable(met.get(at), symbols));
+        UnreadComparison.Quantity.NotRead<TermPath> notRead =
+                new UnreadComparison.Quantity.NotRead<>(here.origin());
+        java.util.function.Predicate<TermPath> ordered =
+                at -> met.containsKey(at) && orderable(met.get(at), symbols);
+        java.util.SequencedMap<FilingCoordinate, BlockReason.RuleReadingStopped> out =
+                new java.util.LinkedHashMap<>();
+        for (FilingCoordinate at : filedAt(comparison, inputs, reads, symbols)) {
+            out.putIfAbsent(at,
+                    UnreadComparison.whereItStopped(ruleAt(at, left, right), notRead, ordered));
+        }
+        return out;
+    }
+
+    /**
+     * What a rule filed at {@code at} is about, as this reader knows it.
+     *
+     * <p>The values at a position where a whole side of the comparison is that position and nothing
+     * else. {@code s < Won} states something about the values of {@code s}, whatever the reading
+     * made of the other side; {@code n < l1.l2.leaf.x} states nothing about the values of
+     * {@code l1.l2.leaf}, which is where the walk happened to meet a position on its way through an
+     * expression it could not take apart.
+     *
+     * <p>And of the position's own value, not of a number taken of it. A rule about a length is
+     * filed at the length, and what strings are ordered on is no part of what it says.
+     *
+     * <p>Which is the same question the reading of clauses answers of its own coordinates, put in
+     * this reader's names. Answered from the coordinate alone, {@code s < Won} came out as a rule
+     * about something other than {@code s}: the coordinate says the reading named no number there,
+     * and there is no number to name — the values of a case of a sum are not counted.
+     */
+    private static RuleAt<TermPath> ruleAt(FilingCoordinate at, Names left, Names right) {
+        TermPath here = at instanceof FilingCoordinate.OfTerm it
+                && !(it.term() instanceof NumericTerm.ValueOf) ? null : at.path();
+        return here != null && (isExactly(left.origin(), here) || isExactly(right.origin(), here))
+                ? new RuleAt.AboutOwnValues<>(at.path())
+                : new RuleAt.NotAboutOwnValues<>(at.path());
+    }
+
+    /** Whether a whole side of the comparison is the position at {@code path} and nothing else. */
+    private static boolean isExactly(ValueOrigin<TermPath> side, TermPath path) {
+        return side instanceof ValueOrigin.IsAPosition<TermPath> one && one.at().equals(path);
     }
 
     /**
@@ -443,7 +483,7 @@ public final class GuardThresholds {
      * of the input, or about what the behavior answers, was never about a position for anything to
      * be left at.
      *
-     * <p>Which of them it is, is {@link ComparisonAssessment#whyTheLineReadingDrewNone}'s and not
+     * <p>Which of them it is, is {@link ComparisonAssessment#whatEachPlaceIsLeftWith}'s and not
      * this reader's. The same table stood here and in the clause reader, so a case added to an
      * assessment had to be answered twice; and worked out from the comparison afterwards rather
      * than where the reading stopped, one whose carrier stopped the reading came back as a rule
@@ -452,26 +492,18 @@ public final class GuardThresholds {
      */
     private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
                                 ComparisonAssessment read, List<RuleWithoutALine> out) {
-        read.whyTheLineReadingDrewNone().ifPresent(why ->
-                publish(behavior, comparison, plan, read, out, why));
-    }
-
-    /** The same, once there is something to say. */
-    private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
-                                ComparisonAssessment read, List<RuleWithoutALine> out,
-                                BlockReason.RuleWithoutLineReason why) {
         RuleRef.Comparison rule = new RuleRef.Comparison(behavior, comparison.origin());
         souther.compiler.check.RuleCitation cited = citationOf(comparison, plan.comparisons());
-        // Whose positions these are is the assessment's answer, not this reader's: a rule that was
-        // read is filed at its quantity's coordinates and one that stopped at the positions the
-        // walk met.
-        List<FilingCoordinate> named = read.filedAt();
-        for (FilingCoordinate at : named) {
+        // What each place is left with, and which places there are, are the assessment's one
+        // answer. A rule that was read is filed at its quantity's coordinates and says one thing
+        // there, because the quantity is one subject; a reading that stopped has none, and each
+        // place says what stopped it there.
+        read.whatEachPlaceIsLeftWith().forEach((at, why) -> {
             RuleWithoutALine said = new RuleWithoutALine(rule, cited, at, why);
             if (out.stream().noneMatch(had -> had.sameAs(said))) {
                 out.add(said);
             }
-        }
+        });
     }
 
     /** How a row meets a line a body's condition drew, which is a guard's own answer: what it takes

--- a/souther-compiler/src/test/java/souther/compiler/check/AReasonBelongsToTheConjunctItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReasonBelongsToTheConjunctItCameFromTest.java
@@ -28,8 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  */
 class AReasonBelongsToTheConjunctItCameFromTest {
 
-    /** What the reading of ends said about the line of the one clause written here. */
-    private static List<String> whyTheLineStands(String clause) {
+    /** Which limit the reading of ends was stopped by, of the one clause written here. */
+    private static String whyTheLineStands(String clause) {
+        return standing(clause).why().getClass().getSimpleName();
+    }
+
+    /** The whole answer to the one boundary question the clause written here leaves standing. */
+    private static FieldDomains.BoundaryStanding standing(String clause) {
         Compilation compilation = Compilation.ofSource("""
                 module m
 
@@ -47,23 +52,45 @@ class AReasonBelongsToTheConjunctItCameFromTest {
                 .filter(e -> e.getKey().obligation() == CoverageObligation.BOUNDARY)
                 .map(e -> assertInstanceOf(RuleAccounting.Outcome.Unaccounted.class, e.getValue()))
                 .map(e -> assertInstanceOf(RuleAccounting.Why.TheEndReadingSays.class, e.why()))
-                .map(e -> e.why().stream().map(each -> each.getClass().getSimpleName()).toList())
+                .map(RuleAccounting.Why.TheEndReadingSays::standing)
                 .findFirst().orElseThrow(() -> new AssertionError("the line was answered"));
+    }
+
+    /** The parts of the clause standing behind that answer. */
+    private static List<Integer> partsBehindTheLine(String clause) {
+        return standing(clause).conjuncts();
     }
 
     /**
      * One model, two orders, one answer: the bound this could not fold is why.
      *
-     * <p>The whole of the answer and not its first entry. A question stands with every part that
-     * was stopped behind it, so asserting one of them would pass a reading that had added the
-     * conjunct beside it as well — and that conjunct was read from end to end.
+     * <p>One word and not a list of them. Which limit stopped the reading is read off the
+     * coordinate, so every part of the rule raising this question comes to the same one — and a
+     * reader is owed the limit rather than a tally of the parts that met it.
      */
     @Test
     void theOrderTheConjunctsAreWrittenInDoesNotDecideWhy() {
-        assertEquals(List.of("UnreadComparisonForm"), whyTheLineStands(
+        assertEquals("UnreadComparisonForm", whyTheLineStands(
                 "invariant said = x <= 10 * 2 && x <= y"));
-        assertEquals(List.of("UnreadComparisonForm"), whyTheLineStands(
+        assertEquals("UnreadComparisonForm", whyTheLineStands(
                 "invariant said = x <= y && x <= 10 * 2"),
                 "and not the reason of the conjunct beside it, which relates two positions");
+    }
+
+    /**
+     * And which parts are behind it is its own count.
+     *
+     * <p>Both conjuncts bound {@code x} and neither placed an end, so both are standing: a part
+     * behind another is a second thing an author has to lift. Read off the reason instead, two
+     * parts one limit stopped were one thing to do, and a rule half of which was read came out
+     * looking like a rule none of which was.
+     */
+    @Test
+    void everyPartStoppedBehindTheLineIsCounted() {
+        assertEquals(List.of(0, 1),
+                partsBehindTheLine("invariant said = x <= 10 * 2 && x <= 3 * 7"));
+        assertEquals(List.of(0),
+                partsBehindTheLine("invariant said = x <= 10 * 2 && x <= y"),
+                "the conjunct that relates two positions raises no question about this line");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
@@ -13,6 +13,7 @@ import souther.compiler.types.TypeSymbols;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A comparison the arithmetic read is filed at the quantity it cuts, and nowhere else.
@@ -94,6 +95,23 @@ class ARuleIsFiledAtWhatItsQuantityIsAboutTest {
                 UnreadComparison.filedAt(new UnreadComparison.Quantity.CutsNothing<>(), met),
                 "a quantity over nothing has no place of its own, and what is worth saying is that "
                         + "the model names these and cuts none of them");
+    }
+
+    /**
+     * A quantity running over a place the walk never met is two readings of one comparison
+     * disagreeing, and it is refused.
+     *
+     * <p>Which is what makes the walk the ordering and not the membership. Kept as an intersection,
+     * the two would be reconciled to whatever they have in common: the rule would go out filed at
+     * one place short, and nothing would say a second was ever expected.
+     */
+    @Test
+    void aQuantityOverAPlaceTheWalkNeverMetIsRefused() {
+        assertThrows(IllegalStateException.class, () -> UnreadComparison.filedAt(
+                new UnreadComparison.Quantity.OverSeveral<>(java.util.Set.of("x", "z")),
+                List.of("x", "y")));
+        assertThrows(IllegalStateException.class, () -> UnreadComparison.filedAt(
+                new UnreadComparison.Quantity.OverOne<>("z"), List.of("x", "y")));
     }
 
     private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read, String path) {

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comparison the arithmetic read is filed at the quantity it cuts, and nowhere else.
+ *
+ * <p>What a rule is about is the quantity its canonical form comes to, so a position that cancelled
+ * out of that form is one the rule says nothing about. Filed at the positions the comparison
+ * mentions instead, {@code x + y - y <= 10 * 2} left a finding at {@code y} — and the word left
+ * there was the one worked out for {@code x}, which is a fact about a carrier {@code y} does not
+ * have to share.
+ *
+ * <p>Both halves are asserted. That the cancelled position is left alone is what the change is for;
+ * that the surviving ones are still filed is what stops the same assertion passing over a reader
+ * that files nothing at all.
+ */
+class ARuleIsFiledAtWhatItsQuantityIsAboutTest {
+
+    /**
+     * One position cancels, and the threshold is not a form an end is read out of.
+     *
+     * <p>{@code 10 * 2} rather than {@code 20} so that the reading of ends places nothing and there
+     * is a finding to file: the question is where it is filed, and a rule that came to an end
+     * leaves nothing anywhere.
+     */
+    private static final String ONE_CANCELS = """
+            module demo
+
+            data N = { x: Int, y: Int }
+                invariant said = x + y - y <= 10 * 2
+            """;
+
+    /** The same with a third position, so that what survives is a relation between two of them. */
+    private static final String ONE_CANCELS_OF_THREE = """
+            module demo
+
+            data N = { x: Int, y: Int, z: Int }
+                invariant said = x + y - y + z <= 10 * 2
+            """;
+
+    /** A position the rule cancelled is not one the rule is about. */
+    @Test
+    void aCancelledPositionIsFiledAtByNothing() {
+        FieldDomains read = read(ONE_CANCELS);
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "x"),
+                "the position the quantity is over carries what the reading was left with");
+        assertEquals(List.of(), reasonsAt(read, "y"),
+                "and the position it cancelled is one the rule states nothing about");
+    }
+
+    /**
+     * And the surviving positions of a form over several are all of them.
+     *
+     * <p>The word is the one a relation between positions gets, which is what the rule that
+     * survives the cancellation is. Said at {@code y} as well, an author would be sent looking for
+     * a pair the rule does not name.
+     */
+    @Test
+    void everyPositionTheQuantityRunsOverIsFiledAt() {
+        FieldDomains read = read(ONE_CANCELS_OF_THREE);
+
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "x"));
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "z"));
+        assertEquals(List.of(), reasonsAt(read, "y"));
+    }
+
+    /** Which of the places a walk met a read comparison is filed at, over every shape of quantity. */
+    @Test
+    void theQuantityDecidesWhichPlacesAreFiledAt() {
+        List<String> met = List.of("x", "y", "z");
+
+        assertEquals(List.of("x"),
+                UnreadComparison.filedAt(new UnreadComparison.Quantity.OverOne<>("x"), met));
+        assertEquals(List.of("x", "z"),
+                UnreadComparison.filedAt(
+                        new UnreadComparison.Quantity.OverSeveral<>(java.util.Set.of("z", "x")),
+                        met),
+                "in the order the walk met them, which is the order a document names them in");
+        assertEquals(met,
+                UnreadComparison.filedAt(new UnreadComparison.Quantity.CutsNothing<>(), met),
+                "a quantity over nothing has no place of its own, and what is worth saying is that "
+                        + "the model names these and cuts none of them");
+    }
+
+    private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read, String path) {
+        return read.noLineAt(path).stream().map(FieldDomains.NoLine::why).toList();
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name,
+                (Hir.Data) symbols.declarations().declaration(name.key()), symbols,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
@@ -1,0 +1,92 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Where a reading stopped, each place it was left at says what stopped it there.
+ *
+ * <p>A comparison the arithmetic could not take apart has no quantity to be about, so there is no
+ * one subject for the places it names to share. One of them may be a position the rule states
+ * something about the values of, and the next may be a position the walk met on its way through an
+ * expression it did not read — and what is true of the first is no fact about the second.
+ *
+ * <p>Worked out once from whichever side named a position and handed to all of them, the answer for
+ * one was printed at the other: a carrier no line is drawn on is a fact about the position that
+ * carries it, and a position beside it in the same comparison need not carry the same thing.
+ */
+class AStoppedReadingSaysWhatStoppedItAtEachPlaceTest {
+
+    /**
+     * One comparison, two places, two answers.
+     *
+     * <p>{@code s} is a whole side of the comparison, so the rule states something about the values
+     * standing there — and nothing draws a line on a case of a sum, which is what a reader of
+     * {@code s} is owed. {@code v} is where the walk met a position inside the call on the other
+     * side, read through to a {@code match} it does not take apart; the rule states nothing about
+     * which case stands there, and what it does say is the part that went unread.
+     *
+     * <p>Answered from a side of the comparison, both came back as a carrier nothing draws a line
+     * on — because the side that names a position is {@code s}, and {@code v} was handed the answer
+     * about {@code s}.
+     */
+    private static final String ONE_SIDE_IS_A_POSITION_AND_ONE_IS_NOT = """
+            module demo
+
+            data Prospecting
+            data Qualified
+            data Won
+            data Stage = Prospecting | Qualified | Won
+
+            data Near = { q: Qualified }
+            data Far = { q: Qualified }
+            data Side = Near | Far
+
+            let pick (v: Side) : Qualified = match v with
+                | Near as n -> n.q
+                | Far as f -> f.q
+
+            data N = { s: Qualified, v: Side }
+                invariant said = s < pick(v)
+            """;
+
+    @Test
+    void twoPlacesOfOneComparisonSayTwoThings() {
+        FieldDomains read = read(ONE_SIDE_IS_A_POSITION_AND_ONE_IS_NOT);
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonDomain()), reasonsAt(read, "s"),
+                "a whole side is this position, so what its values are carried on is the answer");
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "v"),
+                "and here the walk met a position inside a form it did not read, which says "
+                        + "nothing about what that position carries");
+    }
+
+    private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read, String path) {
+        return read.noLineAt(path).stream().map(FieldDomains.NoLine::why).toList();
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name,
+                (Hir.Data) symbols.declarations().declaration(name.key()), symbols,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
@@ -133,8 +133,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
                             && unaccounted.why()
                                     instanceof RuleAccounting.Why.TheEndReadingSays says) {
                         out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
-                                says.why().stream()
-                                        .map(each -> each.getClass().getSimpleName()).toList());
+                                List.of(says.why().getClass().getSimpleName()));
                     }
                 }));
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleInABodyIsFiledAtWhatItsQuantityIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleInABodyIsFiledAtWhatItsQuantityIsAboutTest.java
@@ -1,0 +1,78 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.RuleWithoutALine;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A comparison in a body is filed at the quantity it cuts, exactly as a clause of a declaration is.
+ *
+ * <p>The two readers describe one kind of evidence (ADR-0090), so a position a canonical form
+ * cancelled is one neither of them files at. Written down here because the agreement is what the
+ * shared classifier is for: held only on the side that happened to have it, the readers would drift
+ * apart again the next time one of them was changed.
+ */
+class ARuleInABodyIsFiledAtWhatItsQuantityIsAboutTest {
+
+    /** Where each rule this drew no line from was filed, spelled as a report names it. */
+    private static List<String> filedAt(String condition) {
+        return read(condition).stream()
+                .map(each -> each.at() + "/" + each.why().getClass().getSimpleName())
+                .toList();
+    }
+
+    /**
+     * A position that cancels out of the form is not one the rule is filed at.
+     *
+     * <p>What survives relates two positions, so what the rule leaves at each of them is that; and
+     * {@code t.y} is left alone, because the rule the arithmetic came to does not mention it.
+     */
+    @Test
+    void aCancelledPositionIsFiledAtByNothing() {
+        assertEquals(
+                List.of("t.x/ComparisonBetweenPositions", "t.z/ComparisonBetweenPositions"),
+                filedAt("t.x + t.y - t.y + t.z <= 10"));
+    }
+
+    private static List<RuleWithoutALine> read(String condition) {
+        String source = """
+                module example.guarded
+
+                data Triple = { x: Int, y: Int, z: Int }
+
+                data Low
+                data High
+
+                behavior pick : (t: Triple) -> Low | High
+
+                let pick (t) =
+                    if CONDITION
+                        then High
+                        else Low
+                """.replace("CONDITION", condition);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, () -> "the model under test compiles: " + condition);
+        Core body = checked.behaviorBodies().get("pick");
+        assertNotNull(body);
+        CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                checked.supplied());
+        return GuardThresholds.of("pick", body, plan,
+                compilation.db().ask(new souther.compiler.query.Adequacy.Inputs(module))
+                        .value().get("pick"), symbols).rulesWithoutALine();
+    }
+}


### PR DESCRIPTION
Closes #1148.

## What was wrong

A reason for a comparison that drew no line was decided once per comparison and filed at every
place the comparison named. What it was read off is a side — `UnreadComparison.speakingSide`, which
takes the left where both name a position — so at every other place it stated a fact about a
position that place is not.

The same shape stood in both readers: a loop in `InvariantChecker.noLineDrawn`, and
`ComparisonAssessment.Unread(why, filedAt)` with the loop in `GuardThresholds.publish`.

Three keys where there is one question: a question is `(rule, coordinate)`, a reason was
`(rule, conjunct)`, and evidence is filed at `(rule, conjunct, coordinate)`.

## What it is now

Two questions, and which is asked turns on whether the arithmetic reached a quantity.

**Read to the end — the quantity is the subject.** It says what the rule leaves, and
`UnreadComparison.filedAt` says which of the places the walk met are the rule's at all.
`x + y - y <= 10 * 2` is `x <= 20`, so `y` gets nothing. The guard reader already held this and
wrote down why (`ComparisonAssessment.filedAt`); the clause reader took its places from the walk
over the comparison, which is where the two disagreed.

`CutsNothing` keeps its places, deliberately: its support is empty and what is worth saying is that
the model names those positions and cuts none of them.

**Stopped — each place is asked for itself.** `UnreadComparison.whereItStopped` takes a `RuleAt`,
which is the reader's answer to the one question a classifier of expressions cannot see: whether the
rule constrains the values at this position or something taken from them. `ValueOrigin` reads a call
through to its body, so `describe(a) > 0` arrives as arithmetic holding the position with no
operation left to recognise — the distinction has to come from what the reader knew when it chose
the place.

Both readers answer it the same way: a whole side of the comparison is that position and nothing
else, and the coordinate there is the position's own value.

`RuleAt.NotAboutOwnValues` is named for what it denies because its members share nothing else — a
length taken of a string, a call read through, and a position met inside an expression the walk did
not take apart. What they have in common is that the carrier is not the rule's subject, which is the
one thing the type exists to gate.

`speakingSide`, `whyItStopped` and both copy loops are gone. What each place is left with is one
answer of the assessment (`whatEachPlaceIsLeftWith`), and the copy survives only inside
`sameAtEachPlace`, where the places are one quantity's coordinates.

## Not added

A reason for a position outside a non-empty support. It was on the table, and reading the guard side
settled it the other way: filing a read rule at its quantity is already the design there, so the
state that word would name stops being reachable rather than needing a name. A published vocabulary
is the wrong place to fix an impossible state.

## Measured

Before the change, every row `noLineDrawn` files over the whole suite: 12838, of which 11012 carry a
quantity read to the end.

```
support known, filing position outside it        0
support known and empty (CutsNothing)          108
support known, filing position inside it     10856
support unknown (NotRead)                     1826
```

The 1826 unread rows split by what a per-place classifier needs to decide them, and every one of
them keeps the word it had:

```
derived, whatever the carrier                    368
a whole side is this position, ordered            46
a whole side is this position, not ordered        12   (the only Domain rows)
not a whole side                                1400
```

No checked-in report moves. Full suite green: 7715 (7710 before, plus five new).

## Controls

- `ARuleIsFiledAtWhatItsQuantityIsAboutTest` — a cancelled position is filed at by nothing, and the
  surviving ones still are. Both halves, so the assertion cannot pass over a reader that files
  nothing. Plus `filedAt` over the three shapes of quantity.
- `AStoppedReadingSaysWhatStoppedItAtEachPlaceTest` — one comparison, two places, two words: `s`
  carries no order and is told so, `v` was met inside a call read through to a `match` and is told
  the form. Under the old rule both came back as the carrier's answer about `s`.
- `ARuleInABodyIsFiledAtWhatItsQuantityIsAboutTest` — the same source shape in a body, so the
  agreement between the two readers is written down rather than held on one side.

Both mutations go red: `RuleAt` always `AboutOwnValues` moves `v` to the carrier's answer, and
`filedAt` passing every place through fails all three of the first test's assertions.

## One arm without a control

Where a line could not be realized on a quantity that was read
(`Cutting.realized`), the places now come from the quantity as well. That arm is reachable —
`guard a > b` over two cases of a sum — but the model that reaches it names the same two places
either way, and no model distinguishes the two rules, because a form on a sum's order has nothing to
cancel. Kept because the alternative is `Read.Stopped` taking its places from a different authority
depending on which producer built it, which is the shape this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)