### PR TITLE
Read a rule root under the condition it was opened, and the subjects it shares

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -695,6 +695,18 @@ public final class FieldDomains {
             atomAt.forEach((path, atom) -> at(where, atom, Coordinate.value(path)));
             countAt.forEach((path, counted) -> at(where, counted.atom(),
                     Coordinate.takenBy(path, counted.by())));
+            // And every other subject this reading knows a name for, which is what a caller can
+            // name and what these two maps are narrower than: they hold the numbers, and a name
+            // holds whatever stands there. Left to `otherwise`, a subject of a name would be
+            // carried as something to be equal to and nothing more — so a rule of one value about a
+            // name its cases share and a rule of the case about the same name would arrive as two
+            // subjects, and every reading that has no word for a number would stop meeting at the
+            // narrowing.
+            namedBy.forEach((atom, path) -> {
+                if (!where.containsKey(atom)) {
+                    at(where, atom, Coordinate.value(path));
+                }
+            });
             InjectiveRenaming<FactSubject, B> naming = InjectiveRenaming.of(atom -> {
                 Coordinate coordinate = where.get(atom);
                 return coordinate == null ? otherwise.apply(atom) : named.apply(coordinate);
@@ -1262,11 +1274,18 @@ public final class FieldDomains {
     }
 
     /**
-     * One number of one name: what stands at the name, or the count taken of it.
+     * One thing at one name: what stands at the name, or a number taken of it.
      *
      * <p>The pair {@link #leftAt} already asks by, written down so that a form over several names
      * can be. A name measured two ways is two coordinates at one name, and a form naming the other
      * one is a form about another quantity.
+     *
+     * <p><b>What stands at a name is not always a number.</b> A string is bounded on its order and
+     * admits a set of values and is at a name like anything else, and a caller that has to say what
+     * two readings of one name come to needs it under the same coordinate whichever of those the
+     * rules happened to reach. So this says where a subject sits and which of the things there it
+     * is; a reader that only has numbers to give finds nothing at a name it takes none of
+     * ({@link Settled#given}), which is the answer rather than a case to rule out.
      *
      * <p><b>A name the rules of this value write, and never a place a row writes a value at.</b>
      * The two part at a sum whose cases share a spread, and a coordinate is on the side the rules
@@ -1280,7 +1299,7 @@ public final class FieldDomains {
             if (path == null) {
                 throw new IllegalArgumentException("a coordinate is at a name of the value");
             }
-            java.util.Objects.requireNonNull(kind, "and is some number of what is there");
+            java.util.Objects.requireNonNull(kind, "and is one of the things that are there");
         }
 
         /** What stands at the name. */

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1028,6 +1028,22 @@ public final class FieldDomains {
     }
 
     /**
+     * Which number of {@code path} the rules take as a count of what it holds, or null where they
+     * take none.
+     *
+     * <p><b>The owner of which number that is.</b> A caller holding a place and wanting the count
+     * there has two things it could ask: what a reading of the input decided to measure the position
+     * at, and what the rules of the value it sits in are about. Those are not the same — a rule can
+     * relate the length of a list to a field beside it while the position itself is read by its own
+     * value — and a caller asking the first for the second is told there is no count wherever the
+     * clause that mentions it is written about something else as well.
+     */
+    public Coordinate countedAt(RuleKey path) {
+        Counted counted = countAt.get(path);
+        return counted == null ? null : Coordinate.takenBy(path, counted.by());
+    }
+
+    /**
      * Which values may stand at {@code path}, and how much of its rules was read.
      *
      * <p>{@link ValueSet#ANY} where the rules leave it open, which is also what a name nothing

--- a/souther-compiler/src/main/java/souther/compiler/inputs/CaseOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/CaseOutcome.java
@@ -1,0 +1,47 @@
+package souther.compiler.inputs;
+
+/**
+ * What became of one case of a sum when the reading reached it.
+ *
+ * <p>Every case of every sum the walk met has exactly one of these, which is what lets a reader ask
+ * whether a sum has a value at all: a sum stands wherever any of its cases does, so the question is
+ * answered over the whole list or it is not answered.
+ *
+ * <p><b>Two of these are facts about the model and two are not.</b> That naming a case builds it,
+ * and that the rules leave nothing at one, are what the declarations say. That a reading was opened
+ * under a case, and that this walk did not go down one, are facts about this reading — and the
+ * second of those is the one a reader must not take for the first kind. A case this walk never
+ * entered has not been shown to hold nothing; it has not been shown anything, and a proof built from
+ * it would say a model has no value because this compiler stopped looking.
+ */
+sealed interface CaseOutcome {
+
+    /**
+     * A reading of the case was opened, and stands at {@code at}.
+     *
+     * <p>Whether anything is left of it is that reading's answer and not this one's: what is here is
+     * where to ask.
+     */
+    record Opened(TermPath at) implements CaseOutcome {}
+
+    /**
+     * Naming the case builds it, so there is nothing under it to read.
+     *
+     * <p>A value, and the plainest one there is. A sum with one of these among its cases has a value
+     * whatever the rules do to the others.
+     */
+    record StandsAlone() implements CaseOutcome {}
+
+    /** The rules leave no value of this case, so nothing under it was owed. */
+    record RefusedByTheRules() implements CaseOutcome {}
+
+    /**
+     * This reading did not go down the case.
+     *
+     * <p>How far a walk goes is settled by what was demanded of it and by where a path returns to a
+     * declaration already open — neither of which is anything the model says about this case. So
+     * what is known about it is nothing, and nothing is not the same answer as
+     * {@link RefusedByTheRules}.
+     */
+    record NotWalked() implements CaseOutcome {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/CaseOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/CaseOutcome.java
@@ -17,12 +17,14 @@ package souther.compiler.inputs;
 sealed interface CaseOutcome {
 
     /**
-     * A reading of the case was opened, and stands at {@code at}.
+     * A reading of the case was opened.
      *
-     * <p>Whether anything is left of it is that reading's answer and not this one's: what is here is
-     * where to ask.
+     * <p>Whether anything is left of it is that reading's answer and not this one's, and where to
+     * ask is not written down here either: a reading is reached by asking under the narrowing this
+     * case is, which is the same fact from the side that knows it. Carried as a path as well, the
+     * two could disagree about which reading answers for this case.
      */
-    record Opened(TermPath at) implements CaseOutcome {}
+    record Opened() implements CaseOutcome {}
 
     /**
      * Naming the case builds it, so there is nothing under it to read.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/CasesRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/CasesRead.java
@@ -1,0 +1,25 @@
+package souther.compiler.inputs;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.SequencedMap;
+
+/**
+ * Every case of one sum, and what became of each.
+ *
+ * <p>The whole list, because what is asked of it is asked of all of them at once: a sum has a value
+ * wherever any case does, so a reader holding some of the cases can say nothing. Assembled from the
+ * roots a walk opened and the cases it turned back at, the list would be one fact in three places —
+ * and the case nobody thought to look for would be the one that says the model has a value.
+ *
+ * <p>In the order the cases are declared, which is the order a reason about them reads in.
+ *
+ * @param sum      where the sum stands
+ * @param outcomes what became of each of its cases
+ */
+record CasesRead(TermPath sum, SequencedMap<Refinement, CaseOutcome> outcomes) {
+
+    CasesRead {
+        outcomes = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(outcomes));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/EmptyInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/EmptyInput.java
@@ -35,6 +35,21 @@ public sealed interface EmptyInput {
     record TwoValuesAtOnePosition(NumericTerm term, Count one, Count other) implements EmptyInput {}
 
     /**
+     * One position was asked to be two cases.
+     *
+     * <p>Beside {@link TwoValuesAtOnePosition} and the same kind of fact: what contradicts is what
+     * the caller said, and the declarations were never asked. A position holds one value, so a
+     * value that is a {@code GlobalQuery} is not also a {@code FeedQuery}, and something fixed under
+     * each of them is fixed in no row.
+     *
+     * <p>Refinements and not cases, because a sum's cases and an optional's presence are narrowings
+     * of one kind ({@link Refinement}) — read as cases, the same contradiction under an optional
+     * would arrive as a shape of its own with nothing to be an instance of.
+     */
+    record TwoRefinementsAtOnePosition(TermPath at, Refinement one, Refinement other)
+            implements EmptyInput {}
+
+    /**
      * A position was fixed at a value the term itself cannot take.
      *
      * <p>Against what the term guarantees of its own values and against nothing else, which is the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputAtom.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputAtom.java
@@ -53,24 +53,38 @@ sealed interface InputAtom {
      * held in the name, one number arriving from the declaration's reading and from a caller's form
      * would be two, and a rule about it would say nothing about the form that names it.
      *
-     * @param parameter which of the behavior's inputs this sits under
-     * @param path      what that parameter's own rules call the place
-     * @param measured  whether this is the count taken of the place rather than its own value. Two
-     *                  numbers at one place, and a rule about one says nothing about the other
+     * @param root     the value whose rules name the place, which is the parameter where no
+     *                 narrowing was taken and the case where one was. A field the cases of a sum
+     *                 share is one place named by two of those, and it is this one — the nearest,
+     *                 whose rules can name it — so that the rules of both arrive about one subject
+     * @param path     what that value's own rules call the place
+     * @param kind     whether this is the count taken of the place rather than its own value. Two
+     *                 numbers at one place, and a rule about one says nothing about the other
      */
-    record Named(String parameter, RuleKey path,
+    record Named(String root, RuleKey path,
                  souther.compiler.check.FieldDomains.CoordinateKind kind) implements InputAtom {
 
         public Named {
-            if (parameter == null || path == null) {
+            if (root == null || path == null) {
                 throw new IllegalArgumentException("a named number sits somewhere");
             }
             java.util.Objects.requireNonNull(kind, "and is some number of what is there");
         }
 
+        /**
+         * Where the number sits, as a reader of this input spells a place.
+         *
+         * <p>Read here and not assembled by whoever needs it. A proof that names a place and the
+         * rendering of a subject are the same spelling, and two of them would be one place written
+         * two ways the day a step wears something.
+         */
+        String place() {
+            return path.isTheValueItself() ? root : root + "." + path;
+        }
+
         @Override
         public String toString() {
-            String at = path.isTheValueItself() ? parameter : parameter + "." + path;
+            String at = place();
             return switch (kind) {
                 case souther.compiler.check.FieldDomains.CoordinateKind.OfItsOwnValue _ -> at;
                 case souther.compiler.check.FieldDomains.CoordinateKind
@@ -94,18 +108,18 @@ sealed interface InputAtom {
      * from two readings is two numbers, and without the parameter their rules would be put together
      * as rules about one.
      */
-    record Anonymous(String parameter, Object subject) implements InputAtom {
+    record Anonymous(String root, Object subject) implements InputAtom {
 
         public Anonymous {
-            if (parameter == null || subject == null) {
+            if (root == null || subject == null) {
                 throw new IllegalArgumentException(
-                        "a number with no term of this input is still one parameter's");
+                        "a number with no term of this input is still one reading's");
             }
         }
 
         @Override
         public String toString() {
-            return parameter + ":<" + subject + ">";
+            return root + ":<" + subject + ">";
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1200,8 +1200,7 @@ public final class InputDomain {
         // back at a value it has already been at would leave a case pointing at a reading nobody
         // made.
         if (opening instanceof RootOpening.Refined it) {
-            observed.became(it.crossing().sum(), it.crossing().branch(),
-                    new CaseOutcome.Opened(opened));
+            observed.became(it.crossing().sum(), it.crossing().branch(), new CaseOutcome.Opened());
         }
         if (reach.handedOn()) {
             handoffs.accepts(by, at, opened);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -114,7 +114,7 @@ public final class InputDomain {
     /** Nothing to read: a behavior whose signature is not in hand. */
     public static final InputDomain NONE =
             new InputDomain(List.of(), Map.of(), List.of(), List.of(), null, NameReach.NONE,
-                    List.of(), List.of());
+                    List.of(), List.of(), List.of());
 
     private final List<Position> positions;
     private final Map<TermPath, Position> byPath;
@@ -147,11 +147,23 @@ public final class InputDomain {
      * agreed about the parameters and disagreed here would be disagreeing with itself.
      */
     private final List<ClauseWithoutAnEnd> clauses;
+    /**
+     * Every sum this reading met and what became of each of its cases.
+     *
+     * <p>What says whether a sum has a value at all, which is a question about the whole list of
+     * them rather than about any one case.
+     *
+     * <p>No part of what makes two readings one, for the reason {@link #clauses} is not: the same
+     * parameters walked under the same policy meet the same cases, so a reading that agreed about
+     * the positions and disagreed here would be disagreeing with itself.
+     */
+    private final List<CasesRead> cases;
 
     private InputDomain(List<Position> positions, Map<BindingId, String> read,
                         List<Parameter> parameters, List<RuleRoot> roots, ReadingPolicy policy,
                         NameReach reach, List<PlacementSeed> placed,
-                        List<ClauseWithoutAnEnd> clauses) {
+                        List<ClauseWithoutAnEnd> clauses, List<CasesRead> cases) {
+        this.cases = List.copyOf(cases);
         this.placed = List.copyOf(placed);
         this.clauses = List.copyOf(clauses);
         this.positions = List.copyOf(positions);
@@ -276,7 +288,7 @@ public final class InputDomain {
                 .toList();
         return settled.isEmpty() ? NONE
                 : new InputDomain(settled, read, parameters, roots, policy, observed.reach(),
-                        account.placed(), account.clauses());
+                        account.placed(), account.clauses(), observed.cases());
     }
 
     /**
@@ -750,8 +762,8 @@ public final class InputDomain {
         // position first and the declarations under one the reading stopped above, which is the one
         // resolution of it — worked out again from the positions this hands over, a rule about a
         // name every case of a sum spreads would be read as naming nothing.
-        return ReadQuantities.of(byRoot, byRoot.keySet(), byPath, path -> typeAt(path, symbols),
-                symbols);
+        return ReadQuantities.of(byRoot, byRoot.keySet(), byPath, cases,
+                path -> typeAt(path, symbols), symbols);
     }
 
     /**
@@ -1067,8 +1079,6 @@ public final class InputDomain {
                     }
                     standing.add(branch);
                     passedTo.add(path.refine(branch.refinement()));
-                    observed.became(path, branch.refinement(),
-                            new CaseOutcome.Opened(path.refine(branch.refinement())));
                 }
                 if (!stopped) {
                     handoffs.passesTo(placed.root(), path, passedTo);
@@ -1177,6 +1187,14 @@ public final class InputDomain {
                                          PlacedRules.Reaching crossing, RootOpening opening,
                                          Gathered account, Reach reach) {
         roots.add(new RuleRoot(opened, type, opening));
+        // Said where a reading is actually opened, so that a case recorded as opened is one there
+        // is somewhere to ask about. Said where the branch was chosen instead, a descent that turns
+        // back at a value it has already been at would leave a case pointing at a reading nobody
+        // made.
+        if (opening instanceof RootOpening.Refined it) {
+            observed.became(it.crossing().sum(), it.crossing().branch(),
+                    new CaseOutcome.Opened(opened));
+        }
         if (reach.handedOn()) {
             handoffs.accepts(by, at, opened);
         }
@@ -1223,6 +1241,9 @@ public final class InputDomain {
         // this walk already reported; saying they were read here as well would be one reading
         // discharging an obligation raised somewhere it never went.
         if (visited.contains(branch.under())) {
+            // Where the descent stops, and nothing under this case was read. What is known about it
+            // is nothing, which is not what the rules leaving nothing at it would be.
+            observed.became(path, branch.refinement(), new CaseOutcome.NotWalked());
             return;
         }
         java.util.Set<Type> deeper = new java.util.LinkedHashSet<>(visited);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -101,8 +101,15 @@ public final class InputDomain {
      * <p>Kept as the declarations rather than as a reading of them, for the reason the parameters
      * are: what is answered with is compared as a value by whatever decides that a compile changed
      * nothing.
+     *
+     * <p><b>And with the condition it was opened under.</b> A reading of one of these holds of the
+     * rows the opening admits and not of every row, so a reader that met them all together would
+     * have every case of every sum holding at once ({@link RootOpening}). Recorded here because it
+     * is known here and nowhere else: the descent that opens the reading is what says whether it
+     * crossed a narrowing or a container, and a reader working it back out of the path would be
+     * answering from the steps rather than from the descent that took them.
      */
-    public record RuleRoot(TermPath at, Type type) {}
+    public record RuleRoot(TermPath at, Type type, RootOpening opening) {}
 
     /** Nothing to read: a behavior whose signature is not in hand. */
     public static final InputDomain NONE =
@@ -248,7 +255,7 @@ public final class InputDomain {
                 read.putIfAbsent(parameter.binding(), parameter.name());
             }
             TermPath at = TermPath.of(parameter.name());
-            roots.add(new RuleRoot(at, parameter.type()));
+            roots.add(new RuleRoot(at, parameter.type(), new RootOpening.Taken()));
             PlacedRules rules = PlacedRules.of(at, parameter.type(), symbols, policy);
             account.from(rules);
             // One walk, carrying the paths the measurement named under this parameter. Walked once
@@ -1022,7 +1029,7 @@ public final class InputDomain {
                 // of its own.
                 takeTheRulesOver(placed.root(), path, at, elements.element(), ancestry, symbols,
                         policy, found, roots, java.util.Set.of(), handoffs, observed, null,
-                        account, on);
+                        new RootOpening.Inside(placed.root(), path), account, on);
             }
             case StructuralInspection.Continuation.Branches branches -> {
                 // Asked where the branches are, which is the only place a name can cross one.
@@ -1058,16 +1065,20 @@ public final class InputDomain {
                 for (StructuralInspection.Branch branch : standing) {
                     int before = found.size();
                     // What the value above calls the positions under this case, where it calls them
-                    // anything: the names its cases share and nothing else. Handed down as the
-                    // reading of the case is opened, so a clause written above is read at the
-                    // position it is about by the one reading of that position.
-                    PlacedRules.Reaching crossing = shared.isEmpty() ? null
-                            : new PlacedRules.Reaching(placed, path, branch.refinement(),
-                                    new java.util.LinkedHashSet<>(shared));
+                    // anything: the names its cases share and nothing else.
+                    SharedNames crossing = new SharedNames(path, branch.refinement(),
+                            new java.util.LinkedHashSet<>(shared));
+                    // Handed down as the reading of the case is opened, so a clause written above
+                    // is read at the position it is about by the one reading of that position.
+                    // Nothing to hand down where nothing crosses, which is not the same as the case
+                    // standing under no narrowing — that is what the opening beside this says.
+                    PlacedRules.Reaching reaching =
+                            shared.isEmpty() ? null : new PlacedRules.Reaching(placed, crossing);
                     walkBranch(branch, placed.root(), path, ancestry, symbols, policy, found, roots,
-                            visited, handoffs, observed, crossing, account,
+                            visited, handoffs, observed, reaching,
+                            new RootOpening.Refined(placed.root(), crossing), account,
                             reach.into(path.refine(branch.refinement()), stopped), stopped);
-                    crossed(observed, path, shared, branch.refinement(), found, before, crossing);
+                    crossed(observed, crossing, found, before);
                 }
             }
         }
@@ -1084,15 +1095,15 @@ public final class InputDomain {
      * @param from  where the walk's positions began before this branch was walked, so that what is
      *              looked through is what this branch put there
      */
-    private static void crossed(NameReach.Observed observed, TermPath at, List<String> shared,
-                                Refinement branch, List<Position> found, int from,
-                                PlacedRules.Reaching crossing) {
-        if (shared.isEmpty()) {
+    private static void crossed(NameReach.Observed observed, SharedNames crossing,
+                                List<Position> found, int from) {
+        if (crossing.names().isEmpty()) {
             return;
         }
-        TermPath narrowed = at.refine(branch);
+        TermPath at = crossing.sum();
+        TermPath narrowed = at.refine(crossing.branch());
         List<Position> made = found.subList(from, found.size());
-        for (String field : shared) {
+        for (String field : crossing.names()) {
             // What the value above calls this position, asked of the one thing that answers it —
             // which is what the reading of the position asks when a clause of that value is read
             // here. Worked out again, this would be a second statement of one relation, and a break
@@ -1103,7 +1114,7 @@ public final class InputDomain {
                     .filter(each -> at.then(field).equals(crossing.outerPathOf(each)))
                     .findFirst().orElse(null);
             if (stands != null) {
-                observed.crosses(at, field, branch, stands);
+                observed.crosses(at, field, crossing.branch(), stands);
                 continue;
             }
             // Nowhere under this case, and the reading of the case is what says why. Asked of the
@@ -1111,7 +1122,7 @@ public final class InputDomain {
             // silence would be read as the model putting no such field here.
             BlockReason.AboutThePosition why = whereItStopped(made, narrowed);
             if (why != null) {
-                observed.doesNotStand(at, field, branch, why);
+                observed.doesNotStand(at, field, crossing.branch(), why);
             }
         }
     }
@@ -1152,9 +1163,9 @@ public final class InputDomain {
                                          List<Position> found, List<RuleRoot> roots,
                                          java.util.Set<Type> visited, RuleHandoffs handoffs,
                                          NameReach.Observed observed,
-                                         PlacedRules.Reaching crossing,
+                                         PlacedRules.Reaching crossing, RootOpening opening,
                                          Gathered account, Reach reach) {
-        roots.add(new RuleRoot(opened, type));
+        roots.add(new RuleRoot(opened, type, opening));
         if (reach.handedOn()) {
             handoffs.accepts(by, at, opened);
         }
@@ -1183,6 +1194,7 @@ public final class InputDomain {
                                    List<Position> found, List<RuleRoot> roots,
                                    java.util.Set<Type> visited, RuleHandoffs handoffs,
                                    NameReach.Observed observed, PlacedRules.Reaching crossing,
+                                   RootOpening opening,
                                    Gathered account, Reach reach, boolean stopped) {
         // <b>A descent that costs no level stops only where it returns to a value it has already
         // been at without a step into one.</b> That is the whole of the rule, and what it is keyed
@@ -1205,8 +1217,8 @@ public final class InputDomain {
         java.util.Set<Type> deeper = new java.util.LinkedHashSet<>(visited);
         deeper.add(branch.under());
         takeTheRulesOver(by, path, path.refine(branch.refinement()), branch.under(), ancestry,
-                symbols, policy, found, roots, deeper, handoffs, observed, crossing, account,
-                reach);
+                symbols, policy, found, roots, deeper, handoffs, observed, crossing, opening,
+                account, reach);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1065,16 +1065,24 @@ public final class InputDomain {
                     // A branch that is the whole of a value puts no position anywhere, and one the
                     // rules leave nothing at has no row to be written at it. Neither is a place the
                     // rules were passed to, so neither is owed a reading.
+                    //
+                    // Whether the rules leave the case is asked first, because it is the question
+                    // the other one presupposes: that naming a case builds it says there is nothing
+                    // under it to read, and says nothing about whether a value may stand there at
+                    // all. Asked the other way round, a case the rules refuse comes back standing
+                    // on its own wherever it holds nothing — which is a case with no value being
+                    // recorded as the plainest kind of value there is, and read as one by everything
+                    // that asks whether a sum has a value.
+                    if (!owed(here, branch.refinement())) {
+                        observed.became(path, branch.refinement(),
+                                new CaseOutcome.RefusedByTheRules());
+                        continue;
+                    }
                     if (branch.under() == null) {
                         // A name has nowhere to stand under a case that holds nothing, which is not
                         // a shortfall and is not the answer below. Said apart from it so that a
                         // reader of what became of this case reads which it was.
                         observed.became(path, branch.refinement(), new CaseOutcome.StandsAlone());
-                        continue;
-                    }
-                    if (!owed(here, branch.refinement())) {
-                        observed.became(path, branch.refinement(),
-                                new CaseOutcome.RefusedByTheRules());
                         continue;
                     }
                     standing.add(branch);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -733,13 +733,18 @@ public final class InputDomain {
      * comparison written about it. Built at the top of whatever is walking, and handed down.
      */
     public Quantities quantities(Symbols symbols) {
-        Map<TermPath, PlacedRules> byRoot = new LinkedHashMap<>();
+        Map<TermPath, OpenedRules> byRoot = new LinkedHashMap<>();
         for (RuleRoot root : roots) {
             // The first reading under a path stands, for the same reason the first reading of a
             // position does: two roots at one path would be one place answering differently
             // depending on which reader looked it up.
+            //
+            // And with the condition it was opened under, which is what says whose rows its rules
+            // are about. Read without it, the cases of a sum are rules about every row and refuse
+            // an input between them.
             byRoot.computeIfAbsent(root.at(),
-                    at -> PlacedRules.of(at, root.type(), symbols, policy));
+                    at -> new OpenedRules(PlacedRules.of(at, root.type(), symbols, policy),
+                            root.opening()));
         }
         // Where a term's subject stands, handed over already answered. What comes back asks a
         // position first and the declarations under one the reading stopped above, which is the one

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1042,7 +1042,12 @@ public final class InputDomain {
                 List<StructuralInspection.Branch> standing = new ArrayList<>();
                 List<TermPath> passedTo = new ArrayList<>();
                 for (StructuralInspection.Branch branch : branches.branches()) {
+                    // Said of every case, including the ones this walk turns back at, because what
+                    // a reader of a sum asks is answered over the whole list of them: a sum has a
+                    // value wherever any case does.
                     if (!reach.into(path.refine(branch.refinement()), stopped).enters()) {
+                        // How far the walk goes, and not anything the model says about this case.
+                        observed.became(path, branch.refinement(), new CaseOutcome.NotWalked());
                         continue;
                     }
                     // A branch that is the whole of a value puts no position anywhere, and one the
@@ -1052,17 +1057,18 @@ public final class InputDomain {
                         // A name has nowhere to stand under a case that holds nothing, which is not
                         // a shortfall and is not the answer below. Said apart from it so that a
                         // reader of what became of this case reads which it was.
-                        observed.didNotEnter(path, branch.refinement(),
-                                new NameReach.NotEntered.NothingStandsUnderIt());
+                        observed.became(path, branch.refinement(), new CaseOutcome.StandsAlone());
                         continue;
                     }
                     if (!owed(here, branch.refinement())) {
-                        observed.didNotEnter(path, branch.refinement(),
-                                new NameReach.NotEntered.TheRulesLeaveNothingAtIt());
+                        observed.became(path, branch.refinement(),
+                                new CaseOutcome.RefusedByTheRules());
                         continue;
                     }
                     standing.add(branch);
                     passedTo.add(path.refine(branch.refinement()));
+                    observed.became(path, branch.refinement(),
+                            new CaseOutcome.Opened(path.refine(branch.refinement())));
                 }
                 if (!stopped) {
                     handoffs.passesTo(placed.root(), path, passedTo);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NameReach.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NameReach.java
@@ -169,8 +169,18 @@ public record NameReach(List<Crossing> crossings, List<BranchNotEntered> branche
     static final class Observed {
 
         private final List<Crossing> crossings = new ArrayList<>();
-        private final List<BranchNotEntered> notEntered = new ArrayList<>();
         private final List<NotStanding> notStanding = new ArrayList<>();
+        /**
+         * What became of every case of every sum the walk met, by the sum it belongs to.
+         *
+         * <p>One recording and two readings of it. Why a name did not cross a case and whether that
+         * case has a value are different questions with one answer behind them — the walk decides
+         * both at the step it turns back at a branch — so what is written down is what became of the
+         * case, and {@link #reach()} is a view of it rather than a second account.
+         */
+        private final java.util.SequencedMap<TermPath,
+                java.util.SequencedMap<Refinement, CaseOutcome>> cases =
+                new java.util.LinkedHashMap<>();
 
         /** Say that {@code field}, written at the sum standing at {@code at}, stands at {@code to}
          *  once the value there is the case {@code branch} names. */
@@ -178,10 +188,16 @@ public record NameReach(List<Crossing> crossings, List<BranchNotEntered> branche
             crossings.add(new Crossing(at, field, branch, to));
         }
 
-        /** Say that the reading did not go down this case of the sum standing at {@code at}, and
-         *  which of the two reasons it was. */
-        void didNotEnter(TermPath at, Refinement branch, NotEntered why) {
-            notEntered.add(new BranchNotEntered(at, branch, why));
+        /** Say what became of this case of the sum standing at {@code at}. */
+        void became(TermPath at, Refinement branch, CaseOutcome outcome) {
+            cases.computeIfAbsent(at, of -> new java.util.LinkedHashMap<>()).put(branch, outcome);
+        }
+
+        /** Every sum the walk met, with what became of each of its cases. */
+        List<CasesRead> cases() {
+            List<CasesRead> out = new ArrayList<>();
+            cases.forEach((at, outcomes) -> out.add(new CasesRead(at, outcomes)));
+            return List.copyOf(out);
         }
 
         /** Say that {@code field} stands nowhere under this case, and what the reading of the case
@@ -192,6 +208,20 @@ public record NameReach(List<Crossing> crossings, List<BranchNotEntered> branche
         }
 
         NameReach reach() {
+            List<BranchNotEntered> notEntered = new ArrayList<>();
+            // The two the model answers for, read off the one recording. A case the walk opened has
+            // its answer under it, and a case the walk never went down is this reading's shortfall
+            // and not a case a name failed to reach — read as one, a name would be reported as
+            // standing nowhere because the walk stopped before it got there.
+            cases.forEach((at, outcomes) -> outcomes.forEach((branch, outcome) -> {
+                switch (outcome) {
+                    case CaseOutcome.StandsAlone _ -> notEntered.add(new BranchNotEntered(at,
+                            branch, new NotEntered.NothingStandsUnderIt()));
+                    case CaseOutcome.RefusedByTheRules _ -> notEntered.add(new BranchNotEntered(at,
+                            branch, new NotEntered.TheRulesLeaveNothingAtIt()));
+                    case CaseOutcome.Opened _, CaseOutcome.NotWalked _ -> { }
+                }
+            }));
             return crossings.isEmpty() && notEntered.isEmpty() && notStanding.isEmpty() ? NONE
                     : new NameReach(crossings, notEntered, notStanding);
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/OpenedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/OpenedRules.java
@@ -1,0 +1,14 @@
+package souther.compiler.inputs;
+
+/**
+ * One value's rules, and the condition the reading of them holds under.
+ *
+ * <p>The two together because a reader of the first needs the second to know what it may do with it.
+ * What a case's clauses say is true of the rows whose value turned out to be that case, and a
+ * reading handed the rules alone can only take them for rules about every row — which is a sum's
+ * cases meeting into one space and refusing an input between them.
+ *
+ * @param rules   what the declaration at this root states
+ * @param opening why the reading was opened here, which says when what it states holds
+ */
+record OpenedRules(PlacedRules rules, RootOpening opening) {}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -46,40 +46,17 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
      * something has a rule of that name, a clause of a case would answer for the same field of every
      * other.
      *
-     * @param outer  the rules of the value the narrowing was taken from
-     * @param sum    where that value's sum stands, which is where the narrowing was taken
-     * @param branch which case was taken
-     * @param shared the names the cases share, which are the only ones that cross
+     * @param outer    the rules of the value the narrowing was taken from
+     * @param crossing the narrowing, and which of the value above's names reach across it. Held and
+     *                 not spelled out again here: where a name written above stands is one fact,
+     *                 and this reading is one of the two that ask it
      */
-    record Reaching(PlacedRules outer, TermPath sum, Refinement branch, java.util.Set<String> shared) {
+    record Reaching(PlacedRules outer, SharedNames crossing) {
 
-        Reaching {
-            shared = java.util.Set.copyOf(shared);
-        }
-
-        /**
-         * What the value above calls the position at {@code here}, or null where it calls it
-         * nothing.
-         *
-         * <p>The narrowing taken back out, which is what a name written above means down here: a row
-         * at {@code h.q@A.limit} writes the {@code limit} a clause of {@code h} called
-         * {@code q.limit}, and the two differ by the step that says which case the value turned out
-         * to be. Null for the case itself and for anything under a name the cases do not share,
-         * which is every position the value above cannot name.
-         */
+        /** What the value above calls the position at {@code here}, or null where it calls it
+         *  nothing. */
         TermPath outerPathOf(TermPath here) {
-            List<TermPath.Step> steps = here.steps();
-            int narrowing = sum.steps().size();
-            if (steps.size() <= narrowing + 1
-                    || !(steps.get(narrowing) instanceof TermPath.Step.Refine taken)
-                    || !taken.refinement().equals(branch)
-                    || !(steps.get(narrowing + 1) instanceof TermPath.Step.Field field)
-                    || !shared.contains(field.name())) {
-                return null;
-            }
-            List<TermPath.Step> without = new ArrayList<>(steps.subList(0, narrowing));
-            without.addAll(steps.subList(narrowing + 1, steps.size()));
-            return new TermPath(here.head(), without);
+            return crossing.outerPathOf(here);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Quantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Quantities.java
@@ -72,6 +72,23 @@ import java.util.Optional;
  * is in that space, so a reading kept beside it could answer the same question over the same rules
  * renamed, and which of the two spoke would be settled by the order they were asked in — with the
  * one that cannot see across two parameters asked first.
+ *
+ * <p><b>And one space per question and not one for the input, because a position exists under
+ * conditions.</b> A field of a case is there where the value turned out to be that case, and a
+ * field of an element where the sequence holds one — so a question naming such a position is asked
+ * of the rows that meet those conditions, and the rules that reach it are the ones about those
+ * rows. Every reading met into one space instead, the cases of a sum would be rules that hold
+ * together, and one case its own rules refuse would refuse an input whose other cases are rows an
+ * author can write.
+ *
+ * <p>What those conditions come to is part of what a question is answered against and not only part
+ * of deciding whose rules to read: a question that names a position inside a container is a
+ * question about rows whose container holds something, which is a fact the rules have a word for.
+ *
+ * <p>Which leaves {@link #emptiness} asking something no one context answers. Whether a value of
+ * this input exists at all is quantified over the alternatives a value has — a sum has one wherever
+ * any case does, a container that may be empty has one whatever it would hold — so it is a fold
+ * over those and not a projection out of a space.
  */
 public sealed interface Quantities permits ReadQuantities {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -1,6 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.ConstraintState;
+import souther.compiler.check.Emptiness;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.RuleKey;
 import souther.compiler.numeric.Count;
@@ -32,6 +33,9 @@ final class ReadQuantities implements Quantities {
 
     /** Every value whose rules reach this input, with the condition each reading holds under. */
     private final Map<TermPath, OpenedRules> byRoot;
+    /** Every sum this input holds, and what became of each of its cases. What the choice between
+     *  alternatives is folded over. */
+    private final List<CasesRead> cases;
     /** What says how the values of a position are spaced, which the arithmetic needs of every
      *  number it is told a bound on. Held rather than asked for per question: the reading of an
      *  input is what a caller has, and where a position's values step is a fact about its type. */
@@ -112,10 +116,11 @@ final class ReadQuantities implements Quantities {
     }
 
     private ReadQuantities(Map<TermPath, OpenedRules> byRoot, Set<TermPath> roots,
-                           Map<TermPath, Position> byPath,
+                           Map<TermPath, Position> byPath, List<CasesRead> cases,
                            java.util.function.Function<TermPath, Type> typeAt,
                            Map<NumericTerm, Fixed> fixed,
                            souther.compiler.check.Symbols symbols, List<Assumed> assumed) {
+        this.cases = List.copyOf(cases);
         this.symbols = symbols;
         this.typeAt = typeAt;
         this.assumed = List.copyOf(assumed);
@@ -134,10 +139,11 @@ final class ReadQuantities implements Quantities {
 
     /** Before anything is fixed. */
     static ReadQuantities of(Map<TermPath, OpenedRules> byRoot, Set<TermPath> roots,
-                             Map<TermPath, Position> byPath,
+                             Map<TermPath, Position> byPath, List<CasesRead> cases,
                              java.util.function.Function<TermPath, Type> typeAt,
                              souther.compiler.check.Symbols symbols) {
-        return new ReadQuantities(byRoot, roots, byPath, typeAt, Map.of(), symbols, List.of());
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, Map.of(), symbols,
+                List.of());
     }
 
     /**
@@ -276,7 +282,7 @@ final class ReadQuantities implements Quantities {
         }
         List<Assumed> both = new ArrayList<>(assumed);
         both.add(taking);
-        return new ReadQuantities(byRoot, roots, byPath, typeAt, fixed, symbols, both);
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, fixed, symbols, both);
     }
 
     /**
@@ -429,9 +435,9 @@ final class ReadQuantities implements Quantities {
      * behavior's whole input, which no reading names and no parameter is — so a parameter carrying
      * nothing of its own comes out as the parameter and not as the value the proof is about.
      */
-    private java.util.SequencedMap<InputAtom, souther.compiler.check.Emptiness.AtAField.Where>
+    private java.util.SequencedMap<InputAtom, Emptiness.AtAField.Where>
             positions(StructuralContext under) {
-        java.util.SequencedMap<InputAtom, souther.compiler.check.Emptiness.AtAField.Where> made =
+        java.util.SequencedMap<InputAtom, Emptiness.AtAField.Where> made =
                 new LinkedHashMap<>();
         conditioned(under).forEach((root, carried) -> carried.named().forEach(
                 // Off the subject and not off the reading it arrived from. A field the cases of a
@@ -440,7 +446,7 @@ final class ReadQuantities implements Quantities {
                 // which is what the subject itself says.
                 // What a newtype wraps is at no name of its own, so the place is the value.
                 (atom, path) -> made.put(atom,
-                        new souther.compiler.check.Emptiness.AtAField.Where.In(
+                        new Emptiness.AtAField.Where.In(
                                 atom instanceof InputAtom.Named named ? named.place()
                                         : path.isEmpty() ? root.toString() : root + "." + path))));
         return Collections.unmodifiableSequencedMap(made);
@@ -661,7 +667,7 @@ final class ReadQuantities implements Quantities {
             both.merge(term, new Fixed(each.getValue(), each.getValue()),
                     (had, one) -> had.and(one.least()));
         }
-        return new ReadQuantities(byRoot, roots, byPath, typeAt, both, symbols, assumed);
+        return new ReadQuantities(byRoot, roots, byPath, cases, typeAt, both, symbols, assumed);
     }
 
     /**
@@ -706,9 +712,88 @@ final class ReadQuantities implements Quantities {
         // answers it. Every parameter's reading is in here, renamed, so there is nothing a
         // per-parameter reading could add — and a contradiction between two parameters, or between a
         // declaration and something a caller took in, can be seen nowhere else.
-        StructuralContext under = asked(List.of());
-        return constraints(under).holdsNothing(positions(under))
-                .map(EmptyInput.ProvedByTheRules::new);
+        return switch (viability(asked(List.of()))) {
+            case Viability.ProvedImpossible it ->
+                    Optional.of(new EmptyInput.ProvedByTheRules(it.why()));
+            // Neither of these is a proof. One says nothing showed the input empty and the other
+            // says this reading did not look, and a caller that read either as "there is a value"
+            // would be reading the absence of a proof as one.
+            case Viability.MayStand _, Viability.NotRead _ -> Optional.empty();
+        };
+    }
+
+    /**
+     * Whether anything stands under {@code under}, and what showed it where nothing does.
+     *
+     * <p><b>The alternatives a value has are quantified over, not met.</b> What the rules of the
+     * values a context names leave is one part of the answer; the other is that the context has not
+     * said which case every sum turned out to be, and a sum has a value wherever any of its cases
+     * does. So a case its own rules refuse takes nothing with it while a sibling stands, and the
+     * input is empty only where every alternative of some sum is impossible.
+     *
+     * <p>Depth first, and it stops at the first alternative that may stand: what is being asked is
+     * whether any assignment of cases leaves anything, so one that does is the whole answer. Two
+     * sums are settled one after another rather than apart, because a rule written above a
+     * narrowing reaches the numbers under it — a clause relating a shared name of one sum to a
+     * shared name of another is contradictory under some pairs of cases and not others, and each
+     * pair is a context of its own.
+     */
+    private Viability viability(StructuralContext under) {
+        Optional<Emptiness> here =
+                constraints(under).holdsNothing(positions(under));
+        if (here.isPresent()) {
+            return new Viability.ProvedImpossible(here.get());
+        }
+        for (CasesRead sum : cases) {
+            // A sum inside a case is a place to ask about only once the value is that case, and one
+            // this context has already settled is not a choice any more.
+            if (!under.covers(StructuralContext.of(sum.sum()))
+                    || under.refinements().at(sum.sum()) != null) {
+                continue;
+            }
+            Viability across = across(sum, under);
+            if (!(across instanceof Viability.MayStand)) {
+                return across;
+            }
+        }
+        return new Viability.MayStand();
+    }
+
+    /**
+     * What the cases of one sum come to together.
+     *
+     * <p>All of them, because that is what makes the proof a proof: picking one to speak for the
+     * rest would answer a question about which case is at fault that nothing asked. And a case this
+     * walk never entered stops the proof rather than joining it — nothing was shown about it, which
+     * is not the same as its having been shown to hold nothing.
+     */
+    private Viability across(CasesRead sum, StructuralContext under) {
+        List<Emptiness> refused = new ArrayList<>();
+        Viability unread = null;
+        for (Map.Entry<Refinement, CaseOutcome> each : sum.outcomes().entrySet()) {
+            Viability of = switch (each.getValue()) {
+                // Naming the case builds it, so there is a value here whatever the rules do to the
+                // others.
+                case CaseOutcome.StandsAlone _ -> new Viability.MayStand();
+                case CaseOutcome.RefusedByTheRules _ ->
+                        new Viability.ProvedImpossible(new Emptiness.ConflictingRules());
+                case CaseOutcome.NotWalked _ ->
+                        new Viability.NotRead(sum.sum().refine(each.getKey()));
+                case CaseOutcome.Opened _ -> viability(under.and(sum.sum(), each.getKey()));
+            };
+            switch (of) {
+                case Viability.MayStand _ -> {
+                    return of;
+                }
+                case Viability.ProvedImpossible it -> refused.add(it.why());
+                case Viability.NotRead _ -> unread = of;
+            }
+        }
+        return unread != null ? unread : new Viability.ProvedImpossible(
+                new Emptiness.AtAField(
+                        new Emptiness.AtAField.Where.In(
+                                sum.sum().toString()),
+                        new Emptiness.AcrossEveryCase(refused)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -177,18 +177,32 @@ final class ReadQuantities implements Quantities {
                     "`" + at + "` is no position of this input, so there is nothing here to say"
                             + " how many it holds");
         }
-        // The position's own count, which is the one question here that names an arm — and it names
-        // it because it is about that arm.
-        if (!(position.term() instanceof NumericTerm.TakenOf taken)
-                || !(taken.takenAs()
-                        instanceof souther.compiler.semantics.TakenAs.HowManyItHolds)) {
+        NumericTerm counted = howManyItHolds(at.at());
+        if (counted == null) {
             return Integer.MAX_VALUE;
         }
         // Asked of the rules when the question arrives rather than solved for every container as
         // the reading is made: what they leave a count moves with whatever else has been settled.
-        NumericDomain.Bounds runs = runsBetween(position.term());
-        return runs == null ? Integer.MAX_VALUE
-                : souther.compiler.numeric.CountDomain.mostFrom(runs.max());
+        NumericDomain.Bounds runs = runsBetween(counted);
+        return runs == null ? Integer.MAX_VALUE : CountDomain.mostFrom(runs.max());
+    }
+
+    /**
+     * The number of what stands at {@code at} that is how many it holds, or null where this reading
+     * measures it at something else.
+     *
+     * <p>Which number a position is measured at is settled where the position was read, and this is
+     * the one question about it that names an arm — it names it because it is about that arm. Asked
+     * in two places, a reader deciding how many a container may hold and a reader deciding whether
+     * it may hold none would each spell out what a count is, and the second one written would be
+     * the one that forgot that a count taken of a string is a different quantity.
+     */
+    private NumericTerm howManyItHolds(TermPath at) {
+        Position position = byPath.get(at);
+        return position != null
+                && position.term() instanceof NumericTerm.TakenOf taken
+                && taken.takenAs() instanceof TakenAs.HowManyItHolds
+                ? position.term() : null;
     }
 
     /**
@@ -349,12 +363,19 @@ final class ReadQuantities implements Quantities {
         return made;
     }
 
-    /** Whether every one of these terms stands in the values {@code under} describes. */
-    private static boolean stands(Collection<NumericTerm> terms,
-                                  StructuralContext under) {
+    /**
+     * Whether every one of these terms stands in the values {@code under} describes.
+     *
+     * <p>Asked as whether the context already says what each of them needs, and not as whether it
+     * could. A condition about a case holds of the rows that are that case; a context that has not
+     * settled which case the value is is one such a condition says nothing in, and taking it in
+     * there would state it of every row. The two questions agree wherever a context is built from
+     * everything taken in — which is where these are asked from today, and not a reason to ask the
+     * weaker one.
+     */
+    private static boolean stands(Collection<NumericTerm> terms, StructuralContext under) {
         for (NumericTerm term : terms) {
-            if (!(StructuralContext.of(term.subjectPath()).merge(under)
-                    instanceof StructuralContext.Merge.Together)) {
+            if (!under.covers(StructuralContext.of(term.subjectPath()))) {
                 return false;
             }
         }
@@ -453,11 +474,24 @@ final class ReadQuantities implements Quantities {
                 // arrive here as one subject — so the place is the one that subject stands at,
                 // which is what the subject itself says.
                 // What a newtype wraps is at no name of its own, so the place is the value.
-                (atom, path) -> made.put(atom,
-                        new Emptiness.AtAField.Where.In(
-                                atom instanceof InputAtom.Named named ? named.place()
-                                        : path.isEmpty() ? root.toString() : root + "." + path))));
+                (atom, path) -> made.put(atom, placeOf(atom, root, path))));
         return Collections.unmodifiableSequencedMap(made);
+    }
+
+    /**
+     * Where a subject of this input sits, for a proof that names a place.
+     *
+     * <p>Two kinds of subject and two ways of knowing. A named one carries where it is and spells
+     * it itself, which is what keeps the place a proof names and the place a report renders one
+     * spelling. A subject this input has no term for carries only what made it, so where it sits is
+     * what the reading it came from called it, joined to the value that reading was of — it cannot
+     * be asked, so it is told.
+     */
+    private static Emptiness.AtAField.Where placeOf(InputAtom atom, TermPath root, String path) {
+        return new Emptiness.AtAField.Where.In(atom instanceof InputAtom.Named named
+                ? named.place()
+                // What a newtype wraps is at no name of its own, so the place is the value.
+                : path.isEmpty() ? root.toString() : root + "." + path);
     }
 
     /**
@@ -706,9 +740,12 @@ final class ReadQuantities implements Quantities {
      *
      * <p>Looked for in one order, which is a settled order and not a preference. A position fixed at
      * two values contradicts without anything being read; a value the term itself cannot take
-     * contradicts against what the term guarantees; and what the declarations refuse is theirs to
-     * refuse. The terms are taken in the order they are written down, so two contradictions of one
-     * kind are told apart by where they sit rather than by when they were found.
+     * contradicts against what the term guarantees; two things fixed under cases no value is both
+     * of contradict against where they were fixed and against nothing else; and what the
+     * declarations refuse is theirs to refuse. Everything a caller said comes before everything the
+     * declarations say, because what a caller said is what the caller can go and change. The terms
+     * are taken in the order they are written down, so two contradictions of one kind are told
+     * apart by where they sit rather than by when they were found.
      */
     @Override
     public Optional<EmptyInput> emptiness() {
@@ -808,12 +845,11 @@ final class ReadQuantities implements Quantities {
      * container for one that must hold something would refuse a model for a rule nobody wrote.
      */
     private Viability holds(TermPath sequence, StructuralContext under) {
-        Position at = byPath.get(sequence);
-        if (at == null || !(at.term() instanceof NumericTerm.TakenOf taken)
-                || !(taken.takenAs() instanceof TakenAs.HowManyItHolds)) {
+        NumericTerm counted = howManyItHolds(sequence);
+        if (counted == null) {
             return new Viability.MayStand();
         }
-        NumericDomain.Bounds many = runsIn(under, NumericDomain.LinearForm.atom(at.term()));
+        NumericDomain.Bounds many = runsIn(under, NumericDomain.LinearForm.atom(counted));
         if (many == null || CountDomain.leastFrom(many.min()) < 1) {
             return new Viability.MayStand();
         }
@@ -849,8 +885,7 @@ final class ReadQuantities implements Quantities {
                 // this compiler stopped.
                 case CaseOutcome.RefusedByTheRules _ ->
                         new Viability.ProvedImpossible(new Emptiness.ConflictingRules());
-                case CaseOutcome.NotWalked _ ->
-                        new Viability.NotRead(sum.sum().refine(each.getKey()));
+                case CaseOutcome.NotWalked _ -> new Viability.NotRead();
                 case CaseOutcome.Opened _ -> viability(under.and(sum.sum(), each.getKey()));
             };
             switch (of) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -12,6 +12,7 @@ import souther.compiler.numeric.Rational;
 import souther.compiler.numeric.RationalCut;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -188,21 +189,39 @@ final class ReadQuantities implements Quantities {
     }
 
     /**
-     * The number of what stands at {@code at} that is how many it holds, or null where this reading
-     * measures it at something else.
+     * The number that is how many the value at {@code at} holds, or null where nothing takes one
+     * there.
      *
-     * <p>Which number a position is measured at is settled where the position was read, and this is
-     * the one question about it that names an arm — it names it because it is about that arm. Asked
-     * in two places, a reader deciding how many a container may hold and a reader deciding whether
-     * it may hold none would each spell out what a count is, and the second one written would be
-     * the one that forgot that a count taken of a string is a different quantity.
+     * <p>Asked of the rules of the value it sits in, which is what knows. Which number a position is
+     * <em>measured</em> at is a reading's choice about that position, and it is not this question: a
+     * clause can hold the length of a list against a field beside it while the position itself is
+     * read by its own value, and a caller taking the measured number for the count is told there is
+     * no count wherever that is so.
+     *
+     * <p>One owner, because it is asked twice — how many a container may hold, and whether it may
+     * hold none — and the second reader written would be the one that answered from whichever of
+     * the two facts was nearer to hand.
+     *
+     * <p>Counts of containers and nothing else. What this feeds bounds how many elements stand
+     * somewhere, so an operation whose number is not how many the value holds has no business here:
+     * {@code Time.hour(t)} is a number the rules take at a place and is not a count of it.
      */
     private NumericTerm howManyItHolds(TermPath at) {
-        Position position = byPath.get(at);
-        return position != null
-                && position.term() instanceof NumericTerm.TakenOf taken
-                && taken.takenAs() instanceof TakenAs.HowManyItHolds
-                ? position.term() : null;
+        UnderARoot root = rootOf(at);
+        if (root == null) {
+            return null;
+        }
+        FieldDomains.Coordinate counted =
+                byRoot.get(root.root()).rules().bounds().countedAt(root.named());
+        if (counted == null
+                || !(counted.kind()
+                        instanceof FieldDomains.CoordinateKind.OfWhatAnOperationAnswers taken)
+                || !(taken.operation() instanceof ValueName.Stdlib operation)) {
+            return null;
+        }
+        NumericTerm.TakenOf term =
+                NumericTerm.TakenOf.of(operation, at, typeAt.apply(at), symbols);
+        return term != null && term.takenAs() instanceof TakenAs.HowManyItHolds ? term : null;
     }
 
     /**
@@ -334,6 +353,13 @@ final class ReadQuantities implements Quantities {
         for (FieldDomains.Carried<InputAtom> each : conditioned(under).values()) {
             made = made.meet(each.constraints().under(sets));
         }
+        // And what the context itself says about the values, which is as much a part of what the
+        // question is asked against as any clause. A row this question is about is one the
+        // prerequisites hold of, so where the rules have a word for one of them it is said here
+        // rather than left as a fact about whose rules to read.
+        for (StructuralContext.Assumption each : under.assumptions()) {
+            made = alsoStating(made, each, under);
+        }
         // And what the caller took in, onto the same rules rather than met against the answer
         // afterwards. A condition relating two positions says nothing about either of them alone,
         // so met afterwards it would be gone.
@@ -361,6 +387,47 @@ final class ReadQuantities implements Quantities {
         }
         answered.put(under, made);
         return made;
+    }
+
+    /**
+     * The same rules, with what one prerequisite of the context says about the values taken in.
+     *
+     * <p>Exhaustive over {@link StructuralContext.Assumption}, with no {@code default}, and this is
+     * the one place a context is turned into what it means. A prerequisite of a kind added later
+     * stops this compiling rather than joining the ones the rules were never told about — which is
+     * how a container came to say whose rules were read without saying that it holds something.
+     *
+     * <p>That a value turned out to be a case says nothing here, and that is not it going unread:
+     * the rules of that case are in this state and the names its value shares are spelled as the
+     * numbers they stand at, which is the whole of what the narrowing means. There is no number in
+     * it left over to state.
+     *
+     * <p>That a sequence holds something is a number, and one no clause writes: it is what the
+     * question assumed by naming a position inside it. Said only where this reading measures the
+     * container by how many it holds — where it does not, there is no subject to say it of, and what
+     * the rules leave is wider rather than wrong.
+     */
+    private ConstraintState<InputAtom> alsoStating(ConstraintState<InputAtom> rules,
+                                                   StructuralContext.Assumption said,
+                                                   StructuralContext under) {
+        switch (said) {
+            case StructuralContext.Assumption.TheCaseAt _ -> {
+                return rules;
+            }
+            case StructuralContext.Assumption.HoldingSomething it -> {
+                NumericTerm counted = howManyItHolds(it.sequence());
+                if (counted == null) {
+                    return rules;
+                }
+                InputAtom.Named atom = called(counted, under);
+                souther.compiler.numeric.Granularity spaced =
+                        spacingOf(rules.numbers(), counted, atom);
+                return spaced == null ? rules : rules.taking(
+                        NumericDomain.LinearForm.<InputAtom>atom(atom)
+                                .minus(NumericDomain.LinearForm.constant(BigDecimal.ONE)),
+                        NumericDomain.Rel.GE, Map.of(atom, spaced));
+            }
+        }
     }
 
     /**
@@ -798,11 +865,10 @@ final class ReadQuantities implements Quantities {
      * input is empty only where every alternative of some sum is impossible.
      *
      * <p>Depth first, and it stops at the first alternative that may stand: what is being asked is
-     * whether any assignment of cases leaves anything, so one that does is the whole answer. Two
-     * sums are settled one after another rather than apart, because a rule written above a
-     * narrowing reaches the numbers under it — a clause relating a shared name of one sum to a
-     * shared name of another is contradictory under some pairs of cases and not others, and each
-     * pair is a context of its own.
+     * whether any assignment of cases leaves anything, so one that does is the whole answer. Each
+     * sum is walked where it stands and its alternatives are asked about what is under them, so
+     * what this walks is the choices one structure offers and never the product of two — see
+     * {@link #inside}, which says what that gives up.
      *
      * <p><b>The structures a value has at once are a conjunction, and the cases of one of them are a
      * choice.</b> So what is folded here is {@link Viability#with} and what is folded across the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -28,9 +28,15 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The one reading of a behavior's input, asked about a quantity over several of its positions.
  *
- * <p>What {@link Quantities} says, made. The declarations reaching each parameter are read when one
- * of these is made, and not again: a question with several positions in it, and the same question
- * with some of them settled, are both answered from what that reading came to.
+ * <p>What {@link Quantities} says, made. The declarations reaching this input are read under what a
+ * question assumes stands ({@link StructuralContext}) — which values turned out to be which cases,
+ * and which containers hold something — because a reading opened at a case says what it says of the
+ * rows that are that case and of no others. A question with several positions in it, and the same
+ * question with some of them settled, are answered from the same reading of the same context.
+ *
+ * <p>Read once per context and kept, which is a memo and not a second answer: what the rules leave
+ * under a context is a function of this value and that context, so the table may be dropped without
+ * changing anything this says.
  */
 final class ReadQuantities implements Quantities {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -368,12 +368,18 @@ final class ReadQuantities implements Quantities {
      * where a fixing put a number, what a condition was taken in about, and — where a question is
      * being answered — what the question names. A reader working it out from the paths it happens to
      * hold would answer the same question two ways as soon as two of them were taken in.
+     *
+     * <p>In the order the terms are written down, which is a settled order and not the order they
+     * arrived in. Two things said under two cases contradict whichever was said first, and a
+     * disagreement carrying the order the questions were asked in would name the two narrowings one
+     * way round for one caller and the other way round for the next.
      */
     private StructuralContext.Merge accumulated() {
         StructuralContext.Merge merged = new StructuralContext.Merge.Together(
                 StructuralContext.NONE);
         List<NumericTerm> said = new ArrayList<>(fixed.keySet());
         assumed.forEach(each -> said.addAll(each.form().coefs().keySet()));
+        said.sort(java.util.Comparator.comparing(NumericTerm::toString));
         for (NumericTerm term : said) {
             if (!(merged instanceof StructuralContext.Merge.Together it)) {
                 return merged;
@@ -510,6 +516,11 @@ final class ReadQuantities implements Quantities {
      * <p>Nothing moves under a narrowing this context has not selected. A shared name whose case is
      * undecided is one number all the same, standing at the sum's own name — and the rules about it
      * stay one relation until a context says which case the value turned out to be.
+     *
+     * <p>Run to a fixed point rather than swept once, because a name two narrowings down is moved by
+     * the outer one before the inner one can see it. Today the readings are held in the order the
+     * walk opened them, outermost first, so one sweep settles every name — which is a fact about a
+     * map's order and not about what a name means.
      */
     private TermPath standingUnder(TermPath place, StructuralContext under) {
         boolean moved = true;

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.ConstraintState;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.RuleKey;
 import souther.compiler.numeric.Count;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The one reading of a behavior's input, asked about a quantity over several of its positions.
@@ -70,6 +72,27 @@ final class ReadQuantities implements Quantities {
      * accumulates, and what the whole of it leaves is worked out where everything else is.
      */
     private final List<Assumed> assumed;
+    /**
+     * What has already been worked out, by the context it was worked out under.
+     *
+     * <p>A memo of {@link #constraints} and of nothing else. What the rules leave under a context is
+     * a function of this value and that context — the same question asked twice has the same answer,
+     * and nothing here is consulted to decide what the answer is. So this may be dropped without
+     * changing what this reading says, and is here because a search asks the same context a great
+     * many times: where a form runs, whether anything is left, and where the next form runs are
+     * three questions under one context, and reading every declaration again for each of them is
+     * what a row costs three times over.
+     *
+     * <p>Per value, since the readings are conditioned on what this refinement fixed. A table shared
+     * between refinements would answer one refinement's question out of another's.
+     */
+    private final Map<StructuralContext, Map<TermPath, FieldDomains.Carried<InputAtom>>> read =
+            new ConcurrentHashMap<>();
+    /** The same, of what those readings come to said together. Held beside them because both are
+     *  asked for on their own: a proof of emptiness names a place out of the first and shows what
+     *  it shows out of the second. */
+    private final Map<StructuralContext, ConstraintState<InputAtom>> answered =
+            new ConcurrentHashMap<>();
 
     /** One thing taken in about a form of this input's terms: {@code form rel 0}. */
     private record Assumed(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel) {}
@@ -199,6 +222,10 @@ final class ReadQuantities implements Quantities {
      * refusing an input between its alternatives.
      */
     private Map<TermPath, FieldDomains.Carried<InputAtom>> conditioned(StructuralContext under) {
+        Map<TermPath, FieldDomains.Carried<InputAtom>> had = read.get(under);
+        if (had != null) {
+            return had;
+        }
         Map<TermPath, FieldDomains.Carried<InputAtom>> made = new LinkedHashMap<>();
         byRoot.forEach((root, opened) -> {
             if (under.holds(opened.opening())) {
@@ -207,7 +234,9 @@ final class ReadQuantities implements Quantities {
                         subject -> new InputAtom.Anonymous(root.toString(), subject)));
             }
         });
-        return Collections.unmodifiableMap(made);
+        Map<TermPath, FieldDomains.Carried<InputAtom>> answer = Collections.unmodifiableMap(made);
+        read.put(under, answer);
+        return answer;
     }
 
     @Override
@@ -268,10 +297,12 @@ final class ReadQuantities implements Quantities {
      * nothing about a form that also names a third the rules leave unbounded, and met afterwards
      * against a floor this reading did have, the rule is gone.
      */
-    private souther.compiler.check.ConstraintState<InputAtom> constraints(
-            StructuralContext under) {
-        souther.compiler.check.ConstraintState<InputAtom> made =
-                souther.compiler.check.ConstraintState.top();
+    private ConstraintState<InputAtom> constraints(StructuralContext under) {
+        ConstraintState<InputAtom> had = answered.get(under);
+        if (had != null) {
+            return had;
+        }
+        ConstraintState<InputAtom> made = ConstraintState.top();
         // What the values of this space cost to work out. One for the space and not one per
         // parameter: what each parameter was read under is the allowance of its own declaration,
         // and the set a position finally admits here is met out of all of them — so this is the
@@ -306,6 +337,7 @@ final class ReadQuantities implements Quantities {
                 made = made.taking(over(each.form(), under), each.rel(), spacing);
             }
         }
+        answered.put(under, made);
         return made;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -10,6 +10,9 @@ import souther.compiler.numeric.RationalCut;
 import souther.compiler.types.Type;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +28,8 @@ import java.util.Set;
  */
 final class ReadQuantities implements Quantities {
 
-    private final Map<TermPath, PlacedRules> byRoot;
+    /** Every value whose rules reach this input, with the condition each reading holds under. */
+    private final Map<TermPath, OpenedRules> byRoot;
     /** What says how the values of a position are spaced, which the arithmetic needs of every
      *  number it is told a bound on. Held rather than asked for per question: the reading of an
      *  input is what a caller has, and where a position's values step is a fact about its type. */
@@ -66,39 +70,6 @@ final class ReadQuantities implements Quantities {
      * accumulates, and what the whole of it leaves is worked out where everything else is.
      */
     private final List<Assumed> assumed;
-    /**
-     * The rules read with everything fixed, worked out when something is asked and not before.
-     *
-     * <p>One reading per value and not one per question. A search asks where a position runs and
-     * whether anything is left of the same refinement, and reading the declarations once per
-     * question would read them twice a step. Held here rather than shared, since what it is a
-     * reading of is what this refinement fixed.
-     */
-    private volatile Map<TermPath, FieldDomains.Carried<InputAtom>> conditioned;
-    /**
-     * Every rule reaching this input, about this input's own subjects, in one place.
-     *
-     * <p>Not one reading per parameter with the answers added afterwards. Adding per-parameter
-     * answers is the composition a rule spanning two parameters cannot survive, and where such a
-     * rule comes from is not this layer's business — what is here is a constraint space over the
-     * input, and where one parameter's positions run is a projection out of it rather than a
-     * reading of its own.
-     *
-     * <p><b>The whole state and not the numbers of it.</b> Whether anything is left of this input is
-     * one question, and this is the one thing that answers it: a per-parameter reading kept beside
-     * this one could answer it too, over the same numbers renamed, and then which of two proofs is
-     * written would be settled by the order they are asked in — with the weaker of them, the one
-     * that cannot see across two parameters, asked first. The parameters supply rules here and
-     * answer nothing.
-     *
-     * <p>Worked out when something is asked and kept, the same as {@link #conditioned}: it is a
-     * reading of what this refinement fixed, so it belongs to this value and not to a shared table.
-     */
-    private volatile souther.compiler.check.ConstraintState<InputAtom> constraints;
-    /** Where each position of the input sits, in the order the parameters and their positions are
-     *  declared. What a proof of emptiness names a place out of. */
-    private volatile java.util.SequencedMap<InputAtom,
-            souther.compiler.check.Emptiness.AtAField.Where> positions;
 
     /** One thing taken in about a form of this input's terms: {@code form rel 0}. */
     private record Assumed(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel) {}
@@ -117,7 +88,7 @@ final class ReadQuantities implements Quantities {
         }
     }
 
-    private ReadQuantities(Map<TermPath, PlacedRules> byRoot, Set<TermPath> roots,
+    private ReadQuantities(Map<TermPath, OpenedRules> byRoot, Set<TermPath> roots,
                            Map<TermPath, Position> byPath,
                            java.util.function.Function<TermPath, Type> typeAt,
                            Map<NumericTerm, Fixed> fixed,
@@ -128,18 +99,18 @@ final class ReadQuantities implements Quantities {
         // In the order the behavior declares its parameters. A proof of emptiness names one of them
         // and a report is a document compared against the one written last time, so an order read
         // off a hash would move which parameter is named between runs.
-        this.byRoot = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(byRoot));
+        this.byRoot = Collections.unmodifiableMap(new LinkedHashMap<>(byRoot));
         this.roots = Set.copyOf(roots);
         this.byPath = Map.copyOf(byPath);
         // Kept in the order the fixings arrived, so that the order they are answered in is chosen
         // here rather than inherited. An immutable copy iterates in an order salted once per JVM
         // run, which is a fine order and not one anybody chose — read off it, which of two
         // contradictions a proof names would move between runs of the same compiler.
-        this.fixed = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(fixed));
+        this.fixed = Collections.unmodifiableMap(new LinkedHashMap<>(fixed));
     }
 
     /** Before anything is fixed. */
-    static ReadQuantities of(Map<TermPath, PlacedRules> byRoot, Set<TermPath> roots,
+    static ReadQuantities of(Map<TermPath, OpenedRules> byRoot, Set<TermPath> roots,
                              Map<TermPath, Position> byPath,
                              java.util.function.Function<TermPath, Type> typeAt,
                              souther.compiler.check.Symbols symbols) {
@@ -218,19 +189,25 @@ final class ReadQuantities implements Quantities {
      *  {@link #rootOf}, so holding one is holding a root that can name what was asked about. */
     private record UnderARoot(TermPath root, RuleKey named) {}
 
-    /** Each parameter's rules read with what is fixed under it, once, under this input's names. */
-    private Map<TermPath, FieldDomains.Carried<InputAtom>> conditioned() {
-        Map<TermPath, FieldDomains.Carried<InputAtom>> read = conditioned;
-        if (read == null) {
-            Map<TermPath, FieldDomains.Carried<InputAtom>> made = new LinkedHashMap<>();
-            byRoot.forEach((root, rules) -> made.put(root,
-                    rules.given(under(root)).constraintsOver(
-                            at -> called(root, at),
-                            subject -> new InputAtom.Anonymous(root.toString(), subject))));
-            read = java.util.Collections.unmodifiableMap(made);
-            conditioned = read;
-        }
-        return read;
+    /**
+     * The rules of every value this context says stands, read with what is fixed under each and
+     * said in this input's names.
+     *
+     * <p>Under the context and not all of them. A reading opened at a case holds of the rows whose
+     * value turned out to be that case, so putting one into a space asked about rows that are some
+     * other case would be stating a rule of nobody's — and putting every case in at once is a sum
+     * refusing an input between its alternatives.
+     */
+    private Map<TermPath, FieldDomains.Carried<InputAtom>> conditioned(StructuralContext under) {
+        Map<TermPath, FieldDomains.Carried<InputAtom>> made = new LinkedHashMap<>();
+        byRoot.forEach((root, opened) -> {
+            if (under.holds(opened.opening())) {
+                made.put(root, opened.rules().given(under(root)).constraintsOver(
+                        at -> called(root, at, under),
+                        subject -> new InputAtom.Anonymous(root.toString(), subject)));
+            }
+        });
+        return Collections.unmodifiableMap(made);
     }
 
     @Override
@@ -255,9 +232,12 @@ final class ReadQuantities implements Quantities {
         if (form == null || form.coefs().isEmpty()) {
             return this;
         }
+        form.coefs().keySet().forEach(this::held);
+        // Refused where the form is over positions no one value has, the same as a question about
+        // where it runs: what would be taken in is a condition on a row nobody can write.
+        StructuralContext under = asked(form.coefs().keySet());
         for (NumericTerm term : form.coefs().keySet()) {
-            held(term);
-            if (spacingOf(constraints().numbers(), term, called(term)) == null) {
+            if (spacingOf(constraints(under).numbers(), term, called(term, under)) == null) {
                 return this;
             }
         }
@@ -265,7 +245,7 @@ final class ReadQuantities implements Quantities {
         if (assumed.contains(taking)) {
             return this;
         }
-        List<Assumed> both = new java.util.ArrayList<>(assumed);
+        List<Assumed> both = new ArrayList<>(assumed);
         both.add(taking);
         return new ReadQuantities(byRoot, roots, byPath, typeAt, fixed, symbols, both);
     }
@@ -288,11 +268,8 @@ final class ReadQuantities implements Quantities {
      * nothing about a form that also names a third the rules leave unbounded, and met afterwards
      * against a floor this reading did have, the rule is gone.
      */
-    private souther.compiler.check.ConstraintState<InputAtom> constraints() {
-        souther.compiler.check.ConstraintState<InputAtom> read = constraints;
-        if (read != null) {
-            return read;
-        }
+    private souther.compiler.check.ConstraintState<InputAtom> constraints(
+            StructuralContext under) {
         souther.compiler.check.ConstraintState<InputAtom> made =
                 souther.compiler.check.ConstraintState.top();
         // What the values of this space cost to work out. One for the space and not one per
@@ -301,30 +278,107 @@ final class ReadQuantities implements Quantities {
         // answer being built and this is where building it is charged.
         souther.compiler.values.Allowance<InputAtom> sets =
                 souther.compiler.values.Allowance.ofAdmittedValues();
-        for (FieldDomains.Carried<InputAtom> each : conditioned().values()) {
+        for (FieldDomains.Carried<InputAtom> each : conditioned(under).values()) {
             made = made.meet(each.constraints().under(sets));
         }
         // And what the caller took in, onto the same rules rather than met against the answer
         // afterwards. A condition relating two positions says nothing about either of them alone,
         // so met afterwards it would be gone.
+        //
+        // Read under this context like everything else. A condition is about the positions it
+        // names, so one taken in about a case says nothing where the value is another — left in, it
+        // would be a rule about a row that is not the row being asked about.
         for (Assumed each : assumed) {
+            if (!stands(each.form().coefs().keySet(), under)) {
+                continue;
+            }
             Map<InputAtom, souther.compiler.numeric.Granularity> spacing = new LinkedHashMap<>();
             for (NumericTerm term : each.form().coefs().keySet()) {
                 souther.compiler.numeric.Granularity spaced =
-                        spacingOf(made.numbers(), term, called(term));
+                        spacingOf(made.numbers(), term, called(term, under));
                 if (spaced == null) {
                     spacing = null;
                     break;
                 }
-                spacing.put(called(term), spaced);
+                spacing.put(called(term, under), spaced);
             }
             if (spacing != null) {
-                made = made.taking(over(each.form()), each.rel(), spacing);
+                made = made.taking(over(each.form(), under), each.rel(), spacing);
             }
         }
-        read = made;
-        constraints = read;
-        return read;
+        return made;
+    }
+
+    /** Whether every one of these terms stands in the values {@code under} describes. */
+    private static boolean stands(Collection<NumericTerm> terms,
+                                  StructuralContext under) {
+        for (NumericTerm term : terms) {
+            if (!(StructuralContext.of(term.subjectPath()).merge(under)
+                    instanceof StructuralContext.Merge.Together)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * What this reading has been told stands, from everything taken in so far.
+     *
+     * <p>Assembled here and nowhere else, out of the three things that can say a value is a case:
+     * where a fixing put a number, what a condition was taken in about, and — where a question is
+     * being answered — what the question names. A reader working it out from the paths it happens to
+     * hold would answer the same question two ways as soon as two of them were taken in.
+     */
+    private StructuralContext.Merge accumulated() {
+        StructuralContext.Merge merged = new StructuralContext.Merge.Together(
+                StructuralContext.NONE);
+        List<NumericTerm> said = new ArrayList<>(fixed.keySet());
+        assumed.forEach(each -> said.addAll(each.form().coefs().keySet()));
+        for (NumericTerm term : said) {
+            if (!(merged instanceof StructuralContext.Merge.Together it)) {
+                return merged;
+            }
+            merged = it.context().merge(StructuralContext.of(term.subjectPath()));
+        }
+        return merged;
+    }
+
+    /**
+     * The context a question over {@code terms} is answered in, or the disagreement that says no
+     * value is being asked about.
+     *
+     * <p>The question's own and what has already been taken in, together. Built from the question
+     * alone, a region that has fixed a number under one case would answer about another as though
+     * nothing had been said.
+     */
+    private StructuralContext.Merge asking(Collection<NumericTerm> terms) {
+        StructuralContext.Merge merged = accumulated();
+        for (NumericTerm term : terms) {
+            if (!(merged instanceof StructuralContext.Merge.Together it)) {
+                return merged;
+            }
+            merged = it.context().merge(StructuralContext.of(term.subjectPath()));
+        }
+        return merged;
+    }
+
+    /**
+     * The same, where the question is one no value of this input stands for.
+     *
+     * <p>Refused rather than answered wide. What was asked is where a quantity runs, and a quantity
+     * over positions no one value has is one nothing runs between — an answer of "nothing bounds it"
+     * would be read as the rules leaving it open. That two fixings cannot both hold is the other
+     * question and is an emptiness ({@link #emptiness}), because there the caller said something
+     * about the input rather than asking for a number.
+     */
+    private StructuralContext asked(Collection<NumericTerm> terms) {
+        return switch (asking(terms)) {
+            case StructuralContext.Merge.Together it -> it.context();
+            case StructuralContext.Merge.Disagreeing it -> throw new IllegalArgumentException(
+                    "`" + it.why().at() + "` is asked to be " + it.why().one().spelled()
+                            + " and " + it.why().other().spelled() + ", which no value of this"
+                            + " input is, so there is nothing here to answer about " + terms);
+        };
     }
 
     /**
@@ -344,22 +398,20 @@ final class ReadQuantities implements Quantities {
      * nothing of its own comes out as the parameter and not as the value the proof is about.
      */
     private java.util.SequencedMap<InputAtom, souther.compiler.check.Emptiness.AtAField.Where>
-            positions() {
-        java.util.SequencedMap<InputAtom, souther.compiler.check.Emptiness.AtAField.Where> read =
-                positions;
-        if (read != null) {
-            return read;
-        }
+            positions(StructuralContext under) {
         java.util.SequencedMap<InputAtom, souther.compiler.check.Emptiness.AtAField.Where> made =
                 new LinkedHashMap<>();
-        conditioned().forEach((root, carried) -> carried.named().forEach(
-                // What a newtype wraps is at no name of its own, so the place is the parameter.
+        conditioned(under).forEach((root, carried) -> carried.named().forEach(
+                // Off the subject and not off the reading it arrived from. A field the cases of a
+                // sum share is one place named by the sum's rules and by the case's, and the two
+                // arrive here as one subject — so the place is the one that subject stands at,
+                // which is what the subject itself says.
+                // What a newtype wraps is at no name of its own, so the place is the value.
                 (atom, path) -> made.put(atom,
                         new souther.compiler.check.Emptiness.AtAField.Where.In(
-                                path.isEmpty() ? root.toString() : root + "." + path))));
-        read = java.util.Collections.unmodifiableSequencedMap(made);
-        positions = read;
-        return read;
+                                atom instanceof InputAtom.Named named ? named.place()
+                                        : path.isEmpty() ? root.toString() : root + "." + path))));
+        return Collections.unmodifiableSequencedMap(made);
     }
 
     /**
@@ -370,16 +422,72 @@ final class ReadQuantities implements Quantities {
      * turned into one of those positions would be one of however many the name reaches, chosen by
      * nothing.
      */
-    private static InputAtom called(TermPath root, FieldDomains.Coordinate at) {
-        return new InputAtom.Named(root.toString(), at.path(), at.kind());
+    private InputAtom called(TermPath root, FieldDomains.Coordinate at, StructuralContext under) {
+        return atomAt(standingUnder(pathOf(root, at.path()), under), at.kind());
     }
 
     /** The same, of a term this input holds. One number under one name whichever side it arrives
      *  from — the reading of a declaration, or a form a caller wrote. */
-    private InputAtom.Named called(NumericTerm term) {
+    private InputAtom.Named called(NumericTerm term, StructuralContext under) {
         UnderARoot at = rootOf(term.subjectPath());
         FieldDomains.Coordinate where = coordinateOf(at, term);
-        return new InputAtom.Named(at.root().toString(), where.path(), where.kind());
+        return atomAt(standingUnder(pathOf(at.root(), where.path()), under), where.kind());
+    }
+
+    /** Where a value's own rules put a coordinate, as a place of this input. */
+    private static TermPath pathOf(TermPath root, RuleKey named) {
+        TermPath at = root;
+        for (String field : named.steps()) {
+            at = at.then(field);
+        }
+        return at;
+    }
+
+    /**
+     * The subject at a place: the nearest value whose rules can name it, and what those rules call
+     * it.
+     *
+     * <p>The nearest, so that a place reached from two readings is one subject. A field the cases of
+     * a sum share is named by the sum's rules and by the case's, and named by the sum it would be a
+     * number standing under however many cases there are — chosen by nothing.
+     */
+    private InputAtom.Named atomAt(TermPath place,
+                                   FieldDomains.CoordinateKind kind) {
+        UnderARoot at = rootOf(place);
+        return new InputAtom.Named(at.root().toString(), at.named(), kind);
+    }
+
+    /**
+     * Where a place stands once every narrowing this context selects has been taken.
+     *
+     * <p><b>All of them at once and not one crossing at a time.</b> What the rules of a value above
+     * say about a name its cases share is what they say about the number standing under the case,
+     * and a question can select narrowings under several sums — so a clause relating two of those
+     * names is about two numbers under two cases. Renamed a crossing at a time, either copy of the
+     * clause still spells the other name the way the value above wrote it, and the two copies
+     * relate nothing when they are met.
+     *
+     * <p>Nothing moves under a narrowing this context has not selected. A shared name whose case is
+     * undecided is one number all the same, standing at the sum's own name — and the rules about it
+     * stay one relation until a context says which case the value turned out to be.
+     */
+    private TermPath standingUnder(TermPath place, StructuralContext under) {
+        boolean moved = true;
+        while (moved) {
+            moved = false;
+            for (OpenedRules opened : byRoot.values()) {
+                if (!(opened.opening() instanceof RootOpening.Refined it)
+                        || !under.holds(it)) {
+                    continue;
+                }
+                TermPath deeper = it.crossing().standingUnderTheCase(place);
+                if (deeper != null) {
+                    place = deeper;
+                    moved = true;
+                }
+            }
+        }
+        return place;
     }
 
     /**
@@ -396,12 +504,13 @@ final class ReadQuantities implements Quantities {
      * is the only shape such a position is ever asked in.
      */
     private souther.compiler.numeric.NumericDomain<InputAtom> holding(
-            souther.compiler.numeric.NumericDomain<InputAtom> rules, NumericTerm term) {
+            souther.compiler.numeric.NumericDomain<InputAtom> rules, NumericTerm term,
+            StructuralContext under) {
         NumericDomain.Bounds runs = whereOneTermRuns(term);
         if (runs == null || (asCut(runs.min()) == null && asCut(runs.max()) == null)) {
             return rules;
         }
-        InputAtom atom = called(term);
+        InputAtom atom = called(term, under);
         souther.compiler.numeric.Granularity spaced = spacingOf(rules, term, atom);
         if (spaced == null) {
             return rules;
@@ -457,11 +566,15 @@ final class ReadQuantities implements Quantities {
         // parameter are said together and what each number is on its own is said onto them, so what
         // a form runs between is read off that space rather than assembled out of per-parameter
         // answers — assembling is what a rule spanning two parameters cannot survive.
-        souther.compiler.numeric.NumericDomain<InputAtom> rules = constraints().numbers();
+        //
+        // Under the context this question is asked in, which is what says which of those rules are
+        // about the row being asked about at all.
+        StructuralContext under = asked(form.coefs().keySet());
+        souther.compiler.numeric.NumericDomain<InputAtom> rules = constraints(under).numbers();
         for (NumericTerm term : form.coefs().keySet()) {
-            rules = holding(rules, term);
+            rules = holding(rules, term, under);
         }
-        NumericDomain.Bounds projected = rules.boundsOf(over(form));
+        NumericDomain.Bounds projected = rules.boundsOf(over(form, under));
         // One term taken as itself, which is the arithmetic being the identity rather than a second
         // answer to the same question. It is also the only shape a position the arithmetic cannot
         // count is ever asked in — a form adds its terms together and two strings have no sum — so
@@ -486,9 +599,10 @@ final class ReadQuantities implements Quantities {
      * caller wrote two spellings of a number this input has one of.
      */
     private NumericDomain.LinearForm<InputAtom> over(
-            NumericDomain.LinearForm<NumericTerm> form) {
+            NumericDomain.LinearForm<NumericTerm> form, StructuralContext under) {
         Map<InputAtom, BigDecimal> coefs = new LinkedHashMap<>();
-        form.coefs().forEach((term, coef) -> coefs.merge(called(term), coef, BigDecimal::add));
+        form.coefs().forEach((term, coef) ->
+                coefs.merge(called(term, under), coef, BigDecimal::add));
         return new NumericDomain.LinearForm<>(form.constant(), coefs);
     }
 
@@ -549,11 +663,20 @@ final class ReadQuantities implements Quantities {
                         each.getValue().least()));
             }
         }
+        // Two things fixed under cases no one value is both of. Said here rather than by the rules,
+        // for the reason a position fixed at two values is: what contradicts is the pair of
+        // assignments, and the declarations were never asked.
+        if (accumulated() instanceof StructuralContext.Merge.Disagreeing it) {
+            return Optional.of(new EmptyInput.TwoRefinementsAtOnePosition(
+                    it.why().at(), it.why().one(), it.why().other()));
+        }
         // And what the rules leave once they are all said together, which is the one thing that
         // answers it. Every parameter's reading is in here, renamed, so there is nothing a
         // per-parameter reading could add — and a contradiction between two parameters, or between a
         // declaration and something a caller took in, can be seen nowhere else.
-        return constraints().holdsNothing(positions()).map(EmptyInput.ProvedByTheRules::new);
+        StructuralContext under = asked(List.of());
+        return constraints(under).holdsNothing(positions(under))
+                .map(EmptyInput.ProvedByTheRules::new);
     }
 
     /**
@@ -563,7 +686,7 @@ final class ReadQuantities implements Quantities {
      * fixings arrived in, which is the caller's business and not the model's.
      */
     private List<Map.Entry<NumericTerm, Fixed>> inOrder() {
-        List<Map.Entry<NumericTerm, Fixed>> out = new java.util.ArrayList<>(fixed.entrySet());
+        List<Map.Entry<NumericTerm, Fixed>> out = new ArrayList<>(fixed.entrySet());
         out.sort(java.util.Comparator.comparing(each -> each.getKey().toString()));
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -481,17 +481,22 @@ final class ReadQuantities implements Quantities {
     /**
      * Where a subject of this input sits, for a proof that names a place.
      *
-     * <p>Two kinds of subject and two ways of knowing. A named one carries where it is and spells
-     * it itself, which is what keeps the place a proof names and the place a report renders one
-     * spelling. A subject this input has no term for carries only what made it, so where it sits is
-     * what the reading it came from called it, joined to the value that reading was of — it cannot
-     * be asked, so it is told.
+     * <p>Asked of the subject, which is the one thing that knows. A subject the reading it came from
+     * has a name for arrives here under a name of this input's, and that name carries the place — so
+     * the place a proof names and the place a report renders are one spelling and cannot part.
+     *
+     * <p>A subject with a name and no place is this reading disagreeing with itself: what the
+     * reading handed over as sitting somewhere would have arrived as something to be equal to and
+     * nothing more, and every rule about it would have stopped meeting the rules the value above
+     * wrote about the same place.
      */
     private static Emptiness.AtAField.Where placeOf(InputAtom atom, TermPath root, String path) {
-        return new Emptiness.AtAField.Where.In(atom instanceof InputAtom.Named named
-                ? named.place()
-                // What a newtype wraps is at no name of its own, so the place is the value.
-                : path.isEmpty() ? root.toString() : root + "." + path);
+        if (!(atom instanceof InputAtom.Named named)) {
+            throw new IllegalStateException(
+                    "`" + root + "` names a subject at `" + path + "` that arrived here with no"
+                            + " place, so nothing can say where a proof about it is");
+        }
+        return new Emptiness.AtAField.Where.In(named.place());
     }
 
     /**
@@ -773,7 +778,7 @@ final class ReadQuantities implements Quantities {
         // answers it. Every parameter's reading is in here, renamed, so there is nothing a
         // per-parameter reading could add — and a contradiction between two parameters, or between a
         // declaration and something a caller took in, can be seen nowhere else.
-        return switch (viability(asked(List.of()))) {
+        return switch (viability(asked(List.of()), null)) {
             case Viability.ProvedImpossible it ->
                     Optional.of(new EmptyInput.ProvedByTheRules(it.why()));
             // Neither of these is a proof. One says nothing showed the input empty and the other
@@ -798,37 +803,68 @@ final class ReadQuantities implements Quantities {
      * narrowing reaches the numbers under it — a clause relating a shared name of one sum to a
      * shared name of another is contradictory under some pairs of cases and not others, and each
      * pair is a context of its own.
+     *
+     * <p><b>The structures a value has at once are a conjunction, and the cases of one of them are a
+     * choice.</b> So what is folded here is {@link Viability#with} and what is folded across the
+     * cases of a sum is {@link Viability#oneOf}, and the difference is which of three answers wins.
+     * A structure this reading never finished with may not hide what the structure beside it
+     * proved — read as a choice, whichever of the two the fields happen to declare first would
+     * settle whether the input is refused at all.
      */
-    private Viability viability(StructuralContext under) {
+    private Viability viability(StructuralContext under, TermPath below) {
         Optional<Emptiness> here =
                 constraints(under).holdsNothing(positions(under));
         if (here.isPresent()) {
             return new Viability.ProvedImpossible(here.get());
         }
+        Viability standing = new Viability.MayStand();
         for (CasesRead sum : cases) {
             // A sum inside a case is a place to ask about only once the value is that case, and one
             // this context has already settled is not a choice any more.
             if (!under.covers(StructuralContext.of(sum.sum()))
-                    || under.refinements().at(sum.sum()) != null) {
+                    || under.refinements().at(sum.sum()) != null
+                    || !inside(sum.sum(), below)) {
                 continue;
             }
-            Viability across = across(sum, under);
-            if (!(across instanceof Viability.MayStand)) {
-                return across;
+            standing = standing.with(across(sum, under));
+            // Everything else it may say is already said. Kept going only for the one answer that
+            // is not yet in hand, which is a proof — what a caller is told is the first the model
+            // writes down, and the rest of the walk cannot change it.
+            if (standing instanceof Viability.ProvedImpossible) {
+                return standing;
             }
         }
         for (OpenedRules opened : byRoot.values()) {
             if (!(opened.opening() instanceof RootOpening.Inside it)
                     || under.nonEmptySequences().contains(it.sequence())
-                    || !under.covers(StructuralContext.of(it.sequence()))) {
+                    || !under.covers(StructuralContext.of(it.sequence()))
+                    || !inside(it.sequence(), below)) {
                 continue;
             }
-            Viability holding = holds(it.sequence(), under);
-            if (!(holding instanceof Viability.MayStand)) {
-                return holding;
+            standing = standing.with(holds(it.sequence(), under));
+            if (standing instanceof Viability.ProvedImpossible) {
+                return standing;
             }
         }
-        return new Viability.MayStand();
+        return standing;
+    }
+
+    /**
+     * Whether a structure is one this step of the fold answers for.
+     *
+     * <p><b>Each structure is folded where it stands and nowhere else.</b> A sum beside the one
+     * being walked is not part of what its alternatives come to: it has the same cases whichever way
+     * that one turned out, so answering for it again under each alternative would refuse the
+     * alternative for what stands beside it — and the place a proof names would be whichever of the
+     * two the fields happen to declare first.
+     *
+     * <p>What that gives up is a pair: two structures the declarations relate can be impossible
+     * together while each of them stands alone, and folded apart that is a proof nobody makes. It is
+     * the direction this may be wrong in — no proof rather than a proof of the wrong thing — and it
+     * is what keeps a walk of the alternatives from being the product of every choice in the input.
+     */
+    private static boolean inside(TermPath structure, TermPath below) {
+        return below == null || structure.isAtOrUnder(below);
     }
 
     /**
@@ -853,7 +889,7 @@ final class ReadQuantities implements Quantities {
         if (many == null || CountDomain.leastFrom(many.min()) < 1) {
             return new Viability.MayStand();
         }
-        Viability inside = viability(under.holding(sequence));
+        Viability inside = viability(under.holding(sequence), sequence);
         return inside instanceof Viability.ProvedImpossible it
                 ? new Viability.ProvedImpossible(new Emptiness.AtAField(
                         new Emptiness.AtAField.Where.In(sequence.toString()),
@@ -870,10 +906,9 @@ final class ReadQuantities implements Quantities {
      * is not the same as its having been shown to hold nothing.
      */
     private Viability across(CasesRead sum, StructuralContext under) {
-        List<Emptiness> refused = new ArrayList<>();
-        Viability unread = null;
+        List<Viability> alternatives = new ArrayList<>();
         for (Map.Entry<Refinement, CaseOutcome> each : sum.outcomes().entrySet()) {
-            Viability of = switch (each.getValue()) {
+            alternatives.add(switch (each.getValue()) {
                 // Naming the case builds it, so there is a value here whatever the rules do to the
                 // others.
                 case CaseOutcome.StandsAlone _ -> new Viability.MayStand();
@@ -886,21 +921,16 @@ final class ReadQuantities implements Quantities {
                 case CaseOutcome.RefusedByTheRules _ ->
                         new Viability.ProvedImpossible(new Emptiness.ConflictingRules());
                 case CaseOutcome.NotWalked _ -> new Viability.NotRead();
-                case CaseOutcome.Opened _ -> viability(under.and(sum.sum(), each.getKey()));
-            };
-            switch (of) {
-                case Viability.MayStand _ -> {
-                    return of;
-                }
-                case Viability.ProvedImpossible it -> refused.add(it.why());
-                case Viability.NotRead _ -> unread = of;
-            }
+                case CaseOutcome.Opened _ -> viability(under.and(sum.sum(), each.getKey()),
+                        sum.sum().refine(each.getKey()));
+            });
         }
-        return unread != null ? unread : new Viability.ProvedImpossible(
-                new Emptiness.AtAField(
-                        new Emptiness.AtAField.Where.In(
-                                sum.sum().toString()),
-                        new Emptiness.AcrossEveryCase(refused)));
+        // Where every case is refused, the sum is refused by all of them together and the place is
+        // where it stands. Which of the three answers wins is the choice's to say and not this
+        // caller's.
+        return Viability.oneOf(alternatives, refused -> new Emptiness.AtAField(
+                new Emptiness.AtAField.Where.In(sum.sum().toString()),
+                new Emptiness.AcrossEveryCase(refused)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -5,10 +5,12 @@ import souther.compiler.check.Emptiness;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.RuleKey;
 import souther.compiler.numeric.Count;
+import souther.compiler.numeric.CountDomain;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Rational;
 import souther.compiler.numeric.RationalCut;
+import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
 
 import java.math.BigDecimal;
@@ -607,7 +609,18 @@ final class ReadQuantities implements Quantities {
         //
         // Under the context this question is asked in, which is what says which of those rules are
         // about the row being asked about at all.
-        StructuralContext under = asked(form.coefs().keySet());
+        return runsIn(asked(form.coefs().keySet()), form);
+    }
+
+    /**
+     * The same, in a context a caller already holds.
+     *
+     * <p>For a reader that is walking contexts rather than answering a question in the one this
+     * value accumulated — which is the fold that asks how many a container holds under a case, where
+     * the context is the one the fold has reached and not the one anybody fixed.
+     */
+    private NumericDomain.Bounds runsIn(StructuralContext under,
+                                        NumericDomain.LinearForm<NumericTerm> form) {
         souther.compiler.numeric.NumericDomain<InputAtom> rules = constraints(under).numbers();
         for (NumericTerm term : form.coefs().keySet()) {
             rules = holding(rules, term, under);
@@ -756,7 +769,49 @@ final class ReadQuantities implements Quantities {
                 return across;
             }
         }
+        for (OpenedRules opened : byRoot.values()) {
+            if (!(opened.opening() instanceof RootOpening.Inside it)
+                    || under.nonEmptySequences().contains(it.sequence())
+                    || !under.covers(StructuralContext.of(it.sequence()))) {
+                continue;
+            }
+            Viability holding = holds(it.sequence(), under);
+            if (!(holding instanceof Viability.MayStand)) {
+                return holding;
+            }
+        }
         return new Viability.MayStand();
+    }
+
+    /**
+     * What a sequence and the values it holds come to together.
+     *
+     * <p><b>An element nothing can build refuses the sequence only where the sequence cannot be
+     * empty.</b> A container that may hold none is a value whatever is true of what it would hold,
+     * so what its element's rules refuse is a row nobody has to write rather than an input nobody
+     * can. The two are one question asked in the order the model settles it: how many the rules
+     * leave it, and then — only where they leave it no way to be empty — whether anything can stand
+     * inside it.
+     *
+     * <p>Where nothing says how many it holds, nothing is proved. A reading that took an unmeasured
+     * container for one that must hold something would refuse a model for a rule nobody wrote.
+     */
+    private Viability holds(TermPath sequence, StructuralContext under) {
+        Position at = byPath.get(sequence);
+        if (at == null || !(at.term() instanceof NumericTerm.TakenOf taken)
+                || !(taken.takenAs() instanceof TakenAs.HowManyItHolds)) {
+            return new Viability.MayStand();
+        }
+        NumericDomain.Bounds many = runsIn(under, NumericDomain.LinearForm.atom(at.term()));
+        if (many == null || CountDomain.leastFrom(many.min()) < 1) {
+            return new Viability.MayStand();
+        }
+        Viability inside = viability(under.holding(sequence));
+        return inside instanceof Viability.ProvedImpossible it
+                ? new Viability.ProvedImpossible(new Emptiness.AtAField(
+                        new Emptiness.AtAField.Where.In(sequence.toString()),
+                        new Emptiness.NonEmptyCollectionWithNoElement(it.why())))
+                : inside;
     }
 
     /**
@@ -775,6 +830,12 @@ final class ReadQuantities implements Quantities {
                 // Naming the case builds it, so there is a value here whatever the rules do to the
                 // others.
                 case CaseOutcome.StandsAlone _ -> new Viability.MayStand();
+                // Impossible because the rules leave the case nothing, which is what the reading of
+                // the position settled when it said the case was owed no row
+                // ({@link Position#obligationCases}) — a refusal that holds whether or not every
+                // rule was read. Not because the walk did not go down it: how far a walk goes is
+                // the other arm, and reading this one as that would be a proof made out of where
+                // this compiler stopped.
                 case CaseOutcome.RefusedByTheRules _ ->
                         new Viability.ProvedImpossible(new Emptiness.ConflictingRules());
                 case CaseOutcome.NotWalked _ ->

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RootOpening.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RootOpening.java
@@ -1,0 +1,54 @@
+package souther.compiler.inputs;
+
+/**
+ * Why a value's rules were opened where they were, which is what says when the positions under them
+ * stand.
+ *
+ * <p>A rule root is a reading opened at a value, and not a fact about every value the behavior
+ * takes. What a parameter's rules say holds of every row; what a case's rules say holds of the rows
+ * whose value turned out to be that case, and what an element's say holds where the sequence holds
+ * one. A reading that met all of them into one space would be saying that every row is every case
+ * at once — which is a sum's cases refusing an input between them, and a rule of the value above
+ * reaching a position under a name nothing resolves to.
+ *
+ * <p>Read where the reading is opened and never worked out afterwards from the path. The steps say
+ * a narrowing was taken; they do not say which value's rules were being read when it was, and a
+ * reader recovering the second from the first would be answering with whichever root it happened to
+ * find.
+ */
+sealed interface RootOpening {
+
+    /** A parameter: the behavior takes it, so its rules hold of every row. */
+    record Taken() implements RootOpening {}
+
+    /**
+     * A case: its rules hold where the value at {@link SharedNames#sum} turned out to be that case.
+     *
+     * <p><b>Written for a refinement and not for a sum's case.</b> A sum states its cases and an
+     * optional states whether it holds anything, and {@link Refinement} already reads both as
+     * narrowings of one kind — so an optional's {@code Some} is one of these rather than a shape
+     * that arrives later with nothing to be an instance of.
+     *
+     * <p><b>Standing under a narrowing and carrying a name across it are two facts.</b> This is
+     * written wherever a case is opened, and the crossing it carries names nothing where the cases
+     * share nothing. Read as one — a narrowing being recorded only where a name crosses it — the
+     * condition a root stands under would go missing at exactly the sums whose cases have nothing
+     * in common.
+     *
+     * @param outer    where the rules the narrowing was taken from were read
+     * @param crossing the narrowing, and which of the value above's names reach across it
+     */
+    record Refined(TermPath outer, SharedNames crossing) implements RootOpening {}
+
+    /**
+     * An element: its rules hold where {@code sequence} holds one.
+     *
+     * <p>Nothing crosses. What a clause of the value out here says is written about the sequence,
+     * and an element is a value with a declaration of its own.
+     *
+     * @param outer    where the rules that were handed on were read
+     * @param sequence the container, whose being empty is a row this behavior takes as readily as
+     *                 one that fills it
+     */
+    record Inside(TermPath outer, TermPath sequence) implements RootOpening {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/SharedNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/SharedNames.java
@@ -1,0 +1,83 @@
+package souther.compiler.inputs;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The names a narrowing carries across, and the one correspondence between what the value above
+ * calls a position and where that position stands.
+ *
+ * <p>The one way a rule of one value reaches a position of another, and it exists because the
+ * language has one: a field every case of a sum spreads is readable on a value of the sum, so a
+ * clause written up there is about the field a row writes down here. Nothing else crosses — what a
+ * case declares of its own is not readable above it, and a clause of the sum has no name for it.
+ *
+ * <p><b>Both directions, from one place.</b> A reading of a position asks what the value above
+ * calls it; a reading that says the rules of the value above in the words of the case asks where a
+ * name of the value above stands. They are one fact, and two owners of it would be free to
+ * disagree about which positions a clause reaches.
+ *
+ * <p><b>Names may be empty, and that is a narrowing nothing crosses.</b> Whether a root stands
+ * under a narrowing and whether a name crosses it are two questions ({@link RootOpening.Refined}),
+ * and a sum whose cases share nothing is the model where they come apart.
+ *
+ * @param sum   where the sum stands, which is where the narrowing was taken
+ * @param branch which case the value turned out to be
+ * @param names the names the cases share, which are the only ones that cross
+ */
+record SharedNames(TermPath sum, Refinement branch, Set<String> names) {
+
+    SharedNames {
+        names = Set.copyOf(names);
+    }
+
+    /**
+     * What the value above calls the position at {@code here}, or null where it calls it nothing.
+     *
+     * <p>The narrowing taken back out, which is what a name written above means down here: a row at
+     * {@code h.q@A.limit} writes the {@code limit} a clause of {@code h} called {@code q.limit}, and
+     * the two differ by the step that says which case the value turned out to be. Null for the case
+     * itself and for anything under a name the cases do not share, which is every position the value
+     * above cannot name.
+     */
+    TermPath outerPathOf(TermPath here) {
+        List<TermPath.Step> steps = here.steps();
+        int narrowing = sum.steps().size();
+        if (steps.size() <= narrowing + 1
+                || !here.isAtOrUnder(sum)
+                || !(steps.get(narrowing) instanceof TermPath.Step.Refine taken)
+                || !taken.refinement().equals(branch)
+                || !(steps.get(narrowing + 1) instanceof TermPath.Step.Field field)
+                || !names.contains(field.name())) {
+            return null;
+        }
+        List<TermPath.Step> without = new ArrayList<>(steps.subList(0, narrowing));
+        without.addAll(steps.subList(narrowing + 1, steps.size()));
+        return new TermPath(here.head(), without);
+    }
+
+    /**
+     * Where the position the value above calls {@code there} stands once the value is this case, or
+     * null where the name does not cross.
+     *
+     * <p>{@link #outerPathOf} the other way round. What is put back is the step that says which case
+     * the value turned out to be, and everything under the shared name comes with it: a clause
+     * relating {@code q.lo} and {@code q.hi} is a clause about the two numbers standing at
+     * {@code q@A.lo} and {@code q@A.hi} once the value is an {@code A}.
+     */
+    TermPath standingUnderTheCase(TermPath there) {
+        List<TermPath.Step> steps = there.steps();
+        int narrowing = sum.steps().size();
+        if (steps.size() <= narrowing
+                || !there.isAtOrUnder(sum)
+                || !(steps.get(narrowing) instanceof TermPath.Step.Field field)
+                || !names.contains(field.name())) {
+            return null;
+        }
+        List<TermPath.Step> under = new ArrayList<>(steps.subList(0, narrowing));
+        under.add(new TermPath.Step.Refine(branch));
+        under.addAll(steps.subList(narrowing, steps.size()));
+        return new TermPath(there.head(), under);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
@@ -1,6 +1,8 @@
 package souther.compiler.inputs;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +33,40 @@ record StructuralContext(Requirements refinements, Set<TermPath> nonEmptySequenc
 
     /** A question that assumes nothing: the parameters, and whatever stands under no condition. */
     static final StructuralContext NONE = new StructuralContext(Requirements.NONE, Set.of());
+
+    /**
+     * One thing a question assumes about the row it is asked of.
+     *
+     * <p><b>Written down as a kind so that every reading of a context is over all of them.</b> A
+     * context is read twice — for which readings of declarations stand in it, and for what it says
+     * about the values themselves — and the two are asked in different places by different callers.
+     * Held as fields to be remembered one at a time, a kind of prerequisite is read by whichever of
+     * them its author happened to touch: which is how the containers came to decide whose rules were
+     * read without ever saying that they hold something.
+     */
+    sealed interface Assumption {
+
+        /** The value at {@code at} turned out to be this case. */
+        record TheCaseAt(TermPath at, Refinement is) implements Assumption {}
+
+        /** The sequence at {@code sequence} holds an element, or the position named inside it
+         *  stands nowhere. */
+        record HoldingSomething(TermPath sequence) implements Assumption {}
+    }
+
+    /**
+     * Everything this context assumes, in a settled order.
+     *
+     * <p>The narrowings in the order they were reached and the containers in the order they were
+     * needed, which is the order a reason about them reads in. What a reader does with each of them
+     * is its own; that it has to answer for every kind of them is this.
+     */
+    List<Assumption> assumptions() {
+        List<Assumption> out = new ArrayList<>();
+        refinements.refinements().forEach((at, is) -> out.add(new Assumption.TheCaseAt(at, is)));
+        nonEmptySequences.forEach(each -> out.add(new Assumption.HoldingSomething(each)));
+        return List.copyOf(out);
+    }
 
     StructuralContext {
         nonEmptySequences = Set.copyOf(nonEmptySequences);
@@ -141,9 +177,10 @@ record StructuralContext(Requirements refinements, Set<TermPath> nonEmptySequenc
     boolean holds(RootOpening opening) {
         return switch (opening) {
             case RootOpening.Taken _ -> true;
-            case RootOpening.Refined it ->
-                    it.crossing().branch().equals(refinements.at(it.crossing().sum()));
-            case RootOpening.Inside it -> nonEmptySequences.contains(it.sequence());
+            case RootOpening.Refined it -> assumptions().contains(
+                    new Assumption.TheCaseAt(it.crossing().sum(), it.crossing().branch()));
+            case RootOpening.Inside it ->
+                    assumptions().contains(new Assumption.HoldingSomething(it.sequence()));
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
@@ -1,6 +1,7 @@
 package souther.compiler.inputs;
 
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -82,6 +83,33 @@ record StructuralContext(Requirements refinements, Set<TermPath> nonEmptySequenc
          * are an emptiness — and neither of those readings belongs to the disagreement itself.
          */
         record Disagreeing(Requirements.Merge.Conflict why) implements Merge {}
+    }
+
+    /**
+     * The same, with the value at {@code at} settled as {@code branch} as well.
+     *
+     * <p>What a reader walking the alternatives of a sum asks about one of them. A narrowing already
+     * settled here is not settled again: {@link Requirements#and} refuses a second answer at one
+     * position, which is a caller asking about a case it has already ruled out.
+     */
+    StructuralContext and(TermPath at, Refinement branch) {
+        return new StructuralContext(refinements.and(at, branch), nonEmptySequences);
+    }
+
+    /**
+     * Whether everything {@code other} assumes is already assumed here.
+     *
+     * <p>What says a position exists in the values this describes: a sum inside a case is a place to
+     * ask about only once the value is that case, and asking about it under a context that has not
+     * settled the case would be walking alternatives of a sum that stands nowhere.
+     */
+    boolean covers(StructuralContext other) {
+        for (Map.Entry<TermPath, Refinement> each : other.refinements.refinements().entrySet()) {
+            if (!each.getValue().equals(refinements.at(each.getKey()))) {
+                return false;
+            }
+        }
+        return nonEmptySequences.containsAll(other.nonEmptySequences);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
@@ -1,0 +1,108 @@
+package souther.compiler.inputs;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * What a question about an input assumes stands: the narrowings it selects, and the sequences it
+ * needs to hold an element.
+ *
+ * <p>Every position of an input exists under conditions. A field of a case is there where the value
+ * turned out to be that case; a field of an element is there where the sequence holds one. So a
+ * question naming positions is a question asked of the rows that meet those conditions, and which
+ * rules reach it is settled by that and by nothing else ({@link #holds}).
+ *
+ * <p><b>Structural and nothing else.</b> It records the refinements selected and the containing
+ * sequences required to hold an element. It holds no numeric constraint, no fixed value and no
+ * assumption: <em>those are interpreted under this context, not made part of it.</em> Which is what
+ * the name is for. Called a context outright it would be where the next reader files a fixed value —
+ * a fixed value being part of the context of a question in every sense but this one — and the line
+ * this draws between what a reading assumes exists and what it then says about it would have been
+ * rubbed out from the left.
+ *
+ * <p><b>One owner, because one place has to decide it.</b> Everything asked of a reading of an
+ * input — where a form runs, what a fixing settles, what a condition takes in, whether anything is
+ * left — is asked under one of these, assembled the same way from the same three sources. Worked out
+ * per question instead, each reader would look at a path and decide for itself that a case was
+ * wanted, and the readers would come apart one at a time.
+ */
+record StructuralContext(Requirements refinements, Set<TermPath> nonEmptySequences) {
+
+    /** A question that assumes nothing: the parameters, and whatever stands under no condition. */
+    static final StructuralContext NONE = new StructuralContext(Requirements.NONE, Set.of());
+
+    StructuralContext {
+        nonEmptySequences = Set.copyOf(nonEmptySequences);
+    }
+
+    /**
+     * What naming {@code path} assumes.
+     *
+     * <p>Both halves read off the path, which is where they are already kept:
+     * {@link TermPath#requirements} says which narrowings were taken to get here, and
+     * {@link TermPath#sequencesContainingIt} says which containers have to hold something for this
+     * to be anywhere. Kept beside a path instead, a position would carry a second account of what it
+     * already says.
+     */
+    static StructuralContext of(TermPath path) {
+        return new StructuralContext(path.requirements(),
+                new LinkedHashSet<>(path.sequencesContainingIt()));
+    }
+
+    /**
+     * Both, or the position they disagree about.
+     *
+     * <p>Refinements are compared by {@link Requirements#merge} and by nothing written here: whether
+     * two narrowings hold of one value is that type's question, asked by everything that decides
+     * whether two positions can be in one row. Sequences only accumulate — needing one to hold an
+     * element and needing another to hold one are never at odds.
+     */
+    Merge merge(StructuralContext other) {
+        return switch (refinements.merge(other.refinements)) {
+            case Requirements.Merge.Conflict it -> new Merge.Disagreeing(it);
+            case Requirements.Merge.Merged it -> {
+                Set<TermPath> both = new LinkedHashSet<>(nonEmptySequences);
+                both.addAll(other.nonEmptySequences);
+                yield new Merge.Together(new StructuralContext(it.requirements(), both));
+            }
+        };
+    }
+
+    /** What came of putting two of them together. */
+    sealed interface Merge {
+
+        /** They hold of one value, and this is what such a value has to be. */
+        record Together(StructuralContext context) implements Merge {}
+
+        /**
+         * They do not, and this is the position that cannot be both.
+         *
+         * <p>Carried as the refinements' own answer. What a caller does about it differs — a
+         * question about a quantity of no value is refused, and two fixings that cannot both hold
+         * are an emptiness — and neither of those readings belongs to the disagreement itself.
+         */
+        record Disagreeing(Requirements.Merge.Conflict why) implements Merge {}
+    }
+
+    /**
+     * Whether a reading opened this way holds of the values this context describes.
+     *
+     * <p>Exhaustive over {@link RootOpening}, with no {@code default}: a way of opening a reading
+     * added later stops this compiling rather than joining whichever side its author's condition
+     * happened to leave it on — which, for a reading that is met into a constraint space, is the
+     * difference between rules that hold of every row and rules that hold of some.
+     *
+     * <p>A narrowing this context does not select is not refused here. What such a case says is left
+     * out of the space, and whether any value stands under it at all is the other question
+     * ({@code emptiness}) — asked of every alternative rather than of the one a caller happened to
+     * name.
+     */
+    boolean holds(RootOpening opening) {
+        return switch (opening) {
+            case RootOpening.Taken _ -> true;
+            case RootOpening.Refined it ->
+                    it.crossing().branch().equals(refinements.at(it.crossing().sum()));
+            case RootOpening.Inside it -> nonEmptySequences.contains(it.sequence());
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralContext.java
@@ -97,6 +97,19 @@ record StructuralContext(Requirements refinements, Set<TermPath> nonEmptySequenc
     }
 
     /**
+     * The same, with {@code sequence} required to hold an element as well.
+     *
+     * <p>What a reader asking whether anything can stand inside a container assumes while it asks.
+     * A container that may be empty is a value whatever is true of what it would hold, so the
+     * question is only ever asked under this.
+     */
+    StructuralContext holding(TermPath sequence) {
+        Set<TermPath> more = new LinkedHashSet<>(nonEmptySequences);
+        more.add(sequence);
+        return new StructuralContext(refinements, more);
+    }
+
+    /**
      * Whether everything {@code other} assumes is already assumed here.
      *
      * <p>What says a position exists in the values this describes: a sum inside a case is a place to

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
@@ -2,6 +2,10 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.Emptiness;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
 /**
  * What is known about whether a value stands somewhere.
  *
@@ -20,6 +24,57 @@ import souther.compiler.check.Emptiness;
  * and a count nothing has shown to be none is not a claim that a value exists.
  */
 sealed interface Viability {
+
+    /**
+     * What two things a value has at once come to.
+     *
+     * <p>A conjunction, and the connective is the whole of the difference from {@link #oneOf}: a row
+     * has every one of these, so one of them standing nowhere is the row standing nowhere, and every
+     * one of them has to be possible for the row to be. What is not known about one of them cannot
+     * hide what another was shown — so a proof wins over an unread, and an unread wins over nothing
+     * having been shown.
+     *
+     * <p>Written here rather than at each fold. The two connectives read alike and mean opposite
+     * things, and a caller working out for itself which of three answers to keep would sooner or
+     * later keep the one that reads like the other fold's.
+     */
+    default Viability with(Viability other) {
+        if (this instanceof ProvedImpossible) {
+            return this;
+        }
+        if (other instanceof ProvedImpossible) {
+            return other;
+        }
+        return this instanceof NotRead ? this : other;
+    }
+
+    /**
+     * What the alternatives of one choice come to.
+     *
+     * <p>A disjunction. A value is one of these, so one that may stand is the whole answer, and what
+     * proves there is none is every one of them at once — which is why the proofs are taken
+     * together rather than one being picked to speak for the rest. An alternative nothing is known
+     * about leaves the choice unproved however many of the others are refused.
+     *
+     * @param alternatives what became of each, in the order the model writes them
+     * @param proof        what the refusals come to where every one of them is refused, which is
+     *                     whatever kind of choice this is
+     */
+    static Viability oneOf(List<Viability> alternatives,
+                           Function<List<Emptiness>, Emptiness> proof) {
+        List<Emptiness> refused = new ArrayList<>();
+        boolean unread = false;
+        for (Viability each : alternatives) {
+            switch (each) {
+                case MayStand _ -> {
+                    return each;
+                }
+                case ProvedImpossible it -> refused.add(it.why());
+                case NotRead _ -> unread = true;
+            }
+        }
+        return unread ? new NotRead() : new ProvedImpossible(proof.apply(refused));
+    }
 
     /** Nothing showed that nothing stands here. Not a claim that something does. */
     record MayStand() implements Viability {}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
@@ -37,7 +37,10 @@ sealed interface Viability {
     /**
      * This reading did not go there, so nothing is known either way.
      *
-     * @param at where it stopped, which is what a report of a reading's limits is about
+     * <p>Where it stopped is not carried. Nothing asks it yet, and a place picked out of however
+     * many alternatives went unread would be chosen by the order they were walked in rather than by
+     * anything the model says — which is the shape of answer this type exists to keep out. A reader
+     * that needs the place is a reader that says which of them it wants.
      */
-    record NotRead(TermPath at) implements Viability {}
+    record NotRead() implements Viability {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Viability.java
@@ -1,0 +1,43 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.Emptiness;
+
+/**
+ * What is known about whether a value stands somewhere.
+ *
+ * <p><b>One arm proves and the other two do not, and that asymmetry is the whole of it.</b> A proof
+ * of emptiness may be built out of {@link ProvedImpossible} and out of nothing else: where every
+ * alternative of a sum carries one, the sum has no value; where any of them carries anything else,
+ * nothing has been shown. {@link MayStand} and {@link NotRead} are one answer to that calculus —
+ * not shown impossible — and differ only in what a report may say about why.
+ *
+ * <p>Which is why the third is written down rather than left as an absence. A case this walk never
+ * entered has no root, no reading and nothing to look up, and every one of those is a shape some
+ * later reader takes for "there is nothing there". Given a name of its own, taking it for a proof is
+ * something that has to be typed out.
+ *
+ * <p>The same asymmetry {@code Cardinality} holds: a count carries its proof or it carries nothing,
+ * and a count nothing has shown to be none is not a claim that a value exists.
+ */
+sealed interface Viability {
+
+    /** Nothing showed that nothing stands here. Not a claim that something does. */
+    record MayStand() implements Viability {}
+
+    /** Nothing stands here, and this is what showed it. */
+    record ProvedImpossible(Emptiness why) implements Viability {
+
+        public ProvedImpossible {
+            if (why == null) {
+                throw new IllegalArgumentException("what is impossible is impossible for a reason");
+            }
+        }
+    }
+
+    /**
+     * This reading did not go there, so nothing is known either way.
+     *
+     * @param at where it stopped, which is what a report of a reading's limits is about
+     */
+    record NotRead(TermPath at) implements Viability {}
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ABoundOnASharedNameReachesTheNumbersItStandsAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ABoundOnASharedNameReachesTheNumbersItStandsAtTest.java
@@ -88,6 +88,27 @@ class ABoundOnASharedNameReachesTheNumbersItStandsAtTest {
         }
     }
 
+    /**
+     * And the two readings of that end are one answer.
+     *
+     * <p>What a rule of the value above leaves a position is read twice: once per name, as the
+     * reading of the position is made, and once as a rule said in the words of the case, where the
+     * relations are. Both are readings of one crossing, and the day they part is the day a caller's
+     * answer depends on which of them it happened to ask.
+     */
+    @Test
+    void andThePositionAndTheQuantityAgreeAboutIt() {
+        for (String at : List.of("h.q@A.limit", "h.q@B.limit")) {
+            InputDomain read = reading(SHARED, "read");
+            NumericDomain.Bounds position = read.positions().stream()
+                    .filter(each -> each.path().toString().equals(at))
+                    .map(Position::numericDomain).findFirst().orElseThrow();
+
+            assertEquals(position, runsAt(SHARED, at),
+                    at + " stops where it stops, whichever reading is asked");
+        }
+    }
+
     private static NumericDomain.Bounds runsAt(String source, String spelled) {
         InputDomain read = reading(source, "read");
         return read.quantities(symbolsOf(source))

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ACaseTheRulesRefuseIsNotOneThatStandsOnItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ACaseTheRulesRefuseIsNotOneThatStandsOnItsOwnTest.java
@@ -1,0 +1,103 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Whether the rules leave a case is asked before what stands under it.
+ *
+ * <p>The two are different questions and one presupposes the other. That naming a case builds it
+ * says there is nothing under it to read; it does not say a value may stand there. A case with
+ * nothing under it that the rules refuse is both at once, and read as the second it comes back as
+ * the plainest kind of value there is — which is what every reader asking whether a sum has a value
+ * then takes for a witness.
+ */
+class ACaseTheRulesRefuseIsNotOneThatStandsOnItsOwnTest {
+
+    private static final String REFUSED = """
+            module g
+
+            data Prospecting
+            data Qualified
+            data Won
+            data Stage = Prospecting | Qualified | Won
+
+            data StageI = Stage
+                invariant onlyLater = value >= Qualified
+
+            data Holder = { s: StageI }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same model with the rule taken out, so that what the rule does is what is measured. */
+    private static final String UNRULED =
+            REFUSED.replace("    invariant onlyLater = value >= Qualified\n", "");
+
+    @Test
+    void aBareCaseTheRulesRefuseIsRefusedAndNotStanding() {
+        NameReach.NotEntered why = whyNotEntered(REFUSED, "Prospecting");
+
+        assertInstanceOf(NameReach.NotEntered.TheRulesLeaveNothingAtIt.class, why,
+                "the rules leave no Prospecting, which is why the reading did not go down it");
+    }
+
+    @Test
+    void andOneNothingRefusesStandsOnItsOwn() {
+        NameReach.NotEntered why = whyNotEntered(UNRULED, "Prospecting");
+
+        assertInstanceOf(NameReach.NotEntered.NothingStandsUnderIt.class, why,
+                "naming the case builds it, and no rule says otherwise");
+    }
+
+    /** And the cases the rule leaves are read the same way it always was. */
+    @Test
+    void aCaseTheRuleLeavesIsStillOneThatStandsOnItsOwn() {
+        for (String at : List.of("Qualified", "Won")) {
+            assertInstanceOf(NameReach.NotEntered.NothingStandsUnderIt.class,
+                    whyNotEntered(REFUSED, at),
+                    at + " is left by the rule, and naming it builds it");
+        }
+    }
+
+    private static NameReach.NotEntered whyNotEntered(String source, String branch) {
+        List<NameReach.BranchNotEntered> not =
+                reading(source, "read").reach().branchesNotEntered().stream()
+                        .filter(each -> each.branch().spelled().equals(branch))
+                        .toList();
+
+        assertEquals(1, not.size(),
+                () -> "the reading turned back at " + branch + " once, and said so once");
+        return not.get(0).why();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest.java
@@ -92,6 +92,30 @@ class ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest {
             behavior read : (h: Holder) -> Ok
             """;
 
+    private static final String TWO_DEEP = """
+            module g
+
+            data Deep = { lo: Int, hi: Int }
+            data DA = { ...Deep, x: Int }
+            data DB = { ...Deep, y: Int }
+            data D = DA | DB
+
+            data Mid = { d: D }
+            data MA = { ...Mid, p: Int }
+            data MB = { ...Mid, q: Int }
+            data M = MA | MB
+
+            data Holder = { m: M }
+                invariant ordered = m.d.lo <= m.d.hi
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    private static final String TWO_DEEP_UNRULED =
+            TWO_DEEP.replace("    invariant ordered = m.d.lo <= m.d.hi\n", "");
+
     /** The rule the record wrote about the sum, read at the numbers one case stands at. */
     @Test
     void aRelationReachesTheCaseTheNumbersStandUnder() {
@@ -157,6 +181,81 @@ class ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest {
 
         assertTrue(runs == null || runs.max() == null,
                 () -> "h.left@A.lo is stopped by nothing once the rule is gone, and runs " + runs);
+    }
+
+    /**
+     * A name that crosses two narrowings on the way down.
+     *
+     * <p>What the value above calls {@code m.d.lo} stands at {@code m@MA.d@DA.lo}, two cases in. The
+     * renamings compose or they do not: applied in an order that takes the second before the first
+     * has moved the name, the clause is left about a place no position of this input is at.
+     */
+    @Test
+    void aRelationCrossesTwoNarrowingsOneUnderTheOther() {
+        NumericDomain.Bounds runs =
+                stoppedAt(TWO_DEEP, "h.m@MA.d@DA.lo", "h.m@MA.d@DA.hi", 7);
+
+        assertNotNull(runs, "h.m@MA.d@DA.lo is a number this reading answers about");
+        assertNotNull(runs.max(),
+                () -> "h.m@MA.d@DA.lo stops where h.m@MA.d@DA.hi was fixed, and runs " + runs);
+        assertEquals("7", number(runs.max()),
+                "the rule reaches the numbers its names stand at, two narrowings down");
+    }
+
+    @Test
+    void andWithoutThatRuleNothingStopsItTwoDeepEither() {
+        NumericDomain.Bounds runs =
+                stoppedAt(TWO_DEEP_UNRULED, "h.m@MA.d@DA.lo", "h.m@MA.d@DA.hi", 7);
+
+        assertTrue(runs == null || runs.max() == null,
+                () -> "h.m@MA.d@DA.lo is stopped by nothing once the rule is gone, and runs "
+                        + runs);
+    }
+
+    private static final String BESIDE_A_SUM = """
+            module g
+
+            data A = { x: Int }
+            data B = { y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q, note: Int }
+                invariant capped = note <= 5
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same, with one case of the sum left with no value, and with an element of one. */
+    private static final String BESIDE_A_DEAD_CASE = BESIDE_A_SUM.replace(
+            "data A = { x: Int }",
+            """
+                    data A = { x: Int }
+                        invariant impossible = x >= 1 && x <= 0""");
+
+    private static final String BESIDE_A_DEAD_ELEMENT = BESIDE_A_SUM.replace(
+            "data Holder = { q: Q, note: Int }",
+            """
+                    data Item = { charge: Int }
+                        invariant impossible = charge >= 1 && charge <= 0
+                    data Holder = { q: Q, note: Int, items: List<Item> }""");
+
+    /**
+     * A question about a position under no narrowing answers the same whatever became of the cases.
+     *
+     * <p>Which rules reach a position is settled by where it stands, so a case the rules refuse
+     * takes nothing away from a number beside it — and neither does an element declaration nothing
+     * can build. Read as one space met out of every reading, both of those emptied the answer here.
+     */
+    @Test
+    void aQuestionOutsideTheNarrowingDoesNotMove() {
+        NumericDomain.Bounds alone = stoppedAt(BESIDE_A_SUM, "h.note", "h.note", 3);
+
+        for (String beside : List.of(BESIDE_A_DEAD_CASE, BESIDE_A_DEAD_ELEMENT)) {
+            assertEquals(alone, stoppedAt(beside, "h.note", "h.note", 3),
+                    "h.note runs where its own rule leaves it, whatever stands beside it");
+        }
     }
 
     /** Where {@code asked} runs once {@code fixed} stands at {@code at}. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest.java
@@ -1,0 +1,204 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule relating two names a sum's cases share reaches the numbers those names stand at.
+ *
+ * <p>Beside {@link ABoundOnASharedNameReachesTheNumbersItStandsAtTest}, which measures an end. An
+ * end is a per-name answer and reaches the case through the reading of the position; a relation is
+ * not a per-name answer, and what carries it is the rules of the value above said again in the
+ * words of the case.
+ *
+ * <p><b>Once per context and not once per narrowing crossed.</b> The last measurement here relates
+ * two names under two sums that are narrowed independently. A renaming worked out edge by edge
+ * leaves one of the two names spelled as the sum wrote it in either copy, and the two copies relate
+ * nothing when they are met.
+ */
+class ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest {
+
+    private static final String ONE_SUM = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+                invariant ordered = q.lo <= q.hi
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same model with the rule taken out, so that what the rule does is what is measured. */
+    private static final String UNRULED =
+            ONE_SUM.replace("    invariant ordered = q.lo <= q.hi\n", "");
+
+    private static final String TWO_SUMS = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { left: Q, right: Q }
+                invariant across = left.lo <= right.hi
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    private static final String TWO_SUMS_UNRULED =
+            TWO_SUMS.replace("    invariant across = left.lo <= right.hi\n", "");
+
+    private static final String ONE_SUM_OF_TWO = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { p: Q, r: Q }
+                invariant ordered = p.lo <= p.hi
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The rule the record wrote about the sum, read at the numbers one case stands at. */
+    @Test
+    void aRelationReachesTheCaseTheNumbersStandUnder() {
+        for (String at : List.of("A", "B")) {
+            NumericDomain.Bounds runs = stoppedAt(ONE_SUM,
+                    "h.q@" + at + ".lo", "h.q@" + at + ".hi", 7);
+
+            assertNotNull(runs, "h.q@" + at + ".lo is a number this reading answers about");
+            assertNotNull(runs.max(), () -> "h.q@" + at + ".lo stops where h.q@" + at
+                    + ".hi was fixed, and runs " + runs);
+            assertEquals("7", number(runs.max()),
+                    "h.q@" + at + ".lo stops where the rule the record wrote put it");
+        }
+    }
+
+    /** And nothing else stops it, so the end above is the rule's doing. */
+    @Test
+    void andWithoutTheRuleNothingStopsIt() {
+        NumericDomain.Bounds runs = stoppedAt(UNRULED, "h.q@A.lo", "h.q@A.hi", 7);
+
+        assertTrue(runs == null || runs.max() == null,
+                () -> "h.q@A.lo is stopped by nothing once the rule is gone, and runs " + runs);
+    }
+
+    /**
+     * The relation carried into one case is about that case's numbers.
+     *
+     * <p>Two values of one sum's declaration, related by a rule written about one of them. Fixing
+     * the one leaves the other where its own type leaves it — a renaming that carried the rule to
+     * every position spelled {@code lo} would stop this one too.
+     */
+    @Test
+    void andItIsAboutTheValueTheRuleWasWrittenAbout() {
+        NumericDomain.Bounds runs = stoppedAt(ONE_SUM_OF_TWO, "h.r@A.lo", "h.p@A.hi", 7);
+
+        assertTrue(runs == null || runs.max() == null,
+                () -> "h.r@A.lo is stopped by nothing, the rule being about h.p, and runs " + runs);
+    }
+
+    /**
+     * One relation, two sums narrowed independently, and it reaches both.
+     *
+     * <p>What the whole context selects, in one renaming. Crossed one narrowing at a time, the copy
+     * carried into {@code left@A} still calls the other name {@code right.hi} and the copy carried
+     * into {@code right@B} still calls this one {@code left.lo}, so nothing relates the two numbers
+     * a caller asked about.
+     */
+    @Test
+    void aRelationCrossesTwoNarrowingsAtOnce() {
+        NumericDomain.Bounds runs = stoppedAt(TWO_SUMS, "h.left@A.lo", "h.right@B.hi", 7);
+
+        assertNotNull(runs, "h.left@A.lo is a number this reading answers about");
+        assertNotNull(runs.max(),
+                () -> "h.left@A.lo stops where h.right@B.hi was fixed, and runs " + runs);
+        assertEquals("7", number(runs.max()),
+                "h.left@A.lo stops where the rule across the two sums put it");
+    }
+
+    @Test
+    void andWithoutThatRuleNothingStopsItEither() {
+        NumericDomain.Bounds runs =
+                stoppedAt(TWO_SUMS_UNRULED, "h.left@A.lo", "h.right@B.hi", 7);
+
+        assertTrue(runs == null || runs.max() == null,
+                () -> "h.left@A.lo is stopped by nothing once the rule is gone, and runs " + runs);
+    }
+
+    /** Where {@code asked} runs once {@code fixed} stands at {@code at}. */
+    private static NumericDomain.Bounds stoppedAt(String source, String asked, String fixed,
+                                                  int at) {
+        InputDomain read = reading(source, "read");
+        Quantities quantities = read.quantities(symbolsOf(source));
+        return quantities
+                .given(new NumericTerm.ValueOf(pathOf(read, fixed)),
+                        Count.of(BigDecimal.valueOf(at)))
+                .runsBetween(new NumericTerm.ValueOf(pathOf(read, asked)));
+    }
+
+    private static String number(souther.compiler.numeric.Endpoint end) {
+        return Count.number(end.at()).at().stripTrailingZeros().toPlainString();
+    }
+
+    private static TermPath pathOf(InputDomain read, String spelled) {
+        return read.positions().stream().map(Position::path)
+                .filter(each -> each.toString().equals(spelled))
+                .findFirst().orElseThrow(() -> new AssertionError(
+                        "no position at " + spelled + " among " + read.positions().stream()
+                                .map(Position::path).toList()));
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ASharedNameIsOneSubjectInEveryLanguageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ASharedNameIsOneSubjectInEveryLanguageTest.java
@@ -1,0 +1,136 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name the cases of a sum share is one subject in every language the rules are read in.
+ *
+ * <p>What the value above says about it and what the case says about it are about the same thing,
+ * whether what they say is a relation between numbers, a bound on an order, or which values may
+ * stand there. Carried as one subject for the arithmetic and as two for the rest, a clause of the
+ * sum and a clause of the case stop meeting the moment neither of them is about a number — and
+ * nothing says so, because two subjects that never meet leave every answer wider rather than wrong.
+ *
+ * <p>Beside {@link ARelationOverSharedNamesReachesTheNumbersTheyStandAtTest}, which measures the
+ * same crossing where the rules are arithmetic.
+ */
+class ASharedNameIsOneSubjectInEveryLanguageTest {
+
+    /**
+     * A bound on an order, said above and said in every case, that no value meets.
+     *
+     * <p>Neither clause refuses anything on its own. Read as one subject they leave the name
+     * nothing, and every case of the sum is a case no value stands at.
+     */
+    private static final String ON_AN_ORDER = """
+            module g
+
+            data Shared = { tag: String }
+            data A = { ...Shared, x: Int }
+                invariant late = tag >= "M"
+            data B = { ...Shared, y: Int }
+                invariant late = tag >= "M"
+            data Q = A | B
+
+            data Holder = { q: Q }
+                invariant early = q.tag <= "A"
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same model with the rule the value above wrote taken out. */
+    private static final String ON_AN_ORDER_UNRULED =
+            ON_AN_ORDER.replace("    invariant early = q.tag <= \"A\"\n", "");
+
+    /**
+     * Which values may stand at the name, said above and said in every case.
+     *
+     * <p>An equality is a set of one and an exclusion is that set taken away, and neither is a range
+     * — so this is the reading that answers where the order and the arithmetic have nothing to say.
+     */
+    private static final String ON_THE_VALUES = """
+            module g
+
+            data Shared = { tag: String }
+            data A = { ...Shared, x: Int }
+                invariant notThat = tag /= "A"
+            data B = { ...Shared, y: Int }
+                invariant notThat = tag /= "A"
+            data Q = A | B
+
+            data Holder = { q: Q }
+                invariant thatOne = q.tag == "A"
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    private static final String ON_THE_VALUES_UNRULED =
+            ON_THE_VALUES.replace("    invariant thatOne = q.tag == \"A\"\n", "");
+
+    @Test
+    void whatTheValueAboveBoundsOnAnOrderMeetsWhatTheCaseBounds() {
+        assertTrue(emptinessOf(ON_AN_ORDER).isPresent(),
+                "no tag is both at most \"A\" and at least \"M\", so no case of Q has a value");
+    }
+
+    @Test
+    void andWhichValuesItAdmitsMeetsWhatTheCaseAdmits() {
+        assertTrue(emptinessOf(ON_THE_VALUES).isPresent(),
+                "no tag is both \"A\" and not \"A\", so no case of Q has a value");
+    }
+
+    /** And with the rule above taken out, each of them leaves the input its values. */
+    @Test
+    void andWithoutTheRuleAboveNothingRefusesTheInput() {
+        for (String source : List.of(ON_AN_ORDER_UNRULED, ON_THE_VALUES_UNRULED)) {
+            assertEquals(Optional.empty(), emptinessOf(source),
+                    "what one case says of the name refuses nothing on its own");
+        }
+    }
+
+    private static Optional<EmptyInput> emptinessOf(String source) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source)).emptiness();
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ASumIsEmptyOnlyWhereEveryCaseIsKnownImpossibleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ASumIsEmptyOnlyWhereEveryCaseIsKnownImpossibleTest.java
@@ -1,0 +1,134 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Emptiness;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two halves of what a choice between alternatives means.
+ *
+ * <p>A sum has a value wherever any of its cases does, so what proves it has none is every case at
+ * once — and a case this reading never entered is not one of those. Nothing was shown about it,
+ * which is not the same as its having been shown to hold nothing, and a proof built from it would
+ * say a model has no value because this compiler stopped looking.
+ *
+ * <p>Beside {@link AViableCaseSurvivesADeadSiblingTest}, which measures that one refused case takes
+ * nothing with it. What this measures is that the reading can still prove the thing it is supposed
+ * to prove, and that it stops proving it exactly where it stops knowing.
+ */
+class ASumIsEmptyOnlyWhereEveryCaseIsKnownImpossibleTest {
+
+    private static final String EVERY_CASE_REFUSED = """
+            module g
+
+            data A = { x: Int }
+                invariant impossible = x >= 1 && x <= 0
+            data B = { y: Int }
+                invariant impossible = y >= 1 && y <= 0
+            data Q = A | B
+
+            data Holder = { q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same, with one case left standing, so that what refuses the input is the whole list. */
+    private static final String ONE_CASE_STANDS =
+            EVERY_CASE_REFUSED.replace("    invariant impossible = y >= 1 && y <= 0\n", "");
+
+    /**
+     * A sum whose cases the reading never enters, because the walk turns back where a path returns
+     * to a declaration already open on it.
+     */
+    private static final String NEVER_ENTERED = """
+            module g
+
+            data Leaf = { n: Int }
+                invariant impossible = n >= 1 && n <= 0
+            data Node = { left: Tree, right: Tree }
+            data Tree = Leaf | Node
+
+            data Holder = { tree: Tree }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    @Test
+    void everyCaseRefusedLeavesTheInputNone() {
+        Optional<EmptyInput> why = emptinessOf(EVERY_CASE_REFUSED);
+
+        assertTrue(why.isPresent(), "no value of Q is left, so no value of the input is");
+        Emptiness proof = ((EmptyInput.ProvedByTheRules) why.orElseThrow()).why();
+        Emptiness.AtAField at = assertInstanceOf(Emptiness.AtAField.class, proof,
+                "the lack is at the sum, which is the place a reader is sent to");
+        assertEquals(new Emptiness.AtAField.Where.In("h.q"), at.where());
+        assertEquals(2, assertInstanceOf(Emptiness.AcrossEveryCase.class, at.under(),
+                "and it is proved over every case rather than by one of them").cases().size());
+    }
+
+    @Test
+    void andOneStandingCaseIsEnoughToLeaveIt() {
+        assertEquals(Optional.empty(), emptinessOf(ONE_CASE_STANDS),
+                "every B is a row this behavior takes");
+    }
+
+    /**
+     * A case this reading did not enter proves nothing.
+     *
+     * <p>The walk stops where a path returns to a declaration already open on it, so the sums under
+     * {@code Node} are met and never read. Read as cases that hold nothing, the recursion itself
+     * would refuse every model that has one.
+     */
+    @Test
+    void aCaseThisReadingDidNotEnterProvesNothing() {
+        assertEquals(Optional.empty(), emptinessOf(NEVER_ENTERED),
+                "a tree of one node is a row this behavior takes, and the deeper sums were never"
+                        + " read");
+    }
+
+    private static Optional<EmptyInput> emptinessOf(String source) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source)).emptiness();
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AViableCaseSurvivesADeadSiblingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AViableCaseSurvivesADeadSiblingTest.java
@@ -88,6 +88,70 @@ class AViableCaseSurvivesADeadSiblingTest {
             behavior read : (h: Holder) -> Ok
             """;
 
+    /**
+     * A sum whose cases share nothing, one of which the rules refuse.
+     *
+     * <p>What says the case stands under a narrowing and what says a name crosses one are two facts.
+     * Recorded as one — a narrowing written down only where something crosses it — the reading of
+     * this model would have the case's rules holding of every row.
+     */
+    private static final String NOTHING_SHARED = """
+            module g
+
+            data A = { x: Int }
+                invariant impossible = x >= 1 && x <= 0
+            data B = { y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /**
+     * A sequence inside a case, of an element the rules refuse, that the case says holds something.
+     *
+     * <p>Both conditions at once: the element's rules are about the rows where {@code q} is an
+     * {@code A} and where the list holds something, and neither of those is every row. So {@code A}
+     * has no value and {@code B} is untouched.
+     */
+    private static final String A_SEQUENCE_INSIDE_A_CASE = """
+            module g
+
+            data Item = { charge: Int }
+                invariant impossible = charge >= 1 && charge <= 0
+            data A = { items: List<Item> }
+                invariant atLeastOne = List.length(items) >= 1
+            data B = { y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** A sum inside a sequence, one case of which the rules refuse. */
+    private static final String A_CASE_INSIDE_A_SEQUENCE = """
+            module g
+
+            data A = { x: Int }
+                invariant impossible = x >= 1 && x <= 0
+            data B = { y: Int }
+            data Q = A | B
+
+            data Item = { q: Q }
+            data Holder = { items: List<Item> }
+                invariant atLeastOne = List.length(items) >= 1
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
     @Test
     void aCaseItsOwnRulesRefuseLeavesTheInputItsOtherCases() {
         assertEquals(Optional.empty(), emptinessOf(DEAD_CASE),
@@ -104,6 +168,24 @@ class AViableCaseSurvivesADeadSiblingTest {
     void anElementTheRulesRefuseLeavesTheEmptySequence() {
         assertEquals(Optional.empty(), emptinessOf(DEAD_ELEMENT),
                 "an empty list is a value this behavior takes, so the input is not proved empty");
+    }
+
+    @Test
+    void andSoDoesOneWhoseCasesShareNothing() {
+        assertEquals(Optional.empty(), emptinessOf(NOTHING_SHARED),
+                "a case stands under its narrowing whether or not a name crosses it");
+    }
+
+    @Test
+    void aSequenceInsideACaseIsRefusedNoFurtherThanTheCase() {
+        assertEquals(Optional.empty(), emptinessOf(A_SEQUENCE_INSIDE_A_CASE),
+                "every B is a row this behavior takes, whatever A's list would have to hold");
+    }
+
+    @Test
+    void andACaseInsideASequenceLeavesTheSequenceItsOtherCase() {
+        assertEquals(Optional.empty(), emptinessOf(A_CASE_INSIDE_A_SEQUENCE),
+                "a list of Items that are all B is a row this behavior takes");
     }
 
     private static Optional<EmptyInput> emptinessOf(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AViableCaseSurvivesADeadSiblingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AViableCaseSurvivesADeadSiblingTest.java
@@ -1,0 +1,133 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A sum has a value wherever one of its cases does, so a case the rules refuse leaves the input its
+ * other cases.
+ *
+ * <p>The cases of a sum are a choice. Read as a conjunction — every case's rules met into one space
+ * — a model with one refused case comes back as a behavior that takes nothing, and every comparison
+ * written about it is answered {@code NoFeasibleInput} while the rows a reader is owed are rows an
+ * author can write.
+ *
+ * <p>The same of a sequence, whose element is a value the input has where the sequence holds one.
+ * An element declaration the rules refuse leaves the empty sequence, which is a value this behavior
+ * takes.
+ */
+class AViableCaseSurvivesADeadSiblingTest {
+
+    private static final String DEAD_CASE = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+                invariant impossible = x >= 1 && x <= 0
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /**
+     * The same, with the case refused by its own rules together with the rule the record wrote.
+     *
+     * <p>Neither {@code lo >= 10} nor {@code hi <= 5} refuses {@code A} on its own, and the record's
+     * {@code lo <= hi} refuses nothing until it is read at the numbers the names stand at. So this
+     * is a case that is empty only once the relation is carried, and it is the model that says the
+     * carry and the choice are one change: carried into a conjunction of the cases, this refuses the
+     * whole input.
+     */
+    private static final String DEAD_ONCE_THE_RELATION_IS_CARRIED = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+                invariant low = lo >= 10
+                invariant high = hi <= 5
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+                invariant ordered = q.lo <= q.hi
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    private static final String DEAD_ELEMENT = """
+            module g
+
+            data Item = { charge: Int }
+                invariant impossible = charge >= 1 && charge <= 0
+            data Holder = { items: List<Item> }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    @Test
+    void aCaseItsOwnRulesRefuseLeavesTheInputItsOtherCases() {
+        assertEquals(Optional.empty(), emptinessOf(DEAD_CASE),
+                "every B is a row this behavior takes, so the input is not proved empty");
+    }
+
+    @Test
+    void andSoDoesACaseRefusedOnlyOnceTheRelationIsCarried() {
+        assertEquals(Optional.empty(), emptinessOf(DEAD_ONCE_THE_RELATION_IS_CARRIED),
+                "every B is a row this behavior takes, so the input is not proved empty");
+    }
+
+    @Test
+    void anElementTheRulesRefuseLeavesTheEmptySequence() {
+        assertEquals(Optional.empty(), emptinessOf(DEAD_ELEMENT),
+                "an empty list is a value this behavior takes, so the input is not proved empty");
+    }
+
+    private static Optional<EmptyInput> emptinessOf(String source) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source)).emptiness();
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AnElementNothingCanBuildRefusesOnlyANonEmptySequenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AnElementNothingCanBuildRefusesOnlyANonEmptySequenceTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Emptiness;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a sequence holds refuses the input only where the sequence cannot be empty.
+ *
+ * <p>A container that may hold none is a value whatever is true of what it would hold, so an element
+ * declaration nothing can build leaves a row an author can still write. Where a rule says the
+ * container holds at least one, the same declaration leaves the input nothing — and the proof says
+ * which of the two it was.
+ *
+ * <p>The same asymmetry the cases of a sum are read with: what is quantified over is the values the
+ * model has, and an alternative nobody can take is only a refusal when there is no other.
+ */
+class AnElementNothingCanBuildRefusesOnlyANonEmptySequenceTest {
+
+    private static final String MAY_BE_EMPTY = """
+            module g
+
+            data Item = { charge: Int }
+                invariant impossible = charge >= 1 && charge <= 0
+            data Holder = { items: List<Item> }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same, with the container told to hold something. */
+    private static final String HOLDS_AT_LEAST_ONE = MAY_BE_EMPTY.replace(
+            "data Holder = { items: List<Item> }",
+            """
+                    data Holder = { items: List<Item> }
+                        invariant atLeastOne = List.length(items) >= 1""");
+
+    /** And the same again with an element there is a value of, so that what refuses the input is
+     *  the pair and not the rule about the length. */
+    private static final String AND_AN_ELEMENT_THAT_STANDS =
+            HOLDS_AT_LEAST_ONE.replace("    invariant impossible = charge >= 1 && charge <= 0\n",
+                    "");
+
+    @Test
+    void anEmptySequenceIsAValueWhateverItsElementWouldBe() {
+        assertEquals(Optional.empty(), emptinessOf(MAY_BE_EMPTY),
+                "an empty list is a row this behavior takes");
+    }
+
+    @Test
+    void andOneThatCannotBeEmptyIsRefusedByWhatItWouldHold() {
+        Optional<EmptyInput> why = emptinessOf(HOLDS_AT_LEAST_ONE);
+
+        assertTrue(why.isPresent(), "the list holds an Item and there is no Item to hold");
+        Emptiness proof = ((EmptyInput.ProvedByTheRules) why.orElseThrow()).why();
+        Emptiness.AtAField at = assertInstanceOf(Emptiness.AtAField.class, proof,
+                "the lack is at the container, which is the place a reader is sent to");
+        assertEquals(new Emptiness.AtAField.Where.In("h.items"), at.where());
+        assertInstanceOf(Emptiness.NonEmptyCollectionWithNoElement.class, at.under(),
+                "and it says which of the two facts it took to refuse the input");
+    }
+
+    @Test
+    void andTheRuleAboutTheLengthRefusesNothingOnItsOwn() {
+        assertEquals(Optional.empty(), emptinessOf(AND_AN_ELEMENT_THAT_STANDS),
+                "a list of one Item is a row this behavior takes");
+    }
+
+    private static Optional<EmptyInput> emptinessOf(String source) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source)).emptiness();
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NoRowIsTwoCasesOfOneSumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NoRowIsTwoCasesOfOneSumTest.java
@@ -1,0 +1,113 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.numeric.Count;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Numbers fixed under two cases of one sum are fixed in no row.
+ *
+ * <p>A position holds one value, so a value that is an {@code A} is not also a {@code B}, and a
+ * caller that put a number under each of them has asked about a row nothing can write. The rules
+ * were never consulted: what contradicts is the pair of assignments, which is what tells this from
+ * an input the declarations refuse.
+ *
+ * <p><b>And the answer does not carry the order the fixings arrived in.</b> Two of them said either
+ * way round are the same two, so which position a refusal names, and which two narrowings it names
+ * there, are settled by the model rather than by which question the caller asked first.
+ */
+class NoRowIsTwoCasesOfOneSumTest {
+
+    private static final String MODEL = """
+            module g
+
+            data Shared = { lo: Int, hi: Int }
+            data A = { ...Shared, x: Int }
+            data B = { ...Shared, y: Int }
+            data Q = A | B
+
+            data Holder = { q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    @Test
+    void twoCasesFixedAtOncePutTheRowNowhere() {
+        EmptyInput.TwoRefinementsAtOnePosition why = bothFixed(false);
+
+        assertEquals("h.q", why.at().toString(), "the position that cannot be both");
+        assertEquals("A", why.one().spelled());
+        assertEquals("B", why.other().spelled());
+    }
+
+    @Test
+    void andTheOrderTheyWereFixedInIsNoPartOfTheAnswer() {
+        assertEquals(bothFixed(false), bothFixed(true),
+                "the same two fixings, whichever way round they were said");
+    }
+
+    /** Both positions fixed, in one order or the other. */
+    private static EmptyInput.TwoRefinementsAtOnePosition bothFixed(boolean reversed) {
+        InputDomain read = reading(MODEL, "read");
+        NumericTerm underA = new NumericTerm.ValueOf(pathOf(read, "h.q@A.lo"));
+        NumericTerm underB = new NumericTerm.ValueOf(pathOf(read, "h.q@B.lo"));
+        Quantities asked = read.quantities(symbolsOf(MODEL));
+        Optional<EmptyInput> why = (reversed
+                ? asked.given(underB, Count.of(BigDecimal.TWO))
+                        .given(underA, Count.of(BigDecimal.ONE))
+                : asked.given(underA, Count.of(BigDecimal.ONE))
+                        .given(underB, Count.of(BigDecimal.TWO)))
+                .emptiness();
+
+        return assertInstanceOf(EmptyInput.TwoRefinementsAtOnePosition.class,
+                why.orElseThrow(() -> new AssertionError("no row is both cases, and nothing said so")),
+                "what contradicts is the pair of assignments and not anything the rules say");
+    }
+
+    private static TermPath pathOf(InputDomain read, String spelled) {
+        return read.positions().stream().map(Position::path)
+                .filter(each -> each.toString().equals(spelled))
+                .findFirst().orElseThrow(() -> new AssertionError(
+                        "no position at " + spelled + " among " + read.positions().stream()
+                                .map(Position::path).toList()));
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheInputsEmptinessHasOneOwnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheInputsEmptinessHasOneOwnerTest.java
@@ -201,9 +201,13 @@ class TheInputsEmptinessHasOneOwnerTest {
      */
     private static List<?> factorsOf(Quantities asked) {
         try {
-            java.lang.reflect.Method held = asked.getClass().getDeclaredMethod("constraints");
+            java.lang.reflect.Method held = asked.getClass()
+                    .getDeclaredMethod("constraints", StructuralContext.class);
             held.setAccessible(true);
-            Object values = ((souther.compiler.check.ConstraintState<?>) held.invoke(asked)).values();
+            // Asked assuming nothing, which is every parameter: what is being measured is that the
+            // readings of thirteen of them are held apart, and no narrowing is involved in it.
+            Object values = ((souther.compiler.check.ConstraintState<?>)
+                    held.invoke(asked, StructuralContext.NONE)).values();
             java.lang.reflect.Method factors = values.getClass().getDeclaredMethod("factors");
             factors.setAccessible(true);
             return (List<?>) factors.invoke(values);

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatAContextAssumesIsReadIntoTheRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatAContextAssumesIsReadIntoTheRulesTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a question assumes stands is read into the rules it is answered against.
+ *
+ * <p>Naming a position inside a sequence assumes the sequence holds something. That is a fact about
+ * the rows being asked about, and it is one the rules have a word for — so it belongs in the state
+ * the question is answered out of, and not only in the decision about whose rules to read.
+ *
+ * <p>Read as the second alone, a context whose prerequisites the declarations refuse comes back as
+ * a reading that leaves values, and a number the declarations tie to a length comes back running
+ * where no row of that question puts it.
+ */
+class WhatAContextAssumesIsReadIntoTheRulesTest {
+
+    private static final String NO_ROOM = """
+            module g
+
+            data Item = { n: Int }
+            data Holder = { items: List<Item> }
+                invariant empty = List.length(items) <= 0
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    private static final String COUNTED = """
+            module g
+
+            data Item = { n: Int }
+            data Holder = { items: List<Item>, count: Int }
+                invariant same = count == List.length(items)
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /**
+     * A number fixed inside a sequence the declarations leave no room in.
+     *
+     * <p>Fixing it says the sequence holds something; the rule says it holds nothing. Neither refuses
+     * anything on its own, and no row meets both.
+     */
+    @Test
+    void aNumberFixedInsideASequenceTheRulesLeaveEmptyRefusesTheInput() {
+        assertTrue(withAnElementFixed(NO_ROOM, "h.items[*].n").emptiness().isPresent(),
+                "the rule leaves the list no room and the fixing puts something in it");
+    }
+
+    /** And with nothing fixed, the empty list is a row this behavior takes. */
+    @Test
+    void andWithNothingFixedTheEmptyListIsARow() {
+        InputDomain read = reading(NO_ROOM, "read");
+
+        assertEquals(Optional.empty(), read.quantities(symbolsOf(NO_ROOM)).emptiness(),
+                "nothing asked for an element, so nothing needs the list to hold one");
+    }
+
+    /**
+     * And a number the declarations tie to the length runs where the question puts it.
+     *
+     * <p>The rule says the count is the length; the question says the list holds something. So the
+     * count is at least one — which no clause writes down and the question does.
+     */
+    @Test
+    void aNumberTiedToTheLengthKnowsTheSequenceHoldsSomething() {
+        InputDomain read = reading(COUNTED, "read");
+        NumericDomain.Bounds runs = withAnElementFixed(COUNTED, "h.items[*].n")
+                .runsBetween(new NumericTerm.ValueOf(pathOf(read, "h.count")));
+
+        assertNotNull(runs, "h.count is a number this reading answers about");
+        assertNotNull(runs.min(), () -> "h.count starts where the question puts it, and runs "
+                + runs);
+        assertEquals("1", Count.number(runs.min().at()).at().stripTrailingZeros().toPlainString(),
+                "the list holds something, so the count it equals is at least one");
+    }
+
+    /** Where {@code element} is fixed at one, which is a question about rows whose list holds it. */
+    private static Quantities withAnElementFixed(String source, String element) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source))
+                .given(new NumericTerm.ValueOf(pathOf(read, element)), Count.of(BigDecimal.ONE));
+    }
+
+    private static TermPath pathOf(InputDomain read, String spelled) {
+        return read.positions().stream().map(Position::path)
+                .filter(each -> each.toString().equals(spelled))
+                .findFirst().orElseThrow(() -> new AssertionError(
+                        "no position at " + spelled + " among " + read.positions().stream()
+                                .map(Position::path).toList()));
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatTwoIndependentStructuresComeToIsNotAChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatTwoIndependentStructuresComeToIsNotAChoiceTest.java
@@ -1,0 +1,130 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two structures a value has at once are a conjunction, and the cases of one of them are a choice.
+ *
+ * <p>The same three answers are folded two ways. Over the alternatives of one sum, one that may
+ * stand is the whole answer and every one of them has to be impossible for the sum to be; over two
+ * structures a row has both of, one that is impossible is the whole answer and every one of them has
+ * to be possible for the row to be. Folded alike, a sum this reading never finished with hides what
+ * the sum beside it proved — and which of the two a caller hears about is settled by the order the
+ * fields happen to be declared in.
+ */
+class WhatTwoIndependentStructuresComeToIsNotAChoiceTest {
+
+    /**
+     * A sum this walk turns back at, beside one whose every case the rules refuse.
+     *
+     * <p>{@code Tree} is read as far as it goes and no further, so nothing is known about the sums
+     * under it. {@code Q} is known: neither of its cases has a value, so no value of the input has
+     * one either — whatever is or is not known about the tree beside it.
+     */
+    private static final String UNREAD_BESIDE_REFUSED = """
+            module g
+
+            data Leaf = { n: Int }
+            data Node = { left: Tree, right: Tree }
+            data Tree = Leaf | Node
+
+            data A = { x: Int }
+                invariant impossible = x >= 1 && x <= 0
+            data B = { y: Int }
+                invariant impossible = y >= 1 && y <= 0
+            data Q = A | B
+
+            data Holder = { tree: Tree, q: Q }
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    /** The same two fields, declared the other way round. */
+    private static final String REFUSED_BESIDE_UNREAD =
+            UNREAD_BESIDE_REFUSED.replace("data Holder = { tree: Tree, q: Q }",
+                    "data Holder = { q: Q, tree: Tree }");
+
+    /** A sequence that cannot be empty, of an element there is no value of, beside the same
+     *  unfinished tree. */
+    private static final String UNREAD_BESIDE_A_DEAD_ELEMENT = """
+            module g
+
+            data Leaf = { n: Int }
+            data Node = { left: Tree, right: Tree }
+            data Tree = Leaf | Node
+
+            data Item = { charge: Int }
+                invariant impossible = charge >= 1 && charge <= 0
+
+            data Holder = { tree: Tree, items: List<Item> }
+                invariant atLeastOne = List.length(items) >= 1
+
+            data Ok
+
+            behavior read : (h: Holder) -> Ok
+            """;
+
+    @Test
+    void aSumNothingIsKnownAboutDoesNotHideWhatTheSumBesideItRefuses() {
+        for (String source : List.of(UNREAD_BESIDE_REFUSED, REFUSED_BESIDE_UNREAD)) {
+            assertTrue(emptinessOf(source).isPresent(),
+                    "no value of Q exists, so no row does, whatever was read of the tree");
+        }
+    }
+
+    @Test
+    void andWhichOfTheTwoIsDeclaredFirstIsNoPartOfTheAnswer() {
+        assertEquals(emptinessOf(UNREAD_BESIDE_REFUSED), emptinessOf(REFUSED_BESIDE_UNREAD),
+                "the same two structures, whichever order the fields were written in");
+    }
+
+    @Test
+    void andASequenceThatCannotBeFilledIsNotHiddenEither() {
+        assertTrue(emptinessOf(UNREAD_BESIDE_A_DEAD_ELEMENT).isPresent(),
+                "the list holds an Item and there is no Item to hold");
+    }
+
+    private static Optional<EmptyInput> emptinessOf(String source) {
+        InputDomain read = reading(source, "read");
+        return read.quantities(symbolsOf(source)).emptiness();
+    }
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static InputDomain reading(String source, String behavior) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        return InputDomain.of(spec, sigs.get(behavior), symbols, ReadAs.THE_COMPILATION_DOES);
+    }
+}


### PR DESCRIPTION
Closes #1210.

## What the issue said, and what it turned out to be

The issue reported two faults: a rule over two names a sum's cases share reached
neither of them, and the cases of a sum were met into one space so that one
refused case refused the whole input.

Both are one thing. `ReadQuantities.constraints()` met one state per rule root,
and a rule root is a reading opened under a condition rather than a fact about
every row a behavior takes. The conditions were known during the walk and
dropped: `InputDomain.quantities()` rebuilt every reading with the four-argument
`PlacedRules.of`, whose `alsoReaching` is null. So the space could say neither
*when* a root's positions exist nor *that two roots name one position*.

Measuring it turned up two more of the same shape. An element declaration the
rules refuse refused the input, though the empty sequence is a row the behavior
takes. And a question spanning two cases of one sum was answered as though both
stood — wide today, and about to become a narrow wrong answer once the relation
is carried into each case.

What that costs: `ComparisonAssessment` turns a present `emptiness()` into
`NoFeasibleInput` for every comparison and `NumericWitness` prunes every
candidate, so one uninhabited case took a behavior's whole coverage away. That is
`SearchRegion`'s left inclusion — `what reaches the border ⊆ this` — failing.

## What this does

- **`RootOpening`** says why a reading was opened: a parameter is taken, a case
  is refined, an element is inside a container. Written where the descent decides
  it, not worked back out of the path.
- **`SharedNames`** is the other half and a second fact, not a shape of the
  first: a case stands under its narrowing whether or not a name crosses it. It
  owns the correspondence between what the value above calls a position and where
  that position stands, in both directions, and `PlacedRules.Reaching` holds it
  rather than spelling it out again.
- **`StructuralContext`** is what a question assumes stands, assembled in one
  place out of the fixings, the assumptions and the question. It holds no number:
  those are interpreted under it, not made part of it. What it assumes is a kind
  (`Assumption`), so turning a context into what it means is one exhaustive
  switch and a prerequisite added later stops it compiling rather than being read
  by whichever reader its author touched.
- **`constraints(context)`** meets only the readings that context names, renames
  each once against the whole of it, and states what the context itself says
  about the values. Per edge is not enough: a clause relating a shared name of
  one sum to a shared name of another leaves either copy still spelling the other
  name the way the value above wrote it.
- **`Viability`** is what the fold reads per alternative, and one of its three
  arms proves anything. It owns both connectives: the alternatives of one sum are
  a choice (`oneOf`) and the structures a row has at once are a conjunction
  (`with`), which read alike and mean opposite things. A sum has a value wherever
  any case does; a case this walk never entered is unknown and not impossible; an
  element nothing can build refuses only a container that cannot be empty.
- **Every subject a reading names is named here**, whether or not it is a number:
  the boundary is `FieldDomains.namedBy` and not "does it have a numeric
  coordinate", so a shared name whose rules are about an order or a set of values
  is one subject across the narrowing and not two that never meet.
- Two fixings under cases no value is both of are an `EmptyInput` of their own,
  and a question about a quantity over such positions is refused rather than
  answered wide.

## What measuring found on the way

**A case the rules refuse was recorded as one that stands on its own.** The walk
asked what a case holds before it asked whether the rules leave one, so a bare
case both refused and empty came back as the plainest kind of value there is.
Harmless while it was only a reason a name did not cross; a false witness once
`Viability` reads it as whether an alternative has a value. Fixed in its own
commit, with the boundary pinned from both sides.

**A refusal carried the order the caller fixed things in.** Two numbers fixed
under two cases named their narrowings one way round or the other depending on
which arrived first. The terms are now merged in the order they are written down,
which is the settled order the other two proofs of an assignment already use.

**Removing the memo cost a row search twice over.** Taken out to get the
semantics right first, then measured: one search class had doubled. Put back as a
table keyed by context — a memo of a function, droppable without changing an
answer. Measured again in isolation, three runs each: 37.06/37.05/37.76 →
37.79/37.13/37.28 on the heaviest, 3.16 → 3.29 on the next.

## What review found, and what the cause turned out to be

**A subject was given a place to report and no place to be.** What a caller may
name was decided by whether a subject has a numeric coordinate; what a caller may
name is whether the reading has a name for it, and `namedBy` knows. The same
method used `namedBy` three lines below to tell the caller where each subject
sits. So a shared name whose rules are about an order or a set of values arrived
from the value above and from the case as two subjects that never meet.

**Three answers were folded as a choice where they are a conjunction.** A sum
this walk never finished with hid what the sum beside it refused, and which of
the two a caller heard about was settled by the order the fields were declared
in. Settling that turned up its other half: each structure is folded where it
stands and not again under every alternative of the one beside it, or a sum is
refused for what stands next to it and the proof names the wrong place.

**A context said what it assumes and the rules were told half of it.** Which
narrowings were taken decided whose rules were read and how a shared name is
spelled; that a sequence holds something decided whose rules were read and
nothing else. A fixing inside a list the declarations leave empty came back as a
reading with values in it. Under that: which number is a container's count was
asked of the number the reading measured the position at, which is a reading's
choice about that position and not the rules' record of what they count there.

## Evidence

- 11252 tests green on a clean reactor run, rebased on develop after #1213,
  #1214 and #1218.
- The four defects are pinned by models that fail without the change, and each
  measurement has its control — the same model with the rule taken out, and the
  rule read at a sibling it was not written about.
- Mutation, where a test could be written to survive one: making an unentered
  case impossible refuses a recursive model that has a value; moving the floor
  the collection fold asks for stops it refusing; putting the two branch
  questions back in the old order fails the classification test.
- Each review finding is pinned by a model that fails without its fix, and the
  last of them by two: the second needs the count to be asked of the rules, and a
  patch to `emptiness()` alone leaves it red.

## What this does not do

- No join on `ConstraintState`. A shared subject is one atom named two ways, not
  two alternatives joined, so the numeric domain still has no reading of
  alternatives — which `StatedByClauses` refuses it for its own reasons.
- No synthetic root for an empty sequence or a case that holds nothing.
- No merge with the declaration-side fold. `CardinalityTransfer` reads a fixpoint
  over a recursive type graph; this reads a finite tree with fixings and rules
  that cross parameters. The proof vocabulary is shared and no `Emptiness` arm
  was added.
- **It does not walk the product of two choices.** Each structure is folded where
  it stands, so two structures the declarations relate can be impossible together
  while each stands alone, and that is a proof nobody makes here. No proof rather
  than a proof of the wrong thing, and it is what keeps the walk from being every
  assignment of every choice in the input.
- One arm is exercised by nothing: a case the rules refuse at the sum is read as
  impossible on `obligationCases`'s contract that a refusal is sound without every
  rule being read, and no model reaches it — where every bare case is refused, the
  position's own interval proves the input empty before the fold is asked, and a
  model where only a particular sibling is refused cannot be written, since a case
  cannot be named in a rule. Untestable today rather than unreachable in
  principle, and the justification is written where the arm is.
- Nothing in the suite changed answer, so there is no report difference to
  attribute. The tutorial output lives outside this repository and is regenerated
  where it lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

