### PR TITLE
Hold a position's measures under the position, and make a measure of nothing impossible

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -76,7 +76,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
     private static final Map<String, Integer> INTRODUCED_BY = new LinkedHashMap<>(
             Map.ofEntries(
             Map.entry("souther.compiler.query.Coverages#pairsOf(Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/Coverages$Readings;ZLsouther/compiler/partition/AdequacyPolicy$OfTheMeasures;)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 2),
-            Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/partition/Partitions$Partitioning;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
+            Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/partition/PositionAccount;Lsouther/compiler/partition/Partitions$Partitioning;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
             Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/partition/StandingAtAPoint$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$RowReading;)Lsouther/compiler/query/Measurement;", 3),
             Map.entry("souther.compiler.query.Coverages#whyNoGuardLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 2),
             Map.entry("souther.compiler.query.Coverages#whyNoInvariantLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 1),

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -22,8 +22,8 @@ import java.util.List;
  *
  * <p>A bound is not one of them. An invariant's bound gives a boundary and no partition: everything
  * outside it is refused at construction, so there is no class on the far side to cover (ADR-0090),
- * and what such a position gets is {@link #cuts} and no classes — which is what {@link #measurable}
- * is for. What a bound does contribute to a partition is the range the classes are clipped to: the
+ * and what such a position gets is {@link #cuts} and no classes — which is what
+ * {@link #asksForARow} is for. What a bound does contribute to a partition is the range the classes are clipped to: the
  * two either side of a {@code guard} at 50 run from the bound and not from the type's own ends.
  *
  * <p>{@link #classes} is the one denominator. What a report counts, what a pair space is the
@@ -78,6 +78,15 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
                     "`" + id + "` measures " + term + " at nothing: no class, no line and no"
                             + " parting, which is a position nothing measures and not a measure");
         }
+        // The name says which number this is a measure of, so it is that number as a report writes
+        // it and never a second answer to what is measured here. An identity handed in beside the
+        // number is one a caller chooses, and what a reader keyed by it would then be holding is a
+        // measure of one number filed under the name of another — which every map downstream is
+        // keyed by ({@link EvidenceAccount}, the lines along a measure, what a row was placed at).
+        if (!id.term().equals(term.toString())) {
+            throw new IllegalArgumentException("`" + id + "` names " + id.term()
+                    + " and this measures " + term + "; a measure is named after its own number");
+        }
         for (PartitionClass one : classes) {
             subjectHeld(term, one);
             // A line is a place on the number's order and falls in whichever class holds that
@@ -124,6 +133,20 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING);
     }
 
+    /**
+     * One measure of {@code term}, named after it.
+     *
+     * <p>What a caller has is a number and the behavior whose input it is read from, and the name
+     * follows from the two. Handed the name as well, a caller has a second thing to get right and
+     * the constructor a second answer to refuse — so this is the way in, and passing a name is for
+     * a reader rebuilding a measure it already has.
+     */
+    public static Axis of(String behavior, NumericTerm.FromOnePosition term, Type type,
+                          List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted,
+                          NarrowedBounds narrowed) {
+        return new Axis(AxisId.of(behavior, term), term, type, classes, cuts, parted, narrowed);
+    }
+
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is
      * read off it. Not what the axis is: two terms can be taken of one location, and {@link #id()}
@@ -160,13 +183,14 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         return !classes.isEmpty();
     }
 
-    /** Whether there is a line to draw here — classes to cover, or a boundary to reach.
+    /** Whether there is anything here a row can be written against — a class to sit in, or an edge
+     * to stand at.
      *
      * <p>A numeric newtype bounded by an invariant has the second and not the first: everything
      * outside the bound is refused at construction, so there is no other class, only an edge worth
      * a row. False where the rules part the number and the position holds no value at the parting:
-     * that is a measure, and there is nothing at it for a row to be written against. */
-    public boolean measurable() {
+     * that is a measure of the number, and there is nothing at it to ask an author for. */
+    public boolean asksForARow() {
         return !classes.isEmpty() || !cuts.isEmpty();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -37,10 +37,14 @@ import java.util.List;
  *                a run of classes over the values of a number a row can be asked for somewhere. A
  *                number read from a run of a sequence has no such place, so it draws a line without
  *                dividing anything and never arrives here
- * @param at      the position the number is read from, and what this phase is left answering for
- *                there. Pointed at rather than copied out, because a position carries as many of
- *                these axes as the rules name numbers of it and what is in there is true of the
- *                position once ({@link PositionAccount})
+ * @param type    what stands at the position the number is read from, which is what a value read
+ *                here is of. Not the term's: a string is measured at how long it is, and what
+ *                stands at the location is still a string. The one thing about the location a
+ *                measure needs, and nothing else about it is here — where the walk stopped, what
+ *                the reading left standing and what the location is if nothing answers are true of
+ *                it once however many numbers measure it, and a measure that answered them would
+ *                let any reader ask a location's question through whichever number it happens to
+ *                hold ({@link PositionMeasurements})
  * @param classes exclusive and exhaustive over the term's values, or empty where the model does
  *                not divide them
  * @param cuts    the values the classes meet at, each carrying every rule that drew it there
@@ -51,7 +55,7 @@ import java.util.List;
  *                away from its line is a run of what these leave together, and the cuts alone are
  *                short of the lines that have no value
  */
-public record Axis(AxisId id, NumericTerm.FromOnePosition term, PositionAccount at,
+public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
                    List<PartitionClass> classes,
                    List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
 
@@ -59,8 +63,8 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, PositionAccount 
         classes = List.copyOf(classes);
         cuts = List.copyOf(cuts);
         parted = List.copyOf(parted);
-        if (at == null) {
-            throw new IllegalArgumentException("an axis of no position");
+        if (type == null) {
+            throw new IllegalArgumentException("an axis of a value of nothing");
         }
         for (PartitionClass one : classes) {
             subjectHeld(term, one);
@@ -105,25 +109,8 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, PositionAccount 
 
     public Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
                 List<PartitionClass> classes, List<Cut> cuts) {
-        this(id, term, PositionAccount.at(id.behavior(), term.position(), type), classes, cuts,
-                List.of(), NarrowedBounds.NOTHING);
+        this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING);
     }
-
-    /**
-     * The position's type, which is what a value read here is of. Not the term's: a string is
-     * measured at how long it is, and what stands at the location is still a string.
-     *
-     * <p>One of two things read off {@link #at} here, with {@link #path}. Both are about the
-     * measure — where it reads from and what stands there — and everything else the position's
-     * account holds is asked of the account, in the open. What its reading came to, where the walk
-     * stopped and what it is left with are true of the location once however many numbers measure
-     * it, and a measure that answered them would let any reader ask a location's question through
-     * whichever measure it happened to hold.
-     */
-    public Type type() {
-        return at.type();
-    }
-
 
     /**
      * A position nothing has answered for yet, and what the readings of it found.
@@ -132,8 +119,8 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, PositionAccount 
      * and only where none does is what was found here what a report says — an absence where every
      * reading ran to the end and found nothing, and what stopped one where it did not.
      */
-    public static Axis pendingAt(AxisId id, NumericTerm.FromOnePosition term, PositionAccount at) {
-        return new Axis(id, term, at, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
+    public static Axis pendingAt(AxisId id, NumericTerm.FromOnePosition term, Type type) {
+        return new Axis(id, term, type, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
     }
 
     /**
@@ -148,17 +135,17 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, PositionAccount 
      * divided into, the lines cut on it, where the rules part it and where they leave its ends. At
      * another number they answer a question nobody asked, and carried over they would be answers
      * about one number on an axis of another. What is kept is the one thing here that is the
-     * position's, {@link #at}. What that leaves the axis short of is what the reading measuring it
-     * at the new number puts there.
+     * position's, {@link #type}. What that leaves the axis short of is what the reading measuring
+     * it at the new number puts there.
      */
     public Axis measuredAt(AxisId id, NumericTerm.FromOnePosition term) {
-        return term.equals(this.term) ? new Axis(id, term, at, classes, cuts, parted, narrowed)
-                : new Axis(id, term, at, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
+        return term.equals(this.term) ? new Axis(id, term, type, classes, cuts, parted, narrowed)
+                : new Axis(id, term, type, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
     public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted) {
-        return new Axis(id, term, at, classes, cuts, parted, narrowed);
+        return new Axis(id, term, type, classes, cuts, parted, narrowed);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -122,10 +122,6 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING);
     }
 
-    /** The same position, with what a body's rules divided it into and the lines they drew. */
-    public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted) {
-        return new Axis(id, term, type, classes, cuts, parted, narrowed);
-    }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is
      * read off it. Not what the axis is: two terms can be taken of one location, and {@link #id()}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -66,6 +66,16 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         if (type == null) {
             throw new IllegalArgumentException("an axis of a value of nothing");
         }
+        // A measure is what the rules divided a number into, cut on it, or parted it at, and one
+        // with none of the three measured nothing. Such a one used to stand for a position still to
+        // be answered for — which is a fact about the location and is held there
+        // ({@link PositionMeasurements}), so a reader counting what a behavior is measured at was
+        // counting locations among the measures.
+        if (classes.isEmpty() && cuts.isEmpty() && parted.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "`" + id + "` measures " + term + " at nothing: no class, no line and no"
+                            + " parting, which is a position nothing measures and not a measure");
+        }
         for (PartitionClass one : classes) {
             subjectHeld(term, one);
             // A line is a place on the number's order and falls in whichever class holds that
@@ -110,37 +120,6 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
     public Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
                 List<PartitionClass> classes, List<Cut> cuts) {
         this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING);
-    }
-
-    /**
-     * A position nothing has answered for yet, and what the readings of it found.
-     *
-     * <p>Not a position the model does not divide. A rule a body writes may still draw a line on it,
-     * and only where none does is what was found here what a report says — an absence where every
-     * reading ran to the end and found nothing, and what stopped one where it did not.
-     */
-    public static Axis pendingAt(AxisId id, NumericTerm.FromOnePosition term, Type type) {
-        return new Axis(id, term, type, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
-    }
-
-    /**
-     * The same position, measured at another number.
-     *
-     * <p>A transition rather than a constructor at the call site. What a body's rules add is a term,
-     * classes and cuts; what the position came to was settled by the reading that made this one,
-     * and a caller rebuilding an axis from its parts drops whatever it does not think to name. What
-     * the position came to is one field, so a rebuild names it or does not compile.
-     *
-     * <p>Everything answered about the number goes where the number goes: the classes it was
-     * divided into, the lines cut on it, where the rules part it and where they leave its ends. At
-     * another number they answer a question nobody asked, and carried over they would be answers
-     * about one number on an axis of another. What is kept is the one thing here that is the
-     * position's, {@link #type}. What that leaves the axis short of is what the reading measuring
-     * it at the new number puts there.
-     */
-    public Axis measuredAt(AxisId id, NumericTerm.FromOnePosition term) {
-        return term.equals(this.term) ? new Axis(id, term, type, classes, cuts, parted, narrowed)
-                : new Axis(id, term, type, List.of(), List.of(), List.of(), NarrowedBounds.NOTHING);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -9,14 +9,16 @@ import souther.compiler.types.Type;
 import java.util.List;
 
 /**
- * One input position that a model distinguishes values at, and the classes it distinguishes them into.
+ * One measure a model makes of a number of its input: the classes it divides that number into, and
+ * the lines it draws on it.
  *
  * <p>The model's own distinctions, not invented ones. A type with two cases has two classes; a
  * {@code guard}'s comparison divides what a position holds into the two sides it treats differently.
  * A position the model says nothing about — a plain {@code String}, an {@code Int} with no invariant
- * — has no classes, and that is reported as not derivable rather than filled in with values nobody
- * asked for. The choice matters: a made-up partition measures a rule the model does not have, and
- * reports coverage of it.
+ * — is measured at nothing and has no measure at all, which the position says
+ * ({@link PositionMeasurements}) and a report names as not derivable, rather than being filled in
+ * with values nobody asked for. The choice matters: a made-up partition measures a rule the model
+ * does not have, and reports coverage of it.
  *
  * <p>A bound is not one of them. An invariant's bound gives a boundary and no partition: everything
  * outside it is refused at construction, so there is no class on the far side to cover (ADR-0090),

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -162,9 +162,12 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         return !classes.isEmpty();
     }
 
-    /** Whether there is anything here to measure at all — classes to cover, or a boundary to reach.
-     * A numeric newtype bounded by an invariant has the second and not the first: everything outside
-     * the bound is refused at construction, so there is no other class, only an edge worth a row. */
+    /** Whether there is a line to draw here — classes to cover, or a boundary to reach.
+     *
+     * <p>A numeric newtype bounded by an invariant has the second and not the first: everything
+     * outside the bound is refused at construction, so there is no other class, only an edge worth
+     * a row. False where the rules part the number and the position holds no value at the parting:
+     * that is a measure, and there is nothing at it for a row to be written against. */
     public boolean measurable() {
         return !classes.isEmpty() || !cuts.isEmpty();
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -42,8 +42,13 @@ final class EvidenceAccount {
          * <p>A policy of this stage and not a fact about the model, which is why it is said rather
          * than left out: an author is not told anything, and an account that simply had no entry
          * would be an account that cannot tell this from a loss.
+         *
+         * <p>The position and not one of the measures on it. What refused the evidence is that the
+         * location is measured, which is true of the location however many numbers measure it —
+         * named by one of them, whichever was reached for would be the reason.
          */
-        record ThePositionIsAlreadyMeasured(AxisId by) implements Disposition {}
+        record ThePositionIsAlreadyMeasured(souther.compiler.inputs.TermPath at)
+                implements Disposition {}
     }
 
     /** One piece of evidence and what became of it, held together so that holding the stage to a

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -62,20 +62,16 @@ public final class Partitions {
      *                whatever was written about it — and an axis is re-pointed at another number as
      *                a body's rules are read, which would carry a question about one number onto
      *                another
-     * @param positions the locations of this behavior's input this phase answers for, in the order
-     *                the reading found them. Beside the measures and not derived from them: what a
-     *                reading of a location came to, where the walk stopped and what the location is
-     *                left with are true of it once however many numbers measure it, and the only
-     *                other way to reach one is to walk the measures and put them back together —
-     *                which is a rule about which measure answers for the location, invented once
-     *                per reader
-     * @param axes    the measures made of those locations, in the order the rules name the numbers.
-     *                A location is measured at as many numbers as the rules name of it, so this is
-     *                not a list of positions and its length is not one: {@code Time.hour(slot.at)}
-     *                and {@code Time.minute(slot.at)} are two of these at one location. What a
-     *                behavior is measured at is settled by what its types say and by what its body
-     *                compares, and a count of either is not a measure of what any of that costs
-     *                (see this package's documentation)
+     * @param measurements the locations of this behavior's input this phase answers for, in the
+     *                order the reading found them, each holding the numbers it is measured at. A
+     *                location is measured at as many numbers as the rules name of it — {@code
+     *                Time.hour(slot.at)} and {@code Time.minute(slot.at)} are two measures at one
+     *                location — and none is as much an answer as one. What a behavior is measured
+     *                at is settled by what its types say and by what its body compares, and a count
+     *                of either is not a measure of what any of that costs (see this package's
+     *                documentation). Both {@link #positions()} and {@link #axes()} are read off
+     *                this, so which measure answers for which location is what the model said and
+     *                not a rule a reader invented
      * @param between the lines drawn between two positions, which divide neither of them
      * @param along   the lines drawn on one position, by the axis they are on. Every measurable axis
      *                has an entry, and an axis that is not measurable has no lines to have one for
@@ -86,7 +82,7 @@ public final class Partitions {
      *                about. Null is "not proved empty" and never "there is a value" — what a proof
      *                of emptiness has no proof of is not the opposite claim
      */
-    public record Partitioning(List<PositionAccount> positions, List<Axis> axes,
+    public record Partitioning(List<PositionMeasurements> measurements,
                                List<souther.compiler.inputs.StandingQuestion> unanswered,
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
@@ -100,8 +96,7 @@ public final class Partitions {
                                MeasureClosure.OfTheBorder borderClosure,
                                souther.compiler.inputs.EmptyInput inputIsEmpty) {
         public Partitioning {
-            positions = List.copyOf(positions);
-            axes = List.copyOf(axes);
+            measurements = List.copyOf(measurements);
             unanswered = List.copyOf(unanswered);
             uncertain = java.util.Set.copyOf(uncertain);
             undivided = List.copyOf(undivided);
@@ -119,6 +114,29 @@ public final class Partitions {
                 throw new IllegalArgumentException(
                         "a partitioning with no account of what each measure's reading came to");
             }
+        }
+
+        /**
+         * The locations this phase answers for, in the order the reading found them.
+         *
+         * <p>Read off the measurements rather than kept beside them. What a reading of a location
+         * came to, where the walk stopped and what the location is left with are true of it once
+         * however many numbers measure it, and a second list of them would be the same locations
+         * answering to two lists that nothing holds in step.
+         */
+        public List<PositionAccount> positions() {
+            return measurements.stream().map(PositionMeasurements::position).toList();
+        }
+
+        /**
+         * The measures made of those locations, in the order the rules name the numbers.
+         *
+         * <p>For a reader whose question is about a number. Which location a measure is of is
+         * where the measure sits, so a reader that needs the location asks {@link #measurements()}
+         * and does not put the two back together from how a path is spelled.
+         */
+        public List<Axis> axes() {
+            return measurements.stream().flatMap(each -> each.axes().stream()).toList();
         }
 
         /**
@@ -174,7 +192,7 @@ public final class Partitions {
 
         /** Only the positions the model actually divides. */
         public List<Axis> derivable() {
-            return axes.stream().filter(Axis::derivable).toList();
+            return axes().stream().filter(Axis::derivable).toList();
         }
     }
 
@@ -203,7 +221,6 @@ public final class Partitions {
     public static Partitioning of(String behavior, InputDomain inputs,
                                   souther.compiler.inputs.Quantities quantities, Symbols symbols,
                                   ReadingPolicy policy) {
-        List<Axis> found = new ArrayList<>();
         java.util.Set<NumericTerm> uncertain = new java.util.LinkedHashSet<>();
         List<RuleWithoutALine> rulesWithoutALine = new ArrayList<>();
         // What the reading could not hold together, asked of every position it read rather than of
@@ -212,11 +229,11 @@ public final class Partitions {
         // has something to say, and a position with none is no more affected than any other.
         List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated = new ArrayList<>();
         List<souther.compiler.inputs.StandingQuestion> standing = new ArrayList<>();
-        // The positions this phase answers for, kept as they are made. A collection of its own
-        // because a position is what a reader of a stop or an absence is asking about, and the only
-        // other way to reach one is to walk the measures and put them back together — which is a
-        // rule about which measure answers for the location, invented once per reader.
-        List<PositionAccount> positions = new ArrayList<>();
+        // The positions this phase answers for, each with what measures it, as they are made. A
+        // position is what a reader of a stop or an absence is asking about, and a measure is what
+        // a reader of a class or a line is; holding the second under the first is what keeps which
+        // of them answers for the other from being worked out again by whoever asks.
+        List<PositionMeasurements> measurements = new ArrayList<>();
         for (Position position : inputs.positions()) {
             // Not at a position made of positions. Such a one is given up in favour of what is
             // under it and carries no classes of its own, so what this qualifies is not there —
@@ -228,7 +245,7 @@ public final class Partitions {
                 notSeparated.add(
                         new souther.compiler.inputs.PositionValuesNotSeparated(position.path()));
             }
-            axisOf(behavior, position, symbols, policy, found, positions, uncertain,
+            axisOf(behavior, position, symbols, policy, measurements, uncertain,
                     rulesWithoutALine);
             // What the rules of this position raise that nothing answered, gathered from the
             // reading that found it. Once per position and not once per axis: a question is the
@@ -248,7 +265,9 @@ public final class Partitions {
         // here — `withThresholds` has not run, so a position a `guard` divides has no cut yet — and
         // a selection made now would be made where the least is known about what it selects
         // (see this package's documentation).
-        List<Axis> kept = new ArrayList<>(found);
+        List<PositionAccount> positions =
+                measurements.stream().map(PositionMeasurements::position).toList();
+        List<Axis> kept = measurements.stream().flatMap(each -> each.axes().stream()).toList();
         // A position undivided because a rule about it drew no line says that here, without waiting
         // for a body: a type bounded by a rule this cannot read is one whether or not any behavior
         // compares it, and so is one bounded by a rule read to the end that divides nothing. What
@@ -268,7 +287,7 @@ public final class Partitions {
         read.returning(lines.values().stream().flatMap(List::stream).toList());
         MeasureClosure.Both closed =
                 MeasureClosure.of(positions, standing, rulesWithoutALine, read);
-        return new Partitioning(List.copyOf(positions), kept, standing, uncertain,
+        return new Partitioning(List.copyOf(measurements), standing, uncertain,
                 undividedIn(positions, measured),
                 List.copyOf(rulesWithoutALine), blockedIn(positions, measured),
                 List.copyOf(notSeparated),
@@ -653,23 +672,31 @@ public final class Partitions {
                 rules.add(each);
             }
         }
-        List<Axis> out = new ArrayList<>();
+        List<PositionMeasurements> measurements = new ArrayList<>();
         List<Measured> measured = new ArrayList<>();
         EvidenceAccount account = new EvidenceAccount(evidence);
-        for (Axis axis : base.axes()) {
-            List<NumericTerm.FromOnePosition> numbers =
-                    numbersMeasuring(axis, evidence, account);
-            if (numbers.isEmpty()) {
-                keep(out, measured, axis, null, rules);
-                continue;
+        // A position at a time, so that what a body's rules add is added where the position already
+        // is. Walked as one run of measures, which position each of them came back for is a
+        // question this would have to answer again once the rules name a second number of one.
+        for (PositionMeasurements at : base.measurements()) {
+            List<Axis> here = new ArrayList<>();
+            for (Axis axis : at.axes()) {
+                List<NumericTerm.FromOnePosition> numbers =
+                        numbersMeasuring(axis, evidence, account);
+                if (numbers.isEmpty()) {
+                    keep(here, measured, axis, null, rules);
+                    continue;
+                }
+                for (NumericTerm.FromOnePosition term : numbers) {
+                    AxisId id = term.equals(axis.term()) ? axis.id()
+                            : AxisId.of(axis.id().behavior(), term);
+                    measureAt(here, measured, axis.measuredAt(id, term), term, evidence, reading,
+                            symbols, policy, rules, account);
+                }
             }
-            for (NumericTerm.FromOnePosition term : numbers) {
-                AxisId id = term.equals(axis.term()) ? axis.id()
-                        : AxisId.of(axis.id().behavior(), term);
-                measureAt(out, measured, axis.measuredAt(id, term), term, evidence, reading,
-                        symbols, policy, rules, account);
-            }
+            measurements.add(at.measuredAt(here));
         }
+        List<Axis> out = measurements.stream().flatMap(each -> each.axes().stream()).toList();
         account.everyPieceWasDisposedOf(out);
         // Both producers into the one account. A line that divides a position leaves its border on
         // the position and a line between two leaves its border beside them; they are the same
@@ -681,7 +708,7 @@ public final class Partitions {
         read.returning(across);
         MeasureClosure.Both closed =
                 MeasureClosure.of(base.positions(), base.unanswered(), rules, read);
-        return new Partitioning(base.positions(), out, base.unanswered(), base.uncertain(),
+        return new Partitioning(measurements, base.unanswered(), base.uncertain(),
                 undividedIn(base.positions(), measured), List.copyOf(rules),
                 blockedIn(base.positions(), measured),
                 // Carried across: what a reading could not hold together is a fact about the
@@ -984,7 +1011,7 @@ public final class Partitions {
      */
     private static void axisOf(String behavior, Position position, Symbols symbols,
                                ReadingPolicy policy,
-                               List<Axis> out, List<PositionAccount> positions,
+                               List<PositionMeasurements> measurements,
                                java.util.Set<NumericTerm> uncertain,
                                List<RuleWithoutALine> rulesWithoutALine) {
         for (RuleWithoutALine each : position.rulesWithoutALine()) {
@@ -1011,9 +1038,9 @@ public final class Partitions {
                 // and taking that off the axis with the fallback is how the stop went unreported
                 // (issue #1084).
                 PositionAccount at = PositionAccount.of(behavior, position, null, null);
-                positions.add(at);
-                out.add(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(), List.of(),
-                        position.narrowedEnds()));
+                measurements.add(new PositionMeasurements(at,
+                        List.of(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(),
+                                List.of(), position.narrowedEnds()))));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -1032,8 +1059,8 @@ public final class Partitions {
                     case StructuralInspection.Retained retained -> {
                         PositionAccount at = PositionAccount.of(behavior, position,
                                 retained.continuation(), leftAt(position));
-                        positions.add(at);
-                        out.add(Axis.pendingAt(id, term, at));
+                        measurements.add(new PositionMeasurements(at,
+                                List.of(Axis.pendingAt(id, term, at))));
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -233,8 +233,15 @@ public final class Partitions {
             };
         }
 
-        /** Only the positions the model actually divides. */
-        public List<Axis> derivable() {
+        /**
+         * The measures that divide their number into classes, which is what a partition is over.
+         *
+         * <p>Named here so that a reader wanting them asks for them. A measure may be a boundary
+         * and no partition — a bound refuses everything outside it, so there is no class on the far
+         * side and what such a number gets is an edge worth a row — and every reader that answered
+         * this with a filter of its own was one that could be written without it.
+         */
+        public List<Axis> partitionAxes() {
             return axes().stream().filter(Axis::derivable).toList();
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -74,8 +74,9 @@ public final class Partitions {
      *                this, so which measure answers for which location is what the model said and
      *                not a rule a reader invented
      * @param between the lines drawn between two positions, which divide neither of them
-     * @param along   the lines drawn on one position, by the axis they are on. Every measurable axis
-     *                has an entry, and an axis that is not measurable has no lines to have one for
+     * @param along   the lines drawn on one position, by the measure they are on. Every measure a
+     *                row can be written against has an entry, and one that parts a number where
+     *                the position holds no value has no line to have one for
      * @param inputIsEmpty the proof that the rules reaching this input leave no value at all, or
      *                null where no such proof was found. One fact about the behavior and not one per
      *                rule or per position: two clauses each admitting values are empty together, so
@@ -283,7 +284,7 @@ public final class Partitions {
         // position is what a reader of a stop or an absence is asking about, and a measure is what
         // a reader of a class or a line is; holding the second under the first is what keeps which
         // of them answers for the other from being worked out again by whoever asks.
-        List<PositionMeasurements> measurements = new ArrayList<>();
+        List<Drawn> drawn = new ArrayList<>();
         for (Position position : inputs.positions()) {
             // Not at a position made of positions. Such a one is given up in favour of what is
             // under it and carries no classes of its own, so what this qualifies is not there —
@@ -295,8 +296,7 @@ public final class Partitions {
                 notSeparated.add(
                         new souther.compiler.inputs.PositionValuesNotSeparated(position.path()));
             }
-            axisOf(behavior, position, symbols, policy, measurements, uncertain,
-                    rulesWithoutALine);
+            axisOf(behavior, position, symbols, policy, drawn, uncertain, rulesWithoutALine);
             // What the rules of this position raise that nothing answered, gathered from the
             // reading that found it. Once per position and not once per axis: a question is the
             // model's, and which axis is standing beside it is this compiler's business.
@@ -315,25 +315,24 @@ public final class Partitions {
         // here — `withThresholds` has not run, so a position a `guard` divides has no cut yet — and
         // a selection made now would be made where the least is known about what it selects
         // (see this package's documentation).
-        List<PositionAccount> positions =
-                measurements.stream().map(PositionMeasurements::position).toList();
-        List<Axis> kept = measurements.stream().flatMap(each -> each.axes().stream()).toList();
+        List<PositionAccount> positions = drawn.stream().map(Drawn::at).toList();
+        List<Axis> kept = drawn.stream().flatMap(each -> each.axes().stream()).toList();
         // A position undivided because a rule about it drew no line says that here, without waiting
         // for a body: a type bounded by a rule this cannot read is one whether or not any behavior
         // compares it, and so is one bounded by a rule read to the end that divides nothing. What
         // the rules came to is whether either happened, and which of the two it was — settled
         // beside each axis, as it is once a body has spoken.
         List<PositionMeasurements> settled = new ArrayList<>();
-        for (PositionMeasurements at : measurements) {
+        for (Drawn at : drawn) {
             BodyCutInspection came = null;
             for (Axis axis : at.axes()) {
                 came = BodyCutInspection.outranking(came,
                         cameTo(axis.term(), axis.path(), rulesWithoutALine));
             }
-            if (at.axes().isEmpty()) {
-                came = cameTo(null, at.position().path(), rulesWithoutALine);
+            if (came == null) {
+                came = cameTo(null, at.at().path(), rulesWithoutALine);
             }
-            settled.add(at.measuredAt(at.axes(), came));
+            settled.add(new PositionMeasurements(at.at(), at.axes(), came));
         }
         // The lines first, because the closure is a conclusion about them: whether the reading ran
         // out is asked of what it produced beside what it found, and not of the gaps alone. Both
@@ -355,6 +354,18 @@ public final class Partitions {
                 // asking per position or per rule would be asking what neither of them decides.
                 quantities.emptiness().orElse(null));
     }
+
+    /**
+     * One position and what the declarations measured it at, before what its rules came to is
+     * folded over those measures.
+     *
+     * <p>Not a {@link PositionMeasurements}, which is what this phase answers with and which says
+     * what the rules came to. The fold wants every rule of every position in hand, and that is one
+     * walk later than the walk that reads the positions — so this is what the first walk leaves,
+     * and the answer is made once, whole. Written as the answer with the fold left out, the type a
+     * reader is handed would carry a state only this file ever passes through.
+     */
+    private record Drawn(PositionAccount at, List<Axis> axes) {}
 
     /**
      * What the rules this phase drew no line from leave at one number of a position, or at the
@@ -452,8 +463,11 @@ public final class Partitions {
                                   souther.compiler.inputs.Quantities reading, Symbols symbols,
                                   ReadingPolicy policy,
                                   List<RuleWithoutALine> rules, EvidenceAccount account) {
-        AxisId id = axis != null ? axis.id()
-                : AxisId.of(at.position().behavior(), term);
+        String behavior = at.position().behavior();
+        // What a report calls this measure, which is what its number is called under this
+        // behavior. Read the same way the measure itself takes its name, so that a piece of
+        // evidence said to be measured here and the measure it was measured at are one name.
+        AxisId id = AxisId.of(behavior, term);
         Type type = at.position().type();
         List<LineEvidence> mine = evidence.stream()
                 .filter(each -> each.at().equals(term)).toList();
@@ -469,7 +483,7 @@ public final class Partitions {
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
             mine.forEach(each -> account.measured(each, id));
-            return made(out, at, id, term, type,
+            return made(out, at, behavior, term, type,
                     classesOf(axis, () -> singledClasses(points, term, type, domain, symbols)),
                     mergedPoints(cutsOf(axis), points, carrier),
                     partedOf(axis), narrowedOf(axis),
@@ -512,7 +526,7 @@ public final class Partitions {
         // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
         // written about the position rather than everything that came to nothing.
         NumericDomain.Bounds within = domain;
-        return made(out, at, id, term, type,
+        return made(out, at, behavior, term, type,
                 classesOf(axis, () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
@@ -535,7 +549,7 @@ public final class Partitions {
      * location rather than about a measure of it. Kept anyway, the location would be counted among
      * the measures — which is what a measure of nothing was.
      */
-    private static BodyCutInspection made(List<Axis> out, PositionMeasurements at, AxisId id,
+    private static BodyCutInspection made(List<Axis> out, PositionMeasurements at, String behavior,
                                           NumericTerm.FromOnePosition term, Type type,
                                           List<PartitionClass> classes, List<Cut> cuts,
                                           List<Parting> parted, NarrowedBounds narrowed,
@@ -543,7 +557,7 @@ public final class Partitions {
         if (classes.isEmpty() && cuts.isEmpty() && parted.isEmpty()) {
             return cameTo(term, at.position().path(), rules);
         }
-        out.add(new Axis(id, term, type, classes, cuts, parted, narrowed));
+        out.add(Axis.of(behavior, term, type, classes, cuts, parted, narrowed));
         return drew != null ? drew : cameTo(term, at.position().path(), rules);
     }
 
@@ -796,7 +810,7 @@ public final class Partitions {
             LinesRead read) {
         Map<AxisId, List<Border>> out = new LinkedHashMap<>();
         for (Axis axis : axes) {
-            if (axis.measurable()) {
+            if (axis.asksForARow()) {
                 out.put(axis.id(),
                         bordersOf(axis, symbols, reading.runsBetween(axis.term()), read));
             }
@@ -1030,7 +1044,7 @@ public final class Partitions {
      */
     private static void axisOf(String behavior, Position position, Symbols symbols,
                                ReadingPolicy policy,
-                               List<PositionMeasurements> measurements,
+                               List<Drawn> drawn,
                                java.util.Set<NumericTerm> uncertain,
                                List<RuleWithoutALine> rulesWithoutALine) {
         for (RuleWithoutALine each : position.rulesWithoutALine()) {
@@ -1048,7 +1062,7 @@ public final class Partitions {
                                     + " reading of an input and the axes drawn from it disagree"
                                     + " about which positions there are");
                 }
-                if (divided.cuts() instanceof CutEvidence.Present drawn && drawn.uncertain()) {
+                if (divided.cuts() instanceof CutEvidence.Present cut && cut.uncertain()) {
                     uncertain.add(term);
                 }
                 // No continuation, because something answered for the position and a fallback is
@@ -1057,9 +1071,9 @@ public final class Partitions {
                 // and taking that off the axis with the fallback is how the stop went unreported
                 // (issue #1084).
                 PositionAccount at = PositionAccount.of(behavior, position, null, null);
-                measurements.add(new PositionMeasurements(at,
-                        List.of(new Axis(id, term, at.type(), divided.classes(),
-                                divided.cuts().cuts(), List.of(), position.narrowedEnds())), null));
+                drawn.add(new Drawn(at,
+                        List.of(Axis.of(behavior, term, at.type(), divided.classes(),
+                                divided.cuts().cuts(), List.of(), position.narrowedEnds()))));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -1080,10 +1094,10 @@ public final class Partitions {
                         // declarations name, and a measure with nothing in it would be a location
                         // counted among the measures — what is still to be answered for here is
                         // the position's to carry.
-                        measurements.add(new PositionMeasurements(
+                        drawn.add(new Drawn(
                                 PositionAccount.of(behavior, position, retained.continuation(),
                                         leftAt(position)),
-                                List.of(), null));
+                                List.of()));
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -154,7 +154,7 @@ public final class Partitions {
         public List<UndividedPosition> undivided() {
             List<UndividedPosition> out = new ArrayList<>();
             for (PositionMeasurements at : measurements) {
-                PendingPosition pending = PendingPosition.of(at.position(), at.measured());
+                PendingPosition pending = PendingPosition.of(at.position(), at.hasMeasures());
                 if (pending != null) {
                     out.add(pending.complete(at.inspection()));
                 }
@@ -173,7 +173,7 @@ public final class Partitions {
         public List<souther.compiler.inputs.PositionReadingBlocked> blocked() {
             List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
             for (PositionMeasurements at : measurements) {
-                PendingPosition pending = PendingPosition.of(at.position(), at.measured());
+                PendingPosition pending = PendingPosition.of(at.position(), at.hasMeasures());
                 souther.compiler.inputs.PositionReadingBlocked stopped =
                         pending == null ? null : pending.reportable();
                 if (stopped != null && !out.contains(stopped)) {
@@ -440,7 +440,7 @@ public final class Partitions {
         // A position the declarations already divide keeps the measures they gave it. What a body
         // says about another number of such a position is not taken up as a second measure, and
         // this is where that is said: an account with no entry could not tell a policy from a loss.
-        if (at.measured()) {
+        if (at.hasMeasures()) {
             List<NumericTerm.FromOnePosition> declared =
                     at.axes().stream().map(Axis::term).toList();
             here.stream().filter(each -> !declared.contains(each.at()))

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -85,9 +85,7 @@ public final class Partitions {
     public record Partitioning(List<PositionMeasurements> measurements,
                                List<souther.compiler.inputs.StandingQuestion> unanswered,
                                java.util.Set<NumericTerm> uncertain,
-                               List<UndividedPosition> undivided,
                                List<RuleWithoutALine> rulesWithoutALine,
-                               List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                List<Border> between,
                                java.util.Map<AxisId, List<Border>> along,
@@ -99,9 +97,7 @@ public final class Partitions {
             measurements = List.copyOf(measurements);
             unanswered = List.copyOf(unanswered);
             uncertain = java.util.Set.copyOf(uncertain);
-            undivided = List.copyOf(undivided);
             rulesWithoutALine = List.copyOf(rulesWithoutALine);
-            blocked = List.copyOf(blocked);
             notSeparated = List.copyOf(notSeparated);
             between = List.copyOf(between);
             java.util.Map<AxisId, List<Border>> lines = new LinkedHashMap<>();
@@ -137,6 +133,52 @@ public final class Partitions {
          */
         public List<Axis> axes() {
             return measurements.stream().flatMap(each -> each.axes().stream()).toList();
+        }
+
+        /**
+         * The positions no measure of them came back with anything to divide them by, each saying
+         * which kind of nothing that is.
+         *
+         * <p>Read off the measurements, where both halves of the answer already are: whether
+         * anything measures the location is what it holds, and what the rules written about it came
+         * to is folded there over every number it is measured at. Kept beside them, the two would
+         * be one reading of the positions and one list built from it, in step for as long as
+         * whoever wrote the second remembered the first.
+         *
+         * <p>The structural reason outranks the rules': where the walk could not reach into what
+         * the position holds, a rule naming something inside it is a second description of that
+         * same stop and the first is the cause.
+         */
+        public List<UndividedPosition> undivided() {
+            List<UndividedPosition> out = new ArrayList<>();
+            for (PositionMeasurements at : measurements) {
+                PendingPosition pending = PendingPosition.of(at.position(), at.measured());
+                if (pending != null) {
+                    out.add(pending.complete(at.inspection()));
+                }
+            }
+            return List.copyOf(out);
+        }
+
+        /**
+         * The positions this reading did not get to the rules of.
+         *
+         * <p>Off the same two answers the verdict above is, and neither is read from the other.
+         * Both phases have spoken by the time a measurement exists — what the position's own
+         * declarations answered and what a body's rules drew — and a candidate that neither of them
+         * answered is what an author is waiting on.
+         */
+        public List<souther.compiler.inputs.PositionReadingBlocked> blocked() {
+            List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
+            for (PositionMeasurements at : measurements) {
+                PendingPosition pending = PendingPosition.of(at.position(), at.measured());
+                souther.compiler.inputs.PositionReadingBlocked stopped =
+                        pending == null ? null : pending.reportable();
+                if (stopped != null && !out.contains(stopped)) {
+                    out.add(stopped);
+                }
+            }
+            return List.copyOf(out);
         }
 
         /**
@@ -273,9 +315,14 @@ public final class Partitions {
         // compares it, and so is one bounded by a rule read to the end that divides nothing. What
         // the rules came to is whether either happened, and which of the two it was — settled
         // beside each axis, as it is once a body has spoken.
-        List<Measured> measured = new ArrayList<>();
-        for (Axis axis : kept) {
-            keep(new ArrayList<>(), measured, axis, null, rulesWithoutALine);
+        List<PositionMeasurements> settled = new ArrayList<>();
+        for (PositionMeasurements at : measurements) {
+            BodyCutInspection came = null;
+            for (Axis axis : at.axes()) {
+                came = BodyCutInspection.outranking(came,
+                        keep(new ArrayList<>(), axis, null, rulesWithoutALine));
+            }
+            settled.add(at.measuredAt(at.axes(), came));
         }
         // The lines first, because the closure is a conclusion about them: whether the reading ran
         // out is asked of what it produced beside what it found, and not of the gaps alone. Both
@@ -287,9 +334,8 @@ public final class Partitions {
         read.returning(lines.values().stream().flatMap(List::stream).toList());
         MeasureClosure.Both closed =
                 MeasureClosure.of(positions, standing, rulesWithoutALine, read);
-        return new Partitioning(List.copyOf(measurements), standing, uncertain,
-                undividedIn(positions, measured),
-                List.copyOf(rulesWithoutALine), blockedIn(positions, measured),
+        return new Partitioning(List.copyOf(settled), standing, uncertain,
+                List.copyOf(rulesWithoutALine),
                 List.copyOf(notSeparated),
                 List.of(), lines, ReachingCuts.NONE,
                 closed.partition(), closed.border(),
@@ -299,25 +345,15 @@ public final class Partitions {
                 quantities.emptiness().orElse(null));
     }
 
-    /**
-     * One position, and what the rules written about it came to.
-     *
-     * <p>Paired where both are in hand rather than rejoined afterwards by how a path is spelled.
-     * What holds the two to one position is {@link #keep} making them together — the type says they
-     * travel together, not that they are of the same position — and that is the whole of the
-     * difference from a list of reasons matched to a list of positions later.
-     */
-    private record Measured(Axis axis, BodyCutInspection body) {}
-
     /** The axis, and the body's answer about it — a line it drew, nothing, or a rule about it that
-     *  it drew no line from, with which of the two ways that happened. Kept beside the axis rather
-     *  than looked up afterwards by how its path is spelled. */
-    private static void keep(List<Axis> out, List<Measured> measured, Axis axis,
-                             BodyCutInspection drew, List<RuleWithoutALine> rules) {
+     *  it drew no line from, with which of the two ways that happened. Answered where the axis is
+     *  made, so that what the rules came to travels to the position holding the axis rather than
+     *  being looked up afterwards by how a path is spelled. */
+    private static BodyCutInspection keep(List<Axis> out, Axis axis,
+                                          BodyCutInspection drew, List<RuleWithoutALine> rules) {
         out.add(axis);
         if (drew != null) {
-            measured.add(new Measured(axis, drew));
-            return;
+            return drew;
         }
         // Whether this phase left anything at the position with no line, and not which limit it was.
         // A limit belongs to the rule it stopped, and the findings carry it there; taken as the
@@ -341,8 +377,8 @@ public final class Partitions {
         // something. The verdict below tells a reading that stopped from a rule read to the end,
         // and answered here with one word it read every rule this phase understood as one it could
         // not read.
-        measured.add(new Measured(axis, left == null ? new BodyCutInspection.Exhausted()
-                : new BodyCutInspection.NoLine(left)));
+        return left == null ? new BodyCutInspection.Exhausted()
+                : new BodyCutInspection.NoLine(left);
     }
 
     /**
@@ -393,7 +429,7 @@ public final class Partitions {
      * a position by are two ways to arrive at a number and one thing to do with it, and a second
      * route through this would be a second answer to what a rule about a number comes to.
      */
-    private static void measureAt(List<Axis> out, List<Measured> measured, Axis axis,
+    private static BodyCutInspection measureAt(List<Axis> out, Axis axis,
                                   NumericTerm.FromOnePosition term, List<LineEvidence> evidence,
                                   souther.compiler.inputs.Quantities reading, Symbols symbols,
                                   ReadingPolicy policy,
@@ -412,12 +448,11 @@ public final class Partitions {
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
             mine.forEach(each -> account.measured(each, axis.id()));
-            keep(out, measured, refine(axis,
+            return keep(out, refine(axis,
                     () -> singledClasses(points, term, axis.type(), domain, symbols),
                     mergedPoints(axis.cuts(), points, carrier),
                     axis.parted()),
                     new BodyCutInspection.Evidence(), rules);
-            return;
         }
         // Filtered once, and both answers read the filtered list. A line outside what the
         // position holds divides nothing, and it is not a boundary either: leaving it in the
@@ -456,7 +491,7 @@ public final class Partitions {
         // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
         // written about the position rather than everything that came to nothing.
         NumericDomain.Bounds within = domain;
-        keep(out, measured, refine(axis,
+        return keep(out, refine(axis,
                 () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
@@ -468,85 +503,6 @@ public final class Partitions {
                         .map(each -> Parting.by(each.parts(), each.origin().authoredLine()))
                         .toList()),
                 reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
-    }
-
-    /**
-     * What each position is left with, folded from the two readings that were made of it.
-     *
-     * <p>Nothing is searched for here. Both answers were settled where the position was read — the
-     * structural one on the axis, the rules' one beside it — and this only says which of them a
-     * report is owed, so a reason recovered here by matching a path would be a reading happening
-     * twice.
-     *
-     * <p>The structural reason outranks the rules': where the walk could not reach into what the
-     * position holds, a rule naming something inside it is a second description of that same stop
-     * and the first is the cause (issue #626).
-     *
-     * <p><b>Once per position and not once per measure.</b> That a position is divided no way is a
-     * sentence about the location, and a location is measured at as many numbers as the rules name
-     * of it. Written per measure, a report would say it as many times as the position has numbers —
-     * and say it at all where one of the numbers is divided and another is not, which is a position
-     * the model does divide. What this phase came to about the location is
-     * {@link BodyCutInspection#outranking}'s to fold.
-     */
-    private static List<UndividedPosition> undividedIn(List<PositionAccount> positions,
-                                                       List<Measured> measured) {
-        List<UndividedPosition> out = new ArrayList<>();
-        for (PositionAccount at : positions) {
-            PendingPosition pending = PendingPosition.of(at, anythingMeasures(at, measured));
-            if (pending != null) {
-                out.add(pending.complete(cameTo(at, measured)));
-            }
-        }
-        return List.copyOf(out);
-    }
-
-    /** Whether any measure of this position has something to divide it by. */
-    private static boolean anythingMeasures(PositionAccount at, List<Measured> measured) {
-        return measured.stream()
-                .anyMatch(each -> each.axis().path().equals(at.path())
-                        && each.axis().measurable());
-    }
-
-    /**
-     * What this phase came to about one position, over every number it measures the position at.
-     *
-     * <p>A location is measured at as many numbers as the rules name of it, and what a report says
-     * about the location is one sentence. Which of the answers it is is
-     * {@link BodyCutInspection#outranking}'s, and null where nothing was measured here at all.
-     */
-    private static BodyCutInspection cameTo(PositionAccount at, List<Measured> measured) {
-        BodyCutInspection came = null;
-        for (Measured each : measured) {
-            if (each.axis().path().equals(at.path())) {
-                came = BodyCutInspection.outranking(came, each.body());
-            }
-        }
-        return came;
-    }
-
-    /**
-     * The positions this reading did not get to the rules of, resolved.
-     *
-     * <p>Off the same pairing the verdict is, and neither is read from the other. Both phases have
-     * spoken by the time a {@link Measured} exists — what the position's own declarations answered
-     * and what a body's rules drew — and a candidate that neither of them answered is what an
-     * author is waiting on. Written where the producer records it, every position holding an
-     * `+Option+` said so whether or not the reading of it came to anything, and `not read` would be
-     * a list of what this compiler cannot generally do rather than of what it did not read here.
-     */
-    private static List<souther.compiler.inputs.PositionReadingBlocked> blockedIn(
-            List<PositionAccount> positions, List<Measured> measured) {
-        List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
-        for (PositionAccount at : positions) {
-            PendingPosition pending = PendingPosition.of(at, anythingMeasures(at, measured));
-            souther.compiler.inputs.PositionReadingBlocked stopped =
-                    pending == null ? null : pending.reportable();
-            if (stopped != null && !out.contains(stopped)) {
-                out.add(stopped);
-            }
-        }
-        return List.copyOf(out);
     }
 
     /**
@@ -673,28 +629,33 @@ public final class Partitions {
             }
         }
         List<PositionMeasurements> measurements = new ArrayList<>();
-        List<Measured> measured = new ArrayList<>();
         EvidenceAccount account = new EvidenceAccount(evidence);
         // A position at a time, so that what a body's rules add is added where the position already
         // is. Walked as one run of measures, which position each of them came back for is a
         // question this would have to answer again once the rules name a second number of one.
         for (PositionMeasurements at : base.measurements()) {
             List<Axis> here = new ArrayList<>();
+            // What the rules came to about the location, folded as its numbers are measured. One
+            // sentence for the location: a number the rules divide and a number they say nothing
+            // about are both measures of it, and which of the two answers a report is owed is
+            // `outranking`'s to settle rather than the order this happens to walk them in.
+            BodyCutInspection came = null;
             for (Axis axis : at.axes()) {
                 List<NumericTerm.FromOnePosition> numbers =
                         numbersMeasuring(axis, evidence, account);
                 if (numbers.isEmpty()) {
-                    keep(here, measured, axis, null, rules);
+                    came = BodyCutInspection.outranking(came, keep(here, axis, null, rules));
                     continue;
                 }
                 for (NumericTerm.FromOnePosition term : numbers) {
                     AxisId id = term.equals(axis.term()) ? axis.id()
                             : AxisId.of(axis.id().behavior(), term);
-                    measureAt(here, measured, axis.measuredAt(id, term), term, evidence, reading,
-                            symbols, policy, rules, account);
+                    came = BodyCutInspection.outranking(came,
+                            measureAt(here, axis.measuredAt(id, term), term, evidence, reading,
+                                    symbols, policy, rules, account));
                 }
             }
-            measurements.add(at.measuredAt(here));
+            measurements.add(at.measuredAt(here, came));
         }
         List<Axis> out = measurements.stream().flatMap(each -> each.axes().stream()).toList();
         account.everyPieceWasDisposedOf(out);
@@ -709,8 +670,7 @@ public final class Partitions {
         MeasureClosure.Both closed =
                 MeasureClosure.of(base.positions(), base.unanswered(), rules, read);
         return new Partitioning(measurements, base.unanswered(), base.uncertain(),
-                undividedIn(base.positions(), measured), List.copyOf(rules),
-                blockedIn(base.positions(), measured),
+                List.copyOf(rules),
                 // Carried across: what a reading could not hold together is a fact about the
                 // declarations, and a body drawing a line on a position does not make the product
                 // it was read from the relation the rules admit.
@@ -1040,7 +1000,7 @@ public final class Partitions {
                 PositionAccount at = PositionAccount.of(behavior, position, null, null);
                 measurements.add(new PositionMeasurements(at,
                         List.of(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(),
-                                List.of(), position.narrowedEnds()))));
+                                List.of(), position.narrowedEnds())), null));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -1060,7 +1020,7 @@ public final class Partitions {
                         PositionAccount at = PositionAccount.of(behavior, position,
                                 retained.continuation(), leftAt(position));
                         measurements.add(new PositionMeasurements(at,
-                                List.of(Axis.pendingAt(id, term, at))));
+                                List.of(Axis.pendingAt(id, term, at)), null));
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -8,6 +8,7 @@ import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.FieldDomains;
+import souther.compiler.check.NarrowedBounds;
 import souther.compiler.codegen.InvariantConstraints;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.Position;
@@ -320,7 +321,10 @@ public final class Partitions {
             BodyCutInspection came = null;
             for (Axis axis : at.axes()) {
                 came = BodyCutInspection.outranking(came,
-                        keep(new ArrayList<>(), axis, null, rulesWithoutALine));
+                        cameTo(axis.term(), axis.path(), rulesWithoutALine));
+            }
+            if (at.axes().isEmpty()) {
+                came = cameTo(null, at.position().path(), rulesWithoutALine);
             }
             settled.add(at.measuredAt(at.axes(), came));
         }
@@ -345,33 +349,32 @@ public final class Partitions {
                 quantities.emptiness().orElse(null));
     }
 
-    /** The axis, and the body's answer about it — a line it drew, nothing, or a rule about it that
-     *  it drew no line from, with which of the two ways that happened. Answered where the axis is
-     *  made, so that what the rules came to travels to the position holding the axis rather than
-     *  being looked up afterwards by how a path is spelled. */
-    private static BodyCutInspection keep(List<Axis> out, Axis axis,
-                                          BodyCutInspection drew, List<RuleWithoutALine> rules) {
-        out.add(axis);
-        if (drew != null) {
-            return drew;
-        }
-        // Whether this phase left anything at the position with no line, and not which limit it was.
-        // A limit belongs to the rule it stopped, and the findings carry it there; taken as the
-        // position's, the first rule of however many were stopped alike was the one a report named.
-        //
-        // The number and not the path. A `String` is measured more than one way, and an axis is one
-        // of them: a rule about a length that nothing could read leaves the length blocked and says
-        // nothing about the string's own values. Matched by path alone, either axis answered for
-        // both.
-        //
-        // A finding the reading did not name a number for is at the position, and answers for every
-        // axis on it: what number it was about is what was not read, so an axis cannot be excused by
-        // it naming another.
+    /**
+     * What the rules this phase drew no line from leave at one number of a position, or at the
+     * position itself where nothing measures it.
+     *
+     * <p>Whether this phase left anything with no line, and not which limit it was. A limit belongs
+     * to the rule it stopped, and the findings carry it there; taken as the position's, the first
+     * rule of however many were stopped alike was the one a report named.
+     *
+     * <p>The number where there is one. A {@code String} is measured more than one way: a rule
+     * about a length that nothing could read leaves the length blocked and says nothing about the
+     * string's own values, and matched by path alone either measure answered for both. So where
+     * nothing was measured, a rule naming a number is not what the location is left with either —
+     * it is about that number, which is not the location's own values.
+     *
+     * <p>A finding the reading did not name a number for is at the position, and answers for every
+     * measure on it: what number it was about is what was not read, so a measure cannot be excused
+     * by it naming another.
+     */
+    private static BodyCutInspection cameTo(NumericTerm.FromOnePosition term,
+                                            souther.compiler.inputs.TermPath path,
+                                            List<RuleWithoutALine> rules) {
         LeftAtThePosition left = LeftAtThePosition.of(rules.stream().filter(one -> switch (one.at()) {
             case souther.compiler.inputs.FilingCoordinate.OfTerm it ->
-                    it.term().equals(axis.term());
+                    term != null && it.term().equals(term);
             case souther.compiler.inputs.FilingCoordinate.AtPosition it ->
-                    it.path().equals(axis.path());
+                    it.path().equals(path);
         }).toList());
         // Which of the two this phase was left with, and not merely that it was left with
         // something. The verdict below tells a reading that stopped from a rule read to the end,
@@ -399,25 +402,27 @@ public final class Partitions {
      * are in the order an author wrote them.
      */
     private static List<NumericTerm.FromOnePosition> numbersMeasuring(
-            Axis axis, List<LineEvidence> evidence, EvidenceAccount account) {
-        NumericTerm.FromOnePosition declared = axis.term();
+            PositionMeasurements at, List<LineEvidence> evidence, EvidenceAccount account) {
+        souther.compiler.inputs.TermPath path = at.position().path();
         List<LineEvidence> here = evidence.stream()
-                .filter(each -> each.at().position().equals(axis.path())).toList();
+                .filter(each -> each.at().position().equals(path)).toList();
         List<NumericTerm.FromOnePosition> numbers = new ArrayList<>();
         for (LineEvidence each : here) {
             if (!numbers.contains(each.at())) {
                 numbers.add(each.at());
             }
         }
-        // A position the declarations already divide keeps the measure they gave it. What a body
+        // A position the declarations already divide keeps the measures they gave it. What a body
         // says about another number of such a position is not taken up as a second measure, and
         // this is where that is said: an account with no entry could not tell a policy from a loss.
-        if (axis.measurable()) {
-            here.stream().filter(each -> !each.at().equals(declared))
+        if (at.measured()) {
+            List<NumericTerm.FromOnePosition> declared =
+                    at.axes().stream().map(Axis::term).toList();
+            here.stream().filter(each -> !declared.contains(each.at()))
                     .forEach(each -> account.disposedOf(each,
                             new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(
-                                    axis.id())));
-            return numbers.contains(declared) ? List.of(declared) : List.of();
+                                    at.axes().get(0).id())));
+            return numbers.stream().filter(declared::contains).toList();
         }
         return numbers;
     }
@@ -429,11 +434,14 @@ public final class Partitions {
      * a position by are two ways to arrive at a number and one thing to do with it, and a second
      * route through this would be a second answer to what a rule about a number comes to.
      */
-    private static BodyCutInspection measureAt(List<Axis> out, Axis axis,
+    private static BodyCutInspection measureAt(List<Axis> out, PositionMeasurements at, Axis axis,
                                   NumericTerm.FromOnePosition term, List<LineEvidence> evidence,
                                   souther.compiler.inputs.Quantities reading, Symbols symbols,
                                   ReadingPolicy policy,
                                   List<RuleWithoutALine> rules, EvidenceAccount account) {
+        AxisId id = axis != null ? axis.id()
+                : AxisId.of(at.position().behavior(), term);
+        Type type = at.position().type();
         List<LineEvidence> mine = evidence.stream()
                 .filter(each -> each.at().equals(term)).toList();
         List<Threshold> here = LineEvidence.linesIn(mine);
@@ -442,16 +450,16 @@ public final class Partitions {
         // the record it sits in says about it. Reading the type again here would put a threshold
         // back inside a range the record has no values in.
         NumericDomain.Bounds domain = domainOf(reading, term);
-        Carrier carrier = term.answeredOn(axis.type(), symbols);
+        Carrier carrier = term.answeredOn(type, symbols);
         if (here.isEmpty() && !points.isEmpty()) {
             // Nothing orders this position, so its classes are the values singled out and
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
-            mine.forEach(each -> account.measured(each, axis.id()));
-            return keep(out, refine(axis,
-                    () -> singledClasses(points, term, axis.type(), domain, symbols),
-                    mergedPoints(axis.cuts(), points, carrier),
-                    axis.parted()),
+            mine.forEach(each -> account.measured(each, id));
+            return made(out, at, id, term, type,
+                    classesOf(axis, () -> singledClasses(points, term, type, domain, symbols)),
+                    mergedPoints(cutsOf(axis), points, carrier),
+                    partedOf(axis), narrowedOf(axis),
                     new BodyCutInspection.Evidence(), rules);
         }
         // Filtered once, and both answers read the filtered list. A line outside what the
@@ -465,7 +473,7 @@ public final class Partitions {
                 // A value singled out beside an ordering. The model has drawn the further
                 // distinction itself, so the value is one more line among the ranges and it is
                 // merged with them below.
-                account.measured(each, axis.id());
+                account.measured(each, id);
                 continue;
             }
             // Asked of the place the line falls at, which the position need not hold a value at.
@@ -480,7 +488,7 @@ public final class Partitions {
             if (domain != null && !admits(domain, line.parts())) {
                 continue;
             }
-            account.measured(each, axis.id());
+            account.measured(each, id);
             reachable.add(line);
         }
         // Through `excluding`, so that a class list replaced by the intervals a threshold cuts
@@ -491,18 +499,79 @@ public final class Partitions {
         // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
         // written about the position rather than everything that came to nothing.
         NumericDomain.Bounds within = domain;
-        return keep(out, refine(axis,
-                () -> Intervals.classesOf(
+        return made(out, at, id, term, type,
+                classesOf(axis, () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
-                        term, axis.type(), policy, symbols,
+                        term, type, policy, symbols,
                         within == null ? null : within.min(),
-                        within == null ? null : within.max()),
-                mergedPoints(merged(axis.cuts(), reachable, carrier), points, carrier),
+                        within == null ? null : within.max())),
+                mergedPoints(merged(cutsOf(axis), reachable, carrier), points, carrier),
                 reachable.stream()
                         .map(each -> Parting.by(each.parts(), each.origin().authoredLine()))
-                        .toList()),
+                        .toList(),
+                narrowedOf(axis),
                 reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
+    }
+
+    /**
+     * The measure the rules about one number came to, kept where it measures something.
+     *
+     * <p>A run of classes, the lines cut on the number, or where the rules part it: with none of
+     * the three the rules measured the number at nothing, and what there is to say is about the
+     * location rather than about a measure of it. Kept anyway, the location would be counted among
+     * the measures — which is what a measure of nothing was.
+     */
+    private static BodyCutInspection made(List<Axis> out, PositionMeasurements at, AxisId id,
+                                          NumericTerm.FromOnePosition term, Type type,
+                                          List<PartitionClass> classes, List<Cut> cuts,
+                                          List<Parting> parted, NarrowedBounds narrowed,
+                                          BodyCutInspection drew, List<RuleWithoutALine> rules) {
+        if (classes.isEmpty() && cuts.isEmpty() && parted.isEmpty()) {
+            return cameTo(term, at.position().path(), rules);
+        }
+        out.add(new Axis(id, term, type, classes, cuts, parted, narrowed));
+        return drew != null ? drew : cameTo(term, at.position().path(), rules);
+    }
+
+    /**
+     * What a number is already divided into, or what the rules now read about it divide it into.
+     *
+     * <p>Refinement and not replacement. What a body draws is evidence arriving after the model's
+     * own, and evidence only ever tells a position's values apart more finely — so where the model
+     * already divides the number, the lines a body draws are lines among those classes and the
+     * classes stay as they are. Rebuilt from the lines, a position the model divides three ways
+     * would come back divided two ways, and the loss reads as the model never having stated the
+     * third.
+     *
+     * <p>Which is a rule about the classes and not about the carrier. A position whose rules name
+     * the values it holds is divided just as finely, so a {@code guard} over it replaced what the
+     * model states. The two agree wherever this fires, and by construction rather than by luck: an
+     * enumeration's cases are its classes, and a crossing never leaves a position whose type states
+     * classes without any ({@code LocalInspection}'s {@code constructibleAt}).
+     *
+     * @param otherwise the classes to use where nothing divides the number yet, asked for only
+     *                  there — a number that already has classes has no use for them, and working
+     *                  them out would be a reading whose answer is thrown away
+     */
+    private static List<PartitionClass> classesOf(
+            Axis axis, java.util.function.Supplier<List<PartitionClass>> otherwise) {
+        return axis != null && axis.derivable() ? axis.classes() : otherwise.get();
+    }
+
+    /** The lines already cut on the number, of which there are none where nothing measured it. */
+    private static List<Cut> cutsOf(Axis axis) {
+        return axis == null ? List.of() : axis.cuts();
+    }
+
+    /** Likewise where the rules already part it. */
+    private static List<Parting> partedOf(Axis axis) {
+        return axis == null ? List.of() : axis.parted();
+    }
+
+    /** And where the rules leave its ends, which is an answer about this number and no other. */
+    private static NarrowedBounds narrowedOf(Axis axis) {
+        return axis == null ? NarrowedBounds.NOTHING : axis.narrowed();
     }
 
     /**
@@ -640,20 +709,29 @@ public final class Partitions {
             // about are both measures of it, and which of the two answers a report is owed is
             // `outranking`'s to settle rather than the order this happens to walk them in.
             BodyCutInspection came = null;
+            List<NumericTerm.FromOnePosition> numbers = numbersMeasuring(at, evidence, account);
+            for (NumericTerm.FromOnePosition term : numbers) {
+                // The measure of this number where the declarations made one, and nothing where a
+                // body's rules are the first to name it. What such a measure starts from is what
+                // the location is, which is where this reads it from.
+                Axis measured = at.axes().stream()
+                        .filter(each -> each.term().equals(term)).findFirst().orElse(null);
+                came = BodyCutInspection.outranking(came,
+                        measureAt(here, at, measured, term, evidence, reading,
+                                symbols, policy, rules, account));
+            }
+            // The measures nothing new was said about, kept as they are, and what they were left
+            // with folded in beside the rest.
             for (Axis axis : at.axes()) {
-                List<NumericTerm.FromOnePosition> numbers =
-                        numbersMeasuring(axis, evidence, account);
-                if (numbers.isEmpty()) {
-                    came = BodyCutInspection.outranking(came, keep(here, axis, null, rules));
+                if (numbers.contains(axis.term())) {
                     continue;
                 }
-                for (NumericTerm.FromOnePosition term : numbers) {
-                    AxisId id = term.equals(axis.term()) ? axis.id()
-                            : AxisId.of(axis.id().behavior(), term);
-                    came = BodyCutInspection.outranking(came,
-                            measureAt(here, axis.measuredAt(id, term), term, evidence, reading,
-                                    symbols, policy, rules, account));
-                }
+                here.add(axis);
+                came = BodyCutInspection.outranking(came,
+                        cameTo(axis.term(), axis.path(), rules));
+            }
+            if (came == null) {
+                came = cameTo(null, at.position().path(), rules);
             }
             measurements.add(at.measuredAt(here, came));
         }
@@ -713,38 +791,6 @@ public final class Partitions {
         return out;
     }
 
-    /**
-     * The same position, with what a body's rules add to it.
-     *
-     * <p>Refinement and not replacement. What a body draws is evidence arriving after the model's
-     * own, and evidence only ever tells a position's values apart more finely — so where the model
-     * already divides the position, the lines a body draws are lines among those classes and the
-     * classes stay as they are. Rebuilt from the lines, a position the model divides three ways
-     * would come back divided two ways, and the loss reads as the model never having stated the
-     * third.
-     *
-     * <p>Which is a rule about the classes and not about the carrier. It stood as a test for an
-     * enumeration, being where it was first noticed; a position whose rules name the values it
-     * holds is divided just as finely and had no such test, so a {@code guard} over it replaced
-     * what the model states.
-     *
-     * <p>The two agree wherever the old one fired, and they agree by construction rather than by
-     * luck: an enumeration's cases are its classes, and a crossing never leaves a position whose
-     * type states classes without any ({@code LocalInspection}'s {@code constructibleAt}). So there
-     * is no position with an ordered carrier for these to be about, and ranges over the count an
-     * enumeration's cases are ordered by are never rebuilt into a partition of them.
-     *
-     * <p>The lines are taken either way. A line is still a line where it divides nothing new, and
-     * still owes its rows.
-     *
-     * @param otherwise the classes to use where the model divides the position no way, asked for
-     *                  only there — a position that already has classes has no use for them, and
-     *                  working them out would be a reading whose answer is thrown away
-     */
-    private static Axis refine(Axis axis, java.util.function.Supplier<List<PartitionClass>> otherwise,
-                               List<Cut> cuts, List<Parting> parted) {
-        return axis.carrying(axis.derivable() ? axis.classes() : otherwise.get(), cuts, parted);
-    }
 
     /**
      * The classes a position divided only by equalities has: each value singled out, and the rest.
@@ -1017,10 +1063,14 @@ public final class Partitions {
                     // position that the local reading could not take in, which is what keeps the
                     // position from completing as one the model divides no way.
                     case StructuralInspection.Retained retained -> {
-                        PositionAccount at = PositionAccount.of(behavior, position,
-                                retained.continuation(), leftAt(position));
-                        measurements.add(new PositionMeasurements(at,
-                                List.of(Axis.pendingAt(id, term, at.type())), null));
+                        // The position and no measure of it. Nothing local divided the number the
+                        // declarations name, and a measure with nothing in it would be a location
+                        // counted among the measures — what is still to be answered for here is
+                        // the position's to carry.
+                        measurements.add(new PositionMeasurements(
+                                PositionAccount.of(behavior, position, retained.continuation(),
+                                        leftAt(position)),
+                                List.of(), null));
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -364,11 +364,16 @@ public final class Partitions {
      * to the rule it stopped, and the findings carry it there; taken as the position's, the first
      * rule of however many were stopped alike was the one a report named.
      *
-     * <p>The number where there is one. A {@code String} is measured more than one way: a rule
-     * about a length that nothing could read leaves the length blocked and says nothing about the
-     * string's own values, and matched by path alone either measure answered for both. So where
-     * nothing was measured, a rule naming a number is not what the location is left with either —
-     * it is about that number, which is not the location's own values.
+     * <p>The number where a measure was made of it. A {@code String} is measured more than one
+     * way: a rule about a length that nothing could read leaves the length blocked and says
+     * nothing about the string's own values, and matched by path alone either measure answered for
+     * both.
+     *
+     * <p>Where nothing measures the location, every rule filed anywhere in it is one the location
+     * is left with — filed by where its coordinate sits, and not by which number the reading
+     * happened to name. How exactly a rule was filed is how far its reading got, which is what the
+     * finding says and not a claim about what the rule divides; a location with no measure has no
+     * number for such a rule to be left at instead.
      *
      * <p>A finding the reading did not name a number for is at the position, and answers for every
      * measure on it: what number it was about is what was not read, so a measure cannot be excused
@@ -377,12 +382,14 @@ public final class Partitions {
     private static BodyCutInspection cameTo(NumericTerm.FromOnePosition term,
                                             souther.compiler.inputs.TermPath path,
                                             List<RuleWithoutALine> rules) {
-        LeftAtThePosition left = LeftAtThePosition.of(rules.stream().filter(one -> switch (one.at()) {
-            case souther.compiler.inputs.FilingCoordinate.OfTerm it ->
-                    term != null && it.term().equals(term);
-            case souther.compiler.inputs.FilingCoordinate.AtPosition it ->
-                    it.path().equals(path);
-        }).toList());
+        LeftAtThePosition left = LeftAtThePosition.of(rules.stream().filter(one -> term == null
+                ? one.at().path().equals(path)
+                : switch (one.at()) {
+                    case souther.compiler.inputs.FilingCoordinate.OfTerm it ->
+                            it.term().equals(term);
+                    case souther.compiler.inputs.FilingCoordinate.AtPosition it ->
+                            it.path().equals(path);
+                }).toList());
         // Which of the two this phase was left with, and not merely that it was left with
         // something. The verdict below tells a reading that stopped from a rule read to the end,
         // and answered here with one word it read every rule this phase understood as one it could

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -242,7 +242,7 @@ public final class Partitions {
          * this with a filter of its own was one that could be written without it.
          */
         public List<Axis> partitionAxes() {
-            return axes().stream().filter(Axis::derivable).toList();
+            return measurements.stream().flatMap(each -> each.partitionAxes().stream()).toList();
         }
     }
 
@@ -434,8 +434,7 @@ public final class Partitions {
                     at.axes().stream().map(Axis::term).toList();
             here.stream().filter(each -> !declared.contains(each.at()))
                     .forEach(each -> account.disposedOf(each,
-                            new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(
-                                    at.axes().get(0).id())));
+                            new EvidenceAccount.Disposition.ThePositionIsAlreadyMeasured(path)));
             return numbers.stream().filter(declared::contains).toList();
         }
         return numbers;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -999,8 +999,8 @@ public final class Partitions {
                 // (issue #1084).
                 PositionAccount at = PositionAccount.of(behavior, position, null, null);
                 measurements.add(new PositionMeasurements(at,
-                        List.of(new Axis(id, term, at, divided.classes(), divided.cuts().cuts(),
-                                List.of(), position.narrowedEnds())), null));
+                        List.of(new Axis(id, term, at.type(), divided.classes(),
+                                divided.cuts().cuts(), List.of(), position.narrowedEnds())), null));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -1020,7 +1020,7 @@ public final class Partitions {
                         PositionAccount at = PositionAccount.of(behavior, position,
                                 retained.continuation(), leftAt(position));
                         measurements.add(new PositionMeasurements(at,
-                                List.of(Axis.pendingAt(id, term, at)), null));
+                                List.of(Axis.pendingAt(id, term, at.type())), null));
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionAccount.java
@@ -8,20 +8,22 @@ import souther.compiler.types.Type;
 /**
  * One position of a behavior's input, and what this phase is left answering for at it.
  *
- * <p>Held once for the position and pointed at by every axis on it, because a position is measured
- * at as many numbers as the rules name of it and none of what is here is one of those numbers.
- * Where the walk stopped, what the reading of the declarations left standing, and what the position
- * is if nothing answers are facts about the location — true of it once, whether it is measured at
- * its own content, at how long it is, or at both.
+ * <p>Held once for the position, with the measures made of it under it
+ * ({@link PositionMeasurements}), because a position is measured at as many numbers as the rules
+ * name of it and none of what is here is one of those numbers. Where the walk stopped, what the
+ * reading of the declarations left standing, and what the position is if nothing answers are facts
+ * about the location — true of it once, whether it is measured at its own content, at how long it
+ * is, at both, or at nothing.
  *
  * <p><b>Kept on the position and not on a measure of it.</b> Whether a position is still waiting on
  * anything is a question about the location ({@link PendingPosition}), and a measure that could
  * answer it lets any reader ask through whichever number it happens to hold. Which one that is
  * decides nothing, so a reader that has to pick has been handed the wrong thing.
  *
- * <p>An axis holds one of these rather than a copy of what is in it. A copy per measure is a fact
- * with as many representations as the position has numbers, and any of them may be rebuilt without
- * one of its parts — which is what {@link ReadingResidue} guards one field at a time.
+ * <p>A measure holds none of this. What a measure needs of the location is what stands there, and
+ * it has that; a copy of the rest per measure would be a fact with as many representations as the
+ * position has numbers, and any of them may be rebuilt without one of its parts — which is what
+ * {@link ReadingResidue} guards one field at a time.
  *
  * @param pending  where nothing has answered for this position yet, what the structural reading
  *                 found — and so what the position is left with if nothing else answers. Null where

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -20,10 +20,10 @@ import java.util.List;
  *                   numbers measure it
  * @param axes       the measures made of it, in the order the rules name the numbers
  * @param inspection what the rules written about this location came to, over every number it is
- *                   measured at, or null where this phase read none of them. One sentence for the
- *                   location because that is what a report says about one: written per measure, a
- *                   location measured at two numbers is told twice that it is divided nowhere, and
- *                   told it at all where one of its numbers is divided and another is not
+ *                   measured at. One sentence for the location because that is what a report says
+ *                   about one: written per measure, a location measured at two numbers is told
+ *                   twice that it is divided nowhere, and told it at all where one of its numbers
+ *                   is divided and another is not
  */
 public record PositionMeasurements(PositionAccount position, List<Axis> axes,
                                    BodyCutInspection inspection) {
@@ -32,9 +32,27 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
         if (position == null) {
             throw new IllegalArgumentException("measures of no position");
         }
+        // What the rules came to is part of what this answers, so it is here before anything reads
+        // it. A value without it is a location half answered for, and the readers of it — the
+        // verdict a report writes about the location, and what it is left with — take it as the
+        // answer rather than as something still to arrive.
+        if (inspection == null) {
+            throw new IllegalArgumentException(
+                    position.path() + " has no account of what the rules written about it came to");
+        }
         axes = List.copyOf(axes);
+        java.util.Set<AxisId> named = new java.util.LinkedHashSet<>();
         for (Axis axis : axes) {
             held(position, axis);
+            // One measure per number. What tells two measures of one location apart is the number
+            // each is of, which is what names them, and every reader downstream holds them under
+            // that name — a second measure of one number is one of them silently standing for the
+            // other in a map, and two of them counted where a report counts measures.
+            if (!named.add(axis.id())) {
+                throw new IllegalArgumentException("`" + axis.id() + "` measures " + axis.term()
+                        + " twice at " + position.path()
+                        + "; a location is measured once at each number the rules name of it");
+            }
         }
     }
 
@@ -77,7 +95,7 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
      * nothing stands at come to the same thing for every reader of this.
      */
     public boolean measured() {
-        return axes.stream().anyMatch(Axis::measurable);
+        return axes.stream().anyMatch(Axis::asksForARow);
     }
 
     /** The measures of this location that divide their number into classes. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -16,11 +16,17 @@ import java.util.List;
  * position the rules divide nowhere is still a position this phase answers for: a report names it,
  * and a rule read later can still be the first to draw a line there.
  *
- * @param position what the location is and what its reading came to, true of it once however many
- *                 numbers measure it
- * @param axes     the measures made of it, in the order the rules name the numbers
+ * @param position   what the location is and what its reading came to, true of it once however many
+ *                   numbers measure it
+ * @param axes       the measures made of it, in the order the rules name the numbers
+ * @param inspection what the rules written about this location came to, over every number it is
+ *                   measured at, or null where this phase read none of them. One sentence for the
+ *                   location because that is what a report says about one: written per measure, a
+ *                   location measured at two numbers is told twice that it is divided nowhere, and
+ *                   told it at all where one of its numbers is divided and another is not
  */
-public record PositionMeasurements(PositionAccount position, List<Axis> axes) {
+public record PositionMeasurements(PositionAccount position, List<Axis> axes,
+                                   BodyCutInspection inspection) {
 
     public PositionMeasurements {
         if (position == null) {
@@ -56,7 +62,19 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes) {
     }
 
     /** The same position, measured at what a body's rules added to it. */
-    public PositionMeasurements measuredAt(List<Axis> axes) {
-        return new PositionMeasurements(position, axes);
+    public PositionMeasurements measuredAt(List<Axis> axes, BodyCutInspection inspection) {
+        return new PositionMeasurements(position, axes, inspection);
+    }
+
+    /**
+     * Whether anything here has something to divide the location by.
+     *
+     * <p>Asked of the measures the location has, which is where the answer is. A location nothing
+     * measures has none of them, and one measured at a number the rules say nothing about has one
+     * that divides it nowhere — two different things that a report tells apart, and neither of them
+     * a question about which measure was asked.
+     */
+    public boolean measured() {
+        return axes.stream().anyMatch(Axis::measurable);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -67,15 +67,17 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
     }
 
     /**
-     * Whether anything here has something to divide the location by.
+     * Whether anything here has something to divide the location by — a class to cover, or a line
+     * to reach.
      *
-     * <p>Asked of the measures the location has, which is where the answer is. A location nothing
-     * measures has none of them, and one measured at a number the rules say nothing about has one
-     * that divides it nowhere — two different things that a report tells apart, and neither of them
-     * a question about which measure was asked.
+     * <p>Asked of the measures the location has, which is where the answer is. Not whether it has
+     * any: a measure that only parts the number where the location holds no value has nothing at it
+     * for a row to be written against, and a report telling an author what was measured here would
+     * be naming work nobody can do. A location with no measure at all and one measured at a parting
+     * nothing stands at come to the same thing for every reader of this.
      */
     public boolean measured() {
-        return !axes.isEmpty();
+        return axes.stream().anyMatch(Axis::measurable);
     }
 
     /** The measures of this location that divide their number into classes. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -85,17 +85,16 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
     }
 
     /**
-     * Whether anything here has something to divide the location by — a class to cover, or a line
-     * to reach.
+     * Whether anything measures this location.
      *
-     * <p>Asked of the measures the location has, which is where the answer is. Not whether it has
-     * any: a measure that only parts the number where the location holds no value has nothing at it
-     * for a row to be written against, and a report telling an author what was measured here would
-     * be naming work nobody can do. A location with no measure at all and one measured at a parting
-     * nothing stands at come to the same thing for every reader of this.
+     * <p>Which is whether it has a measure, and nothing more. What one of them asks a row for is
+     * that measure's answer ({@link Axis#asksForARow}) and what divides the number into classes is
+     * another ({@link #partitionAxes}) — three questions about one location, and every one of them
+     * has a reader that would be given the wrong answer by either of the others. A location the
+     * rules part where it holds no value is measured, and asks an author for nothing.
      */
-    public boolean measured() {
-        return axes.stream().anyMatch(Axis::asksForARow);
+    public boolean hasMeasures() {
+        return !axes.isEmpty();
     }
 
     /** The measures of this location that divide their number into classes. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -75,6 +75,11 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
      * a question about which measure was asked.
      */
     public boolean measured() {
-        return axes.stream().anyMatch(Axis::measurable);
+        return !axes.isEmpty();
+    }
+
+    /** The measures of this location that divide their number into classes. */
+    public List<Axis> partitionAxes() {
+        return axes.stream().filter(Axis::derivable).toList();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -1,0 +1,62 @@
+package souther.compiler.partition;
+
+import java.util.List;
+
+/**
+ * One position of a behavior's input, and the numbers this phase measured it at.
+ *
+ * <p>The measures a location has are held under the location, because that is the relation the
+ * model states: a location is measured at as many numbers as the rules name of it, and none, one or
+ * several is the whole of what can be there. Held in a list of its own beside a list of locations,
+ * the relation is in neither of them — and the only way back to it is to compare how each is
+ * spelled, which is a reading of the paths invented once per reader and free to answer differently
+ * from the reading that made them.
+ *
+ * <p>Empty where nothing measures the location, which is an answer and not an absence to fill in. A
+ * position the rules divide nowhere is still a position this phase answers for: a report names it,
+ * and a rule read later can still be the first to draw a line there.
+ *
+ * @param position what the location is and what its reading came to, true of it once however many
+ *                 numbers measure it
+ * @param axes     the measures made of it, in the order the rules name the numbers
+ */
+public record PositionMeasurements(PositionAccount position, List<Axis> axes) {
+
+    public PositionMeasurements {
+        if (position == null) {
+            throw new IllegalArgumentException("measures of no position");
+        }
+        axes = List.copyOf(axes);
+        for (Axis axis : axes) {
+            held(position, axis);
+        }
+    }
+
+    /**
+     * That {@code axis} is a measure of this position, which is what holding it here says.
+     *
+     * <p>Checked where the two are put together and nowhere else. An axis names the position its
+     * number is taken of, so which position a measure belongs to has two spellings the moment one is
+     * held under the other — and a reader that met them apart would have to decide which of the two
+     * to believe. Asked here once, every reader afterwards has the answer by where the measure sits.
+     */
+    private static void held(PositionAccount position, Axis axis) {
+        if (!axis.term().position().equals(position.path())) {
+            throw new IllegalArgumentException("`" + axis.id() + "` measures a number of "
+                    + axis.term().position() + ", and is held under " + position.path());
+        }
+        if (!axis.type().equals(position.type())) {
+            throw new IllegalArgumentException("`" + axis.id() + "` reads a value of "
+                    + axis.type() + " where " + position.path() + " holds " + position.type());
+        }
+        if (!axis.id().behavior().equals(position.behavior())) {
+            throw new IllegalArgumentException("`" + axis.id() + "` is a measure of another"
+                    + " behavior's input than " + position.path() + " of " + position.behavior());
+        }
+    }
+
+    /** The same position, measured at what a body's rules added to it. */
+    public PositionMeasurements measuredAt(List<Axis> axes) {
+        return new PositionMeasurements(position, axes);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
@@ -12,15 +12,16 @@ import java.util.Set;
  * What a reading of one position left behind that no later phase can take away.
  *
  * <p><b>Two facts with one lifetime, held together so that one cannot be carried without the
- * other.</b> An axis is rebuilt whenever a body's rules re-point it at another number
- * ({@link Axis#measuredAt}) or divide it ({@link Axis#carrying}), and each of those is a place a
- * caller writes the parts out by hand. A position whose elements could not be reached once came
- * back from the second phase with nothing to say it had ever stopped, because one such rebuild did
- * not name the field. Written as one value, a rebuild names it or does not compile.
+ * other.</b> What a position is measured at is rebuilt as a body's rules are read
+ * ({@link PositionMeasurements#measuredAt}), which is a place a caller writes the parts out by
+ * hand. A position whose elements could not be reached once came back from the second phase with
+ * nothing to say it had ever stopped, because one such rebuild did not name the field. Written as
+ * one value, a rebuild names it or does not compile.
  *
- * <p><b>Not what the position is still waiting on.</b> {@link Axis#pending} is a fallback: it is
- * what a position is left with <em>if nothing else answers for it</em>, and it is gone the moment
- * something does. These two are observations, and they stay true whatever answers later — a
+ * <p><b>Not what the position is still waiting on.</b> {@link PositionAccount#pending} is a
+ * fallback: it is what a position is left with <em>if nothing else answers for it</em>, and it is
+ * gone the moment something does. These two are observations, and they stay true whatever answers
+ * later — a
  * {@code Map} nothing can be read into is one nothing was read into however plainly a rule about its
  * size divides it. Holding the three in one value would put a phase-local state and two settled
  * facts under one lifetime, which is the merge issue #1084 is about, one level up.

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -168,13 +168,19 @@ final class Coverages {
         Readings readings = Readings.of(rows, where, partitioning.axes(),
                 observed.gaps().stream()
                         .filter(gap -> gap.code().leftNoRowRead()).toList());
-        for (Axis axis : partitioning.axes()) {
-            if (!axis.measurable()) {
-                continue;   // said by `undivided`, which also says which kind of nothing it is
-            }
-            if (axis.derivable()) {
-                axes.add(coverageOf(axis, partitioning, readings, level.readsRows()));
-                divided.add(axis);
+        // A position at a time, because what one of its measures is owed to say includes what the
+        // reading of the position left unread — which is the position's answer and is asked of it
+        // here rather than of whichever measure happens to be in hand.
+        for (souther.compiler.partition.PositionMeasurements at : partitioning.measurements()) {
+            for (Axis axis : at.axes()) {
+                if (!axis.measurable()) {
+                    continue;   // said by `undivided`, which also says which kind of nothing it is
+                }
+                if (axis.derivable()) {
+                    axes.add(coverageOf(axis, at.position(), partitioning, readings,
+                            level.readsRows()));
+                    divided.add(axis);
+                }
             }
         }
         // Each measure asked its own closure, and neither told from the length of what came back.
@@ -442,16 +448,16 @@ final class Coverages {
 
 
     private static PartitionEvidence.AxisCoverage coverageOf(Axis axis,
+            souther.compiler.partition.PositionAccount at,
             souther.compiler.partition.Partitions.Partitioning partitioning, Readings readings,
             boolean asked) {
         List<String> classes = axis.classes().stream().map(PartitionClass::id).toList();
-        // What the axis already says about which of this position's rules nothing accounted for,
-        // each named. Read off the axis rather than worked out here, and in the questions' own
-        // words: the vocabulary beside it says why a division could not be derived, which is a
-        // different question, and borrowing it left a reader with a sentence that named neither
-        // (issue #842).
+        // Which of this position's rules nothing accounted for, each named. Read off the position
+        // rather than worked out here, and in the questions' own words: the vocabulary beside it
+        // says why a division could not be derived, which is a different question, and borrowing it
+        // left a reader with a sentence that named neither.
         PartitionEvidence.AxisCoverage.Reading read = new PartitionEvidence.AxisCoverage.Reading(
-                axis.at().residue().rulesLeftUnread().isEmpty()
+                at.residue().rulesLeftUnread().isEmpty()
                         ? PartitionEvidence.AxisCoverage.Reach.EVERY_RULE
                         : PartitionEvidence.AxisCoverage.Reach.SOME_OUT_OF_SIGHT,
                 // Of the questions standing at this position, the ones this measure is the reader

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -165,7 +165,10 @@ final class Coverages {
         List<PartitionEvidence.AxisCoverage> axes = new ArrayList<>();
 
         List<Axis> divided = new ArrayList<>();
-        Readings readings = Readings.of(rows, where, partitioning.axes(),
+        // The measures that divide their number, which are the ones a row is placed at. Handed
+        // every measure, this asks a classifier about numbers there are no classes to place a value
+        // in, and the count it comes back with is over a set no answer here is about.
+        Readings readings = Readings.of(rows, where, partitioning.partitionAxes(),
                 observed.gaps().stream()
                         .filter(gap -> gap.code().leftNoRowRead()).toList());
         // A position at a time, because what one of its measures is owed to say includes what the
@@ -197,7 +200,7 @@ final class Coverages {
                 // no axis came back for still has whatever was written about it.
                 partitioning.notSeparated(), unansweredIn(partitioning),
                 whyUnclassified(readings.byRow(),
-                        partitioning.axes().stream().map(Axis::id).toList()));
+                        partitioning.partitionAxes().stream().map(Axis::id).toList()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -172,15 +172,14 @@ final class Coverages {
         // reading of the position left unread — which is the position's answer and is asked of it
         // here rather than of whichever measure happens to be in hand.
         for (souther.compiler.partition.PositionMeasurements at : partitioning.measurements()) {
-            for (Axis axis : at.axes()) {
-                if (!axis.measurable()) {
-                    continue;   // said by `undivided`, which also says which kind of nothing it is
-                }
-                if (axis.derivable()) {
-                    axes.add(coverageOf(axis, at.position(), partitioning, readings,
-                            level.readsRows()));
-                    divided.add(axis);
-                }
+            // The measures that divide their number, which is what a partition is counted over. A
+            // measure that is a boundary and no partition is covered by the rows at its edge and
+            // said there, and a location nothing measures is said by `undivided`, which also says
+            // which kind of nothing it is.
+            for (Axis axis : at.partitionAxes()) {
+                axes.add(coverageOf(axis, at.position(), partitioning, readings,
+                        level.readsRows()));
+                divided.add(axis);
             }
         }
         // Each measure asked its own closure, and neither told from the length of what came back.

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
@@ -143,7 +143,7 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
         Measured minute = measured(TAKEN, "gate/Time.minute(slot.at)");
         Cut line = minute.line();
 
-        assertNotEquals(minute.carrier(), minute.axis().at().type(),
+        assertNotEquals(minute.carrier(), minute.axis().type(),
                 "the number is counted on an order of its own");
         assertTrue(minute.axis().classes().stream().allMatch(each ->
                         !(each.classifier().membershipOf(minute.carrier().valueOf(line.at()))

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
@@ -2,8 +2,11 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.Carrier;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Towards;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
@@ -13,6 +16,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,7 +99,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
         PositionMeasurements note = at("slot.note");
 
         assertEquals(List.of(), note.axes());
-        assertFalse(note.measured());
+        assertFalse(note.hasMeasures());
         assertTrue(divided().undivided().stream()
                         .anyMatch(each -> each.at().toString().equals("slot.note")),
                 "and what a report says about it comes from the position");
@@ -108,7 +112,45 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
 
         assertEquals(List.of("gate/slot.n"),
                 n.axes().stream().map(each -> each.id().toString()).toList());
-        assertTrue(n.measured());
+        assertTrue(n.hasMeasures());
+    }
+
+    /**
+     * Three questions about one location, and no two of them are the same question.
+     *
+     * <p>Whether anything measures it, whether a measure of it asks a row for anything, and which
+     * of its measures divide their number into classes. A measure that parts a number where the
+     * location holds no value answers the first and neither of the others, which is the one value
+     * that tells the three apart — and every one of them has a reader that the other two would
+     * answer wrongly. The location is measured, so nothing is pending at it and a report says
+     * nothing about it being undivided; there is nothing at the parting to ask an author for, so no
+     * line is assembled along it; and it divides the number into no classes, so no partition counts
+     * it.
+     */
+    @Test
+    void aMeasureThatOnlyPartsANumberIsAMeasureAndAsksForNoRow() {
+        PositionMeasurements n = at("slot.n");
+        Axis reading = n.axes().get(0);
+        Carrier whole = new Carrier.Whole();
+        Axis partsOnly = new Axis(reading.id(), reading.term(), reading.type(), List.of(),
+                List.of(),
+                List.of(Parting.by(
+                        Seam.of(LevelSpace.onACarrier(whole),
+                                new Level.OnACarrier(whole, Count.of(java.math.BigDecimal.TEN)),
+                                Towards.BELOW),
+                        WhatTheRulesTogetherLeaveAQuantityTest.aLine(1))),
+                souther.compiler.check.NarrowedBounds.NOTHING);
+        PositionMeasurements parting =
+                new PositionMeasurements(n.position(), List.of(partsOnly), READ_TO_THE_END);
+
+        assertTrue(parting.hasMeasures(), "the rules part the number, which is a measure of it");
+        assertFalse(partsOnly.asksForARow(),
+                "and the location holds no value at the parting, so nothing is owed a row");
+        assertEquals(List.of(), parting.partitionAxes(),
+                "and it divides the number into no classes");
+        assertNull(PendingPosition.of(parting.position(), parting.hasMeasures()),
+                "so the location is answered for, and a report says nothing about it being"
+                        + " undivided");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
@@ -31,6 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AMeasureIsHeldUnderThePositionItMeasuresTest {
 
+    /** What the rules came to where every one of them was read and none drew a line, which is what
+     *  the fixtures below are not about. */
+    private static final BodyCutInspection READ_TO_THE_END = new BodyCutInspection.Exhausted();
+
     private static final String MODEL = """
             module example.held
 
@@ -120,7 +124,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
         assertEquals(n.position().type(), ofAnother.type(), "the two hold the same type");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new PositionMeasurements(n.position(), List.of(ofAnother), null));
+                () -> new PositionMeasurements(n.position(), List.of(ofAnother), READ_TO_THE_END));
 
         assertTrue(refused.getMessage().contains("slot.m")
                 && refused.getMessage().contains("slot.n"), refused.getMessage());
@@ -135,10 +139,54 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
                 List.of(), reading.cuts());
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new PositionMeasurements(n.position(), List.of(ofAString), null));
+                () -> new PositionMeasurements(n.position(), List.of(ofAString), READ_TO_THE_END));
 
         assertTrue(refused.getMessage().contains(Type.STRING.toString())
                 && refused.getMessage().contains(Type.INT.toString()), refused.getMessage());
+    }
+
+    /**
+     * A measure is named after the number it is of, so its name cannot say another.
+     *
+     * <p>The name is what every reader downstream holds a measure under — the lines along it, what
+     * a row was placed at, what a piece of evidence was measured by — so a measure of one number
+     * filed under the name of another is not a wrong word in a report; it is that reader holding
+     * the wrong measure.
+     */
+    @Test
+    void aMeasureCannotBeNamedAfterANumberItDoesNotMeasure() {
+        Axis reading = at("slot.n").axes().get(0);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Axis(AxisId.of("gate", at("slot.m").axes().get(0).term()),
+                        reading.term(), reading.type(), reading.classes(), reading.cuts()));
+
+        assertTrue(refused.getMessage().contains("slot.m")
+                && refused.getMessage().contains("slot.n"), refused.getMessage());
+    }
+
+    /** And a location is measured once at each number, because that name is what tells them apart. */
+    @Test
+    void aLocationIsNotMeasuredTwiceAtOneNumber() {
+        PositionMeasurements n = at("slot.n");
+        Axis once = n.axes().get(0);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new PositionMeasurements(n.position(), List.of(once, once), READ_TO_THE_END));
+
+        assertTrue(refused.getMessage().contains("twice"), refused.getMessage());
+    }
+
+    /** And what the rules about the location came to is part of the answer, not something a reader
+     *  waits for. */
+    @Test
+    void aLocationAnsweredForSaysWhatItsRulesCameTo() {
+        PositionMeasurements n = at("slot.n");
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new PositionMeasurements(n.position(), n.axes(), null));
+
+        assertTrue(refused.getMessage().contains("slot.n"), refused.getMessage());
     }
 
     /** Nor one made for another behavior's input, which an axis names on its own. */
@@ -150,7 +198,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
                 reading.type(), reading.classes(), reading.cuts());
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new PositionMeasurements(n.position(), List.of(elsewhere), null));
+                () -> new PositionMeasurements(n.position(), List.of(elsewhere), READ_TO_THE_END));
 
         assertTrue(refused.getMessage().contains("other"), refused.getMessage());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
@@ -1,0 +1,157 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A measure measures something, and it is held under the location whose number it is of.
+ *
+ * <p>Two rules with one purpose. A location a behavior takes and a measure made of it are answers
+ * to different questions — where a row is written, and what the rules divide — and a run of measures
+ * that a location could stand in makes the second answer the first. That is what a measure with no
+ * class, no line and nothing parted was: a location, counted among the measures and filtered back
+ * out by every reader that could remember to.
+ *
+ * <p>So a measure of nothing cannot be built, and which location a measure is of is where it sits
+ * rather than something a reader works out from how a path is spelled. What holds the two together
+ * is checked once, where they are put together.
+ */
+class AMeasureIsHeldUnderThePositionItMeasuresTest {
+
+    private static final String MODEL = """
+            module example.held
+
+            data Yes
+            data No
+            data Answer = Yes | No
+
+            data Slot = { note: String, n: Int, m: Int }
+
+            behavior gate : (slot: Slot) -> Answer
+            let gate (slot) = {
+                guard slot.n >= 5 else No
+                guard slot.m >= 7 else No
+                Yes
+            }
+            """;
+
+    private static Partitions.Partitioning divided() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Partitions.Partitioning read = compilation.db()
+                .ask(new Adequacy.Divided(compilation.modules().get(0), "gate")).value();
+        assertNotNull(read, "the model under test compiles and is measured");
+        return read;
+    }
+
+    private static PositionMeasurements at(String path) {
+        PositionMeasurements found = divided().measurements().stream()
+                .filter(each -> each.position().path().toString().equals(path))
+                .findFirst().orElse(null);
+        assertNotNull(found, "the behavior takes " + path);
+        return found;
+    }
+
+    /** The state the run of measures could hold, refused where a measure is built. */
+    @Test
+    void aMeasureWithNoClassNoLineAndNoPartingCannotBeBuilt() {
+        TermPath at = TermPath.of("slot").then("note");
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(at);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Axis(AxisId.of("gate", term), term, Type.STRING,
+                        List.of(), List.of()));
+
+        assertTrue(refused.getMessage().contains("measures a number of no")
+                        || refused.getMessage().contains("at nothing"),
+                refused.getMessage());
+    }
+
+    /**
+     * And the model this compiler reads produces the location such a measure stood for, so the rule
+     * above is about something. A plain string nothing compares is a position of the input and is
+     * measured at no number.
+     */
+    @Test
+    void aLocationNothingMeasuresIsAPositionWithNoMeasures() {
+        PositionMeasurements note = at("slot.note");
+
+        assertEquals(List.of(), note.axes());
+        assertFalse(note.measured());
+        assertTrue(divided().undivided().stream()
+                        .anyMatch(each -> each.at().toString().equals("slot.note")),
+                "and what a report says about it comes from the position");
+    }
+
+    /** While the location the rules do divide holds the measure they made of it. */
+    @Test
+    void aLocationTheRulesDivideHoldsTheMeasureOfIt() {
+        PositionMeasurements n = at("slot.n");
+
+        assertEquals(List.of("gate/slot.n"),
+                n.axes().stream().map(each -> each.id().toString()).toList());
+        assertTrue(n.measured());
+    }
+
+    /**
+     * A measure of another location is not held here, and the two are never worked out apart.
+     *
+     * <p>Of a location holding the same type, so that the location is the only thing wrong with it:
+     * a witness of another type would be refused for that whichever location it sat under.
+     */
+    @Test
+    void aMeasureOfAnotherLocationIsNotHeldUnderThisOne() {
+        PositionMeasurements n = at("slot.n");
+        Axis ofAnother = at("slot.m").axes().get(0);
+        assertEquals(n.position().type(), ofAnother.type(), "the two hold the same type");
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new PositionMeasurements(n.position(), List.of(ofAnother), null));
+
+        assertTrue(refused.getMessage().contains("slot.m")
+                && refused.getMessage().contains("slot.n"), refused.getMessage());
+    }
+
+    /** Nor a measure that reads a value of another type, whatever it is called. */
+    @Test
+    void aMeasureThatReadsAnotherTypeIsNotHeldHere() {
+        PositionMeasurements n = at("slot.n");
+        Axis reading = n.axes().get(0);
+        Axis ofAString = new Axis(reading.id(), reading.term(), Type.STRING,
+                List.of(), reading.cuts());
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new PositionMeasurements(n.position(), List.of(ofAString), null));
+
+        assertTrue(refused.getMessage().contains(Type.STRING.toString())
+                && refused.getMessage().contains(Type.INT.toString()), refused.getMessage());
+    }
+
+    /** Nor one made for another behavior's input, which an axis names on its own. */
+    @Test
+    void aMeasureOfAnotherBehaviorsInputIsNotHeldHere() {
+        PositionMeasurements n = at("slot.n");
+        Axis reading = n.axes().get(0);
+        Axis elsewhere = new Axis(AxisId.of("other", reading.term()), reading.term(),
+                reading.type(), reading.classes(), reading.cuts());
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new PositionMeasurements(n.position(), List.of(elsewhere), null));
+
+        assertTrue(refused.getMessage().contains("other"), refused.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -74,10 +74,11 @@ class AStopThisCompilerMadeIsSaidOnceTest {
     /**
      * The same map again, with the line drawn by the body rather than by a declaration.
      *
-     * <p>The other way an axis is rebuilt. Nothing divides the map, so the axis is re-pointed at the
-     * number the body measures ({@link Axis#measuredAt}) — a caller writing the parts of an axis out
-     * by hand, and the place a position that had stopped once came back with nothing to say so.
-     * Named for a module of its own because {@code guard} is a word of the language.
+     * <p>The other way what a position is measured at is rebuilt. Nothing divides the map, so the
+     * measure is made at the number the body names ({@link PositionMeasurements#measuredAt}) — a
+     * caller writing the parts of a position's measurements out by hand, and the place a position
+     * that had stopped once came back with nothing to say so. Named for a module of its own because
+     * {@code guard} is a word of the language.
      */
     private static final String A_MAP_A_BODY_MEASURES = """
             module probe.bodyline
@@ -151,13 +152,13 @@ class AStopThisCompilerMadeIsSaidOnceTest {
     }
 
     /**
-     * And it survives the axis being re-pointed at the number a body measures.
+     * And it survives a measure being made at the number a body names.
      *
-     * <p>Both ways an axis is rebuilt, because what holds the two facts together is that they
-     * travel as one value and every rebuild is a place a caller can drop one. This one goes through
-     * {@link Axis#measuredAt}; the test above goes through the division. The finding names the term
-     * the axis was re-pointed to, which is the axis carrying the fact and not the position that was
-     * blocked — the position is that axis's path.
+     * <p>Both ways what a position is measured at is rebuilt, because what holds the two facts
+     * together is that they travel as one value and every rebuild is a place a caller can drop one.
+     * This one goes through {@link PositionMeasurements#measuredAt}; the test above goes through the
+     * division. The finding names the term the measure was made at, which is the measure carrying
+     * the fact and not the position that was blocked — the position is that measure's path.
      */
     @Test
     void andItSurvivesTheAxisBeingRePointedAtWhatABodyMeasures() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -71,7 +71,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
 
     /** What is still to be answered for at this position. */
     private static PendingPosition of(PositionMeasurements at) {
-        return PendingPosition.of(at.position(), at.measured());
+        return PendingPosition.of(at.position(), at.hasMeasures());
     }
 
     private static PositionMeasurements pending(StructuralInspection.Continuation found) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -48,31 +48,37 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
 
     private static final AxisId ID = AxisId.of("run", new NumericTerm.ValueOf(AT));
 
-    private static Axis measured() {
-        return new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
+    private static PositionMeasurements measured() {
+        return at(new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
                 List.of(PartitionClass.of("true", "true", new Recognition.Nothing(),
                                 RepresentativeSource.of(FixtureTemplate.bool(true)))
                         .ofTheNumber(new NumericTerm.ValueOf(AT))),
-                List.of());
+                List.of()), null, null);
     }
 
-    /** What is still to be answered for at the position this axis is of. The fixtures here are
-     *  axis-shaped, and the question is the position's. */
-    private static PendingPosition of(Axis axis) {
-        return PendingPosition.of(axis.at(), axis.measurable());
+    /** One position with nothing left to answer for, measured at the one number. */
+    private static PositionMeasurements at(Axis axis, StructuralInspection.Continuation found,
+                                           BlockReason.RuleWithoutLineReason unread) {
+        return new PositionMeasurements(
+                new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
+                        unread == null ? null : LeftAtThePosition.of(unread)),
+                List.of(axis), null);
     }
 
-    private static Axis pending(StructuralInspection.Continuation found) {
+    /** What is still to be answered for at this position. */
+    private static PendingPosition of(PositionMeasurements at) {
+        return PendingPosition.of(at.position(), at.measured());
+    }
+
+    private static PositionMeasurements pending(StructuralInspection.Continuation found) {
         return pending(found, null);
     }
 
     /** The same, with a rule about the position's own values that the local reading could not take
      *  in — which is a second way a position can be left unable to reach an absence. */
-    private static Axis pending(StructuralInspection.Continuation found,
-                                BlockReason.RuleWithoutLineReason unread) {
-        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT),
-                new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
-                        unread == null ? null : LeftAtThePosition.of(unread)));
+    private static PositionMeasurements pending(StructuralInspection.Continuation found,
+                                                BlockReason.RuleWithoutLineReason unread) {
+        return at(Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL), found, unread);
     }
 
     /**
@@ -151,8 +157,9 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      *  said of it is this compiler's state, written down as what the model divides. */
     @Test
     void aPositionNothingReadIsNotAnsweredFor() {
-        assertThrows(IllegalStateException.class, () -> of(
-                new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL, List.of(), List.of())));
+        assertThrows(IllegalStateException.class, () -> of(new PositionMeasurements(
+                new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, null, null),
+                List.of(), null)));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -62,7 +62,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         return new PositionMeasurements(
                 new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
                         unread == null ? null : LeftAtThePosition.of(unread)),
-                List.of(axis), null);
+                axis == null ? List.of() : List.of(axis), null);
     }
 
     /** What is still to be answered for at this position. */
@@ -78,7 +78,10 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static PositionMeasurements pending(StructuralInspection.Continuation found,
                                                 BlockReason.RuleWithoutLineReason unread) {
-        return at(Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL), found, unread);
+        return new PositionMeasurements(
+                new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
+                        unread == null ? null : LeftAtThePosition.of(unread)),
+                List.of(), null);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -48,6 +48,10 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
 
     private static final AxisId ID = AxisId.of("run", new NumericTerm.ValueOf(AT));
 
+    /** What the rules came to where every one of them was read and none drew a line. The chain
+     *  below is about what a position is pending on, which is asked before this is read. */
+    private static final BodyCutInspection READ_TO_THE_END = new BodyCutInspection.Exhausted();
+
     private static PositionMeasurements measured() {
         return at(new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
                 List.of(PartitionClass.of("true", "true", new Recognition.Nothing(),
@@ -62,7 +66,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         return new PositionMeasurements(
                 new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
                         unread == null ? null : LeftAtThePosition.of(unread)),
-                List.of(axis), null);
+                List.of(axis), READ_TO_THE_END);
     }
 
     /** What is still to be answered for at this position. */
@@ -81,7 +85,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         return new PositionMeasurements(
                 new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
                         unread == null ? null : LeftAtThePosition.of(unread)),
-                List.of(), null);
+                List.of(), READ_TO_THE_END);
     }
 
     /**
@@ -162,7 +166,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     void aPositionNothingReadIsNotAnsweredFor() {
         assertThrows(IllegalStateException.class, () -> of(new PositionMeasurements(
                 new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, null, null),
-                List.of(), null)));
+                List.of(), READ_TO_THE_END)));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -62,7 +62,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         return new PositionMeasurements(
                 new PositionAccount("run", AT, Type.BOOL, ReadingResidue.NOTHING, found,
                         unread == null ? null : LeftAtThePosition.of(unread)),
-                axis == null ? List.of() : List.of(axis), null);
+                List.of(axis), null);
     }
 
     /** What is still to be answered for at this position. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
@@ -187,30 +187,31 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
     }
 
     /**
-     * The same position measured at another number keeps the position and none of the old number's
-     * answers.
+     * A position measured at a number taken of it holds that measure and no other.
      *
-     * <p>What the classes and the lines are is how the rules divided one number and where they cut
-     * it, so the position measured at a second number starts with none of them and is given what the
-     * rules leave that number. Carried over, they would be the classes of one number on an axis of
-     * another, which is the thing above that cannot be built.
+     * <p>Which is what keeps the classes of one number off an axis of another: a measure is made
+     * from the rules about one number and holds what they gave it, so there is nothing for a second
+     * number to inherit. A string the body compares the length of has one measure, of the length —
+     * and none of the string's own value, which no rule here divides.
      */
     @Test
-    void thePositionMeasuredAtAnotherNumberCarriesNoneOfTheFirstsClasses() {
+    void aPositionHoldsTheMeasuresTheRulesNameOfItAndNoOthers() {
         Partitions.Partitioning read = divided();
-        Axis length = axisOf(read, "gate/String.length(slot.c)");
-        Axis count = axisOf(read, "gate/slot.n");
-        assertFalse(length.classes().isEmpty(), "there is something to be carried or dropped");
 
-        Axis elsewhere = length.measuredAt(count.id(), count.term());
+        assertEquals(List.of("gate/String.length(slot.c)"), idsAt(read, "slot.c"));
+        assertEquals(List.of("gate/slot.n"), idsAt(read, "slot.n"));
+        assertFalse(axisOf(read, "gate/String.length(slot.c)").classes().isEmpty(),
+                "and the one measure is the rules' own division of that number");
+    }
 
-        assertEquals(List.of(), elsewhere.classes());
-        assertEquals(List.of(), elsewhere.cuts());
-        assertEquals(List.of(), elsewhere.parted());
-        assertSame(souther.compiler.check.NarrowedBounds.NOTHING, elsewhere.narrowed(),
-                "where the rules leave the first number's ends is an answer about that number");
-        assertSame(length.type(), elsewhere.type(),
-                "and what stands at the position is what stands there, whichever number is read");
+    /** What one position of the model is measured at, named as a report names it. */
+    private static List<String> idsAt(Partitions.Partitioning read, String path) {
+        PositionMeasurements at = read.measurements().stream()
+                .filter(each -> each.position().path().toString().equals(path))
+                .findFirst().orElse(null);
+        assertNotNull(at, "the behavior takes " + path + ", among " + read.measurements().stream()
+                .map(each -> each.position().path().toString()).toList());
+        return at.axes().stream().map(each -> each.id().toString()).toList();
     }
 
     /**
@@ -343,9 +344,12 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         assertNotNull(again, "the length of a string is a number this compiler names");
         assertNotSame(length.term(), again, "a second naming, built here");
         assertEquals(length.term(), again, "of the number the reading already named");
-        assertSame(again, length.measuredAt(length.id(), again).term(),
+
+        Axis measuring = new Axis(length.id(), again, length.type(),
+                length.classes(), length.cuts());
+
+        assertSame(again, measuring.term(),
                 "so the classes of that number are the classes of an axis measuring it");
-        assertEquals(length.classes(),
-                length.measuredAt(length.id(), again).classes());
+        assertEquals(length.classes(), measuring.classes());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
@@ -209,7 +209,8 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         assertEquals(List.of(), elsewhere.parted());
         assertSame(souther.compiler.check.NarrowedBounds.NOTHING, elsewhere.narrowed(),
                 "where the rules leave the first number's ends is an answer about that number");
-        assertSame(length.at(), elsewhere.at(), "and the position is the position");
+        assertSame(length.type(), elsewhere.type(),
+                "and what stands at the position is what stands there, whichever number is read");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
@@ -68,6 +68,11 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
                 .ask(new Adequacy.Divided(compilation.modules().get(0), "gate")).value();
     }
 
+    /** The same measure, offered another run of classes and another set of lines. */
+    private static Axis carrying(Axis axis, List<PartitionClass> classes, List<Cut> cuts) {
+        return new Axis(axis.id(), axis.term(), axis.type(), classes, cuts);
+    }
+
     private static Axis axisOf(Partitions.Partitioning read, String id) {
         Axis found = read.axes().stream().filter(each -> each.id().toString().equals(id))
                 .findFirst().orElse(null);
@@ -116,7 +121,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         Axis truth = axisOf(read, "gate/slot.on");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> count.carrying(truth.classes(), List.of(), List.of()));
+                () -> carrying(count, truth.classes(), List.of()));
 
         assertTrue(refused.getMessage().contains("slot.on")
                         && refused.getMessage().contains("slot.n"),
@@ -134,7 +139,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
                 .toList();
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> count.carrying(unstamped, List.of(), List.of()));
+                () -> carrying(count, unstamped, List.of()));
 
         assertTrue(refused.getMessage().contains("no measure"), refused.getMessage());
     }
@@ -147,7 +152,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         Axis count = axisOf(read, "gate/slot.n");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> length.carrying(count.classes(), List.of(), List.of()));
+                () -> carrying(length, count.classes(), List.of()));
 
         assertTrue(refused.getMessage().contains("slot.n")
                         && refused.getMessage().contains("String.length(slot.c)"),
@@ -167,7 +172,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         Axis truth = axisOf(read, "gate/slot.on");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> length.carrying(truth.classes(), List.of(), List.of()));
+                () -> carrying(length, truth.classes(), List.of()));
 
         assertTrue(refused.getMessage().contains("String.length(slot.c)"), refused.getMessage());
     }
@@ -181,7 +186,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         Partitions.Partitioning read = divided();
         Axis truth = axisOf(read, "gate/slot.on");
 
-        Axis again = truth.carrying(truth.classes(), List.of(), List.of());
+        Axis again = carrying(truth, truth.classes(), List.of());
 
         assertEquals(truth.classes(), again.classes());
     }
@@ -233,10 +238,10 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
                 .toList();
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> count.carrying(placeless, count.cuts(), List.of()));
+                () -> carrying(count, placeless, count.cuts()));
 
         assertTrue(refused.getMessage().contains("lines"), refused.getMessage());
-        assertEquals(placeless, count.carrying(placeless, List.of(), List.of()).classes(),
+        assertEquals(placeless, carrying(count, placeless, List.of()).classes(),
                 "while with no line to hold, such classes are what a position with no order has");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.BlockedDescent;
-import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
@@ -133,16 +132,9 @@ class OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest {
      */
     @Test
     void twoClassesOfOneLocationWantingDifferentValuesComposeNoRow() {
-        Symbols symbols = symbolsOf();
-        NumericTerm.ValueOf at = new NumericTerm.ValueOf(TermPath.of("a"));
-        Axis hour = new Axis(new AxisId("f", "Time.hour(a)"), at, Type.INT,
-                List.of(number("early", 1).ofTheNumber(at)), List.of());
-        Axis minute = new Axis(new AxisId("f", "Time.minute(a)"), at, Type.INT,
-                List.of(number("late", 40).ofTheNumber(at)), List.of());
-        Generator.Subject subject = new Generator.Subject("f",
-                new BehaviorInputs(List.of("a"), List.of(Type.INT), symbols,
-                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
-                List.of(hour, minute), HeldCounts.NONE);
+        Partitions.Partitioning read = partitioningOf();
+        Generator.Subject subject = new Generator.Subject("gate", inputsOf(), read.axes(),
+                HeldCounts.NONE);
 
         FillResult filled = Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY,
                 Budgets.generation());
@@ -153,9 +145,16 @@ class OneLocationMeasuredAtTwoNumbersIsStillOneLocationTest {
                 filled.unresolved().toString());
     }
 
-    private static PartitionClass number(String id, long candidate) {
-        return PartitionClass.of(id, id, new Recognition.Nothing(),
-                RepresentativeSource.of(FixtureTemplate.integer(candidate)));
+    /** What the behavior takes, as the reader that composes a row is told it. */
+    private static BehaviorInputs inputsOf() {
+        Compilation compilation = Compilation.ofSource(TWO_NUMBERS, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        return new BehaviorInputs(List.of("slot"),
+                compilation.db().ask(new souther.compiler.query.Bodies.Signatures(module)).value()
+                        .get("gate").inputTypes(),
+                souther.compiler.query.Scopes.derived(compilation.db(), module).value(),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 
     private static Symbols symbolsOf() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -307,7 +307,7 @@ class PartitionsTest {
                 let feeFor (amount, region) = Fee { yen = 0 }
                 """, "feeFor");
 
-        assertEquals(2, shipping.derivable().size());
+        assertEquals(2, shipping.partitionAxes().size());
         assertEquals(List.of("UnderThreeThousand", "ThreeThousandOrOver"),
                 classIds(axis(shipping, "amount")));
         assertEquals(List.of("Remote", "NotRemote"), classIds(axis(shipping, "region")));
@@ -345,11 +345,11 @@ class PartitionsTest {
 
         Partitions.Partitioning partitioning = partitioningOf(wide, "run");
 
-        assertEquals(15, partitioning.derivable().size(),
-                () -> "every field is divided: " + partitioning.derivable().stream()
+        assertEquals(15, partitioning.partitionAxes().size(),
+                () -> "every field is divided: " + partitioning.partitionAxes().stream()
                         .map(each -> each.id().toString()).toList());
         assertEquals("run/wide.f14",
-                partitioning.derivable().get(14).id().toString(),
+                partitioning.partitionAxes().get(14).id().toString(),
                 "including the last, which no ordering may quietly leave out");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -219,10 +219,15 @@ class PartitionsTest {
 
     @Test
     void aTypeTheModelDrawsNoLineThroughIsNotDerivable() {
-        Axis note = axis(partitioningOf(KINDS, "submit"), "request.note");
+        Partitions.Partitioning partitioning = partitioningOf(KINDS, "submit");
+        PositionMeasurements note = partitioning.measurements().stream()
+                .filter(each -> each.position().path().toString().equals("request.note"))
+                .findFirst().orElseThrow();
 
-        assertFalse(note.measurable());
-        assertEquals(List.of(), classIds(note));
+        assertEquals(List.of(), note.axes(), "a plain string is measured at nothing");
+        assertTrue(partitioning.undivided().stream()
+                        .anyMatch(each -> each.at().toString().equals("request.note")),
+                "and the position says so, which is where a report reads it");
     }
 
     @Test
@@ -248,7 +253,7 @@ class PartitionsTest {
      */
     @Test
     void aProductIsTakenApartFieldByField() {
-        List<String> paths = partitioningOf(KINDS, "submit").axes().stream()
+        List<String> paths = partitioningOf(KINDS, "submit").positions().stream()
                 .map(a -> a.path().toString()).toList();
 
         assertEquals(List.of("request.kind", "request.cost", "request.urgent", "request.memo",

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -107,7 +107,7 @@ class PartitionsTest {
 
         assertEquals(List.of(), classIds(cost));
         assertFalse(cost.derivable());
-        assertTrue(cost.measurable(), "there is still an edge to reach");
+        assertTrue(cost.asksForARow(), "there is still an edge to reach");
         assertEquals(List.of(Count.of(0L), Count.of(1000L)),
                 cost.cuts().stream().map(Cut::at).toList());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -70,6 +70,13 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
                 .anyMatch(each -> each.at().toString().equals(position) && each.isAbsent());
     }
 
+    /** And that the verdict says a rule states something here that came to no line. */
+    private static boolean leftWithARule(PartitionEvidence evidence, String position) {
+        return evidence.notDerivable().stream()
+                .anyMatch(each -> each.at().toString().equals(position)
+                        && each.why() instanceof UndividedPosition.Why.StatedWithoutALine);
+    }
+
     /** And that the verdict says nothing was established, without saying what stopped it. */
     private static boolean couldNotDerive(PartitionEvidence evidence, String position) {
         return evidence.notDerivable().stream()
@@ -137,19 +144,24 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
     }
 
     /**
-     * And a rule the second phase read and could do nothing with does not take the first phase's
-     * answer away.
+     * A rule the second phase read and could do nothing with is what the position it names is left
+     * with, however far the reading of it got.
      *
      * <p>A body compares the length against a number outside what a length can be: the comparison
      * is understood — it is a threshold, on a term this measures — and it divides nothing, because
-     * no value of the position is on the far side of it.
+     * no value of the position is on the far side of it. Nothing stopped the reading, and the rule
+     * came to no line, so the list is a position a rule was written about and no line drawn on.
      *
-     * <p>So the list comes back to the same place it was, which is a position nothing divides. What
-     * is inside it is a position of its own and answers for itself, and is not what the list is
-     * left with.
+     * <p>Which the report says rather than that the model divides it no way. A reading that got as
+     * far as {@code List.length(items)} knows there is a rule here; an absence says the model
+     * states nothing about the position, and an author reading that stops looking.
+     *
+     * <p>How exactly the rule was filed is how far its reading got, and does not decide where it
+     * lands: a finding at the position and one naming a number of it are both what the position is
+     * left with, and the number stays on the finding for a report to name.
      */
     @Test
-    void aRuleThatDividedNothingLeavesThePositionWithWhatItHad() {
+    void aRuleThatDividedNothingIsWhatThePositionIsLeftWith() {
         PartitionEvidence measured = measured("""
                 module demo
                 data Ok
@@ -161,13 +173,16 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
 
         assertEquals(List.of(), whyAt(measured, "items"),
                 () -> "nothing stopped the reading of the list: " + whyAt(measured, "items"));
-        assertTrue(absent(measured, "items"), "and the model divides it no way");
+        assertFalse(absent(measured, "items"),
+                "a rule was written about it and came to no line, which is not an absence");
+        assertTrue(leftWithARule(measured, "items"), "so that is what it is left with");
         // And what it holds is a position of its own, answering for itself. Nothing is written
         // about the elements here — the guard is on how many there are — so it divides no way
         // either, which is a conclusion about the model and not about this reading.
         assertTrue(absent(measured, "items[*].charge"),
                 "the elements carry no rule, so nothing divides them");
     }
+
 
     /**
      * Issue #631. A sum under a name is that sum, so the position divides into its cases — where

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -393,7 +393,8 @@ final class AnswerClosure {
             // has — and the walk that asks each object what it is meets the end on the way.
             narrowedEnd(Q + "Adequacy$Divided", walked(Scenario.VALID_CORPUS),
                     m(ANSWER, "value"),
-                    m("souther.compiler.partition.Partitions$Partitioning", "axes"), ELEMENT,
+                    m("souther.compiler.partition.Partitions$Partitioning", "measurements"),
+                    ELEMENT, m("souther.compiler.partition.PositionMeasurements", "axes"), ELEMENT,
                     m("souther.compiler.partition.Axis", "narrowed"),
                     m("souther.compiler.check.NarrowedBounds$Reading", "lower")),
             new Known(at(EVERY_ANSWER, "souther.compiler.diag.Diagnostic",
@@ -566,7 +567,8 @@ final class AnswerClosure {
         // The machine a class denotes where what it denotes is a pattern's strings, reached at each
         // of the two places an axis is carried from.
         theMachineUnderALanguage(out, Q + "Adequacy$Divided",
-                part("souther.compiler.partition.Partitions$Partitioning", "axes"), HELD,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
                 part("souther.compiler.partition.Axis", "classes"), HELD,
                 part("souther.compiler.partition.PartitionClass", "denotes"));
         theMachineUnderALanguage(out, Q + "Adequacy$Generated",
@@ -575,7 +577,8 @@ final class AnswerClosure {
                         part("souther.compiler.partition.PartitionClass", "denotes")));
         // The same ends, reached where an axis carries what the reading left the position.
         bothEndsOfARange(out, Q + "Adequacy$Divided",
-                part("souther.compiler.partition.Partitions$Partitioning", "axes"), HELD,
+                part("souther.compiler.partition.Partitions$Partitioning", "measurements"), HELD,
+                part("souther.compiler.partition.PositionMeasurements", "axes"), HELD,
                 part("souther.compiler.partition.Axis", "narrowed"));
         bothEndsOfARange(out, Q + "Adequacy$Generated",
                 then(A_SUBJECT, part("souther.compiler.partition.Generator$Subject", "axes"), HELD,


### PR DESCRIPTION
Closes #1142.

## What was wrong

`Partitions.Partitioning.axes` held two kinds of thing: the measures this compiler made, and one
empty `Axis` per position the reading kept and measured at nothing — a work slot, so that the stage
reading a body's rules had somewhere to put what they add. Over the conformance and bench corpora
(56 behaviors) that was 1075 of 2059 entries.

The ownership between a location and the numbers it is measured at was in neither list, so
`anythingMeasures`, `cameTo` and `blockedIn` recovered it by comparing how each spelled a path, and
every consumer had to remember which entries were measures.

## What is here

`Partitioning` stores one thing:

    Partitioning
      measurements : List<PositionMeasurements>
           position   : PositionAccount
           axes       : List<Axis>              0..*, empty where nothing measures the location
           inspection : BodyCutInspection       what the rules about the location came to

`positions()`, `axes()`, `partitionAxes()`, `undivided()` and `blocked()` are read off it. The
projections keep the order the reading found: the rules are walked a position at a time, so dropping
the empty entries leaves the relative order of the rest alone.

`Axis` carries the position's `Type` rather than its `PositionAccount`, which takes away the path by
which a location's question was asked through whichever number happened to measure it — the one
reader that did (`Coverages.coverageOf`, reading `residue()`) takes the position from the entry it is
measuring. `Axis.pendingAt` and `Axis.measuredAt` are gone, and an axis with no class, no line and
nothing parted is refused where it is built.

The invariants split by owner: an axis holds `id.term == term`, and `PositionMeasurements` checks
that a measure held under a location is of that location's path, reads that location's type, and
belongs to that behavior. Path equality is still used to file incoming evidence and rules into a
position, and to check the integrity above; the ownership is never recovered from it afterwards.

## Measured

Over the same 56 behaviors, before and after:

    positions            2059    2059
    axes                 2059     984
      measurable          984     984
      class-bearing       124     124
      empty              1075       0

`partition axes N` counts what it counted before. The checked-in corpus documents
(`expected.report.json`, `expected.generated.txt`) are unchanged.

## One dependency on the placeholder, found while removing it

The empty axes reached no reader's output, but the term one was built with did: it selected which
term-scoped `RuleWithoutALine` a position with no measure was left with. A `List` whose length a body
compares came back as a position the model divides no way, while the same shape over a type whose own
number is that length came back as one a rule states something about — a difference made by the
representation rather than by the model.

So the rules a location with no measure is left with are the ones filed anywhere in it
(`rule.at().path()`). How exactly a rule was filed is how far its reading got, which the finding
still says and which is what `FilingCoordinate` is for; it does not decide where the finding lands.
`WhatStoppedADerivationIsWhatIsReportedTest.aRuleThatDividedNothingIsWhatThePositionIsLeftWith`
changes with it, and is the witness.

The matching case at a position whose own number is taken of it could not be built: the declarations'
reader turns such a rule into a cut before this stage sees it, so the position has a measure and the
question does not arise. Two models were written for it and both came back measured.

## Verification

`mvn -o test` green from the reactor root (7746 in the compiler module, and every other module),
corpus documents unchanged.

Mutations, each confirmed to fail the test that claims it:

- the refusal of an empty measure — **green before this branch added a test for it**, so
  `AMeasureIsHeldUnderThePositionItMeasuresTest` was written until it went red
- each of the three integrity checks — the first witness for ownership passed for the wrong reason
  (the measure was of another type, so the type check fired), and was rewritten over two locations
  holding the same type
- measuring a location at only the first number its rules name — the `hour`/`minute` witnesses fail
- dropping a location nothing measures from the positions — the `not derivable` witnesses fail
- filing only the findings that name no number at a location with no measure — the witness above
  fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
