### PR TITLE
A row of a behavior with dependencies crosses with what stood in for them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -26,8 +26,7 @@ import souther.compiler.evaluate.EvaluationContext;
 import souther.compiler.evaluate.StepLimitExceeded;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.FieldTypes;
-import souther.compiler.observe.ObservedValue;
-import souther.compiler.observe.StoodIn;
+import souther.compiler.observe.RowStatements;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -969,13 +968,21 @@ public final class ExampleStatements {
      * behavior carries it to an output that has to answer the dependency itself, and a reader of the
      * examples repository is shown it beside the text. Read twice, the two would be free to observe
      * one row as two values.
+     *
+     * <p>Each value with where that value is written, and not with where the row is. A row states
+     * one for each of the dependency's arguments and one more for the answer; told only which row a
+     * value that could not be carried is on, an author is left to work out which of them nothing
+     * could be made of.
      */
-    static StoodIn.Entry carried(FixtureReader fixtures, Standin entry) {
-        List<ObservedValue> arguments = new ArrayList<>();
-        for (Object argument : entry.arguments()) {
-            arguments.add(fixtures.observed(argument));
+    static RowStatements.StandInRead.EntryRead carried(FixtureReader fixtures, Standin entry) {
+        List<RowStatements.StandInRead.Written> arguments = new ArrayList<>();
+        for (int i = 0; i < entry.arguments().length; i++) {
+            arguments.add(new RowStatements.StandInRead.Written(
+                    fixtures.observed(entry.arguments()[i]), entry.row().inputs().get(i).pos()));
         }
-        return new StoodIn.Entry(arguments, fixtures.observed(entry.answer().value()),
+        return new RowStatements.StandInRead.EntryRead(arguments,
+                new RowStatements.StandInRead.Written(fixtures.observed(entry.answer().value()),
+                        entry.row().output().pos()),
                 entry.row().pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -26,6 +26,8 @@ import souther.compiler.evaluate.EvaluationContext;
 import souther.compiler.evaluate.StepLimitExceeded;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.FieldTypes;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -959,6 +961,23 @@ public final class ExampleStatements {
      * into. */
     record Standin(Object[] arguments, Hir.FakeRow row, FixtureReader.BuiltFixture answer)
             implements Stated {}
+
+    /**
+     * One row of a built table, as something that did not read the source can hold it.
+     *
+     * <p>The one reading of what a table's row states, for the two that want it: a row of the faked
+     * behavior carries it to an output that has to answer the dependency itself, and a reader of the
+     * examples repository is shown it beside the text. Read twice, the two would be free to observe
+     * one row as two values.
+     */
+    static StoodIn.Entry carried(FixtureReader fixtures, Standin entry) {
+        List<ObservedValue> arguments = new ArrayList<>();
+        for (Object argument : entry.arguments()) {
+            arguments.add(fixtures.observed(argument));
+        }
+        return new StoodIn.Entry(arguments, fixtures.observed(entry.answer().value()),
+                entry.row().pos());
+    }
 
     /**
      * A row the table's dispatch can never return, and the row it returns instead.

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -304,11 +304,16 @@ public final class ExampleVerifier {
             // What the row states, read the one way a table's row is read. What a person is shown
             // is beside it and is this reader's own: the two are not one string, which is the
             // whole reason a machine-readable half is carried at all.
-            StoodIn.Entry carried = ExampleStatements.carried(fixtures, entry);
+            RowStatements.StandInRead.EntryRead carried =
+                    ExampleStatements.carried(fixtures, entry);
             List<String> shownInputs = new ArrayList<>();
             for (int i = 0; i < entry.arguments().length; i++) {
                 shownInputs.add(fixtures.shown(fixtures.structured(entry.arguments()[i]),
                         sig.ins().get(i).type()));
+            }
+            List<ObservedValue> inputs = new ArrayList<>();
+            for (RowStatements.StandInRead.Written argument : carried.arguments()) {
+                inputs.add(argument.value());
             }
             List<RecordedRow> alsoBy = new ArrayList<>();
             for (StatedRow stated : rows) {
@@ -317,7 +322,7 @@ public final class ExampleVerifier {
                 }
             }
             entries.add(new StandinEntry(of, behavior, first.pos(), entry.row(),
-                    carried.arguments(), carried.answer(), shownInputs,
+                    inputs, carried.answer().value(), shownInputs,
                     fixtures.shown(fixtures.structured(entry.answer().value()), sig.outputType()),
                     alsoBy));
         }
@@ -2107,14 +2112,16 @@ public final class ExampleVerifier {
         // What the table was written to answer, off the same build the dispatch above is. The rows
         // it cannot dispatch to are not among them: a reader walking these is walking answers the
         // stand-in can give, and which rows those are is the table's own rule to have decided.
-        List<StoodIn.Entry> entries = new ArrayList<>();
+        List<RowStatements.StandInRead.EntryRead> entries = new ArrayList<>();
         for (ExampleStatements.Standin entry : table.explicit()) {
             entries.add(ExampleStatements.carried(fixtures, entry));
         }
+        // The `_` row's answer, quoted where that answer is written rather than where the row
+        // begins: it is the only value the row states, and it is the one a reader is sent to.
         ExampleStatements.Standin fallback = table.fallback();
         StoodIn.Otherwise otherwise = fallback == null ? new StoodIn.Otherwise.NothingStated()
                 : new StoodIn.Otherwise.Answer(fixtures.observed(fallback.answer().value()),
-                        fallback.row().pos());
+                        fallback.row().output().pos());
         return new StoodInFor.Read(new DependencyStandin(dependency, arity, body),
                 RowStatements.StandInRead.of(dependency, fk.pos(), takes(depSig), entries,
                         otherwise));

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1984,9 +1984,9 @@ public final class ExampleVerifier {
                     // to ask of either.
                     yield new StoodInFor.Read(
                             new DependencyStandin(dependency, depSig.ins().size(), _ -> value),
-                            RowStatements.StandInRead.of(dependency, w.pos(), List.of(),
-                                    new StoodIn.Otherwise.Answer(fixtures.observed(value),
-                                            w.value().pos())));
+                            RowStatements.StandInRead.of(dependency, w.pos(), takes(depSig),
+                                    List.of(), new StoodIn.Otherwise.Answer(
+                                            fixtures.observed(value), w.value().pos())));
                 } catch (FixtureException fe) {
                     // The row does supply a fake. What failed is building its value, which is a
                     // different problem from a dependency nothing stands in for.
@@ -2005,6 +2005,23 @@ public final class ExampleVerifier {
                                 + "` table"));
             }
         };
+    }
+
+    /**
+     * What the dependency declares it takes, as the row states it.
+     *
+     * <p>Off the signature the stand-in's values were built and compared against, which is the one
+     * the table's rows were held to. What a reader of the row compares an argument at has to be
+     * that one: read again from wherever a reader can reach the declaration, it would be a second
+     * reading of the same declaration and would answer for a dependency this program does not
+     * publish at all.
+     */
+    private static List<Type> takes(Sig signature) {
+        List<Type> takes = new ArrayList<>();
+        for (BoundaryInput input : signature.ins()) {
+            takes.add(input.type());
+        }
+        return takes;
     }
 
     /** A dependency nothing was read for, and what a run that needed it is told. */
@@ -2099,7 +2116,8 @@ public final class ExampleVerifier {
                 : new StoodIn.Otherwise.Answer(fixtures.observed(fallback.answer().value()),
                         fallback.row().pos());
         return new StoodInFor.Read(new DependencyStandin(dependency, arity, body),
-                RowStatements.StandInRead.of(dependency, fk.pos(), entries, otherwise));
+                RowStatements.StandInRead.of(dependency, fk.pos(), takes(depSig), entries,
+                        otherwise));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -32,6 +32,8 @@ import souther.compiler.observe.Expectation;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.Mismatch;
 import souther.compiler.observe.RowStatement;
+import souther.compiler.observe.RowStatements;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.Verdict;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.Incompleteness;
@@ -299,10 +301,12 @@ public final class ExampleVerifier {
         List<StandinEntry> entries = new ArrayList<>();
         List<StatedRow> rows = recordedRowsOf(of, behavior, fixtures, sig);
         for (ExampleStatements.Standin entry : built.standins().explicit()) {
-            List<ObservedValue> inputs = new ArrayList<>();
+            // What the row states, read the one way a table's row is read. What a person is shown
+            // is beside it and is this reader's own: the two are not one string, which is the
+            // whole reason a machine-readable half is carried at all.
+            StoodIn.Entry carried = ExampleStatements.carried(fixtures, entry);
             List<String> shownInputs = new ArrayList<>();
             for (int i = 0; i < entry.arguments().length; i++) {
-                inputs.add(fixtures.observed(entry.arguments()[i]));
                 shownInputs.add(fixtures.shown(fixtures.structured(entry.arguments()[i]),
                         sig.ins().get(i).type()));
             }
@@ -312,8 +316,8 @@ public final class ExampleVerifier {
                     alsoBy.add(stated.handle());
                 }
             }
-            entries.add(new StandinEntry(of, behavior, first.pos(), entry.row(), inputs,
-                    fixtures.observed(entry.answer().value()), shownInputs,
+            entries.add(new StandinEntry(of, behavior, first.pos(), entry.row(),
+                    carried.arguments(), carried.answer(), shownInputs,
                     fixtures.shown(fixtures.structured(entry.answer().value()), sig.outputType()),
                     alsoBy));
         }
@@ -1275,30 +1279,24 @@ public final class ExampleVerifier {
     /**
      * What the row states, as something that did not read the source can hold it.
      *
-     * <p>Read once, here, from what this evaluation already has: the inputs it built and observed,
-     * and what it made of the expectation. Read a second time somewhere else, the helpers a fixture
-     * names would be applied a second time — which is counted twice against the row and does
-     * whatever they do twice.
+     * <p>Read once, from what this evaluation already has: what it read of each stand-in, the inputs
+     * it built and observed, and what it made of the expectation. Read a second time somewhere else,
+     * the helpers a fixture names would be applied a second time — which is counted twice against
+     * the row and does whatever they do twice.
      *
-     * <p>In one order, so that what a reader is told is settled rather than depending on which of
-     * two things was noticed first. What the behavior needs stood in for comes before the values,
-     * because a row of a behavior that takes something injected does not state a runnable thing at
-     * all — what stands in for the dependency is the rest of the obligation, and a reader given the
-     * values alone would apply the behavior with nothing to answer the dependency with. Then the
-     * inputs in the order they are written, then the expectation.
+     * <p>What the statement is made of them is not decided here. Whether these are values a reader
+     * can be given, and which of them stopped the row being handed over, is one question with one
+     * owner ({@link RowStatements#read}) — and that owner is somewhere this run cannot be named
+     * from, so what the row states cannot come to depend on what this run found to apply the
+     * behavior with.
      */
-    private static RowStatement statementOf(ExampleTarget target, List<ObservedValue> inputs,
+    private static RowStatement statementOf(List<StoodInFor> standIns, List<ObservedValue> inputs,
                                             Expectation stated) {
-        if (!target.requirements().isEmpty()) {
-            List<ValueName.Behavior> dependencies = new ArrayList<>();
-            for (BehaviorRequirement required : target.requirements()) {
-                dependencies.add(required.dependency());
-            }
-            return new RowStatement.RequiresStandIns(dependencies);
+        List<RowStatements.StandInRead> read = new ArrayList<>();
+        for (StoodInFor standIn : standIns) {
+            read.add(standIn.stated());
         }
-        // What a statement of values is, is not decided here: whether these are values a reader can
-        // be given is one question, and what answers it is what a statement is made by.
-        return RowStatement.of(inputs, stated);
+        return RowStatements.read(read, inputs, stated);
     }
 
     /** What the row turned out to be, from the state its worker left. */
@@ -1555,7 +1553,14 @@ public final class ExampleVerifier {
             state.failed(FailurePhase.EXPECTED_FIXTURE);
             return;
         }
-        state.statement = statementOf(target, state.inputs, stated);
+        // What stands in for each dependency, read here and not where a run needs it. What the row
+        // states of a stand-in and what a run applies the behavior with are two halves of one
+        // reading — the fixtures a `with` or a table names are applied once, and both halves are
+        // what that one application produced. What is wrong with one is not said here: a row nothing
+        // was going to run is not a row a missing stand-in stops, and saying it here would report a
+        // behavior with no implementation as a behavior with no fake.
+        List<StoodInFor> standIns = readStandIns(fixtures, target, row);
+        state.statement = statementOf(standIns, state.inputs, stated);
         state.got(Stage.FIXTURES_VALIDATED);
         // What the row states, held to what the behavior declares of what it answers. Before
         // anything is applied, and so before the row is let go for having nothing to apply it: the
@@ -1594,10 +1599,10 @@ public final class ExampleVerifier {
             }
             case Handing.MayApply(Answerer.Answer.Something something) -> applies = something;
         }
-        List<DependencyStandin> standins = resolveFakes(fixtures, target, row, out);
+        List<DependencyStandin> standins = applyingWith(standIns, out);
         if (standins == null) {
             state.failed(FailurePhase.FAKE_RESOLUTION);
-            return;   // a fake was missing/invalid; the diagnostic is already reported
+            return;   // a fake was missing/invalid, and what a run is told about it is now said
         }
         Answerer.Applying applying;
         try {
@@ -1866,30 +1871,93 @@ public final class ExampleVerifier {
     // --- fakes for what a behavior depends on ---------------------------------------------------
 
     /**
-     * What stands in for each of the target's requirements, in the order its constructor takes them;
-     * null (with a diagnostic reported) when one is missing or invalid.
+     * What was read for one of the behavior's dependencies.
+     *
+     * <p>Two halves of one reading. What a run hands the behavior is an instance the loader the
+     * implementation came from can be constructed with, and what the row states of the stand-in is
+     * values; both come of building what was written, and building it twice would apply the helpers
+     * a fixture names twice — counted twice against the row and doing whatever they do twice.
+     */
+    private sealed interface StoodInFor {
+
+        /** What the row states of it, which it has whether or not anything is going to run it. */
+        RowStatements.StandInRead stated();
+
+        /** It was read: this is what a run applies the behavior with, and what the row states. */
+        record Read(DependencyStandin runtime,
+                    RowStatements.StandInRead stated) implements StoodInFor {}
+
+        /**
+         * Nothing was read that states what the dependency answers.
+         *
+         * <p>{@code saying} is what a run that needed it is told, said where that run is and not
+         * here: a row nothing applies the behavior for is not a row a missing stand-in stops. Empty
+         * where what is wrong is wrong about a table — that is said once where the table is written,
+         * and every row reaching it would otherwise repeat it.
+         */
+        record NotRead(RowStatements.StandInRead stated,
+                       List<Diagnostic> saying) implements StoodInFor {
+
+            public NotRead {
+                saying = List.copyOf(saying);
+            }
+        }
+    }
+
+    /**
+     * What stands in for each of the target's requirements, in the order its constructor takes them,
+     * up to and including the first that could not be read.
+     *
+     * <p>Stopping there rather than reading the rest: what a row states of its stand-ins is the
+     * first one that could not be handed over, and a run needing them is stopped by the first one
+     * missing. Reading past it would build fixtures for a row that is already not going to run.
+     */
+    private List<StoodInFor> readStandIns(FixtureReader fixtures, ExampleTarget target,
+                                          Hir.ExampleRow row) {
+        List<StoodInFor> standIns = new ArrayList<>(target.requirements().size());
+        for (BehaviorRequirement req : target.requirements()) {
+            StoodInFor standIn = readStandIn(fixtures, target.name(), req, row);
+            standIns.add(standIn);
+            if (standIn instanceof StoodInFor.NotRead) {
+                break;
+            }
+        }
+        return standIns;
+    }
+
+    /**
+     * What a run applies the behavior with, from what was read; null where a stand-in it needs was
+     * not, having said so.
+     *
+     * <p>Where what a run is told about a missing stand-in is said. What is wrong with one is a
+     * fact whichever row met it, and this is the one place a row is stopped by it — so a row that
+     * was never going to be applied is not told about it at all.
+     */
+    private static List<DependencyStandin> applyingWith(List<StoodInFor> standIns,
+                                                        List<Diagnostic> out) {
+        List<DependencyStandin> runtime = new ArrayList<>(standIns.size());
+        for (StoodInFor standIn : standIns) {
+            switch (standIn) {
+                case StoodInFor.NotRead(RowStatements.StandInRead _, List<Diagnostic> saying) -> {
+                    out.addAll(saying);
+                    return null;
+                }
+                case StoodInFor.Read(DependencyStandin applies, RowStatements.StandInRead _) ->
+                        runtime.add(applies);
+            }
+        }
+        return runtime;
+    }
+
+    /**
+     * What stands in for one requirement, read once.
      *
      * <p>What a stand-in answers and nothing more. Making it something the behavior can be constructed
      * with is a fact about the loader the implementation comes from, so it is the answerer's
      * ({@link Answerer#applying}) — and reading a row's fakes is the same reading whoever that is.
      */
-    private List<DependencyStandin> resolveFakes(FixtureReader fixtures, ExampleTarget target,
-                                                 Hir.ExampleRow row, List<Diagnostic> out) {
-        List<BehaviorRequirement> reqs = target.requirements();
-        List<DependencyStandin> standins = new ArrayList<>(reqs.size());
-        for (BehaviorRequirement req : reqs) {
-            DependencyStandin standin = resolveFake(fixtures, target.name(), req, row, out);
-            if (standin == null) {
-                return null;
-            }
-            standins.add(standin);
-        }
-        return standins;
-    }
-
-    private DependencyStandin resolveFake(FixtureReader fixtures, String target,
-                                          BehaviorRequirement req, Hir.ExampleRow row,
-                                          List<Diagnostic> out) {
+    private StoodInFor readStandIn(FixtureReader fixtures, String target,
+                                   BehaviorRequirement req, Hir.ExampleRow row) {
         // The behavior, as the declaration it is. What a requirement is, is settled where the
         // `depends on` clause is read; the name this module happens to reach it by is not asked for
         // here and never decides which behavior a stand-in is built against.
@@ -1900,9 +1968,8 @@ public final class ExampleVerifier {
             // Nothing this module can name says what it answers, which is not a missing fake. A
             // dependency reaches here only after the check accepted the clause that named it, so a
             // signature that is not here is a module that did not build far enough to have one.
-            out.add(fakeMissingDiag(target, req, row, "`" + depName
+            return notRead(dependency, row.pos(), fakeMissingDiag(target, req, row, "`" + depName
                     + "` has no signature to build a stand-in against"));
-            return null;
         }
         BoundaryOutput outType = depSig.out();
         // What stands in, and where it was written, is ExampleProvisioning's; building the value it
@@ -1912,27 +1979,39 @@ public final class ExampleVerifier {
                 Hir.With w = onTheRow.written();
                 try {
                     Object value = fixtures.buildFixture(w.value(), outType).value();
-                    // a constant: it ignores its inputs
-                    yield new DependencyStandin(dependency, depSig.ins().size(), _ -> value);
+                    // A `with` lists nothing and answers everything: one shape for the two ways of
+                    // writing what a dependency answers, so that a reader of a row has one question
+                    // to ask of either.
+                    yield new StoodInFor.Read(
+                            new DependencyStandin(dependency, depSig.ins().size(), _ -> value),
+                            RowStatements.StandInRead.of(dependency, w.pos(), List.of(),
+                                    new StoodIn.Otherwise.Answer(fixtures.observed(value),
+                                            w.value().pos())));
                 } catch (FixtureException fe) {
                     // The row does supply a fake. What failed is building its value, which is a
                     // different problem from a dependency nothing stands in for.
-                    out.add(Diagnostic.at(w.value().pos())
+                    yield notRead(dependency, w.value().pos(), Diagnostic.at(w.value().pos())
                             .say(new ExampleMessage.TheFakeValueCouldNotBeBuilt(depName,
                                     fe.getMessage()))
                             .build());
-                    yield null;
                 }
             }
             case ExampleProvisioning.Standin.InTheModule inTheModule ->
                     tableStandin(fixtures, inTheModule.table().read(), dependency, depSig);
             case ExampleProvisioning.Standin.Nothing _ -> {
                 String spelt = spelling(dependency);
-                out.add(fakeMissingDiag(target, req, row, "add `with " + spelt
-                        + " = ...` on the row, or a `fake " + spelt + "` table"));
-                yield null;
+                yield notRead(dependency, row.pos(), fakeMissingDiag(target, req, row,
+                        "add `with " + spelt + " = ...` on the row, or a `fake " + spelt
+                                + "` table"));
             }
         };
+    }
+
+    /** A dependency nothing was read for, and what a run that needed it is told. */
+    private static StoodInFor notRead(ValueName.Behavior dependency, SourcePos at,
+                                      Diagnostic... saying) {
+        return new StoodInFor.NotRead(RowStatements.StandInRead.nothingRead(dependency, at),
+                List.of(saying));
     }
 
     /** How to write {@code dependency} here, for a hint that shows what to type. */
@@ -1966,9 +2045,10 @@ public final class ExampleVerifier {
     /** Precomputes a function fake's input→output table (decoded fixtures) as a tuple-keyed lookup, and
      * answers by matching an actual input tuple by value equality, falling back to the {@code _}
      * default or a miss. Works for any arity: a 0/1-input dep's tuple has 0/1 elements, a 2+-input
-     * dep's has one per parameter (issue #57). */
-    private DependencyStandin tableStandin(FixtureReader fixtures, Hir.Fake fk,
-                                           ValueName.Behavior dependency, Sig depSig) {
+     * dep's has one per parameter (issue #57). What the row states of the table is read off the same
+     * build, so the two say what one table was written to answer. */
+    private StoodInFor tableStandin(FixtureReader fixtures, Hir.Fake fk,
+                                    ValueName.Behavior dependency, Sig depSig) {
         // The dependency's own signature, which admitted what its boundary carries. Rebuilding the
         // types from what it declared would put them through that walk a second time, and a
         // stand-in stands where the behavior does.
@@ -1980,7 +2060,7 @@ public final class ExampleVerifier {
         ExampleStatements.BuiltTable built =
                 ExampleStatements.standins(fixtures, fk, paramTypes, depSig.out(), new ArrayList<>());
         if (built == null) {
-            return null;
+            return notRead(dependency, fk.pos());
         }
         if (!ExampleStatements.notKept(ensures, fk, built).isEmpty()) {
             // A table stating what the dependency declares cannot happen is not one to stand in
@@ -1989,7 +2069,7 @@ public final class ExampleVerifier {
             // table is written. Running against it would put the rest of this behavior in a state
             // the model rules out, and everything the row then reported would be about a run that
             // cannot happen.
-            return null;
+            return notRead(dependency, fk.pos());
         }
         // The dispatch, which is what a row runs against. What the table was written with and cannot
         // dispatch to is said where the fake is written, and is nothing a stand-in can answer with.
@@ -2007,7 +2087,19 @@ public final class ExampleVerifier {
             }
             return answering.answer().value();
         };
-        return new DependencyStandin(dependency, arity, body);
+        // What the table was written to answer, off the same build the dispatch above is. The rows
+        // it cannot dispatch to are not among them: a reader walking these is walking answers the
+        // stand-in can give, and which rows those are is the table's own rule to have decided.
+        List<StoodIn.Entry> entries = new ArrayList<>();
+        for (ExampleStatements.Standin entry : table.explicit()) {
+            entries.add(ExampleStatements.carried(fixtures, entry));
+        }
+        ExampleStatements.Standin fallback = table.fallback();
+        StoodIn.Otherwise otherwise = fallback == null ? new StoodIn.Otherwise.NothingStated()
+                : new StoodIn.Otherwise.Answer(fixtures.observed(fallback.answer().value()),
+                        fallback.row().pos());
+        return new StoodInFor.Read(new DependencyStandin(dependency, arity, body),
+                RowStatements.StandInRead.of(dependency, fk.pos(), entries, otherwise));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/observe/Comparisons.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Comparisons.java
@@ -34,4 +34,27 @@ public final class Comparisons {
         }
         return new ValueMatch(types).verdict(stated, answered, answers);
     }
+
+    /**
+     * Whether {@code left} and {@code right} are the same value, read with {@code types} and at
+     * {@code position}.
+     *
+     * <p>The other question, and it is not the one above with a statement made up for one side. A
+     * statement is what a text wrote and carries what it wrote it as; two values that were both
+     * arrived at wrote nothing, and holding one of them up as what was expected would answer a
+     * question about a text where there is no text — a value with parts, offered as a value with
+     * none, is read as a value of no type at all and is the same as nothing.
+     *
+     * <p>Yes or no, and the same walk. What being the same value means — a set is its elements, a
+     * decimal is the amount it stands for, a value is of its type first — is answered for both
+     * questions in one place, so a fake's table picks the row an execution picks.
+     */
+    public static boolean same(ObservedValue left, ObservedValue right, ValueTypes types,
+                               Position position) {
+        if (left == null || right == null || types == null || position == null) {
+            throw new IllegalArgumentException("two values are the same or not, read with what the"
+                    + " declarations say and where they stand");
+        }
+        return new ValueMatch(types).same(left, right, position);
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/Comparisons.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Comparisons.java
@@ -48,6 +48,16 @@ public final class Comparisons {
      * <p>Yes or no, and the same walk. What being the same value means — a set is its elements, a
      * decimal is the amount it stands for, a value is of its type first — is answered for both
      * questions in one place, so a fake's table picks the row an execution picks.
+     *
+     * <p>Of two values that are there, which is what makes yes or no the whole of the answer. An
+     * observation that stopped, or that could not read what it met, is not a value: what stands
+     * where it stopped may be anything, including the value it is being compared with. Answered
+     * "no" for one, this would hand a caller the difference between two values where what it has is
+     * the absence of one — and the caller would go on to whatever it does when two values differ.
+     * That is what {@link #verdict} says as {@code UNREADABLE} rather than as a value that did not
+     * hold, and it is refused here because a yes-or-no has nowhere to say it.
+     *
+     * @throws IllegalArgumentException if either side is not a value that is there in full
      */
     public static boolean same(ObservedValue left, ObservedValue right, ValueTypes types,
                                Position position) {
@@ -55,6 +65,19 @@ public final class Comparisons {
             throw new IllegalArgumentException("two values are the same or not, read with what the"
                     + " declarations say and where they stand");
         }
+        // Held to what admits a value that is there and not to what a snapshot keeps. Whether two
+        // values are the same does not depend on how much of one may be carried somewhere, and a
+        // large whole value refused here would put that question inside this one.
+        refuseWhatIsNotThere(left, "the first");
+        refuseWhatIsNotThere(right, "the second");
         return new ValueMatch(types).same(left, right, position);
+    }
+
+    private static void refuseWhatIsNotThere(ObservedValue value, String which) {
+        Incompleteness.Code stopped = Limits.UNBOUNDED.stoppedBy(value);
+        if (stopped != null) {
+            throw new IllegalArgumentException(which + " of two values being compared is not a"
+                    + " value: " + stopped);
+        }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/Expectation.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Expectation.java
@@ -11,7 +11,7 @@ import souther.compiler.types.TypeSymbol;
  * evidence and still evidence.
  *
  * <p>What it states and nothing more. Whether an answer keeps it is asked of what is bound to the
- * declarations the row was read against ({@code CheckedRow.Reproducible#holds}), and not of this:
+ * declarations the row was read against ({@code CheckedRow.SelfContained#holds}), and not of this:
  * a comparison reachable from a statement is one a reader can make with declarations of its own,
  * and two readings of one row would then answer differently about one answer — which is the whole
  * of what asking the language rather than the reader means.

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatement.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatement.java
@@ -1,5 +1,6 @@
 package souther.compiler.observe;
 
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ValueName;
 
 import java.util.List;
@@ -14,10 +15,10 @@ import java.util.List;
  *
  * <p>Three arms, and the second is three. A row hands over values or it does not, which is the one
  * thing a reader has to know before it can do anything with the row; why it does not is the second
- * question, and each answer to it has a different owner — what the behavior requires, what a limit
- * keeps, and what read the row. A row that cannot be handed over must not arrive as no row all the
- * same: a reader given nothing for it would count a row it never saw among the ones it walked and
- * found nothing wrong with.
+ * question, and each answer to it names which of the row's values could not be handed over — one a
+ * stand-in states, one the row states itself — or says that nothing read the row at all. A row that
+ * cannot be handed over must not arrive as no row all the same: a reader given nothing for it would
+ * count a row it never saw among the ones it walked and found nothing wrong with.
  *
  * <p>The third is not one of those. {@link StoppedBeforeItsValues} is how far an evaluation got and
  * not something about the row, and it is beside {@link NotStated} rather than among its arms
@@ -31,17 +32,18 @@ import java.util.List;
 public sealed interface RowStatement {
 
     /**
-     * The inputs the row hands over and what it states of the answer.
+     * What the row hands over: what stands in for each dependency, the inputs, and what it states of
+     * the answer.
      *
-     * <p>Every value here is whole and is one these limits keep. Made by {@link #of}, which is what
-     * decides that: a value read whole is not always one a snapshot may carry, and the two
-     * questions answered in two places would be a {@code Stated} that means one thing where it was
-     * built and another where it was read.
+     * <p>Every value here is whole and is one these limits keep. Made by {@link RowStatements#read},
+     * which is what decides that: a value read whole is not always one a snapshot may carry, and the
+     * two questions answered in two places would be a {@code Stated} that means one thing where it
+     * was built and another where it was read.
      *
      * <p>A class and not a record, so that the one rule about what these hold cannot be gone round.
      * A record's canonical constructor is as public as the record, and a value larger than what is
      * kept would be written straight past the reading that decides what a row states; made only by
-     * {@link #of}, it is that reading whichever side makes one.
+     * {@link RowStatements#read}, it is that reading whichever side makes one.
      *
      * <p>A value all the same, and it says so itself. What a query stops work on is whether an
      * answer equals the one before it, and this rides inside one — so a statement that answered
@@ -50,12 +52,33 @@ public sealed interface RowStatement {
      */
     final class Stated implements RowStatement {
 
+        private final List<StoodIn> standIns;
         private final List<ObservedValue> inputs;
         private final Expectation expects;
 
-        private Stated(List<ObservedValue> inputs, Expectation expects) {
+        private Stated(List<StoodIn> standIns, List<ObservedValue> inputs, Expectation expects) {
+            this.standIns = List.copyOf(standIns);
             this.inputs = List.copyOf(inputs);
             this.expects = expects;
+        }
+
+        /** For the reading that decides what a row states, having decided it. */
+        static Stated of(List<StoodIn> standIns, List<ObservedValue> inputs, Expectation expects) {
+            return new Stated(standIns, inputs, expects);
+        }
+
+        /**
+         * What stands in for each of the behavior's dependencies, in the order it requires them.
+         *
+         * <p>Empty for a behavior that depends on nothing, which is a behavior with nothing to stand
+         * in for rather than a row that left something out.
+         *
+         * <p>Beside the inputs and not among them. A dependency is not an argument: the inputs are
+         * what the row hands the behavior, and these are what answers the behavior while it runs
+         * with them.
+         */
+        public List<StoodIn> standIns() {
+            return standIns;
         }
 
         /** What the row hands the behavior, in the order it takes them. */
@@ -70,18 +93,18 @@ public sealed interface RowStatement {
 
         @Override
         public boolean equals(Object other) {
-            return other instanceof Stated it && inputs.equals(it.inputs)
-                    && expects.equals(it.expects);
+            return other instanceof Stated it && standIns.equals(it.standIns)
+                    && inputs.equals(it.inputs) && expects.equals(it.expects);
         }
 
         @Override
         public int hashCode() {
-            return inputs.hashCode() * 31 + expects.hashCode();
+            return (standIns.hashCode() * 31 + inputs.hashCode()) * 31 + expects.hashCode();
         }
 
         @Override
         public String toString() {
-            return inputs + " -> " + expects;
+            return (standIns.isEmpty() ? "" : standIns + " | ") + inputs + " -> " + expects;
         }
     }
 
@@ -94,25 +117,72 @@ public sealed interface RowStatement {
     sealed interface NotStated extends RowStatement {}
 
     /**
-     * The behavior takes something injected, so the row states more than values.
+     * What stands in for a dependency the behavior takes could not be handed over, and why.
      *
      * <p>A row runs against a bound implementation, and where the behavior depends on something
-     * injected, what stands in for that dependency is the rest of what makes the row runnable.
-     * Handing over the inputs and the expectation alone would not be handing over the row: a reader
-     * whose dependency is an import has nothing to answer that import with, and one that applied the
-     * behavior anyway would be reporting what a run that cannot happen answered.
+     * injected, what stands in for that dependency is the rest of what makes the row runnable. What
+     * a stand-in states is written down — a value on the row, or a table beside it — so it crosses
+     * the way the row's own values cross, and a stand-in holding a value that could not be is a row
+     * that hands over nothing: a reader given the inputs alone would apply the behavior with nothing
+     * to answer its dependency with.
      *
-     * <p>So the row crosses as itself and says what is missing. Which dependencies those are is what
-     * the behavior requires, in the order it takes them.
+     * <p>The first such stand-in in the order the row is read: what stands in, in the order the
+     * behavior requires it, then the inputs, then the expectation. So this says what stopped the
+     * statement being made and not everything that is wrong with the row.
+     *
+     * <p>{@code at} is where a reader is sent, and which place that is follows from {@link #why}.
+     * A value that could not be carried is quoted where that value is written — a table states one
+     * on each of its rows and one more where it answers what it does not list, and naming the table
+     * would leave a reader to find which of them nothing could be made of. A place rather than a
+     * {@link Side}, because what a stand-in states is not a list a place in it can be counted along.
      */
-    record RequiresStandIns(List<ValueName.Behavior> dependencies) implements NotStated {
+    record StandInUnavailable(ValueName.Behavior dependency, SourcePos at,
+                              Why why) implements NotStated {
 
-        public RequiresStandIns {
-            dependencies = List.copyOf(dependencies);
-            if (dependencies.isEmpty()) {
-                throw new IllegalArgumentException("a row that needs nothing stood in for states"
-                        + " its values");
+        public StandInUnavailable {
+            if (dependency == null || at == null || why == null) {
+                throw new IllegalArgumentException("a stand-in that could not be handed over is one"
+                        + " dependency's, is quoted somewhere, and says why");
             }
+        }
+
+        /**
+         * Why what stands in for the dependency could not be handed over.
+         *
+         * <p>Two, and they are not one fact said twice. A value that was read and cannot be carried
+         * is a fact about that value; nothing having been read is a fact about the compile, and
+         * there is no value in it for anything to be said about. One reason covering both would
+         * have a reader that wants to quote the value ask first whether there is one.
+         */
+        sealed interface Why {
+
+            /**
+             * It states a value that could not be carried: larger than what is kept, or not one
+             * that could be read.
+             *
+             * <p>The same two a row's own values are refused for, said with the same codes. What a
+             * reader may be given is one question, and a stand-in's values are values.
+             */
+            record AValueOfIt(Incompleteness.Code code) implements Why {
+
+                public AValueOfIt {
+                    if (code != Incompleteness.Code.VALUE_TRUNCATED
+                            && code != Incompleteness.Code.VALUE_UNREADABLE) {
+                        throw new IllegalArgumentException(
+                                code + " is not something that happens to a value");
+                    }
+                }
+            }
+
+            /**
+             * Nothing this compile read states what the dependency answers.
+             *
+             * <p>Nothing stands in for it, or what does would not build. Either is said where the
+             * row is written the moment anything runs the row, so a program the language accepted
+             * holds this only for a row nothing was going to run — and a reader of one is told that
+             * the row states no stand-in, rather than being handed an empty one to run against.
+             */
+            record NothingWasRead() implements Why {}
         }
     }
 
@@ -198,46 +268,4 @@ public sealed interface RowStatement {
         record TheExpectation() implements Side {}
     }
 
-    /**
-     * What a row with these values states.
-     *
-     * <p>The one place a statement is made of values, so that what {@link Stated} means is decided
-     * once. A value that is not there in full, and one larger than what is kept, are both values a
-     * reader cannot be given — the first because nothing here has it, the second because carrying
-     * it would carry a value nobody wrote — and both come back as {@link Incomplete} saying which
-     * and why.
-     *
-     * <p>Held to {@link Limits#DEFAULT} and not to limits a caller chooses. What a row's inputs are
-     * observed under is that one, so a row's two halves are held to one size; and a type whose
-     * meaning came from an argument would mean one thing where it was made and another where it was
-     * read, which is what a reader of a {@link Stated} would then have to ask about before it could
-     * do anything with the values. How much is kept is a thing to change, in the one place it is
-     * written; whose choice it is, is not.
-     */
-    static RowStatement of(List<ObservedValue> inputs, Expectation expects) {
-        return under(inputs, expects, Limits.DEFAULT);
-    }
-
-    private static RowStatement under(List<ObservedValue> inputs, Expectation expects,
-                                      Limits kept) {
-        if (expects == null) {
-            throw new IllegalArgumentException("a row states something of the answer");
-        }
-        for (int i = 0; i < inputs.size(); i++) {
-            Incompleteness.Code stopped = kept.stoppedBy(inputs.get(i));
-            if (stopped != null) {
-                return new Incomplete(new Side.AnInput(i), stopped);
-            }
-        }
-        // What the row states of the answer is read whole, so that a comparison is made against what
-        // was written; whether it may be carried is asked of the same limits an input is held to, so
-        // that one row's two halves are held to one size.
-        Incompleteness.Code stopped = switch (expects) {
-            case Expectation.TheValue(Asserted value) -> kept.stoppedBy(value);
-            // A case is a name. Nothing about it can be too large or fail to be read.
-            case Expectation.TheCase _ -> null;
-        };
-        return stopped != null ? new Incomplete(new Side.TheExpectation(), stopped)
-                : new Stated(inputs, expects);
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatement.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatement.java
@@ -154,7 +154,7 @@ public sealed interface RowStatement {
          * there is no value in it for anything to be said about. One reason covering both would
          * have a reader that wants to quote the value ask first whether there is one.
          */
-        sealed interface Why {
+        public sealed interface Why {
 
             /**
              * It states a value that could not be carried: larger than what is kept, or not one

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
@@ -1,6 +1,7 @@
 package souther.compiler.observe;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -87,10 +88,12 @@ public final class RowStatements {
          * states what it is asked. The first that could not be carried is what comes back, so what
          * is said is what stopped the stand-in being handed over rather than everything about it.
          *
-         * @param at where what stands in is written, which is what the stand-in is quoted at; where
-         *           a value of it could not be carried, the place said is that value's own
+         * @param at    where what stands in is written, which is what the stand-in is quoted at;
+         *              where a value of it could not be carried, the place said is that value's own
+         * @param takes what the dependency declares it takes, read where this stand-in's values were
+         *              built and compared against
          */
-        static StandInRead of(ValueName.Behavior dependency, SourcePos at,
+        static StandInRead of(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
                               List<StoodIn.Entry> entries, StoodIn.Otherwise otherwise) {
             if (dependency == null || at == null || otherwise == null) {
                 throw new IllegalArgumentException("a stand-in is one dependency's, written"
@@ -114,7 +117,7 @@ public final class RowStatements {
                     return unavailable(dependency, where, stopped);
                 }
             }
-            return new Available(StoodIn.of(dependency, at, entries, otherwise));
+            return new Available(StoodIn.of(dependency, at, takes, entries, otherwise));
         }
 
         private static StandInRead unavailable(ValueName.Behavior dependency, SourcePos at,

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
@@ -1,0 +1,172 @@
+package souther.compiler.observe;
+
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What a row states, made once from what was read of it.
+ *
+ * <p>The one place a statement is made, so that what {@link RowStatement.Stated} means is decided
+ * once. A value that is not there in full, and one larger than what is kept, are both values a
+ * reader cannot be given — the first because nothing here has it, the second because carrying it
+ * would carry a value nobody wrote — and a row holding one of them hands over nothing and says
+ * which value and why.
+ *
+ * <p>Held to {@link Limits#DEFAULT} and not to limits a caller chooses. What a row's inputs are
+ * observed under is that one, so everything a row hands over is held to one size; and a statement
+ * whose meaning came from an argument would mean one thing where it was made and another where it
+ * was read, which is what a reader of a statement would then have to ask about before it could do
+ * anything with the values. How much is kept is a thing to change, in the one place it is written;
+ * whose choice it is, is not.
+ *
+ * <p>What is read here is what the row wrote, and nothing else reaches it. Whether this compile had
+ * anything to apply the behavior with is not part of what the row states: a row of a behavior no
+ * implementation was found for states the same values as one of a behavior that ran, and a snapshot
+ * whose rows said otherwise would be publishing the compile it was taken from. Kept that way by
+ * where this stands rather than by a rule to keep: this package is not one the run that applies a
+ * behavior can be named from, so a statement made here cannot ask what applied anything.
+ */
+public final class RowStatements {
+
+    private RowStatements() {}
+
+    /**
+     * What was read of one dependency's stand-in.
+     *
+     * <p>Between the reading that builds a stand-in's values and the statement made of them, and
+     * nothing further. The values a stand-in states are built where a fixture is read, and whether
+     * they are values a row can hand over is decided here — so the two are one step apart, and a
+     * caller that had to decide the second for itself would be a second place that knew what a row
+     * may carry.
+     */
+    public sealed interface StandInRead {
+
+        /** It states values that can be handed over, and this is what it states. */
+        record Available(StoodIn stoodIn) implements StandInRead {
+
+            public Available {
+                if (stoodIn == null) {
+                    throw new IllegalArgumentException("a stand-in that was read is what it states");
+                }
+            }
+        }
+
+        /** It could not be handed over, and this is where a reader is sent and why. */
+        record Unavailable(ValueName.Behavior dependency, SourcePos at,
+                           RowStatement.StandInUnavailable.Why why) implements StandInRead {
+
+            public Unavailable {
+                if (dependency == null || at == null || why == null) {
+                    throw new IllegalArgumentException("a stand-in that could not be handed over"
+                            + " names the dependency, where to look, and why");
+                }
+            }
+        }
+
+        /**
+         * Nothing was read that states what {@code dependency} answers, quoted at {@code at}.
+         *
+         * <p>Beside {@link #of} and not among its answers: that reads what a stand-in states, and
+         * this is a caller with nothing to read it. Which of the two a reading is, is the reader's
+         * to say — a factory answering it from an empty table would make a stand-in that lists
+         * nothing and a dependency nothing stands in for one thing.
+         */
+        static StandInRead nothingRead(ValueName.Behavior dependency, SourcePos at) {
+            return new Unavailable(dependency, at,
+                    new RowStatement.StandInUnavailable.Why.NothingWasRead());
+        }
+
+        /**
+         * What a stand-in stating these was read as.
+         *
+         * <p>Every value it states, in the order it states them: each entry as it is written, its
+         * arguments before the answer it states for them, and then what it answers where no entry
+         * states what it is asked. The first that could not be carried is what comes back, so what
+         * is said is what stopped the stand-in being handed over rather than everything about it.
+         *
+         * @param at where what stands in is written, which is what the stand-in is quoted at; where
+         *           a value of it could not be carried, the place said is that value's own
+         */
+        static StandInRead of(ValueName.Behavior dependency, SourcePos at,
+                              List<StoodIn.Entry> entries, StoodIn.Otherwise otherwise) {
+            if (dependency == null || at == null || otherwise == null) {
+                throw new IllegalArgumentException("a stand-in is one dependency's, written"
+                        + " somewhere, and answers what it is not written to");
+            }
+            for (StoodIn.Entry entry : entries) {
+                for (ObservedValue argument : entry.arguments()) {
+                    Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(argument);
+                    if (stopped != null) {
+                        return unavailable(dependency, entry.at(), stopped);
+                    }
+                }
+                Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(entry.answer());
+                if (stopped != null) {
+                    return unavailable(dependency, entry.at(), stopped);
+                }
+            }
+            if (otherwise instanceof StoodIn.Otherwise.Answer(ObservedValue value, SourcePos where)) {
+                Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(value);
+                if (stopped != null) {
+                    return unavailable(dependency, where, stopped);
+                }
+            }
+            return new Available(StoodIn.of(dependency, at, entries, otherwise));
+        }
+
+        private static StandInRead unavailable(ValueName.Behavior dependency, SourcePos at,
+                                               Incompleteness.Code stopped) {
+            return new Unavailable(dependency, at,
+                    new RowStatement.StandInUnavailable.Why.AValueOfIt(stopped));
+        }
+    }
+
+    /**
+     * What the row states, from what was read of it.
+     *
+     * <p>In one order, so that what a reader is told is settled rather than depending on which of
+     * two things was noticed first. What the behavior needs stood in for comes first, because a row
+     * of a behavior that takes something injected does not hand over a runnable thing without it —
+     * a reader given the values alone would apply the behavior with nothing to answer the dependency
+     * with. Then the inputs in the order they are written, then the expectation.
+     *
+     * @param standIns what was read of each dependency's stand-in, in the order the behavior
+     *                 requires them; empty for a behavior that depends on nothing
+     */
+    public static RowStatement read(List<StandInRead> standIns, List<ObservedValue> inputs,
+                                    Expectation expects) {
+        if (expects == null) {
+            throw new IllegalArgumentException("a row states something of the answer");
+        }
+        List<StoodIn> stood = new ArrayList<>();
+        for (StandInRead standIn : standIns) {
+            switch (standIn) {
+                case StandInRead.Unavailable(ValueName.Behavior dependency, SourcePos at,
+                                             RowStatement.StandInUnavailable.Why why) -> {
+                    return new RowStatement.StandInUnavailable(dependency, at, why);
+                }
+                case StandInRead.Available(StoodIn stoodIn) -> stood.add(stoodIn);
+            }
+        }
+        for (int i = 0; i < inputs.size(); i++) {
+            Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(inputs.get(i));
+            if (stopped != null) {
+                return new RowStatement.Incomplete(new RowStatement.Side.AnInput(i), stopped);
+            }
+        }
+        // What the row states of the answer is read whole, so that a comparison is made against what
+        // was written; whether it may be carried is asked of the same limits an input is held to, so
+        // that one row's halves are held to one size.
+        Incompleteness.Code stopped = switch (expects) {
+            case Expectation.TheValue(Asserted value) -> Limits.DEFAULT.stoppedBy(value);
+            // A case is a name. Nothing about it can be too large or fail to be read.
+            case Expectation.TheCase _ -> null;
+        };
+        return stopped != null
+                ? new RowStatement.Incomplete(new RowStatement.Side.TheExpectation(), stopped)
+                : RowStatement.Stated.of(stood, inputs, expects);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
@@ -121,8 +121,10 @@ public final class RowStatements {
          *
          * @param at    where what stands in is written, which is what the stand-in is quoted at;
          *              where a value of it could not be carried, the place said is that value's own
-         * @param takes what the dependency declares it takes, read where this stand-in's values were
-         *              built and compared against
+         * @param takes what the dependency declares it takes, for the entries to be held to. Read
+         *              and not carried: what a reader compares an argument at is the same
+         *              declaration, bound where a reading of the declarations already is, and a
+         *              stand-in carrying it would be that declaration written down twice
          */
         static StandInRead of(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
                               List<EntryRead> entries, StoodIn.Otherwise otherwise) {
@@ -160,7 +162,7 @@ public final class RowStatements {
                     return unavailable(dependency, where, stopped);
                 }
             }
-            return new Available(StoodIn.of(dependency, at, takes, carried, otherwise));
+            return new Available(StoodIn.of(dependency, at, carried, otherwise));
         }
 
         private static StandInRead unavailable(ValueName.Behavior dependency, SourcePos at,

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
@@ -81,6 +81,37 @@ public final class RowStatements {
         }
 
         /**
+         * One value of a stand-in as it was read: what it is, and where it is written.
+         *
+         * <p>Kept until the stand-in is known to be one a row can hand over, and not after. What a
+         * reader is given is the values; where each of them was written is what a reader is sent to
+         * when one of them turns out not to be carryable, and there is nothing to send anyone to
+         * once they all are.
+         */
+        record Written(ObservedValue value, SourcePos at) {
+
+            public Written {
+                if (value == null || at == null) {
+                    throw new IllegalArgumentException("a value a stand-in states is written"
+                            + " somewhere");
+                }
+            }
+        }
+
+        /** One entry as it was read: the arguments it answers for, its answer, and where the entry
+         *  itself is written. */
+        record EntryRead(List<Written> arguments, Written answer, SourcePos at) {
+
+            public EntryRead {
+                arguments = List.copyOf(arguments);
+                if (answer == null || at == null) {
+                    throw new IllegalArgumentException("an entry answers what it states, and is"
+                            + " written somewhere");
+                }
+            }
+        }
+
+        /**
          * What a stand-in stating these was read as.
          *
          * <p>Every value it states, in the order it states them: each entry as it is written, its
@@ -94,12 +125,13 @@ public final class RowStatements {
          *              built and compared against
          */
         static StandInRead of(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
-                              List<StoodIn.Entry> entries, StoodIn.Otherwise otherwise) {
+                              List<EntryRead> entries, StoodIn.Otherwise otherwise) {
             if (dependency == null || at == null || otherwise == null) {
                 throw new IllegalArgumentException("a stand-in is one dependency's, written"
                         + " somewhere, and answers what it is not written to");
             }
-            for (StoodIn.Entry entry : entries) {
+            List<StoodIn.Entry> carried = new ArrayList<>();
+            for (EntryRead entry : entries) {
                 if (entry.arguments().size() != takes.size()) {
                     // An entry states a call, and a call to this dependency is as many values as it
                     // declares. One stating another number is an entry nothing can ever be matched
@@ -108,16 +140,19 @@ public final class RowStatements {
                     throw new IllegalArgumentException("`" + dependency + "` takes " + takes.size()
                             + " and an entry states " + entry.arguments().size());
                 }
-                for (ObservedValue argument : entry.arguments()) {
-                    Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(argument);
+                List<ObservedValue> arguments = new ArrayList<>();
+                for (Written argument : entry.arguments()) {
+                    Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(argument.value());
                     if (stopped != null) {
-                        return unavailable(dependency, entry.at(), stopped);
+                        return unavailable(dependency, argument.at(), stopped);
                     }
+                    arguments.add(argument.value());
                 }
-                Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(entry.answer());
+                Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(entry.answer().value());
                 if (stopped != null) {
-                    return unavailable(dependency, entry.at(), stopped);
+                    return unavailable(dependency, entry.answer().at(), stopped);
                 }
+                carried.add(new StoodIn.Entry(arguments, entry.answer().value(), entry.at()));
             }
             if (otherwise instanceof StoodIn.Otherwise.Answer(ObservedValue value, SourcePos where)) {
                 Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(value);
@@ -125,7 +160,7 @@ public final class RowStatements {
                     return unavailable(dependency, where, stopped);
                 }
             }
-            return new Available(StoodIn.of(dependency, at, takes, entries, otherwise));
+            return new Available(StoodIn.of(dependency, at, takes, carried, otherwise));
         }
 
         private static StandInRead unavailable(ValueName.Behavior dependency, SourcePos at,

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowStatements.java
@@ -100,6 +100,14 @@ public final class RowStatements {
                         + " somewhere, and answers what it is not written to");
             }
             for (StoodIn.Entry entry : entries) {
+                if (entry.arguments().size() != takes.size()) {
+                    // An entry states a call, and a call to this dependency is as many values as it
+                    // declares. One stating another number is an entry nothing can ever be matched
+                    // against — carried, it would be a stand-in with an answer no argument reaches
+                    // and a reader with no way to tell that from one it simply was not asked.
+                    throw new IllegalArgumentException("`" + dependency + "` takes " + takes.size()
+                            + " and an entry states " + entry.arguments().size());
+                }
                 for (ObservedValue argument : entry.arguments()) {
                     Incompleteness.Code stopped = Limits.DEFAULT.stoppedBy(argument);
                     if (stopped != null) {

--- a/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
@@ -1,7 +1,6 @@
 package souther.compiler.observe;
 
 import souther.compiler.diag.SourcePos;
-import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.List;
@@ -40,23 +39,21 @@ public final class StoodIn {
 
     private final ValueName.Behavior dependency;
     private final SourcePos at;
-    private final List<Type> takes;
     private final List<Entry> entries;
     private final Otherwise otherwise;
 
-    private StoodIn(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
-                    List<Entry> entries, Otherwise otherwise) {
+    private StoodIn(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
+                    Otherwise otherwise) {
         this.dependency = dependency;
         this.at = at;
-        this.takes = List.copyOf(takes);
         this.entries = List.copyOf(entries);
         this.otherwise = otherwise;
     }
 
     /** For the reading that decides whether a stand-in can be handed over, having decided it. */
-    static StoodIn of(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
-                      List<Entry> entries, Otherwise otherwise) {
-        return new StoodIn(dependency, at, takes, entries, otherwise);
+    static StoodIn of(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
+                      Otherwise otherwise) {
+        return new StoodIn(dependency, at, entries, otherwise);
     }
 
     /**
@@ -73,22 +70,6 @@ public final class StoodIn {
     /** Where what stands in is written: the {@code with} on the row, or the table beside the rows. */
     public SourcePos at() {
         return at;
-    }
-
-    /**
-     * What the dependency declares it takes, in the order it takes them.
-     *
-     * <p>Here rather than looked up. What an entry's arguments were built and compared against is
-     * this, read where the stand-in was read; asked again of whatever a reader can reach the
-     * dependency's declaration through, it would be a second reading of one declaration — and a
-     * dependency this program does not declare, which is one another compile handed over, could not
-     * be asked at all.
-     *
-     * <p>What a comparison is made at as well as how many are made: whether an argument that is a
-     * sequence is the same one in another order is what the type reading it says.
-     */
-    public List<Type> takes() {
-        return takes;
     }
 
     /**
@@ -115,14 +96,13 @@ public final class StoodIn {
     @Override
     public boolean equals(Object other) {
         return other instanceof StoodIn it && dependency.equals(it.dependency) && at.equals(it.at)
-                && takes.equals(it.takes) && entries.equals(it.entries)
-                && otherwise.equals(it.otherwise);
+                && entries.equals(it.entries) && otherwise.equals(it.otherwise);
     }
 
     @Override
     public int hashCode() {
-        return (((dependency.hashCode() * 31 + at.hashCode()) * 31 + takes.hashCode()) * 31
-                + entries.hashCode()) * 31 + otherwise.hashCode();
+        return ((dependency.hashCode() * 31 + at.hashCode()) * 31 + entries.hashCode()) * 31
+                + otherwise.hashCode();
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
@@ -1,6 +1,7 @@
 package souther.compiler.observe;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.List;
@@ -39,21 +40,23 @@ public final class StoodIn {
 
     private final ValueName.Behavior dependency;
     private final SourcePos at;
+    private final List<Type> takes;
     private final List<Entry> entries;
     private final Otherwise otherwise;
 
-    private StoodIn(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
-                    Otherwise otherwise) {
+    private StoodIn(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
+                    List<Entry> entries, Otherwise otherwise) {
         this.dependency = dependency;
         this.at = at;
+        this.takes = List.copyOf(takes);
         this.entries = List.copyOf(entries);
         this.otherwise = otherwise;
     }
 
     /** For the reading that decides whether a stand-in can be handed over, having decided it. */
-    static StoodIn of(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
-                      Otherwise otherwise) {
-        return new StoodIn(dependency, at, entries, otherwise);
+    static StoodIn of(ValueName.Behavior dependency, SourcePos at, List<Type> takes,
+                      List<Entry> entries, Otherwise otherwise) {
+        return new StoodIn(dependency, at, takes, entries, otherwise);
     }
 
     /**
@@ -70,6 +73,22 @@ public final class StoodIn {
     /** Where what stands in is written: the {@code with} on the row, or the table beside the rows. */
     public SourcePos at() {
         return at;
+    }
+
+    /**
+     * What the dependency declares it takes, in the order it takes them.
+     *
+     * <p>Here rather than looked up. What an entry's arguments were built and compared against is
+     * this, read where the stand-in was read; asked again of whatever a reader can reach the
+     * dependency's declaration through, it would be a second reading of one declaration — and a
+     * dependency this program does not declare, which is one another compile handed over, could not
+     * be asked at all.
+     *
+     * <p>What a comparison is made at as well as how many are made: whether an argument that is a
+     * sequence is the same one in another order is what the type reading it says.
+     */
+    public List<Type> takes() {
+        return takes;
     }
 
     /**
@@ -96,18 +115,19 @@ public final class StoodIn {
     @Override
     public boolean equals(Object other) {
         return other instanceof StoodIn it && dependency.equals(it.dependency) && at.equals(it.at)
-                && entries.equals(it.entries) && otherwise.equals(it.otherwise);
+                && takes.equals(it.takes) && entries.equals(it.entries)
+                && otherwise.equals(it.otherwise);
     }
 
     @Override
     public int hashCode() {
-        return ((dependency.hashCode() * 31 + at.hashCode()) * 31 + entries.hashCode()) * 31
-                + otherwise.hashCode();
+        return (((dependency.hashCode() * 31 + at.hashCode()) * 31 + takes.hashCode()) * 31
+                + entries.hashCode()) * 31 + otherwise.hashCode();
     }
 
     @Override
     public String toString() {
-        return dependency.module() + "." + dependency.name() + " " + entries + " " + otherwise;
+        return dependency + " " + entries + " " + otherwise;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/StoodIn.java
@@ -1,0 +1,161 @@
+package souther.compiler.observe;
+
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+
+/**
+ * What one dependency was stated to answer while a row runs.
+ *
+ * <p>A row of a behavior that depends on something injected does not run against its inputs alone:
+ * something answers that dependency while it runs, and what it answers is written down beside the
+ * row. This is that, as something that did not read the source can hold it — an output whose
+ * dependency is an import has an answer for the import rather than an implementation of it.
+ *
+ * <p>What was written and not what a run built from it. A run turns this into an instance of the
+ * dependency's own base in the loader the implementation came from, which is a piece of the compile
+ * that made it; the entries and the answers are values, and they cross.
+ *
+ * <p>One shape for the two ways of writing one. A {@code with dep = value} on the row answers the
+ * same value whatever it is asked, and a {@code fake dep | table} beside the rows dispatches on what
+ * it is asked; a {@code with} is a table that lists nothing and answers everything, so it is that
+ * table here. Which of the two was written is a fact about the text and not about what the
+ * dependency answers, and a reader told them apart would have two ways to ask one question.
+ *
+ * <p>Nothing here dispatches. What a table answers for arguments it does not list is the table's own
+ * rule and not the reader's, and asking it takes what the declarations say a value's parts are — so
+ * the asking is where a reading of the declarations is bound to it ({@code CheckedRow}), and what is
+ * here is what the asking is made of.
+ *
+ * <p>A class and not a record, so that a stand-in holding a value that could not be carried cannot
+ * be made. It is made by the reading that decides that ({@link RowStatements.StandInRead#of}) and
+ * nowhere else, which is what lets a reader take every value in one as a value that is there.
+ *
+ * <p>A value all the same, and it says so itself: a row's statement rides inside a query's answer,
+ * and what stops that query is whether the answer equals the one before it.
+ */
+public final class StoodIn {
+
+    private final ValueName.Behavior dependency;
+    private final SourcePos at;
+    private final List<Entry> entries;
+    private final Otherwise otherwise;
+
+    private StoodIn(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
+                    Otherwise otherwise) {
+        this.dependency = dependency;
+        this.at = at;
+        this.entries = List.copyOf(entries);
+        this.otherwise = otherwise;
+    }
+
+    /** For the reading that decides whether a stand-in can be handed over, having decided it. */
+    static StoodIn of(ValueName.Behavior dependency, SourcePos at, List<Entry> entries,
+                      Otherwise otherwise) {
+        return new StoodIn(dependency, at, entries, otherwise);
+    }
+
+    /**
+     * The behavior this stands in for, as the declaration it is.
+     *
+     * <p>The module is part of it: a behavior depends on what its own module declares and on what
+     * another's does alike, and the name the module the row is written in happens to reach it by is
+     * not what it is.
+     */
+    public ValueName.Behavior dependency() {
+        return dependency;
+    }
+
+    /** Where what stands in is written: the {@code with} on the row, or the table beside the rows. */
+    public SourcePos at() {
+        return at;
+    }
+
+    /**
+     * What it was written to answer, in the order the answering reads them.
+     *
+     * <p>The order is the rule's and not a listing's: the first entry stating what it is asked is
+     * the one that answers, so entries in another order are a stand-in that answers differently.
+     * Empty for a stand-in that lists nothing.
+     *
+     * <p>Every one of these is an entry the stand-in can answer with. An entry a table is written
+     * with that its own rule can never reach is a fact about the source, said where the table is
+     * written, and it is not here — a reader walking these is walking answers, and one that had to
+     * work out which of them are reachable would be dispatching for itself.
+     */
+    public List<Entry> entries() {
+        return entries;
+    }
+
+    /** What it answers when it is asked something no entry states. */
+    public Otherwise otherwise() {
+        return otherwise;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof StoodIn it && dependency.equals(it.dependency) && at.equals(it.at)
+                && entries.equals(it.entries) && otherwise.equals(it.otherwise);
+    }
+
+    @Override
+    public int hashCode() {
+        return ((dependency.hashCode() * 31 + at.hashCode()) * 31 + entries.hashCode()) * 31
+                + otherwise.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return dependency.module() + "." + dependency.name() + " " + entries + " " + otherwise;
+    }
+
+    /**
+     * One entry: the arguments it answers for, and the answer it states for them.
+     *
+     * <p>The arguments in the order the dependency takes them, and all of them — a dependency taking
+     * two is answered for a pair and not for either half, which is the same rule the language states
+     * for what a fake's row is written as.
+     */
+    public record Entry(List<ObservedValue> arguments, ObservedValue answer, SourcePos at) {
+
+        public Entry {
+            arguments = List.copyOf(arguments);
+            if (answer == null || at == null) {
+                throw new IllegalArgumentException("an entry answers what it states, and is written"
+                        + " somewhere");
+            }
+        }
+    }
+
+    /**
+     * What a stand-in answers where no entry states what it was asked.
+     *
+     * <p>Two arms, and which of them it is is what the source wrote: a table with a {@code _} row
+     * answers that row, and one without answers nothing. Said as arms rather than as an answer that
+     * may be absent, so that a reader cannot read "nothing is stated for this" as "nothing is the
+     * answer".
+     */
+    public sealed interface Otherwise {
+
+        /** It answers this, whatever it was asked. */
+        record Answer(ObservedValue value, SourcePos at) implements Otherwise {
+
+            public Answer {
+                if (value == null || at == null) {
+                    throw new IllegalArgumentException("an answer is a value, written somewhere");
+                }
+            }
+        }
+
+        /**
+         * It states no answer for anything it does not list.
+         *
+         * <p>Not an error and not an answer. A run that asked such a stand-in something it does not
+         * list is a run that cannot go on, which the language says where the fake is used; a reader
+         * that reaches this has asked the dependency something the row never covered, which is a
+         * fact about the reader's own run.
+         */
+        record NothingStated() implements Otherwise {}
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/observe/ValueMatch.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/ValueMatch.java
@@ -1,26 +1,36 @@
 package souther.compiler.observe;
 
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * Whether what was stated and what was answered are the same value, and where they are not.
+ * Whether two values are the same value, and where they are not.
  *
- * <p>The two sides are not one kind of thing and are not read as one. {@link Asserted} is what a
- * text wrote, carrying the names and the forms it wrote them under; {@link ObservedValue} is what a
- * value turned out to be. Two values differ when their types differ as much as when their contents
- * do, and saying which is the whole reason this is not equality over the run-time objects: those
- * are compared as values of one type, and the question here is whether they are of one type at all.
+ * <p>Two questions are asked of this and they are not one question. Whether an answer is what a text
+ * stated holds an {@link Asserted} against an {@link ObservedValue}: the first carries the names and
+ * the forms a text wrote them under, the second is what a value turned out to be, and the two are
+ * not one kind of thing. Whether two values that were both arrived at are the same holds an
+ * {@link ObservedValue} against another, and nothing about it is a statement.
  *
- * <p>{@code position} is what the declaration says stands here, so it says what the <em>answer</em>
- * is: an {@link ObservedValue.Sequence} is a {@code List} and a {@code Set} alike, and which one it
- * is comes from the type that produced it. It says nothing about what was stated. A text that wrote
- * which collection it meant is held to that, and one that did not — {@code [ 1 ]} is how both are
- * written — is read at what the answer is, since there is nothing else for it to be.
+ * <p>What being the same value means is one answer all the same — a set is its elements whichever
+ * side asked, a decimal is the amount it stands for, a value is of its type before it is anything
+ * else — so the two questions enter here and walk one walk. {@link Compared} is what that walk
+ * reads, and each side is projected into it; a second walk beside this one would be the place a
+ * {@code Set} came to be compared in order on one of the two routes.
+ *
+ * <p>{@code position} is what the declaration says stands here, so it says what the value on the
+ * right is: an {@link ObservedValue.Sequence} is a {@code List} and a {@code Set} alike, and which
+ * one it is comes from the type that produced it. A text that wrote which collection it meant is
+ * held to that, and one that did not — {@code [ 1 ]} is how both are written — is read at what the
+ * right-hand value is, since there is nothing else for it to be. An observation states no
+ * container of its own, so a value arriving from one is read that way too.
  *
  * <p>What it reads of the declarations is one question ({@link ValueTypes}), so this is the same
  * comparison wherever it is made: by the compile that read the text, and by an output holding what
@@ -51,7 +61,7 @@ final class ValueMatch {
             // holding a whole value against one would report a difference nobody stated. Which case
             // an answer is is the declaration it is of, which the reading that produced the answer
             // already settled.
-            case Expectation.TheCase(souther.compiler.types.TypeSymbol name) -> {
+            case Expectation.TheCase(TypeSymbol name) -> {
                 if (answered.unread() != null) {
                     yield new Verdict.NotHeld(new Mismatch(List.of(), Mismatch.Reason.UNREADABLE,
                             stated, answered, answers));
@@ -65,24 +75,176 @@ final class ValueMatch {
 
     /** Null where the two are the same value. */
     Mismatch compare(Asserted stated, ObservedValue observed, Position position) {
-        return at(List.of(), stated, observed, position);
+        Difference differs = at(List.of(), stated(stated), observed, position);
+        return differs == null ? null : mismatch(differs);
     }
 
-    private Mismatch at(List<PathElement> path, Asserted a, ObservedValue o, Position position) {
-        if (o.unread() != null) {
-            return differs(path, Mismatch.Reason.UNREADABLE, a, o, position);
-        }
-        return switch (a) {
-            case Asserted.Value(ObservedValue v) -> leaf(path, a, v, o, position);
-            case Asserted.Built built -> constructed(path, a, built, o, position);
-            case Asserted.Elements elements -> sequence(path, a, elements, o, position);
-            case Asserted.Entries entries -> mapping(path, a, entries, o, position);
+    /**
+     * Whether two values that were both arrived at are the same value.
+     *
+     * <p>Answered as a yes or a no. Where a difference is, and what stood at either end of it, is
+     * what a text is told when an answer did not keep what it stated; two values neither of which
+     * states anything have nothing to be told about, and a {@link Mismatch} made of them would name
+     * one of them as what was expected.
+     */
+    boolean same(ObservedValue left, ObservedValue right, Position position) {
+        return at(List.of(), observed(left), right, position) == null;
+    }
+
+    /**
+     * What one side of a comparison is, as the walk reads it.
+     *
+     * <p>Four shapes, which is what deciding whether two values are the same takes: a value with no
+     * parts, a construction, a sequence and a mapping. Not a value: nothing here is built to be
+     * held, passed on or compared against anything but the walk that made it, and what {@link #from}
+     * carries is the value it was made from rather than a value of its own. Kept inside this class
+     * for that reason — reachable from the package it would be a third vocabulary beside the two
+     * {@link Asserted} and {@link ObservedValue} are, which are held apart on purpose.
+     */
+    private sealed interface Compared {
+
+        /** The value this was projected from, which a report about a difference quotes. */
+        Origin from();
+    }
+
+    /** A value with no parts, as the value it is. */
+    private record Leaf(ObservedValue value, Origin from) implements Compared {}
+
+    /** A construction, under the name it is of and with the parts it holds. */
+    private record Built(TypeSymbol type, Map<String, Compared> fields,
+                         Origin from) implements Compared {}
+
+    /** A sequence, and which sequence its side said it was: a text may say, an observation does
+     *  not. */
+    private record Elements(Asserted.Container container, List<Compared> elements,
+                            Origin from) implements Compared {}
+
+    /** A mapping, as the pairs it holds in the order its side holds them. */
+    private record Entries(List<Pair> entries, Origin from) implements Compared {}
+
+    /** One pair of a mapping. */
+    private record Pair(Compared key, Compared value) {}
+
+    /**
+     * Which of the two a side was projected from.
+     *
+     * <p>Carried through the walk rather than worked out at the end, because what a report quotes
+     * is the value at the place the two parted and not the value the comparison started from.
+     */
+    private sealed interface Origin {
+
+        /** A text stated it. */
+        record Stated(Asserted value) implements Origin {}
+
+        /** An execution turned out to hold it. */
+        record Observed(ObservedValue value) implements Origin {}
+    }
+
+    /**
+     * Where two values parted, as the walk found it.
+     *
+     * <p>Everything a report needs, taken where the difference was found. A difference said as a
+     * reason and a path alone would have whoever writes the report walk the two values again to
+     * reach what stood there — which is the second walk this one traversal exists to do without.
+     */
+    private record Difference(List<PathElement> path, Mismatch.Reason reason, Compared left,
+                              ObservedValue right, Position position) {}
+
+    /** What a text stated, as the walk reads it. */
+    private static Compared stated(Asserted stated) {
+        Origin from = new Origin.Stated(stated);
+        return switch (stated) {
+            case Asserted.Value(ObservedValue value) -> new Leaf(value, from);
+            case Asserted.Built built -> {
+                Map<String, Compared> fields = new LinkedHashMap<>();
+                built.fields().forEach((name, field) -> fields.put(name, stated(field)));
+                yield new Built(built.type(), fields, from);
+            }
+            case Asserted.Elements elements -> {
+                List<Compared> parts = new ArrayList<>();
+                for (Asserted element : elements.elements()) {
+                    parts.add(stated(element));
+                }
+                yield new Elements(elements.stated(), parts, from);
+            }
+            case Asserted.Entries entries -> {
+                List<Pair> pairs = new ArrayList<>();
+                for (Asserted.Entry entry : entries.entries()) {
+                    pairs.add(new Pair(stated(entry.key()), stated(entry.value())));
+                }
+                yield new Entries(pairs, from);
+            }
         };
     }
 
-    private static Mismatch differs(List<PathElement> path, Mismatch.Reason reason, Asserted a,
-                                    ObservedValue o, Position position) {
-        return new Mismatch(path, reason, new Expectation.TheValue(a), o, position);
+    /**
+     * What an execution turned out to hold, as the walk reads it.
+     *
+     * <p>A sequence states no container. Which one it is is what the declaration reading it says,
+     * and an observation that answered for it would be answering with the type that produced it —
+     * which is the reading the position is here to make.
+     */
+    private static Compared observed(ObservedValue observed) {
+        Origin from = new Origin.Observed(observed);
+        return switch (observed) {
+            case ObservedValue.Constructed constructed -> {
+                Map<String, Compared> fields = new LinkedHashMap<>();
+                constructed.fields().forEach((name, field) -> fields.put(name, observed(field)));
+                yield new Built(constructed.type(), fields, from);
+            }
+            case ObservedValue.Sequence sequence -> {
+                List<Compared> parts = new ArrayList<>();
+                for (ObservedValue element : sequence.elements()) {
+                    parts.add(observed(element));
+                }
+                yield new Elements(Asserted.Container.UNSTATED, parts, from);
+            }
+            case ObservedValue.Mapping mapping -> {
+                List<Pair> pairs = new ArrayList<>();
+                for (ObservedValue.Entry entry : mapping.entries()) {
+                    pairs.add(new Pair(observed(entry.key()), observed(entry.value())));
+                }
+                yield new Entries(pairs, from);
+            }
+            // Said arm by arm rather than as what is left over, so that a value with a new shape is
+            // read here rather than arriving as one with no parts.
+            case ObservedValue.Bool _, ObservedValue.Integer _, ObservedValue.Decimal _,
+                 ObservedValue.Text _, ObservedValue.Temporal _, ObservedValue.Unit _,
+                 ObservedValue.Absent _, ObservedValue.Unknown _, ObservedValue.Truncated _ ->
+                    new Leaf(observed, from);
+        };
+    }
+
+    /** The difference, as a text that stated one side is told about it. */
+    private static Mismatch mismatch(Difference differs) {
+        if (!(differs.left().from() instanceof Origin.Stated(Asserted value))) {
+            // The walk keeps each side's origin through every step, so a comparison entered with a
+            // statement parts from the answer at a stated value. Reaching here is those two having
+            // come apart, and what would be written instead is an observation reported as what a
+            // text expected.
+            throw new IllegalStateException("a comparison against what a text stated parted from it"
+                    + " at a value no text stated");
+        }
+        return new Mismatch(differs.path(), differs.reason(), new Expectation.TheValue(value),
+                differs.right(), differs.position());
+    }
+
+    private Difference at(List<PathElement> path, Compared left, ObservedValue right,
+                          Position position) {
+        if (right.unread() != null) {
+            return differs(path, Mismatch.Reason.UNREADABLE, left, right, position);
+        }
+        return switch (left) {
+            case Leaf leaf -> leaf(path, leaf, right, position);
+            case Built built -> constructed(path, built, right, position);
+            case Elements elements -> sequence(path, elements, right, position);
+            case Entries entries -> mapping(path, entries, right, position);
+        };
+    }
+
+    private static Difference differs(List<PathElement> path, Mismatch.Reason reason, Compared left,
+                                      ObservedValue right, Position position) {
+        return new Difference(path, reason, left, right, position);
     }
 
     private static List<PathElement> into(List<PathElement> path, PathElement step) {
@@ -93,46 +255,52 @@ final class ValueMatch {
 
     /** A value with no parts against one. Absence is neither a type nor a value of one: a position
      *  holds nothing or holds something, and that is its own answer. */
-    private Mismatch leaf(List<PathElement> path, Asserted a, ObservedValue v, ObservedValue o,
-                          Position position) {
-        if (v.unread() != null) {
-            return differs(path, Mismatch.Reason.UNREADABLE, a, o, position);
+    private Difference leaf(List<PathElement> path, Leaf left, ObservedValue right,
+                            Position position) {
+        ObservedValue value = left.value();
+        if (value.unread() != null) {
+            return differs(path, Mismatch.Reason.UNREADABLE, left, right, position);
         }
-        if (v instanceof ObservedValue.Absent || o instanceof ObservedValue.Absent) {
-            return v instanceof ObservedValue.Absent && o instanceof ObservedValue.Absent
-                    ? null : differs(path, Mismatch.Reason.ABSENCE, a, o, position);
+        if (value instanceof ObservedValue.Absent || right instanceof ObservedValue.Absent) {
+            return value instanceof ObservedValue.Absent && right instanceof ObservedValue.Absent
+                    ? null : differs(path, Mismatch.Reason.ABSENCE, left, right, position);
         }
-        // Of one type before anything else, and which type a written value with no parts is has one
-        // answer for every reader of it. A text writing `1` where a `Decimal` came out wrote an `Int`
-        // — the difference is written in the language, and reading a whole number as an amount is
-        // what a boundary does and not what the text did.
-        Type.Prim stated = v.primitive();
-        Type.Prim answered = o.primitive();
+        // Of one type before anything else, and which type a value with no parts is has one answer
+        // for every reader of it. A text writing `1` where a `Decimal` came out wrote an `Int` — the
+        // difference is written in the language, and reading a whole number as an amount is what a
+        // boundary does and not what the text did.
+        Type.Prim stated = value.primitive();
+        Type.Prim answered = right.primitive();
         if (stated == null || stated != answered) {
-            return v instanceof ObservedValue.Unit x && o instanceof ObservedValue.Unit y
+            return value instanceof ObservedValue.Unit x && right instanceof ObservedValue.Unit y
                     && x.type().equals(y.type())
-                    ? null : differs(path, Mismatch.Reason.TYPE, a, o, position);
+                    ? null : differs(path, Mismatch.Reason.TYPE, left, right, position);
         }
-        return switch (v) {
+        return switch (value) {
             case ObservedValue.Bool x ->
-                    same(path, x.value() == ((ObservedValue.Bool) o).value(), a, o, position);
+                    differsUnless(path, x.value() == ((ObservedValue.Bool) right).value(), left,
+                            right, position);
             case ObservedValue.Integer x ->
-                    same(path, x.value() == ((ObservedValue.Integer) o).value(), a, o, position);
+                    differsUnless(path, x.value() == ((ObservedValue.Integer) right).value(), left,
+                            right, position);
             // A decimal is the amount it stands for, so two that differ only in scale are one amount
             // — the rule `Values.equal` states for the run-time values.
-            case ObservedValue.Decimal x -> same(path,
-                    x.value().compareTo(((ObservedValue.Decimal) o).value()) == 0, a, o, position);
+            case ObservedValue.Decimal x -> differsUnless(path,
+                    x.value().compareTo(((ObservedValue.Decimal) right).value()) == 0, left, right,
+                    position);
             case ObservedValue.Text x ->
-                    same(path, x.value().equals(((ObservedValue.Text) o).value()), a, o, position);
+                    differsUnless(path, x.value().equals(((ObservedValue.Text) right).value()), left,
+                            right, position);
             case ObservedValue.Temporal x ->
-                    same(path, x.iso().equals(((ObservedValue.Temporal) o).iso()), a, o, position);
-            default -> differs(path, Mismatch.Reason.UNREADABLE, a, o, position);
+                    differsUnless(path, x.iso().equals(((ObservedValue.Temporal) right).iso()), left,
+                            right, position);
+            default -> differs(path, Mismatch.Reason.UNREADABLE, left, right, position);
         };
     }
 
-    private static Mismatch same(List<PathElement> path, boolean equal, Asserted a, ObservedValue o,
-                                 Position position) {
-        return equal ? null : differs(path, Mismatch.Reason.VALUE, a, o, position);
+    private static Difference differsUnless(List<PathElement> path, boolean equal, Compared left,
+                                            ObservedValue right, Position position) {
+        return equal ? null : differs(path, Mismatch.Reason.VALUE, left, right, position);
     }
 
     /**
@@ -140,27 +308,27 @@ final class ValueMatch {
      * a {@code Receipt} whose {@code total} was written as a number and one whose {@code total} is
      * an {@code AmountN} are not one value written two ways.
      */
-    private Mismatch constructed(List<PathElement> path, Asserted a, Asserted.Built built,
-                                 ObservedValue o, Position position) {
-        if (!(o instanceof ObservedValue.Constructed b) || !built.type().equals(b.type())) {
-            return differs(path, Mismatch.Reason.TYPE, a, o, position);
+    private Difference constructed(List<PathElement> path, Built left, ObservedValue right,
+                                   Position position) {
+        if (!(right instanceof ObservedValue.Constructed b) || !left.type().equals(b.type())) {
+            return differs(path, Mismatch.Reason.TYPE, left, right, position);
         }
-        Set<String> names = new LinkedHashSet<>(built.fields().keySet());
+        Set<String> names = new LinkedHashSet<>(left.fields().keySet());
         names.addAll(b.fields().keySet());
         for (String name : names) {
-            Asserted x = built.fields().get(name);
+            Compared x = left.fields().get(name);
             ObservedValue y = b.field(name);
             if (x == null || y == null) {
                 // At the construction and not at the field: what differs is which places the two
                 // hold, which is a fact about them rather than about a place one of them has not
                 // got. Said at the field, the path would name somewhere the values beside it are
                 // not from — and there is no value there to name it with.
-                return differs(path, Mismatch.Reason.SHAPE, a, o, position);
+                return differs(path, Mismatch.Reason.SHAPE, left, right, position);
             }
             List<PathElement> inside = into(path, new PathElement.Field(name));
             // The child's position comes from what this value's own type declares that field to be,
             // so nothing outside the value supplies one for what stands under it.
-            Mismatch under = at(inside, x, y, types.field(built.type(), name));
+            Difference under = at(inside, x, y, types.field(left.type(), name));
             if (under != null) {
                 return under;
             }
@@ -170,36 +338,37 @@ final class ValueMatch {
 
     /**
      * Two sequences, ordered or not as what they are says. A {@code List} is its elements in order and
-     * a {@code Set} is its elements; the answer is whichever its declaration made it, and what was
-     * stated is whichever it wrote — a text that wrote neither is read at the answer's, since
-     * {@code [ 1 ]} is how both are written and states no preference between them.
+     * a {@code Set} is its elements; the value on the right is whichever its declaration made it, and
+     * the one on the left is whichever it said it was — a side that said neither is read at the
+     * right's, since {@code [ 1 ]} is how both are written and states no preference between them.
      */
-    private Mismatch sequence(List<PathElement> path, Asserted a, Asserted.Elements xs,
-                              ObservedValue o, Position position) {
-        if (!(o instanceof ObservedValue.Sequence ys)) {
-            return differs(path, Mismatch.Reason.TYPE, a, o, position);
+    private Difference sequence(List<PathElement> path, Elements left, ObservedValue right,
+                                Position position) {
+        if (!(right instanceof ObservedValue.Sequence ys)) {
+            return differs(path, Mismatch.Reason.TYPE, left, right, position);
         }
         Type open = position.opened() instanceof Position.At(Type type) ? type : null;
         Asserted.Container answered = open instanceof Type.SetOf ? Asserted.Container.SET
                 : open instanceof Type.ListOf ? Asserted.Container.LIST : Asserted.Container.UNSTATED;
-        if (xs.stated() != Asserted.Container.UNSTATED && answered != Asserted.Container.UNSTATED
-                && xs.stated() != answered) {
-            return differs(path, Mismatch.Reason.TYPE, a, o, position);
+        if (left.container() != Asserted.Container.UNSTATED
+                && answered != Asserted.Container.UNSTATED && left.container() != answered) {
+            return differs(path, Mismatch.Reason.TYPE, left, right, position);
         }
-        Asserted.Container reading = xs.stated() != Asserted.Container.UNSTATED ? xs.stated() : answered;
+        Asserted.Container reading =
+                left.container() != Asserted.Container.UNSTATED ? left.container() : answered;
         Position element = switch (open) {
             case Type.ListOf l -> Position.at(l.element());
             case Type.SetOf s -> Position.at(s.element());
             case null, default -> Position.UNREAD;
         };
-        if (xs.elements().size() != ys.elements().size()) {
-            return differs(path, Mismatch.Reason.SHAPE, a, o, position);
+        if (left.elements().size() != ys.elements().size()) {
+            return differs(path, Mismatch.Reason.SHAPE, left, right, position);
         }
         if (reading == Asserted.Container.SET) {
-            return unordered(path, xs.elements(), ys.elements(), element, a, o, position);
+            return unordered(path, left, ys.elements(), element, right, position);
         }
-        for (int i = 0; i < xs.elements().size(); i++) {
-            Mismatch under = at(into(path, new PathElement.Index(i)), xs.elements().get(i),
+        for (int i = 0; i < left.elements().size(); i++) {
+            Difference under = at(into(path, new PathElement.Index(i)), left.elements().get(i),
                     ys.elements().get(i), element);
             if (under != null) {
                 return under;
@@ -209,20 +378,20 @@ final class ValueMatch {
     }
 
     /** A set: each element of one stands for one of the other, and which one is not part of the value. */
-    private Mismatch unordered(List<PathElement> path, List<Asserted> xs, List<ObservedValue> ys,
-                               Position element, Asserted a, ObservedValue o, Position position) {
-        List<ObservedValue> left = new ArrayList<>(ys);
-        for (Asserted x : xs) {
+    private Difference unordered(List<PathElement> path, Elements left, List<ObservedValue> ys,
+                                 Position element, ObservedValue right, Position position) {
+        List<ObservedValue> remaining = new ArrayList<>(ys);
+        for (Compared x : left.elements()) {
             boolean found = false;
-            for (int i = 0; i < left.size(); i++) {
-                if (at(path, x, left.get(i), element) == null) {
-                    left.remove(i);
+            for (int i = 0; i < remaining.size(); i++) {
+                if (at(path, x, remaining.get(i), element) == null) {
+                    remaining.remove(i);
                     found = true;
                     break;
                 }
             }
             if (!found) {
-                return differs(path, Mismatch.Reason.SHAPE, a, o, position);
+                return differs(path, Mismatch.Reason.SHAPE, left, right, position);
             }
         }
         return null;
@@ -233,34 +402,36 @@ final class ValueMatch {
      * everything else here is compared by, which a hash lookup would answer with Java's equality — and
      * a key written under a name is not the base it wraps.
      */
-    private Mismatch mapping(List<PathElement> path, Asserted a, Asserted.Entries xs,
-                             ObservedValue o, Position position) {
-        if (!(o instanceof ObservedValue.Mapping ys)) {
-            return differs(path, Mismatch.Reason.TYPE, a, o, position);
+    private Difference mapping(List<PathElement> path, Entries left, ObservedValue right,
+                               Position position) {
+        if (!(right instanceof ObservedValue.Mapping ys)) {
+            return differs(path, Mismatch.Reason.TYPE, left, right, position);
         }
         Position key = position.key();
         Position value = position.value();
-        if (xs.entries().size() != ys.entries().size()) {
-            return differs(path, Mismatch.Reason.SHAPE, a, o, position);
+        if (left.entries().size() != ys.entries().size()) {
+            return differs(path, Mismatch.Reason.SHAPE, left, right, position);
         }
-        List<ObservedValue.Entry> left = new ArrayList<>(ys.entries());
-        for (Asserted.Entry entry : xs.entries()) {
+        List<ObservedValue.Entry> remaining = new ArrayList<>(ys.entries());
+        for (Pair entry : left.entries()) {
             int found = -1;
-            for (int i = 0; i < left.size(); i++) {
-                if (at(path, entry.key(), left.get(i).key(), key) == null) {
+            for (int i = 0; i < remaining.size(); i++) {
+                if (at(path, entry.key(), remaining.get(i).key(), key) == null) {
                     found = i;
                     break;
                 }
             }
             if (found < 0) {
-                return differs(path, Mismatch.Reason.SHAPE, a, o, position);
+                return differs(path, Mismatch.Reason.SHAPE, left, right, position);
             }
-            ObservedValue.Entry match = left.remove(found);
+            ObservedValue.Entry match = remaining.remove(found);
             // The key the entry was found by, which says which entry this is. Every leaf of it was
             // compared to get here, so it is a value that is there — which is what a step naming an
-            // entry has to be.
-            Mismatch under = at(into(path, new PathElement.Key(entry.key())), entry.value(),
-                    match.value(), value);
+            // entry has to be. A key that no text stated names no step: what a path is read for is a
+            // report about a statement, and the comparison of two arrived-at values makes none.
+            List<PathElement> inside = entry.key().from() instanceof Origin.Stated(Asserted stated)
+                    ? into(path, new PathElement.Key(stated)) : path;
+            Difference under = at(inside, entry.value(), match.value(), value);
             if (under != null) {
                 return under;
             }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * language says a behavior answers rather than a test of this compiler — a program whose rows do not
  * hold is not accepted — so an output emitting from this can hold what it emitted to what the model
  * owes, instead of to a test it wrote itself over inputs it picked itself. Whether an answer keeps a
- * row is asked of the language ({@link CheckedRow.Reproducible#holds}), and only of a row that
+ * row is asked of the language ({@link CheckedRow.SelfContained#holds}), and only of a row that
  * hands over values — one that does not says why instead, and there is nothing to ask.
  *
  * <p>How this compiler works out its answers is not here. There is no {@code Db} on this object and

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -19,7 +19,6 @@ import souther.compiler.observe.FieldTypes;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.RowStatement;
-import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.query.Acceptance;
 import souther.compiler.query.Bodies;
@@ -83,18 +82,9 @@ final class CheckedProgramAssembler {
         }
         ValueTypes types =
                 ValueTypes.over(FieldTypes.over(DeclaredFields.over(everyDeclaration)));
-        // What every behavior of this program declares, before any row is written down. A row states
-        // what stood in for the behaviors its own depends on, and where each of a dependency's
-        // arguments stands is what that dependency declares — which is not always something the
-        // module the row is written in declares.
-        Map<ValueName.Behavior, CheckedSignature> declared = new LinkedHashMap<>();
-        for (ModuleReading module : read) {
-            module.signatures().forEach((name, signature) -> declared.put(
-                    new ValueName.Behavior(module.name(), name), signatureOf(signature)));
-        }
         List<CheckedModule> modules = new ArrayList<>();
         for (ModuleReading module : read) {
-            modules.add(moduleOf(module, types, declared));
+            modules.add(moduleOf(module, types));
         }
         return new CheckedProgram(modules, language, onThePath,
                 libraryOf(db).kernelSignatures());
@@ -272,8 +262,7 @@ final class CheckedProgramAssembler {
      * program's rather than this module's: a row written here may state a value of a data declared
      * elsewhere.
      */
-    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types,
-                                          Map<ValueName.Behavior, CheckedSignature> signatures) {
+    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types) {
         List<CheckedBehavior> behaviors = new ArrayList<>();
         for (Hir.BehaviorDef declared : read.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(read.name(), declared.name());
@@ -282,8 +271,8 @@ final class CheckedProgramAssembler {
                     implementationOf(named, declared, read.bodies(), read.implementations(),
                             read.checked(), read.compositions()),
                     EnsuresEnforcement.in(read.checks(), read.name(), named),
-                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types, signature,
-                            signatures)));
+                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types,
+                            signature)));
         }
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());
@@ -299,12 +288,11 @@ final class CheckedProgramAssembler {
      * from.
      */
     private static List<CheckedRow> rowsOf(List<Output.RowsRead.ReadRow> read, ValueTypes types,
-                                           CheckedSignature signature,
-                                           Map<ValueName.Behavior, CheckedSignature> signatures) {
+                                           CheckedSignature signature) {
         List<CheckedRow> rows = new ArrayList<>();
         for (Output.RowsRead.ReadRow row : read) {
             rows.add(new CheckedRow(row.identity(), row.at(),
-                    statementOf(row, types, signature, signatures)));
+                    statementOf(row, types, signature)));
         }
         return rows;
     }
@@ -322,9 +310,7 @@ final class CheckedProgramAssembler {
      * into whichever arm it happens to reach.
      */
     private static CheckedRow.Statement statementOf(Output.RowsRead.ReadRow row, ValueTypes types,
-                                                    CheckedSignature signature,
-                                                    Map<ValueName.Behavior,
-                                                            CheckedSignature> signatures) {
+                                                    CheckedSignature signature) {
         // A switch over both sums, so a row nothing came back for is written down here rather than
         // being whatever falls out of reading a list of the ones that did — which is a row an output
         // would never hear of, and a behavior reading as having said nothing about an input someone
@@ -335,8 +321,7 @@ final class CheckedProgramAssembler {
                         ? new CheckedRow.SelfContained(stated, types,
                                 Position.at(signature.answers()))
                         : new CheckedRow.WithStandIns(stated, types,
-                                Position.at(signature.answers()),
-                                standingIn(stated, types, signatures));
+                                Position.at(signature.answers()));
                 case RowStatement.NotStated why -> new CheckedRow.NotReproducible(why);
                 // What acceptance guarantees, asserted where the guarantee is relied on. A row an
                 // evaluation stopped before the values of is one the language refuses the program
@@ -351,36 +336,6 @@ final class CheckedProgramAssembler {
             case Output.RowsRead.ReadRow.NotRun notRun ->
                     new CheckedRow.NotReproducible(new RowStatement.NotRead(notRun.why()));
         };
-    }
-
-    /**
-     * What answers each of the behavior's dependencies, as a reader may ask it.
-     *
-     * <p>Each is given where the dependency's own arguments stand, which is what says whether an
-     * argument that is a sequence is answered for in order. Read off what that behavior declares
-     * here — the same reading the program publishes for it — so a stand-in and the behavior it
-     * stands in for cannot come to disagree about what the dependency takes.
-     */
-    private static List<StandsIn> standingIn(RowStatement.Stated stated, ValueTypes types,
-                                             Map<ValueName.Behavior, CheckedSignature> signatures) {
-        List<StandsIn> standIns = new ArrayList<>();
-        for (StoodIn stoodIn : stated.standIns()) {
-            CheckedSignature declared = signatures.get(stoodIn.dependency());
-            if (declared == null) {
-                // The row states what stood in for this behavior, so this compile read the clause
-                // that required it and the signature it was built against. Handing the row over
-                // without one would hand an output a stand-in it cannot ask anything of.
-                throw new IllegalStateException("`" + stoodIn.dependency().module() + "."
-                        + stoodIn.dependency().name() + "` was stood in for and this program says"
-                        + " nothing about what it takes");
-            }
-            List<Position> arguments = new ArrayList<>();
-            for (Type takes : declared.takes()) {
-                arguments.add(Position.at(takes));
-            }
-            standIns.add(new StandsIn(stoodIn, types, arguments));
-        }
-        return standIns;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -19,6 +19,7 @@ import souther.compiler.observe.FieldTypes;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.RowStatement;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.query.Acceptance;
 import souther.compiler.query.Bodies;
@@ -82,9 +83,18 @@ final class CheckedProgramAssembler {
         }
         ValueTypes types =
                 ValueTypes.over(FieldTypes.over(DeclaredFields.over(everyDeclaration)));
+        // What every behavior of this program declares, before any row is written down. A row states
+        // what stood in for the behaviors its own depends on, and where each of a dependency's
+        // arguments stands is what that dependency declares — which is not always something the
+        // module the row is written in declares.
+        Map<ValueName.Behavior, CheckedSignature> declared = new LinkedHashMap<>();
+        for (ModuleReading module : read) {
+            module.signatures().forEach((name, signature) -> declared.put(
+                    new ValueName.Behavior(module.name(), name), signatureOf(signature)));
+        }
         List<CheckedModule> modules = new ArrayList<>();
         for (ModuleReading module : read) {
-            modules.add(moduleOf(module, types));
+            modules.add(moduleOf(module, types, declared));
         }
         return new CheckedProgram(modules, language, onThePath,
                 libraryOf(db).kernelSignatures());
@@ -262,7 +272,8 @@ final class CheckedProgramAssembler {
      * program's rather than this module's: a row written here may state a value of a data declared
      * elsewhere.
      */
-    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types) {
+    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types,
+                                          Map<ValueName.Behavior, CheckedSignature> signatures) {
         List<CheckedBehavior> behaviors = new ArrayList<>();
         for (Hir.BehaviorDef declared : read.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(read.name(), declared.name());
@@ -271,8 +282,8 @@ final class CheckedProgramAssembler {
                     implementationOf(named, declared, read.bodies(), read.implementations(),
                             read.checked(), read.compositions()),
                     EnsuresEnforcement.in(read.checks(), read.name(), named),
-                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types,
-                            signature)));
+                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types, signature,
+                            signatures)));
         }
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());
@@ -288,11 +299,12 @@ final class CheckedProgramAssembler {
      * from.
      */
     private static List<CheckedRow> rowsOf(List<Output.RowsRead.ReadRow> read, ValueTypes types,
-                                           CheckedSignature signature) {
+                                           CheckedSignature signature,
+                                           Map<ValueName.Behavior, CheckedSignature> signatures) {
         List<CheckedRow> rows = new ArrayList<>();
         for (Output.RowsRead.ReadRow row : read) {
             rows.add(new CheckedRow(row.identity(), row.at(),
-                    statementOf(row, types, signature)));
+                    statementOf(row, types, signature, signatures)));
         }
         return rows;
     }
@@ -310,15 +322,21 @@ final class CheckedProgramAssembler {
      * into whichever arm it happens to reach.
      */
     private static CheckedRow.Statement statementOf(Output.RowsRead.ReadRow row, ValueTypes types,
-                                                    CheckedSignature signature) {
+                                                    CheckedSignature signature,
+                                                    Map<ValueName.Behavior,
+                                                            CheckedSignature> signatures) {
         // A switch over both sums, so a row nothing came back for is written down here rather than
         // being whatever falls out of reading a list of the ones that did — which is a row an output
         // would never hear of, and a behavior reading as having said nothing about an input someone
         // wrote down.
         return switch (row) {
             case Output.RowsRead.ReadRow.Ran(RowOutcome outcome) -> switch (outcome.statement()) {
-                case RowStatement.Stated stated -> new CheckedRow.Reproducible(stated, types,
-                        Position.at(signature.answers()));
+                case RowStatement.Stated stated -> stated.standIns().isEmpty()
+                        ? new CheckedRow.SelfContained(stated, types,
+                                Position.at(signature.answers()))
+                        : new CheckedRow.WithStandIns(stated, types,
+                                Position.at(signature.answers()),
+                                standingIn(stated, types, signatures));
                 case RowStatement.NotStated why -> new CheckedRow.NotReproducible(why);
                 // What acceptance guarantees, asserted where the guarantee is relied on. A row an
                 // evaluation stopped before the values of is one the language refuses the program
@@ -333,6 +351,36 @@ final class CheckedProgramAssembler {
             case Output.RowsRead.ReadRow.NotRun notRun ->
                     new CheckedRow.NotReproducible(new RowStatement.NotRead(notRun.why()));
         };
+    }
+
+    /**
+     * What answers each of the behavior's dependencies, as a reader may ask it.
+     *
+     * <p>Each is given where the dependency's own arguments stand, which is what says whether an
+     * argument that is a sequence is answered for in order. Read off what that behavior declares
+     * here — the same reading the program publishes for it — so a stand-in and the behavior it
+     * stands in for cannot come to disagree about what the dependency takes.
+     */
+    private static List<StandsIn> standingIn(RowStatement.Stated stated, ValueTypes types,
+                                             Map<ValueName.Behavior, CheckedSignature> signatures) {
+        List<StandsIn> standIns = new ArrayList<>();
+        for (StoodIn stoodIn : stated.standIns()) {
+            CheckedSignature declared = signatures.get(stoodIn.dependency());
+            if (declared == null) {
+                // The row states what stood in for this behavior, so this compile read the clause
+                // that required it and the signature it was built against. Handing the row over
+                // without one would hand an output a stand-in it cannot ask anything of.
+                throw new IllegalStateException("`" + stoodIn.dependency().module() + "."
+                        + stoodIn.dependency().name() + "` was stood in for and this program says"
+                        + " nothing about what it takes");
+            }
+            List<Position> arguments = new ArrayList<>();
+            for (Type takes : declared.takes()) {
+                arguments.add(Position.at(takes));
+            }
+            standIns.add(new StandsIn(stoodIn, types, arguments));
+        }
+        return standIns;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -293,9 +293,10 @@ final class CheckedProgramAssembler {
      *
      * <p>Written down rather than worked out: what each row states was read where the row was read,
      * and what is made here is the handle a reader holds it by. Each is given what answering
-     * {@link CheckedRow.Reproducible#holds} takes — how a value's parts are read, and where this
+     * {@link CheckedRow.SelfContained#holds} takes — how a value's parts are read, and where this
      * behavior's answer stands — so that asking is not a question about the program the row came
-     * from.
+     * from. A row that stands something in for a dependency is given where that dependency's
+     * arguments stand as well, for the same reason.
      */
     private static List<CheckedRow> rowsOf(List<Output.RowsRead.ReadRow> read, ValueTypes types,
                                            CheckedSignature signature,

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -3,6 +3,7 @@ package souther.compiler.program;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorImplementation;
+import souther.compiler.check.BoundaryInput;
 import souther.compiler.check.CoreBinders;
 import souther.compiler.check.Derived;
 import souther.compiler.check.Lower;
@@ -19,6 +20,7 @@ import souther.compiler.observe.FieldTypes;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.RowStatement;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.query.Acceptance;
 import souther.compiler.query.Bodies;
@@ -187,6 +189,7 @@ final class CheckedProgramAssembler {
      */
     private record ModuleReading(String name, Hir.Module bodies, Bodies.Elaborated checked,
                                  Map<String, Sig> signatures,
+                                 Map<ValueName.Behavior, Sig> reachable,
                                  Map<String, BehaviorImplementation> implementations,
                                  Map<ValueName.Behavior, Composition> compositions,
                                  Map<ValueName.Behavior, EnsuresEnforcement> checks,
@@ -220,6 +223,12 @@ final class CheckedProgramAssembler {
         Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();
         Lower.Lowered lowering = db.ask(new Bodies.Lowering(module)).value();
         Map<String, Sig> signatures = db.ask(new Bodies.Signatures(module)).value();
+        // What every behavior this module can name declares — its own and the ones it borrows, each
+        // under the declaration it belongs to. The same answer the run that read this module's rows
+        // was given, so what a stand-in's arguments were built and compared against and what a
+        // reader compares them at are one reading; and a dependency another compile declared is
+        // among them, which is what this module names it by.
+        Map<ValueName.Behavior, Sig> reachable = db.ask(new Bodies.Reachable(module)).value();
         Map<String, BehaviorImplementation> implementations =
                 db.ask(new Bodies.Implementation(module)).value();
         Map<ValueName.Behavior, Composition> compositions =
@@ -238,7 +247,8 @@ final class CheckedProgramAssembler {
         // read here and dropped here, and nothing it was reached through is carried into what is
         // made.
         Symbols symbols = Names.derivedSymbols(db, module).value();
-        if (checked == null || lowering == null || signatures == null || implementations == null
+        if (checked == null || lowering == null || signatures == null || reachable == null
+                || implementations == null
                 || compositions == null || symbols == null || shapes == null || checks == null) {
             // Not a report: the failure above is what a caller is told, and reaching here past it
             // means the two readings of whether this program checked have come apart.
@@ -251,8 +261,8 @@ final class CheckedProgramAssembler {
         // agree with the checker only for as long as lowering left declarations alone.
         Hir.Module declarations = lowering.settled();
         Hir.Module bodies = lowering.lowered();
-        return new ModuleReading(module, bodies, checked, signatures, implementations, compositions,
-                checks, dataOf(declarations, symbols, shapes), rowsOf(db, module));
+        return new ModuleReading(module, bodies, checked, signatures, reachable, implementations,
+                compositions, checks, dataOf(declarations, symbols, shapes), rowsOf(db, module));
     }
 
     /**
@@ -271,8 +281,8 @@ final class CheckedProgramAssembler {
                     implementationOf(named, declared, read.bodies(), read.implementations(),
                             read.checked(), read.compositions()),
                     EnsuresEnforcement.in(read.checks(), read.name(), named),
-                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types,
-                            signature)));
+                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types, signature,
+                            read.reachable())));
         }
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());
@@ -288,11 +298,12 @@ final class CheckedProgramAssembler {
      * from.
      */
     private static List<CheckedRow> rowsOf(List<Output.RowsRead.ReadRow> read, ValueTypes types,
-                                           CheckedSignature signature) {
+                                           CheckedSignature signature,
+                                           Map<ValueName.Behavior, Sig> reachable) {
         List<CheckedRow> rows = new ArrayList<>();
         for (Output.RowsRead.ReadRow row : read) {
             rows.add(new CheckedRow(row.identity(), row.at(),
-                    statementOf(row, types, signature)));
+                    statementOf(row, types, signature, reachable)));
         }
         return rows;
     }
@@ -310,7 +321,8 @@ final class CheckedProgramAssembler {
      * into whichever arm it happens to reach.
      */
     private static CheckedRow.Statement statementOf(Output.RowsRead.ReadRow row, ValueTypes types,
-                                                    CheckedSignature signature) {
+                                                    CheckedSignature signature,
+                                                    Map<ValueName.Behavior, Sig> reachable) {
         // A switch over both sums, so a row nothing came back for is written down here rather than
         // being whatever falls out of reading a list of the ones that did — which is a row an output
         // would never hear of, and a behavior reading as having said nothing about an input someone
@@ -321,7 +333,8 @@ final class CheckedProgramAssembler {
                         ? new CheckedRow.SelfContained(stated, types,
                                 Position.at(signature.answers()))
                         : new CheckedRow.WithStandIns(stated, types,
-                                Position.at(signature.answers()));
+                                Position.at(signature.answers()),
+                                whereArgumentsStand(stated, reachable));
                 case RowStatement.NotStated why -> new CheckedRow.NotReproducible(why);
                 // What acceptance guarantees, asserted where the guarantee is relied on. A row an
                 // evaluation stopped before the values of is one the language refuses the program
@@ -336,6 +349,38 @@ final class CheckedProgramAssembler {
             case Output.RowsRead.ReadRow.NotRun notRun ->
                     new CheckedRow.NotReproducible(new RowStatement.NotRead(notRun.why()));
         };
+    }
+
+    /**
+     * Where the arguments of each dependency the row stood in for stand.
+     *
+     * <p>Off what this module can name, which is the answer the run that read the row was given —
+     * so what a stand-in's entries were built against and what a reader compares an argument at are
+     * one reading of one declaration, rather than the same declaration written down twice and held
+     * to itself by a law.
+     *
+     * <p>It is what says how a comparison is made as well as how many are: whether an argument that
+     * is a sequence is the same one written in another order is what the type reading it says.
+     */
+    private static Map<ValueName.Behavior, List<Position>> whereArgumentsStand(
+            RowStatement.Stated stated, Map<ValueName.Behavior, Sig> reachable) {
+        Map<ValueName.Behavior, List<Position>> stands = new LinkedHashMap<>();
+        for (StoodIn stoodIn : stated.standIns()) {
+            Sig declared = reachable.get(stoodIn.dependency());
+            if (declared == null) {
+                // The row stood in for it, so this compile read the clause that required it against
+                // this module's own reading of what it can name. Reaching here is that reading and
+                // this one having come apart.
+                throw new IllegalStateException("`" + stoodIn.dependency() + "` was stood in for by"
+                        + " a row of a module that cannot name it");
+            }
+            List<Position> arguments = new ArrayList<>();
+            for (BoundaryInput takes : declared.ins()) {
+                arguments.add(Position.at(takes.type()));
+            }
+            stands.put(stoodIn.dependency(), arguments);
+        }
+        return stands;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
@@ -1,12 +1,15 @@
 package souther.compiler.program;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.observe.Comparisons;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowIdentity;
 import souther.compiler.observe.RowStatement;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.observe.Verdict;
+
+import java.util.List;
 
 /**
  * One {@code example} row of a behavior, for an output that lives outside this compiler.
@@ -65,56 +68,132 @@ public final class CheckedRow {
     /**
      * What a row states, as a reader of a checked program may act on it.
      *
-     * <p>Two arms, because there are two things a reader can do. A row that hands over values can be
-     * asked whether an answer keeps it; one that does not says why, and there is nothing to ask.
-     * Said as arms rather than as a question that refuses to be asked, so that a reader which never
-     * looked cannot get a verdict about a row that stated no values — the type is what stops it,
-     * rather than a rule it has to have read.
+     * <p>Three arms, because there are three things a reader can do. A row of a behavior that
+     * depends on nothing can be applied to the emission and asked whether the answer keeps it; a row
+     * of one that takes something injected can too, once what the row states the dependency answers
+     * is behind the import; a row that hands over no values says why, and there is nothing to ask.
+     * Said as arms rather than as one arm answering for all three, so that a reader written before a
+     * row could need a stand-in cannot be handed one — a row it would apply with nothing behind its
+     * imports, reporting what a run that cannot happen answered. The type is what stops it, rather
+     * than a rule it has to have read.
      *
      * <p>And nothing here answers with what a row states, which each arm answers for itself. Asked
-     * of both at once, the answer would be the whole of what an evaluation can come away with — a
+     * of all at once, the answer would be the whole of what an evaluation can come away with — a
      * compile that has not finished with a row among it — and a state no output can be handed would
      * be one every output has to consider, one method away from the arms that leave it out.
      */
     public sealed interface Statement {}
 
     /**
-     * A row an output can put to its own emission: the inputs it hands over, and what it states of
-     * the answer.
+     * A row an output can put to its own emission as it stands: the inputs it hands over, and what
+     * it states of the answer.
      *
      * <p>What it carries to answer {@link #holds} is the question and not an answerer: what this
      * program's declarations say stands inside a value, and where this behavior's answer stands.
      * It holds no program, no module and no declaration of its own — a row is a row of the program
      * it was read from, and it is that program's reading of the declarations that it asks.
      */
-    public static final class Reproducible implements Statement {
+    public static final class SelfContained implements Statement {
 
-        private final RowStatement.Stated stated;
-        private final ValueTypes types;
-        private final Position answers;
+        private final Asking asking;
 
-        Reproducible(RowStatement.Stated stated, ValueTypes types, Position answers) {
-            if (stated == null || types == null || answers == null) {
-                throw new IllegalArgumentException("a row that can be asked states values, and is"
-                        + " read with what the declarations say and where its answer stands");
+        SelfContained(RowStatement.Stated stated, ValueTypes types, Position answers) {
+            this.asking = new Asking(stated, types, answers);
+            if (!stated.standIns().isEmpty()) {
+                // What the behavior takes injected is the rest of what makes the row runnable, so a
+                // row stating one is not a row an output applies to its emission and nothing else.
+                throw new IllegalArgumentException("a row that needs something stood in for is not"
+                        + " one an output can run on its own");
             }
-            this.stated = stated;
-            this.types = types;
-            this.answers = answers;
         }
 
         /** The values it hands over and what it states of the answer. */
         public RowStatement.Stated states() {
-            return stated;
+            return asking.stated();
         }
 
         /** Whether {@code answered} is what this row states the behavior answers. */
         public Verdict holds(ObservedValue answered) {
+            return asking.holds(answered);
+        }
+
+        @Override
+        public String toString() {
+            return asking.toString();
+        }
+    }
+
+    /**
+     * A row an output can put to its emission once it has answered what the behavior depends on.
+     *
+     * <p>The same row as {@link SelfContained} with one thing more, and an arm of its own all the
+     * same. What an output does with this one it cannot do with the values alone: the behavior it
+     * emits imports what it depends on, and running the row means putting what {@link #standsIn}
+     * answers behind each import. A reader that walked past that would apply the behavior against
+     * whatever its own imports answer — a different row, with this row's inputs.
+     */
+    public static final class WithStandIns implements Statement {
+
+        private final Asking asking;
+        private final List<StandsIn> standIns;
+
+        WithStandIns(RowStatement.Stated stated, ValueTypes types, Position answers,
+                     List<StandsIn> standIns) {
+            this.asking = new Asking(stated, types, answers);
+            this.standIns = List.copyOf(standIns);
+            if (this.standIns.isEmpty()) {
+                throw new IllegalArgumentException("a row with nothing stood in for is one an"
+                        + " output can run on its own");
+            }
+        }
+
+        /** The values it hands over and what it states of the answer. */
+        public RowStatement.Stated states() {
+            return asking.stated();
+        }
+
+        /**
+         * What answers each of the behavior's dependencies, in the order it requires them.
+         *
+         * <p>All of them: a behavior reaches every one of them, and a row run with some of them
+         * answered is a row that stopped at the first import nothing was behind.
+         */
+        public List<StandsIn> standsIn() {
+            return standIns;
+        }
+
+        /** Whether {@code answered} is what this row states the behavior answers. */
+        public Verdict holds(ObservedValue answered) {
+            return asking.holds(answered);
+        }
+
+        @Override
+        public String toString() {
+            return asking.toString();
+        }
+    }
+
+    /**
+     * What holding a row to an answer takes, for the arms that can be asked.
+     *
+     * <p>One of these and not one for each arm. Whether an answer is what a row states is one
+     * question however the row is run, and two arms answering it apart would be two readings of one
+     * row — which is the thing {@link SelfContained#holds} exists to prevent a reader from being.
+     */
+    private record Asking(RowStatement.Stated stated, ValueTypes types, Position answers) {
+
+        private Asking {
+            if (stated == null || types == null || answers == null) {
+                throw new IllegalArgumentException("a row that can be asked states values, and is"
+                        + " read with what the declarations say and where its answer stands");
+            }
+        }
+
+        Verdict holds(ObservedValue answered) {
             if (answered == null) {
                 throw new IllegalArgumentException("a row is held against an answer");
             }
-            return souther.compiler.observe.Comparisons.verdict(stated.expects(), answered, types,
-                    answers);
+            return Comparisons.verdict(stated.expects(), answered, types, answers);
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
@@ -24,8 +24,8 @@ import java.util.Map;
  * apply the behavior — and what it can do with it is apply its own emission and ask whether the row
  * holds.
  *
- * <p>Asking is {@link Reproducible#holds}, and it is asked of the language rather than answered by
- * the reader. Whether an answer is the value a row states is a decision the language makes — a
+ * <p>Asking is {@link SelfContained#holds}, or {@link WithStandIns#holds} for a row that needed
+ * something stood in for, and it is asked of the language rather than answered by the reader. Whether an answer is the value a row states is a decision the language makes — a
  * written {@code Set.fromList([1])} at a {@code List} is not the sequence a list is, and two values
  * differ when their types differ as much as when their contents do. An output free to answer it for
  * itself would be a second reading of what a row means, and two outputs of one program would then

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
@@ -9,9 +9,11 @@ import souther.compiler.observe.RowStatement;
 import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.observe.Verdict;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * One {@code example} row of a behavior, for an output that lives outside this compiler.
@@ -139,18 +141,27 @@ public final class CheckedRow {
         private final Asking asking;
         private final List<StandsIn> standIns;
 
-        WithStandIns(RowStatement.Stated stated, ValueTypes types, Position answers) {
+        WithStandIns(RowStatement.Stated stated, ValueTypes types, Position answers,
+                     Map<ValueName.Behavior, List<Position>> arguments) {
             this.asking = new Asking(stated, types, answers);
             if (stated.standIns().isEmpty()) {
                 throw new IllegalArgumentException("a row with nothing stood in for is one an"
                         + " output can run on its own");
             }
-            // Made here rather than handed in. What the row states of its stand-ins and what a
-            // reader asks them are one fact, and taking the second as an argument would let a row
-            // answer one thing about a dependency through `states` and another through `standsIn`.
+            // One per stand-in the row states, made here rather than handed in. What the row states
+            // of its stand-ins and what a reader asks them are one fact, and taking the second as a
+            // list would let a row answer one thing about a dependency through `states` and another
+            // through `standsIn`. What comes from outside is where each dependency's arguments
+            // stand, which is what its declaration says and not what the row states.
             List<StandsIn> standIns = new ArrayList<>();
             for (StoodIn stoodIn : stated.standIns()) {
-                standIns.add(new StandsIn(stoodIn, types));
+                List<Position> stands = arguments.get(stoodIn.dependency());
+                if (stands == null) {
+                    throw new IllegalArgumentException("nothing says where the arguments of `"
+                            + stoodIn.dependency() + "` stand, which is what its stand-in is asked"
+                            + " at");
+                }
+                standIns.add(new StandsIn(stoodIn, types, stands));
             }
             this.standIns = List.copyOf(standIns);
         }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedRow.java
@@ -6,9 +6,11 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowIdentity;
 import souther.compiler.observe.RowStatement;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
 import souther.compiler.observe.Verdict;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -137,14 +139,20 @@ public final class CheckedRow {
         private final Asking asking;
         private final List<StandsIn> standIns;
 
-        WithStandIns(RowStatement.Stated stated, ValueTypes types, Position answers,
-                     List<StandsIn> standIns) {
+        WithStandIns(RowStatement.Stated stated, ValueTypes types, Position answers) {
             this.asking = new Asking(stated, types, answers);
-            this.standIns = List.copyOf(standIns);
-            if (this.standIns.isEmpty()) {
+            if (stated.standIns().isEmpty()) {
                 throw new IllegalArgumentException("a row with nothing stood in for is one an"
                         + " output can run on its own");
             }
+            // Made here rather than handed in. What the row states of its stand-ins and what a
+            // reader asks them are one fact, and taking the second as an argument would let a row
+            // answer one thing about a dependency through `states` and another through `standsIn`.
+            List<StandsIn> standIns = new ArrayList<>();
+            for (StoodIn stoodIn : stated.standIns()) {
+                standIns.add(new StandsIn(stoodIn, types));
+            }
+            this.standIns = List.copyOf(standIns);
         }
 
         /** The values it hands over and what it states of the answer. */

--- a/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
@@ -7,10 +7,8 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
-import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -39,21 +37,14 @@ public final class StandsIn {
     private final ValueTypes types;
     private final List<Position> arguments;
 
-    StandsIn(StoodIn stated, ValueTypes types) {
-        if (stated == null || types == null) {
+    StandsIn(StoodIn stated, ValueTypes types, List<Position> arguments) {
+        if (stated == null || types == null || arguments == null) {
             throw new IllegalArgumentException("what stands in for a dependency is what the row"
-                    + " states of it, read with what the declarations say");
+                    + " states of it, read with what the declarations say and where the dependency's"
+                    + " arguments stand");
         }
         this.stated = stated;
         this.types = types;
-        List<Position> arguments = new ArrayList<>();
-        // Where each of the dependency's arguments stands, off what the stand-in states the
-        // dependency takes. Read off the declaration a second time — through whatever this program
-        // publishes for that behavior — it could be a reading the entries were never built against,
-        // and a dependency declared in a module this compile only read would have none here at all.
-        for (Type takes : stated.takes()) {
-            arguments.add(Position.at(takes));
-        }
         this.arguments = List.copyOf(arguments);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
@@ -1,0 +1,145 @@
+package souther.compiler.program;
+
+import souther.compiler.diag.SourcePos;
+import souther.compiler.observe.Comparisons;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.Position;
+import souther.compiler.observe.StoodIn;
+import souther.compiler.observe.ValueTypes;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+
+/**
+ * What answers one of a behavior's dependencies while a row of it runs, for an output outside this
+ * compiler.
+ *
+ * <p>A row of a behavior that depends on something injected does not run against its inputs alone.
+ * An output emits that dependency as an import, and what it has to put behind the import is an
+ * answer rather than an implementation: this is what the row states that answer to be, and asking
+ * it is asking what the row was written to run against.
+ *
+ * <p>What it answers is asked here rather than read off {@link #stated}. Which entry answers is the
+ * table's own rule — the first stating what it was asked, and otherwise whatever it was written to
+ * answer for the rest — and whether an argument is what an entry states is the language's, since
+ * two values differ when their types differ as much as when their contents do. A reader deciding
+ * either for itself would have the fake answer one thing in this compile and another in the output
+ * built from it, which is the row running against something nobody wrote.
+ *
+ * <p>What it takes is what {@link CheckedRow.SelfContained#holds} takes: values as they were
+ * observed. An output that can say what its own answer was — which holding a row to what it states
+ * already asks of it — can say what its emission handed the import.
+ */
+public final class StandsIn {
+
+    private final StoodIn stated;
+    private final ValueTypes types;
+    private final List<Position> arguments;
+
+    StandsIn(StoodIn stated, ValueTypes types, List<Position> arguments) {
+        if (stated == null || types == null) {
+            throw new IllegalArgumentException("what stands in for a dependency is what the row"
+                    + " states of it, read with what the declarations say");
+        }
+        this.stated = stated;
+        this.types = types;
+        this.arguments = List.copyOf(arguments);
+    }
+
+    /** The behavior this stands in for, which is the one an output emits as an import. */
+    public ValueName.Behavior dependency() {
+        return stated.dependency();
+    }
+
+    /**
+     * What the row states it answers.
+     *
+     * <p>What a report shows and what a generated test is written from. Not how to answer: the
+     * entries are in the order the rule reads them, and the rule is {@link #answering}.
+     */
+    public StoodIn stated() {
+        return stated;
+    }
+
+    /**
+     * What it answers for {@code arguments}, in the order the dependency takes them.
+     *
+     * <p>The stand-in's own rule and not a lookup a reader arranges: the first entry stating these
+     * arguments answers, and where none states them the answer is whatever the stand-in was written
+     * to answer for the rest — which may be nothing.
+     */
+    public Answer answering(List<ObservedValue> asked) {
+        if (asked == null) {
+            throw new IllegalArgumentException("a stand-in is asked what it answers for values");
+        }
+        for (ObservedValue value : asked) {
+            if (value == null) {
+                throw new IllegalArgumentException("a stand-in is asked what it answers for"
+                        + " values");
+            }
+        }
+        if (asked.size() != arguments.size()) {
+            // A call and not a value of one: what a dependency taking two is asked is a pair, and
+            // an entry stating a pair states neither half of it on its own.
+            throw new IllegalArgumentException("`" + dependency().name() + "` takes "
+                    + arguments.size() + " and was asked what it answers for " + asked.size());
+        }
+        for (StoodIn.Entry entry : stated.entries()) {
+            if (states(entry.arguments(), asked)) {
+                return new Answer.TheValue(entry.answer());
+            }
+        }
+        return switch (stated.otherwise()) {
+            case StoodIn.Otherwise.Answer(ObservedValue value, SourcePos _) ->
+                    new Answer.TheValue(value);
+            case StoodIn.Otherwise.NothingStated _ -> new Answer.NothingStated();
+        };
+    }
+
+    /**
+     * Whether an entry states the arguments a call arrived with.
+     *
+     * <p>Each of them at the place the dependency's declaration puts it, which is what says whether
+     * a sequence there is compared in order. A dependency taking several is answered for all of
+     * them together: an entry states a call and not one argument of one.
+     */
+    private boolean states(List<ObservedValue> entry, List<ObservedValue> asked) {
+        if (entry.size() != asked.size()) {
+            return false;
+        }
+        for (int i = 0; i < entry.size(); i++) {
+            if (!Comparisons.same(entry.get(i), asked.get(i), types, arguments.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return stated.toString();
+    }
+
+    /**
+     * What a stand-in answers for one call.
+     *
+     * <p>Two arms rather than a value that may be absent. A stand-in that states nothing for what it
+     * was asked has not answered with nothing — a run reaching that is a run the row never covered,
+     * and a reader handed an absent value would put it behind the import as an answer.
+     */
+    public sealed interface Answer {
+
+        /** It answers this. */
+        record TheValue(ObservedValue value) implements Answer {
+
+            public TheValue {
+                if (value == null) {
+                    throw new IllegalArgumentException("an answer is a value");
+                }
+            }
+        }
+
+        /** It states no answer for what it was asked. */
+        record NothingStated() implements Answer {}
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
@@ -2,6 +2,7 @@ package souther.compiler.program;
 
 import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.Comparisons;
+import souther.compiler.observe.Limits;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.StoodIn;
@@ -77,15 +78,27 @@ public final class StandsIn {
      * <p>The stand-in's own rule and not a lookup a reader arranges: the first entry stating these
      * arguments answers, and where none states them the answer is whatever the stand-in was written
      * to answer for the rest — which may be nothing.
+     *
+     * <p>Asked with values that are there. What a stand-in answers is decided by comparing what it
+     * was asked against what its entries state, and an observation that stopped is not something an
+     * entry either states or does not — read as "not this entry", it would walk on to what the
+     * stand-in answers for arguments it does not list, which is the fake answering one thing here
+     * and another where the row ran. A reader has the value it handed the import; one that could not
+     * read its own value has not got as far as asking this.
+     *
+     * @throws IllegalArgumentException if any of {@code asked} is not a value that is there in full
      */
     public Answer answering(List<ObservedValue> asked) {
         if (asked == null) {
             throw new IllegalArgumentException("a stand-in is asked what it answers for values");
         }
-        for (ObservedValue value : asked) {
-            if (value == null) {
-                throw new IllegalArgumentException("a stand-in is asked what it answers for"
-                        + " values");
+        // All of them before any of them is compared. The comparison refuses one of these too, but
+        // it is reached for an argument only where an earlier one matched — so which entries the
+        // stand-in happens to hold would decide whether asking it is refused at all.
+        for (int i = 0; i < asked.size(); i++) {
+            if (asked.get(i) == null || !Limits.UNBOUNDED.admits(asked.get(i))) {
+                throw new IllegalArgumentException("`" + dependency() + "` is asked what it answers"
+                        + " for values, and the one at " + i + " is not there in full");
             }
         }
         if (asked.size() != arguments.size()) {

--- a/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/StandsIn.java
@@ -6,8 +6,10 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.ValueTypes;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -36,13 +38,21 @@ public final class StandsIn {
     private final ValueTypes types;
     private final List<Position> arguments;
 
-    StandsIn(StoodIn stated, ValueTypes types, List<Position> arguments) {
+    StandsIn(StoodIn stated, ValueTypes types) {
         if (stated == null || types == null) {
             throw new IllegalArgumentException("what stands in for a dependency is what the row"
                     + " states of it, read with what the declarations say");
         }
         this.stated = stated;
         this.types = types;
+        List<Position> arguments = new ArrayList<>();
+        // Where each of the dependency's arguments stands, off what the stand-in states the
+        // dependency takes. Read off the declaration a second time — through whatever this program
+        // publishes for that behavior — it could be a reading the entries were never built against,
+        // and a dependency declared in a module this compile only read would have none here at all.
+        for (Type takes : stated.takes()) {
+            arguments.add(Position.at(takes));
+        }
         this.arguments = List.copyOf(arguments);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AStandInIsBuiltOnceForTheRowThatStatesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AStandInIsBuiltOnceForTheRowThatStatesItTest.java
@@ -1,0 +1,106 @@
+package souther.compiler;
+
+import souther.compiler.execute.EvaluationPolicy;
+import souther.compiler.observe.ArmObservation;
+import souther.compiler.observe.Counting;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.source.SourceId;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a row states of a stand-in and what the run applies the behavior with come of one reading.
+ *
+ * <p>A stand-in is written as a value, and a value is built by applying whatever helpers it names.
+ * The run needs it as something the behavior can be constructed with, and the row needs it as values
+ * an output can be handed; read twice, the helpers behind it run twice — charged twice against the
+ * row's budget, and doing whatever they do twice.
+ *
+ * <p>Counted rather than argued. What a row spends is what this compile counted its generated code
+ * through, fixtures and application alike, so a helper applied a second time is a second helping of
+ * steps and shows up here as one.
+ */
+class AStandInIsBuiltOnceForTheRowThatStatesItTest {
+
+    /**
+     * Three rows of one behavior, differing in where the work is.
+     *
+     * <p>The first states nothing costly, the second spends a helper building an input, and the
+     * third spends the same helper building what stands in for the dependency. So what the third
+     * costs over the first is what building a stand-in costs, and the second says what one
+     * application of that helper is.
+     */
+    private static final String MODEL = """
+            module example.once
+
+            data N = Int
+            data Out = Int
+            data Rate = Int
+
+            partial let spin (n: Int): Int = if n == 0 then 0 else spin(n - 1)
+
+            behavior rateFor : () -> Rate
+
+            behavior run : (n: N) -> Out
+                depends on rateFor
+                constructs Out
+
+            let run (n, rateFor) = Out(n.value + rateFor().value)
+
+            fake rateFor
+                | _ -> Rate(1)
+
+            example run
+              | "nothing costly" : (N(0)) -> Out(1)
+              | "a helper in an input" : (N(spin(1000))) -> Out(1)
+              | "the same helper in the stand-in" : (N(0)) with rateFor = Rate(spin(1000)) -> Out(0)
+            """;
+
+    @Test
+    void aStandInCostsWhatBuildingItOnceCosts() {
+        List<RowOutcome> rows = rowsOf(MODEL);
+        assertEquals(3, rows.size(), () -> "the rows read are " + rows);
+
+        long cheap = steps(rows.get(0));
+        long inAnInput = steps(rows.get(1));
+        long inTheStandIn = steps(rows.get(2));
+
+        // The premise of the measurement, measured: a helper that cost nothing would make every
+        // comparison below hold whatever the reading did.
+        long once = inAnInput - cheap;
+        assertTrue(once > 500, () -> "one application of the helper costs " + once
+                + " steps, so nothing below is being told apart by it");
+
+        long standingIn = inTheStandIn - cheap;
+        assertTrue(standingIn > once / 2, () -> "the stand-in cost " + standingIn + " steps and"
+                + " building it once costs " + once + ": the helper it names did not run");
+        assertTrue(standingIn < once * 3 / 2, () -> "the stand-in cost " + standingIn + " steps and"
+                + " building it once costs " + once + ": it was built more than once");
+    }
+
+    /** What a row spent: the counted work of its whole evaluation, fixtures and application alike. */
+    private static long steps(RowOutcome row) {
+        return assertInstanceOf(Counting.Read.class, row.run().counting(),
+                "the row came back, so its counting was read").steps();
+    }
+
+    private static List<RowOutcome> rowsOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.withEvaluationPolicy(
+                EvaluationPolicy.of(10_000_000L).withOuterTimeout(Duration.ofSeconds(30)));
+        compilation.answerEverything();
+        SourceId sourceId = compilation.exampleSourcesOf("example.once").getFirst();
+        return compilation.db()
+                .ask(new Output.Examples("example.once", sourceId, ArmObservation.OMIT)).value()
+                .rows();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForADependencyIsMadeInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForADependencyIsMadeInOnePlaceTest.java
@@ -1,0 +1,63 @@
+package souther.compiler.examples;
+
+import souther.compiler.WhatWasCompiled;
+import souther.compiler.observe.RowStatements;
+import souther.compiler.observe.StoodIn;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What stands in for a dependency is read once, and what crosses is minted where that is decided.
+ *
+ * <p>Two halves come of reading a stand-in: something the behavior can be constructed with, which is
+ * of the loader the implementation came from, and the values the row states, which are of nothing.
+ * They are the same text read once — the helpers a stand-in names are applied where it is built, and
+ * a second reading applies them again — so both come out of one place, and this says which.
+ *
+ * <p>Read off the class files rather than the source. A call is in the caller's constant pool
+ * whatever the call site is spelled like, and a lambda's body is compiled into the class that wrote
+ * it, so a second reading cannot get out of this by being written somewhere shorter.
+ */
+class WhatStandsInForADependencyIsMadeInOnePlaceTest {
+
+    /**
+     * A stand-in that crosses is made where it is held to what a reader may be given.
+     *
+     * <p>The one caller is the reading that asks whether every value it states is one these limits
+     * keep. Minted anywhere else, a stand-in could carry a value larger than what is kept — and a
+     * reader taking the values in one as values that are there would be reading a value nobody
+     * wrote.
+     */
+    @Test
+    void whatCrossesIsMintedByTheReadingThatChecksIt() {
+        assertEquals(List.of("souther.compiler.observe.RowStatements$StandInRead"),
+                List.copyOf(WhatWasCompiled.callersOf(StoodIn.class, "of")),
+                "what a row states of a stand-in is made where it is decided that it may be");
+    }
+
+    /** And the reading is entered from the one place a row's stand-ins are read. */
+    @Test
+    void andTheReadingIsEnteredWhereARowIsRead() {
+        assertEquals(List.of("souther.compiler.examples.ExampleVerifier"),
+                List.copyOf(WhatWasCompiled.callersOf(RowStatements.StandInRead.class, "of")),
+                "a row's stand-ins are read where the row is");
+    }
+
+    /**
+     * And what a run applies the behavior with is built there too.
+     *
+     * <p>The two halves in one class is what makes them one reading. Built somewhere else, the
+     * fixtures behind a stand-in would be applied a second time — charged twice against the row's
+     * budget, and doing whatever they do twice.
+     */
+    @Test
+    void andSoIsWhatTheRunAppliesTheBehaviorWith() {
+        assertEquals(List.of("souther.compiler.examples.ExampleVerifier"),
+                List.copyOf(WhatWasCompiled.callersOf(DependencyStandin.class, "<init>")),
+                "what a run stands in with is built where the row's stand-ins are read");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest.java
@@ -1,0 +1,169 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.CheckedDeclarations;
+import souther.compiler.check.Symbols;
+import souther.compiler.observe.Comparisons;
+import souther.compiler.observe.FieldTypes;
+import souther.compiler.observe.Limits;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.Position;
+import souther.compiler.observe.ValueTypes;
+import souther.compiler.types.Type;
+import souther.runtime.Values;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A fake's table picks the same row on both sides of the boundary.
+ *
+ * <p>A row that ran through a table ran through the row that table's dispatch picked, and it picked
+ * it by {@link Values#equal} over the values the run had. An output holding that row picks a row for
+ * itself, out of values it was handed, by {@link Comparisons#same}. The two are different code and
+ * have to be: one compares what a class loader built, the other what an observation carries, and
+ * making the run observe every argument it dispatches on would put the limits an observation is held
+ * to into what a fake answers.
+ *
+ * <p>So they are held to answering the same. Where they part, a row holds in this compile against an
+ * answer the output's run of it never produces — the fake answering one thing here and another
+ * there — and nothing about the row says so.
+ *
+ * <p>At the place the value stands, which is what the law is about. Which of a list and a set a
+ * sequence is, is what the declaration reading it says on one side and what the class carrying it is
+ * on the other; the two agree because a stand-in is asked at what the dependency declares it takes,
+ * and a pair read at some other place is not what either side is asked.
+ */
+class WhatTwoValuesAreEqualByIsOneAnswerOnBothSidesOfTheBoundaryTest {
+
+    private static final Type INT = Type.Prim.named("Int");
+    private static final Type DECIMAL = Type.Prim.named("Decimal");
+    private static final Type STRING = Type.Prim.named("String");
+    private static final Type BOOL = Type.Prim.named("Bool");
+    private static final Type DATE = Type.Prim.named("Date");
+
+    /** Two values of one declared type, and where a value of it stands. */
+    private record Pair(String says, Type at, Object left, Object right) {}
+
+    private static final List<Pair> PAIRS = pairs();
+
+    private static List<Pair> pairs() {
+        List<Pair> pairs = new ArrayList<>();
+        pairs.add(new Pair("one number and the same", INT, 1L, 1L));
+        pairs.add(new Pair("one number and another", INT, 1L, 2L));
+        pairs.add(new Pair("an amount and the same amount written to another scale", DECIMAL,
+                new BigDecimal("1.50"), new BigDecimal("1.5")));
+        pairs.add(new Pair("an amount and another", DECIMAL,
+                new BigDecimal("1.50"), new BigDecimal("1.51")));
+        pairs.add(new Pair("a text and the same", STRING, "ada", "ada"));
+        pairs.add(new Pair("a text and another", STRING, "ada", "grace"));
+        pairs.add(new Pair("a text and one that differs by case", STRING, "ada", "Ada"));
+        pairs.add(new Pair("both of the two truths", BOOL, true, true));
+        pairs.add(new Pair("one truth and the other", BOOL, true, false));
+        pairs.add(new Pair("a date and the same", DATE,
+                LocalDate.parse("2026-01-31"), LocalDate.parse("2026-01-31")));
+        pairs.add(new Pair("a date and another", DATE,
+                LocalDate.parse("2026-01-31"), LocalDate.parse("2026-02-01")));
+        pairs.add(new Pair("a list and the same list", Type.list(INT),
+                List.of(1L, 2L), List.of(1L, 2L)));
+        pairs.add(new Pair("a list and the same elements in another order", Type.list(INT),
+                List.of(1L, 2L), List.of(2L, 1L)));
+        pairs.add(new Pair("a list and a longer one starting the same way", Type.list(INT),
+                List.of(1L, 2L), List.of(1L, 2L, 3L)));
+        pairs.add(new Pair("a list of lists and the same", Type.list(Type.list(INT)),
+                List.of(List.of(1L), List.of(2L)), List.of(List.of(1L), List.of(2L))));
+        pairs.add(new Pair("a list of lists differing inside one of them",
+                Type.list(Type.list(INT)),
+                List.of(List.of(1L), List.of(2L)), List.of(List.of(1L), List.of(3L))));
+        pairs.add(new Pair("a set and the same elements met in another order", Type.set(INT),
+                set(1L, 2L), set(2L, 1L)));
+        pairs.add(new Pair("a set and one holding something else", Type.set(INT),
+                set(1L, 2L), set(1L, 3L)));
+        pairs.add(new Pair("a map and the same entries written in another order",
+                Type.map(STRING, INT), map("a", 1L, "b", 2L), map("b", 2L, "a", 1L)));
+        pairs.add(new Pair("a map and one answering differently under a key",
+                Type.map(STRING, INT), map("a", 1L, "b", 2L), map("a", 1L, "b", 3L)));
+        pairs.add(new Pair("a map and one that does not hold a key at all",
+                Type.map(STRING, INT), map("a", 1L, "b", 2L), map("a", 1L, "c", 2L)));
+        pairs.add(new Pair("a map holding lists and the same", Type.map(STRING, Type.list(INT)),
+                Map.of("a", List.of(1L, 2L)), Map.of("a", List.of(1L, 2L))));
+        return List.copyOf(pairs);
+    }
+
+    /**
+     * Whatever the run says of two values, an output holding them says the same.
+     *
+     * <p>Both ways round as well, since one of the two walks the left value and the other the right:
+     * a rule reading only what it is given first is one that answers by which value it was asked
+     * about.
+     */
+    @Test
+    void whatTheRunPicksARowByAndWhatAnOutputPicksOneByAgree() {
+        for (Pair pair : PAIRS) {
+            boolean equal = Values.equal(pair.left(), pair.right());
+            Position at = Position.at(pair.at());
+
+            assertEquals(equal, Comparisons.same(observe(pair.left()), observe(pair.right()),
+                            declarations(), at),
+                    () -> pair.says() + ", read at " + pair.at());
+            assertEquals(equal, Comparisons.same(observe(pair.right()), observe(pair.left()),
+                            declarations(), at),
+                    () -> pair.says() + ", read at " + pair.at() + ", the other way round");
+        }
+    }
+
+    /**
+     * And the pairs say both things.
+     *
+     * <p>A law over pairs that were all equal, or all not, is one a rule answering the same to
+     * everything would keep. What makes the check a check is that the two sides part on the same
+     * pairs, so both answers have to be among them.
+     */
+    @Test
+    void andThePairsAreBothTheSameValueAndNot() {
+        List<String> same = new ArrayList<>();
+        List<String> differ = new ArrayList<>();
+        for (Pair pair : PAIRS) {
+            (Values.equal(pair.left(), pair.right()) ? same : differ).add(pair.says());
+        }
+
+        assertTrue(same.size() >= 8, () -> "pairs of one value: " + same);
+        assertTrue(differ.size() >= 8, () -> "pairs of two: " + differ);
+    }
+
+    private static Set<Object> set(Object... elements) {
+        return new LinkedHashSet<>(List.of(elements));
+    }
+
+    private static Map<String, Object> map(String k1, Object v1, String k2, Object v2) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(k1, v1);
+        map.put(k2, v2);
+        return map;
+    }
+
+    /** No module is being read, so nothing here declares a data whose fields could be asked for. */
+    private static ValueTypes declarations() {
+        Symbols symbols = Symbols.none(DefaultStdlib.get());
+        return ValueTypes.over(FieldTypes.over(new CheckedDeclarations(symbols, _ -> null)));
+    }
+
+    private static ObservedValue observe(Object live) {
+        Symbols symbols = Symbols.none(DefaultStdlib.get());
+        return ObservedValues.of(live, symbols,
+                new NeutralForm(symbols,
+                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))),
+                Limits.DEFAULT);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/observe/WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/observe/WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.observe;
+
+import souther.compiler.program.CheckedBehavior;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.program.CheckedRow;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * What a row states is what the row wrote, whether or not anything applied the behavior.
+ *
+ * <p>A row is written down before anything runs it, and what it hands over — what stands in for each
+ * dependency, the inputs, the expectation — is the same text either way. A snapshot whose rows said
+ * one thing where this compile found an implementation and another where it did not would be
+ * publishing the compile rather than the program: the same source, read twice, would hand two
+ * different obligations to two outputs.
+ *
+ * <p>Kept two ways, and the first is not a rule to remember. {@link RowStatements} is in
+ * {@code observe}, and what a run found to apply a behavior with is private to {@code examples},
+ * which this package may not name — so the reading cannot ask. What is left to check here is that
+ * nothing is handed it either: a caller can carry an answer across a boundary the compiler keeps by
+ * putting it in an argument, and a {@code boolean} saying whether anything applies the behavior
+ * would be exactly that.
+ */
+class WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest {
+
+    /**
+     * What making a statement takes, said out loud.
+     *
+     * <p>Reflection and not a reading of the source, because what a caller can hand over is the
+     * signature the compiler produced. A parameter added here is a line to change with a reason
+     * beside it — and the reason cannot be that a statement wants to know what this compile could
+     * run, which is what this list exists to make hard to write.
+     */
+    @Test
+    void whatMakingAStatementTakesIsTheRowAndNothingElse() {
+        List<String> takes = new ArrayList<>();
+        for (Method method : RowStatements.class.getDeclaredMethods()) {
+            if (!Modifier.isPublic(method.getModifiers())) {
+                continue;
+            }
+            List<String> parameters = new ArrayList<>();
+            for (Class<?> parameter : method.getParameterTypes()) {
+                parameters.add(parameter.getSimpleName());
+            }
+            takes.add(method.getName() + parameters);
+        }
+
+        assertEquals(List.of("read[List, List, Expectation]"), takes,
+                "what a row states is made of what was read of the row");
+    }
+
+    /**
+     * And a row of a behavior nothing implements states what stood in for its dependencies.
+     *
+     * <p>Nothing applies {@code rateOf} here — it is declared and never written — so this row is one
+     * no run reached. It states its stand-in all the same, because the {@code fake} beside it is
+     * what the row was written to run against and that is true of the text rather than of the run.
+     */
+    @Test
+    void aRowOfABehaviorNothingAppliesStatesWhatStandsInForIt() {
+        CheckedProgram program = CheckedProgram.of(List.of("""
+                module demo
+
+                data Price = Int
+                data Rate = Int
+
+                behavior rateFor : (of: Price) -> Rate
+
+                behavior rateOf : (base: Price) -> Rate
+                    depends on rateFor
+
+                fake rateFor
+                    | (Price(1)) -> Rate(10)
+
+                example rateOf
+                    | "the one price it lists" : (Price(1)) -> Rate(10)
+                """));
+
+        CheckedBehavior rateOf =
+                program.module("demo").behavior(new ValueName.Behavior("demo", "rateOf"));
+        CheckedRow.WithStandIns states = assertInstanceOf(CheckedRow.WithStandIns.class,
+                rateOf.rows().get(0).statement(),
+                "a row states its stand-ins whether or not anything was found to run it");
+
+        assertEquals(new ValueName.Behavior("demo", "rateFor"),
+                states.standsIn().get(0).dependency());
+        assertEquals(1, states.standsIn().get(0).stated().entries().size(),
+                "and the entries the table states are the ones it was written with");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/observe/WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/observe/WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +55,9 @@ class WhatARowStatesDoesNotDependOnWhatAppliedTheBehaviorTest {
             }
             takes.add(method.getName() + parameters);
         }
+        // Sorted, because what order the methods come back in is not answered for: a second one
+        // added here would make the list depend on the run rather than on what was declared.
+        takes.sort(Comparator.naturalOrder());
 
         assertEquals(List.of("read[List, List, Expectation]"), takes,
                 "what a row states is made of what was read of the row");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -128,7 +128,7 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
     private static souther.compiler.observe.RowStatement statingTheSame(RowOutcome row,
                                                                         List<ObservedValue> inputs) {
         return row.statement() instanceof souther.compiler.observe.RowStatement.Stated stated
-                ? souther.compiler.observe.RowStatement.of(inputs, stated.expects())
+                ? souther.compiler.observe.RowStatements.read(List.of(), inputs, stated.expects())
                 : row.statement();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/InputClassificationsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/InputClassificationsTest.java
@@ -172,7 +172,7 @@ class InputClassificationsTest {
                 // A row whose input the observation stopped in states no values, which is what the
                 // one place that decides answers for these. Kept as the row's own, the fixture
                 // would say two different things about what it handed over.
-                souther.compiler.observe.RowStatement.of(
+                souther.compiler.observe.RowStatements.read(List.of(),
                         List.of(new ObservedValue.Constructed(request.type(), broken)),
                         ((souther.compiler.observe.RowStatement.Stated) row.statement()).expects()),
                 row.run());

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -128,7 +128,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
     private static souther.compiler.observe.RowStatement statingTheSame(RowOutcome row,
                                                                         List<ObservedValue> inputs) {
         return row.statement() instanceof souther.compiler.observe.RowStatement.Stated stated
-                ? souther.compiler.observe.RowStatement.of(inputs, stated.expects())
+                ? souther.compiler.observe.RowStatements.read(List.of(), inputs, stated.expects())
                 : row.statement();
     }
 

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
@@ -104,6 +104,33 @@ class AStandInAnswersWhatItAnsweredWhenTheRowRanTest {
     }
 
     /**
+     * What a stand-in states the dependency takes is what this program says it takes.
+     *
+     * <p>A stand-in carries it because that is what its entries were built and compared against, and
+     * because a dependency another compile declared has nothing here to be asked. Where this program
+     * does declare it, the two are the same declaration — and a stand-in comparing arguments at a
+     * type the behavior does not take would be answering for a call nothing can make.
+     */
+    @Test
+    void whatAStandInStatesADependencyTakesIsWhatTheProgramDeclares() {
+        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
+
+        List<String> checked = new ArrayList<>();
+        for (CheckedRow row : rowsOf(program)) {
+            for (StandsIn standsIn : assertInstanceOf(CheckedRow.WithStandIns.class,
+                    row.statement()).standsIn()) {
+                CheckedBehavior dependency = program.module("demo").behavior(standsIn.dependency());
+                assertEquals(dependency.signature().takes(), standsIn.stated().takes(),
+                        () -> "what " + standsIn.dependency() + " takes");
+                checked.add(standsIn.dependency().name());
+            }
+        }
+
+        assertEquals(List.of("rateFor", "rateFor", "rateFor", "labelFor"), checked,
+                "every dependency stood in for by a row of this program");
+    }
+
+    /**
      * A table asked something it does not list, and does not answer for, states no answer.
      *
      * <p>The table's own rule and not the reader's. A stand-in that answered anything here would

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
@@ -1,20 +1,25 @@
 package souther.program.api;
 
+import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.Verdict;
 import souther.compiler.program.CheckedBehavior;
 import souther.compiler.program.CheckedModule;
 import souther.compiler.program.CheckedProgram;
 import souther.compiler.program.CheckedRow;
 import souther.compiler.program.StandsIn;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A stand-in answers an output what it answered the run.
@@ -131,6 +136,39 @@ class AStandInAnswersWhatItAnsweredWhenTheRowRanTest {
     }
 
     /**
+     * A stand-in is asked with values, and an observation that stopped is not one.
+     *
+     * <p>The table below answers everything it does not list, so a value it cannot be compared with
+     * would fall through to that: an argument whose observation stopped would be answered {@code 99}
+     * on the strength of not being {@code 1} or {@code 2}, when what stands where it stopped may be
+     * either of them. That is the fake answering one thing here and another where the row ran, which
+     * is what carrying the table across was for.
+     *
+     * <p>Refused rather than answered, wherever it is: a value with nothing readable in it, one a
+     * limit stopped, and one whose field is either — the walk goes down, so the rule has to.
+     */
+    @Test
+    void aStandInIsAskedWithValuesThatAreThere() {
+        CheckedRow row = behavior(CheckedProgram.of(List.of(MODULE)), "rateOf").rows().get(0);
+        StandsIn standsIn = assertInstanceOf(CheckedRow.WithStandIns.class, row.statement())
+                .standsIn().get(0);
+
+        for (ObservedValue nothing : List.of(new ObservedValue.Unknown("nothing read it"),
+                new ObservedValue.Truncated(),
+                priceHolding(new ObservedValue.Unknown("nothing read it")),
+                priceHolding(new ObservedValue.Truncated()))) {
+            assertThrows(IllegalArgumentException.class, () -> standsIn.answering(List.of(nothing)),
+                    () -> "asked with " + nothing);
+        }
+
+        // And what it does answer for a value that is there, so that the refusal above is about the
+        // value rather than about everything this stand-in is asked.
+        assertEquals(new StandsIn.Answer.TheValue(
+                        newtype("Rate", new ObservedValue.Integer(99))),
+                standsIn.answering(List.of(price(7))));
+    }
+
+    /**
      * A table asked something it does not list, and does not answer for, states no answer.
      *
      * <p>The table's own rule and not the reader's. A stand-in that answered anything here would
@@ -226,14 +264,22 @@ class AStandInAnswersWhatItAnsweredWhenTheRowRanTest {
                 .standsIn().get(0);
     }
 
-    /** A price as an output would hand it over, which is what a newtype is written as. */
-    private static souther.compiler.observe.ObservedValue price(long value) {
-        java.util.Map<String, souther.compiler.observe.ObservedValue> fields =
-                souther.compiler.observe.ObservedValue.fields();
-        fields.put("value", new souther.compiler.observe.ObservedValue.Integer(value));
-        return new souther.compiler.observe.ObservedValue.Constructed(
-                souther.compiler.types.TypeSymbols.declared(
-                        new souther.compiler.types.TypeKey("demo", "Price")), fields);
+    /** A price as an output would hand it over. */
+    private static ObservedValue price(long value) {
+        return newtype("Price", new ObservedValue.Integer(value));
+    }
+
+    /** A price holding something an observation did not come back with. */
+    private static ObservedValue priceHolding(ObservedValue value) {
+        return newtype("Price", value);
+    }
+
+    /** A value under a name, which is the single field every newtype is written with. */
+    private static ObservedValue newtype(String data, ObservedValue value) {
+        Map<String, ObservedValue> fields = ObservedValue.fields();
+        fields.put("value", value);
+        return new ObservedValue.Constructed(TypeSymbols.declared(new TypeKey("demo", data)),
+                fields);
     }
 
     /** The rows of every behavior that depends on something, in the order they are written. */

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
@@ -1,0 +1,226 @@
+package souther.program.api;
+
+import souther.compiler.observe.Verdict;
+import souther.compiler.program.CheckedBehavior;
+import souther.compiler.program.CheckedModule;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.program.CheckedRow;
+import souther.compiler.program.StandsIn;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A stand-in answers an output what it answered the run.
+ *
+ * <p>Which row of a fake's table answers a call is decided twice: by the run this compile made, out
+ * of the values it built, and by an output holding the row, out of the values it was handed. The two
+ * are different code — one compares what a class loader built and the other what an observation
+ * carries — and where they part, a row that held here is a row the output's run of it fails, with
+ * nothing about either saying why.
+ *
+ * <p>Held to each other through the rows. Each behavior below hands its input straight to what it
+ * depends on and answers what that answers, so what the row states of the answer is what the fake
+ * answered when the row ran — and the program was accepted, which is this compile saying the row
+ * held. Asking the stand-in the same question and holding the row to what it says puts the two
+ * dispatches on one row: the same table, the same arguments, and one answer they both have to give.
+ */
+class AStandInAnswersWhatItAnsweredWhenTheRowRanTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Price = Int
+            data Rate = Int
+            data Tags = { of: Set<Int> }
+            data Label = String
+
+            behavior rateFor : (of: Price) -> Rate
+
+            behavior rateOf : (base: Price) -> Rate
+                depends on rateFor
+
+            let rateOf (base, rateFor) = rateFor(base)
+
+            behavior labelFor : (tags: Tags) -> Label
+
+            behavior labelOf : (tags: Tags) -> Label
+                depends on labelFor
+
+            let labelOf (tags, labelFor) = labelFor(tags)
+
+            fake rateFor
+                | (Price(1)) -> Rate(10)
+                | (Price(2)) -> Rate(20)
+                | _ -> Rate(99)
+
+            fake labelFor
+                | (Tags { of = [ 1, 2 ] }) -> Label("both")
+
+            example rateOf
+                | "a price the table lists" : (Price(1)) -> Rate(10)
+                | "another price it lists" : (Price(2)) -> Rate(20)
+                | "a price it does not list" : (Price(7)) -> Rate(99)
+
+            example labelOf
+                | "the same set in another order" : (Tags { of = [ 2, 1 ] }) -> Label("both")
+            """;
+
+    /**
+     * Every row of a behavior that passes its input on holds against what its stand-in answers.
+     *
+     * <p>Over all four, so that the row the table lists, the row nothing lists, and the row whose
+     * argument is the same set written in another order are each one the two dispatches agree on.
+     */
+    @Test
+    void whatAStandInAnswersIsWhatTheRowWasHeldAgainst() {
+        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
+
+        List<String> asked = new ArrayList<>();
+        for (CheckedRow row : rowsOf(program)) {
+            CheckedRow.WithStandIns states =
+                    assertInstanceOf(CheckedRow.WithStandIns.class, row.statement(),
+                            () -> row + " is a row of a behavior that depends on something");
+            StandsIn standsIn = states.standsIn().get(0);
+            StandsIn.Answer answered = standsIn.answering(states.states().inputs());
+
+            StandsIn.Answer.TheValue value = assertInstanceOf(StandsIn.Answer.TheValue.class,
+                    answered, () -> standsIn + " answered nothing for " + row);
+            assertEquals(new Verdict.Held(), states.holds(value.value()),
+                    () -> "what " + standsIn + " answers for " + row + " is not what the row was"
+                            + " held against when it ran");
+            asked.add(row.identity().shown());
+        }
+
+        assertEquals(List.of("a price the table lists", "another price it lists",
+                        "a price it does not list", "the same set in another order"), asked,
+                "every row of a behavior that passes its input on");
+    }
+
+    /**
+     * A table asked something it does not list, and does not answer for, states no answer.
+     *
+     * <p>The table's own rule and not the reader's. A stand-in that answered anything here would
+     * have an output run the row against a value nobody wrote; one that could not be asked would
+     * have the output decide for itself what an unlisted argument means.
+     */
+    @Test
+    void aTableWithNoDefaultStatesNoAnswerForWhatItDoesNotList() {
+        CheckedProgram program = CheckedProgram.of(List.of("""
+                module demo
+
+                data Price = Int
+                data Rate = Int
+
+                behavior rateFor : (of: Price) -> Rate
+
+                behavior rateOf : (base: Price) -> Rate
+                    depends on rateFor
+
+                let rateOf (base, rateFor) = rateFor(base)
+
+                fake rateFor
+                    | (Price(1)) -> Rate(10)
+
+                example rateOf
+                    | "the one price it lists" : (Price(1)) -> Rate(10)
+                """));
+
+        CheckedRow row = behavior(program, "rateOf").rows().get(0);
+        StandsIn standsIn = assertInstanceOf(CheckedRow.WithStandIns.class, row.statement())
+                .standsIn().get(0);
+
+        assertEquals(new StandsIn.Answer.NothingStated(),
+                standsIn.answering(List.of(price(2))),
+                "the table lists one price and answers nothing for the rest");
+    }
+
+    /**
+     * A {@code with} and a table that lists nothing cross as one thing.
+     *
+     * <p>The two are one thing to a reader — what this dependency answers — and which of them was
+     * written is a fact about the text. Crossing as two, an output would have two ways to ask one
+     * question, and would answer for itself what a `with` does with an argument it was not written
+     * for.
+     */
+    @Test
+    void aWithAndATableThatListsNothingCrossAsOneThing() {
+        String written = """
+                module demo
+
+                data Price = Int
+                data Rate = Int
+
+                behavior rateFor : (of: Price) -> Rate
+
+                behavior rateOf : (base: Price) -> Rate
+                    depends on rateFor
+
+                let rateOf (base, rateFor) = rateFor(base)
+
+                %s
+                """;
+
+        StandsIn onTheRow = onlyStandIn(String.format(written, """
+                example rateOf
+                    | "on the row" : (Price(1)) with rateFor = Rate(10) -> Rate(10)
+                """));
+        StandsIn inATable = onlyStandIn(String.format(written, """
+                fake rateFor
+                    | _ -> Rate(10)
+
+                example rateOf
+                    | "in a table" : (Price(1)) -> Rate(10)
+                """));
+
+        assertEquals(List.of(), onTheRow.stated().entries(),
+                "a `with` lists nothing: it answers the same whatever it is asked");
+        assertEquals(List.of(), inATable.stated().entries(),
+                "and neither does a table written with only a default");
+        // Asked the same, they answer the same — for an argument neither of them was written
+        // against as much as for one either was.
+        for (long price : List.of(1L, 7L)) {
+            assertEquals(onTheRow.answering(List.of(price(price))),
+                    inATable.answering(List.of(price(price))),
+                    () -> "what the two answer for " + price);
+        }
+    }
+
+    /** The one stand-in of the one row of a module's only behavior that depends on something. */
+    private static StandsIn onlyStandIn(String module) {
+        CheckedRow row = behavior(CheckedProgram.of(List.of(module)), "rateOf").rows().get(0);
+        return assertInstanceOf(CheckedRow.WithStandIns.class, row.statement())
+                .standsIn().get(0);
+    }
+
+    /** A price as an output would hand it over, which is what a newtype is written as. */
+    private static souther.compiler.observe.ObservedValue price(long value) {
+        java.util.Map<String, souther.compiler.observe.ObservedValue> fields =
+                souther.compiler.observe.ObservedValue.fields();
+        fields.put("value", new souther.compiler.observe.ObservedValue.Integer(value));
+        return new souther.compiler.observe.ObservedValue.Constructed(
+                souther.compiler.types.TypeSymbols.declared(
+                        new souther.compiler.types.TypeKey("demo", "Price")), fields);
+    }
+
+    /** The rows of every behavior that depends on something, in the order they are written. */
+    private static List<CheckedRow> rowsOf(CheckedProgram program) {
+        List<CheckedRow> rows = new ArrayList<>();
+        for (CheckedModule module : program.modules()) {
+            for (CheckedBehavior behavior : module.behaviors()) {
+                rows.addAll(behavior.rows());
+            }
+        }
+        return rows;
+    }
+
+    private static CheckedBehavior behavior(CheckedProgram program, String name) {
+        return program.module("demo").behavior(new ValueName.Behavior("demo", name));
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInAnswersWhatItAnsweredWhenTheRowRanTest.java
@@ -109,33 +109,6 @@ class AStandInAnswersWhatItAnsweredWhenTheRowRanTest {
     }
 
     /**
-     * What a stand-in states the dependency takes is what this program says it takes.
-     *
-     * <p>A stand-in carries it because that is what its entries were built and compared against, and
-     * because a dependency another compile declared has nothing here to be asked. Where this program
-     * does declare it, the two are the same declaration — and a stand-in comparing arguments at a
-     * type the behavior does not take would be answering for a call nothing can make.
-     */
-    @Test
-    void whatAStandInStatesADependencyTakesIsWhatTheProgramDeclares() {
-        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
-
-        List<String> checked = new ArrayList<>();
-        for (CheckedRow row : rowsOf(program)) {
-            for (StandsIn standsIn : assertInstanceOf(CheckedRow.WithStandIns.class,
-                    row.statement()).standsIn()) {
-                CheckedBehavior dependency = program.module("demo").behavior(standsIn.dependency());
-                assertEquals(dependency.signature().takes(), standsIn.stated().takes(),
-                        () -> "what " + standsIn.dependency() + " takes");
-                checked.add(standsIn.dependency().name());
-            }
-        }
-
-        assertEquals(List.of("rateFor", "rateFor", "rateFor", "labelFor"), checked,
-                "every dependency stood in for by a row of this program");
-    }
-
-    /**
      * A stand-in is asked with values, and an observation that stopped is not one.
      *
      * <p>The table below answers everything it does not list, so a value it cannot be compared with

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInForABehaviorFromThePathCrossesTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInForABehaviorFromThePathCrossesTest.java
@@ -76,11 +76,11 @@ class AStandInForABehaviorFromThePathCrossesTest {
             StandsIn rateFor = states.standsIn().get(0);
             assertEquals(new ValueName.Behavior("lib.rates", "rateFor"), rateFor.dependency(),
                     "the dependency is the declaration it is, in the module that declares it");
-            assertEquals(1, rateFor.stated().takes().size(),
-                    "and what it takes came from the signature the table was built against");
 
             // The behavior hands the number inside its input straight on, so what the stand-in
-            // answers for that number is what the row was held against when it ran.
+            // answers for that number is what the row was held against when it ran. Asking at all
+            // takes where the dependency's arguments stand, which this program has because the
+            // module the row is written in can name the behavior.
             ObservedValue price = states.states().inputs().get(0);
             StandsIn.Answer answered = rateFor.answering(
                     List.of(assertInstanceOf(ObservedValue.Constructed.class, price).field("value")));

--- a/souther-program-api-test/src/test/java/souther/program/api/AStandInForABehaviorFromThePathCrossesTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AStandInForABehaviorFromThePathCrossesTest.java
@@ -1,0 +1,95 @@
+package souther.program.api;
+
+import souther.compiler.Compiler;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.Verdict;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.program.CheckedRow;
+import souther.compiler.program.StandsIn;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A row stood in for by a behavior another compile declared crosses like any other.
+ *
+ * <p>What a behavior depends on is not always something the module the row is written in declares,
+ * and not always something this compile read the source of: a published module exposes an injected
+ * behavior, and a module importing it stands in for it while its own rows run. What the row states
+ * of that stand-in is the same fact whichever of the two the dependency was declared in.
+ *
+ * <p>Two source modules compiled together do not say this. Both are among what a snapshot is taken
+ * of, so anything the snapshot works out for itself about a dependency is there to be found; a
+ * dependency declared only on the path is what says whether what a stand-in states came from the
+ * reading that built it.
+ */
+class AStandInForABehaviorFromThePathCrossesTest {
+
+    /** Published by another project: a type and a behavior nothing there implements. */
+    private static final String PUBLISHED = """
+            module lib.rates exposing ( Rate, rateFor )
+            data Rate = Int
+            behavior rateFor : (of: Int) -> Rate
+            """;
+
+    private static final String USES = """
+            module app.uses
+            import lib.rates ( Rate, rateFor )
+
+            data Price = Int
+
+            behavior rateOf : (base: Price) -> Rate
+                depends on rateFor
+
+            let rateOf (base, rateFor) = rateFor(base.value)
+
+            fake rateFor
+                | (1) -> Rate(10)
+                | _ -> Rate(99)
+
+            example rateOf
+                | "a base the table lists" : (Price(1)) -> Rate(10)
+                | "one it does not" : (Price(7)) -> Rate(99)
+            """;
+
+    @Test
+    void aDependencyDeclaredOnlyOnThePathIsStoodInForAcrossTheBoundary() {
+        Map<String, ClassFileImage> published = Compiler.compile(PUBLISHED);
+        CheckedProgram program = CheckedProgram.of(List.of(USES), ModulePath.of(published));
+
+        List<CheckedRow> rows = program.module("app.uses")
+                .behavior(new ValueName.Behavior("app.uses", "rateOf")).rows();
+        assertEquals(2, rows.size(), () -> "the rows that crossed are " + rows);
+
+        for (CheckedRow row : rows) {
+            CheckedRow.WithStandIns states =
+                    assertInstanceOf(CheckedRow.WithStandIns.class, row.statement(),
+                            () -> row + " stands in for a behavior another compile declared");
+            StandsIn rateFor = states.standsIn().get(0);
+            assertEquals(new ValueName.Behavior("lib.rates", "rateFor"), rateFor.dependency(),
+                    "the dependency is the declaration it is, in the module that declares it");
+            assertEquals(1, rateFor.stated().takes().size(),
+                    "and what it takes came from the signature the table was built against");
+
+            // The behavior hands the number inside its input straight on, so what the stand-in
+            // answers for that number is what the row was held against when it ran.
+            ObservedValue price = states.states().inputs().get(0);
+            StandsIn.Answer answered = rateFor.answering(
+                    List.of(assertInstanceOf(ObservedValue.Constructed.class, price).field("value")));
+            StandsIn.Answer.TheValue value =
+                    assertInstanceOf(StandsIn.Answer.TheValue.class, answered,
+                            () -> rateFor + " answered nothing for " + row);
+            assertEquals(new Verdict.Held(), states.holds(value.value()),
+                    () -> "what " + rateFor + " answers for " + row + " is not what the row was"
+                            + " held against when it ran");
+        }
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
@@ -277,6 +277,56 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
     }
 
     /**
+     * And a value a limit stopped inside a stand-in leaves the row unavailable too.
+     *
+     * <p>A stand-in's values are values. A row crossing with a shortened one would have an output
+     * answer the dependency with something nobody wrote, which is the row running against a fake
+     * this program does not hold — so the row states nothing, and says which value and where it is
+     * written.
+     */
+    @Test
+    void andSoDoesAValueAStandInStatesThatWasNotKept() {
+        StringBuilder elements = new StringBuilder();
+        for (int i = 0; i < 65; i++) {
+            elements.append(i == 0 ? "" : ", ").append(i);
+        }
+        CheckedProgram program = CheckedProgram.of(List.of("""
+                module demo
+
+                data Count = Int
+
+                behavior everyTag : () -> List<Int>
+
+                behavior countOf : () -> Count
+                    depends on everyTag
+                    constructs Count
+
+                let countOf (everyTag) = Count(List.length(everyTag()))
+
+                fake everyTag
+                    | _ -> [ %s ]
+
+                example countOf
+                    | "a long list stood in" : () -> Count(65)
+                """.formatted(elements)));
+
+        CheckedRow row = behavior(program, "demo", "countOf").rows().get(0);
+        CheckedRow.NotReproducible states =
+                assertInstanceOf(CheckedRow.NotReproducible.class, row.statement());
+        RowStatement.StandInUnavailable why =
+                assertInstanceOf(RowStatement.StandInUnavailable.class, states.why());
+        assertEquals(new ValueName.Behavior("demo", "everyTag"), why.dependency());
+        assertEquals(new RowStatement.StandInUnavailable.Why.AValueOfIt(
+                        souther.compiler.observe.Incompleteness.Code.VALUE_TRUNCATED), why.why());
+        // The table's row and not the table: a table states a value on each of its rows and one
+        // more where it answers what it does not list, so naming the table would leave a reader to
+        // find which of them nothing could be made of. Line 13 is `fake everyTag` and line 17 is
+        // the example row; 14 is the value.
+        assertEquals(14, why.at().line(),
+                "quoted at the value that was not kept, which is where it is written");
+    }
+
+    /**
      * What a field holds is read from what declares it, all the way from the program.
      *
      * <p>A row writing {@code [ 1, 2 ]} says which elements and not which order they are in, and

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
@@ -327,6 +327,54 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
     }
 
     /**
+     * And which value of the stand-in it was, where a row states more than one.
+     *
+     * <p>A table's row states one value for each of the dependency's arguments and one more for the
+     * answer. Told only which row nothing could be made of, an author is left to work out which of
+     * them it was — so what is said is the place that value is written, which is what tells the
+     * second argument from the first.
+     */
+    @Test
+    void andWhichOfTheValuesOnTheRowItWas() {
+        StringBuilder elements = new StringBuilder();
+        for (int i = 0; i < 65; i++) {
+            elements.append(i == 0 ? "" : ", ").append(i);
+        }
+        CheckedProgram program = CheckedProgram.of(List.of("""
+                module demo
+
+                data Count = Int
+
+                behavior tally : (label: String, xs: List<Int>) -> Count
+
+                behavior countOf : (label: String) -> Count
+                    depends on tally
+
+                let countOf (label, tally) = tally(label, [ ])
+
+                fake tally
+                    | ("a",
+                       [ %s ])
+                        -> Count(1)
+                    | _ -> Count(0)
+
+                example countOf
+                    | "counted by what stands in" : ("a") -> Count(0)
+                """.formatted(elements)));
+
+        CheckedRow row = behavior(program, "demo", "countOf").rows().get(0);
+        RowStatement.StandInUnavailable why = assertInstanceOf(
+                RowStatement.StandInUnavailable.class,
+                assertInstanceOf(CheckedRow.NotReproducible.class, row.statement()).why());
+
+        // The row begins on line 13 with its first argument, its second is on 14, and the answer it
+        // states for them is on 15. What was not kept is the second argument, and neither the row
+        // nor the answer is what a reader is sent to.
+        assertEquals(14, why.at().line(),
+                "quoted at the value that was not kept, which is the second argument");
+    }
+
+    /**
      * What a field holds is read from what declares it, all the way from the program.
      *
      * <p>A row writing {@code [ 1, 2 ]} says which elements and not which order they are in, and

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatABehaviorsExamplesSaidTest.java
@@ -12,6 +12,7 @@ import souther.compiler.program.CheckedBehavior;
 import souther.compiler.program.CheckedModule;
 import souther.compiler.program.CheckedProgram;
 import souther.compiler.program.CheckedRow;
+import souther.compiler.program.StandsIn;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
@@ -77,9 +78,9 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
         return of.behavior(new ValueName.Behavior(module, name));
     }
 
-    /** A row that hands over values, which is the arm an answer can be held against. */
-    private static CheckedRow.Reproducible reproducible(CheckedRow row) {
-        return assertInstanceOf(CheckedRow.Reproducible.class, row.statement());
+    /** A row an output runs on its own, which is the arm for a behavior that depends on nothing. */
+    private static CheckedRow.SelfContained selfContained(CheckedRow row) {
+        return assertInstanceOf(CheckedRow.SelfContained.class, row.statement());
     }
 
     /** Every row a behavior has, in the order they are written. */
@@ -110,7 +111,7 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
 
         assertEquals(List.of(newtype(NAME, new ObservedValue.Text("ada")),
                         newtype(AMOUNT, new ObservedValue.Integer(3))),
-                reproducible(row).states().inputs());
+                selfContained(row).states().inputs());
     }
 
     /**
@@ -126,9 +127,9 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
         CheckedRow row = behavior(CheckedProgram.of(List.of(MODULE)), "demo", "receiptFor")
                 .rows().get(0);
 
-        assertEquals(new Verdict.Held(), reproducible(row).holds(receipt("ada", 3)));
+        assertEquals(new Verdict.Held(), selfContained(row).holds(receipt("ada", 3)));
 
-        Mismatch differs = notHeld(reproducible(row).holds(receipt("ada", 4)));
+        Mismatch differs = notHeld(selfContained(row).holds(receipt("ada", 4)));
         assertEquals(Mismatch.Reason.VALUE, differs.reason());
         assertEquals(List.of(new PathElement.Field("total"), new PathElement.Field("value")),
                 differs.path(), "and where inside the two values they part");
@@ -150,7 +151,7 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
         fields.put("total", new ObservedValue.Integer(3));
 
         Mismatch differs =
-                notHeld(reproducible(row).holds(new ObservedValue.Constructed(RECEIPT, fields)));
+                notHeld(selfContained(row).holds(new ObservedValue.Constructed(RECEIPT, fields)));
         assertEquals(Mismatch.Reason.TYPE, differs.reason());
         assertEquals(List.of(new PathElement.Field("total")), differs.path());
     }
@@ -166,14 +167,14 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
         CheckedRow row = behavior(CheckedProgram.of(List.of(MODULE)), "demo", "receiptFor")
                 .rows().get(1);
 
-        assertEquals(new Expectation.TheCase(REFUSED), reproducible(row).states().expects());
+        assertEquals(new Expectation.TheCase(REFUSED), selfContained(row).states().expects());
 
         Map<String, ObservedValue> why = ObservedValue.fields();
         why.put("why", new ObservedValue.Text("anything at all"));
         assertEquals(new Verdict.Held(),
-                reproducible(row).holds(new ObservedValue.Constructed(REFUSED, why)));
+                selfContained(row).holds(new ObservedValue.Constructed(REFUSED, why)));
         assertEquals(Mismatch.Reason.TYPE,
-                notHeld(reproducible(row).holds(receipt("ada", 3))).reason());
+                notHeld(selfContained(row).holds(receipt("ada", 3))).reason());
     }
 
     /**
@@ -189,21 +190,21 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
                 .rows().get(0);
 
         assertEquals(Mismatch.Reason.UNREADABLE,
-                notHeld(reproducible(row)
+                notHeld(selfContained(row)
                         .holds(new ObservedValue.Unknown("the output could not read it")))
                         .reason());
     }
 
     /**
-     * A row of a behavior that takes something injected states what has to stand in, and no values.
+     * A row of a behavior that takes something injected crosses with what stood in for it.
      *
      * <p>A row runs against a bound implementation, and what stands in for an injected dependency is
-     * the rest of what makes it runnable. An output whose dependency is an import has nothing to
-     * answer that import with, so it is told what the row needs rather than handed values it cannot
-     * use.
+     * the rest of what makes it runnable. An output whose dependency is an import has nothing of its
+     * own to answer that import with, so it is handed what the row states the dependency answers —
+     * as values and a rule, rather than as anything it has to apply.
      */
     @Test
-    void aRowOfABehaviorThatNeedsAStandInSaysSoRatherThanCrossingAsValues() {
+    void aRowOfABehaviorThatNeedsAStandInCrossesWithWhatStoodInForIt() {
         CheckedProgram program = CheckedProgram.of(List.of("""
                 module demo
 
@@ -223,13 +224,20 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
                 """));
 
         CheckedRow row = behavior(program, "demo", "priceOf").rows().get(0);
-        // And there is nothing to ask it: what a row states says which of the two it is, and only
-        // the one that hands over values answers whether an answer keeps it.
-        CheckedRow.NotReproducible states =
-                assertInstanceOf(CheckedRow.NotReproducible.class, row.statement());
-        assertEquals(new RowStatement.RequiresStandIns(
-                        List.of(new ValueName.Behavior("demo", "rateNow"))),
-                states.why());
+        // An arm of its own, so that a reader written for rows that run on their own cannot be
+        // handed one that does not: what it has to do with this row is in the type.
+        CheckedRow.WithStandIns states =
+                assertInstanceOf(CheckedRow.WithStandIns.class, row.statement());
+        assertEquals(List.of(newtype(declared("Price"), new ObservedValue.Integer(10))),
+                states.states().inputs(), "and it hands over its inputs like any other row");
+
+        StandsIn rateNow = states.standsIn().get(0);
+        assertEquals(new ValueName.Behavior("demo", "rateNow"), rateNow.dependency());
+        // What a `with` answers, asked rather than read: it lists nothing and answers everything,
+        // which is the same shape a table with a `_` row is.
+        assertEquals(new StandsIn.Answer.TheValue(
+                        newtype(declared("Rate"), new ObservedValue.Integer(2))),
+                rateNow.answering(List.of()));
     }
 
     /**
@@ -291,7 +299,7 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
                     | "a set of two" : ([ 1, 2 ]) -> Tags { of = [ 1, 2 ] }
                 """));
 
-        CheckedRow.Reproducible row = reproducible(
+        CheckedRow.SelfContained row = selfContained(
                 behavior(program, "demo", "tagsOf").rows().get(0));
         Map<String, ObservedValue> of = ObservedValue.fields();
         of.put("of", new ObservedValue.Sequence(List.of(new ObservedValue.Integer(2),
@@ -325,7 +333,7 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
                     | "not there" : (false) -> Missing
                 """));
 
-        CheckedRow.Reproducible row = reproducible(
+        CheckedRow.SelfContained row = selfContained(
                 behavior(program, "demo", "lookUp").rows().get(0));
         assertEquals(new Expectation.TheCase(declared("Missing")), row.states().expects());
         assertEquals(new Verdict.Held(),
@@ -398,8 +406,7 @@ class AnOutputReadsWhatABehaviorsExamplesSaidTest {
         }
         assertEquals(3, every.size(), () -> "the rows that crossed are " + every);
         assertTrue(every.stream().anyMatch(row -> row.statement()
-                        instanceof CheckedRow.NotReproducible needs
-                        && needs.why() instanceof RowStatement.RequiresStandIns),
+                        instanceof CheckedRow.WithStandIns),
                 "including the one that needs something stood in for");
     }
 

--- a/souther-program-api-test/src/test/java/souther/program/api/NothingReachableFromACheckedProgramNamesTheCompilerTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/NothingReachableFromACheckedProgramNamesTheCompilerTest.java
@@ -89,6 +89,13 @@ class NothingReachableFromACheckedProgramNamesTheCompilerTest {
                 () -> "nothing a row stated in " + reached);
         assertTrue(reached.contains("souther.compiler.observe.Mismatch"),
                 () -> "nowhere two values part in " + reached);
+        // And what stood in for what the behavior depends on, which is the rest of what makes a row
+        // runnable — reached through the arm for a row that needs one, so the walk goes down into
+        // what an output has to put behind its imports rather than stopping at the row.
+        assertTrue(reached.contains("souther.compiler.program.StandsIn"),
+                () -> "nothing standing in for a dependency in " + reached);
+        assertTrue(reached.contains("souther.compiler.observe.StoodIn$Entry"),
+                () -> "nothing a stand-in states in " + reached);
         assertTrue(reached.size() > 50, () -> "the walk reached only " + reached.size());
     }
 

--- a/souther-program-api-test/src/test/java/souther/program/api/WhatCrossesIsAValueNothingCanChangeTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/WhatCrossesIsAValueNothingCanChangeTest.java
@@ -1,5 +1,6 @@
 package souther.program.api;
 
+import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.Asserted;
 import souther.compiler.observe.Expectation;
 import souther.compiler.observe.Mismatch;
@@ -7,6 +8,8 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.PathElement;
 import souther.compiler.observe.Position;
 import souther.compiler.observe.RowStatement;
+import souther.compiler.observe.RowStatements;
+import souther.compiler.observe.StoodIn;
 import souther.compiler.observe.Verdict;
 import souther.compiler.program.CheckedRow;
 import souther.compiler.types.Type;
@@ -57,6 +60,7 @@ class WhatCrossesIsAValueNothingCanChangeTest {
         List<Class<?>> reached = new ArrayList<>();
         Set<Class<?>> seen = new LinkedHashSet<>();
         Deque<Class<?>> pending = new ArrayDeque<>(List.of(CheckedRow.class, RowStatement.class,
+                StoodIn.class,
                 Expectation.class, Asserted.class, ObservedValue.class, Verdict.class,
                 Mismatch.class, PathElement.class, Position.class));
         while (!pending.isEmpty()) {
@@ -88,7 +92,11 @@ class WhatCrossesIsAValueNothingCanChangeTest {
         }
         // Said out loud, so that a type that stops being asked about is a line to change rather
         // than a check that quietly walks fewer things than it used to.
-        assertEquals(List.of("Mismatch", "RequiresStandIns", "Built", "Elements", "Entries",
+        //
+        // `Entry` is what a stand-in states one call to a dependency as: the arguments it answers
+        // for are a list because a dependency takes as many as it declares, and an output holding
+        // one asks what it answers by handing over as many.
+        assertEquals(List.of("Mismatch", "Entry", "Built", "Elements", "Entries",
                         "Constructed", "Sequence", "Mapping"),
                 asked, "what an output holds that keeps a collection");
     }
@@ -98,7 +106,7 @@ class WhatCrossesIsAValueNothingCanChangeTest {
     void andSoDoesTheOneThatIsMadeByAsking() {
         List<ObservedValue> given = new ArrayList<>();
         given.add(new ObservedValue.Integer(1));
-        RowStatement stated = RowStatement.of(given,
+        RowStatement stated = RowStatements.read(List.of(), given,
                 new Expectation.TheValue(new Asserted.Value(new ObservedValue.Integer(2))));
         given.add(new ObservedValue.Integer(3));
 
@@ -243,6 +251,9 @@ class WhatCrossesIsAValueNothingCanChangeTest {
         }
         if (type == ValueName.Behavior.class) {
             return new ValueName.Behavior("demo", "billFor");
+        }
+        if (type == SourcePos.class) {
+            return new SourcePos(1, 1);
         }
         if (type == java.math.BigDecimal.class) {
             return java.math.BigDecimal.ONE;


### PR DESCRIPTION
Closes #1124.

A row of a behavior that depends on something injected crossed as unavailable:
`#1121` handed it over saying what it needed and nothing else. It crosses with
what stood in for each dependency now — the entries a `fake` table states, and
what it answers where no entry states what it was asked — so an output whose
dependency is an import has an answer to put behind it.

## What crosses

`observe.StoodIn` is what one dependency was stated to answer: the dependency,
where it is written, the entries in the order the rule reads them, and what it
answers otherwise. Values and a rule, and nothing about a declaration:
`with dep = value` and `fake dep | table` are one shape here — a `with` lists
nothing and answers everything, which is a table with a `_` row and no others.

`program.StandsIn` is that bound to a reading of the declarations, and it is
where the dispatch is asked. Which entry answers is the table's rule; whether an
argument is what an entry states is the language's, through the new
`Comparisons.same`. A reader that decided either for itself would have the fake
answer one thing in this compile and another in the output built from it.

`CheckedRow.Statement` is three arms: `SelfContained`, `WithStandIns`,
`NotReproducible`. The old `Reproducible` is `SelfContained` — a row that needs a
stand-in is reproducible too, once the stand-ins are behind the imports. A new
arm rather than an accessor on the old one, so a reader written for #1121 cannot
be handed a row whose imports nothing is behind.

## Comparing two arrived-at values is a second question

`Comparisons.verdict` holds an `Asserted` — what a text wrote — against an
`ObservedValue`. Dispatch asks whether two values that were both arrived at are
the same, which is not that question with a statement made up for one side:
`Asserted.Value` is a value with no parts, so a construction, a sequence or a
mapping offered to it is read as a value of no type and matches nothing, without
an error. `Comparisons.same` is the second question, and `ValueMatch` now
projects each side into what one walk reads — so a set is its elements and a
decimal is the amount it stands for, answered once for both.

It is of two values that are there. A walk that meets something an observation
stopped at returns an UNREADABLE difference, which a yes-or-no has nowhere to
put: answered "no", an argument nothing could be read of would fall through to
what the stand-in answers for what it does not list. Held to `Limits.UNBOUNDED`,
which admits a value that is there in full — how much of a value may be carried
somewhere is a different question and does not belong inside this one.

## Where things are decided

- `observe.RowStatements` makes the statement, from what was read of the row and
  nothing else. `ExampleTarget` and `Handing` are private to `ExampleVerifier` in
  `examples`, which `observe` may not name (`TheCompileAndAnOutputAreTwoReadersOfWhatARowStatesTest`),
  so what a row states cannot come to depend on whether this compile found
  anything to apply the behavior with. A row of a behavior nothing implements
  states its stand-ins.
- Each stand-in decides whether its own values can be carried; the reading owns
  only the order they are asked in — stand-ins, then inputs, then the
  expectation. Each value keeps where it is written until it is known to be one
  a row can hand over, so a stand-in a limit stopped is quoted at that value —
  the argument or the answer, not the row it is on.
- Where a dependency's arguments stand comes from `Bodies.Reachable(module)`,
  which is what every behavior a module can name declares and the answer the run
  that read the row was given. So a dependency another compile declared is
  stood in for like any other, and what a declaration says is not written down a
  second time.
- `readStandIn` produces what the run applies the behavior with and what the row
  states of it from one reading, so the helpers a fixture names are applied once.

`RowStatement.RequiresStandIns` becomes `StandInUnavailable(dependency, at,
why)`, with `why` saying whether a value of it could not be carried or nothing
was read that states it.

## What holds it up

Six laws, each mutation-checked:

1. A `with` and a table written with only a default answer the same.
2. A stand-in is built once — 1001 steps against 2002 when it is read twice.
3. `Values.equal` and `Comparisons.same` agree over pairs read at the place they
   stand.
4. The two dispatches pick the same row, held together through rows that pass
   their input on to what they depend on.
5. What a row states does not depend on what applied the behavior — the layer
   rule, the signature of `RowStatements.read`, and a row nothing implements.
6. A stand-in a limit stopped is quoted at the value, told apart from the row it
   is written on and from the answer beside it.

And a dependency declared only on the path is stood in for across the boundary,
which two source modules compiled together do not say.

`mvn -o test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)