### PR TITLE
Ask what the general form needs where it needs it, and name the answer for what was found

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -268,10 +268,12 @@ sealed interface ComparisonAssessment {
             case Cutting.Read.Stopped stopped -> stopped.why().isEmpty()
                     ? aboutNoPosition(comparison, reads, read.symbols())
                     : new Unread(stopped.why());
-            // And where the quantity was read and no line could be built on it, the carrier is
+            // And where the quantity was read and stands on no order this counts, the carrier is
             // what a reader is owed — at the quantity's own coordinates, because the quantity is
-            // what such a rule is about.
-            case Cutting.Read.NoLineOnTheQuantity over -> over.over().isEmpty()
+            // what such a rule is about. The word is what the reading established and not what is
+            // left when several answers were absent: it says the values here carry no order to
+            // draw a line on, and that is exactly what was found.
+            case Cutting.Read.NoOrderToCountOn over -> over.over().isEmpty()
                     ? aboutNoPosition(comparison, reads, read.symbols())
                     : new Unread(atEachOf(over.over(),
                             new BlockReason.UnreadComparisonDomain()));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -191,12 +191,14 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * values, two positions held apart, and a form over several. Nothing here reads the comparison
      * again — what each of them is handed is the form the reading already came to.
      *
-     * <p><b>Which shape it is, and what that shape needs, are two questions and only the second is
-     * a fact about the model.</b> The two narrower readings answer nothing for a form that is not
-     * theirs, and read as an answer that told a rule whose shape was simply not a line on one
-     * position that its values carry no order. So the shapes are tried first and say nothing when
-     * they decline, and what the general form needs — an order that counts, under every term — is
-     * asked once, between the last of them and it.
+     * <p><b>A shape declining and a recognised shape failing to draw are two different things.</b>
+     * A recogniser answers nothing where the form is not its shape and where the orders that shape
+     * would need are not there, and neither of those is an answer about the model — the next shape
+     * may still draw the line, which is exactly what a form on an order that counts nothing does
+     * one reading further down. What must not happen is the other one: a shape that was recognised
+     * and then could not be realized falling to the next reading, where whatever that reading is
+     * short of becomes the reason. So a recogniser is asked first and its answer decides which
+     * reading owns the form, and only then is a line built.
      *
      * <p>Asked in that order and not before them. The narrower readings reach orders this counts
      * nothing on: two strings stand no measurable distance apart and the place they meet is still a
@@ -204,18 +206,20 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      */
     private static Read realized(String behavior, AffineReading read,
                                  Quantities quantities) {
-        // Which shape this quantity is, asked narrowest first. Both of these answer null for a form
-        // that is not theirs, and that is a dispatch and no fact about the model — read as one, a
-        // rule whose shape simply was not a line on one position came out as a rule about values
-        // nothing draws a line on.
-        Cutting drawn = atAPosition(behavior, ComparedLine.fromTheForm(read, quantities),
-                quantities);
-        if (drawn == null) {
-            drawn = apart(behavior, ComparedTerms.fromTheForm(read, quantities), read.claim(),
-                    quantities);
+        // Which shape this quantity is, asked narrowest first, and each answered before anything is
+        // built. A recogniser answering nothing is this form not being that shape, and the next
+        // shape is asked; a recogniser that answered and a line that then could not be built are
+        // two facts about one shape, and falling from the second to the next shape is how the
+        // first came to be reported as the last one's absence.
+        ComparedLine line = ComparedLine.fromTheForm(read, quantities);
+        if (line != null) {
+            return new Read.Cuts(realizedAt(atAPosition(behavior, line, quantities),
+                    "a line on one position", read));
         }
-        if (drawn != null) {
-            return new Read.Cuts(drawn);
+        ComparedTerms pair = ComparedTerms.fromTheForm(read, quantities);
+        if (pair != null) {
+            return new Read.Cuts(realizedAt(apart(behavior, pair, read.claim(), quantities),
+                    "a distance between two positions", read));
         }
         // And what the general form needs, asked once and here. Not before the two above: they
         // reach orders that do not count — two strings stand no measurable distance apart and the
@@ -227,6 +231,31 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
                     AffineReading.filedAt(read.form().coefs().keySet()));
         }
         return new Read.Cuts(overAForm(behavior, read, on, quantities));
+    }
+
+    /**
+     * The line a recognised shape draws, which is one it draws.
+     *
+     * <p>What is watched here is a shape this reading recognised and could not put a line on. Only
+     * one thing refuses past recognition — an order with no place at the level the rule wrote
+     * ({@link LevelSpace#canCutAt}) — and it is a fact about the model rather than a limit of this
+     * compiler: a rule holding two strings three apart asks for a line at a distance the order has
+     * no place for at all, and there is none to find.
+     *
+     * <p>Unreachable while the language admits no arithmetic over an order that counts nothing, so
+     * a distance on such an order is only ever the place the two meet, which every such order has.
+     * That is a fact about what can be written and not about these types, so it stops here rather
+     * than falling to the reading below — where a shape that was recognised would have been
+     * answered for by whether the general form's orders were there, and gone out as values nothing
+     * draws a line on.
+     */
+    private static Cutting realizedAt(Cutting drawn, String shape, AffineReading read) {
+        if (drawn == null) {
+            throw new IllegalStateException("this reading recognised " + shape
+                    + " and its order has no place at the level the rule wrote: "
+                    + read.form() + " at " + read.cut());
+        }
+        return drawn;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -48,11 +48,16 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
     /**
      * What reading {@code comparison} as a line came to.
      *
-     * <p>Three answers, and the two that are not a line are not one absence. A comparison whose
-     * positions cancel was read from end to end and there was no line in it; one this compiler could
-     * not take apart leaves whatever it states unknown. Told apart by a {@code null}, whoever asked
-     * had to work out which — and worked it out by reading the comparison a second time, which is
-     * how a rule read in full came to be described as one whose spelling defeated this compiler.
+     * <p>Four answers, and the three that are not a line are not one absence. A comparison whose
+     * positions cancel was read from end to end and there was no line in it; one this compiler
+     * could not take apart leaves whatever it states unknown; and one whose quantity was read and
+     * stands on no order this counts is neither. Told apart by a {@code null}, whoever asked had to
+     * work out which — and worked it out by reading the comparison a second time, which is how a
+     * rule read in full came to be described as one whose spelling defeated this compiler.
+     *
+     * <p>Each of them says what was found rather than what came of it. An arm named for the absence
+     * of a line holds every way of failing to draw one, so the next one added goes out under the
+     * word the last one earned.
      */
     sealed interface Read {
 
@@ -125,7 +130,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
     }
 
     /**
-     * The same, said as which of the three it is.
+     * The same, said as which of the four it is.
      *
      * <p>The reason a reading stopped is settled here, where it stopped, and not asked for
      * afterwards by whoever met the absence. Worked out later, the reason came from a second walk
@@ -185,6 +190,17 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * <p>Three shapes and one order among them, which is the arithmetic's: one position's own
      * values, two positions held apart, and a form over several. Nothing here reads the comparison
      * again — what each of them is handed is the form the reading already came to.
+     *
+     * <p><b>Which shape it is, and what that shape needs, are two questions and only the second is
+     * a fact about the model.</b> The two narrower readings answer nothing for a form that is not
+     * theirs, and read as an answer that told a rule whose shape was simply not a line on one
+     * position that its values carry no order. So the shapes are tried first and say nothing when
+     * they decline, and what the general form needs — an order that counts, under every term — is
+     * asked once, between the last of them and it.
+     *
+     * <p>Asked in that order and not before them. The narrower readings reach orders this counts
+     * nothing on: two strings stand no measurable distance apart and the place they meet is still a
+     * line, so a reader wanting counting orders first refuses lines the model draws.
      */
     private static Read realized(String behavior, AffineReading read,
                                  Quantities quantities) {
@@ -295,8 +311,11 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * variable — and the four sides of the box its positions sit in are not it.
      *
      * <p>Each position on the order it is written back on, which the reading answers per position.
-     * Only where every one of them has an order with counts under it: a position with no number is
-     * one a sum has nothing to add.
+     * The orders are the parameter and not something asked for here: a position with no number is
+     * one a sum has nothing to add, and whether every term has one is what the caller settled
+     * before choosing this shape at all. So this draws a line and never declines — left able to,
+     * the next refusal added to it would arrive where a missing order is reported and be described
+     * as one.
      *
      * <p><b>Whatever the operator states, and not orders alone.</b> {@code 2 * a == 8} names four
      * and {@code a + b == 10} names the place their sum reaches ten, and both are quantities this
@@ -310,10 +329,12 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         Cutting drawn = made(new BorderQuantity.OverAForm(behavior, read.form(), on),
                 new Level.ACount(new Count(read.cut())), read.claim(), quantities);
         if (drawn == null) {
-            // Every term of this form stands on an order that counts, and an order that counts is
-            // parted anywhere. So this is the two saying different things about one order rather
-            // than a rule this compiler is short of — and told apart from one, it would go out as a
-            // rule about values nothing draws a line on, which is the opposite of what happened.
+            // What this watches: `OverAForm.levels()` answers `steppingBy` or `overFiniteDecimals`,
+            // and neither of those parts anywhere but everywhere — the one order that names a
+            // single place is the one two values meet on, and every term here counts, so that order
+            // is not reachable from this shape. An override added to either of those two is what
+            // would bring it here, and it should stop rather than be reported as a rule about
+            // values nothing draws a line on, which is the opposite of what would have happened.
             throw new IllegalStateException(
                     "a form over orders that count produced a line its order has no place for: "
                             + read.form() + " at " + read.cut());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -93,21 +93,32 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         }
 
         /**
-         * The quantity was read and no line could be built on it: a position with no order to be
-         * counted on, or an order whose values this draws no line against.
+         * The quantity was read, and there is no order this compiler can realize it as a count on.
+         *
+         * <p><b>Named for what was found and not for what came of it.</b> "No line was built" is
+         * true of every way of failing to build one, so an arm carrying that name takes the next
+         * one added to it — and the word a document then prints was decided by whichever answers
+         * happened to be absent rather than by anything anybody established.
+         *
+         * <p>What is established here is one thing: some term of the form stands on no order, or on
+         * one whose values do not count, so a sum over the terms has nothing to be spaced by
+         * ({@link AffineReading#carriers}). A line on a single position and a distance between two
+         * are asked before this and reach orders this does not — two strings stand no measurable
+         * distance apart and are still one above the other — so what is left here is the general
+         * form, and the general form is what needs every term to count.
          *
          * <p>Its own answer and not {@link Stopped}. Nothing about the form fell short — it is
-         * right here, and it is the carrier that stopped this — so the quantity is the subject and
-         * the places are its own, which is what every read comparison's are. Said as a reading that
-         * stopped, the places would come from a walk over the operands, and which of two authorities
-         * a comparison's places came from would turn on which producer built the answer.
+         * right here — so the quantity is the subject and the places are its own, which is what
+         * every read comparison's are. Said as a reading that stopped, the places would come from a
+         * walk over the operands, and which of two authorities a comparison's places came from
+         * would turn on which producer built the answer.
          *
          * @param over the coordinates of the quantity, which is where a reader is sent
          */
-        record NoLineOnTheQuantity(
+        record NoOrderToCountOn(
                 java.util.List<souther.compiler.inputs.FilingCoordinate> over) implements Read {
 
-            public NoLineOnTheQuantity {
+            public NoOrderToCountOn {
                 over = java.util.List.copyOf(over);
             }
         }
@@ -177,6 +188,10 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      */
     private static Read realized(String behavior, AffineReading read,
                                  Quantities quantities) {
+        // Which shape this quantity is, asked narrowest first. Both of these answer null for a form
+        // that is not theirs, and that is a dispatch and no fact about the model — read as one, a
+        // rule whose shape simply was not a line on one position came out as a rule about values
+        // nothing draws a line on.
         Cutting drawn = atAPosition(behavior, ComparedLine.fromTheForm(read, quantities),
                 quantities);
         if (drawn == null) {
@@ -186,14 +201,16 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         if (drawn != null) {
             return new Read.Cuts(drawn);
         }
-        Cutting form = overAForm(behavior, read, quantities);
-        if (form != null) {
-            return new Read.Cuts(form);
+        // And what the general form needs, asked once and here. Not before the two above: they
+        // reach orders that do not count — two strings stand no measurable distance apart and the
+        // place they meet is a line — so a reader asking this first would refuse lines the model
+        // draws.
+        java.util.Map<NumericTerm, TermOrders> on = read.carriers(quantities);
+        if (on == null) {
+            return new Read.NoOrderToCountOn(
+                    AffineReading.filedAt(read.form().coefs().keySet()));
         }
-        // The quantity was read and no line could be built on it. Filed at the quantity, because
-        // the quantity is what the rule is about.
-        return new Read.NoLineOnTheQuantity(
-                AffineReading.filedAt(read.form().coefs().keySet()));
+        return new Read.Cuts(overAForm(behavior, read, on, quantities));
     }
 
     /**
@@ -288,17 +305,20 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * the form is right here.
      */
     private static Cutting overAForm(String behavior, AffineReading read,
+                                     java.util.Map<NumericTerm, TermOrders> on,
                                      Quantities quantities) {
-        if (read == null || read.claim() instanceof ComparisonClaim.Nothing) {
-            return null;
-        }
-        java.util.Map<NumericTerm, TermOrders> on =
-                read.carriers(quantities);
-        if (on == null) {
-            return null;
-        }
-        return made(new BorderQuantity.OverAForm(behavior, read.form(), on),
+        Cutting drawn = made(new BorderQuantity.OverAForm(behavior, read.form(), on),
                 new Level.ACount(new Count(read.cut())), read.claim(), quantities);
+        if (drawn == null) {
+            // Every term of this form stands on an order that counts, and an order that counts is
+            // parted anywhere. So this is the two saying different things about one order rather
+            // than a rule this compiler is short of — and told apart from one, it would go out as a
+            // rule about values nothing draws a line on, which is the opposite of what happened.
+            throw new IllegalStateException(
+                    "a form over orders that count produced a line its order has no place for: "
+                            + read.form() + " at " + read.cut());
+        }
+        return drawn;
     }
 
     /** What the operator of a line at a position states, which the reading of it already answered

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -193,16 +193,20 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      *
      * <p><b>A shape declining and a recognised shape failing to draw are two different things.</b>
      * A recogniser answers nothing where the form is not its shape and where the orders that shape
-     * would need are not there, and neither of those is an answer about the model — the next shape
-     * may still draw the line, which is exactly what a form on an order that counts nothing does
-     * one reading further down. What must not happen is the other one: a shape that was recognised
-     * and then could not be realized falling to the next reading, where whatever that reading is
-     * short of becomes the reason. So a recogniser is asked first and its answer decides which
-     * reading owns the form, and only then is a line built.
+     * would need are not there. The second of those is a fact about the model — an order is missing,
+     * and that is worth saying — but it is not this reading's to classify, because a reading further
+     * down may still answer: a form on an order that counts nothing is turned away by both narrower
+     * shapes and gets its line from neither, and what it is left with is settled at the one place
+     * that knows it has run out of readings.
      *
-     * <p>Asked in that order and not before them. The narrower readings reach orders this counts
-     * nothing on: two strings stand no measurable distance apart and the place they meet is still a
-     * line, so a reader wanting counting orders first refuses lines the model draws.
+     * <p>What must not happen is the other one: a shape that was recognised and then could not be
+     * realized falling to the next reading, where whatever that reading is short of becomes the
+     * reason. So a recogniser is asked first and its answer decides which reading owns the form,
+     * and only then is a line built.
+     *
+     * <p>And that one place is after the narrower shapes, not before them. They reach orders this
+     * counts nothing on: two strings stand no measurable distance apart and the place they meet is
+     * still a line, so a reader asking for counting orders first refuses lines the model draws.
      */
     private static Read realized(String behavior, AffineReading read,
                                  Quantities quantities) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
@@ -354,6 +354,26 @@ class ALineBetweenTwoPositionsIsStillALineTest {
     }
 
     /**
+     * And what each position is left with is the carrier, which is what was found.
+     *
+     * <p>The word beside the one above, because that one holds over any way of drawing no line and
+     * this one says which. Both positions stand on an order this counts nothing on, so a sum over
+     * them has nothing to be spaced by — and that is established where the orders are asked for
+     * rather than left over when three readings declined.
+     *
+     * <p>Paired with {@link #aCarrierOfStringsDrawsOneToo}, which is the same question answered the
+     * other way: two strings also count nothing and the place they meet is a line, so a reader
+     * asking for counting orders before the narrower readings would refuse a line the model draws.
+     * Together they hold the question to "is there an order this quantity can be realized on" and
+     * away from "is this domain numeric".
+     */
+    @Test
+    void aCarrierNoOrderCountsOnSaysThatAtEachPositionOfTheQuantity() {
+        assertEquals(List.of("a: UNSUPPORTED_DOMAIN", "b: UNSUPPORTED_DOMAIN"),
+                notRead(NO_CARRIER));
+    }
+
+    /**
      * An offset on one side moves the line rather than taking it away.
      *
      * <p>{@code charge > ceiling + 1000} is {@code charge - ceiling > 1000}: a line on the same


### PR DESCRIPTION
Closes #1193. Splits off #1206.

## What was wrong

`Cutting.realized` tried three readings and concluded from their combined silence, and
`ComparisonAssessment` wrote one word for that silence — `UnreadComparisonDomain`, the values
compared are not ones a line can be drawn on here.

Nothing established that. The nulls it read do not mean one thing:

- **which shape this quantity is.** `ComparedLine.fromTheForm` answers null for a form that is not
  over one coordinate, `ComparedTerms.fromTheForm` for one that is not a pair. A dispatch, carrying
  no fact about the model.
- **whether the shape can be realized.** The same two answer null where an order is absent or does
  not count, and `made` where an order has no place at the level the rule wrote. Facts, and not the
  same fact.

`LevelSpace` writes the last one down itself: a rule holding two strings three apart "asks for a
line at a distance the order has no place for at all, which is not a line this compiler could not
find — there is none". Reported as `UnreadComparisonDomain`, a model that states something with no
line is described as one this compiler was not able to read.

This is #1148's shape one layer down — a reason recovered by a consumer from an absence rather than
said by what holds the fact.

## What it is now

```java
// Which shape it is, narrowest first, and each answered before anything is built.
ComparedLine line = ComparedLine.fromTheForm(read, quantities);
if (line != null) {
    return new Read.Cuts(realizedAt(atAPosition(behavior, line, quantities),
            "a line on one position", read));
}
ComparedTerms pair = ComparedTerms.fromTheForm(read, quantities);
if (pair != null) {
    return new Read.Cuts(realizedAt(apart(behavior, pair, read.claim(), quantities),
            "a distance between two positions", read));
}
// And what the general form needs, asked once and here.
Map<NumericTerm, TermOrders> on = read.carriers(quantities);
if (on == null) {
    return new Read.NoOrderToCountOn(AffineReading.filedAt(read.form().coefs().keySet()));
}
return new Read.Cuts(overAForm(behavior, read, on, quantities));
```

**A recogniser is asked first, and its answer decides which reading owns the form.** A recogniser
answering nothing is this form not being that shape, and the next shape is asked; a recogniser that
answered and a line that then could not be built are two facts about one shape, and the second stops
at `realizedAt` rather than falling to a reading whose own shortfall would become the reason.

A recogniser's null is not, in itself, free of facts about the model — an order the shape would need
may be missing, and that is worth saying. What it is not is this reading's to classify, because a
reading further down may still answer. A form on an order that counts nothing is turned away by both
narrower shapes and is settled at the one place that knows it has run out of readings.

**That place is after the shape readings, not before.** They reach orders that do not count — two
strings stand no measurable distance apart and the place they meet is a line — so asking for
counting orders first refuses lines the model draws.

**`overAForm` is total.** Its preconditions were the claim and the carriers; both are settled before
it is called. Past them `made` refuses only where an order that counts has no place at a level,
which is two readings disagreeing about one order rather than a rule this compiler is short of, and
it says so where it happens.

**`canCutAt` stays.** `atAPosition`, `apart`, `movedTo` and `Seam` ask it for their own reasons, and
a false there is a real answer for a distance on the meeting-point order. What is gone is `made`
turning one into a null that becomes a published word.

**The arm is named for what was found.** `NoLineOnTheQuantity` held for every way of failing to
build a line, so the next one added would have gone out under the word this one earned.
`NoOrderToCountOn` is made at one place, from the answer that decides it.

## Measured

Which reading answers, over the whole suite, against whether every term has an order that counts:

```
atAPosition           carriers present   1994
overAForm             carriers present   1285
apart                 carriers present    360
apart                 carriers ABSENT       7
NoOrderToCountOn      carriers absent       1
```

The 7 are why the gate cannot come first. The 1285 are why `overAForm` is total: `made` refused none
of them, and the only `canCutAt` override belongs to an order that does not count, which the gate
has already excluded.

## Controls

`aCarrierNoOrderCountsOnSaysThatAtEachPositionOfTheQuantity` is new, and it is the one the route was
missing: before it, changing the published word for this answer to anything else left the whole
suite green. It pins `a: UNSUPPORTED_DOMAIN, b: UNSUPPORTED_DOMAIN` for the model that reaches the
arm.

`aCarrierOfStringsDrawsOneToo` is the same question from the other side. The pair holds this to "is
there an order this quantity can be realized on" rather than "is this domain numeric".

Mutations: moving the gate ahead of the shape readings turns 5 tests red across 4 classes, that one
among them; changing the word for the reached route turns the new control red.

And for the boundary above it, one mutation shows both halves. Make the meeting-point order refuse
the place two values meet, then run `aCarrierOfStringsDrawsOneToo` twice: with the shapes falling
through to the general form it reports `UNSUPPORTED_DOMAIN`, and with the recogniser asked first it
stops and names the shape it recognised. A recogniser succeeding and `made` then refusing happens 0
times in this suite for either shape, so what stands there is a tripwire on a language change and is
written as one.

Full suite green, 7788.

## Split off

#1206 — `ComparisonClaim.Nothing` is still spelled six times below the point where an operator has
been established to compare. The arm that turned it into a published word is gone here; making it
inexpressible wants a narrower claim type across `AffineReading`, `ComparedLine`, `ComparedTerms`,
`ReachingCuts` and `Cutting`, which is the reason it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
