### PR TITLE
A claim that says the operator is no comparison is answered for below where one is required

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Comparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Comparison.java
@@ -1,0 +1,79 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+
+import java.util.Optional;
+
+/**
+ * A binary the language reads as a comparison, together with what its operator placed.
+ *
+ * <p><b>The two are one value because they have to agree.</b> What a rule places is a function of
+ * the operator it was written with, and every reader below the point where a node was recognised as
+ * a comparison needs both: the node to read the two sides from, and the claim to say what the rule
+ * states about the line. Passed as two arguments, the pair is only as true as each caller made it;
+ * held here, there is nowhere for a claim of one operator to arrive beside the node of another.
+ *
+ * <p><b>Made in one place, which is what carries the recognition.</b> {@link #of} is the only way
+ * in, so a value of this type is itself the evidence that the operator compares — a reader holding
+ * one has no case left for an operator that placed nothing, and no reason to go back to the operator
+ * and ask again. A {@code boolean} answering the same question leaves the fact behind at the
+ * {@code if}, which is how the readings below came to carry the wider classification and answer for
+ * a case none of them could be handed.
+ *
+ * <p><b>Equal where the nodes are equal.</b> The claim is read off the node's operator, so it adds
+ * nothing to tell two of these apart, and a record holding one compares as it did when it held the
+ * node alone. This is a comparison's value and not an occurrence's identity: which occurrence of a
+ * comparison a body is at is a question about the tree, kept where the tree is
+ * ({@link souther.compiler.coverage.ComparisonCatalog}), and a reader wanting that asks about the
+ * node.
+ */
+public final class Comparison {
+
+    private final Core.Binary at;
+    private final ComparisonClaim claim;
+
+    private Comparison(Core.Binary at, ComparisonClaim claim) {
+        this.at = at;
+        this.claim = claim;
+    }
+
+    /** {@code at} as a comparison, or nothing where its operator compares no values. */
+    public static Optional<Comparison> of(Core.Binary at) {
+        return switch (ComparisonPlacement.of(at.op())) {
+            case ComparisonPlacement.Nothing _ -> Optional.empty();
+            case ComparisonClaim claim -> Optional.of(new Comparison(at, claim));
+        };
+    }
+
+    /** The comparison itself, for a reader of what its two sides name. */
+    public Core.Binary at() {
+        return at;
+    }
+
+    /** What its operator placed on the values. */
+    public ComparisonClaim claim() {
+        return claim;
+    }
+
+    /** Everything this holds, which is what an identity is of. The claim adds nothing to the
+     *  answer — it is read off the node's operator, so two of these over one node carry one claim —
+     *  and it is read here all the same, because a field left out of an identity is a field a
+     *  reader of the identity is told has not changed. */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Comparison that
+                && at.equals(that.at) && claim.equals(that.claim);
+    }
+
+    /** Off the node alone, which spreads these exactly as the claim would: one node has one
+     *  claim. */
+    @Override
+    public int hashCode() {
+        return at.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Comparison[" + at + "]";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
@@ -1,9 +1,7 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
-
 /**
- * What a comparison places on a position's values, read off the comparison and nothing else.
+ * What a comparison placed on a position's values, read off the comparison and nothing else.
  *
  * <p>One classification, asked wherever a rule compares a position to something: a clause of an
  * invariant, a comparison in a body, a clause of an {@code ensures}. A rule is read the same way
@@ -14,11 +12,12 @@ import souther.compiler.types.BinOp;
  * word. Three answers to one question drift, and two of them already had: an equality places a line
  * where a body writes it and placed nothing where a {@code data} did.
  *
- * <p><b>Nothing about a carrier, a term, or a number here.</b> Whether the other side can be read as
- * a value of the position's order, and where the position sits in the value, are what a reading
- * answers about the comparison — and a question the model raises may not be decided by what a
- * reading managed (#851). So this takes an operator and gives what the model states, and a reader
- * that could not find the number still knows a line was placed.
+ * <p><b>Two cases, because an operator that placed nothing is no comparison.</b> That an operator
+ * compares is settled where a comparison is recognised ({@link Comparison}), and this is what such
+ * an operator placed — so there is no arm here for one that placed nothing, and no reader below
+ * that point has one to answer for. Held as the wider {@link ComparisonPlacement}, every one of
+ * them did, and what each answered was invented: a {@code null} for a relation that does not exist,
+ * a {@code false} for a rule that holds at no value because there is no rule.
  *
  * <p><b>And nothing about which values exist.</b> Whether there is anything on the far side of the
  * line is not the comparison's to say: an invariant refuses everything outside its bound at
@@ -26,7 +25,20 @@ import souther.compiler.types.BinOp;
  * fact about the construct the rule is written in, asked beside this rather than inside it — read as
  * one question, a guard's classification would carry an invariant's reason.
  */
-public sealed interface ComparisonClaim {
+public sealed interface ComparisonClaim
+        extends ComparisonPlacement permits ComparisonClaim.Cut, ComparisonClaim.Singled {
+
+    /**
+     * Whether the comparison is true at the value it names.
+     *
+     * <p>Asked of either shape, because either answers it: {@code x <= c} and {@code x > c} agree
+     * about which class the value is in and disagree here, and {@code x == c} is met at the value
+     * where {@code x /= c} is not.
+     */
+    boolean holdsAtTheValue();
+
+    @Override
+    ComparisonClaim turned();
 
     /**
      * An order: the values either side of the line are different classes.
@@ -38,7 +50,15 @@ public sealed interface ComparisonClaim {
      *                          from the other: {@code x <= c} and {@code x > c} agree about which
      *                          class the number is in and disagree here
      */
-    record Cut(boolean valueBelongsBelow, boolean holdsAtTheValue) implements ComparisonClaim {}
+    record Cut(boolean valueBelongsBelow, boolean holdsAtTheValue) implements ComparisonClaim {
+
+        /** Turning the sides round moves the number named to the other class and leaves whether the
+         *  rule holds there alone: {@code x <= c} and {@code -x >= -c} are one statement. */
+        @Override
+        public ComparisonClaim turned() {
+            return new Cut(!valueBelongsBelow, holdsAtTheValue);
+        }
+    }
 
     /**
      * A value singled out: the number named, and every other value as one class.
@@ -53,40 +73,13 @@ public sealed interface ComparisonClaim {
      * and a refused one leaves a hole rather than an edge: the values beside it are on both sides,
      * which is not what a boundary with a low side and a high side can carry.
      */
-    record Singled(boolean holdsAtTheValue) implements ComparisonClaim {}
+    record Singled(boolean holdsAtTheValue) implements ComparisonClaim {
 
-    /** Not a comparison of values at all, so nothing was placed. */
-    record Nothing() implements ComparisonClaim {}
-
-    /**
-     * What {@code op} places, which is nothing where it is not a comparison.
-     *
-     * <p>Which operators compare is {@link BinOp#compares}'s answer and this asks it rather
-     * than listing them again. Two lists can be given different answers about one operator added
-     * later, and they fail in opposite directions: the numbering would leave it out of the
-     * comparisons of a body while this said what it cuts, so a line would be drawn on a comparison
-     * no run records and no row could ever meet it.
-     */
-    static ComparisonClaim of(BinOp op) {
-        if (!op.compares()) {
-            return new Nothing();
+        /** An equality names a value and orders nothing, so there is nothing to turn round. */
+        @Override
+        public ComparisonClaim turned() {
+            return this;
         }
-        return switch (op) {
-            case LE -> new Cut(true, true);
-            case GT -> new Cut(true, false);
-            case LT -> new Cut(false, false);
-            case GE -> new Cut(false, true);
-            case EQ -> new Singled(true);
-            case NE -> new Singled(false);
-            // Refused above and written out here so the switch stays exhaustive: an operator added
-            // to the language stops the compile here and is decided about rather than falling in.
-            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> new Nothing();
-        };
-    }
-
-    /** Whether {@code op} orders the values either side of what it names. */
-    static boolean orders(BinOp op) {
-        return of(op) instanceof Cut;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonPlacement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonPlacement.java
@@ -1,0 +1,83 @@
+package souther.compiler.check;
+
+import souther.compiler.types.BinOp;
+
+/**
+ * What an operator places on a position's values, asked of any operator the language writes.
+ *
+ * <p>The wide answer, and the one place the two vocabularies meet. An operator either compares two
+ * values or does not, and only the first kind places anything: {@code &&} joins comparisons and
+ * {@code +} answers a number, and neither divides a position. So this has an arm for an operator
+ * that places nothing, and {@link ComparisonClaim} — what a comparison placed — has none.
+ *
+ * <p><b>Asked once, and carried as what it answered.</b> Whoever establishes that an operator
+ * compares holds the claim from that moment, rather than a {@code boolean} saying it does: a reader
+ * handed the {@code boolean} still holds an operator, and reading the operator again below the
+ * point where the question was settled leaves every consumer answering for a case that was already
+ * excluded. What such an answer says is invented, and nothing observes it until the day something
+ * does.
+ *
+ * <p><b>Nothing about a carrier, a term, or a number here.</b> Whether the other side can be read as
+ * a value of the position's order, and where the position sits in the value, are what a reading
+ * answers about the comparison. So this takes an operator and gives what the model states, and a
+ * reader that could not find the number still knows a line was placed.
+ */
+public sealed interface ComparisonPlacement permits ComparisonClaim, ComparisonPlacement.Nothing {
+
+    /**
+     * The same placement, read with the comparison's two sides written the other way round.
+     *
+     * <p>The meaning of the swap and not the swap itself. A reader that has one side on the left
+     * and wants the other there turns the statement round once, here, rather than making the
+     * operator it would have been written with and asking what that one places — two ways from an
+     * operator to a meaning, and the second is a table of operators standing beside this one.
+     */
+    ComparisonPlacement turned();
+
+    /** Not a comparison of values at all, so nothing was placed. */
+    record Nothing() implements ComparisonPlacement {
+
+        @Override
+        public ComparisonPlacement turned() {
+            return this;
+        }
+    }
+
+    /**
+     * What {@code op} places, which is nothing where it is not a comparison.
+     *
+     * <p>Which operators compare is {@link BinOp#compares}'s answer and this asks it rather
+     * than listing them again. Two lists can be given different answers about one operator added
+     * later, and they fail in opposite directions: the numbering would leave it out of the
+     * comparisons of a body while this said what it cuts, so a line would be drawn on a comparison
+     * no run records and no row could ever meet it.
+     */
+    static ComparisonPlacement of(BinOp op) {
+        if (!op.compares()) {
+            return new Nothing();
+        }
+        return switch (op) {
+            case LE -> new ComparisonClaim.Cut(true, true);
+            case GT -> new ComparisonClaim.Cut(true, false);
+            case LT -> new ComparisonClaim.Cut(false, false);
+            case GE -> new ComparisonClaim.Cut(false, true);
+            case EQ -> new ComparisonClaim.Singled(true);
+            case NE -> new ComparisonClaim.Singled(false);
+            // Refused above and written out here so the switch stays exhaustive: an operator added
+            // to the language stops the compile here and is decided about rather than falling in.
+            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> new Nothing();
+        };
+    }
+
+    /**
+     * Whether {@code op} orders the values either side of what it names.
+     *
+     * <p>For a reader that holds an operator and nothing else. A reader inside the comparison's own
+     * reading holds the claim and asks it instead: this answers about an operator, and what a rule
+     * placed is the claim's to say.
+     */
+    static boolean orders(BinOp op) {
+        return of(op) instanceof ComparisonClaim.Cut;
+    }
+
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -191,7 +191,7 @@ public record InvariantBound(boolean lower, Endpoint end) {
 
     /** Whether {@code op} says where values stop rather than which one a value is. */
     static boolean ordering(BinOp op) {
-        return ComparisonClaim.orders(op);
+        return ComparisonPlacement.orders(op);
     }
 
     /** One end, from the comparison and how the carrier's counts are spaced. */

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonCatalog.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonCatalog.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import souther.compiler.check.Comparison;
 import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
 
@@ -35,42 +36,52 @@ public final class ComparisonCatalog {
      * it, so one comparison the author wrote stands here once per call — each reached under its
      * caller's own conditions, and each its own thing to say something about.
      *
-     * @param node the comparison itself, which is what every reader joins on. Held by identity:
-     *             Core nodes are records, so two comparisons that look the same are equal, and a
-     *             reader handed the wrong one of two would be answering about the other body
-     * @param at   where it is written, as a report may say it. A {@link Citation} and not a
-     *             position, because a comparison spliced in from another module is written in that
-     *             module's file and reached from a call in this one — and it is here rather than
-     *             taken again wherever a report needs one, so that a rule and the line it draws are
-     *             found at one place because they read one answer
+     * @param comparison the comparison itself, which is what every reader joins on, together with
+     *                   what its operator placed. Recognising the node as a comparison is what puts
+     *                   it here, so what the recognition established travels with it and a reader
+     *                   below has no operator left to read again. Joined on by identity: Core nodes
+     *                   are records, so two comparisons that look the same are equal, and a reader
+     *                   handed the wrong one of two would be answering about the other body
+     * @param at         where it is written, as a report may say it. A {@link Citation} and not a
+     *                   position, because a comparison spliced in from another module is written in
+     *                   that module's file and reached from a call in this one — and it is here
+     *                   rather than taken again wherever a report needs one, so that a rule and the
+     *                   line it draws are found at one place because they read one answer
      */
-    public record Comparison(Core.Binary node, Citation at) {}
+    public record Catalogued(Comparison comparison, Citation at) {
 
-    private final IdentityHashMap<Core, Comparison> byNode;
+        /** The node itself, for a reader joining on the tree. */
+        public Core.Binary node() {
+            return comparison.at();
+        }
+    }
 
-    private ComparisonCatalog(IdentityHashMap<Core, Comparison> byNode) {
+    private final IdentityHashMap<Core, Catalogued> byNode;
+
+    private ComparisonCatalog(IdentityHashMap<Core, Catalogued> byNode) {
         this.byNode = byNode;
     }
 
     /** The comparisons of every behavior body of one module. */
     public static ComparisonCatalog of(Map<String, Core> behaviorBodies) {
-        IdentityHashMap<Core, Comparison> byNode = new IdentityHashMap<>();
+        IdentityHashMap<Core, Catalogued> byNode = new IdentityHashMap<>();
         for (Core body : behaviorBodies.values()) {
             walk(body, byNode);
         }
         return new ComparisonCatalog(byNode);
     }
 
-    private static void walk(Core e, IdentityHashMap<Core, Comparison> byNode) {
+    private static void walk(Core e, IdentityHashMap<Core, Catalogued> byNode) {
         // What a representation kept standing for an analysis to read. What a run does is measured
         // over the tree that runs, which keeps none of these, so reaching one would mean this
         // enumeration was taken over a tree nothing executes.
         if (e instanceof Core.PreservedCall preserved) {
             throw preserved.unexpectedIn("the comparisons of a body");
         }
-        if (e instanceof Core.Binary binary && binary.op().compares()
-                && binary.origin() != null && binary.origin().isWritten()) {
-            byNode.put(binary, new Comparison(binary, Citation.of(binary.pos())));
+        if (e instanceof Core.Binary binary && binary.origin() != null
+                && binary.origin().isWritten()) {
+            Comparison.of(binary).ifPresent(comparison ->
+                    byNode.put(binary, new Catalogued(comparison, Citation.of(binary.pos()))));
         }
         Core.forEachChild(e, child -> walk(child, byNode));
     }
@@ -83,7 +94,7 @@ public final class ComparisonCatalog {
      * standing in a tree this catalog was not taken over — three things a reader deciding for itself
      * would have had to remember to ask about separately.
      */
-    public Optional<Comparison> at(Core node) {
+    public Optional<Catalogued> at(Core node) {
         return Optional.ofNullable(byNode.get(node));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import souther.compiler.check.Comparison;
 import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
@@ -251,13 +252,19 @@ public final class CoverageSites {
 
         private static void requireIsACatalogued(Core node, ComparisonCatalog comparisons,
                                                  String what) {
-            if (!(node instanceof Core.Binary comparison) || !comparison.op().compares()) {
+            // Whether it is a comparison at all is asked where that is decided, so this reading
+            // holds no list of operators of its own. The two questions stay two: a node that is no
+            // comparison and a comparison outside this catalog are different breakages, and one
+            // answer for both would send a reader after the wrong one.
+            Comparison comparison = node instanceof Core.Binary binary
+                    ? Comparison.of(binary).orElse(null) : null;
+            if (comparison == null) {
                 throw new IllegalArgumentException(
                         "something that is not a comparison was " + what + ": " + node);
             }
-            if (comparisons.at(comparison).isEmpty()) {
+            if (comparisons.at(comparison.at()).isEmpty()) {
                 throw new IllegalArgumentException("a comparison this plan's catalog does not hold "
-                        + "was " + what + " at " + comparison.pos()
+                        + "was " + what + " at " + comparison.at().pos()
                         + "; the numbering and the catalog are one answer or they are two");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
@@ -1,6 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.Carrier;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.ComparisonPlacement;
 import souther.compiler.core.Core;
@@ -54,41 +55,88 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlac
     /**
      * What {@code binary} says, or null where it names no number of this input at all.
      *
-     * <p>The number-bearing side is read first and the comparison is turned round where the number
-     * is on the right. What is answered here is layered: the number always, and the place and the
-     * side only where the other operand is a value the number's order writes. A reader wanting a
-     * line asks for one ({@link #line}); a reader wanting to know what the decision is about takes
-     * the number and needs no more.
+     * <p><b>The way in for a reader of any binary a walk met.</b> Not for one holding a recognised
+     * comparison: it would arrive with what the operator placed and leave through a door that reads
+     * the operator for itself, and the classification it was handed would be worked out a second
+     * time. Such a reader asks {@link #lineOf}. Kept to this package so that the difference is
+     * javac's to enforce rather than a habit — {@link ComparedNumbers} is the one way in from
+     * outside, and what it reads is a body's binaries.
+     *
+     * <p>What is answered here is layered: the number always, and the place and the side only where
+     * the other operand is a value the number's order writes. A reader wanting a line asks for one
+     * ({@link #line}); a reader wanting to know what the decision is about takes the number and
+     * needs no more.
      */
-    public static ComparedNumber of(Core.Binary binary, InputReading read, InputReads reads) {
-        ComparisonPlacement placed = ComparisonPlacement.of(binary.op());
-        // Whichever side draws a line, and the left where neither does and it names a number. A
-        // number on the left that the right is not a value of is still the number the comparison
-        // is about, unless the right is a number the left is a value of — then the line is on that
-        // one, and the comparison is read turned round.
-        ComparedNumber left = onOneSide(binary.left(), binary.right(), placed, read, reads);
-        if (left != null && left.at() != null) {
-            return left;
+    static ComparedNumber of(Core.Binary binary, InputReading read, InputReads reads) {
+        OnASide side = sideOf(binary, read, reads);
+        if (side == null) {
+            return null;
         }
         // Turned round as what it states and not as the operator it would have been written with:
         // which side a number stands on is how the source was spelled, and what the rule places is
         // read off the operator once.
-        ComparedNumber right =
-                onOneSide(binary.right(), binary.left(), placed.turned(), read, reads);
+        ComparisonPlacement placed = ComparisonPlacement.of(binary.op());
+        return new ComparedNumber(side.named().term(), side.named().orders(),
+                side.turned() ? placed.turned() : placed, side.at());
+    }
+
+    /**
+     * The line {@code comparison} draws on one position, or null where it draws none there.
+     *
+     * <p><b>The way in for a reader that has a comparison.</b> What the rule placed comes from the
+     * comparison, so nothing here reads an operator, and there is no case for one that places
+     * nothing — this answers with a line or with nothing, and never with a reading that has to be
+     * asked what it is.
+     *
+     * <p>The same side and the same turn as {@link #of}, because which side a comparison is about
+     * is one question. Answered here a second time, a rule written with the number on the right
+     * would be about one position for a reader that came this way and another for one that came the
+     * other.
+     */
+    public static DrawnLine lineOf(Comparison comparison, InputReading read, InputReads reads) {
+        OnASide side = sideOf(comparison.at(), read, reads);
+        NumericTerm.FromOnePosition position =
+                side == null ? null : side.named().term().atOnePosition();
+        if (position == null || side.at() == null || side.named().orders() == null) {
+            return null;
+        }
+        ComparisonClaim claim = comparison.claim();
+        return new DrawnLine(position, side.at(), side.named().orders(),
+                side.turned() ? claim.turned() : claim);
+    }
+
+    /**
+     * Which side of a binary the reading is about, and whether saying so turned the two round.
+     *
+     * <p>Whichever side draws a line, and the left where neither does and it names a number. A
+     * number on the left that the right is not a value of is still the number the comparison is
+     * about, unless the right is a number the left is a value of — then the line is on that one,
+     * and the comparison is read turned round.
+     */
+    private static OnASide sideOf(Core.Binary binary, InputReading read, InputReads reads) {
+        OnASide left = onOneSide(binary.left(), binary.right(), false, read, reads);
+        if (left != null && left.at() != null) {
+            return left;
+        }
+        OnASide right = onOneSide(binary.right(), binary.left(), true, read, reads);
         return right != null && right.at() != null ? right : left != null ? left : right;
     }
 
-    /** The comparison read as being about a number {@code side} names, or null where it names none. */
-    private static ComparedNumber onOneSide(Core side, Core other, ComparisonPlacement placed,
-                                            InputReading read, InputReads reads) {
+    /** What {@code side} names, or null where it names no number of this input. */
+    private static OnASide onOneSide(Core side, Core other, boolean turned, InputReading read,
+                                     InputReads reads) {
         Named named = namedBy(side, read, reads);
         if (named == null) {
             return null;
         }
         Carrier order = named.orders() == null ? null : named.orders().answered();
-        return new ComparedNumber(named.term(), named.orders(), placed,
-                order == null ? null : order.literalOf(other, read.symbols()));
+        return new OnASide(named, order == null ? null : order.literalOf(other, read.symbols()),
+                turned);
     }
+
+    /** One side's number, where the other side falls on its order, and whether reading it this way
+     *  put the two round the other way. */
+    private record OnASide(Named named, Place at, boolean turned) { }
 
     /** The number this is about where one position answers it, and null where none does. */
     public NumericTerm.FromOnePosition atOnePosition() {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
@@ -2,12 +2,12 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.check.ComparisonPlacement;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Place;
-import souther.compiler.types.BinOp;
 
 /**
- * One comparison of a body, said as the number it is about and what it claims of that number.
+ * One binary of a body, said as the number it is about and what its operator places on that number.
  *
  * <p>The one reading of a comparison. Which number is compared, which side of it the comparison
  * keeps, and where the other side falls on that number's order are one answer and not three — a
@@ -23,46 +23,70 @@ import souther.compiler.types.BinOp;
  *               too: it is what the comparison is about, and it is answered by no single position
  * @param orders the order the number is written on and the one it is counted on, or null where
  *               nothing puts an order under it
- * @param claim  what the comparison says of the values either side of {@link #at}, with the operator
- *               turned round where the number was written on the right
+ * @param placed what the comparison says of the values either side of {@link #at}, turned round
+ *               where the number was written on the right. The wide classification, because what
+ *               reaches this reading is any binary a walk met: an arithmetic operator names numbers
+ *               too and places nothing on them
  * @param at     where the other side falls on the number's order, or null where it is not a value
  *               that order writes — another position, a value this compiler does not place
  */
-public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonClaim claim, Place at) {
+public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlacement placed,
+                             Place at) {
 
     /**
-     * What {@code comparison} says, or null where it names no number of this input at all.
+     * What one comparison of a body draws: the number, where the line falls on it, and what the
+     * rule placed there.
+     *
+     * <p>Everything a line is, in one value, made where all of it is known. A reader handed the
+     * reading and a {@code boolean} saying it draws a line still holds the parts that may be absent
+     * and the classification of an operator that places nothing, and has to take them apart again —
+     * so this is what such a reader is handed instead, and there is no state of it in which a line
+     * is missing a part of itself.
+     *
+     * @param term   the position the line is on
+     * @param at     where on its order the line falls
+     * @param orders the order it is read and written back on
+     * @param claim  what the rule placed there
+     */
+    public record DrawnLine(NumericTerm.FromOnePosition term, Place at, TermOrders orders,
+                            ComparisonClaim claim) {}
+
+    /**
+     * What {@code binary} says, or null where it names no number of this input at all.
      *
      * <p>The number-bearing side is read first and the comparison is turned round where the number
      * is on the right. What is answered here is layered: the number always, and the place and the
      * side only where the other operand is a value the number's order writes. A reader wanting a
-     * line asks for one ({@link #drawsALine}); a reader wanting to know what the decision is about
-     * takes the number and needs no more.
+     * line asks for one ({@link #line}); a reader wanting to know what the decision is about takes
+     * the number and needs no more.
      */
-    public static ComparedNumber of(Core.Binary comparison, InputReading read, InputReads reads) {
+    public static ComparedNumber of(Core.Binary binary, InputReading read, InputReads reads) {
+        ComparisonPlacement placed = ComparisonPlacement.of(binary.op());
         // Whichever side draws a line, and the left where neither does and it names a number. A
         // number on the left that the right is not a value of is still the number the comparison
         // is about, unless the right is a number the left is a value of — then the line is on that
         // one, and the comparison is read turned round.
-        ComparedNumber left = onOneSide(comparison.left(), comparison.right(), comparison.op(),
-                read, reads);
+        ComparedNumber left = onOneSide(binary.left(), binary.right(), placed, read, reads);
         if (left != null && left.at() != null) {
             return left;
         }
-        ComparedNumber right = onOneSide(comparison.right(), comparison.left(),
-                mirrored(comparison.op()), read, reads);
+        // Turned round as what it states and not as the operator it would have been written with:
+        // which side a number stands on is how the source was spelled, and what the rule places is
+        // read off the operator once.
+        ComparedNumber right =
+                onOneSide(binary.right(), binary.left(), placed.turned(), read, reads);
         return right != null && right.at() != null ? right : left != null ? left : right;
     }
 
     /** The comparison read as being about a number {@code side} names, or null where it names none. */
-    private static ComparedNumber onOneSide(Core side, Core other, BinOp op, InputReading read,
-                                            InputReads reads) {
+    private static ComparedNumber onOneSide(Core side, Core other, ComparisonPlacement placed,
+                                            InputReading read, InputReads reads) {
         Named named = namedBy(side, read, reads);
         if (named == null) {
             return null;
         }
         Carrier order = named.orders() == null ? null : named.orders().answered();
-        return new ComparedNumber(named.term(), named.orders(), ComparisonClaim.of(op),
+        return new ComparedNumber(named.term(), named.orders(), placed,
                 order == null ? null : order.literalOf(other, read.symbols()));
     }
 
@@ -72,17 +96,24 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonClai
     }
 
     /**
-     * Whether this says where a line falls: a number one position answers, on an order, cut at a
-     * place of it.
+     * Where this says a line falls, or null where it says no line falls anywhere.
      *
-     * <p>The three together, because a line is all three. A comparison naming a number over a run
+     * <p>All of it together, because a line is all of it. A comparison naming a number over a run
      * divides no position; one whose other side is another position states how far two of them
      * stand apart and is read elsewhere; one whose other side is a value the order does not write
-     * is a rule this compiler did not read.
+     * is a rule this compiler did not read; and an operator that placed nothing drew nothing.
+     *
+     * <p><b>The one narrowing, and it hands over what it established.</b> This is where a reading
+     * of any binary a walk met becomes a line, so it is where an operator that places nothing stops
+     * — and every reader below takes {@link DrawnLine}, which has no case for one.
      */
-    public boolean drawsALine() {
-        return at != null && orders != null && atOnePosition() != null
-                && !(claim instanceof ComparisonClaim.Nothing);
+    public DrawnLine line() {
+        NumericTerm.FromOnePosition position = atOnePosition();
+        if (at == null || orders == null || position == null) {
+            return null;
+        }
+        return placed instanceof ComparisonClaim claim
+                ? new DrawnLine(position, at, orders, claim) : null;
     }
 
     /** The number an expression names together with the orders it is read and counted on, or null
@@ -97,14 +128,4 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonClai
     }
 
     private record Named(NumericTerm term, TermOrders orders) { }
-
-    private static BinOp mirrored(BinOp op) {
-        return switch (op) {
-            case LT -> BinOp.GT;
-            case LE -> BinOp.GE;
-            case GT -> BinOp.LT;
-            case GE -> BinOp.LE;
-            default -> op;
-        };
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.AffineForms;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
@@ -41,11 +42,12 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
     /**
      * {@code comparison} as this form, or null where nothing here reads it.
      *
-     * <p>Null where the arithmetic names no position, where an operand is outside the affine
-     * fragment, and where the comparison places nothing — an operand of a variable product is one
-     * value and the rule about it is one this does not model.
+     * <p>Null where the arithmetic names no position and where an operand is outside the affine
+     * fragment — an operand of a variable product is one value and the rule about it is one this
+     * does not model. What the rule places is not among the reasons: a comparison carries it, and
+     * every comparison places something.
      */
-    static AffineReading of(Core.Binary comparison, InputDomain inputs, InputReads reads,
+    static AffineReading of(Comparison comparison, InputDomain inputs, InputReads reads,
                             Symbols symbols) {
         return read(comparison, inputs, reads, symbols) instanceof OfAComparison.Cuts cuts
                 ? cuts.read() : null;
@@ -104,17 +106,14 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
     }
 
     /** The same, saying which of the three it is. */
-    static OfAComparison read(Core.Binary comparison, InputDomain inputs, InputReads reads,
+    static OfAComparison read(Comparison comparison, InputDomain inputs, InputReads reads,
                               Symbols symbols) {
-        if (!comparison.op().compares()) {
-            return new OfAComparison.CutsNothing(java.util.Set.of());
-        }
         // What this reading names as it goes, kept so that a reading which ran to the end can say
         // what it was about without anybody reading the comparison again.
         java.util.Set<NumericTerm> named = new java.util.LinkedHashSet<>();
         // The left first where both stop, which is the side a threshold would be read off.
         LinearForm<NumericTerm> left = null;
-        for (Core side : java.util.List.of(comparison.left(), comparison.right())) {
+        for (Core side : java.util.List.of(comparison.at().left(), comparison.at().right())) {
             AffineForms.Outcome<NumericTerm, InputReads> read =
                     AffineForms.outcome(side, reads, reading(inputs, symbols, named));
             if (read instanceof AffineForms.Outcome.StoppedAt<NumericTerm, InputReads> stopped) {
@@ -130,13 +129,13 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
                 }
                 AffineReading here = new AffineReading(
                         new LinearForm<>(BigDecimal.ZERO, whole.coefs()),
-                        whole.constant().negate(), ComparisonClaim.of(comparison.op()));
+                        whole.constant().negate(), comparison.claim());
                 // Turned round here and nowhere else. `48 >= 3a + 6b` and `3a + 6b <= 48` are one
                 // rule, and a reader that met the first without turning it round drew its border on
                 // `-3a - 6b` — the same four points under a name no author wrote, and a different
                 // line from the rule written the other way.
                 return new OfAComparison.Cuts(
-                        here.facesTheOtherWay(subjectOf(comparison, left, reads, symbols))
+                        here.facesTheOtherWay(subjectOf(comparison.at(), left, reads, symbols))
                                 ? here.mirrored() : here);
             }
         }
@@ -294,7 +293,7 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
      * whichever way the author wrote the subtraction, and it is not a difference between two rules.
      */
     private AffineReading mirrored() {
-        return new AffineReading(form.negate(), cut.negate(), turned(claim));
+        return new AffineReading(form.negate(), cut.negate(), claim.turned());
     }
 
     /**
@@ -331,19 +330,6 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
             }
         }
         return null;
-    }
-
-    /** What the operator states once both sides are turned round. */
-    private static ComparisonClaim turned(ComparisonClaim claim) {
-        return switch (claim) {
-            // Turning the sides round moves the threshold's own value to the other class and leaves
-            // whether the rule holds there alone: `x <= c` and `-x >= -c` are one statement.
-            case ComparisonClaim.Cut cut ->
-                    new ComparisonClaim.Cut(!cut.valueBelongsBelow(), cut.holdsAtTheValue());
-            // An equality names a value and orders nothing, so there is nothing to turn round.
-            case ComparisonClaim.Singled singled -> singled;
-            case ComparisonClaim.Nothing nothing -> nothing;
-        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -106,8 +106,6 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
                 points.add(new DomainPoint.BesideTheLine(Towards.BELOW));
                 points.add(new DomainPoint.BesideTheLine(Towards.ABOVE));
             }
-            case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                    "a line no comparison placed, asked which points it has: " + origin);
         }
         points.add(new DomainPoint.InTheRegion(Towards.BELOW));
         points.add(new DomainPoint.InTheRegion(Towards.ABOVE));
@@ -608,9 +606,6 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
                             pointAt(space, cut, side, false, reach));
                 }
             }
-            // Refused where a line's facts are made, and written out so the switch stays exhaustive.
-            case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                    "a line no comparison placed, asked what a row against it stands at: " + origin);
         }
     }
 
@@ -701,9 +696,6 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
                         // for the line's own value to settle anything about.
                         || !drawnByAnInvariant && admits(within, cut);
             }
-            // Refused where a line's facts are made, and written out so the switch stays exhaustive.
-            case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                    "a line no comparison placed, asked whether the quantity reaches it");
         };
     }
 
@@ -841,8 +833,6 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
             case ComparisonClaim.Singled _ -> List.of(
                     Parting.by(Seam.of(space, cut, Towards.ABOVE), origin.authoredLine()),
                     Parting.by(Seam.of(space, cut, Towards.BELOW), origin.authoredLine()));
-            case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                    "a line no comparison placed, asked where it parts the values: " + origin);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -1,8 +1,8 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
-import souther.compiler.core.Core;
 import souther.compiler.inputs.ComparedNumber;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
@@ -58,16 +58,12 @@ record ComparedLine(NumericTerm.FromOnePosition term, Place value,
      * nothing, and there is nothing else for a spelling to try: which quantity a rule cuts is the
      * arithmetic's answer, and this reading is reached only where the arithmetic had none.
      */
-    static ComparedLine asWritten(Core.Binary comparison,
+    static ComparedLine asWritten(Comparison comparison,
                                   InputReading read, InputReads reads) {
-        ComparedNumber said = ComparedNumber.of(comparison, read, reads);
-        return said == null ? null : of(said.line());
-    }
-
-    /** The same comparison as a line, or null where it says nothing a line is drawn from. */
-    private static ComparedLine of(ComparedNumber.DrawnLine drawn) {
-        // What the rule placed is carried as what it placed: a line here is the rule's own
-        // classification, so nothing along the way has a side to fill in for a rule that has none.
+        // What the rule placed comes from the comparison and is carried as what it placed, so
+        // nothing on the way here has a side to fill in for a rule that has none — and nothing on
+        // the way here reads the operator, which the comparison has already been read for.
+        ComparedNumber.DrawnLine drawn = ComparedNumber.lineOf(comparison, read, reads);
         return drawn == null ? null
                 : new ComparedLine(drawn.term(), drawn.at(), drawn.orders(), drawn.claim());
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -60,20 +60,16 @@ record ComparedLine(NumericTerm.FromOnePosition term, Place value,
      */
     static ComparedLine asWritten(Core.Binary comparison,
                                   InputReading read, InputReads reads) {
-        return of(ComparedNumber.of(comparison, read, reads));
+        ComparedNumber said = ComparedNumber.of(comparison, read, reads);
+        return said == null ? null : of(said.line());
     }
 
     /** The same comparison as a line, or null where it says nothing a line is drawn from. */
-    private static ComparedLine of(ComparedNumber drawn) {
-        if (drawn == null || !drawn.drawsALine()) {
-            return null;
-        }
-        // A comparison that placed nothing draws no line, and the two that place one are carried as
-        // what they placed: a line here is the rule's own classification, so nothing along the way
-        // has a side to fill in for a rule that has none.
-        return drawn.claim() instanceof ComparisonClaim.Nothing ? null
-                : new ComparedLine(drawn.atOnePosition(), drawn.at(), drawn.orders(),
-                        drawn.claim());
+    private static ComparedLine of(ComparedNumber.DrawnLine drawn) {
+        // What the rule placed is carried as what it placed: a line here is the rule's own
+        // classification, so nothing along the way has a side to fill in for a rule that has none.
+        return drawn == null ? null
+                : new ComparedLine(drawn.term(), drawn.at(), drawn.orders(), drawn.claim());
     }
 
     /**
@@ -104,8 +100,7 @@ record ComparedLine(NumericTerm.FromOnePosition term, Place value,
         }
         Carrier carrier = orders.answered();
         Place value = Count.of(read.cut());
-        return read.claim() instanceof ComparisonClaim.Nothing ? null
-                : new ComparedLine(term, value, orders, read.claim());
+        return new ComparedLine(term, value, orders, read.claim());
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
@@ -1,9 +1,8 @@
 package souther.compiler.partition;
 
-import souther.compiler.types.BinOp;
 import souther.compiler.check.Carrier;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
-import souther.compiler.core.Core;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
@@ -63,13 +62,16 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
      * nothing here has taken apart at all — the canonical form is what says a pair is a pair, and
      * it had no answer.
      */
-    static ComparedTerms asWritten(Core.Binary comparison,
+    static ComparedTerms asWritten(Comparison comparison,
                                    InputReading read, InputReads reads) {
-        if (ordersStrictly(comparison.op())) {
+        // A distance is what an order between the two sides states. A rule that names a value
+        // orders nothing, and what tells the two apart is the claim the comparison carries — an
+        // operator list of this reading's own would be a second answer to that.
+        if (comparison.claim() instanceof ComparisonClaim.Cut) {
             GuardThresholds.Named on =
-                    GuardThresholds.namedBy(comparison.left(), read, reads);
+                    GuardThresholds.namedBy(comparison.at().left(), read, reads);
             GuardThresholds.Named against =
-                    GuardThresholds.namedBy(comparison.right(), read, reads);
+                    GuardThresholds.namedBy(comparison.at().right(), read, reads);
             // A distance runs between two positions, so each side has to be a number one answers.
             NumericTerm.FromOnePosition here = on == null ? null : on.term().atOnePosition();
             NumericTerm.FromOnePosition there =
@@ -133,7 +135,7 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
      */
     static ComparedTerms fromTheForm(AffineReading read,
                                      Quantities quantities) {
-        if (read == null || read.claim() instanceof ComparisonClaim.Nothing) {
+        if (read == null) {
             return null;
         }
         NumericTerm[] pair = read.twoCoordinates();
@@ -173,11 +175,4 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
         return new ComparedTerms(two[0], two[1], carriers, new Count(read.cut()));
     }
 
-    /** Whether an operator orders its two sides, which {@code ==} and {@code /=} do not. */
-    private static boolean ordersStrictly(BinOp op) {
-        return switch (op) {
-            case LT, LE, GT, GE -> true;
-            case EQ, NE, AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
-        };
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.Comparison;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
@@ -237,36 +238,37 @@ sealed interface ComparisonAssessment {
      * form written two ways agree as arithmetic and are made of different things, so the rule they
      * state would come back as one about no input at all.
      */
-    static ComparisonAssessment of(String behavior, Core.Binary comparison,
+    static ComparisonAssessment of(String behavior, Comparison comparison,
                                    InputReading read, InputReads reads,
                                    BindingId answer,
                                    boolean drawnByAnInvariant,
                                    souther.compiler.reach.ComparisonArrival arrival) {
         Quantities quantities = read.quantities();
+        Core.Binary at = comparison.at();
         // Asked first, and of the whole comparison. A rule that reads the answer anywhere in it is
         // one this reading does not put on the input space, whichever side the answer is on and
         // whatever else stands beside it: `value.n + query.offset <= 20` is about the answer and
         // about an input, and the input is no more measurable here for the input being named.
-        if (readsAnswer(comparison, answer)) {
+        if (readsAnswer(at, answer)) {
             return new AnswerDependent();
         }
         return switch (Cutting.read(behavior, comparison, read, reads)) {
             case Cutting.Read.Cuts cuts ->
-                    onTheQuantity(comparison, cuts.cutting(), quantities, drawnByAnInvariant,
+                    onTheQuantity(at, cuts.cutting(), quantities, drawnByAnInvariant,
                             arrival);
             // Read to the end and cutting nothing, which is a fact about the rule and not a limit
             // of this compiler: `a <= a` holds of every row. Where the comparison names no position
             // either, there is no rule about a position to say it of — `2 > 1` is a comparison of
             // constants and states nothing anywhere.
             case Cutting.Read.CutsNothing over -> over.read().isEmpty()
-                    ? aboutNoPosition(comparison, reads, read.symbols())
+                    ? aboutNoPosition(at, reads, read.symbols())
                     : new CutsNothing(AffineReading.filedAt(over.read()));
             // And where the reading stopped, its own answer for having stopped — decided where it
             // stopped rather than worked out again from the comparison afterwards. Here the walk
             // over the expression is the only account of what the rule is about, which is what it
             // is for.
             case Cutting.Read.Stopped stopped -> stopped.why().isEmpty()
-                    ? aboutNoPosition(comparison, reads, read.symbols())
+                    ? aboutNoPosition(at, reads, read.symbols())
                     : new Unread(stopped.why());
             // And where the quantity was read and stands on no order this counts, the carrier is
             // what a reader is owed — at the quantity's own coordinates, because the quantity is
@@ -274,7 +276,7 @@ sealed interface ComparisonAssessment {
             // left when several answers were absent: it says the values here carry no order to
             // draw a line on, and that is exactly what was found.
             case Cutting.Read.NoOrderToCountOn over -> over.over().isEmpty()
-                    ? aboutNoPosition(comparison, reads, read.symbols())
+                    ? aboutNoPosition(at, reads, read.symbols())
                     : new Unread(atEachOf(over.over(),
                             new BlockReason.UnreadComparisonDomain()));
         };

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -1,9 +1,11 @@
 package souther.compiler.partition;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonCatalog;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.types.BinOp;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
 
@@ -57,8 +59,14 @@ final class ComparisonReadings {
      *                reading has no arithmetic for is on the list as a decline, so the two are not
      *                one answer
      */
-    record Reading(Core.Binary comparison, InputReads reads, List<OnTheWay> assumed,
-                   BoundaryPolicy.Standing standing) {}
+    record Reading(Comparison comparison, InputReads reads, List<OnTheWay> assumed,
+                   BoundaryPolicy.Standing standing) {
+
+        /** The node this is a reading of, for a reader joining on the tree. */
+        Core.Binary at() {
+            return comparison.at();
+        }
+    }
 
     private final List<Reading> readings;
 
@@ -75,7 +83,7 @@ final class ComparisonReadings {
     ReachingCuts reaching(CoverageSites.Plan plan) {
         ReachingCuts.Collected cuts = new ReachingCuts.Collected();
         for (Reading each : readings) {
-            plan.comparisonAt(each.comparison())
+            plan.comparisonAt(each.at())
                     .ifPresent(site -> cuts.reached(site, each.assumed()));
         }
         return cuts.made();
@@ -127,7 +135,14 @@ final class ComparisonReadings {
                              List<OnTheWay> assumed, boolean live, List<Reading> out) {
         CoverageSites.Plan plan = in.plan();
         Symbols symbols = in.symbols();
-        if (e instanceof Core.Binary comparison && plan.comparisons().at(comparison).isPresent()) {
+        ComparisonCatalog.Catalogued catalogued = e instanceof Core.Binary binary
+                ? plan.comparisons().at(binary).orElse(null) : null;
+        if (catalogued != null) {
+            // What the catalog holds, which is the node together with what its operator placed.
+            // Recognising it as a comparison is what put it there, so the recognition is taken from
+            // it rather than made again here.
+            Comparison comparison = catalogued.comparison();
+            Core.Binary at = catalogued.node();
             // Read only where the policy admits it, and under the names in force here, which is
             // the one environment the comparison is about. `answer` is null: a body has nothing
             // that is the answer.
@@ -139,13 +154,12 @@ final class ComparisonReadings {
             // existing. Asked as an optional, a policy that stopped proving it would hand the
             // reading below the answer that restricts nothing, and this stage disagreeing with the
             // plan would go out as an arrival nobody could project.
-            BoundaryPolicy.Standing standing = BoundaryPolicy.refuses(comparison, plan, live)
+            BoundaryPolicy.Standing standing = BoundaryPolicy.refuses(at, plan, live)
                     .<BoundaryPolicy.Standing>map(BoundaryPolicy.Standing.Refused::new)
                     .orElseGet(() -> new BoundaryPolicy.Standing.Admitted(
                             ComparisonAssessment.of(in.behavior(), comparison, in.read(), reads,
                                     null, false,
-                                    in.arrives().arrivalAt(
-                                            plan.requireComparisonAt(comparison)))));
+                                    in.arrives().arrivalAt(plan.requireComparisonAt(at)))));
             out.add(new Reading(comparison, reads, assumed, standing));
         }
         switch (e) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -1,8 +1,9 @@
 package souther.compiler.partition;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.check.Comparison;
 import souther.compiler.core.Core;
 import souther.compiler.inputs.InputReads;
+import souther.compiler.types.BinOp;
 
 /**
  * What a condition of a body is made of.
@@ -68,12 +69,21 @@ sealed interface Condition {
     /**
      * One comparison, and where the names in it point.
      *
-     * @param reads the reading in force where this comparison stands, which is the outer one with
-     *              every binding between here and the top taken in. A comparison inside an expanded
-     *              helper is about the argument the call handed it, and read against the outer names
-     *              it is about nothing
+     * @param comparison the comparison together with what its operator placed. Recognising it is
+     *                   what this shape is, so what the recognition established is carried rather
+     *                   than left at the test that established it
+     * @param reads      the reading in force where this comparison stands, which is the outer one
+     *                   with every binding between here and the top taken in. A comparison inside
+     *                   an expanded helper is about the argument the call handed it, and read
+     *                   against the outer names it is about nothing
      */
-    record Compares(Core.Binary at, InputReads reads) implements Condition {}
+    record Compares(Comparison comparison, InputReads reads) implements Condition {
+
+        @Override
+        public Core at() {
+            return comparison.at();
+        }
+    }
 
     /** Where this reading stops: a condition of a shape it has no words for. */
     record NotRead(Core at) implements Condition {}
@@ -107,8 +117,11 @@ sealed interface Condition {
             return binary.op() == BinOp.AND
                     ? new Both(binary, left, right) : new Either(binary, left, right);
         }
-        if (e instanceof Core.Binary comparison && comparison.op().compares()) {
-            return new Compares(comparison, reads);
+        if (e instanceof Core.Binary binary) {
+            Comparison comparison = Comparison.of(binary).orElse(null);
+            if (comparison != null) {
+                return new Compares(comparison, reads);
+            }
         }
         return new NotRead(e);
     }
@@ -118,7 +131,7 @@ sealed interface Condition {
         return op == BinOp.AND || op == BinOp.OR;
     }
 
-    // Which operators compare is `BinOp#compares` and is asked rather than spelled out again.
-    // Written here as "a binary that is not `&&` or `||`", this said arithmetic was a comparison —
-    // which nothing in a condition is, so it was a spelling that happened to be right.
+    // Which binaries are comparisons is `Comparison#of`'s answer and is asked rather than spelled
+    // out again. Written here as "a binary that is not `&&` or `||`", this said arithmetic was a
+    // comparison — which nothing in a condition is, so it was a spelling that happened to be right.
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -1,7 +1,7 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
-import souther.compiler.core.Core;
 import souther.compiler.inputs.InputReading;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
@@ -137,7 +137,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * over the comparison and answered about the shape rather than about what this reading could do
      * with it.
      */
-    static Read read(String behavior, Core.Binary comparison,
+    static Read read(String behavior, Comparison comparison,
                      InputReading read, InputReads reads) {
         AffineReading.OfAComparison canonical =
                 AffineReading.read(comparison, read.domain(), reads, read.symbols());
@@ -269,21 +269,24 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * a case of an enumeration, one string against another. Reached only from a reading that
      * stopped, so a spelling never answers a question the canonical form has already answered.
      */
-    private static Read asWritten(String behavior, Core.Binary comparison,
+    private static Read asWritten(String behavior, Comparison comparison,
                                   AffineReading.OfAComparison.Stopped canonical,
                                   InputReading read, InputReads reads) {
         Quantities quantities = read.quantities();
         Cutting drawn = atAPosition(behavior,
-                ComparedLine.asWritten(comparison, read, reads), quantities);
+                ComparedLine.asWritten(comparison.at(), read, reads), quantities);
         if (drawn == null) {
+            // What the rule placed, carried from where the comparison was recognised. Read off the
+            // operator again here, this reading would be a second answer to a question the value in
+            // hand already answers.
             drawn = apart(behavior, ComparedTerms.asWritten(comparison, read, reads),
-                    ComparisonClaim.of(comparison.op()), quantities);
+                    comparison.claim(), quantities);
         }
         if (drawn != null) {
             return new Read.Cuts(drawn);
         }
-        return new Read.Stopped(
-                GuardThresholds.whatEachPlaceIsLeftWith(comparison, canonical, read, reads));
+        return new Read.Stopped(GuardThresholds.whatEachPlaceIsLeftWith(
+                comparison.at(), canonical, read, reads));
     }
 
     /** One position's own values, cut where the reading found the line, or null where that reading
@@ -597,11 +600,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
     }
 
     boolean holdsAtTheValue() {
-        return switch (claim) {
-            case ComparisonClaim.Cut cut -> cut.holdsAtTheValue();
-            case ComparisonClaim.Singled singled -> singled.holdsAtTheValue();
-            case ComparisonClaim.Nothing _ -> false;
-        };
+        return claim.holdsAtTheValue();
     }
 
     /** The line this draws, as a border reads it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -599,10 +599,6 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         return claim instanceof ComparisonClaim.Cut cut ? cut : null;
     }
 
-    boolean holdsAtTheValue() {
-        return claim.holdsAtTheValue();
-    }
-
     /** The line this draws, as a border reads it. */
     BoundaryTarget target() {
         return BoundaryTarget.at(of, at);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -274,7 +274,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
                                   InputReading read, InputReads reads) {
         Quantities quantities = read.quantities();
         Cutting drawn = atAPosition(behavior,
-                ComparedLine.asWritten(comparison.at(), read, reads), quantities);
+                ComparedLine.asWritten(comparison, read, reads), quantities);
         if (drawn == null) {
             // What the rule placed, carried from where the comparison was recognised. Read off the
             // operator again here, this reading would be a second answer to a question the value in

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -65,7 +66,11 @@ public final class DeclaredThresholds {
     private static void drawn(String behavior, ClauseWithoutAnEnd clause,
                               InputReading read, List<LineDrawn> out) {
         Symbols symbols = read.symbols();
-        if (!(clause.part() instanceof Core.Binary comparison) || !comparison.op().compares()) {
+        if (!(clause.part() instanceof Core.Binary binary)) {
+            return;
+        }
+        Comparison comparison = Comparison.of(binary).orElse(null);
+        if (comparison == null) {
             return;
         }
         Map<BindingId, TermPath> roots = rootsOf(clause, symbols);

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.types.BinOp;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.StatedContract;
@@ -194,7 +195,9 @@ public final class EnsuresThresholds {
         // Anything else is a form this walk does not read. Which positions it is about is still
         // said, because a position left out of every answer is reported as one the model draws no
         // line through — and the model says otherwise in the rule this stopped on.
-        if (!(e instanceof Core.Binary comparison) || !comparison.op().compares()) {
+        Comparison comparison = e instanceof Core.Binary binary
+                ? Comparison.of(binary).orElse(null) : null;
+        if (comparison == null) {
             // A statement that is not a comparison was not assessed as one, so what stopped this
             // is the form it is written in — the one of the reasons that does not turn on what two
             // sides name — and the positions the walk met are all there is to file it at.
@@ -221,7 +224,7 @@ public final class EnsuresThresholds {
         // What the positions this names are left with, where the reading of lines drew none. Asked
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.
-        reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(),
+        reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison.at(), rule.value(),
                 assessed.whatEachPlaceIsLeftWith(), out.rulesWithoutALine());
         // And the geometry, which is this reader's own. Only the two arms that draw something have
         // anything to add here.
@@ -248,9 +251,6 @@ public final class EnsuresThresholds {
                             out.evidence().add(new LineEvidence.Divides(
                                     new Threshold(at.position(), at.cutting().seam(),
                                             order.valueBelongsBelow(), origin)));
-                    case ComparisonClaim.Nothing _ ->
-                            throw new IllegalStateException("a line no comparison placed, filed as"
-                                    + " one an ensures drew: " + origin);
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at: the classes either side are what the model tells apart, and the border is

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -158,7 +158,7 @@ public final class GuardThresholds {
         for (ComparisonReadings.Reading each : comparisons.all()) {
             switch (each.standing()) {
                 case BoundaryPolicy.Standing.Admitted admitted ->
-                        lineAt(behavior, each.comparison(), plan, symbols,
+                        lineAt(behavior, each.at(), plan, symbols,
                                 admitted.read(), found, between, withoutALine);
                 // Not a rule with no line here: its outcome is about no row, whichever of the
                 // reasons refused it ({@link NotABoundary}), so there is nothing for a report to
@@ -432,8 +432,6 @@ public final class GuardThresholds {
                     case ComparisonClaim.Cut order -> out.add(new LineEvidence.Divides(
                             new Threshold(at.position(), at.cutting().seam(),
                                     order.valueBelongsBelow(), origin)));
-                    case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                            "a line no comparison placed, filed as one a guard drew: " + origin);
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at. It divides the position — the classes either side are what the model

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
@@ -30,15 +30,6 @@ import souther.compiler.check.ComparisonClaim;
  */
 public record LineFacts(ComparisonClaim claim) {
 
-    public LineFacts {
-        // A line is something a comparison placed. What an operator that compares nothing places is
-        // no line at all, and a reading that got here holding one has answered a question about a
-        // rule that never drew.
-        if (!(claim instanceof ComparisonClaim.Cut || claim instanceof ComparisonClaim.Singled)) {
-            throw new IllegalArgumentException("a line is what some comparison placed: " + claim);
-        }
-    }
-
     /**
      * The line a rule that keeps a run of the values drew, which is what a bound is.
      *
@@ -61,15 +52,7 @@ public record LineFacts(ComparisonClaim claim) {
      * where {@code x /= c} is not.
      */
     public boolean holdsAtTheValue() {
-        return switch (claim) {
-            case ComparisonClaim.Cut cut -> cut.holdsAtTheValue();
-            case ComparisonClaim.Singled singled -> singled.holdsAtTheValue();
-            // Refused where one of these is made, and written out here so the switch stays
-            // exhaustive: a shape added to the classification stops the compile at both places
-            // rather than falling into whichever arm was listed last.
-            case ComparisonClaim.Nothing _ -> throw new IllegalStateException(
-                    "a line that no comparison placed: " + claim);
-        };
+        return claim.holdsAtTheValue();
     }
 
     /** Whether the rule names a value rather than ordering the values either side of it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -181,12 +181,12 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
     private static OnTheWay of(Condition.Compares comparison, InputDomain inputs, boolean holding,
                                Symbols symbols) {
         Citation at = Citation.of(comparison.at().pos());
-        AffineReading read =
-                AffineReading.of(comparison.at(), inputs, comparison.reads(), symbols);
-        Rel states = read == null ? null : relOf(read.claim());
-        if (states == null) {
+        AffineReading read = AffineReading.of(
+                comparison.comparison(), inputs, comparison.reads(), symbols);
+        if (read == null) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ComparisonNotRepresentedAsACut());
         }
+        Rel states = relOf(read.claim());
         // The form with the threshold moved into it, since what a domain is told is `f rel 0`.
         LinearForm<NumericTerm> against =
                 read.form().minus(LinearForm.constant(read.cut()));
@@ -209,7 +209,6 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
                     : (cut.holdsAtTheValue() ? Rel.GE : Rel.GT);
             case ComparisonClaim.Singled singled ->
                     singled.holdsAtTheValue() ? Rel.EQ : Rel.NE;
-            case ComparisonClaim.Nothing _ -> null;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/reading/NumberWays.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/NumberWays.java
@@ -66,17 +66,18 @@ final class NumberWays implements ComparisonWays {
 
     @Override
     public boolean comesOut(Core e, boolean want, Function<Core.Read, Core> settledBy) {
-        ComparedNumber drawn =
-                e instanceof Core.Binary comparison ? numbers.of(comparison, reads) : null;
-        return drawn == null || !drawn.drawsALine()
+        ComparedNumber said =
+                e instanceof Core.Binary binary ? numbers.of(binary, reads) : null;
+        ComparedNumber.DrawnLine drawn = said == null ? null : said.line();
+        return drawn == null
                 ? ComparisonWays.OF_THE_TREE.comesOut(e, want, settledBy)
                 : leaves(drawn, want);
     }
 
     /** Whether the values the rules leave the number include one the comparison comes out
      *  {@code want} at. */
-    private boolean leaves(ComparedNumber drawn, boolean want) {
-        NumericDomain.Bounds runs = quantities.runsBetween(drawn.atOnePosition());
+    private boolean leaves(ComparedNumber.DrawnLine drawn, boolean want) {
+        NumericDomain.Bounds runs = quantities.runsBetween(drawn.term());
         return switch (drawn.claim()) {
             case ComparisonClaim.Cut cut -> {
                 // Which side the way needs, from the two facts the claim carries: which side of the
@@ -90,8 +91,6 @@ final class NumberWays implements ComparisonWays {
             // and nothing else.
             case ComparisonClaim.Singled singled -> singled.holdsAtTheValue() == want
                     ? holds(runs, drawn.at()) : notOnlyOneValue(runs, drawn.at());
-            // Refused before this: a comparison claiming nothing draws no line.
-            case ComparisonClaim.Nothing ignored -> false;
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -13,14 +13,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeSet;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * Who reads an operator for what it places, which is what keeps a recognised comparison recognised.
+ * Who reads an operator for what it places, and how often.
  *
  * <p>A reader below the point where a binary was recognised as a comparison holds
  * {@link ComparisonClaim}, which has no case for an operator that places nothing. That stands only
@@ -28,11 +28,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * hands back the wide answer, and whoever made it has a case to invent an answer for again — which
  * is how six readings came to answer for a comparison that was never one.
  *
- * <p>So the readers of the wide answer are named here. Outside the classification itself they are
- * the two boundaries this arrangement has: {@link Comparison} refines a node into a comparison, and
- * {@link souther.compiler.inputs.ComparedNumber} reads any binary a walk met, where an operator
- * that places nothing is a thing that really arrives. Beside them is the boolean spelling of the
- * same answer, which is in the classification and asked in one place of its own.
+ * <p><b>How often, and not only where.</b> A method is licensed here for the question it asks, and
+ * a second call inside it is a second question wearing the first one's licence — a reading that
+ * reaches the wide answer twice has somewhere in it that could disagree with itself. So the count
+ * is part of what is declared, and a call added anywhere lands as a number that does not match.
+ *
+ * <p>What a count cannot say is who came through a door: a licence given to a method covers every
+ * caller of it. So the doors are held apart by the language instead.
+ * {@link souther.compiler.inputs.ComparedNumber#of} is the wide one and is package-private, which
+ * makes {@code ComparedNumbers} the one way to it from outside and a body's binaries the one thing
+ * that arrives; a reader holding a comparison takes {@code lineOf} and hands over the claim it
+ * already has.
  *
  * <p>Read off the compiled classes, because what a method calls is what the class file says. A
  * reading of the sources would answer the same question a second way, and would not see a call
@@ -42,49 +48,59 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
 
     private static final String PLACEMENT = "souther/compiler/check/ComparisonPlacement";
 
-    /** Who may read an operator for what it places, and why. */
-    private static final Map<String, String> MAY_ASK = asking();
+    /** A method that may read an operator for what it places, how many times it does, and why. */
+    private record Licence(String who, int calls, String why) { }
 
-    private static Map<String, String> asking() {
-        Map<String, String> may = new LinkedHashMap<>();
-        may.put("souther.compiler.check.Comparison.of",
-                "the one place a node becomes a comparison, which is what carries the claim to"
-                        + " every reader below it");
-        may.put("souther.compiler.check.ComparisonPlacement.orders",
-                "the same answer asked as a boolean, for a reader that holds an operator and no"
-                        + " comparison");
-        may.put("souther.compiler.inputs.ComparedNumber.of",
-                "reads any binary a walk met, so an operator that places nothing arrives here and"
-                        + " is answered rather than excluded");
-        return may;
-    }
+    private static final List<Licence> MAY_ASK = List.of(
+            new Licence("souther.compiler.check.Comparison.of", 1,
+                    "the one place a node becomes a comparison, which is what carries the claim to"
+                            + " every reader below it"),
+            new Licence("souther.compiler.check.ComparisonPlacement.orders", 1,
+                    "the same answer asked as a boolean, for a reader that holds an operator and"
+                            + " no comparison"),
+            new Licence("souther.compiler.inputs.ComparedNumber.of", 1,
+                    "reads any binary a walk met, so an operator that places nothing arrives here"
+                            + " and is answered rather than excluded"));
 
     /** Who may ask whether an operator orders its values, which is the wide answer read as a
      *  boolean. The reading of an invariant's clauses is the one left, and it is where the same
      *  arrangement is still to be made. */
-    private static final Map<String, String> MAY_ASK_ORDERS = Map.of(
-            "souther.compiler.check.InvariantBound.ordering",
-            "a clause of a data is read off the syntax tree and has no recognised comparison to"
-                    + " carry a claim");
+    private static final List<Licence> MAY_ASK_ORDERS = List.of(
+            new Licence("souther.compiler.check.InvariantBound.ordering", 1,
+                    "a clause of a data is read off the syntax tree and has no recognised"
+                            + " comparison to carry a claim"));
 
     @Test
     void onlyTheTwoBoundariesReadAnOperatorForWhatItPlaces() throws IOException {
-        assertEquals(new TreeSet<>(MAY_ASK.keySet()), callersOf("of"),
+        assertEquals(declared(MAY_ASK), callsTo("of"),
                 "a reader below a recognised comparison that asks the operator again holds the"
-                        + " wide answer, and has a case to invent an answer for. Each of the two"
-                        + " that may is here with why: " + MAY_ASK);
+                        + " wide answer, and has a case to invent an answer for; a second call in a"
+                        + " licensed reader is a second question under the first one's licence."
+                        + " What each of these may ask, and why: " + why(MAY_ASK));
     }
 
     @Test
     void whetherAnOperatorOrdersIsAskedOnlyWhereNoComparisonIsHeld() throws IOException {
-        assertEquals(new TreeSet<>(MAY_ASK_ORDERS.keySet()), callersOf("orders"),
+        assertEquals(declared(MAY_ASK_ORDERS), callsTo("orders"),
                 "asked as a boolean, what an operator places is left behind at the test. Where"
-                        + " that is still done is here with why: " + MAY_ASK_ORDERS);
+                        + " that is still done, and why: " + why(MAY_ASK_ORDERS));
     }
 
-    /** Every method of the compiler that calls {@code ComparisonPlacement.<name>}. */
-    private static TreeSet<String> callersOf(String name) throws IOException {
-        TreeSet<String> callers = new TreeSet<>();
+    private static Map<String, Integer> declared(List<Licence> licences) {
+        Map<String, Integer> out = new TreeMap<>();
+        licences.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why(List<Licence> licences) {
+        Map<String, String> out = new LinkedHashMap<>();
+        licences.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler calls {@code ComparisonPlacement.<name>}. */
+    private static Map<String, Integer> callsTo(String name) throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
         int read = 0;
         for (Path each : classes()) {
             ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
@@ -95,13 +111,13 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                     if (element instanceof InvokeInstruction call
                             && call.owner().asInternalName().equals(PLACEMENT)
                             && call.name().stringValue().equals(name)) {
-                        callers.add(owner + "." + method.methodName().stringValue());
+                        calls.merge(owner + "." + method.methodName().stringValue(), 1, Integer::sum);
                     }
                 }));
             }
         }
         assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
-        return callers;
+        return calls;
     }
 
     private static List<Path> classes() throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -1,0 +1,113 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Who reads an operator for what it places, which is what keeps a recognised comparison recognised.
+ *
+ * <p>A reader below the point where a binary was recognised as a comparison holds
+ * {@link ComparisonClaim}, which has no case for an operator that places nothing. That stands only
+ * while nothing down there goes back to the operator: one call to {@link ComparisonPlacement#of}
+ * hands back the wide answer, and whoever made it has a case to invent an answer for again — which
+ * is how six readings came to answer for a comparison that was never one.
+ *
+ * <p>So the readers of the wide answer are named here. Outside the classification itself they are
+ * the two boundaries this arrangement has: {@link Comparison} refines a node into a comparison, and
+ * {@link souther.compiler.inputs.ComparedNumber} reads any binary a walk met, where an operator
+ * that places nothing is a thing that really arrives. Beside them is the boolean spelling of the
+ * same answer, which is in the classification and asked in one place of its own.
+ *
+ * <p>Read off the compiled classes, because what a method calls is what the class file says. A
+ * reading of the sources would answer the same question a second way, and would not see a call
+ * written inside a lambda as the method that holds it.
+ */
+class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
+
+    private static final String PLACEMENT = "souther/compiler/check/ComparisonPlacement";
+
+    /** Who may read an operator for what it places, and why. */
+    private static final Map<String, String> MAY_ASK = asking();
+
+    private static Map<String, String> asking() {
+        Map<String, String> may = new LinkedHashMap<>();
+        may.put("souther.compiler.check.Comparison.of",
+                "the one place a node becomes a comparison, which is what carries the claim to"
+                        + " every reader below it");
+        may.put("souther.compiler.check.ComparisonPlacement.orders",
+                "the same answer asked as a boolean, for a reader that holds an operator and no"
+                        + " comparison");
+        may.put("souther.compiler.inputs.ComparedNumber.of",
+                "reads any binary a walk met, so an operator that places nothing arrives here and"
+                        + " is answered rather than excluded");
+        return may;
+    }
+
+    /** Who may ask whether an operator orders its values, which is the wide answer read as a
+     *  boolean. The reading of an invariant's clauses is the one left, and it is where the same
+     *  arrangement is still to be made. */
+    private static final Map<String, String> MAY_ASK_ORDERS = Map.of(
+            "souther.compiler.check.InvariantBound.ordering",
+            "a clause of a data is read off the syntax tree and has no recognised comparison to"
+                    + " carry a claim");
+
+    @Test
+    void onlyTheTwoBoundariesReadAnOperatorForWhatItPlaces() throws IOException {
+        assertEquals(new TreeSet<>(MAY_ASK.keySet()), callersOf("of"),
+                "a reader below a recognised comparison that asks the operator again holds the"
+                        + " wide answer, and has a case to invent an answer for. Each of the two"
+                        + " that may is here with why: " + MAY_ASK);
+    }
+
+    @Test
+    void whetherAnOperatorOrdersIsAskedOnlyWhereNoComparisonIsHeld() throws IOException {
+        assertEquals(new TreeSet<>(MAY_ASK_ORDERS.keySet()), callersOf("orders"),
+                "asked as a boolean, what an operator places is left behind at the test. Where"
+                        + " that is still done is here with why: " + MAY_ASK_ORDERS);
+    }
+
+    /** Every method of the compiler that calls {@code ComparisonPlacement.<name>}. */
+    private static TreeSet<String> callersOf(String name) throws IOException {
+        TreeSet<String> callers = new TreeSet<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String owner = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(PLACEMENT)
+                            && call.name().stringValue().equals(name)) {
+                        callers.add(owner + "." + method.methodName().stringValue());
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return callers;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.types.BinOp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The algebra of what an operator places, which is what lets a reader stop holding the operator.
+ *
+ * <p>Three laws, and each of them is what some reading rests on. That the classification and
+ * {@link BinOp#compares} agree is what makes a claim the evidence that an operator compares. That
+ * turning a statement round twice is the statement is what lets a reading turn one round wherever
+ * it meets it. And that classifying the operator a swap would have been written with is the same as
+ * turning the classification round is what lets a reader swap the sides without an operator table
+ * of its own — the table a reading of a body's comparisons used to hold.
+ */
+class WhatAnOperatorPlacesIsOneAnswerTest {
+
+    /** The operator each one states when its two operands change places. Written out here and
+     *  nowhere in the compiler: what a reading does with a swap is turn the claim round, and this
+     *  is the table that says the two are one. */
+    private static final Map<BinOp, BinOp> SWAPPED = swapped();
+
+    private static Map<BinOp, BinOp> swapped() {
+        Map<BinOp, BinOp> pairs = new LinkedHashMap<>();
+        pairs.put(BinOp.LT, BinOp.GT);
+        pairs.put(BinOp.GT, BinOp.LT);
+        pairs.put(BinOp.LE, BinOp.GE);
+        pairs.put(BinOp.GE, BinOp.LE);
+        pairs.put(BinOp.EQ, BinOp.EQ);
+        pairs.put(BinOp.NE, BinOp.NE);
+        return pairs;
+    }
+
+    /** What an operator places is a claim exactly where the operator compares. Two spellings of one
+     *  membership drift, and an operator added to the language would land in them differently. */
+    @Test
+    void whatPlacesSomethingIsWhatCompares() {
+        Map<BinOp, Boolean> places = new LinkedHashMap<>();
+        Map<BinOp, Boolean> compares = new LinkedHashMap<>();
+        for (BinOp op : BinOp.values()) {
+            places.put(op, ComparisonPlacement.of(op) instanceof ComparisonClaim);
+            compares.put(op, op.compares());
+        }
+        assertEquals(compares, places,
+                "what an operator places and whether it compares are one question");
+    }
+
+    /** Turning a statement round twice is the statement. Asked of every operator and not of the
+     *  comparisons alone, because it is the wide answer a reader of any binary turns round. */
+    @Test
+    void turningAPlacementRoundTwiceLeavesIt() {
+        for (BinOp op : BinOp.values()) {
+            ComparisonPlacement placed = ComparisonPlacement.of(op);
+            assertEquals(placed, placed.turned().turned(),
+                    () -> "turning " + op + " round twice states what it stated");
+        }
+    }
+
+    /**
+     * Reading the swapped operator and turning the reading round come to the same claim.
+     *
+     * <p>What a reader of a comparison written the other way round rests on. Where the two part, a
+     * reading that swaps the sides and turns the claim round says something the source did not, and
+     * the only way to notice is to write the operator table again beside it.
+     */
+    @Test
+    void swappingTheSidesIsTurningWhatWasPlaced() {
+        for (Map.Entry<BinOp, BinOp> each : SWAPPED.entrySet()) {
+            assertEquals(ComparisonPlacement.of(each.getValue()),
+                    ComparisonPlacement.of(each.getKey()).turned(),
+                    () -> "what " + each.getKey() + " places, turned round, is what "
+                            + each.getValue() + " places");
+        }
+    }
+
+    /** An operator that places nothing has nothing to turn round, which is what lets a reading of
+     *  any binary turn one round before it knows whether it is a comparison. */
+    @Test
+    void anOperatorThatPlacesNothingTurnsIntoItself() {
+        for (BinOp op : BinOp.values()) {
+            if (op.compares()) {
+                continue;
+            }
+            ComparisonPlacement placed = ComparisonPlacement.of(op);
+            assertEquals(placed, placed.turned(),
+                    () -> op + " places nothing, and nothing turned round is nothing");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameStandsForEveryValueItsContainerWasWrittenWithTest.java
@@ -144,7 +144,7 @@ class ANameStandsForEveryValueItsContainerWasWrittenWithTest {
         ComparisonReadings.Reading only = read.only();
         Symbols symbols = read.symbols();
 
-        Core side = only.comparison().right();
+        Core side = only.at().right();
         InputReads at = only.reads();
         while (true) {
             if (side instanceof Core.FieldAccess field) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ReadComparisons.java
@@ -53,7 +53,7 @@ record ReadComparisons(List<ComparisonReadings.Reading> comparisons,
      *  them by where it stands, after which a fixture could be about a rule nobody meant. */
     ComparisonReadings.Reading only() {
         assertEquals(1, comparisons.size(), () -> "the body under test writes one comparison: "
-                + comparisons.stream().map(each -> each.comparison().pos().toString()).toList());
+                + comparisons.stream().map(each -> each.at().pos().toString()).toList());
         return comparisons.get(0);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.core.Contract;
+import souther.compiler.check.Comparison;
 import souther.compiler.check.StatedContract;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
@@ -68,8 +69,10 @@ class WhatAComparisonIsARuleAboutTest {
         StatedContract.StatedRule rule = stated.rules().get(0);
         assertEquals(1, rule.conjuncts().size(), "the rule states one comparison");
         Core read = rule.conjuncts().get(0).stated().orNull();
-        Core.Binary comparison = assertInstanceOf(Core.Binary.class, read,
+        Core.Binary binary = assertInstanceOf(Core.Binary.class, read,
                 () -> clause + " arrives as a comparison");
+        Comparison comparison = Comparison.of(binary)
+                .orElseThrow(() -> new AssertionError(clause + " compares its two sides"));
 
         Map<BindingId, String> roots = new LinkedHashMap<>();
         for (Contract.Param param : stated.params()) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest.java
@@ -80,7 +80,7 @@ class WhyAComparisonBearsNoLineIsAnAnswerAndNotAnAbsenceTest {
                         // What arrives is not what this is about: read with nothing said about it,
                         // every line is held to the declarations alone.
                         souther.compiler.check.PathReachability.Answers.NONE).all()) {
-            byLine.put(each.comparison().pos().line(), each.standing());
+            byLine.put(each.at().pos().line(), each.standing());
         }
         return byLine;
     }


### PR DESCRIPTION
Closes #1206.

## The cause

The issue names six arms that answer for `ComparisonClaim.Nothing` under
`Cutting.read`, where an operator has been established to compare. Reading for
the invariant behind them rather than for the list found fifteen, in two shapes
and under two gates:

| what established it | what still answered for it |
|---|---|
| `AffineReading.read`'s `op.compares()` | `AffineReading.turned`, `ComparedLine.fromTheForm`, `ComparedTerms.fromTheForm`, `ReachingCuts.relOf`, `Cutting.holdsAtTheValue`, `LineFacts` (a constructor check and `holdsAtTheValue`), `Border` ×4, `GuardThresholds`, `EnsuresThresholds`; and `Cutting.asWritten`, which asked the operator again |
| `ComparedNumber.drawsALine()` | `ComparedLine.of`, `NumberWays.leaves` |

They are one defect: **a `boolean` cannot carry what it established**, so every
reader below the test still held the wide classification. What each of them
answered was invented — a `null` for a relation that does not exist, a `false`
for a rule that holds at no value because there is no rule, and, in the readings
#1205 added, a `throw` for a state nothing can build. `LineFacts` checks in its
constructor exactly what a type can refuse.

`Nothing` is not removable. Measured, not assumed: a `throw` in
`ComparedNumber.onOneSide` for a non-comparison that names a number fails 16
tests, reached as `ValueArrivals.comparedOut → NumberWays.comesOut →
ComparedNumbers.of` with `SUB` and `MUL`. That reading is above the boundary and
the wide answer is what it is for. The same probe in `AffineReading.read` leaves
the whole suite green, so the gate that was there was already dead — an arm for
"not a comparison" added there would have been the same defect one level up.

## The mechanism

`ComparisonPlacement` is what any operator places, `ComparisonClaim extends
ComparisonPlacement` is what a comparison placed, and only the first has an arm
for an operator that places nothing. Between them is `Comparison` — a node and
its claim, made only by `Comparison.of` and so itself the evidence that the
operator compares. `Core.Binary` no longer crosses the boundary: what recognised
a comparison mints one and hands it down, and the readings take that.

```
BinOp ──▶ ComparisonPlacement.of ──┬── Nothing ──▶ ComparedNumber only
                                   └── ComparisonClaim
                                            │
                              Comparison.of (private constructor)
                                            │
   Condition.Compares · ComparisonCatalog.Catalogued · declaration · ensures
                                            │
        ComparisonAssessment ─▶ Cutting ─▶ AffineReading ─▶ the readings
```

The fifteen arms are gone because javac no longer requires them, not because a
`default` was added. So are `ComparedTerms.ordersStrictly` (a third spelling of
an operator set already spelled twice), `ComparedNumber.mirrored(BinOp)` (a swap
is now the claim turned round, so there is one way from an operator to a
meaning), `AffineReading`'s static `turned`, and `LineFacts`'s constructor check.
`ComparisonCatalog.Comparison` becomes `Catalogued` and holds one.
`CoverageSites.requireIsACatalogued` keeps its two diagnostics and asks
`Comparison.of` for the first: what is checked there is a plan against a
catalog, and "not a comparison" and "not in this catalog" are different
breakages.

`ComparisonPlacement.Nothing` is now written in one place in the compiler:
`Comparison.of`.

## What holds it up

The arms cannot be tested — nothing reaches them, which is why they went on
answering wrongly. Two things a test can say hold the arrangement instead.

Four laws: what an operator places is a claim exactly where `BinOp.compares`
says so; turning a placement round twice leaves it (asked of every operator,
`Nothing` included); reading the operator a swap would have been written with is
turning the reading round — which is the theorem that lets `mirrored(BinOp)` go.

Two counts off the compiled classes: who may read `ComparisonPlacement.of`
(`Comparison.of`, `ComparedNumber.of`, and the boolean spelling beside them) and
who may ask `orders` (`InvariantBound.ordering`), each with why.

Neither is idle. Three mutations, each red at the test meant for it:
`Cut.turned()` returning `this` (the swap law), `NE` classified as `Nothing`
(the membership law), one added `ComparisonPlacement.of` call in
`ComparedTerms.asWritten` (the count, naming the method).

`Comparison.equals` reads the claim as well as the node, though the claim is a
function of the node. Left out, `AnAnswersIdentityCoversEverythingItAnswersWith`
fails, and adding an entry to its exception list would be silencing a rule that
exists for a real failure. Reading it costs nothing: one node has one claim.

## Left for a follow-up

`InvariantChecker.arithmeticOf` gates on `compares()` and
`Arithmetic.holdsOfEveryRow(BinOp)` answers `false` for the operators it
excluded. Same shape, different question — that one evaluates a comparison at a
residue rather than saying what it placed, and deriving it from the claim is its
own piece of algebra. `ComparisonPlacement.orders` and `InvariantBound.ordering`
go with it: a clause of a `data` is read off the syntax tree, so it has no
recognised comparison to carry a claim, and that boundary is a design of its own.

`mvn -o test`: 7815 tests in the compiler, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
