### PR TITLE
Stop a reading of a position where it has been, not after so many names

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ElementBindings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ElementBindings.java
@@ -141,11 +141,10 @@ public record ElementBindings(Map<BindingId, Core> containers, Map<BindingId, Co
                     provenance.projectedFrom(parameter), held)) {
                 return;
             }
-            java.util.List<String> steps =
-                    souther.compiler.inputs.InputPath.projectionOf(body, parameter, held, symbols);
-            if (steps != null) {
-                out.put(read.binding(),
-                        new souther.compiler.inputs.ElementProjection(steps));
+            souther.compiler.inputs.ElementProjection projected =
+                    souther.compiler.inputs.ElementProjection.read(body, parameter, held, symbols);
+            if (projected != null) {
+                out.put(read.binding(), projected);
             }
         });
         return out;

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -554,10 +554,10 @@ public final class PathReachability {
 
     /** Where a side of a comparison sits, reading through a newtype's own value. */
     private TermPath pathUnder(Core side, InputReads reads) {
-        TermPath here = reads.pathOf(side, symbols);
+        TermPath here = reads.pathOf(side, symbols).found();
         return here != null ? here
-                : side instanceof Core.FieldAccess field ? reads.pathOf(field.target(), symbols)
-                        : null;
+                : side instanceof Core.FieldAccess field
+                        ? reads.pathOf(field.target(), symbols).found() : null;
     }
 
     /** What the rules leave {@code position}, where they leave it numbers at all. */
@@ -649,7 +649,7 @@ public final class PathReachability {
         if (arms == null) {
             return;
         }
-        TermPath path = reads.pathOf(match.scrutinee(), symbols);
+        TermPath path = reads.pathOf(match.scrutinee(), symbols).found();
         if (path == null) {
             return;   // not a position of this input: nothing here has rules about it
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -8,6 +8,7 @@ import souther.compiler.coverage.ControlPointId;
 import souther.compiler.inputs.Admits;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.Position;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.NumericDomain;
@@ -554,10 +555,18 @@ public final class PathReachability {
 
     /** Where a side of a comparison sits, reading through a newtype's own value. */
     private TermPath pathUnder(Core side, InputReads reads) {
-        TermPath here = reads.pathOf(side, symbols).found();
+        TermPath here = positionOf(side, reads);
         return here != null ? here
-                : side instanceof Core.FieldAccess field
-                        ? reads.pathOf(field.target(), symbols).found() : null;
+                : side instanceof Core.FieldAccess field ? positionOf(field.target(), reads) : null;
+    }
+
+    /** Where {@code e} stands, and null where it stands nowhere or was not read — which are one
+     *  answer to a reader asking whether the guards above reach a position. */
+    private TermPath positionOf(Core e, InputReads reads) {
+        return switch (reads.pathOf(e, symbols)) {
+            case PathResolution.At(var at) -> at;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
     }
 
     /** What the rules leave {@code position}, where they leave it numbers at all. */
@@ -649,9 +658,11 @@ public final class PathReachability {
         if (arms == null) {
             return;
         }
-        TermPath path = reads.pathOf(match.scrutinee(), symbols).found();
+        // Not a position of this input, or not one this reading reached: either way nothing here
+        // has rules about it to carry.
+        TermPath path = positionOf(match.scrutinee(), reads);
         if (path == null) {
-            return;   // not a position of this input: nothing here has rules about it
+            return;
         }
         // The reading this walk was given, which is the one held here. Which location the name
         // stands for is the environment's answer and what the rules leave there is the reading's,

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
@@ -111,7 +111,7 @@ public final class UnreachableClaims {
     private static void claimedIn(Core.Match match, InputReads reads, Symbols symbols,
                                   souther.compiler.coverage.CoverageSites.Plan plan,
                                   NormalReturn answering, List<Claim> found) {
-        TermPath path = reads.pathOf(match.scrutinee(), symbols);
+        TermPath path = reads.pathOf(match.scrutinee(), symbols).found();
         if (path == null) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
@@ -6,6 +6,7 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.NormalReturn;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.TermPath;
 
 import java.util.ArrayList;
@@ -111,7 +112,12 @@ public final class UnreachableClaims {
     private static void claimedIn(Core.Match match, InputReads reads, Symbols symbols,
                                   souther.compiler.coverage.CoverageSites.Plan plan,
                                   NormalReturn answering, List<Claim> found) {
-        TermPath path = reads.pathOf(match.scrutinee(), symbols).found();
+        // A claim is about a position, so a scrutinee that names none carries none — and one this
+        // reading did not follow carries none it could name either.
+        TermPath path = switch (reads.pathOf(match.scrutinee(), symbols)) {
+            case PathResolution.At(var at) -> at;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
         if (path == null) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BindingEnvironment.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BindingEnvironment.java
@@ -1,0 +1,61 @@
+package souther.compiler.inputs;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+
+/**
+ * What is known of the names in a tree, as facts and with nothing made of them.
+ *
+ * <p>Two readings are built out of these and they are not the same reading. What a name stands for
+ * ({@link ReadMeaning}) is one, and which position of the input an expression reaches
+ * ({@link InputPath}) is the other; the first is written in terms of the second, and both are
+ * written in terms of what is here. Between them there is one order to read these facts in, and it
+ * belongs to whichever reading a caller asked for.
+ *
+ * <p><b>Facts and never an answer.</b> A reading held here would be reachable from the reading built
+ * on it, and the two would call each other: what a name means is worked out by asking which position
+ * it reaches, so a walk after a position that could ask what a name means would be asking a question
+ * whose answer it is. Kept to facts, that is not something a caller can write.
+ *
+ * <p>Which is also what keeps a traversal from measuring itself against the environment. How many
+ * names are known here is not how far a value's provenance runs — a name bound in one arm is read
+ * under bindings written elsewhere — and there is nothing to count with: what stops a walk over
+ * these facts is where it has been ({@link BindingTrail}), never how much there is.
+ */
+public interface BindingEnvironment {
+
+    /** The position {@code binding} is the name of, or null where it names none. */
+    TermPath rootOf(BindingId binding);
+
+    /** What {@code binding} holds where this reading has got to, or null where it holds nothing
+     *  here. */
+    Core boundValueOf(BindingId binding);
+
+    /**
+     * The same over the whole body rather than down the way to here, or null where nothing bound it.
+     *
+     * <p>Beside {@link #boundValueOf} and not a wider version of it. A container built by one
+     * operation and handed to the next is bound beside the closure that reads it rather than above
+     * it, so the way to it is not the way here — which is a thing to reach for when the question is
+     * where a container's elements are, and not when it is what a name stands for.
+     */
+    Core heldAnywhereBy(BindingId binding);
+
+    /** The container an operation handed {@code binding} an element of, or null where none did. */
+    Core containerOf(BindingId binding);
+
+    /** The binding whose elements {@code binding}'s are, or null where none is recorded. */
+    BindingId sameElementsAs(BindingId binding);
+
+    /** The binding {@code binding}'s elements were made from, or null where none is recorded. */
+    BindingId madeFrom(BindingId binding);
+
+    /**
+     * Whether an operation the language defines the meaning of is left standing in this tree.
+     *
+     * <p>It is in the representation a declaration's own rules are read in and it is not in the one
+     * that runs. A call left standing names no location, which is an answer where such a tree is
+     * what was handed over and a fault in the caller where it is not.
+     */
+    boolean callsStand();
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BindingTrail.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BindingTrail.java
@@ -1,0 +1,64 @@
+package souther.compiler.inputs;
+
+import souther.compiler.diag.TheCompilerDisagreesWithItself;
+import souther.compiler.types.BindingId;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * The bindings a reading of where a value came from is inside, so that a walk over the binding graph
+ * stops where it arrives at one it is already answering.
+ *
+ * <p>The whole of what stops such a walk. Everything else it does descends an expression — a field's
+ * target, a call's argument, a {@code let}'s body — and a tree is finite, so a step that stays
+ * inside one is a step nothing has to bound. What crosses to another expression is a binding: what a
+ * name holds, what handed a name the elements of a container, which binding another's elements are
+ * the same as. Those steps are the graph, and this is where the graph is kept acyclic.
+ *
+ * <p><b>The way here and not the ways gone.</b> A binding leaves the trail when the walk that
+ * entered it comes back, so two attempts one after the other are two walks and neither is the
+ * other's cycle: a name is answered for by what it holds, and where that reaches no position, by
+ * being an element of a container — the same binding, twice, along different ways. A set that only
+ * grew would refuse the second for having been to the first, and the answer would depend on which
+ * order the attempts happen to be written in.
+ *
+ * <p>What a cycle is, is that this compiler's own representation is not what it says it is: a
+ * binding holds one value, worked out where the binding was written, so a value read through itself
+ * is nothing a body could mean. So it is raised rather than reported. A walk that answered "no
+ * position" for it would say of a model that it states no rule where a position, and a reader has no
+ * way to tell that from a model that states none.
+ */
+final class BindingTrail {
+
+    private final Set<BindingId> active = new HashSet<>();
+
+    /**
+     * {@code answer}, worked out with {@code binding} on the way.
+     *
+     * <p>Wrapped around the step rather than checked before it, so that leaving is not something a
+     * caller can forget on the way out of an arm.
+     */
+    <T> T through(BindingId binding, Supplier<T> answer) {
+        if (!active.add(binding)) {
+            throw new ReadThroughItself(binding);
+        }
+        try {
+            return answer.get();
+        } finally {
+            active.remove(binding);
+        }
+    }
+
+    /** A binding whose value is read through the binding itself. */
+    static final class ReadThroughItself extends IllegalStateException
+            implements TheCompilerDisagreesWithItself {
+
+        private static final long serialVersionUID = 1L;
+
+        ReadThroughItself(BindingId binding) {
+            super("the value of " + binding + " is read through " + binding);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BindingTrail.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BindingTrail.java
@@ -24,11 +24,16 @@ import java.util.function.Supplier;
  * grew would refuse the second for having been to the first, and the answer would depend on which
  * order the attempts happen to be written in.
  *
- * <p>What a cycle is, is that this compiler's own representation is not what it says it is: a
- * binding holds one value, worked out where the binding was written, so a value read through itself
- * is nothing a body could mean. So it is raised rather than reported. A walk that answered "no
- * position" for it would say of a model that it states no rule where a position, and a reader has no
- * way to tell that from a model that states none.
+ * <p>What a cycle is, is that this compiler's own representation is not what it says it is. What is
+ * violated is not that a binding holds one value — two bindings holding each other hold one value
+ * each — but that the lineage built here runs one way: what a name holds is worked out where the
+ * name was written, from what stood before it, and the record of which binding another's elements
+ * came from is written where the operation that made them still stood. A walk that arrives back at
+ * a binding it is answering has been handed a graph nothing here builds.
+ *
+ * <p>So it is raised rather than reported. A walk that answered "no position" for it would say of a
+ * model that it states no rule where a position, and a reader has no way to tell that from a model
+ * that states none.
  */
 final class BindingTrail {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ElementProjection.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ElementProjection.java
@@ -1,6 +1,12 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.Location;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+
 import java.util.List;
+import java.util.Map;
 
 /**
  * Where in an element the value a walk answered stands: the steps from the element to it.
@@ -23,6 +29,87 @@ public record ElementProjection(List<String> steps) {
 
     public ElementProjection {
         steps = List.copyOf(steps);
+    }
+
+    /**
+     * What a closure whose parameter is {@code element} answered, as the way from the element to it,
+     * or null where the answer is not read out of the element.
+     *
+     * <p>Read here and not where a position of the input is worked out. That reading asks which
+     * position of a behavior's input an expression names and has the roots, the containers and the
+     * provenance of elements to answer with; this one asks where inside one value another value
+     * stands, and a name, a {@code let} and a field are the whole of what it takes. Answered by the
+     * same walk, the steps that reach a behavior's parameters would be reachable from here, and the
+     * relative way inside an element would quietly become an absolute one.
+     *
+     * <p><b>Null wherever the answer is not read out of the element.</b> A branch chooses between
+     * two of them and is neither; arithmetic over one is a value the element does not hold; a
+     * construction is something new. None of those is a place a row writes, so a rule about what a
+     * walk answered is not a rule about any position, and saying so is this reading's whole job on
+     * that side.
+     *
+     * <p>Nothing here says the answer is one per element. That is a fact about the operation that
+     * handed the closure its elements, proved where that operation stood; a caller wanting a run
+     * needs both, and this is the half about the reading.
+     *
+     * @param held what each binding on the way holds, over the whole body the closure was left in
+     */
+    public static ElementProjection read(Core answer, BindingId element,
+                                         Map<BindingId, Core> held, Symbols symbols) {
+        List<String> steps = new Reading(held, symbols).from(answer, element);
+        return steps == null ? null : new ElementProjection(steps);
+    }
+
+    /**
+     * One reading of one closure's answer.
+     *
+     * <p>A value rather than a run of static calls, so that the bindings it is inside travel with
+     * it. What stops it is that walk over the binding graph coming back to a binding it is already
+     * answering ({@link BindingTrail}), which is the same law the reading of an input position
+     * stops by — the one thing the two readings share.
+     */
+    private record Reading(Map<BindingId, Core> held, Symbols symbols) {
+
+        private List<String> from(Core e, BindingId element) {
+            return steps(e, element, new BindingTrail());
+        }
+
+        private List<String> steps(Core e, BindingId element, BindingTrail trail) {
+            switch (e) {
+                // What a `let` comes to is what its body comes to, and the name it bound is answered
+                // where it is read. Ordinary binding semantics, and what a helper applied to the
+                // element leaves behind once it is spliced in: `amountOf(line).value` is a field of
+                // a binding holding the element, and reading only the field would stop at the
+                // splice.
+                case Core.LetIn let -> {
+                    return steps(let.body(), element, trail);
+                }
+                case Core.Read read -> {
+                    if (element.equals(read.binding())) {
+                        return List.of();
+                    }
+                    Core through = held.get(read.binding());
+                    return through == null ? null
+                            : trail.through(read.binding(),
+                                    () -> steps(through, element, trail));
+                }
+                case Core.FieldAccess fa -> {
+                    List<String> base = steps(fa.target(), element, trail);
+                    if (base == null) {
+                        return null;
+                    }
+                    if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
+                        return base;
+                    }
+                    List<String> longer = new java.util.ArrayList<>(base);
+                    longer.add(fa.field());
+                    return List.copyOf(longer);
+                }
+                case null, default -> {
+                    return null;
+                }
+            }
+        }
     }
 
     /** The position this reaches from {@code element}. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDemand.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDemand.java
@@ -84,9 +84,11 @@ public record InputDemand(List<TermPath> paths) {
     }
 
     private static void walk(Core e, InputReads names, Symbols symbols, Set<TermPath> found) {
-        TermPath at = names.pathOf(e, symbols).found();
-        if (at != null) {
-            found.add(at);
+        // What is demanded are the positions named. One that stands nowhere and one this reading
+        // did not follow are alike in demanding none: what a walk cannot name, nothing asks for.
+        switch (names.pathOf(e, symbols)) {
+            case PathResolution.At(var at) -> found.add(at);
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> { }
         }
         switch (e) {
             // The body of a `let` is where the name stands for what was bound to it.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDemand.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDemand.java
@@ -84,7 +84,7 @@ public record InputDemand(List<TermPath> paths) {
     }
 
     private static void walk(Core e, InputReads names, Symbols symbols, Set<TermPath> found) {
-        TermPath at = names.pathOf(e, symbols);
+        TermPath at = names.pathOf(e, symbols).found();
         if (at != null) {
             found.add(at);
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -38,7 +38,12 @@ public final class InputNumber {
     public static NumericTerm of(Core e, InputDomain inputs, InputReads reads, Symbols symbols) {
         NumericMeasures.Measured measured = NumericMeasures.takenIn(e);
         if (measured != null) {
-            TermPath of = reads.pathOf(measured.of(), symbols).found();
+            // A taking is of a location, and a walk that named none is a walk with no location to
+            // take it of — whether the argument stands nowhere or was not read to the end.
+            TermPath of = switch (reads.pathOf(measured.of(), symbols)) {
+                case PathResolution.At(var at) -> at;
+                case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+            };
             if (of != null) {
                 return NumericTerm.TakenOf.of(measured.operation(), of,
                         inputs.typeAt(of, symbols), symbols);
@@ -48,8 +53,13 @@ public final class InputNumber {
             // those values are read from a place.
             return overARun(measured, inputs, reads, symbols);
         }
-        TermPath path = reads.pathOf(e, symbols).found();
-        return path == null ? null : new NumericTerm.ValueOf(path);
+        // And a number of the input is the value at a position, so an expression naming none names
+        // no number here — the same answer for a value the input does not hold and for one this
+        // reading did not follow.
+        return switch (reads.pathOf(e, symbols)) {
+            case PathResolution.At(var at) -> new NumericTerm.ValueOf(at);
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
     }
 
     /**
@@ -104,7 +114,12 @@ public final class InputNumber {
             return null;
         }
         ElementProjection answered = where.elements().projectionAt(element);
-        TermPath at = where.elementAt(element, symbols).found();
+        // Where the elements stand, and nothing where they stand nowhere: a run is over the values
+        // at a position, so a container this reading could not place leaves no run to take.
+        TermPath at = switch (where.elementAt(element, symbols)) {
+            case PathResolution.At(var stands) -> stands;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
         if (answered == null || at == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputNumber.java
@@ -38,7 +38,7 @@ public final class InputNumber {
     public static NumericTerm of(Core e, InputDomain inputs, InputReads reads, Symbols symbols) {
         NumericMeasures.Measured measured = NumericMeasures.takenIn(e);
         if (measured != null) {
-            TermPath of = reads.pathOf(measured.of(), symbols);
+            TermPath of = reads.pathOf(measured.of(), symbols).found();
             if (of != null) {
                 return NumericTerm.TakenOf.of(measured.operation(), of,
                         inputs.typeAt(of, symbols), symbols);
@@ -48,7 +48,7 @@ public final class InputNumber {
             // those values are read from a place.
             return overARun(measured, inputs, reads, symbols);
         }
-        TermPath path = reads.pathOf(e, symbols);
+        TermPath path = reads.pathOf(e, symbols).found();
         return path == null ? null : new NumericTerm.ValueOf(path);
     }
 
@@ -104,7 +104,7 @@ public final class InputNumber {
             return null;
         }
         ElementProjection answered = where.elements().projectionAt(element);
-        TermPath at = where.elementAt(element, symbols);
+        TermPath at = where.elementAt(element, symbols).found();
         if (answered == null || at == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -32,6 +32,10 @@ import souther.compiler.types.BindingId;
  * a count of how many names a reading may pass through is a count of how a model was written, and
  * one name more than it allows is a position this reports as one nothing names.
  *
+ * <p>Which is about what stops the steps and not about how many shapes are taken. Not every shape
+ * is descended — an expression that binds a name of its own is one this does not go under, and it
+ * comes back said rather than answered ({@link PathResolution.Reason}).
+ *
  * <p>What is known of the names comes in as facts and nothing else ({@link BindingEnvironment}).
  * How many of them there are is not a fact about how far a value's provenance runs — a name bound in
  * an arm is read under bindings written elsewhere — and a reading of what a name means is built on
@@ -156,15 +160,7 @@ public final class InputPath {
                 // walks over one collection joined into one leave a binding that is both: it
                 // holds what the first walk made, and it is what the second was handed. Stopping
                 // at the first left every rule inside the second reading as being about nothing.
-                PathResolution element = elementOf(r.binding(), names);
-                if (element instanceof PathResolution.At) {
-                    yield element;
-                }
-                // And where neither reached one, what the name holds decides which of the two
-                // answers this is. A name holding a shape this does not read is a name whose
-                // position is not known; saying instead that it stands at none would be this
-                // compiler's reach reported as the model's silence.
-                yield holds instanceof PathResolution.Unread ? holds : element;
+                yield either(holds, elementOf(r.binding(), names));
             }
             case Core.FieldAccess fa -> switch (named(fa.target(), names)) {
                 case PathResolution.At(var base) -> new PathResolution.At(
@@ -225,17 +221,36 @@ public final class InputPath {
         if (named instanceof PathResolution.At) {
             return named;
         }
-        // And where the expression does not name a position, its elements may still be at one — so
-        // the ways an operation's answer holds them are tried, and what the expression itself came
-        // to is what is left where none of them arrives.
-        PathResolution through = elementsOf(e, names, named);
-        return through instanceof PathResolution.At || !(named instanceof PathResolution.Unread)
-                ? through : named;
+        // And where the expression names no position, its elements may still be at one, so the ways
+        // an operation's answer holds them are tried beside it.
+        return either(named, elementsOf(e, names));
     }
 
-    /** The ways an operation's answer holds the elements of what it was given, and {@code named}
-     *  where none of them reaches a position. */
-    private PathResolution elementsOf(Core e, BindingEnvironment names, PathResolution named) {
+    /**
+     * The answer of two readings of one expression.
+     *
+     * <p>A position wherever either reached one, since each is a way to the same place and neither
+     * is asked unless the other came back without it. Where neither did, what this compiler did not
+     * read stands over what the model does not hold: one of the two says the answer is not known
+     * here, and an absence that has that in it is not an absence.
+     *
+     * <p>The one place the three are ordered. Written at each meeting of two readings instead, the
+     * orderings drift apart, and the one that forgets turns a reading that stopped into a model
+     * that states nothing — which is the whole of what this type is for.
+     */
+    private static PathResolution either(PathResolution one, PathResolution other) {
+        if (one instanceof PathResolution.At) {
+            return one;
+        }
+        if (other instanceof PathResolution.At) {
+            return other;
+        }
+        return one instanceof PathResolution.Unread ? one : other;
+    }
+
+    /** The ways an operation's answer holds the elements of what it was given, and no position
+     *  where the expression is not one of them. */
+    private PathResolution elementsOf(Core e, BindingEnvironment names) {
         if (e instanceof Core.Read r) {
             // Through a binding an expansion wrote, where the operation it removed answered the
             // elements it was given. The operation is gone from this tree, so what says so was
@@ -249,16 +264,16 @@ public final class InputPath {
             // path to here: a container built by one operation and handed to the next is bound
             // beside the closure that reads it rather than above it.
             Core held = names.heldAnywhereBy(r.binding());
-            return held == null ? named
+            return held == null ? new PathResolution.NotAPosition()
                     : trail.through(r.binding(), () -> containerPath(held, names));
         }
         // Or through an operation the language keeps standing that answers what it was given.
         if (!(e instanceof Core.Call call) || !(call.fn() instanceof Core.Reached reached)) {
-            return named;
+            return new PathResolution.NotAPosition();
         }
         ArgumentRef holds = ElementLineage.holdsTheElementsOf(reached.denotes());
         int argument = holds == null ? -1 : CallArguments.positionIn(holds, reached.denotes());
-        return argument < 0 || argument >= call.args().size() ? named
+        return argument < 0 || argument >= call.args().size() ? new PathResolution.NotAPosition()
                 : containerPath(call.args().get(argument), names);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -9,7 +9,8 @@ import souther.compiler.semantics.ElementLineage;
 import souther.compiler.types.BindingId;
 
 /**
- * Which position of a behavior's input an expression names, or nothing where it names none.
+ * Which position of a behavior's input an expression names, where it names none, or where this did
+ * not read far enough to say ({@link PathResolution}).
  *
  * <p>One answer, for every reader of a body that has something to say about a position. A
  * {@code guard} comparing a field, a {@code match} on a parameter and an arm declaring a case
@@ -77,10 +78,23 @@ public final class InputPath {
         /**
          * The binding whose elements {@code binding}'s are, or null where this question is not
          * entitled to one.
+         *
+         * <p>Answered per question and never by asking whether this is one of them. A question added
+         * here is one nobody has said what these edges mean for, and read as "not that one" it would
+         * follow whichever edges the last question happened to leave — the answer arrived at by not
+         * being asked.
          */
         BindingId predecessorOf(BindingId binding, BindingEnvironment names) {
             BindingId same = names.sameElementsAs(binding);
-            return same != null || this == NAMED_POSITION ? same : names.madeFrom(binding);
+            if (same != null) {
+                return same;
+            }
+            return switch (this) {
+                // What is made from a position came from it and is not it, so the walk after which
+                // position an expression names stops where the elements stop being the same ones.
+                case NAMED_POSITION -> null;
+                case VALUE_ORIGIN -> names.madeFrom(binding);
+            };
         }
     }
 
@@ -108,7 +122,7 @@ public final class InputPath {
     }
 
     /**
-     * The position {@code e}'s value came from, or null where it came from none.
+     * Where {@code e}'s value came from, and that it came from none where it did.
      *
      * <p>Beside {@link #of} and licensing less. That one answers which position an expression names,
      * and what a row writes at a position is what a rule about it is about; this answers where a
@@ -125,7 +139,7 @@ public final class InputPath {
     }
 
     /**
-     * The position an element handed to {@code binding} stands at, or null where it stands at none.
+     * Where an element handed to {@code binding} stands, and that it stands at none where it does.
      *
      * <p>What an operation of the language hands its closure is an element of the container it was
      * given, so the name it arrives under stands at that container's position, inside it. Asked of
@@ -203,7 +217,7 @@ public final class InputPath {
     }
 
     /**
-     * Which position holds the elements {@code e} holds, or null where none does.
+     * Which position holds the elements {@code e} holds, and that none does where none does.
      *
      * <p>Beside {@link #named} and not the same question. That one answers what an expression names,
      * and an operation's answer names no position — {@code List.reverse(xs)} is a value, not a place
@@ -239,13 +253,17 @@ public final class InputPath {
      * that states nothing — which is the whole of what this type is for.
      */
     private static PathResolution either(PathResolution one, PathResolution other) {
-        if (one instanceof PathResolution.At) {
-            return one;
-        }
-        if (other instanceof PathResolution.At) {
-            return other;
-        }
-        return one instanceof PathResolution.Unread ? one : other;
+        return switch (one) {
+            case PathResolution.At _ -> one;
+            case PathResolution.Unread _ -> switch (other) {
+                case PathResolution.At _ -> other;
+                case PathResolution.NotAPosition _, PathResolution.Unread _ -> one;
+            };
+            case PathResolution.NotAPosition _ -> switch (other) {
+                case PathResolution.At _, PathResolution.NotAPosition _,
+                     PathResolution.Unread _ -> other;
+            };
+        };
     }
 
     /** The ways an operation's answer holds the elements of what it was given, and no position

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -1,13 +1,12 @@
 package souther.compiler.inputs;
 
-import souther.compiler.semantics.ArgumentRef;
-import souther.compiler.semantics.ElementLineage;
+import souther.compiler.check.CallArguments;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
+import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.ElementLineage;
 import souther.compiler.types.BindingId;
-
-import java.util.Map;
 
 /**
  * Which position of a behavior's input an expression names, or nothing where it names none.
@@ -24,14 +23,65 @@ import java.util.Map;
  * Read by name, the reads below it are the parameter's, and what is said about the parameter's rules
  * is said about a value they never reached ({@link BindingId} states this for every reader at once).
  *
+ * <p><b>Two kinds of step and no third.</b> Descending an expression — a field's target, a call's
+ * argument — stays inside one finite tree and needs nothing to stop it. Crossing to another
+ * expression goes through a binding: what a name holds, what handed a name the elements of a
+ * container, which binding another's elements are the same as. Those steps are a walk over the
+ * binding graph and {@link BindingTrail} is the whole of what stops them, so a step added here is
+ * one of the two and never a share of somebody's allowance. Nothing counts how far a walk has come:
+ * a count of how many names a reading may pass through is a count of how a model was written, and
+ * one name more than it allows is a position this reports as one nothing names.
+ *
+ * <p>What is known of the names comes in as facts and nothing else ({@link BindingEnvironment}).
+ * How many of them there are is not a fact about how far a value's provenance runs — a name bound in
+ * an arm is read under bindings written elsewhere — and a reading of what a name means is built on
+ * this one rather than beside it, so neither is something a walk here can reach for.
+ *
  * <p>Nothing about the reading of an input reaches this and nothing here reaches it: what a position
  * can hold is read from the declarations ({@link InputDomain}), and this only says which position an
  * expression is pointing at.
  */
 public final class InputPath {
 
+    private final Symbols symbols;
+    private final Lineage asked;
+    private final BindingTrail trail = new BindingTrail();
+
+    private InputPath(Symbols symbols, Lineage asked) {
+        this.symbols = symbols;
+        this.asked = asked;
+    }
+
     /**
-     * The position {@code e} names.
+     * Which question a walk is answering, which decides which steps it is entitled to take.
+     *
+     * <p>Two questions and not one flag. Where a value <em>is</em> and where a value <em>came
+     * from</em> are answered by the same steps until a binding holds what an operation made of
+     * another's elements: what is made from a position came from it and is not it, so a walk after
+     * the position an expression names stops there and a walk after provenance goes on.
+     */
+    private enum Lineage {
+
+        /** Which position an expression names, so that a rule about it is a rule about the values
+         *  a row writes there. */
+        NAMED_POSITION,
+
+        /** Which position a value came from, which is what says a rule was written at all where the
+         *  rule is about something made from those values. */
+        VALUE_ORIGIN;
+
+        /**
+         * The binding whose elements {@code binding}'s are, or null where this question is not
+         * entitled to one.
+         */
+        BindingId predecessorOf(BindingId binding, BindingEnvironment names) {
+            BindingId same = names.sameElementsAs(binding);
+            return same != null || this == NAMED_POSITION ? same : names.madeFrom(binding);
+        }
+    }
+
+    /**
+     * The position {@code e} names, read where {@code reads} has got to.
      *
      * <p>Which fields are steps is {@link Location}'s rule, asked here rather than restated: a
      * newtype's {@code value} is not one, so {@code request.cost} and {@code request.cost.value}
@@ -42,107 +92,15 @@ public final class InputPath {
      * declares, and a declared parameter is not a binding — a behavior with no implementation has
      * positions all the same — so a path is rooted at the declaration and {@link Location} at the
      * binding a body gave it.
+     *
+     * <p>Through what a run of {@code let}s bound on the way, since what a {@code let} binds is
+     * evaluated on the way to the answer: a body that names its argument and then matches the name
+     * is matching the argument. That is what a helper expanded into a body looks like, and reading
+     * only the outermost name would leave every claim inside an expanded helper about a position
+     * nothing here can name.
      */
-    public static TermPath of(Core e, InputDomain read, Symbols symbols) {
-        Map<BindingId, TermPath> roots = new java.util.LinkedHashMap<>();
-        read.parameterReads().forEach((binding, name) -> roots.put(binding, TermPath.of(name)));
-        return of(e, roots, Map.of(),
-                souther.compiler.check.ElementBindings.NONE, symbols, false);
-    }
-
-    /**
-     * The same, through what a run of {@code let}s bound on the way.
-     *
-     * <p>A name bound to an input position is that position: what a {@code let} binds is evaluated
-     * on the way to the answer, so a body that names its argument and then matches the name is
-     * matching the argument. That is what a helper expanded into a body looks like — the call's
-     * argument bound to the helper's own parameter — and reading only the outermost name would
-     * leave every claim inside an expanded helper about a position nothing here can name.
-     *
-     * <p>Only through what was bound, and only to a value that is itself a position. A binding whose
-     * value is a call is a value the rules of no position say anything about, and it answers
-     * nothing here.
-     *
-     * @param roots      which bindings name which position, in the tree being walked. A position
-     *                   and not a parameter: a name an arm binds stands for the scrutinee's
-     *                   position narrowed to the case that arm selects, which is a position of the
-     *                   input like any other
-     * @param bound      what each binding on the way holds, in the order they were passed
-     * @param callsStand whether this tree is one that keeps the operations the language defines the
-     *                   meaning of standing. Where it is, such a call names no location and that is
-     *                   the answer; where it is not, meeting one says the walk was handed a
-     *                   representation it does not read
-     */
-    public static TermPath of(Core e, Map<BindingId, TermPath> roots, Map<BindingId, Core> bound,
-                              souther.compiler.check.ElementBindings elements, Symbols symbols,
-                              boolean callsStand) {
-        return of(e, roots, bound, elements, symbols, callsStand, 0, false);
-    }
-
-    /**
-     * The way from {@code root} to what {@code e} reads, or null where {@code e} is not a place
-     * inside it.
-     *
-     * <p>The ordinary meaning of a read, a binding and a field, and nothing else. What a closure
-     * answered is an expression like any other, and asking where in its argument the answer stands
-     * is asking what path it names — so the rules are the ones every other path reading uses,
-     * including {@link Location#isStep}, which is why {@code amount.value} over a numeric newtype
-     * comes back as one step and not two.
-     *
-     * <p><b>Null wherever the answer is not read out of the element.</b> A branch chooses between
-     * two of them and is neither; arithmetic over one is a value the element does not hold; a
-     * construction is something new. None of those is a place a row writes, so a rule about what a
-     * walk answered is not a rule about any position, and saying so is this method's whole job on
-     * that side.
-     *
-     * <p>Nothing here says the answer is one per element. That is a fact about the operation that
-     * handed the closure its elements, proved where that operation stood; a caller wanting a run
-     * needs both, and this is the half about the reading.
-     */
-    public static java.util.List<String> projectionOf(Core e, BindingId root,
-                                                      Map<BindingId, Core> bound, Symbols symbols) {
-        return projection(e, root, bound, symbols, 0);
-    }
-
-    private static java.util.List<String> projection(Core e, BindingId root,
-                                                     Map<BindingId, Core> bound, Symbols symbols,
-                                                     int through) {
-        if (through > FOLLOWED) {
-            return null;
-        }
-        switch (e) {
-            // What a `let` comes to is what its body comes to, and the name it bound is answered
-            // where it is read. Ordinary binding semantics, and what a helper applied to the
-            // element leaves behind once it is spliced in: `amountOf(line).value` is a field of a
-            // binding holding the element, and reading only the field would stop at the splice.
-            case Core.LetIn let -> {
-                return projection(let.body(), root, bound, symbols, through);
-            }
-            case Core.Read read -> {
-                if (root.equals(read.binding())) {
-                    return java.util.List.of();
-                }
-                Core held = bound.get(read.binding());
-                return held == null || held == e ? null
-                        : projection(held, root, bound, symbols, through + 1);
-            }
-            case Core.FieldAccess fa -> {
-                java.util.List<String> base =
-                        projection(fa.target(), root, bound, symbols, through);
-                if (base == null) {
-                    return null;
-                }
-                if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
-                    return base;
-                }
-                java.util.List<String> longer = new java.util.ArrayList<>(base);
-                longer.add(fa.field());
-                return java.util.List.copyOf(longer);
-            }
-            case null, default -> {
-                return null;
-            }
-        }
+    public static PathResolution of(Core e, BindingEnvironment names, Symbols symbols) {
+        return new InputPath(symbols, Lineage.NAMED_POSITION).named(e, names);
     }
 
     /**
@@ -158,71 +116,8 @@ public final class InputPath {
      * nothing at all — which reads as a model with no rule there rather than a rule this could not
      * follow.
      */
-    public static TermPath cameFrom(Core e, Map<BindingId, TermPath> roots,
-                                    Map<BindingId, Core> bound,
-                                    souther.compiler.check.ElementBindings elements,
-                                    Symbols symbols, boolean callsStand) {
-        return of(e, roots, bound, elements, symbols, callsStand, 0, true);
-    }
-
-    /**
-     * Which position holds the elements {@code container} holds, or null where none does.
-     *
-     * <p>Beside {@link #of} and not the same question. That one answers what an expression names,
-     * and an operation's answer names no position — {@code List.reverse(xs)} is a value, not a place
-     * a row writes at. What is asked here is where the elements of that value are, and the library
-     * says: a {@code reverse} answers the elements it was given and a {@code filter} some of them,
-     * so an element of either is an element of what went in.
-     *
-     * <p>Only where they are the same values. Where an answer holds what a closure made of an
-     * element, what it holds came from a position and is not one — and a line drawn there would be
-     * at a position whose values are not the ones the rule is about, which an author cannot tell
-     * from a line their model states.
-     */
-    private static TermPath containerPath(Core e, Map<BindingId, TermPath> roots,
-                                          Map<BindingId, Core> bound,
-                                          souther.compiler.check.ElementBindings elements,
-                                          Symbols symbols, boolean callsStand, int through,
-                                          boolean made) {
-        TermPath named = of(e, roots, bound, elements, symbols, callsStand, through, made);
-        if (named != null || through >= bound.size() + elements.containers().size() + FOLLOWED) {
-            return named;
-        }
-        if (e instanceof Core.Read r) {
-            // Through a binding an expansion wrote, where the operation it removed answered the
-            // elements it was given. The operation is gone from this tree, so what says so was
-            // written where it still stood.
-            souther.compiler.types.BindingId same =
-                    elements.provenance().sameElementsAs(r.binding());
-            // And through one whose elements were made from another's, where what is being asked is
-            // where a value came from. Never where the question is which position it is: a value
-            // made from a position is not that position.
-            if (same == null && made) {
-                same = elements.provenance().madeFrom(r.binding());
-            }
-            if (same != null) {
-                return containerPath(new Core.Read(r.name(), same, r.type(), r.pos()),
-                        roots, bound, elements, symbols, callsStand, through + 1, made);
-            }
-            // Or through what the binding holds. Looked up over the whole body and not down the
-            // path to here: a container built by one operation and handed to the next is bound
-            // beside the closure that reads it rather than above it.
-            Core held = bound.containsKey(r.binding()) ? bound.get(r.binding())
-                    : elements.boundTo(r.binding());
-            return held == null ? null
-                    : containerPath(held, roots, bound, elements, symbols, callsStand,
-                        through + 1, made);
-        }
-        // Or through an operation the language keeps standing that answers what it was given.
-        if (!(e instanceof Core.Call call) || !(call.fn() instanceof Core.Reached reached)) {
-            return null;
-        }
-        ArgumentRef holds =
-                ElementLineage.holdsTheElementsOf(reached.denotes());
-        int argument = holds == null ? -1 : souther.compiler.check.CallArguments.positionIn(holds, reached.denotes());
-        return argument < 0 || argument >= call.args().size() ? null
-                : containerPath(call.args().get(argument), roots, bound, elements, symbols,
-                        callsStand, through + 1, made);
+    public static PathResolution cameFrom(Core e, BindingEnvironment names, Symbols symbols) {
+        return new InputPath(symbols, Lineage.VALUE_ORIGIN).named(e, names);
     }
 
     /**
@@ -233,41 +128,17 @@ public final class InputPath {
      * the binding rather than of the container's expression: a container built by one operation and
      * handed to the next names no position of its own, and the elements are the same elements.
      */
-    public static TermPath elementAt(BindingId binding, Map<BindingId, TermPath> roots,
-                                     Map<BindingId, Core> bound,
-                                     souther.compiler.check.ElementBindings elements,
-                                     Symbols symbols, boolean callsStand) {
-        return elementOf(binding, roots, bound, elements, symbols, callsStand, 0, false);
+    public static PathResolution elementAt(BindingId binding, BindingEnvironment names,
+                                           Symbols symbols) {
+        return new InputPath(symbols, Lineage.NAMED_POSITION).elementOf(binding, names);
     }
 
-    private static TermPath elementOf(BindingId binding, Map<BindingId, TermPath> roots,
-                                      Map<BindingId, Core> bound,
-                                      souther.compiler.check.ElementBindings elements,
-                                      Symbols symbols, boolean callsStand, int through,
-                                      boolean made) {
-        Core container = elements.containerOf(binding);
-        if (container == null) {
-            return null;
-        }
-        TermPath at = containerPath(container, roots, bound, elements, symbols,
-                callsStand, through + 1, made);
-        // The container names no position of this behavior's input — it is what another operation
-        // answered, or something this does not read — so neither does an element of it. Where a
-        // reading of provenance goes on from there is not this walk's.
-        return at == null ? null : at.element();
-    }
-
-    /** How many operations deep the elements of one container are followed. */
-    private static final int FOLLOWED = 8;
-
-    private static TermPath of(Core e, Map<BindingId, TermPath> roots, Map<BindingId, Core> bound,
-                               souther.compiler.check.ElementBindings elements, Symbols symbols,
-                               boolean callsStand, int through, boolean made) {
+    private PathResolution named(Core e, BindingEnvironment names) {
         return switch (e) {
             case Core.Read r -> {
-                TermPath stands = roots.get(r.binding());
+                TermPath stands = names.rootOf(r.binding());
                 if (stands != null) {
-                    yield stands;
+                    yield new PathResolution.At(stands);
                 }
                 // Three ways a name reaches a position and no more. It is a parameter; or it holds
                 // what something else was, which is followed; or an operation of the language handed
@@ -275,49 +146,119 @@ public final class InputPath {
                 // it. The third is the one no walk over the tree that runs could work out — what
                 // handed it is gone by then — and it is read from what was recorded where the
                 // operation still stood.
-                Core held = bound.get(r.binding());
-                // A binding holds one value, so following it cannot come back to itself; the count
-                // is what says so to a reader rather than a claim in a comment.
-                int steps = bound.size() + elements.containers().size();
-                if (through >= steps) {
-                    yield null;
+                Core held = names.boundValueOf(r.binding());
+                PathResolution holds = held == null ? new PathResolution.NotAPosition()
+                        : trail.through(r.binding(), () -> named(held, names));
+                if (holds instanceof PathResolution.At) {
+                    yield holds;
                 }
-                if (held != null) {
-                    TermPath through_ =
-                            of(held, roots, bound, elements, symbols, callsStand, through + 1, made);
-                    if (through_ != null) {
-                        yield through_;
-                    }
-                    // What it holds names no position, and it may still be an element of one. Two
-                    // walks over one collection joined into one leave a binding that is both: it
-                    // holds what the first walk made, and it is what the second was handed. Stopping
-                    // at the first left every rule inside the second reading as being about nothing.
+                // What it holds names no position, and it may still be an element of one. Two
+                // walks over one collection joined into one leave a binding that is both: it
+                // holds what the first walk made, and it is what the second was handed. Stopping
+                // at the first left every rule inside the second reading as being about nothing.
+                PathResolution element = elementOf(r.binding(), names);
+                if (element instanceof PathResolution.At) {
+                    yield element;
                 }
-                yield elementOf(r.binding(), roots, bound, elements, symbols, callsStand,
-                        through, made);
+                // And where neither reached one, what the name holds decides which of the two
+                // answers this is. A name holding a shape this does not read is a name whose
+                // position is not known; saying instead that it stands at none would be this
+                // compiler's reach reported as the model's silence.
+                yield holds instanceof PathResolution.Unread ? holds : element;
             }
-            case Core.FieldAccess fa -> {
-                TermPath base = of(fa.target(), roots, bound, elements, symbols, callsStand,
-                        through, made);
-                if (base == null) {
-                    yield null;
-                }
-                yield Location.isStep(fa.target().type(), fa.field(), symbols)
-                        ? base.then(fa.field()) : base;
-            }
+            case Core.FieldAccess fa -> switch (named(fa.target(), names)) {
+                case PathResolution.At(var base) -> new PathResolution.At(
+                        Location.isStep(fa.target().type(), fa.field(), symbols)
+                                ? base.then(fa.field()) : base);
+                case PathResolution other -> other;
+            };
+            // A name bound inside the expression handed over, which this reading does not go under.
+            // What it comes to is what its body comes to under that name, and whether the name may
+            // stand for the position its value names is a question about the model rather than
+            // about the shape — so what is said is that this was not read.
+            case Core.LetIn _ -> new PathResolution.Unread(
+                    PathResolution.Reason.A_NAME_BOUND_INSIDE_THE_EXPRESSION);
             // A call kept standing names no location. Where the walk is over a tree that keeps them
             // that is the answer, and where it is not, its presence says this walk was handed a
             // representation it does not read — said rather than answered with "no path", which
             // would be the same answer a number gives.
             case Core.PreservedCall p -> {
-                if (!callsStand) {
+                if (!names.callsStand()) {
                     throw p.unexpectedIn("an input position");
                 }
-                yield null;
+                yield new PathResolution.NotAPosition();
             }
-            case null, default -> null;
+            case null, default -> new PathResolution.NotAPosition();
         };
     }
 
-    private InputPath() {}
+    private PathResolution elementOf(BindingId binding, BindingEnvironment names) {
+        Core container = names.containerOf(binding);
+        if (container == null) {
+            return new PathResolution.NotAPosition();
+        }
+        // The container names no position of this behavior's input — it is what another operation
+        // answered, or something this does not read — so neither does an element of it. Where a
+        // reading of provenance goes on from there is not this walk's.
+        return switch (trail.through(binding, () -> containerPath(container, names))) {
+            case PathResolution.At(var at) -> new PathResolution.At(at.element());
+            case PathResolution other -> other;
+        };
+    }
+
+    /**
+     * Which position holds the elements {@code e} holds, or null where none does.
+     *
+     * <p>Beside {@link #named} and not the same question. That one answers what an expression names,
+     * and an operation's answer names no position — {@code List.reverse(xs)} is a value, not a place
+     * a row writes at. What is asked here is where the elements of that value are, and the library
+     * says: a {@code reverse} answers the elements it was given and a {@code filter} some of them,
+     * so an element of either is an element of what went in.
+     *
+     * <p>Only where they are the same values. Where an answer holds what a closure made of an
+     * element, what it holds came from a position and is not one — and a line drawn there would be
+     * at a position whose values are not the ones the rule is about, which an author cannot tell
+     * from a line their model states.
+     */
+    private PathResolution containerPath(Core e, BindingEnvironment names) {
+        PathResolution named = named(e, names);
+        if (named instanceof PathResolution.At) {
+            return named;
+        }
+        // And where the expression does not name a position, its elements may still be at one — so
+        // the ways an operation's answer holds them are tried, and what the expression itself came
+        // to is what is left where none of them arrives.
+        PathResolution through = elementsOf(e, names, named);
+        return through instanceof PathResolution.At || !(named instanceof PathResolution.Unread)
+                ? through : named;
+    }
+
+    /** The ways an operation's answer holds the elements of what it was given, and {@code named}
+     *  where none of them reaches a position. */
+    private PathResolution elementsOf(Core e, BindingEnvironment names, PathResolution named) {
+        if (e instanceof Core.Read r) {
+            // Through a binding an expansion wrote, where the operation it removed answered the
+            // elements it was given. The operation is gone from this tree, so what says so was
+            // written where it still stood.
+            BindingId same = asked.predecessorOf(r.binding(), names);
+            if (same != null) {
+                return trail.through(r.binding(), () -> containerPath(
+                        new Core.Read(r.name(), same, r.type(), r.pos()), names));
+            }
+            // Or through what the binding holds. Looked up over the whole body and not down the
+            // path to here: a container built by one operation and handed to the next is bound
+            // beside the closure that reads it rather than above it.
+            Core held = names.heldAnywhereBy(r.binding());
+            return held == null ? named
+                    : trail.through(r.binding(), () -> containerPath(held, names));
+        }
+        // Or through an operation the language keeps standing that answers what it was given.
+        if (!(e instanceof Core.Call call) || !(call.fn() instanceof Core.Reached reached)) {
+            return named;
+        }
+        ArgumentRef holds = ElementLineage.holdsTheElementsOf(reached.denotes());
+        int argument = holds == null ? -1 : CallArguments.positionIn(holds, reached.denotes());
+        return argument < 0 || argument >= call.args().size() ? named
+                : containerPath(call.args().get(argument), names);
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -180,7 +180,12 @@ public record InputReads(Map<BindingId, TermPath> roots,
         if (arm.caseTypes().size() != 1) {
             return admitting(match, arm, symbols);
         }
-        TermPath scrutinee = pathOf(match.scrutinee(), symbols).found();
+        // What the arm narrows is a position of the input, and a scrutinee that is not one narrows
+        // nothing — whether because it stands nowhere or because this reading did not follow it.
+        TermPath scrutinee = switch (pathOf(match.scrutinee(), symbols)) {
+            case PathResolution.At(var at) -> at;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
         if (scrutinee == null) {
             return admitting(match, arm, symbols);
         }
@@ -338,9 +343,14 @@ public record InputReads(Map<BindingId, TermPath> roots,
      */
     private ReadMeaning meaningOf(Core.Read read, Symbols symbols,
                                   java.util.Set<BindingId> met) {
-        TermPath path = pathOf(read, symbols).found();
-        if (path != null) {
-            return new ReadMeaning.Position(path);
+        // A name is what it stands at where it stands at one. The two other answers are alike here:
+        // a name this reading did not follow to a position is one whose meaning the answers below
+        // are asked for, as a name that stands at none is.
+        switch (pathOf(read, symbols)) {
+            case PathResolution.At(var at) -> {
+                return new ReadMeaning.Position(at);
+            }
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> { }
         }
         java.util.List<Denotation> narrowed = alternatives.get(read.binding());
         if (narrowed != null) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -80,7 +80,11 @@ public record InputReads(Map<BindingId, TermPath> roots,
 
     @Override
     public Core heldAnywhereBy(BindingId binding) {
-        return bound.containsKey(binding) ? bound.get(binding) : elements.boundTo(binding);
+        // What is bound on the way here first, and what the body bound anywhere after it. No
+        // binding holds nothing — this environment refuses a null value — so what is not here is
+        // absent rather than bound to nothing, and one lookup says so.
+        Core here = bound.get(binding);
+        return here != null ? here : elements.boundTo(binding);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -60,12 +60,42 @@ public record InputReads(Map<BindingId, TermPath> roots,
                          Map<BindingId, Core> bound,
                          souther.compiler.check.ElementBindings elements,
                          Map<BindingId, java.util.List<Denotation>> alternatives,
-                         boolean callsStand) {
+                         boolean callsStand) implements BindingEnvironment {
 
     public InputReads {
         roots = Map.copyOf(roots);
         bound = Map.copyOf(bound);
         alternatives = Map.copyOf(alternatives);
+    }
+
+    @Override
+    public TermPath rootOf(BindingId binding) {
+        return roots.get(binding);
+    }
+
+    @Override
+    public Core boundValueOf(BindingId binding) {
+        return bound.get(binding);
+    }
+
+    @Override
+    public Core heldAnywhereBy(BindingId binding) {
+        return bound.containsKey(binding) ? bound.get(binding) : elements.boundTo(binding);
+    }
+
+    @Override
+    public Core containerOf(BindingId binding) {
+        return elements.containerOf(binding);
+    }
+
+    @Override
+    public BindingId sameElementsAs(BindingId binding) {
+        return elements.provenance().sameElementsAs(binding);
+    }
+
+    @Override
+    public BindingId madeFrom(BindingId binding) {
+        return elements.provenance().madeFrom(binding);
     }
 
     /**
@@ -150,7 +180,7 @@ public record InputReads(Map<BindingId, TermPath> roots,
         if (arm.caseTypes().size() != 1) {
             return admitting(match, arm, symbols);
         }
-        TermPath scrutinee = pathOf(match.scrutinee(), symbols);
+        TermPath scrutinee = pathOf(match.scrutinee(), symbols).found();
         if (scrutinee == null) {
             return admitting(match, arm, symbols);
         }
@@ -267,9 +297,9 @@ public record InputReads(Map<BindingId, TermPath> roots,
         return new InputReads(roots, wider, elements, alternatives, callsStand);
     }
 
-    /** The position {@code e} names here, or null where it names none. */
-    public TermPath pathOf(Core e, Symbols symbols) {
-        return InputPath.of(e, roots, bound, elements, symbols, callsStand);
+    /** Where {@code e} stands, read here ({@link PathResolution}). */
+    public PathResolution pathOf(Core e, Symbols symbols) {
+        return InputPath.of(e, this, symbols);
     }
 
     /**
@@ -308,7 +338,7 @@ public record InputReads(Map<BindingId, TermPath> roots,
      */
     private ReadMeaning meaningOf(Core.Read read, Symbols symbols,
                                   java.util.Set<BindingId> met) {
-        TermPath path = pathOf(read, symbols);
+        TermPath path = pathOf(read, symbols).found();
         if (path != null) {
             return new ReadMeaning.Position(path);
         }
@@ -405,15 +435,14 @@ public record InputReads(Map<BindingId, TermPath> roots,
         }
     }
 
-    /** The position an element handed to {@code binding} stands at, or null where it stands at
-     *  none ({@link InputPath#elementAt}). */
-    public TermPath elementAt(BindingId binding, Symbols symbols) {
-        return InputPath.elementAt(binding, roots, bound, elements, symbols, callsStand);
+    /** Where an element handed to {@code binding} stands ({@link InputPath#elementAt}). */
+    public PathResolution elementAt(BindingId binding, Symbols symbols) {
+        return InputPath.elementAt(binding, this, symbols);
     }
 
-    /** The position {@code e}'s value came from, or null where it came from none. Not where it is:
-     *  a value made from a position is not that position ({@link InputPath#cameFrom}). */
-    public TermPath cameFrom(Core e, Symbols symbols) {
-        return InputPath.cameFrom(e, roots, bound, elements, symbols, callsStand);
+    /** Where {@code e}'s value came from. Not where it is: a value made from a position is not that
+     *  position ({@link InputPath#cameFrom}). */
+    public PathResolution cameFrom(Core e, Symbols symbols) {
+        return InputPath.cameFrom(e, this, symbols);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
@@ -1,0 +1,64 @@
+package souther.compiler.inputs;
+
+/**
+ * What a reading of where an expression stands came to.
+ *
+ * <p>Three answers and not two, because two of them are about the model and one is about this
+ * compiler. A position reached is one; an expression that names none — arithmetic over a value, a
+ * branch between two, something built — is the model saying there is nothing there, and a reader is
+ * told so. What is neither is a shape this reading does not follow: the model may well name a
+ * position through it, and nothing here knows which.
+ *
+ * <p><b>The third is why this is a type.</b> Held as an absent path beside the second, a reading
+ * that ran out of what it could follow came back as a model that states nothing — and every sentence
+ * written from that absence said of somebody's model what was true of this compiler. There is no
+ * spelling of "no path" that carries the difference, so it is carried by which answer this is.
+ *
+ * <p>A caller for which the last two are one answer says so by asking for {@link #found()}, and one
+ * that reports on what it found reads the arms. What no caller can do is take the first for the
+ * third without having written down that it is.
+ */
+public sealed interface PathResolution {
+
+    /** The position, or null where this reading reached none — whichever of the two that was. */
+    default TermPath found() {
+        return this instanceof At at ? at.path() : null;
+    }
+
+    /** Where the expression stands. */
+    record At(TermPath path) implements PathResolution {}
+
+    /**
+     * The expression names no position of the input, which is a fact about the model.
+     *
+     * <p>What a rule about such a value comes to is a question elsewhere — it may have come from a
+     * position, and where it did that is said ({@link InputReads#cameFrom}) — and this is the answer
+     * that it does not stand at one.
+     */
+    record NotAPosition() implements PathResolution {}
+
+    /**
+     * A shape this reading does not follow, so whether the expression names a position is not
+     * known here.
+     *
+     * <p>Kept apart from an absence and never turned into one. A reader acting on this is looking
+     * at what this compiler does not read yet, and a reader acting on an absence is looking at what
+     * their model says.
+     */
+    record Unread(Reason reason) implements PathResolution {}
+
+    /** Which shape it was, for a reader that says so out loud. */
+    enum Reason {
+
+        /**
+         * A name bound inside the expression itself.
+         *
+         * <p>A helper applied to an argument is left as the helper's body under a name bound to it,
+         * so an expression handed over may bind names the walk that handed it over never went under.
+         * What such an expression comes to is what its body comes to, and reading it takes settling
+         * whether the name stands for the position its value names or only for a value made from
+         * one — which is a question about the model that this reading does not answer.
+         */
+        A_NAME_BOUND_INSIDE_THE_EXPRESSION
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
@@ -18,7 +18,8 @@ package souther.compiler.inputs;
  * answer says so where it asks, arm by arm, and there is nothing here to say it with — a method
  * that answered "the position, or nothing" would be that decision made once for every caller, and
  * an answer added later would arrive at all of them as nothing without one of them being asked.
- * What the arms cost a reader is the same fourteen decisions being visible, which is what they are.
+ * What the arms cost a reader is that every one of those decisions is visible, which is what they
+ * are.
  */
 public sealed interface PathResolution {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PathResolution.java
@@ -14,16 +14,13 @@ package souther.compiler.inputs;
  * written from that absence said of somebody's model what was true of this compiler. There is no
  * spelling of "no path" that carries the difference, so it is carried by which answer this is.
  *
- * <p>A caller for which the last two are one answer says so by asking for {@link #found()}, and one
- * that reports on what it found reads the arms. What no caller can do is take the first for the
- * third without having written down that it is.
+ * <p><b>No way to collapse them but writing it out.</b> A caller for which the last two are one
+ * answer says so where it asks, arm by arm, and there is nothing here to say it with — a method
+ * that answered "the position, or nothing" would be that decision made once for every caller, and
+ * an answer added later would arrive at all of them as nothing without one of them being asked.
+ * What the arms cost a reader is the same fourteen decisions being visible, which is what they are.
  */
 public sealed interface PathResolution {
-
-    /** The position, or null where this reading reached none — whichever of the two that was. */
-    default TermPath found() {
-        return this instanceof At at ? at.path() : null;
-    }
 
     /** Where the expression stands. */
     record At(TermPath path) implements PathResolution {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -247,7 +247,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
 
             @Override
             public boolean readsThrough(Core.FieldAccess fa, InputReads at) {
-                return at.pathOf(fa.target(), symbols) == null
+                return at.pathOf(fa.target(), symbols).found() == null
                         && !Location.isStep(fa.target().type(), fa.field(), symbols);
             }
         };

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -9,6 +9,7 @@ import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 
 import java.math.BigDecimal;
@@ -247,8 +248,14 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
 
             @Override
             public boolean readsThrough(Core.FieldAccess fa, InputReads at) {
-                return at.pathOf(fa.target(), symbols).found() == null
-                        && !Location.isStep(fa.target().type(), fa.field(), symbols);
+                // Read through where the target is at no position of the input: a field of a value
+                // that stands nowhere is arithmetic's to walk into, and so is a field of one this
+                // reading did not follow — neither is a place a row writes at.
+                boolean stands = switch (at.pathOf(fa.target(), symbols)) {
+                    case PathResolution.At _ -> true;
+                    case PathResolution.NotAPosition _, PathResolution.Unread _ -> false;
+                };
+                return !stands && !Location.isStep(fa.target().type(), fa.field(), symbols);
             }
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -179,7 +179,7 @@ public final class GuardThresholds {
     static void cameFrom(Core.Binary comparison, InputReads reads, Symbols symbols,
                                  List<TermPath> out) {
         for (Core side : List.of(comparison.left(), comparison.right())) {
-            TermPath at = reads.cameFrom(side, symbols);
+            TermPath at = reads.cameFrom(side, symbols).found();
             if (at != null && !out.contains(at)) {
                 out.add(at);
             }
@@ -238,12 +238,13 @@ public final class GuardThresholds {
                 }
                 // A call the language defines the meaning of stands for what it answers and not for
                 // a location, however the reading spells the two apart.
-                return here instanceof Core.PreservedCall ? null : at.pathOf(here, symbols);
+                return here instanceof Core.PreservedCall ? null
+                        : at.pathOf(here, symbols).found();
             }
 
             @Override
             public TermPath madeFrom(Core here, InputReads at) {
-                return at.cameFrom(here, symbols);
+                return at.cameFrom(here, symbols).found();
             }
 
             /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -12,6 +12,7 @@ import souther.compiler.inputs.InputNumber;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.Quantities;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.inputs.ReadMeaning;
@@ -179,9 +180,16 @@ public final class GuardThresholds {
     static void cameFrom(Core.Binary comparison, InputReads reads, Symbols symbols,
                                  List<TermPath> out) {
         for (Core side : List.of(comparison.left(), comparison.right())) {
-            TermPath at = reads.cameFrom(side, symbols).found();
-            if (at != null && !out.contains(at)) {
-                out.add(at);
+            // Where a side's values came from, and nothing where that was not reached. A side this
+            // reading did not follow came from somewhere it cannot name, which is as much use here
+            // as a side that came from nowhere.
+            switch (reads.cameFrom(side, symbols)) {
+                case PathResolution.At(var at) -> {
+                    if (!out.contains(at)) {
+                        out.add(at);
+                    }
+                }
+                case PathResolution.NotAPosition _, PathResolution.Unread _ -> { }
             }
         }
     }
@@ -238,13 +246,24 @@ public final class GuardThresholds {
                 }
                 // A call the language defines the meaning of stands for what it answers and not for
                 // a location, however the reading spells the two apart.
-                return here instanceof Core.PreservedCall ? null
-                        : at.pathOf(here, symbols).found();
+                if (here instanceof Core.PreservedCall) {
+                    return null;
+                }
+                // Which position the expression is, and none where the reading did not arrive at
+                // one: the walk this answers for reads through what names nothing, and a shape it
+                // did not follow is one it has nothing to read through with either.
+                return switch (at.pathOf(here, symbols)) {
+                    case PathResolution.At(var stands) -> stands;
+                    case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+                };
             }
 
             @Override
             public TermPath madeFrom(Core here, InputReads at) {
-                return at.cameFrom(here, symbols).found();
+                return switch (at.cameFrom(here, symbols)) {
+                    case PathResolution.At(var from) -> from;
+                    case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+                };
             }
 
             /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.Citation;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.SearchRegion;
 import souther.compiler.inputs.TermPath;
@@ -147,7 +148,13 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
         if (arm.caseTypes().size() != 1) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
-        TermPath scrutinee = reads.pathOf(match.scrutinee(), symbols).found();
+        // The arm is declined for either answer: a search composes against a position read as one
+        // of its cases, and there is no position to narrow whether the scrutinee stands at none or
+        // this reading did not follow it to one.
+        TermPath scrutinee = switch (reads.pathOf(match.scrutinee(), symbols)) {
+            case PathResolution.At(var stands) -> stands;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
         // The position that is narrowed, and not the narrowed one. A case declaring no field has
         // nothing under it and this reading holds no position there, which is what it is for; what
         // has to exist is the position the case is a case of, since that is what a row writes a

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -147,7 +147,7 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
         if (arm.caseTypes().size() != 1) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
-        TermPath scrutinee = reads.pathOf(match.scrutinee(), symbols);
+        TermPath scrutinee = reads.pathOf(match.scrutinee(), symbols).found();
         // The position that is narrowed, and not the narrowed one. A case declaring no field has
         // nothing under it and this reading holds no position there, which is what it is for; what
         // has to exist is the position the case is a case of, since that is what a row writes a

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
@@ -123,7 +123,7 @@ final class CoverageNaming implements Naming<Outcome> {
         if (claim == null) {
             return null;
         }
-        TermPath at = reads.pathOf(match.scrutinee(), symbols);
+        TermPath at = reads.pathOf(match.scrutinee(), symbols).found();
         if (at == null) {
             Condition fork = forkOf(match, part);
             return fork == null ? null : one(new Decision(fork, claim));
@@ -150,7 +150,7 @@ final class CoverageNaming implements Naming<Outcome> {
             return null;
         }
         if (fork instanceof Core.If iff) {
-            TermPath read = reads.pathOf(iff.cond(), symbols);
+            TermPath read = reads.pathOf(iff.cond(), symbols).found();
             Condition what = read == null ? forkOf(fork, part)
                     : new Condition.Case(read, part == 0 ? "true" : "false");
             return what == null ? null : one(new Decision(what, claim));

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageNaming.java
@@ -12,6 +12,7 @@ import souther.compiler.inputs.ComparedNumber;
 import souther.compiler.inputs.ComparedNumbers;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.PathResolution;
 import souther.compiler.inputs.TermPath;
 
 import java.util.ArrayList;
@@ -123,7 +124,12 @@ final class CoverageNaming implements Naming<Outcome> {
         if (claim == null) {
             return null;
         }
-        TermPath at = reads.pathOf(match.scrutinee(), symbols).found();
+        // What a fork is named by is the position it is on, and a scrutinee at none names nothing —
+        // which is also what a scrutinee this reading did not follow leaves to name it with.
+        TermPath at = switch (reads.pathOf(match.scrutinee(), symbols)) {
+            case PathResolution.At(var stands) -> stands;
+            case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+        };
         if (at == null) {
             Condition fork = forkOf(match, part);
             return fork == null ? null : one(new Decision(fork, claim));
@@ -150,7 +156,10 @@ final class CoverageNaming implements Naming<Outcome> {
             return null;
         }
         if (fork instanceof Core.If iff) {
-            TermPath read = reads.pathOf(iff.cond(), symbols).found();
+            TermPath read = switch (reads.pathOf(iff.cond(), symbols)) {
+                case PathResolution.At(var stands) -> stands;
+                case PathResolution.NotAPosition _, PathResolution.Unread _ -> null;
+            };
             Condition what = read == null ? forkOf(fork, part)
                     : new Condition.Case(read, part == 0 ? "true" : "false");
             return what == null ? null : one(new Decision(what, claim));

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
@@ -22,12 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * A name whose value is read through itself is not a name that reaches no position.
  *
- * <p>The two answers are told apart because what a reader is told about the model depends on it. A
- * position nothing names is what an expression this reading does not follow comes to, and a rule
- * about it is reported as being about a value made from somewhere else — a sentence about the model.
- * A binding that holds a value read through itself is not a model at all: a binding holds one value,
- * worked out where it was written, so what is in hand is a representation this compiler built and
- * says is impossible.
+ * <p>The two answers are told apart because what a reader is told about the model depends on it.
+ * Arithmetic over a position stands nowhere, and a rule about it is reported as being about a value
+ * made from somewhere else — a sentence about the model, and a true one. A binding that holds a
+ * value read through itself is not a model at all: the lineage this compiler builds runs one way,
+ * so a value read through itself is a representation it made and says it does not make.
  *
  * <p>Handed one of those, the reading raises rather than answering. What it must not do is come back
  * with the answer a plain expression gets, which would put a report of this compiler's own state

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AValueReadThroughItselfIsNotAPositionNothingNamesTest.java
@@ -1,0 +1,89 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.ElementBindings;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.TheCompilerDisagreesWithItself;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A name whose value is read through itself is not a name that reaches no position.
+ *
+ * <p>The two answers are told apart because what a reader is told about the model depends on it. A
+ * position nothing names is what an expression this reading does not follow comes to, and a rule
+ * about it is reported as being about a value made from somewhere else — a sentence about the model.
+ * A binding that holds a value read through itself is not a model at all: a binding holds one value,
+ * worked out where it was written, so what is in hand is a representation this compiler built and
+ * says is impossible.
+ *
+ * <p>Handed one of those, the reading raises rather than answering. What it must not do is come back
+ * with the answer a plain expression gets, which would put a report of this compiler's own state
+ * into a document about somebody's model — the thing this reading was made to stop doing.
+ *
+ * <p>No source builds one, which is why the environment is written out here: what is being held is
+ * the reading's behavior over an environment it may be handed, and a walk over the models that
+ * compile could never reach it.
+ */
+class AValueReadThroughItselfIsNotAPositionNothingNamesTest {
+
+    private static final SourcePos POS = new SourcePos(0, 0);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("example", "f");
+    private static final BindingId FIRST = new BindingId(OWNER, 1);
+    private static final BindingId SECOND = new BindingId(OWNER, 2);
+    private static final BindingId PARAMETER = new BindingId(OWNER, 0);
+
+    private static Core.Read read(String name, BindingId binding) {
+        return new Core.Read(name, binding, Type.INT, POS);
+    }
+
+    private static InputReads reads(Map<BindingId, Core> bound) {
+        return new InputReads(Map.of(PARAMETER, TermPath.of("n")), bound,
+                ElementBindings.NONE, Map.of(), false);
+    }
+
+    private static Symbols symbols() {
+        return Symbols.none(DefaultStdlib.get());
+    }
+
+    /** A name bound to what a second holds, and that one bound back to the first. */
+    private static InputReads twoNamesHoldingEachOther() {
+        Map<BindingId, Core> bound = new LinkedHashMap<>();
+        bound.put(FIRST, read("b", SECOND));
+        bound.put(SECOND, read("a", FIRST));
+        return reads(bound);
+    }
+
+    /** Raised where a value is read through itself, and named as this compiler's own state. */
+    @Test
+    void readingAValueThroughItselfIsRaised() {
+        InputReads names = twoNamesHoldingEachOther();
+
+        BindingTrail.ReadThroughItself raised = assertThrows(BindingTrail.ReadThroughItself.class,
+                () -> names.pathOf(read("a", FIRST), symbols()));
+
+        assertInstanceOf(TheCompilerDisagreesWithItself.class, raised,
+                "a representation that cannot be is not a limit of this analysis");
+    }
+
+    /** And a name that reaches no position answers that, which is the other thing entirely. */
+    @Test
+    void aNameThatReachesNoPositionSaysSoInstead() {
+        InputReads names = reads(Map.of());
+
+        assertEquals(new PathResolution.NotAPosition(),
+                names.pathOf(read("a", FIRST), symbols()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAClosuresAnswerStandsUnderDoesNotDecideItsProjectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAClosuresAnswerStandsUnderDoesNotDecideItsProjectionTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How many names a closure's answer stands under does not decide where in the element it is.
+ *
+ * <p>The law beside the one held of input positions, and not the same law. That one is about a walk
+ * to a position of the input, with the roots, the containers and the provenance of elements to
+ * reach it by; this is about a way inside one value, read from a name, a {@code let} and a field
+ * and nothing else. Two readings, two statements, and a number reintroduced into either is caught
+ * by its own.
+ *
+ * <p>Held here rather than through a model, because what this reading takes is a closure's answer
+ * and the names in the body it was left in — and a body binds those names for reasons of its own,
+ * so a model grown until the chain is long is a model grown for something else. What the chain is
+ * long by is the point.
+ */
+class HowManyNamesAClosuresAnswerStandsUnderDoesNotDecideItsProjectionTest {
+
+    private static final SourcePos POS = new SourcePos(0, 0);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("example", "f");
+    private static final BindingId ELEMENT = new BindingId(OWNER, 0);
+
+    private static Core.Read read(String name, BindingId binding) {
+        return new Core.Read(name, binding, Type.INT, POS);
+    }
+
+    /**
+     * A closure answering the element's amount, under {@code names} names standing for each other.
+     *
+     * <p>Which is what a body leaves behind once a helper applied to the element is spliced into it,
+     * one name per helper: the answer is a name, and following it arrives at the field.
+     */
+    private static ElementProjection projectionUnder(int names) {
+        Map<BindingId, Core> held = new LinkedHashMap<>();
+        for (int n = 1; n < names; n++) {
+            held.put(new BindingId(OWNER, n), read("a" + (n + 1), new BindingId(OWNER, n + 1)));
+        }
+        held.put(new BindingId(OWNER, names), new Core.FieldAccess(read("一件", ELEMENT), "金額",
+                Type.INT, POS));
+        return ElementProjection.read(read("a1", new BindingId(OWNER, 1)), ELEMENT, held,
+                Symbols.none(DefaultStdlib.get()));
+    }
+
+    /** One name between the answer and the field, or sixteen: the way inside the element is one
+     *  step either way. */
+    @Test
+    void theSameProjectionIsReadHoweverManyNamesStandBetween() {
+        Map<Integer, ElementProjection> read = new LinkedHashMap<>();
+        for (int names : new int[] {1, 4, 8, 16}) {
+            read.put(names, projectionUnder(names));
+        }
+
+        assertEquals(Map.of(1, new ElementProjection(List.of("金額")),
+                        4, new ElementProjection(List.of("金額")),
+                        8, new ElementProjection(List.of("金額")),
+                        16, new ElementProjection(List.of("金額"))),
+                read, () -> "one way inside the element however many names stand between: " + read);
+    }
+
+    /** And a name that stands for nothing this reading has is not a way anywhere, at any length. */
+    @Test
+    void aNameStandingForNothingIsNoProjectionAtAnyLength() {
+        Map<BindingId, Core> held = new LinkedHashMap<>();
+        for (int n = 1; n < 16; n++) {
+            held.put(new BindingId(OWNER, n), read("a" + (n + 1), new BindingId(OWNER, n + 1)));
+        }
+
+        assertEquals(null, ElementProjection.read(read("a1", new BindingId(OWNER, 1)), ELEMENT,
+                held, Symbols.none(DefaultStdlib.get())));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest.java
@@ -28,6 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * could stop at is a model somebody may write — so the regression for the model that was reported
  * would go green again under a larger number, and this would not. The stopping law is where the walk
  * has been ({@link BindingTrail}), which no length reaches.
+ *
+ * <p><b>One shape per way the walk crosses to another expression.</b> Which models are grown is not
+ * a matter of taste: the walk gets longer by a name standing for another and by an operation
+ * answering the elements it was given, and a number put back on either is a number the other says
+ * nothing about. So there is a model per crossing and a crossing added here is a model added — the
+ * reading beside this one, of where in an element a closure's answer stands, crosses by names of its
+ * own and states this law for itself.
  */
 class HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest {
 
@@ -84,26 +91,67 @@ class HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest {
         return out.toString();
     }
 
-    private static BorderAssessment totalsLine(int names) {
-        Compilation compilation = Compilation.ofSource(model(names), "Main");
+    /**
+     * The same rule with the list walked by {@code operations} that answer what they were given.
+     *
+     * <p>The other way a walk to a position gets longer. A {@code reverse} answers the elements it
+     * was handed, so an element of one is an element of what went in, and the way to the position
+     * runs through as many of them as the model wrote — none of which is a statement about the rule
+     * either.
+     */
+    private static String walked(int operations) {
+        StringBuilder walk = new StringBuilder("明細");
+        for (int n = 0; n < operations; n++) {
+            walk.insert(0, "List.reverse(").append(")");
+        }
+        return """
+                module example.through
+
+                data 金額 = Int
+
+                data 明細 = { 金額: 金額 }
+
+                data 高額
+                data 少額
+
+                behavior 判定する : (明細: List<明細>) -> 高額 | 少額
+
+                let 判定する (明細) =
+                    if List.sum(List.map(一件 -> 一件.金額.value, %s)) >= 100000
+                    then 高額 else 少額
+
+                example 判定する
+                    | "ちょうど10万円なら高額" : ([ 明細 { 金額 = 金額(100000) } ]) -> 高額
+                    | "1000円なら少額"        : ([ 明細 { 金額 = 金額(1000) } ])   -> 少額
+                """.formatted(walk);
+    }
+
+    /** The line the threshold draws in {@code source}, where {@code said} is how long its way to the
+     *  position is. */
+    private static BorderAssessment totalsLine(String source, String said) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
         assertEquals(List.of(), compilation.errors().stream()
                 .map(each -> each.diagnostic().code()).toList(),
-                () -> "the model under test compiles at " + names + " names");
+                () -> "the model under test compiles at " + said);
         PartitionEvidence measured = compilation.db()
                 .ask(new Adequacy.Coverage("example.through")).value().get("判定する");
         assertEquals(List.of(), measured.notRead().stream()
                         .filter(each -> each.reason() == souther.compiler.partition
                                 .UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE)
                         .map(PartitionEvidence.NotRead::at).toList(),
-                () -> "no position is told the rule is about a value made from it at "
-                        + names + " names");
+                () -> "no position is told the rule is about a value made from it at " + said);
         BorderAssessment line = Adequacy.readingsOf(compilation.db(), "example.through")
                 .get("判定する").stream()
                 .filter(each -> LINE.equals(each.label())).findFirst().orElse(null);
-        assertNotNull(line, () -> "the threshold is a line at " + names + " names");
+        assertNotNull(line, () -> "the threshold is a line at " + said);
         return line;
+    }
+
+    /** What the line comes to, as the two shapes below compare it. */
+    private static String asked(BorderAssessment line) {
+        return line.label() + " on " + line.axis();
     }
 
     /**
@@ -117,11 +165,29 @@ class HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest {
     void theSameRuleIsAskedForHoweverManyNamesStandBetween() {
         Map<Integer, String> asked = new LinkedHashMap<>();
         for (int names : new int[] {1, 4, 8, 16}) {
-            BorderAssessment line = totalsLine(names);
-            asked.put(names, line.label() + " on " + line.axis());
+            asked.put(names, asked(totalsLine(model(names), names + " names")));
         }
 
         assertEquals(1, java.util.Set.copyOf(asked.values()).size(),
                 () -> "one answer however many names stand between: " + asked);
+    }
+
+    /**
+     * And one operation between the parameter and the walk, or sixteen.
+     *
+     * <p>The other crossing, which the wrappers above do not lengthen: there the way to the position
+     * runs through names, and here through operations that answer the elements they were given. A
+     * number put back on this one is a number the model above says nothing about.
+     */
+    @Test
+    void theSameRuleIsAskedForHoweverManyOperationsTheListIsWalkedBy() {
+        Map<Integer, String> asked = new LinkedHashMap<>();
+        for (int operations : new int[] {1, 4, 8, 16}) {
+            asked.put(operations,
+                    asked(totalsLine(walked(operations), operations + " operations")));
+        }
+
+        assertEquals(1, java.util.Set.copyOf(asked.values()).size(),
+                () -> "one answer however many operations the list is walked by: " + asked);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest.java
@@ -1,0 +1,127 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * How many names a value is read through does not decide what is read.
+ *
+ * <p>A name standing for another is the one thing a model may have any number of. A wrapper taken
+ * apart, a helper applied, a total given a name before it is compared: each leaves one more name
+ * between a rule and the position it is about, and none of them is a statement about the model. So
+ * the rule read at one name deep and the rule read at sixteen are the same rule, and what is asked
+ * for at the line it draws is the same three rows.
+ *
+ * <p>What this holds is the shape of the reading and not one model's answer. A walk that measures
+ * how far it has come answers the short ones and gives up on the long ones, and every number it
+ * could stop at is a model somebody may write — so the regression for the model that was reported
+ * would go green again under a larger number, and this would not. The stopping law is where the walk
+ * has been ({@link BindingTrail}), which no length reaches.
+ */
+class HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest {
+
+    private static final String LINE = "List.sum(明細[*].金額) = 100000";
+
+    /**
+     * The same rule with {@code names} wrappers around the list, each taken apart where the behavior
+     * takes its parameter.
+     *
+     * <p>Every wrapper is one more name between the total and the position its values stand at, and
+     * none of them is a statement about the rule: a model naming its list twice over says what a
+     * model naming it once says.
+     */
+    private static String model(int names) {
+        StringBuilder out = new StringBuilder("""
+                module example.through
+
+                data 金額 = Int
+
+                data 明細 = { 金額: 金額 }
+
+                data 高額
+                data 少額
+
+                data 束1 = List<明細>
+                """);
+        for (int n = 2; n <= names; n++) {
+            out.append("data 束%d = 束%d%n".formatted(n, n - 1));
+        }
+        out.append("%nbehavior 判定する : (明細: 束%d) -> 高額 | 少額%n".formatted(names));
+        StringBuilder taken = new StringBuilder("件");
+        for (int n = 1; n <= names; n++) {
+            taken.insert(0, "束%d(".formatted(n)).append(")");
+        }
+        out.append("""
+
+                let 判定する (%s) =
+                    if List.sum(List.map(一件 -> 一件.金額.value, 件)) >= 100000
+                    then 高額 else 少額
+
+                example 判定する
+                    | "ちょうど10万円なら高額" : (%s) -> 高額
+                    | "1000円なら少額"        : (%s) -> 少額
+                """.formatted(taken, wrapped(names, 100000), wrapped(names, 1000)));
+        return out.toString();
+    }
+
+    /** One list of one detail of {@code amount}, under every wrapper the model declares. */
+    private static String wrapped(int names, int amount) {
+        StringBuilder out = new StringBuilder("[ 明細 { 金額 = 金額(%d) } ]".formatted(amount));
+        for (int n = 1; n <= names; n++) {
+            out.insert(0, "束%d(".formatted(n)).append(")");
+        }
+        return out.toString();
+    }
+
+    private static BorderAssessment totalsLine(int names) {
+        Compilation compilation = Compilation.ofSource(model(names), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.errors().stream()
+                .map(each -> each.diagnostic().code()).toList(),
+                () -> "the model under test compiles at " + names + " names");
+        PartitionEvidence measured = compilation.db()
+                .ask(new Adequacy.Coverage("example.through")).value().get("判定する");
+        assertEquals(List.of(), measured.notRead().stream()
+                        .filter(each -> each.reason() == souther.compiler.partition
+                                .UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE)
+                        .map(PartitionEvidence.NotRead::at).toList(),
+                () -> "no position is told the rule is about a value made from it at "
+                        + names + " names");
+        BorderAssessment line = Adequacy.readingsOf(compilation.db(), "example.through")
+                .get("判定する").stream()
+                .filter(each -> LINE.equals(each.label())).findFirst().orElse(null);
+        assertNotNull(line, () -> "the threshold is a line at " + names + " names");
+        return line;
+    }
+
+    /**
+     * One name between, or sixteen: the same line, drawn where the same rule draws it.
+     *
+     * <p>The line and what it is drawn on. Whether a row can be written at a point of it is asked of
+     * a search and of how much of a value a report reads, and those answer for themselves; what is
+     * held here is that the rule was read, which is what every one of them is downstream of.
+     */
+    @Test
+    void theSameRuleIsAskedForHoweverManyNamesStandBetween() {
+        Map<Integer, String> asked = new LinkedHashMap<>();
+        for (int names : new int[] {1, 4, 8, 16}) {
+            BorderAssessment line = totalsLine(names);
+            asked.put(names, line.label() + " on " + line.axis());
+        }
+
+        assertEquals(1, java.util.Set.copyOf(asked.values()).size(),
+                () -> "one answer however many names stand between: " + asked);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatWasNotReadIsNotWhatStandsNowhereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatWasNotReadIsNotWhatStandsNowhereTest.java
@@ -1,0 +1,80 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.ElementBindings;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.CoverageOrigin;
+import souther.compiler.types.Type;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * An expression this reading does not follow is told apart from one that stands nowhere.
+ *
+ * <p>Two absences with nothing in common but that no path came back. Arithmetic over a position is
+ * a value the input holds nowhere, and a reader told so is being told what the model says. An
+ * expression binding a name of its own is one this reading does not go under, and what the model
+ * says through it is exactly what is not known — so the same silence would be this compiler's reach
+ * printed as a fact about somebody's rule.
+ *
+ * <p>Held at the reading rather than at a report, because that is where the two are still apart.
+ * Every reader downstream may have one answer for them and says so by asking for the position alone;
+ * what none of them can do is take one for the other without that being written where it happens.
+ */
+class WhatWasNotReadIsNotWhatStandsNowhereTest {
+
+    private static final SourcePos POS = new SourcePos(0, 0);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("example", "f");
+    private static final BindingId PARAMETER = new BindingId(OWNER, 0);
+    private static final BindingId LOCAL = new BindingId(OWNER, 1);
+
+    private static InputReads reads() {
+        return new InputReads(Map.of(PARAMETER, TermPath.of("n")), Map.of(),
+                ElementBindings.NONE, Map.of(), false);
+    }
+
+    private static Core.Read parameter() {
+        return new Core.Read("n", PARAMETER, Type.INT, POS);
+    }
+
+    private static PathResolution readingOf(Core e) {
+        return reads().pathOf(e, Symbols.none(DefaultStdlib.get()));
+    }
+
+    /** The parameter itself is where it is. */
+    @Test
+    void aParameterIsAtItsPosition() {
+        assertEquals(new PathResolution.At(TermPath.of("n")), readingOf(parameter()));
+    }
+
+    /** Arithmetic over it stands at no position, which is what the model says. */
+    @Test
+    void arithmeticOverAPositionStandsAtNone() {
+        Core sum = new Core.Binary(souther.compiler.types.BinOp.ADD, parameter(),
+                new Core.Int(1, Type.INT, POS), CoverageOrigin.unwritten(), Type.INT, POS);
+
+        assertEquals(new PathResolution.NotAPosition(), readingOf(sum));
+    }
+
+    /** And an expression binding a name of its own is one this did not read, which is not that. */
+    @Test
+    void anExpressionThatBindsANameOfItsOwnIsNotRead() {
+        Core through = new Core.LetIn(new Core.Binder("x", LOCAL), parameter(),
+                new Core.Read("x", LOCAL, Type.INT, POS), Type.INT, POS);
+
+        assertEquals(new PathResolution.Unread(
+                        PathResolution.Reason.A_NAME_BOUND_INSIDE_THE_EXPRESSION),
+                readingOf(through));
+        assertInstanceOf(PathResolution.Unread.class, readingOf(through),
+                "and never the answer arithmetic gets");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -98,7 +99,7 @@ class ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest {
     void theRowBelowTheThresholdIsOwedAndMissing() {
         ItemAssessment.Owed off = totalsLine().owedAt(PointRole.OFF);
         assertNotNull(off, "a row below the threshold is owed");
-        assertTrue(!off.hasRowWitness(), () -> "no row is below it yet: " + off);
+        assertFalse(off.hasRowWitness(), () -> "no row is below it yet: " + off);
     }
 
     /** No position is left saying the rule is about a value made from it: the rule was read. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest.java
@@ -1,0 +1,115 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A threshold on what a list comes to is asked for wherever the list is named from.
+ *
+ * <p>The rule a behavior exists for is the one the report has to reach. A total over a list is
+ * compared against a number, and what a reader is owed is a row standing on that number, one below
+ * it and one above — the same three a threshold on a field of the input is owed.
+ *
+ * <p>What decides it is nothing about the rule. Here the list arrives under a name a pattern gave
+ * it, one step further from the parameter than a list read straight out of one, and the walk that
+ * says which position the totalled values stand at has that one step more to take. A reading that
+ * measures how far it has come rather than where it has been answers one of the two and not the
+ * other, and the model that gets no answer is told its own rule is about a value nothing here works
+ * out — a sentence about the model, said over a limit of this compiler.
+ */
+class ARuleOnWhatAListComesToIsAskedForHoweverTheListWasNamedTest {
+
+    /** The list under a name of its own, taken apart where the behavior takes its parameter. */
+    private static final String NAMED = """
+            module example.total
+
+            data 金額 = Int
+                invariant value >= 0
+
+            data 明細 = { 金額: 金額 }
+
+            data 明細リスト = List<明細>
+                invariant List.length(value) >= 1
+
+            data 高額
+            data 少額
+
+            behavior 判定する : (明細: 明細リスト) -> 高額 | 少額
+
+            let 合計 (明細リスト(件)): Int =
+                List.sum(List.map(一件 -> 一件.金額.value, 件))
+
+            let 判定する (明細) =
+                if 合計(明細) >= 100000 then 高額 else 少額
+
+            example 判定する
+                | "ちょうど10万円なら高額" : (明細リスト([ 明細 { 金額 = 金額(100000) } ])) -> 高額
+                | "1000円なら少額"        : (明細リスト([ 明細 { 金額 = 金額(1000) } ]))   -> 少額
+            """;
+
+    private static final String LINE = "List.sum(明細[*].金額) = 100000";
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(NAMED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static BorderAssessment totalsLine() {
+        Compilation compilation = compiled();
+        Map<String, List<BorderAssessment>> lines =
+                Adequacy.readingsOf(compilation.db(), compilation.modules().get(0));
+        BorderAssessment line = lines.get("判定する").stream()
+                .filter(each -> LINE.equals(each.label())).findFirst().orElse(null);
+        assertNotNull(line, () -> "the threshold on the total is a line: "
+                + lines.get("判定する").stream().map(BorderAssessment::label).toList());
+        return line;
+    }
+
+    /** The line is drawn where the rule draws it: on the total of the amounts, at its number. */
+    @Test
+    void theThresholdOnTheTotalIsALine() {
+        assertEquals(LINE, totalsLine().label());
+    }
+
+    /** The row the author already wrote — a list planning exactly the threshold — stands on it. */
+    @Test
+    void theRowPlanningExactlyTheThresholdStandsOnThePoint() {
+        ItemAssessment.Owed on = totalsLine().owedAt(PointRole.ON);
+        assertNotNull(on, "a row at the threshold is owed");
+        assertTrue(on.hasRowWitness(), () -> "the row planning 100,000 stands at it: " + on);
+    }
+
+    /** And the point below it is owed and unmet, which is what this model is short of. */
+    @Test
+    void theRowBelowTheThresholdIsOwedAndMissing() {
+        ItemAssessment.Owed off = totalsLine().owedAt(PointRole.OFF);
+        assertNotNull(off, "a row below the threshold is owed");
+        assertTrue(!off.hasRowWitness(), () -> "no row is below it yet: " + off);
+    }
+
+    /** No position is left saying the rule is about a value made from it: the rule was read. */
+    @Test
+    void noPositionIsToldTheRuleIsAboutAValueMadeFromIt() {
+        Compilation compilation = compiled();
+        PartitionEvidence measured = compilation.db()
+                .ask(new Adequacy.Coverage("example.total")).value().get("判定する");
+        assertEquals(List.of(), measured.notRead().stream()
+                .filter(each -> each.reason()
+                        == UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE)
+                .map(PartitionEvidence.NotRead::at).toList());
+    }
+}


### PR DESCRIPTION
Closes #1195.

## What the issue said, and what it turned out to be

The issue says a comparison against the total of a list draws no line. It does, in most models:
the same rule with the list read straight out of the parameter draws its line at
`List.sum(明細[*].金額) = 100000` and owes three rows, one level deeper as well, and with a fork
above it. The run machinery from #1132 / #1153 works.

What the issue's own model has that those do not is a wrapper taken apart where the behavior
takes its parameter. That is one more name between the total and the position its values stand
at, and the reading of positions could not afford it: it counted every hop it took — following a
name, being handed a container's elements, crossing to the binding whose elements are the same —
against `bound.size() + elements.containers().size()`, the names in scope where the walk began.
Four hops needed, three allowed, so the walk stopped one step from the root and the rule came
back as one about a value made from somewhere else.

Measured one element at a time: the wrapper in the parameter pattern is the only axis that makes
the difference. Not the helper `let`, not the invariants, not the newtype on the amount.

## What this does

- **No count anywhere in the walk.** `through`, `bound.size() + containers.size()` and
  `FOLLOWED = 8` are gone. What stops a crossing to another expression is the path it is on: a
  binding it is already answering for cannot be entered twice (`BindingTrail`). Descending an
  expression stops by the tree being finite and spends nothing.
- **A cycle is not an absence.** Entering a binding already on the path raises
  `BindingTrail.ReadThroughItself`, which is a `TheCompilerDisagreesWithItself`. What it violates is
  not that a binding holds one value — two bindings holding each other hold one each — but that the
  lineage built here runs one way: what a name holds is worked out from what stood before it, and
  which binding another's elements came from is recorded where the operation that made them stood.
  Nothing in 11206 tests reaches it.
- **The environment arrives as facts** (`BindingEnvironment`). A reading of what a name means is
  built on the same facts rather than beside them, so a walk after a position cannot ask the
  question whose answer it is, and there is no environment size to measure a traversal against.
- **Which question the walk answers is named** (`Lineage.NAMED_POSITION` / `VALUE_ORIGIN`) instead
  of a `made` boolean, and the rule about which provenance edges each may follow lives on it.
- **What did not reach a position says which of the two it is** (`PathResolution`): an expression
  naming none is the model saying so, and a shape this does not follow is not an answer about the
  model at all. A caller for which they are one answer says so at the call.
- **The relative reading moves out.** Where in an element a closure's answer stands is
  `ElementProjection.read`, sharing the stopping law and nothing else — reachable from the reading
  of input positions, a relative path would quietly become an absolute one.

## Evidence

- The issue's model now owes the three rows at its threshold, and the row the author already
  wrote — a list planning exactly 100,000 — stands on the ON point.
- `HowManyNamesAValueIsReadThroughDoesNotDecideWhatIsReadTest` holds the same answer at 1, 4, 8
  and 16 wrappers. Under a hop budget of 12 the #1195 regression stays green and this one fails,
  which is what it is for: a regression for one model goes green again under a larger number.
- A trail that only grew instead of leaving what it left: 38 classes, 99 failures. The same
  binding is met on two ways as a matter of course, so this is the search's semantics and not an
  implementation choice.
- 11203 tests green on a clean build, rebased on develop.

## Where the third answer stops, for now

`PathResolution.Unread` is reached by one shape today — an expression that binds a name of its
own — and every consumer collapses it with the other absence at the call. Giving it a word of its
own in the report was tried and is wrong until #1211 is settled: the models that produce it are
also models the existing sentence ("about a value made from this one") is right about, and
pinning the new word made two correct sentences false. So the distinction is held at the reading,
where it is true, and `WhatWasNotReadIsNotWhatStandsNowhereTest` holds it there.

## Beside it

- #1211 — following a `let` an inlined helper left, which needs the binder's lineage.
- #1212 — a value truncated by the observation limits reported as a point no row can be written at.
  This is the second face the issue describes, reproduced without the examples repository: at
  sixteen wrappers the line is drawn and all four points come back "not known to be writable".
## The collapse is written where it happens

`PathResolution` has no method that hands back "the position, or nothing". Every reading says so
itself, arm by arm, and what they have in common is not an algorithm — each is one reader stating
that here, today, a position nothing names and a shape this did not follow are the same answer to
it. A fourth arm is a compile error at every one of them, and at the one place that orders two
answers against each other; it travels only through the two that pass an answer on without choosing.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
