### PR TITLE
Read a comparison's meaning from what it placed, not from its operator

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -95,7 +95,8 @@ final class AReportOfOneBorder {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5)))),
-                new souther.compiler.partition.LineFacts(new ComparisonClaim.Cut(true, true)));
+                new souther.compiler.partition.LineFacts(
+                        new ComparisonClaim.Cut(souther.compiler.numeric.Towards.BELOW, true)));
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseComparison.java
@@ -1,0 +1,74 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+
+import java.util.Optional;
+
+/**
+ * A clause the language reads as a comparison: its two sides, and what its operator placed.
+ *
+ * <p>What {@link Comparison} is for a checked body's binary, for a clause read off the syntax tree.
+ * The two recognitions are separate because what they read a comparison out of is: a rule of a
+ * {@code data} is read before anything has been checked, and a body's comparison is a
+ * {@code Core.Binary}. What they share is the claim, which is what the operator placed and is the
+ * same answer wherever the comparison was written.
+ *
+ * <p><b>No operator here.</b> The claim is the meaning of the one this was recognised from, and a
+ * reader handed both could turn the claim round and go on holding an operator that states the
+ * comparison the other way about. What such a reader answers from the operator is not what the
+ * value says, and nothing tells the two apart. So the operator goes no further than {@link #of},
+ * and what a reader wanting the sides the other way round asks for is {@link #turned}.
+ */
+final class ClauseComparison {
+
+    private final Hir.Expr left;
+    private final Hir.Expr right;
+    private final ComparisonClaim claim;
+
+    private ClauseComparison(Hir.Expr left, Hir.Expr right, ComparisonClaim claim) {
+        this.left = left;
+        this.right = right;
+        this.claim = claim;
+    }
+
+    /** {@code clause} as a comparison, or nothing where it is not one or its operator compares no
+     *  values. */
+    static Optional<ClauseComparison> of(Hir.Expr clause) {
+        if (!(clause instanceof Hir.Binary bin)) {
+            return Optional.empty();
+        }
+        return switch (ComparisonPlacement.of(bin.op())) {
+            case ComparisonPlacement.Nothing _ -> Optional.empty();
+            case ComparisonClaim claim ->
+                    Optional.of(new ClauseComparison(bin.left(), bin.right(), claim));
+        };
+    }
+
+    /**
+     * The same comparison with its sides the other way round, which is what a reader wanting the
+     * side it is reading for on the left asks for.
+     *
+     * <p>The sides and the claim move together, because {@code 0 <= value} states of the value what
+     * {@code value >= 0} states. Swapped by a caller and left to turn the claim itself, the two go
+     * out of step at whichever caller forgets, and what it then reads is the comparison the source
+     * did not write.
+     */
+    ClauseComparison turned() {
+        return new ClauseComparison(right, left, claim.turned());
+    }
+
+    /** The side the claim is stated of. */
+    Hir.Expr left() {
+        return left;
+    }
+
+    /** What that side is compared against. */
+    Hir.Expr right() {
+        return right;
+    }
+
+    /** What the comparison placed on the values of its left side. */
+    ComparisonClaim claim() {
+        return claim;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
@@ -1,16 +1,16 @@
 package souther.compiler.check;
 
+import souther.compiler.numeric.Towards;
+
 /**
  * What a comparison placed on a position's values, read off the comparison and nothing else.
  *
  * <p>One classification, asked wherever a rule compares a position to something: a clause of an
  * invariant, a comparison in a body, a clause of an {@code ensures}. A rule is read the same way
  * wherever it is written (spec §boundary-coordinates), and this is the reading that says what it
- * placed. It was three: {@code InvariantBound.ordering} answered it for a {@code data}'s clauses,
- * {@code ComparedLine.of} for a body's and a declaration's comparisons, and
- * {@code GuardThresholds.orders} answered a coarser version of the same question under the same
- * word. Three answers to one question drift, and two of them already had: an equality places a line
- * where a body writes it and placed nothing where a {@code data} did.
+ * placed. Answered once, and carried from wherever a comparison was recognised: a second answer to
+ * it drifts from this one, and an equality places a line under one of them and nothing under the
+ * other while both go on being called what a rule placed.
  *
  * <p><b>Two cases, because an operator that placed nothing is no comparison.</b> That an operator
  * compares is settled where a comparison is recognised ({@link Comparison}), and this is what such
@@ -41,22 +41,72 @@ public sealed interface ComparisonClaim
     ComparisonClaim turned();
 
     /**
+     * What the comparison that holds exactly where this one does not places, which is the same
+     * partition selected the other way round.
+     *
+     * <p>A denial is the comparison's own meaning and not a reader's arrangement: {@code x <= c}
+     * fails exactly where {@code x > c} holds, and both say the number named is on the low side.
+     * Answered from the claim, a reader that meets a rule under a negation has the claim of the
+     * rule it states; answered from the operator, it is a second table of operators that agrees
+     * with this one only for as long as somebody keeps it so.
+     *
+     * <p>Asked of a claim and not of a {@link ComparisonPlacement}, because a denial is of
+     * something stated. There is nothing an operator that placed nothing states the failure of.
+     */
+    ComparisonClaim denied();
+
+    /**
      * An order: the values either side of the line are different classes.
      *
-     * @param valueBelongsBelow whether the number named is on the low side. {@code x <= c} puts it
-     *                          there; {@code x < c} puts it on the high side. Getting this wrong
-     *                          moves the line by one and asks for a row that proves nothing
-     * @param holdsAtTheValue   whether the comparison is true at the number named. Not derivable
-     *                          from the other: {@code x <= c} and {@code x > c} agree about which
-     *                          class the number is in and disagree here
+     * @param valueBelongs    which class the number named is itself in. {@code x <= c} puts it
+     *                        below; {@code x < c} puts it above. Getting this wrong moves the line
+     *                        by one and asks for a row that proves nothing
+     * @param holdsAtTheValue whether the comparison is true at the number named. Not derivable
+     *                        from the other: {@code x <= c} and {@code x > c} agree about which
+     *                        class the number is in and disagree here
      */
-    record Cut(boolean valueBelongsBelow, boolean holdsAtTheValue) implements ComparisonClaim {
+    record Cut(Towards valueBelongs, boolean holdsAtTheValue) implements ComparisonClaim {
 
         /** Turning the sides round moves the number named to the other class and leaves whether the
          *  rule holds there alone: {@code x <= c} and {@code -x >= -c} are one statement. */
         @Override
-        public ComparisonClaim turned() {
-            return new Cut(!valueBelongsBelow, holdsAtTheValue);
+        public Cut turned() {
+            return new Cut(valueBelongs.opposite(), holdsAtTheValue);
+        }
+
+        /** The same line with the other class selected, which is what a denial of an order is. */
+        @Override
+        public Cut denied() {
+            return new Cut(valueBelongs, !holdsAtTheValue);
+        }
+
+        /**
+         * Which side of the line the comparison is true on.
+         *
+         * <p>The one place the two facts a cut holds are put together. Which class the number named
+         * is in and whether the rule holds there are separate answers, and every question about the
+         * line — which end of a range it is, which way a run of values has to lie to satisfy it,
+         * which side a row is owed on — is this one. Worked out where each of those is asked, the
+         * pairing of the two is remembered in as many places as there are readers, and the two
+         * facts are of one type, so a reader that pairs them the other way round is a reader
+         * nothing contradicts.
+         */
+        public Towards satisfyingSide() {
+            return holdsAtTheValue ? valueBelongs : valueBelongs.opposite();
+        }
+
+        /**
+         * The order satisfied on {@code side} that answers {@code holdsAtTheValue} at the value it
+         * names, which is {@link #satisfyingSide} read the other way.
+         *
+         * <p>For a reader that kept the side rather than the class the value is in — a bound
+         * records which end of a range it placed, and which side its own value falls on follows
+         * from that end together with whether the bound admits it. Run backwards by such a reader,
+         * the derivation is the pairing of the two facts written a second time, and a line stated
+         * as one end and read back as the other is a line whose sides are the wrong way round.
+         */
+        public static Cut satisfiedOn(Towards side, boolean holdsAtTheValue) {
+            return new Cut(holdsAtTheValue ? side : side.opposite(), holdsAtTheValue);
         }
     }
 
@@ -77,8 +127,15 @@ public sealed interface ComparisonClaim
 
         /** An equality names a value and orders nothing, so there is nothing to turn round. */
         @Override
-        public ComparisonClaim turned() {
+        public Singled turned() {
             return this;
+        }
+
+        /** The other of the two classes: what is denied of the value named is met everywhere
+         *  else. */
+        @Override
+        public Singled denied() {
+            return new Singled(!holdsAtTheValue);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
@@ -2,6 +2,8 @@ package souther.compiler.check;
 
 import souther.compiler.numeric.Towards;
 
+import java.util.Objects;
+
 /**
  * What a comparison placed on a position's values, read off the comparison and nothing else.
  *
@@ -67,6 +69,18 @@ public sealed interface ComparisonClaim
      */
     record Cut(Towards valueBelongs, boolean holdsAtTheValue) implements ComparisonClaim {
 
+        /**
+         * A side and not the absence of one.
+         *
+         * <p>Which class the number named is in is one of two answers and the language has no way
+         * to say so of a reference, so it is said here. Absent, every reader comparing it to a
+         * side gets the other one — a cut with no side reads as one bounding the values below, and
+         * an order the model never stated goes on being answered about.
+         */
+        public Cut {
+            Objects.requireNonNull(valueBelongs, "which class the number a cut names is in");
+        }
+
         /** Turning the sides round moves the number named to the other class and leaves whether the
          *  rule holds there alone: {@code x <= c} and {@code -x >= -c} are one statement. */
         @Override
@@ -87,9 +101,9 @@ public sealed interface ComparisonClaim
          * is in and whether the rule holds there are separate answers, and every question about the
          * line — which end of a range it is, which way a run of values has to lie to satisfy it,
          * which side a row is owed on — is this one. Worked out where each of those is asked, the
-         * pairing of the two is remembered in as many places as there are readers, and the two
-         * facts are of one type, so a reader that pairs them the other way round is a reader
-         * nothing contradicts.
+         * pairing of the two is remembered in as many places as there are readers, and a reader
+         * that pairs them the other way round answers every one of its own questions consistently
+         * about a line whose sides are swapped.
          */
         public Towards satisfyingSide() {
             return holdsAtTheValue ? valueBelongs : valueBelongs.opposite();

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonPlacement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonPlacement.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.numeric.Towards;
 import souther.compiler.types.BinOp;
 
 /**
@@ -57,27 +58,16 @@ public sealed interface ComparisonPlacement permits ComparisonClaim, ComparisonP
             return new Nothing();
         }
         return switch (op) {
-            case LE -> new ComparisonClaim.Cut(true, true);
-            case GT -> new ComparisonClaim.Cut(true, false);
-            case LT -> new ComparisonClaim.Cut(false, false);
-            case GE -> new ComparisonClaim.Cut(false, true);
+            case LE -> new ComparisonClaim.Cut(Towards.BELOW, true);
+            case GT -> new ComparisonClaim.Cut(Towards.BELOW, false);
+            case LT -> new ComparisonClaim.Cut(Towards.ABOVE, false);
+            case GE -> new ComparisonClaim.Cut(Towards.ABOVE, true);
             case EQ -> new ComparisonClaim.Singled(true);
             case NE -> new ComparisonClaim.Singled(false);
             // Refused above and written out here so the switch stays exhaustive: an operator added
             // to the language stops the compile here and is decided about rather than falling in.
             case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> new Nothing();
         };
-    }
-
-    /**
-     * Whether {@code op} orders the values either side of what it names.
-     *
-     * <p>For a reader that holds an operator and nothing else. A reader inside the comparison's own
-     * reading holds the claim and asks it instead: this answers about an operator, and what a rule
-     * placed is the claim's to say.
-     */
-    static boolean orders(BinOp op) {
-        return of(op) instanceof ComparisonClaim.Cut;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -1,11 +1,11 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
 import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Granularity;
+import souther.compiler.numeric.Towards;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
@@ -83,27 +83,22 @@ public record InvariantBound(boolean lower, Endpoint end) {
      * included — was downgraded to one nothing promises is writable.
      */
     public static Read of(Hir.Expr clause, Carrier carrier) {
-        if (carrier == null || !(clause instanceof Hir.Binary bin)) {
+        ClauseComparison read = carrier == null ? null
+                : ClauseComparison.of(clause).orElse(null);
+        if (read == null) {
             return NO_END;
         }
         // `0 <= value` says what `value >= 0` says: read the value-bearing side as the left one.
-        Hir.Expr left = bin.left();
-        Hir.Expr right = bin.right();
-        BinOp op = bin.op();
-        if (!isValue(left) && isValue(right)) {
-            Hir.Expr swap = left;
-            left = right;
-            right = swap;
-            op = mirrored(op);
+        if (!isValue(read.left())) {
+            read = read.turned();
         }
-        if (!isValue(left)) {
+        // An equality states both ends at once and a disequality states neither, so neither is an
+        // end this has anywhere to put.
+        if (!isValue(read.left()) || !(read.claim() instanceof ComparisonClaim.Cut cut)) {
             return NO_END;
         }
-        Place bound = carrier.literalOf(right);
-        if (bound == null) {
-            return NO_END;
-        }
-        return ordered(op, bound, carrier);
+        Place bound = carrier.literalOf(read.right());
+        return bound == null ? NO_END : ordered(cut, bound, carrier);
     }
 
     /**
@@ -116,18 +111,20 @@ public record InvariantBound(boolean lower, Endpoint end) {
     public static Read ofSize(Hir.Expr clause, ValueName measure) {
         // A size is a whole number whatever it is a size of, so it steps like an `Int` and stops
         // where one does.
-        return sizeComparedIn(clause, measure, VALUE)
-                .map(read -> ordered(read.op(), Count.of(read.count()), Carrier.WHOLE))
-                .orElse(NO_END);
+        SizeComparison read = sizeComparedIn(clause, measure, VALUE).orElse(null);
+        return read != null && read.claim() instanceof ComparisonClaim.Cut cut
+                ? ordered(cut, Count.of(read.count()), Carrier.WHOLE)
+                : NO_END;
     }
 
     /**
      * A comparison of a counted number against a literal, as it was written.
      *
-     * @param op    the operator, with the count on the left however the clause was spelled
+     * @param claim what the comparison placed on the count, read with the count on the left however
+     *              the clause was spelled
      * @param count what it is compared against
      */
-    public record SizeComparison(BinOp op, BigDecimal count) {}
+    private record SizeComparison(ComparisonClaim claim, BigDecimal count) {}
 
     /**
      * The comparison {@code clause} makes about {@code measure} taken of {@code subject}, or empty
@@ -135,30 +132,25 @@ public record InvariantBound(boolean lower, Endpoint end) {
      *
      * <p>Before any reading of what it means. {@link #ofSize} turns one of these into an end of a
      * range and answers nothing for the comparisons that are not ends — an equality states both ends
-     * at once and a disequality states neither, so a range has nowhere to put them. A reader asking
-     * something a range cannot hold, such as whether a count of none is refused, needs the comparison
-     * itself. Recognised here so that the shape is read in one place and what it means in as many as
-     * there are questions.
+     * at once and a disequality states neither, so a range has nowhere to put them. Kept apart from
+     * that reading so that the shape a clause has to be to say anything about a count is recognised
+     * in one place, and what such a comparison means in as many as there are questions to ask of it.
      */
-    public static Optional<SizeComparison> sizeComparedIn(Hir.Expr clause, ValueName measure,
-                                                          String subject) {
-        if (!(clause instanceof Hir.Binary bin)) {
+    private static Optional<SizeComparison> sizeComparedIn(Hir.Expr clause, ValueName measure,
+                                                           String subject) {
+        ClauseComparison read = ClauseComparison.of(clause).orElse(null);
+        if (read == null) {
             return Optional.empty();
         }
-        Hir.Expr left = bin.left();
-        Hir.Expr right = bin.right();
-        BinOp op = bin.op();
-        if (!takesSizeOf(left, measure, subject) && takesSizeOf(right, measure, subject)) {
-            Hir.Expr swap = left;
-            left = right;
-            right = swap;
-            op = mirrored(op);
+        if (!takesSizeOf(read.left(), measure, subject)) {
+            read = read.turned();
         }
-        if (!takesSizeOf(left, measure, subject)) {
+        if (!takesSizeOf(read.left(), measure, subject)) {
             return Optional.empty();
         }
-        BigDecimal count = wholeLiteral(right);
-        return count == null ? Optional.empty() : Optional.of(new SizeComparison(op, count));
+        BigDecimal count = wholeLiteral(read.right());
+        return count == null ? Optional.empty()
+                : Optional.of(new SizeComparison(read.claim(), count));
     }
 
     /**
@@ -173,39 +165,36 @@ public record InvariantBound(boolean lower, Endpoint end) {
      * one question with one answer whatever recognised the coordinate — asked again here, a strict
      * bound would land on the neighbour in one reader and on the literal in the other.
      *
-     * @param op    the comparison, with the coordinate on its left
+     * @param cut   what the comparison placed, stated of the coordinate
      * @param bound what the coordinate is compared against
      */
-    static Read at(BinOp op, Hir.Expr bound, Carrier carrier) {
+    static Read at(ComparisonClaim.Cut cut, Hir.Expr bound, Carrier carrier) {
         if (carrier == null || bound == null) {
             return NO_END;
         }
         Place at = carrier.literalOf(bound);
-        return at == null ? NO_END : ordered(op, at, carrier);
+        return at == null ? NO_END : ordered(cut, at, carrier);
     }
 
-    /** Which comparison an operand on the right states of one on the left. */
-    static BinOp flipped(BinOp op) {
-        return mirrored(op);
-    }
-
-    /** Whether {@code op} says where values stop rather than which one a value is. */
-    static boolean ordering(BinOp op) {
-        return ComparisonPlacement.orders(op);
-    }
-
-    /** One end, from the comparison and how the carrier's counts are spaced. */
-    private static Read ordered(BinOp op, Place bound, Carrier carrier) {
-        boolean steps = carrier.spacing() == Granularity.DISCRETE;
-        return switch (op) {
-            case GE -> placed(true, Endpoint.inclusive(bound));
-            case LE -> placed(false, Endpoint.inclusive(bound));
-            case GT -> steps ? stepped(true, carrier.onTheGrid(Count.number(bound).plus(1)))
-                    : placed(true, Endpoint.exclusive(bound));
-            case LT -> steps ? stepped(false, carrier.onTheGrid(Count.number(bound).minus(1)))
-                    : placed(false, Endpoint.exclusive(bound));
-            default -> NO_END;
-        };
+    /**
+     * One end, from what the comparison placed and how the carrier's counts are spaced.
+     *
+     * <p>Which end it is and whether the end admits the number are the claim's two answers: a rule
+     * bounds a value below exactly where the values it admits are above the number it named, and
+     * the end is the number itself exactly where the rule holds there. What is left for this to
+     * decide is where a refused number leaves the end, which is a fact about the order and not
+     * about the comparison.
+     */
+    private static Read ordered(ComparisonClaim.Cut cut, Place bound, Carrier carrier) {
+        boolean lower = cut.satisfyingSide() == Towards.ABOVE;
+        if (cut.holdsAtTheValue()) {
+            return placed(lower, Endpoint.inclusive(bound));
+        }
+        if (carrier.spacing() != Granularity.DISCRETE) {
+            return placed(lower, Endpoint.exclusive(bound));
+        }
+        Count number = Count.number(bound);
+        return stepped(lower, carrier.onTheGrid(lower ? number.plus(1) : number.minus(1)));
     }
 
     private static Read placed(boolean lower, Endpoint end) {
@@ -246,16 +235,6 @@ public record InvariantBound(boolean lower, Endpoint end) {
 
     private static boolean isValue(Hir.Expr e) {
         return e instanceof Hir.Var v && v.name().equals(VALUE);
-    }
-
-    private static BinOp mirrored(BinOp op) {
-        return switch (op) {
-            case LT -> BinOp.GT;
-            case LE -> BinOp.GE;
-            case GT -> BinOp.LT;
-            case GE -> BinOp.LE;
-            default -> op;
-        };
     }
 
     /** A whole number a literal names, or null where it names one with a fraction: a value that

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1384,9 +1384,11 @@ public final class InvariantChecker {
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
         }
-        // An ordering, or an equality naming one of the values. A disequality states neither end
-        // and an operator that compares nothing states no rule about the values at all, so what
-        // either of them says about where the values stop is nothing.
+        // A rule that orders the values, or one that says which value they take. A rule that only
+        // rules a value out is read no further here, and neither is an operator that compares
+        // nothing: what is below reads a clause for the end it places on a position and for which
+        // declarations narrowed that position, and neither of those is a thing a denial of one
+        // value states.
         ComparisonClaim asWritten = Comparison.of(bin).map(Comparison::claim).orElse(null);
         if (asWritten == null
                 || asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
@@ -1471,7 +1473,7 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            noLineDrawn(bin, said, from, part, at, byName, noLines, read);
+            noLineDrawn(bin, asWritten, from, part, at, byName, noLines, read);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1384,7 +1384,12 @@ public final class InvariantChecker {
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
         }
-        if (!InvariantBound.ordering(bin.op()) && bin.op() != BinOp.EQ) {
+        // An ordering, or an equality naming one of the values. A disequality states neither end
+        // and an operator that compares nothing states no rule about the values at all, so what
+        // either of them says about where the values stop is nothing.
+        ComparisonClaim asWritten = Comparison.of(bin).map(Comparison::claim).orElse(null);
+        if (asWritten == null
+                || asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
             settle(bin, from, states(bin, at, byName, arithmeticOf(bin, at, byName)),
                     new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
@@ -1394,11 +1399,11 @@ public final class InvariantChecker {
         // says.
         Coordinate found = byName.get(nameOf(bin.left(), at));
         Core bound = bin.right();
-        BinOp op = bin.op();
+        ComparisonClaim said = asWritten;
         if (found == null) {
             found = byName.get(nameOf(bin.right(), at));
             bound = bin.left();
-            op = InvariantBound.flipped(op);
+            said = said.turned();
         }
         // An end where the other side is a constant, and a relation everywhere else. Which it is
         // cannot be asked of the other side's name: what a clause compares a coordinate to may be a
@@ -1408,9 +1413,9 @@ public final class InvariantChecker {
         // the order places none — there is no value to draw a line at — and it is not a relation
         // either: what it compares the coordinate to is a constant this read perfectly. So it falls
         // out here rather than being filed as a clause that could have moved an edge.
-        InvariantBound.Read end = found == null || !InvariantBound.ordering(op)
-                ? new InvariantBound.Read.NoEnd()
-                : InvariantBound.at(op, Terms.asWrittenValue(bound), found.carrier());
+        InvariantBound.Read end = found != null && said instanceof ComparisonClaim.Cut cut
+                ? InvariantBound.at(cut, Terms.asWrittenValue(bound), found.carrier())
+                : new InvariantBound.Read.NoEnd();
         Coordinate about = found;
         // What the clause is about, asked of the comparison and not of what `end` came to. A
         // coordinate compared for order against something naming no other coordinate states where
@@ -1425,7 +1430,7 @@ public final class InvariantChecker {
         // `width` stops that no reading can ever answer, because a rule relating two positions
         // places no end (ADR-0090). The reader already knows: the reason it records for such a
         // comparison is `ComparisonBetweenPositions`.
-        if (about != null && InvariantBound.ordering(op)
+        if (about != null && said instanceof ComparisonClaim.Cut
                 && coordinatesIn(bound, at, byName).isEmpty()
                 && shape instanceof ClauseStates.SomethingElse named) {
             Set<RuleKey> names = new LinkedHashSet<>(named.named());
@@ -1466,7 +1471,7 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            noLineDrawn(bin, from, part, at, byName, noLines, read);
+            noLineDrawn(bin, said, from, part, at, byName, noLines, read);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -1662,11 +1667,12 @@ public final class InvariantChecker {
      * left a finding at {@code y} of a rule its own canonical form had cancelled — and the word
      * left there was the word for {@code x}.
      */
-    private void noLineDrawn(Core.Binary comparison, RuleRef.Invariant from, int conjunct,
+    private void noLineDrawn(Core.Binary comparison, ComparisonClaim placed,
+                            RuleRef.Invariant from, int conjunct,
                             Denotations at,
                             Map<FactSubject, Coordinate> byName, List<FieldDomains.NoLine> out,
                             Arithmetic read) {
-        if (!InvariantBound.ordering(comparison.op())) {
+        if (!(placed instanceof ComparisonClaim.Cut)) {
             return;
         }
         Places left = placesIn(comparison.left(), at, byName);

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Endpoint;
@@ -104,15 +103,19 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
 
     /** Where one comparison leaves the position it names, or nothing where it names none. */
     private OrderedIntervals<FactSubject> comparison(Core.Binary bin, boolean positive) {
+        Comparison read = Comparison.of(bin).orElse(null);
+        if (read == null) {
+            return OrderedIntervals.top();
+        }
         // The position-bearing side read as the left one, as `0 <= value` says what `value >= 0`
         // says.
         FactSubject position = positionIn(bin.left());
         Core bound = bin.right();
-        BinOp op = bin.op();
+        ComparisonClaim claim = read.claim();
         if (position == null) {
             position = positionIn(bin.right());
             bound = bin.left();
-            op = InvariantBound.flipped(op);
+            claim = claim.turned();
         }
         Carrier carrier = position == null ? null : carriers.get(position);
         if (carrier == null) {
@@ -122,17 +125,30 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
         // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` is an
         // equality and is read; `!(value == x)` is a disequality and is not, which is the same
         // answer the disequality gets when it is written directly.
-        BinOp said = positive ? op : denied(op);
-        if (said == BinOp.EQ) {
-            Place only = written == null ? null : carrier.literalOf(written);
-            return only == null ? OrderedIntervals.top()
-                    : leaves(position, carrier, new OrderedInterval(
-                            Endpoint.inclusive(only), Endpoint.inclusive(only)));
-        }
-        if (!InvariantBound.ordering(said)) {
-            return OrderedIntervals.top();
-        }
-        return switch (InvariantBound.at(said, written, carrier)) {
+        ComparisonClaim said = positive ? claim : claim.denied();
+        return switch (said) {
+            // A value singled out is a range with that one value in it where the rule holds there,
+            // and a set rather than a range where it does not.
+            case ComparisonClaim.Singled singled -> onlyTheValue(position, carrier,
+                    singled.holdsAtTheValue() ? written : null);
+            case ComparisonClaim.Cut cut -> ends(position, carrier,
+                    InvariantBound.at(cut, written, carrier));
+        };
+    }
+
+    /** The range of one value, or nothing where the rule names none this order reads. */
+    private OrderedIntervals<FactSubject> onlyTheValue(FactSubject position, Carrier carrier,
+                                                       Hir.Expr written) {
+        Place only = written == null ? null : carrier.literalOf(written);
+        return only == null ? OrderedIntervals.top()
+                : leaves(position, carrier, new OrderedInterval(
+                        Endpoint.inclusive(only), Endpoint.inclusive(only)));
+    }
+
+    /** What the end an ordering placed leaves the position. */
+    private OrderedIntervals<FactSubject> ends(FactSubject position, Carrier carrier,
+                                               InvariantBound.Read read) {
+        return switch (read) {
             case InvariantBound.Read.AnEnd it -> leaves(position, carrier, it.bound().lower()
                     ? new OrderedInterval(it.bound().end(), null)
                     : new OrderedInterval(null, it.bound().end()));
@@ -155,21 +171,6 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
     private static OrderedIntervals<FactSubject> leaves(FactSubject position, Carrier carrier,
                                                  OrderedInterval range) {
         return OrderedIntervals.at(position, carrier.extent().meet(range));
-    }
-
-    /** The comparison that holds exactly where {@code op} does not. */
-    private static BinOp denied(BinOp op) {
-        return switch (op) {
-            case EQ -> BinOp.NE;
-            case NE -> BinOp.EQ;
-            case LT -> BinOp.GE;
-            case LE -> BinOp.GT;
-            case GT -> BinOp.LE;
-            case GE -> BinOp.LT;
-            // Not a comparison. Denied or stated, it says nothing about where a position stops, and
-            // answering it with itself lets the caller find that out the one way it does.
-            default -> op;
-        };
     }
 
     /** The position {@code e} is, or null where it is not one this is reading for. */

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -127,10 +127,12 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
         // answer the disequality gets when it is written directly.
         ComparisonClaim said = positive ? claim : claim.denied();
         return switch (said) {
-            // A value singled out is a range with that one value in it where the rule holds there,
-            // and a set rather than a range where it does not.
-            case ComparisonClaim.Singled singled -> onlyTheValue(position, carrier,
-                    singled.holdsAtTheValue() ? written : null);
+            // The value the rule is met at, which is a range with one value in it. What a denial
+            // leaves is every other value, and that is a set rather than a range, so this says
+            // nothing about it.
+            case ComparisonClaim.Singled singled -> singled.holdsAtTheValue()
+                    ? onlyTheValue(position, carrier, written)
+                    : OrderedIntervals.top();
             case ComparisonClaim.Cut cut -> ends(position, carrier,
                     InvariantBound.at(cut, written, carrier));
         };

--- a/souther-compiler/src/main/java/souther/compiler/numeric/EndSide.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/EndSide.java
@@ -38,6 +38,17 @@ public enum EndSide {
         return inward().opposite();
     }
 
+    /**
+     * The end the values run {@code inward} from, which is {@link #inward} read the other way.
+     *
+     * <p>Beside it rather than worked out by a caller, so that the pairing of an end with a
+     * direction is one fact read in whichever direction a reader has. A caller holding the way a
+     * rule is satisfied and wanting the end it keeps is asking this.
+     */
+    public static EndSide facing(Towards inward) {
+        return inward == Towards.ABOVE ? LOWER : UPPER;
+    }
+
     /** Where {@code bounds} stops on this side, or null where nothing stops it that way. */
     public Endpoint at(NumericDomain.Bounds bounds) {
         return bounds == null ? null : this == LOWER ? bounds.min() : bounds.max();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -101,7 +101,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
         points.add(new DomainPoint.AtTheLine());
         switch (origin.lineFacts().claim()) {
             case ComparisonClaim.Cut order -> points.add(new DomainPoint.BesideTheLine(
-                    order.valueBelongsBelow() ? Towards.ABOVE : Towards.BELOW));
+                    order.valueBelongs().opposite()));
             case ComparisonClaim.Singled _ -> {
                 points.add(new DomainPoint.BesideTheLine(Towards.BELOW));
                 points.add(new DomainPoint.BesideTheLine(Towards.ABOVE));
@@ -589,7 +589,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
                 // line of `< 3000`, and neither is the threshold at all where the quantity does not
                 // take it: which way to look for the value the rule wrote is the side that value
                 // belongs to.
-                Towards belongs = order.valueBelongsBelow() ? Towards.BELOW : Towards.ABOVE;
+                Towards belongs = order.valueBelongs();
                 demands.put(new DomainPoint.AtTheLine(),
                         pointAt(space, cut, belongs, true, reach));
                 demands.put(new DomainPoint.BesideTheLine(belongs.opposite()),
@@ -628,7 +628,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
     private static Level levelAgainstTheLineOn(Map<DomainPoint, PointAnswer> demands,
                                                OriginRef origin, Towards side) {
         boolean atTheLine = origin.lineFacts().claim() instanceof ComparisonClaim.Cut order
-                && (order.valueBelongsBelow() ? Towards.BELOW : Towards.ABOVE) == side;
+                && order.valueBelongs() == side;
         PointAnswer point = demands.get(atTheLine ? new DomainPoint.AtTheLine()
                 : new DomainPoint.BesideTheLine(side));
         return point == null ? null : against(point);
@@ -677,7 +677,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
         return switch (claim) {
             case ComparisonClaim.Singled _ -> admits(within, cut);
             case ComparisonClaim.Cut order -> {
-                Towards kept = satisfyingSide(order.holdsAtTheValue(), order.valueBelongsBelow());
+                Towards kept = order.satisfyingSide();
                 yield standsAt(within, cut, parts, kept)
                         // A line with two sides owes a point against the line on each of them, so
                         // the line's own value is enough for it to be one somebody can write a row
@@ -718,19 +718,6 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
         Place at = placeOf(level);
         return (within.min() == null || at.compareTo(within.min().at()) >= 0)
                 && (within.max() == null || at.compareTo(within.max().at()) <= 0);
-    }
-
-    /**
-     * Which way a rule is satisfied from its threshold, from the two things every rule records about
-     * its own line.
-     *
-     * <p>One derivation, asked by whoever holds the pair. A line is read off a cutting before any
-     * rule has been named for it and off that rule's origin afterwards, and the two carry the same
-     * two facts — worked out separately, a line would be satisfied one way while it was a cutting
-     * and the other way once it had an origin.
-     */
-    static Towards satisfyingSide(boolean holdsAtTheValue, boolean valueBelongsBelow) {
-        return holdsAtTheValue == valueBelongsBelow ? Towards.BELOW : Towards.ABOVE;
     }
 
     /**
@@ -825,7 +812,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
         }
         return switch (origin.lineFacts().claim()) {
             case ComparisonClaim.Cut order -> List.of(Parting.by(Seam.of(space, cut,
-                    order.valueBelongsBelow() ? Towards.BELOW : Towards.ABOVE),
+                    order.valueBelongs()),
                     origin.authoredLine()));
             // The place under the value and the place over it, with the value between them. Which
             // of the two bounds which side is the arrangement's answer and not this one's: a run
@@ -1006,8 +993,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
         // — and the range this is held against stops there too. Held against the number instead,
         // the two agree wherever a rule admits its threshold and are one count apart wherever it
         // does not, which is half the operators an author can write.
-        Level leaves = Seam.of(space, cut,
-                valueBelongsBelow(origin) ? Towards.BELOW : Towards.ABOVE).leaving(kept);
+        Level leaves = Seam.of(space, cut, valueBelongs(origin)).leaving(kept);
         if (end == null || !end.at().sameAs(placeOf(leaves))) {
             throw new IllegalStateException(
                     "a bound whose line is not where what it leaves stops: " + origin.named());
@@ -1047,8 +1033,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
      * nothing.
      */
     private static Towards satisfyingSide(OriginRef origin) {
-        ComparisonClaim.Cut order = ordering(origin);
-        return satisfyingSide(order.holdsAtTheValue(), order.valueBelongsBelow());
+        return ordering(origin).satisfyingSide();
     }
 
     /**
@@ -1109,7 +1094,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
                 instanceof ComparisonClaim.Cut order)) {
             return null;
         }
-        return Seam.of(space, cut, order.valueBelongsBelow() ? Towards.BELOW : Towards.ABOVE);
+        return Seam.of(space, cut, order.valueBelongs());
     }
 
     /**
@@ -1139,7 +1124,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<DomainPoint, Poin
     }
 
     /** Which side of the line the threshold's own value belongs to, of a rule that ordered them. */
-    private static boolean valueBelongsBelow(OriginRef origin) {
-        return ordering(origin).valueBelongsBelow();
+    private static Towards valueBelongs(OriginRef origin) {
+        return ordering(origin).valueBelongs();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -410,8 +410,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         // under what it names and over it — and this is the lower of the two, which is a place they
         // genuinely part rather than a side chosen for a rule that has none. Which of the two bounds
         // which run is asked where the runs are ({@link Border#partedBy}), and is no part of this.
-        Towards belongsTo = order == null ? Towards.ABOVE
-                : order.valueBelongsBelow() ? Towards.BELOW : Towards.ABOVE;
+        Towards belongsTo = order == null ? Towards.ABOVE : order.valueBelongs();
         LinearForm<NumericTerm> direction = direction(of);
         java.math.BigDecimal per = QuantityKey.per(direction);
         return Seam.of(of.levels(), at, belongsTo,
@@ -498,7 +497,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
                     + " a value and divides at neither side of it: " + at);
         }
         Seam seam = seam();
-        Level side = order.valueBelongsBelow() ? seam.below() : seam.above();
+        Level side = order.valueBelongs() == Towards.BELOW ? seam.below() : seam.above();
         return side instanceof Level.OnACarrier on ? on.at() : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Comparison;
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -106,14 +107,13 @@ public final class DeclaredThresholds {
         // positions stand apart keeps neither end of it — what it parts is that number from every
         // other one — so there is no end for this to have placed, and a caller reaching here with
         // one is holding a line whose shape it has not established.
-        souther.compiler.check.ComparisonClaim.Cut order = cutting.ordering();
+        ComparisonClaim.Cut order = cutting.ordering();
         if (order == null) {
             throw new IllegalStateException("which end a clause keeps, asked of one that names a"
                     + " value: " + clause.rule());
         }
         return new OriginRef.InvariantOrigin(clause.rule(), clause.conjunct(),
-                endKept(order.valueBelongsBelow(), order.holdsAtTheValue()),
-                order.holdsAtTheValue());
+                endKept(order), order.holdsAtTheValue());
     }
 
     /**
@@ -125,12 +125,14 @@ public final class DeclaredThresholds {
      * two are held against each other: a rule stated as one end and read back as the other is a
      * line whose sides are the wrong way round, and it asks for two rows that prove nothing.
      *
-     * <p>Read off the side alone, the answer is right wherever a rule admits its own threshold and
-     * the other one wherever it does not — so {@code a <= b} lands correctly and {@code a < b} lands
-     * inverted, which is a whole half of the rules a model can write.
+     * <p>Read off the side the rule's own value belongs to alone, the answer is right wherever a
+     * rule admits its threshold and the other one wherever it does not — so {@code a <= b} lands
+     * correctly and {@code a < b} lands inverted, which is a whole half of the rules a model can
+     * write. What the end is read off is the side the rule is satisfied on, which is the claim's
+     * answer and puts the two facts together once.
      */
-    static EndSide endKept(boolean valueBelongsBelow, boolean holdsAtTheValue) {
-        return valueBelongsBelow == holdsAtTheValue ? EndSide.UPPER : EndSide.LOWER;
+    static EndSide endKept(ComparisonClaim.Cut order) {
+        return EndSide.facing(order.satisfyingSide());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -250,7 +250,7 @@ public final class EnsuresThresholds {
                     case ComparisonClaim.Cut order ->
                             out.evidence().add(new LineEvidence.Divides(
                                     new Threshold(at.position(), at.cutting().seam(),
-                                            order.valueBelongsBelow(), origin)));
+                                            order.valueBelongs(), origin)));
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at: the classes either side are what the model tells apart, and the border is

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -451,7 +451,7 @@ public final class GuardThresholds {
                     }
                     case ComparisonClaim.Cut order -> out.add(new LineEvidence.Divides(
                             new Threshold(at.position(), at.cutting().seam(),
-                                    order.valueBelongsBelow(), origin)));
+                                    order.valueBelongs(), origin)));
                 }
                 // And the line itself, where the position has no value beside it for a row to be
                 // owed at. It divides the position — the classes either side are what the model

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Towards;
 import souther.compiler.reading.Condition;
 import souther.compiler.reading.Factor;
 import souther.compiler.reading.Interaction;
@@ -435,9 +436,11 @@ public final class InteractionCells {
                 if (!(guard.facts().claim() instanceof ComparisonClaim.Cut order)) {
                     return null;
                 }
-                boolean homeSideIsUp = !order.valueBelongsBelow();
                 boolean wantedIsHomeSide = order.holdsAtTheValue() == one.held();
-                boolean wantedIsUp = wantedIsHomeSide == homeSideIsUp;
+                // The side the cell wants: the one the rule is satisfied on where it wants the rule
+                // met, and the other where it wants it broken.
+                boolean wantedIsUp = (one.held() ? order.satisfyingSide()
+                        : order.satisfyingSide().opposite()) == Towards.ABOVE;
                 int last = axes.get(axis).classes().size() - 1;
                 int edge = wantedIsHomeSide ? home : (wantedIsUp ? home + 1 : home - 1);
                 if (edge < 0 || edge > last) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
@@ -31,19 +31,6 @@ import souther.compiler.check.ComparisonClaim;
 public record LineFacts(ComparisonClaim claim) {
 
     /**
-     * The line a rule that keeps a run of the values drew, which is what a bound is.
-     *
-     * <p>The one place a caller holding an order as two facts rather than as the claim can make one
-     * of these. A bound keeps the values one way of its own and admits its own value or does not,
-     * and those are the two an order is; a rule that names a value has neither, so there is no way
-     * in here to ask for one and no way to build the state where a value both is named and belongs
-     * to a side.
-     */
-    public static LineFacts ordering(boolean valueBelongsBelow, boolean holdsAtTheValue) {
-        return new LineFacts(new ComparisonClaim.Cut(valueBelongsBelow, holdsAtTheValue));
-    }
-
-    /**
      * Whether the rule is true at the line's own value, which is what says which of the two points
      * against the line a row there stands at.
      *
@@ -80,8 +67,7 @@ public record LineFacts(ComparisonClaim claim) {
             case DomainPoint.AtTheLine _ -> holdsAtTheValue();
             case DomainPoint.BesideTheLine _ -> !holdsAtTheValue();
             case DomainPoint.InTheRegion in -> claim instanceof ComparisonClaim.Cut order
-                    ? in.side() == Border.satisfyingSide(order.holdsAtTheValue(),
-                            order.valueBelongsBelow())
+                    ? in.side() == order.satisfyingSide()
                     : !holdsAtTheValue();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -129,7 +129,7 @@ public final class LinesWhereTheyFall {
 
     /** The same threshold, measured at {@code at}. */
     private static Threshold thresholdAt(Threshold each, NumericTerm.FromOnePosition at) {
-        return new Threshold(at, each.parts(), each.valueBelongsBelow(), each.origin());
+        return new Threshold(at, each.parts(), each.valueBelongs(), each.origin());
     }
 
     /** The same singled-out value, measured at {@code at}. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.source.SourceId;
 
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
@@ -102,14 +103,11 @@ public sealed interface OriginRef {
      * comparison is not modelled, because no measure asks it: a row meets the line by lighting the
      * comparison's own probe.
      *
-     * @param rule              which comparison, which is the rule and the whole of it
-     * @param read              which reading of that rule this is, and where it was met
-     * @param valueBelongsBelow which side of the line the cut value itself is on. It decides which
-     *                          neighbour is the other class's edge: {@code <= 3000} leaves 3001 over
-     *                          there, {@code < 3000} leaves 2999.
-     * @param holdsAtTheValue   whether the comparison is true at the line's own value. Not derivable
-     *                          from {@code valueBelongsBelow}: {@code x <= c} and {@code x > c} agree
-     *                          about the class the value is in and disagree here
+     * @param rule  which comparison, which is the rule and the whole of it
+     * @param read  which reading of that rule this is, and where it was met
+     * @param facts what the rule placed on the values ({@link souther.compiler.check.ComparisonClaim
+     *              ComparisonClaim}), which decides which neighbour is the other class's edge:
+     *              {@code <= 3000} leaves 3001 over there, {@code < 3000} leaves 2999
      */
     record ComparisonOrigin(RuleRef.Comparison rule, Read read, LineFacts facts)
             implements OriginRef {
@@ -181,17 +179,14 @@ public sealed interface OriginRef {
      *                          {@code b}. Counted over all of them and not over the ones a line came
      *                          out of, so that a reading which could make nothing of one still
      *                          numbers the next the same as a reading that could
-     * @param valueBelongsBelow which side of the line the cut value itself is on, which decides
-     *                          which neighbour is the other class's edge
-     * @param holdsAtTheValue   whether the comparison is true at the line's own value. Not derivable
-     *                          from {@code valueBelongsBelow}, and what tells one line of a rule
-     *                          from another written at the same value: {@code id.value <= 5} and
-     *                          {@code id.value > 5} agree about the class the value is in and are
-     *                          two things a row on the line shows apart. On a line between two
-     *                          positions it is the whole of what the row shows, since there is no
-     *                          class either side to read instead
-     * @param singles           whether the comparison singles the value out rather than ordering
-     *                          the values either side of it
+     * @param facts             what the rule placed on the values
+     *                          ({@link souther.compiler.check.ComparisonClaim ComparisonClaim}),
+     *                          which decides which neighbour is the other class's edge and what
+     *                          tells one line of a rule from another written at the same value:
+     *                          {@code id.value <= 5} and {@code id.value > 5} agree about the class
+     *                          the value is in and are two things a row on the line shows apart. On
+     *                          a line between two positions that is the whole of what the row shows,
+     *                          since there is no class either side to read instead
      */
     record EnsuresOrigin(RuleRef.Ensures rule, int conjunct, LineFacts facts)
             implements OriginRef {
@@ -392,9 +387,8 @@ public sealed interface OriginRef {
             // exactly when the bound does not admit it. A bound singles nothing out — it keeps a run
             // of the order — and that the far side holds no value at all is a different answer,
             // given where a border reads what a line has sides.
-            case InvariantOrigin i -> LineFacts.ordering(
-                    (i.keeps() == souther.compiler.numeric.EndSide.UPPER) == i.holdsAtTheValue(),
-                    i.holdsAtTheValue());
+            case InvariantOrigin i -> new LineFacts(ComparisonClaim.Cut.satisfiedOn(
+                    i.keeps().inward(), i.holdsAtTheValue()));
             case NarrowedOrigin n -> n.bound().lineFacts();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -14,6 +14,7 @@ import souther.compiler.inputs.SearchRegion;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.numeric.Towards;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -203,15 +204,14 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
     /**
      * Which way a comparison holds, off what it claims about the value it names.
      *
-     * <p>Two facts and they are enough: whether the value it names is on the side the comparison is
-     * true below, and whether the comparison holds at that value. {@code x <= c} holds below and at
-     * it; {@code x < c} holds below and not at it, and {@code c} is above; {@code x >= c} holds
-     * above and at it; {@code x > c} holds above and not at it, and {@code c} is below. So the true
-     * side is the low one exactly where those two agree.
+     * <p>Which side it is true on and whether it is true at the value it names, which is one
+     * comparison of the six. {@code x <= c} holds below and at it; {@code x < c} holds below and
+     * not at it; {@code x >= c} holds above and at it; {@code x > c} holds above and not at it.
+     * The side is the claim's own answer and is not worked out here from the two facts it holds.
      */
     private static Rel relOf(ComparisonClaim claim) {
         return switch (claim) {
-            case ComparisonClaim.Cut cut -> cut.valueBelongsBelow() == cut.holdsAtTheValue()
+            case ComparisonClaim.Cut cut -> cut.satisfyingSide() == Towards.BELOW
                     ? (cut.holdsAtTheValue() ? Rel.LE : Rel.LT)
                     : (cut.holdsAtTheValue() ? Rel.GE : Rel.GT);
             case ComparisonClaim.Singled singled ->

--- a/souther-compiler/src/main/java/souther/compiler/partition/Threshold.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Threshold.java
@@ -5,6 +5,8 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.Towards;
 
+import java.util.Objects;
+
 /**
  * A value a behavior compares an input against, and which side of it the value itself falls on.
  *
@@ -26,6 +28,13 @@ import souther.compiler.numeric.Towards;
  */
 public record Threshold(NumericTerm.FromOnePosition term, Seam parts, Towards valueBelongs,
                         OriginRef origin) {
+
+    /** A side and not the absence of one, for the reason a cut's own is
+     *  ({@link souther.compiler.check.ComparisonClaim.Cut}): a line with no side reads as one
+     *  whose value falls above it, and asks for a row against the wrong neighbour. */
+    public Threshold {
+        Objects.requireNonNull(valueBelongs, "which side of the line its own value falls on");
+    }
 
     /**
      * Where a row is owed against this line, as a value of the position, or null where the position

--- a/souther-compiler/src/main/java/souther/compiler/partition/Threshold.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Threshold.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Place;
+import souther.compiler.numeric.Towards;
 
 /**
  * A value a behavior compares an input against, and which side of it the value itself falls on.
@@ -23,7 +24,7 @@ import souther.compiler.numeric.Place;
  *                in an {@code ensures}. Both leave values a row can write either side; what differs
  *                is what meeting the line takes, and that is the origin's to answer
  */
-public record Threshold(NumericTerm.FromOnePosition term, Seam parts, boolean valueBelongsBelow,
+public record Threshold(NumericTerm.FromOnePosition term, Seam parts, Towards valueBelongs,
                         OriginRef origin) {
 
     /**
@@ -41,7 +42,7 @@ public record Threshold(NumericTerm.FromOnePosition term, Seam parts, boolean va
      * a third or the decimal next to one.
      */
     public Place value() {
-        Level beside = valueBelongsBelow ? parts.below() : parts.above();
+        Level beside = valueBelongs == Towards.BELOW ? parts.below() : parts.above();
         return beside instanceof Level.OnACarrier on ? on.at() : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/reading/NumberWays.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/NumberWays.java
@@ -11,6 +11,7 @@ import souther.compiler.inputs.Quantities;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Place;
+import souther.compiler.numeric.Towards;
 
 import java.util.function.Function;
 
@@ -80,9 +81,8 @@ final class NumberWays implements ComparisonWays {
         NumericDomain.Bounds runs = quantities.runsBetween(drawn.term());
         return switch (drawn.claim()) {
             case ComparisonClaim.Cut cut -> {
-                // Which side the way needs, from the two facts the claim carries: which side of the
-                // line the named value itself is on, and whether the comparison holds there.
-                boolean upIsTrue = cut.holdsAtTheValue() != cut.valueBelongsBelow();
+                // Which side the way needs, which is the side the comparison is true on.
+                boolean upIsTrue = cut.satisfyingSide() == Towards.ABOVE;
                 yield anythingBeyond(runs, drawn.at(), upIsTrue == want,
                         cut.holdsAtTheValue() == want);
             }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -6,6 +6,7 @@ import souther.compiler.source.SourceId;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.BehaviorImplementation;
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.numeric.Towards;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.RoleAnswer;
 import souther.compiler.diag.Citation;
@@ -2088,7 +2089,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // two lines apart by these facts would be telling them apart by it.
         if (line.facts().claim()
                 instanceof ComparisonClaim.Cut order) {
-            facts.put("valueBelongsBelow", order.valueBelongsBelow());
+            facts.put("valueBelongsBelow", order.valueBelongs() == Towards.BELOW);
         }
         facts.put("holdsAtTheValue", line.facts().holdsAtTheValue());
         facts.put("singles", line.facts().singles());

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest.java
@@ -37,7 +37,8 @@ class AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest {
      *  the operator rather than written out, so the reading is asked what the language says the
      *  comparison places. */
     private static ComparisonClaim.Cut ordering(BinOp op) {
-        return (ComparisonClaim.Cut) ComparisonPlacement.of(op);
+        return assertInstanceOf(ComparisonClaim.Cut.class, ComparisonPlacement.of(op),
+                () -> op + " orders the values either side of what it names");
     }
 
     /** The ordinary reading, which sharpens a strict end onto the count beside it. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest.java
@@ -33,10 +33,17 @@ class AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest {
         return new Hir.IntLit(value, NOWHERE, null);
     }
 
+    /** What {@code op} places, which is an order for every operator this reading takes. Read off
+     *  the operator rather than written out, so the reading is asked what the language says the
+     *  comparison places. */
+    private static ComparisonClaim.Cut ordering(BinOp op) {
+        return (ComparisonClaim.Cut) ComparisonPlacement.of(op);
+    }
+
     /** The ordinary reading, which sharpens a strict end onto the count beside it. */
     @Test
     void aStrictEndInsideTheOrderLandsOnTheCountBesideIt() {
-        InvariantBound.Read read = InvariantBound.at(BinOp.GT, whole(5), Carrier.WHOLE);
+        InvariantBound.Read read = InvariantBound.at(ordering(BinOp.GT), whole(5), Carrier.WHOLE);
 
         InvariantBound.Read.AnEnd end = assertInstanceOf(InvariantBound.Read.AnEnd.class, read);
         assertEquals(new InvariantBound(true, Endpoint.inclusive(Count.of(6))), end.bound());
@@ -52,28 +59,16 @@ class AnEndPastWhereAnOrderStopsIsNotAnEndNobodyReadTest {
     @Test
     void aStrictEndAtTheLastValueOfTheOrderLeavesNothing() {
         InvariantBound.Read read =
-                InvariantBound.at(BinOp.GT, whole(Long.MAX_VALUE), Carrier.WHOLE);
+                InvariantBound.at(ordering(BinOp.GT), whole(Long.MAX_VALUE), Carrier.WHOLE);
 
         assertInstanceOf(InvariantBound.Read.PastWhereTheOrderStops.class, read);
     }
 
-    /**
-     * An equality states no end, which is the answer the one above was being given.
-     *
-     * <p>Kept apart because a reader acting on them differs: nothing follows about the position from
-     * a rule this did not read, and everything follows from a rule that steps off the order.
-     */
-    @Test
-    void anEqualityStatesNoEnd() {
-        assertInstanceOf(InvariantBound.Read.NoEnd.class,
-                InvariantBound.at(BinOp.EQ, whole(5), Carrier.WHOLE));
-    }
-
-    /** And so does an ordering against something the order has no value for. */
+    /** An ordering against something the order has no value for states no end. */
     @Test
     void aLiteralTheOrderDoesNotReadStatesNoEnd() {
         assertInstanceOf(InvariantBound.Read.NoEnd.class,
-                InvariantBound.at(BinOp.GT, new Hir.StringLit("x", NOWHERE, null),
+                InvariantBound.at(ordering(BinOp.GT), new Hir.StringLit("x", NOWHERE, null),
                         Carrier.WHOLE));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -63,7 +63,7 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                             + " and is answered rather than excluded"));
 
     @Test
-    void onlyTheTwoBoundariesReadAnOperatorForWhatItPlaces() throws IOException {
+    void onlyARecognitionReadsAnOperatorForWhatItPlaces() throws IOException {
         assertEquals(declared(MAY_ASK), callsTo("of"),
                 "a reader below a recognised comparison that asks the operator again holds the"
                         + " wide answer, and has a case to invent an answer for; a second call in a"

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -55,20 +55,12 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
             new Licence("souther.compiler.check.Comparison.of", 1,
                     "the one place a node becomes a comparison, which is what carries the claim to"
                             + " every reader below it"),
-            new Licence("souther.compiler.check.ComparisonPlacement.orders", 1,
-                    "the same answer asked as a boolean, for a reader that holds an operator and"
-                            + " no comparison"),
+            new Licence("souther.compiler.check.ClauseComparison.of", 1,
+                    "the one place a clause of a data becomes a comparison, which is what carries"
+                            + " the claim to the readings of what it bounds"),
             new Licence("souther.compiler.inputs.ComparedNumber.of", 1,
                     "reads any binary a walk met, so an operator that places nothing arrives here"
                             + " and is answered rather than excluded"));
-
-    /** Who may ask whether an operator orders its values, which is the wide answer read as a
-     *  boolean. The reading of an invariant's clauses is the one left, and it is where the same
-     *  arrangement is still to be made. */
-    private static final List<Licence> MAY_ASK_ORDERS = List.of(
-            new Licence("souther.compiler.check.InvariantBound.ordering", 1,
-                    "a clause of a data is read off the syntax tree and has no recognised"
-                            + " comparison to carry a claim"));
 
     @Test
     void onlyTheTwoBoundariesReadAnOperatorForWhatItPlaces() throws IOException {
@@ -77,13 +69,6 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                         + " wide answer, and has a case to invent an answer for; a second call in a"
                         + " licensed reader is a second question under the first one's licence."
                         + " What each of these may ask, and why: " + why(MAY_ASK));
-    }
-
-    @Test
-    void whetherAnOperatorOrdersIsAskedOnlyWhereNoComparisonIsHeld() throws IOException {
-        assertEquals(declared(MAY_ASK_ORDERS), callsTo("orders"),
-                "asked as a boolean, what an operator places is left behind at the test. Where"
-                        + " that is still done, and why: " + why(MAY_ASK_ORDERS));
     }
 
     private static Map<String, Integer> declared(List<Licence> licences) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The algebra of what an operator places, which is what lets a reader stop holding the operator.
@@ -207,6 +208,20 @@ class WhatAnOperatorPlacesIsOneAnswerTest {
                     ComparisonClaim.Cut.satisfiedOn(cut.satisfyingSide(), cut.holdsAtTheValue()),
                     () -> op + " read as a side and built back from it");
         }
+    }
+
+    /**
+     * A cut has a side or is not built.
+     *
+     * <p>The side is one of two answers, and a reference can hold neither. Every reader here asks
+     * which side by comparing it to one of the two, so an absent side is read as the other and an
+     * order nothing stated is answered about all the way down.
+     */
+    @Test
+    void aCutWithNoSideIsRefused() {
+        assertThrows(NullPointerException.class,
+                () -> new ComparisonClaim.Cut(null, true),
+                "a cut whose named value is in neither class is not a cut");
     }
 
     private static ComparisonClaim claim(BinOp op) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * The algebra of what an operator places, which is what lets a reader stop holding the operator.
@@ -209,10 +210,12 @@ class WhatAnOperatorPlacesIsOneAnswerTest {
     }
 
     private static ComparisonClaim claim(BinOp op) {
-        return (ComparisonClaim) ComparisonPlacement.of(op);
+        return assertInstanceOf(ComparisonClaim.class, ComparisonPlacement.of(op),
+                () -> op + " compares its two sides, so it placed something");
     }
 
     private static ComparisonClaim.Cut cut(BinOp op) {
-        return (ComparisonClaim.Cut) ComparisonPlacement.of(op);
+        return assertInstanceOf(ComparisonClaim.Cut.class, ComparisonPlacement.of(op),
+                () -> op + " orders the values either side of what it names");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperatorPlacesIsOneAnswerTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.numeric.Towards;
 import souther.compiler.types.BinOp;
 
 import java.util.LinkedHashMap;
@@ -11,12 +12,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * The algebra of what an operator places, which is what lets a reader stop holding the operator.
  *
- * <p>Three laws, and each of them is what some reading rests on. That the classification and
- * {@link BinOp#compares} agree is what makes a claim the evidence that an operator compares. That
- * turning a statement round twice is the statement is what lets a reading turn one round wherever
- * it meets it. And that classifying the operator a swap would have been written with is the same as
- * turning the classification round is what lets a reader swap the sides without an operator table
- * of its own — the table a reading of a body's comparisons used to hold.
+ * <p>Each law is what some reading rests on. That the classification and {@link BinOp#compares}
+ * agree is what makes a claim the evidence that an operator compares. That turning a statement
+ * round twice is the statement is what lets a reading turn one round wherever it meets it. That
+ * classifying the operator a swap would have been written with is the same as turning the
+ * classification round is what lets a reader swap the sides without an operator table of its own,
+ * and the same holds of a denial — a rule met under a negation states the comparison that holds
+ * where it does not, and asking which operator that would have been is a second table.
+ *
+ * <p>And the two facts a cut holds are put together in one place, so the side a rule is satisfied
+ * on is one answer however many readings want it. Turning a comparison round moves it and denying
+ * one moves it, which is the whole of what the two operations do to a line.
  */
 class WhatAnOperatorPlacesIsOneAnswerTest {
 
@@ -24,6 +30,15 @@ class WhatAnOperatorPlacesIsOneAnswerTest {
      *  nowhere in the compiler: what a reading does with a swap is turn the claim round, and this
      *  is the table that says the two are one. */
     private static final Map<BinOp, BinOp> SWAPPED = swapped();
+
+    /** The operator each one states the failure of. Written out here and nowhere in the compiler:
+     *  what a reading does with a negation is deny the claim, and this is the table that says the
+     *  two are one. */
+    private static final Map<BinOp, BinOp> DENIED = denied();
+
+    /** Which side of its own line each order is true on. The four cases of the one derivation from
+     *  the two facts a cut holds. */
+    private static final Map<BinOp, Towards> SATISFIED_ON = satisfiedOn();
 
     private static Map<BinOp, BinOp> swapped() {
         Map<BinOp, BinOp> pairs = new LinkedHashMap<>();
@@ -34,6 +49,26 @@ class WhatAnOperatorPlacesIsOneAnswerTest {
         pairs.put(BinOp.EQ, BinOp.EQ);
         pairs.put(BinOp.NE, BinOp.NE);
         return pairs;
+    }
+
+    private static Map<BinOp, BinOp> denied() {
+        Map<BinOp, BinOp> pairs = new LinkedHashMap<>();
+        pairs.put(BinOp.LT, BinOp.GE);
+        pairs.put(BinOp.GE, BinOp.LT);
+        pairs.put(BinOp.LE, BinOp.GT);
+        pairs.put(BinOp.GT, BinOp.LE);
+        pairs.put(BinOp.EQ, BinOp.NE);
+        pairs.put(BinOp.NE, BinOp.EQ);
+        return pairs;
+    }
+
+    private static Map<BinOp, Towards> satisfiedOn() {
+        Map<BinOp, Towards> sides = new LinkedHashMap<>();
+        sides.put(BinOp.LT, Towards.BELOW);
+        sides.put(BinOp.LE, Towards.BELOW);
+        sides.put(BinOp.GT, Towards.ABOVE);
+        sides.put(BinOp.GE, Towards.ABOVE);
+        return sides;
     }
 
     /** What an operator places is a claim exactly where the operator compares. Two spellings of one
@@ -90,5 +125,94 @@ class WhatAnOperatorPlacesIsOneAnswerTest {
             assertEquals(placed, placed.turned(),
                     () -> op + " places nothing, and nothing turned round is nothing");
         }
+    }
+
+    /**
+     * Reading the operator that holds where one does not and denying the reading come to the same
+     * claim.
+     *
+     * <p>What a reading meeting a rule under a negation rests on. Where the two part, a reading
+     * that denies the claim states a rule the source did not, and the way it was noticed before was
+     * to write the operator table again beside it.
+     */
+    @Test
+    void denyingAComparisonIsReadingTheOneThatHoldsWhereItDoesNot() {
+        for (Map.Entry<BinOp, BinOp> each : DENIED.entrySet()) {
+            assertEquals(ComparisonPlacement.of(each.getValue()),
+                    claim(each.getKey()).denied(),
+                    () -> "what " + each.getKey() + " places, denied, is what "
+                            + each.getValue() + " places");
+        }
+    }
+
+    /** Denying a claim twice is the claim, which is what lets a reading deny one wherever it meets
+     *  a negation rather than counting how many it is under. */
+    @Test
+    void denyingAClaimTwiceLeavesIt() {
+        for (BinOp op : DENIED.keySet()) {
+            assertEquals(claim(op), claim(op).denied().denied(),
+                    () -> "denying " + op + " twice states what it stated");
+        }
+    }
+
+    /** Turning a claim round and denying it are done in either order, which is what lets a reading
+     *  do them as it meets them rather than in an order it has to keep. */
+    @Test
+    void turningAndDenyingAreDoneInEitherOrder() {
+        for (BinOp op : DENIED.keySet()) {
+            assertEquals(claim(op).turned().denied(), claim(op).denied().turned(),
+                    () -> "turning " + op + " round and denying it, either way about");
+        }
+    }
+
+    /**
+     * Which side each order is satisfied on, written out so that the four are the specification.
+     *
+     * <p>The one derivation from the two facts a cut holds. Every reading that wants the side asks
+     * this, and the table is here rather than in any of them.
+     */
+    @Test
+    void anOrderIsSatisfiedOnTheSideItsOwnValueDecides() {
+        Map<BinOp, Towards> sides = new LinkedHashMap<>();
+        for (BinOp op : SATISFIED_ON.keySet()) {
+            sides.put(op, cut(op).satisfyingSide());
+        }
+        assertEquals(SATISFIED_ON, sides,
+                "which side of its line each order is true on");
+    }
+
+    /** Turning an order round moves the side it is satisfied on, and so does denying it. Both move
+     *  it, so a reading that does one of them and keeps the side it had is a reading whose line has
+     *  its sides the wrong way round. */
+    @Test
+    void turningAndDenyingBothMoveTheSatisfyingSide() {
+        for (BinOp op : SATISFIED_ON.keySet()) {
+            Towards side = cut(op).satisfyingSide();
+            assertEquals(side.opposite(), cut(op).turned().satisfyingSide(),
+                    () -> op + " turned round is satisfied on the other side");
+            assertEquals(side.opposite(), cut(op).denied().satisfyingSide(),
+                    () -> op + " denied is satisfied on the other side");
+        }
+    }
+
+    /** An order built from the side it is satisfied on is the order that side was read off, which
+     *  is what a reader holding the end a bound kept rather than the class its value is in rests
+     *  on. */
+    @Test
+    void anOrderIsWhatItsSatisfyingSideBuildsBack() {
+        for (BinOp op : SATISFIED_ON.keySet()) {
+            ComparisonClaim.Cut cut = cut(op);
+            assertEquals(cut,
+                    ComparisonClaim.Cut.satisfiedOn(cut.satisfyingSide(), cut.holdsAtTheValue()),
+                    () -> op + " read as a side and built back from it");
+        }
+    }
+
+    private static ComparisonClaim claim(BinOp op) {
+        return (ComparisonClaim) ComparisonPlacement.of(op);
+    }
+
+    private static ComparisonClaim.Cut cut(BinOp op) {
+        return (ComparisonClaim.Cut) ComparisonPlacement.of(op);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -224,7 +224,8 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(15, 16)))),
-                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(true, true)));
+                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(
+                        souther.compiler.numeric.Towards.BELOW, true)));
     }
 
     /** The clause the bound in these tests names, which is only an identity here. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -10,6 +10,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.Towards;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleRef;
@@ -265,7 +266,7 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
         OriginRef closed = new OriginRef.EnsuresOrigin(
                 new RuleRef.Ensures(new BehaviorContract.RuleId(null, 0, 0, null), "cap"),
                 THE_ONLY_CONJUNCT,
-                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(true, true)));
+                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
         Border border = Border.at(lineAt(new AxisId("cap", "n"), carrier, Count.of(100)), closed,
                 new NumericDomain.Bounds(null, null));
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -14,6 +14,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Towards;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
@@ -187,6 +188,6 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5)))),
-                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(true, true)));
+                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
@@ -8,6 +8,7 @@ import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.Towards;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -45,7 +46,7 @@ class ACutSaysWhatItDividesAndWhereTest {
                 new BorderQuantity.OfACoordinate(AxisId.of("f", term("n")), term("n"),
                         souther.compiler.inputs.TermOrders.itself(WHOLE)),
                 new Level.OnACarrier(WHOLE, new Count(new BigDecimal(t))),
-                new ComparisonClaim.Cut(true, false), null);
+                new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
 
     /** {@code k * n > t}, read as an arithmetic form over a multiple of that position. */
@@ -53,7 +54,7 @@ class ACutSaysWhatItDividesAndWhereTest {
         return new Cutting(
                 new BorderQuantity.OverAForm("f", form("n", k), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal(t))),
-                new ComparisonClaim.Cut(true, false), null);
+                new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
 
     /**
@@ -126,7 +127,7 @@ class ACutSaysWhatItDividesAndWhereTest {
         Cutting closed = new Cutting(
                 new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("9"))),
-                new ComparisonClaim.Cut(true, true), null);
+                new ComparisonClaim.Cut(Towards.BELOW, true), null);
 
         assertEquals("4|5", closed.seam().key());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -89,7 +89,7 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
                         new Level.OnACarrier(new Carrier.Whole(),
                                 new Count(new java.math.BigDecimal(at))),
                         Towards.BELOW),
-                true, origin()));
+                Towards.BELOW, origin()));
     }
 
     /** One rule, written in one place. Two lines of it are told apart by where they part the
@@ -102,6 +102,6 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
                         new souther.compiler.coverage.ComparisonOccurrence(0),
                         new RuleCitation.WrittenAt(Citation.of(
                                 new souther.compiler.diag.SourcePos(1, 1)))),
-                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(true, true)));
+                new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
@@ -231,7 +231,7 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
         // of one rule cannot agree on.
         guards.thresholds().forEach(each ->
                 out.add(each.term() + " " + each.parts().below() + "|" + each.parts().above()
-                        + " below=" + each.valueBelongsBelow()));
+                        + " belongs=" + each.valueBelongs()));
         guards.between().forEach(each -> out.add(quantityOf(each.cuts().of())
                 + " at " + each.cuts().at() + " " + each.cuts().claim()));
         return out.stream().sorted().toList();

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.AReadingOfAPosition;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
@@ -218,6 +219,6 @@ class OneBorderReadTwiceIsOneReadingTest {
         return new AuthoredLine(new RuleRef.Comparison("weigh",
                 new souther.compiler.types.CoverageOrigin("example.weigh", 2, 0,
                         souther.compiler.types.CoverageConstruct.BINARY)),
-                0, LineFacts.ordering(true, true), List.of());
+                0, new LineFacts(new ComparisonClaim.Cut(Towards.BELOW, true)), List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -16,6 +16,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
 
 import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Towards;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -104,7 +105,7 @@ class ThresholdNormalizationTest {
         Threshold threshold = read.thresholds().get(0);
         assertEquals("request.cost", threshold.path().toString());
         assertEquals(Count.of(new BigDecimal(100000)), threshold.value());
-        assertTrue(threshold.valueBelongsBelow(), "`<= c` puts c on the low side");
+        assertEquals(Towards.BELOW, threshold.valueBelongs(), "`<= c` puts c on the low side");
 
         Axis cost = axis(read.partitioning(), "request.cost");
         assertEquals(List.of("0 <= x <= 100000", "100000 < x"), labels(cost));
@@ -216,8 +217,8 @@ class ThresholdNormalizationTest {
         Threshold bare = read.thresholds().get(0);
         Threshold beside = compound.thresholds().get(0);
         assertEquals(
-                List.of(bare.term(), bare.parts(), bare.valueBelongsBelow()),
-                List.of(beside.term(), beside.parts(), beside.valueBelongsBelow()),
+                List.of(bare.term(), bare.parts(), bare.valueBelongs()),
+                List.of(beside.term(), beside.parts(), beside.valueBelongs()),
                 "and the line is the same one either way: " + compound.thresholds());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Towards;
@@ -145,6 +146,6 @@ class TwoSpellingsOfOneLevelAreOneDemandTest {
                         new Clause.Id(TypeSymbols.declared(new TypeKey("example.probe", "Amount")),
                                 0),
                         Optional.of(new ClauseName("floor")))),
-                0, LineFacts.ordering(false, true), List.of());
+                0, new LineFacts(new ComparisonClaim.Cut(Towards.ABOVE, true)), List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -73,7 +73,8 @@ class WhatAClauseDrawsALineOnTest {
         Threshold line = clauses.thresholds().get(0);
         assertEquals("id", line.path().toString());
         assertInstanceOf(OriginRef.EnsuresOrigin.class, line.origin());
-        assertEquals(new souther.compiler.check.ComparisonClaim.Cut(true, false),
+        assertEquals(new souther.compiler.check.ComparisonClaim.Cut(
+                        souther.compiler.numeric.Towards.BELOW, false),
                 ((OriginRef.EnsuresOrigin) line.origin()).facts().claim(),
                 "`> 0` puts the zero on the low side and is not met there, so the row beside it is"
                         + " the one above");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Carrier;
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
 import souther.compiler.numeric.Towards;
@@ -142,7 +143,7 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
                                         new souther.compiler.types.TypeKey("example.runs", "N")),
                                 clause),
                         java.util.Optional.empty())),
-                0, LineFacts.ordering(false, true), List.of());
+                0, new LineFacts(new ComparisonClaim.Cut(Towards.ABOVE, true)), List.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichEndABoundPlacedSurvivesBeingReadBackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichEndABoundPlacedSurvivesBeingReadBackTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.ClauseName;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
 import souther.compiler.numeric.EndSide;
+import souther.compiler.numeric.Towards;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
@@ -34,7 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WhichEndABoundPlacedSurvivesBeingReadBackTest {
 
     /** One row of the law: what a line says about its own value, and the end that says it. */
-    private record Row(boolean valueBelongsBelow, boolean holdsAtTheValue, EndSide keeps) {}
+    private record Row(Towards valueBelongs, boolean holdsAtTheValue, EndSide keeps) {
+
+        /** The line these two facts are of, which is what the derivations under test read. */
+        ComparisonClaim.Cut cut() {
+            return new ComparisonClaim.Cut(valueBelongs, holdsAtTheValue);
+        }
+    }
 
     /**
      * Every way a bound's line can stand to its own value.
@@ -44,10 +51,10 @@ class WhichEndABoundPlacedSurvivesBeingReadBackTest {
      * not.
      */
     private static final List<Row> THE_LAW = List.of(
-            new Row(true, true, EndSide.UPPER),
-            new Row(false, false, EndSide.UPPER),
-            new Row(false, true, EndSide.LOWER),
-            new Row(true, false, EndSide.LOWER));
+            new Row(Towards.BELOW, true, EndSide.UPPER),
+            new Row(Towards.ABOVE, false, EndSide.UPPER),
+            new Row(Towards.ABOVE, true, EndSide.LOWER),
+            new Row(Towards.BELOW, false, EndSide.LOWER));
 
     /** The clause these name, which is only an identity. */
     private static RuleRef.Invariant aClause() {
@@ -60,9 +67,8 @@ class WhichEndABoundPlacedSurvivesBeingReadBackTest {
     @Test
     void theEndFollowsFromWhatTheLineSaysAboutItsOwnValue() {
         for (Row row : THE_LAW) {
-            assertEquals(row.keeps(),
-                    DeclaredThresholds.endKept(row.valueBelongsBelow(), row.holdsAtTheValue()),
-                    () -> "below=" + row.valueBelongsBelow() + " holds=" + row.holdsAtTheValue());
+            assertEquals(row.keeps(), DeclaredThresholds.endKept(row.cut()),
+                    () -> "belongs=" + row.valueBelongs() + " holds=" + row.holdsAtTheValue());
         }
     }
 
@@ -77,11 +83,9 @@ class WhichEndABoundPlacedSurvivesBeingReadBackTest {
     void aBoundBuiltFromThatEndReadsBackAsThePairItCameFrom() {
         for (Row row : THE_LAW) {
             OriginRef.InvariantOrigin origin = new OriginRef.InvariantOrigin(aClause(), 0,
-                    DeclaredThresholds.endKept(row.valueBelongsBelow(), row.holdsAtTheValue()),
-                    row.holdsAtTheValue());
+                    DeclaredThresholds.endKept(row.cut()), row.holdsAtTheValue());
 
-            assertEquals(new ComparisonClaim.Cut(row.valueBelongsBelow(), row.holdsAtTheValue()),
-                    origin.lineFacts().claim(),
+            assertEquals(row.cut(), origin.lineFacts().claim(),
                     () -> "which side the threshold's own value is on and whether the rule admits"
                             + " it, read back: " + row);
         }
@@ -96,8 +100,7 @@ class WhichEndABoundPlacedSurvivesBeingReadBackTest {
     @Test
     void bothEndsAreReached() {
         assertEquals(2, THE_LAW.stream()
-                .map(row -> DeclaredThresholds.endKept(row.valueBelongsBelow(),
-                        row.holdsAtTheValue()))
+                .map(row -> DeclaredThresholds.endKept(row.cut()))
                 .distinct().count(),
                 "a law that answered one end for every pair would round-trip and say nothing");
     }


### PR DESCRIPTION
Closes #1215.

## The cause

The issue names four callers that ask `InvariantBound.ordering` and then read the
operator again. Reading for the invariant rather than for the list found eleven
sites and four tables:

| where | what it reads the operator for |
|---|---|
| `InvariantChecker.direct` ×3, `InvariantChecker.noLineDrawn` | whether the operator orders, and which comparison the swapped sides state |
| `OrderedReading.comparison` ×3 | the same two, and its own `denied(BinOp)` for a rule met under a negation |
| `InvariantBound.of`, `sizeComparedIn` | `mirrored(BinOp)` where the subject is on the right |
| `InvariantBound.ordered` | the four ordering operators, with `default -> NO_END` for the ones `ordering` had already refused |

Two of the issue's claims did not survive measurement. The named callers
`endOf` / `boundOf` / `narrowedBy` do not exist — the reads are inline in `direct`
and `noLineDrawn`. And "`InvariantBound` reads `Hir.Expr`, so `Comparison` cannot
be used" holds for two of the eleven: the other nine read a `Core.Binary` and the
mint #1214 built was already available to them.

**The cause is that a claim could only be reached from a `Core.Binary`, and the
shared tail that reads an end took a `BinOp`.** So a reading of a clause could not
hold what the operator placed, and every reader above the tail went on holding the
operator. The three tables besides `ComparisonPlacement.of` are functions of its
image written from the operator instead.

## The other half of it: two booleans are not an answer either

`ComparisonClaim.Cut` held `boolean valueBelongsBelow` and `boolean
holdsAtTheValue`, and which side an order is satisfied on was worked out from the
pair in five places, in two vocabularies:

```
Border.satisfyingSide(boolean, boolean)   holds == belongsBelow ? BELOW : ABOVE
NumberWays.leaves                         holds != belongsBelow
ReachingCuts.relOf                        belongsBelow == holds ? LE/LT : GE/GT
DeclaredThresholds.endKept(boolean, ...)  belongsBelow == holds ? UPPER : LOWER
InvariantBound.ordered                    (the one this issue would have added)
```

Deleting the operator tables and leaving this would have moved the defect one
level down: four hand-written derivations would have become five, and
`Border.satisfyingSide` takes two arguments of one type, so a caller pairing them
the other way round is a caller nothing contradicts.

## The mechanism

`ComparisonPlacement.of(BinOp)` stays the one place an operator is read for what
it places. What is new is a second way in to it from the other tree, and an owner
for the derivation:

```
Core.Binary ── Comparison.of ───────┐
                                    ├─▶ ComparisonClaim ──▶ turned() / denied()
Hir.Expr    ── ClauseComparison.of ─┘                        Cut.satisfyingSide()
```

- `ClauseComparison` holds the two sides and the claim and **does not publish the
  operator**. `turned()` moves the sides and the claim together, so a caller cannot
  swap one without the other.
- `InvariantBound.at` takes the `ComparisonClaim.Cut` it reads an end from.
  `ordered` has no `default`: which end it is is `satisfyingSide() == ABOVE` and
  whether the end admits the number is `holdsAtTheValue()`, and what is left is the
  carrier's question of where a refused number leaves the end. `at(EQ, ...)` is not
  a call anyone can write.
- `Cut`'s first axis is a `Towards`, because which class the named value is in is a
  direction and `numeric.Towards` already names "which side of a threshold a rule is
  satisfied on" as one of the four questions it answers. The seven
  `? Towards.BELOW : Towards.ABOVE` conversions in `Border` and `Cutting` are reads
  of a field now.
- `EndSide.facing(Towards)` is `inward()` read the other way, and
  `Cut.satisfiedOn(Towards, boolean)` is `satisfyingSide()` read the other way. A
  bound records the end it kept, and reading its line back is these two inverses
  rather than the pairing written a second time.

Gone: `ComparisonPlacement.orders`, `InvariantBound.ordering`, `flipped`,
`mirrored`, `OrderedReading.denied`, `Border.satisfyingSide(boolean, boolean)` and
`LineFacts.ordering`, the last because its production caller went with
`Cut.satisfiedOn` and what it did was rebuild a claim from two booleans.

`InvariantBound` no longer imports `BinOp`.

## What holds it

A reachable-nowhere arm is not defended by a behavioural test, so the same three
as #1214:

1. **The types.** `ordered` cannot be handed a `Singled`; `ClauseComparison` cannot
   be asked for an operator.
2. **The laws** (`WhatAnOperatorPlacesIsOneAnswerTest`): `turned ∘ turned = id`,
   `denied ∘ denied = id`, `turned ∘ denied = denied ∘ turned`, the swapped
   operator's placement is the turned claim, the denied operator's placement is the
   denied claim, the four satisfying sides, and `satisfiedOn` as the inverse of
   `satisfyingSide`.
3. **The count** (`AnOperatorIsAskedWhatItPlacesInOnePlaceTest`): three mints read
   `ComparisonPlacement.of`, one call each. The second test in that class is gone
   with `orders` — an empty declaration would be a check that says nothing.

Each was made to fail: `satisfyingSide` collapsed to `valueBelongs` fails 3 laws,
`denied` flipping both axes fails 2, `ordered`'s end reversed fails 501 tests in
the compiler module, and a second `ComparisonPlacement.of` inside
`ClauseComparison.of` is reported by name and count.

`mvn -o test` is green across the reactor (7832 in the compiler module).

## Left out

The JSON key `valueBelongsBelow` is unchanged. It is in `adequacy-schema-9`,
`adequacy-schema-10` and two expected reports, and renaming it is a version
question rather than this one.

The gate at the top of `InvariantChecker.direct` lets an ordering or an equality
through and stops a disequality, which is what `!ordering(op) && op != BinOp.EQ`
did before. **Nothing observes the difference**: routing every `Singled` down the
early return leaves the whole reactor green. What the arm opens for an equality is
the walk that records which declarations narrowed a position
(`AuthoredLine.narrowedWithin`, published in the report) and the boundary question
a position is left standing with — neither of which is about the ends the old
condition was phrased in terms of. The behaviour is unchanged here and the comment
now says what the gate opens; whether a denial belongs in `narrowers` is a
question about that walk rather than about this boundary.

Three verbatim copies of `mirrored(BinOp)` remain, in `check/Conditions`,
`flow/Witnessed` and `codegen/InvariantConstraints`. They are the same table but
not the same responsibility — each answers a different question after the turn
(`NumericDomain.Rel`, whether a witness exists, which decoder constraint), and each
reads the operator for meaning elsewhere too, so replacing `mirrored` alone would
move this defect rather than close it. #1217 is where they are measured.
