### PR TITLE
A term's orders are the reading's answer, and nothing else derives them

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -71,7 +71,7 @@ final class AReportOfOneBorder {
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
                                 new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,
@@ -101,7 +101,7 @@ final class AReportOfOneBorder {
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
                                 new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,
@@ -119,7 +119,7 @@ final class AReportOfOneBorder {
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
                                 new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -50,6 +50,10 @@ import java.util.function.Function;
  */
 final class AReportOfOneBorder {
 
+    /** The number the lines below are on, which their orders are the orders of. */
+    private static final NumericTerm.ValueOf AT_W_A =
+            new NumericTerm.ValueOf(TermPath.of("w").then("a"));
+
     private AReportOfOneBorder() {}
 
     /**
@@ -70,8 +74,9 @@ final class AReportOfOneBorder {
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
-                                new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
+                                AT_W_A,
+                                souther.compiler.inputs.TermOrdersFixtures
+                                        .itself(AT_W_A, Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,
@@ -100,8 +105,9 @@ final class AReportOfOneBorder {
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
-                                new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
+                                AT_W_A,
+                                souther.compiler.inputs.TermOrdersFixtures
+                                        .itself(AT_W_A, Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,
@@ -118,8 +124,9 @@ final class AReportOfOneBorder {
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
-                                new NumericTerm.ValueOf(TermPath.of("w").then("a")),
-                                souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
+                                AT_W_A,
+                                souther.compiler.inputs.TermOrdersFixtures
+                                        .itself(AT_W_A, Carrier.WHOLE)),
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,

--- a/souther-cli/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
+++ b/souther-cli/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
@@ -15,7 +15,7 @@ public final class TermOrdersFixtures {
     private TermOrdersFixtures() { }
 
     /** A term whose value is the number it answers. */
-    public static TermOrders itself(Carrier carrier) {
-        return TermOrders.itself(carrier);
+    public static TermOrders itself(NumericTerm term, Carrier carrier) {
+        return new TermOrders(term, carrier, carrier);
     }
 }

--- a/souther-cli/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
+++ b/souther-cli/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
@@ -1,0 +1,21 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.Carrier;
+
+/**
+ * Synthetic orders for a test that describes a term rather than reading one.
+ *
+ * <p>The compiler's own tests have one of these; this is the same bridge for the tests here, which
+ * build a report out of evidence rather than out of a model. A package is what package-private
+ * means and a Maven module is not, so a test source set of this package reaches
+ * {@link TermOrders}'s constructor while nothing that ships does.
+ */
+public final class TermOrdersFixtures {
+
+    private TermOrdersFixtures() { }
+
+    /** A term whose value is the number it answers. */
+    public static TermOrders itself(Carrier carrier) {
+        return TermOrders.itself(carrier);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ComparedNumber.java
@@ -34,6 +34,15 @@ import souther.compiler.numeric.Place;
 public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlacement placed,
                              Place at) {
 
+    public ComparedNumber {
+        // The orders say which number they are of, and the number is held here as well because a
+        // comparison may name one this reading puts no order under. Where there are orders, the two
+        // are one thing said twice, and the second is refused here.
+        if (orders != null) {
+            orders.areOf(term);
+        }
+    }
+
     /**
      * What one comparison of a body draws: the number, where the line falls on it, and what the
      * rule placed there.
@@ -50,7 +59,15 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlac
      * @param claim  what the rule placed there
      */
     public record DrawnLine(NumericTerm.FromOnePosition term, Place at, TermOrders orders,
-                            ComparisonClaim claim) {}
+                            ComparisonClaim claim) {
+
+        public DrawnLine {
+            // A line is drawn on a position's own number, which is the narrower kind of term, and
+            // the orders say which number they are of. Refused here rather than carried into a
+            // document that reads a line on one number against the order of another.
+            orders.areOf(term);
+        }
+    }
 
     /**
      * What {@code binary} says, or null where it names no number of this input at all.
@@ -175,5 +192,14 @@ public record ComparedNumber(NumericTerm term, TermOrders orders, ComparisonPlac
         return new Named(term, orders == null || orders.answered() == null ? null : orders);
     }
 
-    private record Named(NumericTerm term, TermOrders orders) { }
+    /** The number an expression names, and what it is counted on where this reading puts an order
+     *  under it. Both, because a comparison may name a number the reading orders by nothing. */
+    private record Named(NumericTerm term, TermOrders orders) {
+
+        private Named {
+            if (orders != null) {
+                orders.areOf(term);
+            }
+        }
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -3,12 +3,9 @@ package souther.compiler.inputs;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.NumericAnswers;
 import souther.compiler.check.Symbols;
-import souther.compiler.numeric.Count;
-import souther.compiler.numeric.Dates;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.Incompleteness;
-import souther.compiler.observe.ObservedValue;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.ResultRange;
@@ -71,11 +68,6 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
             return position();
         }
 
-        /** The number this term names at the one value standing at its position, or why there is
-         *  none. */
-        default Reading read(ObservedValue at, TermOrders on) {
-            return NumericTerm.read(this, at, on);
-        }
     }
 
     /** The number a location holds: a numeric parameter, a field of one, a numeric newtype's value. */
@@ -303,40 +295,6 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
             return source.subjectPath();
         }
 
-        /**
-         * The number this term names over the values of its run, or why there is none.
-         *
-         * <p>Handed the values rather than reaching for them: which rows there are and how many
-         * values stand at a place in one are the measure's, and a term only says what its number is
-         * of them. The plural is the whole difference from a taking of one value, and it is here
-         * rather than in the path or in what a row is asked — a location says nothing about how
-         * many values stand at it, and a reader that asked for one where a run stands would be
-         * given the first of them or none.
-         *
-         * <p>Exhaustive over the accounts, with no {@code default}. An account of a number taken of
-         * one value says nothing about a run of them — which hour a run of times falls in is not a
-         * question — so those answer that this is no number of theirs rather than being read as
-         * whichever value came first.
-         */
-        public Reading readOver(java.util.List<ObservedValue> values, TermOrders on) {
-            // Nothing to read, which a caller that could not walk to the run answers with. Said as
-            // "this is no number of that" rather than as a total over the values it did find.
-            if (values == null) {
-                return new Reading.NotNumber();
-            }
-            for (ObservedValue each : values) {
-                Membership.Incomplete unread = Membership.unread(each);
-                if (unread != null) {
-                    return new Reading.Missing(unread.code());
-                }
-            }
-            return switch (takenAs()) {
-                case TakenAs.TheSumOfWhatItHolds _ -> addedUp(values, on);
-                case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ ->
-                        new Reading.NotNumber();
-            };
-        }
-
         @Override
         public String toString() {
             return operation.qualified() + "(" + source + ")";
@@ -404,213 +362,6 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
             // location, which would be this reading inventing where a walk got its values.
             case TakenOver _ -> null;
         };
-    }
-
-    /**
-     * The number this term names at an observation of {@link #path()}, or why there is none.
-     *
-     * <p>The one reader. What a class asks of a row, what a boundary asks of it, and what a report
-     * prints were three walks down a value that agreed only because they were written the same way.
-     *
-     * <p>The orders are handed in rather than guessed at from the observation. A written temporal
-     * says nothing about whether the position counts days or seconds — the declared type says it —
-     * and a reader that sniffed the text for a {@code T} answered a question that was already
-     * answered, differently.
-     *
-     * <p><b>Both of them, and this picks.</b> What a value is decoded on and what the number it
-     * answers is measured on are two orders, and the one this wants is the first. Given the carrier
-     * instead of the pair, every caller chose which end to hand over and every one of them had to
-     * choose the same way — five places writing {@code .observed()} and getting it right, which is
-     * the arrangement the whole of #1027 exists to stop, one layer along. The decision is here,
-     * where the arms that need it are.
-     */
-    static Reading read(FromOnePosition term, ObservedValue at, TermOrders on) {
-        Carrier observed = on.observed();
-        Membership.Incomplete unread = Membership.unread(at);
-        if (unread != null) {
-            return new Reading.Missing(unread.code());
-        }
-        // A newtype is not a step in a path, so what sits at the position may be the construction and
-        // the value one inside it. Asked again of what is inside rather than walked into: a limit
-        // reached one layer down leaves a construction that reads perfectly well with nothing where
-        // the value should be, and a walk that only looked at the outside would call that a value
-        // this term does not hold.
-        if (at instanceof ObservedValue.Constructed c && c.field("value") != null) {
-            return read(term, c.field("value"), on);
-        }
-        return switch (term) {
-            case ValueOf _ -> asItStands(at, observed);
-            case TakenOf taken -> taken(taken.takenAs(), at, on);
-        };
-    }
-
-    /** The number the term is, where the term is what the location holds. */
-    private static Reading asItStands(ObservedValue at, Carrier observed) {
-        if (observed == null) {
-            return new Reading.NotNumber();
-        }
-        Place read = observed.placeOf(at);
-        return read == null ? new Reading.NotNumber() : new Reading.Number(read);
-    }
-
-    /**
-     * The number an operation answers of an observation of what it was given.
-     *
-     * <p>One arm per declared account of what such an operation takes, and no default. An account
-     * added to {@code semantics} is one this does not compile without, which is what keeps a term
-     * from being read as whichever arm was written first — the state {@code SizeOf} left the reader
-     * in, where a term standing for anything but a size would have been read as the observation
-     * itself (#1027).
-     *
-     * <p>The pair and not one end of it, because which end an account reads its values on is the
-     * account's own answer. A part of a time is a number of the value as it is written; what a
-     * container adds up to is a number of the values it holds, and those are places of the order the
-     * total is measured on. Handed one carrier for every arm, the arms that want the other end have
-     * nothing to say so with — and a container is written on no order at all, so the one that adds
-     * its elements up is handed nothing.
-     */
-    private static Reading taken(TakenAs how, ObservedValue at, TermOrders on) {
-        return switch (how) {
-            case TakenAs.HowManyItHolds _ -> howMany(at);
-            case TakenAs.TheSumOfWhatItHolds _ -> addedUp(at, on);
-            case TakenAs.PartOfTime taken -> partOfTime(taken.part(), at, on.observed());
-            case TakenAs.PartOfDate taken -> partOfDate(taken.part(), at, on.observed());
-        };
-    }
-
-    /**
-     * How much an observation holds.
-     *
-     * <p>Read off the observation under the premise {@link TakenOf} states: the operation and what it
-     * is applied to agree, so counting what is there counts what was asked for. A string counts in
-     * code points, as {@code Strings.length} does — counting UTF-16 units here would put a boundary
-     * one place away from the rule that drew it for every string outside the basic plane.
-     */
-    private static Reading howMany(ObservedValue at) {
-        return switch (at) {
-            case ObservedValue.Text t -> new Reading.Number(
-                    Count.of(t.value().codePointCount(0, t.value().length())));
-            case ObservedValue.Sequence s -> new Reading.Number(Count.of(s.elements().size()));
-            case ObservedValue.Mapping m -> new Reading.Number(Count.of(m.entries().size()));
-            case null, default -> new Reading.NotNumber();
-        };
-    }
-
-    /**
-     * What an observed container's elements add up to.
-     *
-     * <p>Every element, on the order the answer is measured on. That order is the elements' own —
-     * a walk carries what it has so far in the type it answers — so an element is read as a place
-     * of the same carrier the sum is, and there is no second order here for the two ends of the
-     * term to come apart on.
-     *
-     * <p>An element that reads as no place is what a container holding something other than what
-     * the position declares would give, and the sum of those is not a number rather than a number
-     * missing one of its parts. Nothing here reaches into an element: a sum is over what a
-     * container holds, and a value inside one of them is a position of its own.
-     *
-     * <p>Nothing added up is nought, which is what the walk starts from. An empty container is a
-     * value the model may write, and answering that it holds no number would put a row the author
-     * can write outside every class of the number a rule is about.
-     */
-    private static Reading addedUp(ObservedValue at, TermOrders on) {
-        return at instanceof ObservedValue.Sequence held
-                ? addedUp(held.elements(), on) : new Reading.NotNumber();
-    }
-
-    /**
-     * The same, over values a caller gathered rather than over a container standing somewhere.
-     *
-     * <p>Where the end is taken, for both readers at once. A total of what a place holds and a total
-     * over the values of a run are one account of one operation, so which order their elements are
-     * places of is one answer. Taken apiece, the two are free to add the same values up on different
-     * orders.
-     */
-    private static Reading addedUp(java.util.List<ObservedValue> values, TermOrders on) {
-        Carrier elements = on.answered();
-        if (elements == null) {
-            return new Reading.NotNumber();
-        }
-        java.math.BigDecimal total = java.math.BigDecimal.ZERO;
-        for (ObservedValue each : values) {
-            Membership.Incomplete unread = Membership.unread(each);
-            if (unread != null) {
-                return new Reading.Missing(unread.code());
-            }
-            // Through the name an element is written under, as the one value a place holds is read
-            // through it. A run of a newtype over a whole number holds constructions, and the
-            // number each carries is one inside.
-            ObservedValue value = each instanceof ObservedValue.Constructed c
-                    && c.field("value") != null ? c.field("value") : each;
-            Place read = elements.placeOf(value);
-            if (!(read instanceof Count count)) {
-                return new Reading.NotNumber();
-            }
-            total = total.add(count.at());
-        }
-        return new Reading.Number(new Count(total));
-    }
-
-    /**
-     * Which hour, minute or second of its day an observed time falls in.
-     *
-     * <p>Decoded on the order the value is written on — a time counts the seconds into its day — and
-     * answered on the order the operation answers, which is a count by one. The two are different
-     * orders here, which is why the value is not read on the order the answer is measured on: read
-     * that way, {@code 13:45:12} would be the thirteenth second rather than the thirteenth hour.
-     *
-     * <p>Divided and then taken the remainder of, which is what a part of a count is. The hour is
-     * the whole hours in the day so far; the minute is the whole minutes, of which the hours are
-     * dropped.
-     */
-    private static Reading partOfTime(TakenAs.TimePart part, ObservedValue at, Carrier observed) {
-        if (observed == null) {
-            return new Reading.NotNumber();
-        }
-        Place read = observed.placeOf(at);
-        // A place that is not a count is not a time of day. No operation declaring this arm is
-        // given anything else, so this is the observation being something other than what the
-        // position declares, which is what `NotNumber` says.
-        if (!(read instanceof Count count)) {
-            return new Reading.NotNumber();
-        }
-        java.math.BigDecimal seconds = count.at();
-        return new Reading.Number(Count.of(seconds
-                .divideToIntegralValue(java.math.BigDecimal.valueOf(part.seconds()))
-                .remainder(java.math.BigDecimal.valueOf(part.many()))));
-    }
-
-    /**
-     * Which year, month or day of its month an observed date falls in.
-     *
-     * <p>Turned into a date and asked, rather than divided. A date counts days and its parts are the
-     * calendar's: the months are of different lengths and a leap year has a day the year before it
-     * does not, so no step and modulus over the count answers any of the three. What turns a count
-     * into a date is {@link Dates}, which is also what a report and a fixture read, so the date this
-     * takes a part of is the date they would write for the same day.
-     *
-     * <p>Answered on the order the operation answers, which is a count by one, while the value is
-     * decoded on the order it is written on. The two are the same pair of orders a part of a time
-     * travels on, and for the same reason: a line at the twelfth month is not a line at the twelfth
-     * day.
-     */
-    private static Reading partOfDate(TakenAs.DatePart part, ObservedValue at, Carrier observed) {
-        if (observed == null) {
-            return new Reading.NotNumber();
-        }
-        Place read = observed.placeOf(at);
-        // A place that is not a count is not a date. No operation declaring this arm is given
-        // anything else, so this is the observation being something other than what the position
-        // declares, which is what `NotNumber` says.
-        if (!(read instanceof Count count)) {
-            return new Reading.NotNumber();
-        }
-        java.time.LocalDate date = Dates.dateAt(count);
-        return new Reading.Number(Count.of(switch (part) {
-            case YEAR -> date.getYear();
-            case MONTH -> date.getMonthValue();
-            case DAY -> date.getDayOfMonth();
-        }));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -407,68 +407,6 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
     }
 
     /**
-     * The order the number this term names is measured on, or null where it has none.
-     *
-     * <p>What a rule about the length of a string is counted as is an {@code Int} at a position no
-     * line is drawn on, and what a rule about {@code Time.hour(t)} is counted as is a count by one at
-     * a position counting the seconds of its day. Both follow from what the operation answers and
-     * from nothing about where it was applied — asked of the position, the step of the answer was
-     * the step of the argument, and the twelfth hour was a line at the twelfth second.
-     *
-     * <p>Which is why {@code positionType} may be absent. A caller reading a term under more steps
-     * than the walk that finds an input's positions goes down has no position to ask, and what an
-     * operation answers is what it answers all the same — asked for the type first, a caller would
-     * either have nothing to pass or would write out the rule above a second time, at whichever call
-     * site noticed. What is null there is a term measured by its own values, which is the one case
-     * the position was the answer to.
-     */
-    default Carrier answeredOn(Type positionType, Symbols symbols) {
-        return switch (this) {
-            case ValueOf _ -> positionType == null ? null : Carrier.ofValue(positionType, symbols);
-            case TakenOf taken -> {
-                Type answers = NumericAnswers.typeOf(taken.operation(), positionType, symbols);
-                yield answers == null ? null : Carrier.ofValue(answers, symbols);
-            }
-            // Asked of the operation as a taking is, and asked of what it was given: a run is a
-            // container of the values standing at the place it is read from, so what the operation
-            // answers of one is what it answers of a container of them. Written out here as the
-            // element's own order instead, this would be the account of a walk that adds restated
-            // for every account, and the first one that answers something else would be read as
-            // answering what its elements are.
-            case TakenOver over -> {
-                Type answers = positionType == null ? null : NumericAnswers.typeOf(
-                        over.operation(), new Type.ListOf(positionType), symbols);
-                yield answers == null ? null : Carrier.ofValue(answers, symbols);
-            }
-        };
-    }
-
-    /**
-     * The order a value at {@link #path()} is decoded on, or null where nothing orders it.
-     *
-     * <p>The other end of the same term, and null for more than one reason. A container is not
-     * ordered and is read by what it holds rather than by a count of its own; a position whose type
-     * nothing here can follow has no order either. Both are answers a reader can act on — what is
-     * refused is silently reading the value on the order its answer is measured on, which is right
-     * for every operation whose two ends agree and wrong without a word for the first that does not.
-     */
-    default Carrier observedOn(Type positionType, Symbols symbols) {
-        return positionType == null ? null : Carrier.ofValue(positionType, symbols);
-    }
-
-    /** Both ends together, which is what every reader of a row wants and what neither end alone is
-     *  safe to stand in for. A term that is what a location holds has one order twice, and says so
-     *  here rather than by two readings that happen to agree. */
-    default TermOrders ordersAt(Type positionType, Symbols symbols) {
-        Carrier observed = observedOn(positionType, symbols);
-        return switch (this) {
-            case ValueOf _ -> TermOrders.itself(observed);
-            case TakenOf _, TakenOver _ ->
-                    new TermOrders(observed, answeredOn(positionType, symbols));
-        };
-    }
-
-    /**
      * The number this term names at an observation of {@link #path()}, or why there is none.
      *
      * <p>The one reader. What a class asks of a row, what a boundary asks of it, and what a report
@@ -673,12 +611,6 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
             case MONTH -> date.getMonthValue();
             case DAY -> date.getDayOfMonth();
         }));
-    }
-
-    /** How the values beside a boundary on this term are found, which is what the number it names
-     *  is measured on and never what stands at the position it was taken of. */
-    default BoundaryDomain intervals(Type positionType, Symbols symbols) {
-        return BoundaryDomain.on(answeredOn(positionType, symbols));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -169,7 +169,7 @@ final class ReadQuantities implements Quantities {
         // absent, so a term of another input comes back with an order on one end and nothing on the
         // other — an answer about no reading, wearing this one's name.
         held(term);
-        return term.ordersAt(typeAt.apply(term.subjectPath()), symbols);
+        return TermOrdering.of(term, typeAt.apply(term.subjectPath()), symbols);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermOrdering.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermOrdering.java
@@ -1,0 +1,86 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.NumericAnswers;
+import souther.compiler.check.Symbols;
+import souther.compiler.types.Type;
+
+/**
+ * Both orders a term stands on, worked out from what stands where its number comes from.
+ *
+ * <p>The one place the derivation lives, and not reachable from a term. A term is a value that
+ * travels, and a type is in every reader's hand, so a derivation written on the term is a question
+ * anything holding the two can answer — about wherever that type came from, and about no reading in
+ * particular. What settles where a term's number comes from is the reading of the input, so the one
+ * caller here is {@link ReadQuantities#ordersOf}, which puts the reading's own answer in.
+ *
+ * <p>What the answer is about is therefore the reading's to say, and every other layer asks
+ * {@link Quantities#ordersOf} for it rather than working it out again.
+ */
+final class TermOrdering {
+
+    private TermOrdering() { }
+
+    /**
+     * Both ends together, which is what every reader of a row wants and what neither end alone is
+     * safe to stand in for. A term that is what a location holds has one order twice, and says so
+     * here rather than by two readings that happen to agree.
+     */
+    static TermOrders of(NumericTerm term, Type positionType, Symbols symbols) {
+        Carrier observed = observedOn(positionType, symbols);
+        return switch (term) {
+            case NumericTerm.ValueOf _ -> TermOrders.itself(observed);
+            case NumericTerm.TakenOf _, NumericTerm.TakenOver _ ->
+                    new TermOrders(observed, answeredOn(term, positionType, symbols));
+        };
+    }
+
+    /**
+     * The order the number a term names is measured on, or null where it has none.
+     *
+     * <p>What a rule about the length of a string is counted as is an {@code Int} at a position no
+     * line is drawn on, and what a rule about {@code Time.hour(t)} is counted as is a count by one at
+     * a position counting the seconds of its day. Both follow from what the operation answers and
+     * from nothing about where it was applied — asked of the position, the step of the answer was
+     * the step of the argument, and the twelfth hour was a line at the twelfth second.
+     *
+     * <p>Which is why {@code positionType} may be absent. A term under more steps than the walk that
+     * finds an input's positions goes down has no position to ask, and what an operation answers is
+     * what it answers all the same. What is null there is a term measured by its own values, which
+     * is the one case the position was the answer to.
+     */
+    private static Carrier answeredOn(NumericTerm term, Type positionType, Symbols symbols) {
+        return switch (term) {
+            case NumericTerm.ValueOf _ ->
+                    positionType == null ? null : Carrier.ofValue(positionType, symbols);
+            case NumericTerm.TakenOf taken -> {
+                Type answers = NumericAnswers.typeOf(taken.operation(), positionType, symbols);
+                yield answers == null ? null : Carrier.ofValue(answers, symbols);
+            }
+            // Asked of the operation as a taking is, and asked of what it was given: a run is a
+            // container of the values standing at the place it is read from, so what the operation
+            // answers of one is what it answers of a container of them. Written out here as the
+            // element's own order instead, this would be the account of a walk that adds restated
+            // for every account, and the first one that answers something else would be read as
+            // answering what its elements are.
+            case NumericTerm.TakenOver over -> {
+                Type answers = positionType == null ? null : NumericAnswers.typeOf(
+                        over.operation(), new Type.ListOf(positionType), symbols);
+                yield answers == null ? null : Carrier.ofValue(answers, symbols);
+            }
+        };
+    }
+
+    /**
+     * The order a value at the term's path is decoded on, or null where nothing orders it.
+     *
+     * <p>The other end of the same term, and null for more than one reason. A container is not
+     * ordered and is read by what it holds rather than by a count of its own; a position whose type
+     * nothing here can follow has no order either. Both are answers a reader can act on — what is
+     * refused is silently reading the value on the order its answer is measured on, which is right
+     * for every operation whose two ends agree and wrong without a word for the first that does not.
+     */
+    private static Carrier observedOn(Type positionType, Symbols symbols) {
+        return positionType == null ? null : Carrier.ofValue(positionType, symbols);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermOrdering.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermOrdering.java
@@ -28,11 +28,15 @@ final class TermOrdering {
      */
     static TermOrders of(NumericTerm term, Type positionType, Symbols symbols) {
         Carrier observed = observedOn(positionType, symbols);
-        return switch (term) {
-            case NumericTerm.ValueOf _ -> TermOrders.itself(observed);
+        // One construction and not one per arm. A term that is a location's own content answers on
+        // the order its value is read on, which is that order twice rather than a second way of
+        // making a pair — and a second way is a second place a pair can come from.
+        Carrier answered = switch (term) {
+            case NumericTerm.ValueOf _ -> observed;
             case NumericTerm.TakenOf _, NumericTerm.TakenOver _ ->
-                    new TermOrders(observed, answeredOn(term, positionType, symbols));
+                    answeredOn(term, positionType, symbols);
         };
+        return new TermOrders(term, observed, answered);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
@@ -28,23 +28,75 @@ import souther.compiler.check.Carrier;
  */
 public final class TermOrders {
 
+    private final NumericTerm term;
     private final Carrier observed;
     private final Carrier answered;
 
     /**
+     * @param term     the number these are the orders of. Carried, because an answer that leaves
+     *                 the reading and cannot say what it is an answer about is one any reader may
+     *                 put beside any term — and two carriers say nothing about which question they
+     *                 came from
      * @param observed what a value at the term's path is decoded on, or null where nothing orders
      *                 it — a container has no order and is read by what it holds
      * @param answered what the number the term names is measured on, which is what a boundary on it
      *                 is drawn and written back on
      */
-    TermOrders(Carrier observed, Carrier answered) {
+    TermOrders(NumericTerm term, Carrier observed, Carrier answered) {
+        if (term == null) {
+            throw new IllegalArgumentException("orders of no term, which is an answer to nothing");
+        }
+        this.term = term;
         this.observed = observed;
         this.answered = answered;
     }
 
-    /** A term whose value is the number it answers, which is every {@link NumericTerm.ValueOf}. */
-    static TermOrders itself(Carrier carrier) {
-        return new TermOrders(carrier, carrier);
+    /** The number these are the orders of. */
+    public NumericTerm term() {
+        return term;
+    }
+
+    /**
+     * That {@code asked} is the number these are the orders of.
+     *
+     * <p>For the readers that hold a term beside a pair because their own shape needs the narrower
+     * type. Two components are two things to get right, and this is where the second is refused
+     * rather than carried into a document.
+     */
+    public void areOf(NumericTerm asked) {
+        if (!term.equals(asked)) {
+            throw new IllegalArgumentException("these are the orders of " + term
+                    + ", and they are held beside " + asked);
+        }
+    }
+
+    /**
+     * The number this term names at {@code value}, or why there is none.
+     *
+     * <p>Asked of the answer and not of the term, because reading takes both and an entry taking
+     * both is one any caller can hand a term and another term's orders. Here the two arrived
+     * together from the reading that settled them.
+     */
+    public NumericTerm.Reading read(souther.compiler.observe.ObservedValue value) {
+        NumericTerm.FromOnePosition one = term.atOnePosition();
+        if (one == null) {
+            throw new IllegalArgumentException(
+                    term + " is read over the values of a run, and this is one value");
+        }
+        return TermReading.at(one, value, this);
+    }
+
+    /**
+     * The same, over the values of a run.
+     *
+     * <p>Which rows there are and how many values stand at a place in one are the measure's; a term
+     * only says what its number is of them.
+     */
+    public NumericTerm.Reading readOver(java.util.List<souther.compiler.observe.ObservedValue> values) {
+        if (!(term instanceof NumericTerm.TakenOver over)) {
+            throw new IllegalArgumentException(term + " is a number of one value, not of a run");
+        }
+        return TermReading.over(over, values, this);
     }
 
     /** What a value at the term's path is decoded on, or null where nothing orders it. */
@@ -57,20 +109,29 @@ public final class TermOrders {
         return answered;
     }
 
+    /**
+     * Two of these are one where they are the orders of one term.
+     *
+     * <p>The term among them, because these are an answer and not a pair of carriers: what a string
+     * is measured at and what a whole number at another position is measured at come to the same two
+     * orders and are answers to two questions. A reader that wants the carriers alone compares
+     * those.
+     */
     @Override
     public boolean equals(Object other) {
         return other instanceof TermOrders that
+                && term.equals(that.term)
                 && java.util.Objects.equals(observed, that.observed)
                 && java.util.Objects.equals(answered, that.answered);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(observed, answered);
+        return java.util.Objects.hash(term, observed, answered);
     }
 
     @Override
     public String toString() {
-        return "TermOrders[observed=" + observed + ", answered=" + answered + "]";
+        return "TermOrders[" + term + " observed=" + observed + ", answered=" + answered + "]";
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
@@ -19,15 +19,58 @@ import souther.compiler.check.Carrier;
  * with each other and with nothing else. The repair was to hold both ends of one crossing together,
  * and this holds both ends of one term together for the same reason.
  *
- * @param observed what a value at the term's path is decoded on, or null where nothing orders it —
- *                 a container has no order and is read by what it holds
- * @param answered what the number the term names is measured on, which is what a boundary on it is
- *                 drawn and written back on
+ * <p><b>Read anywhere and made in one place.</b> Which orders a term stands on follows from where
+ * the reading of an input has that term standing, so a pair put together outside this package is a
+ * pair about no reading in particular — and a pair whose halves came from two callers is one whose
+ * two ends are free to part. Neither is a class of mistake a reader can see, so neither is a state
+ * this lets anything reach: the way to one of these is {@link Quantities#ordersOf}. A test that
+ * wants a synthetic pair writes one in this package, where the source set says it is a test.
  */
-public record TermOrders(Carrier observed, Carrier answered) {
+public final class TermOrders {
+
+    private final Carrier observed;
+    private final Carrier answered;
+
+    /**
+     * @param observed what a value at the term's path is decoded on, or null where nothing orders
+     *                 it — a container has no order and is read by what it holds
+     * @param answered what the number the term names is measured on, which is what a boundary on it
+     *                 is drawn and written back on
+     */
+    TermOrders(Carrier observed, Carrier answered) {
+        this.observed = observed;
+        this.answered = answered;
+    }
 
     /** A term whose value is the number it answers, which is every {@link NumericTerm.ValueOf}. */
-    public static TermOrders itself(Carrier carrier) {
+    static TermOrders itself(Carrier carrier) {
         return new TermOrders(carrier, carrier);
+    }
+
+    /** What a value at the term's path is decoded on, or null where nothing orders it. */
+    public Carrier observed() {
+        return observed;
+    }
+
+    /** What the number the term names is measured on. */
+    public Carrier answered() {
+        return answered;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof TermOrders that
+                && java.util.Objects.equals(observed, that.observed)
+                && java.util.Objects.equals(answered, that.answered);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(observed, answered);
+    }
+
+    @Override
+    public String toString() {
+        return "TermOrders[observed=" + observed + ", answered=" + answered + "]";
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermOrders.java
@@ -78,12 +78,11 @@ public final class TermOrders {
      * together from the reading that settled them.
      */
     public NumericTerm.Reading read(souther.compiler.observe.ObservedValue value) {
-        NumericTerm.FromOnePosition one = term.atOnePosition();
-        if (one == null) {
+        if (term.atOnePosition() == null) {
             throw new IllegalArgumentException(
                     term + " is read over the values of a run, and this is one value");
         }
-        return TermReading.at(one, value, this);
+        return TermReading.at(this, value);
     }
 
     /**
@@ -93,10 +92,10 @@ public final class TermOrders {
      * only says what its number is of them.
      */
     public NumericTerm.Reading readOver(java.util.List<souther.compiler.observe.ObservedValue> values) {
-        if (!(term instanceof NumericTerm.TakenOver over)) {
+        if (!(term instanceof NumericTerm.TakenOver)) {
             throw new IllegalArgumentException(term + " is a number of one value, not of a run");
         }
-        return TermReading.over(over, values, this);
+        return TermReading.over(this, values);
     }
 
     /** What a value at the term's path is decoded on, or null where nothing orders it. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -1,0 +1,265 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Dates;
+import souther.compiler.numeric.Place;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.semantics.TakenAs;
+
+import souther.compiler.inputs.NumericTerm.Reading;
+
+/**
+ * The number a term names at an observation of its position, or why there is none.
+ *
+ * <p>The one reader. What a class asks of a row, what a boundary asks of it, and what a report
+ * prints were three walks down a value that agreed only because they were written the same way.
+ *
+ * <p>Not reachable from a term, which is why it is here rather than on one. Reading takes a term
+ * and the orders its number is measured on, and an entry that takes the two as arguments is one any
+ * caller can hand a term and another term's orders — the pairing this whole reading exists to stop,
+ * one layer along. The way in is {@link TermOrders#read}, which is asked of an answer that already
+ * says which term it is of.
+ */
+final class TermReading {
+
+    private TermReading() { }
+
+    /**
+     * The orders are the reading's rather than guessed at from the observation. A written temporal
+     * says nothing about whether the position counts days or seconds — the declared type says it —
+     * and a reader that sniffed the text for a {@code T} answered a question that was already
+     * answered, differently.
+     *
+     * <p><b>Both orders, and this picks.</b> What a value is decoded on and what the number it
+     * answers is measured on are two, and the one this wants is the first. Given the carrier instead
+     * of the pair, every caller chose which end to hand over and every one of them had to choose the
+     * same way — five places writing {@code .observed()} and getting it right, which is the
+     * arrangement the whole of #1027 exists to stop. The decision is here, where the arms that need
+     * it are.
+     */
+    static Reading at(NumericTerm.FromOnePosition term, ObservedValue at, TermOrders on) {
+        Carrier observed = on.observed();
+        Membership.Incomplete unread = Membership.unread(at);
+        if (unread != null) {
+            return new Reading.Missing(unread.code());
+        }
+        // A newtype is not a step in a path, so what sits at the position may be the construction and
+        // the value one inside it. Asked again of what is inside rather than walked into: a limit
+        // reached one layer down leaves a construction that reads perfectly well with nothing where
+        // the value should be, and a walk that only looked at the outside would call that a value
+        // this term does not hold.
+        if (at instanceof ObservedValue.Constructed c && c.field("value") != null) {
+            return at(term, c.field("value"), on);
+        }
+        return switch (term) {
+            case NumericTerm.ValueOf _ -> asItStands(at, observed);
+            case NumericTerm.TakenOf taken -> taken(taken.takenAs(), at, on);
+        };
+    }
+
+    /**
+     * The number a term names over the values of its run, or why there is none.
+     *
+     * <p>Handed the values rather than reaching for them: which rows there are and how many values
+     * stand at a place in one are the measure's, and a term only says what its number is of them.
+     * The plural is the whole difference from a taking of one value, and it is here rather than in
+     * the path or in what a row is asked — a location says nothing about how many values stand at
+     * it, and a reader that asked for one where a run stands would be given the first of them or
+     * none.
+     *
+     * <p>Exhaustive over the accounts, with no {@code default}. An account of a number taken of one
+     * value says nothing about a run of them — which hour a run of times falls in is not a question
+     * — so those answer that this is no number of theirs rather than being read as whichever value
+     * came first.
+     */
+    static Reading over(NumericTerm.TakenOver term, java.util.List<ObservedValue> values,
+                        TermOrders on) {
+        // Nothing to read, which a caller that could not walk to the run answers with. Said as
+        // "this is no number of that" rather than as a total over the values it did find.
+        if (values == null) {
+            return new Reading.NotNumber();
+        }
+        for (ObservedValue each : values) {
+            Membership.Incomplete unread = Membership.unread(each);
+            if (unread != null) {
+                return new Reading.Missing(unread.code());
+            }
+        }
+        return switch (term.takenAs()) {
+            case TakenAs.TheSumOfWhatItHolds _ -> addedUp(values, on);
+            case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ ->
+                    new Reading.NotNumber();
+        };
+    }
+
+    /** The number the term is, where the term is what the location holds. */
+    private static Reading asItStands(ObservedValue at, Carrier observed) {
+        if (observed == null) {
+            return new Reading.NotNumber();
+        }
+        Place read = observed.placeOf(at);
+        return read == null ? new Reading.NotNumber() : new Reading.Number(read);
+    }
+
+    /**
+     * The number an operation answers of an observation of what it was given.
+     *
+     * <p>One arm per declared account of what such an operation takes, and no default. An account
+     * added to {@code semantics} is one this does not compile without, which is what keeps a term
+     * from being read as whichever arm was written first — the state {@code SizeOf} left the reader
+     * in, where a term standing for anything but a size would have been read as the observation
+     * itself (#1027).
+     *
+     * <p>The pair and not one end of it, because which end an account reads its values on is the
+     * account's own answer. A part of a time is a number of the value as it is written; what a
+     * container adds up to is a number of the values it holds, and those are places of the order the
+     * total is measured on. Handed one carrier for every arm, the arms that want the other end have
+     * nothing to say so with — and a container is written on no order at all, so the one that adds
+     * its elements up is handed nothing.
+     */
+    private static Reading taken(TakenAs how, ObservedValue at, TermOrders on) {
+        return switch (how) {
+            case TakenAs.HowManyItHolds _ -> howMany(at);
+            case TakenAs.TheSumOfWhatItHolds _ -> addedUp(at, on);
+            case TakenAs.PartOfTime taken -> partOfTime(taken.part(), at, on.observed());
+            case TakenAs.PartOfDate taken -> partOfDate(taken.part(), at, on.observed());
+        };
+    }
+
+    /**
+     * How much an observation holds.
+     *
+     * <p>Read off the observation under the premise {@link NumericTerm.TakenOf} states: the
+     * operation and what it is applied to agree, so counting what is there counts what was asked
+     * for. A string counts in code points, as {@code Strings.length} does — counting UTF-16 units
+     * here would put a boundary one place away from the rule that drew it for every string outside
+     * the basic plane.
+     */
+    private static Reading howMany(ObservedValue at) {
+        return switch (at) {
+            case ObservedValue.Text t -> new Reading.Number(
+                    Count.of(t.value().codePointCount(0, t.value().length())));
+            case ObservedValue.Sequence s -> new Reading.Number(Count.of(s.elements().size()));
+            case ObservedValue.Mapping m -> new Reading.Number(Count.of(m.entries().size()));
+            case null, default -> new Reading.NotNumber();
+        };
+    }
+
+    /**
+     * What an observed container's elements add up to.
+     *
+     * <p>Every element, on the order the answer is measured on. That order is the elements' own —
+     * a walk carries what it has so far in the type it answers — so an element is read as a place
+     * of the same carrier the sum is, and there is no second order here for the two ends of the
+     * term to come apart on.
+     *
+     * <p>An element that reads as no place is what a container holding something other than what
+     * the position declares would give, and the sum of those is not a number rather than a number
+     * missing one of its parts. Nothing here reaches into an element: a sum is over what a
+     * container holds, and a value inside one of them is a position of its own.
+     *
+     * <p>Nothing added up is nought, which is what the walk starts from. An empty container is a
+     * value the model may write, and answering that it holds no number would put a row the author
+     * can write outside every class of the number a rule is about.
+     */
+    private static Reading addedUp(ObservedValue at, TermOrders on) {
+        return at instanceof ObservedValue.Sequence held
+                ? addedUp(held.elements(), on) : new Reading.NotNumber();
+    }
+
+    /**
+     * The same, over values a caller gathered rather than over a container standing somewhere.
+     *
+     * <p>Where the end is taken, for both readers at once. A total of what a place holds and a total
+     * over the values of a run are one account of one operation, so which order their elements are
+     * places of is one answer. Taken apiece, the two are free to add the same values up on different
+     * orders.
+     */
+    private static Reading addedUp(java.util.List<ObservedValue> values, TermOrders on) {
+        Carrier elements = on.answered();
+        if (elements == null) {
+            return new Reading.NotNumber();
+        }
+        java.math.BigDecimal total = java.math.BigDecimal.ZERO;
+        for (ObservedValue each : values) {
+            Membership.Incomplete unread = Membership.unread(each);
+            if (unread != null) {
+                return new Reading.Missing(unread.code());
+            }
+            // Through the name an element is written under, as the one value a place holds is read
+            // through it. A run of a newtype over a whole number holds constructions, and the
+            // number each carries is one inside.
+            ObservedValue value = each instanceof ObservedValue.Constructed c
+                    && c.field("value") != null ? c.field("value") : each;
+            Place read = elements.placeOf(value);
+            if (!(read instanceof Count count)) {
+                return new Reading.NotNumber();
+            }
+            total = total.add(count.at());
+        }
+        return new Reading.Number(new Count(total));
+    }
+
+    /**
+     * Which hour, minute or second of its day an observed time falls in.
+     *
+     * <p>Decoded on the order the value is written on — a time counts the seconds into its day — and
+     * answered on the order the operation answers, which is a count by one. The two are different
+     * orders here, which is why the value is not read on the order the answer is measured on: read
+     * that way, {@code 13:45:12} would be the thirteenth second rather than the thirteenth hour.
+     *
+     * <p>Divided and then taken the remainder of, which is what a part of a count is. The hour is
+     * the whole hours in the day so far; the minute is the whole minutes, of which the hours are
+     * dropped.
+     */
+    private static Reading partOfTime(TakenAs.TimePart part, ObservedValue at, Carrier observed) {
+        if (observed == null) {
+            return new Reading.NotNumber();
+        }
+        Place read = observed.placeOf(at);
+        // A place that is not a count is not a time of day. No operation declaring this arm is
+        // given anything else, so this is the observation being something other than what the
+        // position declares, which is what `NotNumber` says.
+        if (!(read instanceof Count count)) {
+            return new Reading.NotNumber();
+        }
+        java.math.BigDecimal seconds = count.at();
+        return new Reading.Number(Count.of(seconds
+                .divideToIntegralValue(java.math.BigDecimal.valueOf(part.seconds()))
+                .remainder(java.math.BigDecimal.valueOf(part.many()))));
+    }
+
+    /**
+     * Which year, month or day of its month an observed date falls in.
+     *
+     * <p>Turned into a date and asked, rather than divided. A date counts days and its parts are the
+     * calendar's: the months are of different lengths and a leap year has a day the year before it
+     * does not, so no step and modulus over the count answers any of the three. What turns a count
+     * into a date is {@link Dates}, which is also what a report and a fixture read, so the date this
+     * takes a part of is the date they would write for the same day.
+     *
+     * <p>Answered on the order the operation answers, which is a count by one, while the value is
+     * decoded on the order it is written on. The two are the same pair of orders a part of a time
+     * travels on, and for the same reason: a line at the twelfth month is not a line at the twelfth
+     * day.
+     */
+    private static Reading partOfDate(TakenAs.DatePart part, ObservedValue at, Carrier observed) {
+        if (observed == null) {
+            return new Reading.NotNumber();
+        }
+        Place read = observed.placeOf(at);
+        // A place that is not a count is not a date. No operation declaring this arm is given
+        // anything else, so this is the observation being something other than what the position
+        // declares, which is what `NotNumber` says.
+        if (!(read instanceof Count count)) {
+            return new Reading.NotNumber();
+        }
+        java.time.LocalDate date = Dates.dateAt(count);
+        return new Reading.Number(Count.of(switch (part) {
+            case YEAR -> date.getYear();
+            case MONTH -> date.getMonthValue();
+            case DAY -> date.getDayOfMonth();
+        }));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -38,7 +38,8 @@ final class TermReading {
      * arrangement the whole of #1027 exists to stop. The decision is here, where the arms that need
      * it are.
      */
-    static Reading at(NumericTerm.FromOnePosition term, ObservedValue at, TermOrders on) {
+    static Reading at(TermOrders on, ObservedValue at) {
+        NumericTerm.FromOnePosition term = on.term().atOnePosition();
         Carrier observed = on.observed();
         Membership.Incomplete unread = Membership.unread(at);
         if (unread != null) {
@@ -50,7 +51,7 @@ final class TermReading {
         // the value should be, and a walk that only looked at the outside would call that a value
         // this term does not hold.
         if (at instanceof ObservedValue.Constructed c && c.field("value") != null) {
-            return at(term, c.field("value"), on);
+            return at(on, c.field("value"));
         }
         return switch (term) {
             case NumericTerm.ValueOf _ -> asItStands(at, observed);
@@ -73,8 +74,8 @@ final class TermReading {
      * — so those answer that this is no number of theirs rather than being read as whichever value
      * came first.
      */
-    static Reading over(NumericTerm.TakenOver term, java.util.List<ObservedValue> values,
-                        TermOrders on) {
+    static Reading over(TermOrders on, java.util.List<ObservedValue> values) {
+        NumericTerm.TakenOver term = (NumericTerm.TakenOver) on.term();
         // Nothing to read, which a caller that could not walk to the run answers with. Said as
         // "this is no number of that" rather than as a total over the values it did find.
         if (values == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -4,7 +4,6 @@ import souther.compiler.check.NarrowedBounds;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.TermPath;
-import souther.compiler.types.Type;
 
 import java.util.List;
 
@@ -34,19 +33,17 @@ import java.util.List;
  * beside the report rather than taken out of the count — a claim the rules bear out has already
  * left, because the reading these classes come from is what took it out.
  *
+ * <p>Where the number is measured, and nothing about what stands there. What a value at the
+ * position looks like and what order its number is counted on are two questions the reading of the
+ * input answers, and every reader of a measure can reach that reading. Held here as well, the two
+ * would be answers a reader could take from either place, and the day they part is the day a row is
+ * composed at a place one of them says nothing is written.
+ *
  * @param term    the number this axis is of: a location's own content, or something taken of it.
  *                Answered by one input position and held as such, because that is what an axis is:
  *                a run of classes over the values of a number a row can be asked for somewhere. A
  *                number read from a run of a sequence has no such place, so it draws a line without
  *                dividing anything and never arrives here
- * @param type    what stands at the position the number is read from, which is what a value read
- *                here is of. Not the term's: a string is measured at how long it is, and what
- *                stands at the location is still a string. The one thing about the location a
- *                measure needs, and nothing else about it is here — where the walk stopped, what
- *                the reading left standing and what the location is if nothing answers are true of
- *                it once however many numbers measure it, and a measure that answered them would
- *                let any reader ask a location's question through whichever number it happens to
- *                hold ({@link PositionMeasurements})
  * @param classes exclusive and exhaustive over the term's values, or empty where the model does
  *                not divide them
  * @param cuts    the values the classes meet at, each carrying every rule that drew it there
@@ -57,7 +54,7 @@ import java.util.List;
  *                away from its line is a run of what these leave together, and the cuts alone are
  *                short of the lines that have no value
  */
-public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
+public record Axis(AxisId id, NumericTerm.FromOnePosition term,
                    List<PartitionClass> classes,
                    List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
 
@@ -65,9 +62,6 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         classes = List.copyOf(classes);
         cuts = List.copyOf(cuts);
         parted = List.copyOf(parted);
-        if (type == null) {
-            throw new IllegalArgumentException("an axis of a value of nothing");
-        }
         // A measure is what the rules divided a number into, cut on it, or parted it at, and one
         // with none of the three measured nothing. Such a one used to stand for a position still to
         // be answered for — which is a fact about the location and is held there
@@ -128,9 +122,9 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
         }
     }
 
-    public Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
+    public Axis(AxisId id, NumericTerm.FromOnePosition term,
                 List<PartitionClass> classes, List<Cut> cuts) {
-        this(id, term, type, classes, cuts, List.of(), NarrowedBounds.NOTHING);
+        this(id, term, classes, cuts, List.of(), NarrowedBounds.NOTHING);
     }
 
     /**
@@ -141,10 +135,10 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term, Type type,
      * the constructor a second answer to refuse — so this is the way in, and passing a name is for
      * a reader rebuilding a measure it already has.
      */
-    public static Axis of(String behavior, NumericTerm.FromOnePosition term, Type type,
+    public static Axis of(String behavior, NumericTerm.FromOnePosition term,
                           List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted,
                           NarrowedBounds narrowed) {
-        return new Axis(AxisId.of(behavior, term), term, type, classes, cuts, parted, narrowed);
+        return new Axis(AxisId.of(behavior, term), term, classes, cuts, parted, narrowed);
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -71,10 +71,10 @@ public sealed interface BorderQuantity {
          *  is is one position's own values, so a move that leaves it without one leaves it
          *  something else. */
         @Override
-        public BorderQuantity movedTo(NumericTerm from, NumericTerm to, TermOrders orders) {
-            NumericTerm.FromOnePosition landed = to.atOnePosition();
+        public BorderQuantity movedTo(NumericTerm from, TermOrders to) {
+            NumericTerm.FromOnePosition landed = to.term().atOnePosition();
             return term.equals(from) && landed != null
-                    ? new OfACoordinate(new AxisId(axis.behavior(), to.toString()), landed, orders)
+                    ? new OfACoordinate(new AxisId(axis.behavior(), landed.toString()), landed, to)
                     : null;
         }
 
@@ -190,12 +190,12 @@ public sealed interface BorderQuantity {
         }
 
         @Override
-        public BorderQuantity movedTo(NumericTerm from, NumericTerm to, TermOrders orders) {
+        public BorderQuantity movedTo(NumericTerm from, TermOrders to) {
             if (!on.term().equals(from) && !against.term().equals(from)) {
                 return null;
             }
-            TermOrders here = on.term().equals(from) ? orders : on;
-            TermOrders there = against.term().equals(from) ? orders : against;
+            TermOrders here = on.term().equals(from) ? to : on;
+            TermOrders there = against.term().equals(from) ? to : against;
             // A distance is between two positions, so a move that leaves either end answered by no
             // single position leaves the pair something a distance is not. And a name standing at
             // more than one can bring the two ends of one together — answered here, because what a
@@ -426,15 +426,16 @@ public sealed interface BorderQuantity {
         }
 
         @Override
-        public BorderQuantity movedTo(NumericTerm from, NumericTerm to, TermOrders orders) {
-            if (!form.coefs().containsKey(from) || form.coefs().containsKey(to)) {
+        public BorderQuantity movedTo(NumericTerm from, TermOrders to) {
+            NumericTerm landed = to.term();
+            if (!form.coefs().containsKey(from) || form.coefs().containsKey(landed)) {
                 return null;
             }
             Map<NumericTerm, java.math.BigDecimal> coefs = new java.util.LinkedHashMap<>();
-            form.coefs().forEach((term, coef) -> coefs.put(term.equals(from) ? to : term, coef));
+            form.coefs().forEach((term, coef) -> coefs.put(term.equals(from) ? landed : term, coef));
             Map<NumericTerm, TermOrders> moved = new java.util.LinkedHashMap<>();
-            on.forEach((term, its) -> moved.put(term.equals(from) ? to : term,
-                    term.equals(from) ? orders : its));
+            on.forEach((term, its) -> moved.put(term.equals(from) ? landed : term,
+                    term.equals(from) ? to : its));
             return new OverAForm(behavior,
                     new LinearForm<>(form.constant(), coefs), moved);
         }
@@ -642,10 +643,15 @@ public sealed interface BorderQuantity {
      * counted from one to the other, and a caller building the pair itself would be the second place
      * that has to know it.
      *
-     * @param orders what the term is read on and answers at its new position, which is a fact about
-     *               where it lands and cannot be carried over from where it was
+     * <p>Where it lands is read off the orders rather than named beside them. What the term is read
+     * on and answers at its new position is a fact about that position — it cannot be carried over
+     * from where it was — and the reading's answer says which position it is about, so a second
+     * argument saying it is a second thing to get right and one this could not refuse: it does not
+     * use the name it is given.
+     *
+     * @param to what the term is read on and answers at its new position, and which position that is
      */
-    BorderQuantity movedTo(NumericTerm from, NumericTerm to, TermOrders orders);
+    BorderQuantity movedTo(NumericTerm from, TermOrders to);
 
     /**
      * The order one position under this quantity is read and written back on, or null where the
@@ -665,7 +671,13 @@ public sealed interface BorderQuantity {
     /** What each of a form's terms is measured on, for a reader of a line rather than of a row. */
     static Map<NumericTerm, Carrier> answeredOn(Map<NumericTerm, TermOrders> orders) {
         Map<NumericTerm, Carrier> out = new java.util.LinkedHashMap<>();
-        orders.forEach((term, on) -> out.put(term, on.answered()));
+        orders.forEach((term, on) -> {
+            // Each entry's orders are that position's own. A table whose keys are the right numbers
+            // says nothing about which of them each answer came from, and what comes out of here is
+            // a number filed under an order, with the term gone.
+            on.areOf(term);
+            out.put(term, on.answered());
+        });
         return Map.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -51,6 +51,10 @@ public sealed interface BorderQuantity {
                 throw new IllegalArgumentException("a coordinate quantity names a position and an "
                         + "order: " + axis + " " + term + " " + of);
             }
+            // The position is here because a coordinate is a position's own number, which is the
+            // narrower kind of term; the orders say which number they are of. The second spelling
+            // is refused rather than carried into a document.
+            of.areOf(term);
         }
 
         @Override
@@ -86,7 +90,7 @@ public sealed interface BorderQuantity {
             // measured on. The two are one carrier for a position's own content and part for a term
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
-            return switch (term.read(row.at(term.position()), of)) {
+            return switch (of.read(row.at(term.position()))) {
                 case NumericTerm.Reading.Missing _ -> Stands.UNREADABLE;
                 case NumericTerm.Reading.NotNumber _ -> Stands.NO;
                 case NumericTerm.Reading.Number number ->
@@ -168,75 +172,72 @@ public sealed interface BorderQuantity {
      * arithmetic form over both positions and is read as {@link OverAForm}, whose coefficients are
      * where a conversion between two orders is written.
      */
-    record Apart(String behavior, NumericTerm.FromOnePosition on,
-                 NumericTerm.FromOnePosition against,
-                 Map<NumericTerm, TermOrders> carriers) implements BorderQuantity {
+    record Apart(String behavior, TermOrders on, TermOrders against) implements BorderQuantity {
+
+        /** The position at one end. */
+        public NumericTerm.FromOnePosition onTerm() {
+            return on.term().atOnePosition();
+        }
+
+        /** The position at the other. */
+        public NumericTerm.FromOnePosition againstTerm() {
+            return against.term().atOnePosition();
+        }
 
         @Override
         public List<NumericTerm> terms() {
-            return List.of(on, against);
+            return List.of(on.term(), against.term());
         }
 
         @Override
         public BorderQuantity movedTo(NumericTerm from, NumericTerm to, TermOrders orders) {
-            if (!on.equals(from) && !against.equals(from)) {
+            if (!on.term().equals(from) && !against.term().equals(from)) {
                 return null;
             }
+            TermOrders here = on.term().equals(from) ? orders : on;
+            TermOrders there = against.term().equals(from) ? orders : against;
             // A distance is between two positions, so a move that leaves either end answered by no
-            // single position leaves the pair something a distance is not.
-            NumericTerm.FromOnePosition landed = to.atOnePosition();
-            if (landed == null) {
+            // single position leaves the pair something a distance is not. And a name standing at
+            // more than one can bring the two ends of one together — answered here, because what a
+            // caller has in hand is a name that moved and not a pair it chose.
+            if (here.term().atOnePosition() == null || there.term().atOnePosition() == null
+                    || here.term().equals(there.term())) {
                 return null;
             }
-            NumericTerm.FromOnePosition here = on.equals(from) ? landed : on;
-            NumericTerm.FromOnePosition there = against.equals(from) ? landed : against;
-            // A distance runs between two positions, and a name standing at more than one can bring
-            // the two ends of one together. Answered here, because what a caller has in hand is a
-            // name that moved and not a pair it chose.
-            if (here.equals(there)) {
-                return null;
-            }
-            Map<NumericTerm, TermOrders> moved = new java.util.LinkedHashMap<>();
-            moved.put(here, on.equals(from) ? orders : carriers.get(on));
-            moved.put(there, against.equals(from) ? orders : carriers.get(against));
-            return new Apart(behavior, here, there, moved);
+            return new Apart(behavior, here, there);
         }
 
         public Apart {
-            if (behavior == null || on == null || against == null || carriers == null) {
+            if (behavior == null || on == null || against == null) {
                 throw new IllegalArgumentException("a distance names two positions and their orders");
             }
-            // First, because a distance between one position and itself is what the rest of this
-            // cannot be asked about: two terms that are one term are one key, and a map of them
-            // would refuse the pair with a sentence about maps.
-            if (on.equals(against)) {
-                throw new IllegalArgumentException(
-                        "a distance runs between two positions, and this names one twice: " + on);
+            // Each end is a position's own number on the order that position is read and written
+            // on, and the orders say which position that is. Held as a pair of positions beside a
+            // map from position to orders, the keys could name the right pair with the values the
+            // other way round, and both structures would check out.
+            if (on.term().atOnePosition() == null || against.term().atOnePosition() == null) {
+                throw new IllegalArgumentException("a distance runs between two positions, and this"
+                        + " names " + on.term() + " against " + against.term());
             }
-            carriers = Map.copyOf(carriers);
-            // An order per position, held here so no reader has to answer for a position with none.
-            // A map beside a pair is two structures, and two structures are what come apart.
-            if (!carriers.keySet().equals(java.util.Set.of(on, against))) {
-                throw new IllegalArgumentException("a distance is between the positions it names,"
-                        + " each on one order: " + java.util.Set.of(on, against) + " against "
-                        + carriers.keySet());
+            if (on.term().equals(against.term())) {
+                throw new IllegalArgumentException("a distance runs between two positions, and this"
+                        + " names one twice: " + on.term());
             }
-            Carrier here = carriers.get(on).answered();
-            Carrier there = carriers.get(against).answered();
-            if (!here.standsAgainst(there)) {
+            if (!on.answered().standsAgainst(against.answered())) {
                 throw new IllegalArgumentException("a distance is between two orders a value of"
-                        + " one stands somewhere on: " + here + " against " + there);
+                        + " one stands somewhere on: " + on.answered() + " against "
+                        + against.answered());
             }
         }
 
         /** The order the first position is read and written on. */
         private Carrier onCarrier() {
-            return carriers.get(on).answered();
+            return on.answered();
         }
 
         /** The order the other position is read and written on. */
         private Carrier againstCarrier() {
-            return carriers.get(against).answered();
+            return against.answered();
         }
 
         /** Whether the two positions stand on one order, which is every pair a rule names itself and
@@ -269,8 +270,7 @@ public sealed interface BorderQuantity {
             if (!counts()) {
                 return LevelSpace.onlyWhereTheyMeet();
             }
-            return LevelSpace.addedUpOver(carriers.values().stream()
-                    .map(TermOrders::answered).toList())
+            return LevelSpace.addedUpOver(List.of(on.answered(), against.answered()))
                     == souther.compiler.numeric.Granularity.DISCRETE
                     ? LevelSpace.steppingBy(java.math.BigDecimal.ONE) : LevelSpace.dense();
         }
@@ -278,8 +278,10 @@ public sealed interface BorderQuantity {
         /** That position's own, which is what it is read off a row and written back on. */
         @Override
         public Carrier carrierOf(NumericTerm asked) {
-            TermOrders orders = carriers.get(asked);
-            return orders == null ? null : orders.answered();
+            if (on.term().equals(asked)) {
+                return on.answered();
+            }
+            return against.term().equals(asked) ? against.answered() : null;
         }
 
         /**
@@ -299,9 +301,8 @@ public sealed interface BorderQuantity {
             // Each on its own order. Read on one order for the pair, a position written back
             // differently from the other was read as a value it does not hold — a date read as a
             // whole number is no number at all, and the row stood at nothing (#1018).
-            NumericTerm.Reading here = on.read(row.at(on.subjectPath()), carriers.get(on));
-            NumericTerm.Reading there =
-                    against.read(row.at(against.subjectPath()), carriers.get(against));
+            NumericTerm.Reading here = on.read(row.at(on.term().subjectPath()));
+            NumericTerm.Reading there = against.read(row.at(against.term().subjectPath()));
             if (here instanceof NumericTerm.Reading.Missing
                     || there instanceof NumericTerm.Reading.Missing) {
                 return Stands.UNREADABLE;
@@ -356,21 +357,22 @@ public sealed interface BorderQuantity {
         @Override
         public Standing standingAt(Criterion where) {
             if (onOneCarrier()) {
-                return new Standing.OfTwoOnOneCarrier(on, against, onCarrier(), where);
+                return new Standing.OfTwoOnOneCarrier(onTerm(), againstTerm(), onCarrier(), where);
             }
             return new Standing.OfAForm(
-                    LinearForm.<NumericTerm>atom(on).minus(LinearForm.atom(against)),
-                    answeredOn(carriers), levels(), where);
+                    LinearForm.<NumericTerm>atom(on.term()).minus(LinearForm.atom(against.term())),
+                    Map.of(on.term(), on.answered(), against.term(), against.answered()),
+                    levels(), where);
         }
 
         @Override
         public String named() {
-            return new AxisId(behavior, on.toString()).toString();
+            return new AxisId(behavior, onTerm().toString()).toString();
         }
 
         @Override
         public String left() {
-            return on.toString();
+            return onTerm().toString();
         }
 
         /**
@@ -383,9 +385,10 @@ public sealed interface BorderQuantity {
         @Override
         public String writtenAt(Level level) {
             Count apart = level.asACount();
-            return apart.signum() == 0 ? against.toString()
-                    : apart.signum() < 0 ? against + " - " + apart.negate().key()
-                            : against + " + " + apart.key();
+            String there = againstTerm().toString();
+            return apart.signum() == 0 ? there
+                    : apart.signum() < 0 ? there + " - " + apart.negate().key()
+                            : there + " + " + apart.key();
         }
 
         @Override
@@ -453,6 +456,10 @@ public sealed interface BorderQuantity {
                         + " of them is read on one order: " + form.coefs().keySet() + " against "
                         + on.keySet());
             }
+            // And each entry's orders are that position's own. The key set agreeing says the map
+            // is about the right positions and says nothing about which of them each answer came
+            // from: a table with the two ends swapped has exactly the same keys.
+            on.forEach((term, orders) -> orders.areOf(term));
             // And each of those orders has counts under it, which is what a sum adds. Nothing
             // more: whether these positions add up to anything is settled by whatever produced the
             // form, and a rule here would be written without the coefficients. `b + a` over two
@@ -522,10 +529,9 @@ public sealed interface BorderQuantity {
                 // a total would be read off whichever element the row's reading happened to pick.
                 TermOrders orders = on.get(each.getKey());
                 NumericTerm.Reading read = switch (each.getKey()) {
-                    case NumericTerm.FromOnePosition one ->
-                            one.read(row.at(one.position()), orders);
+                    case NumericTerm.FromOnePosition one -> orders.read(row.at(one.position()));
                     case NumericTerm.TakenOver over ->
-                            over.readOver(row.everyValueAt(over.subjectPath()), orders);
+                            orders.readOver(row.everyValueAt(over.subjectPath()));
                 };
                 if (read instanceof NumericTerm.Reading.Missing) {
                     return Stands.UNREADABLE;

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -40,6 +40,13 @@ import souther.compiler.numeric.Place;
 record ComparedLine(NumericTerm.FromOnePosition term, Place value,
                     TermOrders orders, ComparisonClaim claim) {
 
+    ComparedLine {
+        // A line is drawn on a position's own number, which is the narrower kind of term, and the
+        // orders say which number they are of. Two spellings of one thing, so the second is refused
+        // here rather than read further along as a line on one number at the order of another.
+        orders.areOf(term);
+    }
+
     /**
      * What {@code comparison} draws, or null where it draws nothing.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
@@ -10,8 +10,6 @@ import souther.compiler.inputs.Quantities;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.numeric.Count;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * The quantity a comparison over two positions cuts: how far the two stand apart.
@@ -50,9 +48,33 @@ import java.util.Map;
  *                       as one position against another. A number and not a count of steps: an order
  *                       with no smallest step still holds its values a distance apart
  */
-record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition against,
-                     Map<NumericTerm, TermOrders> carriers,
-                     Count stepsApart) {
+record ComparedTerms(TermOrders on, TermOrders against, Count stepsApart) {
+
+    ComparedTerms {
+        // The two ends are the orders, and each says which position it is of. Held as a pair of
+        // positions beside a map from position to orders, the two structures were what a reader
+        // had to keep agreeing: the map's keys could be the right pair and its values the other
+        // way round, and every check either structure made would pass.
+        if (onTerm(on) == null || onTerm(against) == null) {
+            throw new IllegalArgumentException(
+                    "a distance runs between two positions: " + on + " against " + against);
+        }
+    }
+
+    /** The position at one end, or null where those orders are of no single position. */
+    private static NumericTerm.FromOnePosition onTerm(TermOrders orders) {
+        return orders == null ? null : orders.term().atOnePosition();
+    }
+
+    /** The position the line is named by, which is the one the author wrote on the left. */
+    NumericTerm.FromOnePosition onPosition() {
+        return onTerm(on);
+    }
+
+    /** The position it is held apart from. */
+    NumericTerm.FromOnePosition againstPosition() {
+        return onTerm(against);
+    }
 
     /**
      * The two positions {@code comparison} names, or null where it names no such pair.
@@ -72,18 +94,11 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
                     GuardThresholds.namedBy(comparison.at().left(), read, reads);
             GuardThresholds.Named against =
                     GuardThresholds.namedBy(comparison.at().right(), read, reads);
-            // A distance runs between two positions, so each side has to be a number one answers.
-            NumericTerm.FromOnePosition here = on == null ? null : on.term().atOnePosition();
-            NumericTerm.FromOnePosition there =
-                    against == null ? null : against.term().atOnePosition();
-            Map<NumericTerm, TermOrders> carriers =
-                    here == null || there == null ? null
-                            : aDistanceBetween(here, on.orders(), there, against.orders());
-            if (carriers != null) {
+            if (on != null && against != null && aDistanceRuns(on.orders(), against.orders())) {
                 // The subject is the one the author wrote on the left, which the canonical form
                 // keeps too. Which of the two a line is named by is not something to derive where
                 // the source settles it: `charge > ceiling` is a line about the charge.
-                return new ComparedTerms(here, there, carriers, Count.ZERO);
+                return new ComparedTerms(on.orders(), against.orders(), Count.ZERO);
             }
         }
         return null;
@@ -108,18 +123,12 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
      * two positions written back differently — a decimal against a whole number is the pair that
      * exists — is still one distance, and it is only the writing that differs.
      */
-    private static Map<NumericTerm, TermOrders> aDistanceBetween(
-            NumericTerm on, TermOrders here,
-            NumericTerm against, TermOrders there) {
-        if (on == null || against == null || here == null || there == null
-                || here.answered() == null || there.answered() == null
-                || on.equals(against) || !here.answered().standsAgainst(there.answered())) {
-            return null;
-        }
-        Map<NumericTerm, TermOrders> both = new LinkedHashMap<>();
-        both.put(on, here);
-        both.put(against, there);
-        return both;
+    private static boolean aDistanceRuns(TermOrders here, TermOrders there) {
+        return here != null && there != null
+                && onTerm(here) != null && onTerm(there) != null
+                && here.answered() != null && there.answered() != null
+                && !here.term().equals(there.term())
+                && here.answered().standsAgainst(there.answered());
     }
 
     /**
@@ -161,18 +170,13 @@ record ComparedTerms(NumericTerm.FromOnePosition on, NumericTerm.FromOnePosition
         // these counts count", a property of the values stood in for a property of the places: two
         // strings stand no measurable distance apart and are still one above the other, so the
         // place they meet is a line — and this refused it, leaving the spelling to draw one.
-        if (here == null) {
-            return null;
-        }
-        Map<NumericTerm, TermOrders> carriers =
-                aDistanceBetween(two[0], hereOn, two[1], thereOn);
-        if (carriers == null) {
+        if (here == null || !aDistanceRuns(hereOn, thereOn)) {
             return null;
         }
         // The distance as the number it is. Held as a count of the carrier's steps, a threshold
         // that is not a whole number of them — which two decimals a rule holds half apart give —
         // was an exception thrown out of the measure.
-        return new ComparedTerms(two[0], two[1], carriers, new Count(read.cut()));
+        return new ComparedTerms(hereOn, thereOn, new Count(read.cut()));
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -88,9 +88,13 @@ final class ContainersAddingUp {
      *                  a container built here would be read as a different total than it was built
      *                  for
      */
-    static TermRealizations.Realization to(Place answer, RealizationTarget target, Type container,
+    static TermRealizations.Realization to(Place answer, Type container,
                                            TermOrders orders, SearchRegion within,
                                            Symbols symbols, ReadingPolicy policy) {
+        // Which number is being built for, read off the answer that says which number it is of.
+        // Named beside it, the two were free to be about two numbers and this would fill a
+        // container found under one path with elements counted on another's order.
+        RealizationTarget target = RealizationTarget.of(orders.term());
         Carrier elements = orders.answered();
         if (!(answer instanceof Count total) || elements == null) {
             return none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -311,8 +311,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         if (drawn == null) {
             return null;
         }
-        return made(new BorderQuantity.Apart(behavior, drawn.on(), drawn.against(),
-                        drawn.carriers()),
+        return made(new BorderQuantity.Apart(behavior, drawn.on(), drawn.against()),
                 new Level.ACount(drawn.stepsApart()), claim, quantities);
     }
 
@@ -431,8 +430,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
     private static LinearForm<NumericTerm> direction(BorderQuantity of) {
         return switch (of) {
             case BorderQuantity.OfACoordinate one -> LinearForm.atom(one.term());
-            case BorderQuantity.Apart two ->
-                    LinearForm.<NumericTerm>atom(two.on()).minus(LinearForm.atom(two.against()));
+            case BorderQuantity.Apart two -> LinearForm.<NumericTerm>atom(two.on().term())
+                    .minus(LinearForm.atom(two.against().term()));
             case BorderQuantity.OverAForm many -> many.form();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -179,7 +179,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         // What the term it moves to is measured on, asked of the reading that is here anyway. Taken
         // as an argument beside the term, the two were free to be about two terms — and the reading
         // that would have settled it was being handed over in the same call.
-        BorderQuantity moved = of.movedTo(from, to, quantities.ordersOf(to));
+        BorderQuantity moved = of.movedTo(from, quantities.ordersOf(to));
         if (moved == null || !moved.levels().canCutAt(at)) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -175,9 +175,11 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      * rules leave it there — kept as it was, a line would be held inside the values of the position
      * it came from.
      */
-    Cutting movedTo(NumericTerm from, NumericTerm to, TermOrders orders,
-                    Quantities quantities) {
-        BorderQuantity moved = of.movedTo(from, to, orders);
+    Cutting movedTo(NumericTerm from, NumericTerm to, Quantities quantities) {
+        // What the term it moves to is measured on, asked of the reading that is here anyway. Taken
+        // as an argument beside the term, the two were free to be about two terms — and the reading
+        // that would have settled it was being handed over in the same call.
+        BorderQuantity moved = of.movedTo(from, to, quantities.ordersOf(to));
         if (moved == null || !moved.levels().canCutAt(at)) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2628,7 +2628,7 @@ public final class Generator {
         // there is measured on as well, and the two are one value only for as long as no term
         // arrives where they part.
         souther.compiler.inputs.TermOrders on = subject.quantities().ordersOf(target.term());
-        return edgeFrom(TermRealizations.at(target, writtenAt, on, at, within, subject.symbols(),
+        return edgeFrom(TermRealizations.at(writtenAt, on, at, within, subject.symbols(),
                 subject.inputs().policy()), target, at);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2565,17 +2565,16 @@ public final class Generator {
         // readings does; a number over a run is read of all of them at once, since that is what the
         // walk was given and any one of them is not it.
         boolean stands = switch (target) {
-            case RealizationTarget.AtOnePosition one -> {
+            case RealizationTarget.AtOnePosition _ -> {
                 boolean any = false;
                 for (souther.compiler.observe.ObservedValue value : values) {
-                    any |= one.term().read(value, on)
-                            instanceof NumericTerm.Reading.Number number
+                    any |= on.read(value) instanceof NumericTerm.Reading.Number number
                             && number.value().compareTo(at) == 0;
                 }
                 yield any;
             }
-            case RealizationTarget.OverARun over ->
-                    over.term().readOver(values, on) instanceof NumericTerm.Reading.Number number
+            case RealizationTarget.OverARun _ ->
+                    on.readOver(values) instanceof NumericTerm.Reading.Number number
                             && number.value().compareTo(at) == 0;
         };
         return stands ? null

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2,7 +2,6 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.ast.Hir;
-import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Symbols;
@@ -2258,9 +2257,12 @@ public final class Generator {
      * <p>Nothing here decides that a boundary cannot be written at. A refusal is a refusal of the
      * candidates that were tried, and another value of the same edge may build; what comes back says
      * which of the two happened and leaves the reading to the caller.
+     *
+     * <p>What each position's number is measured on is not passed in. It is the subject's reading to
+     * answer, and a caller handing it over would be handing an answer it worked out somewhere else —
+     * for a term this reading might have standing somewhere other than where that caller found it.
      */
     public static BoundaryAttempt probeFixing(MeasuredInput subject, String label,
-                                              java.util.function.Function<NumericTerm, Carrier> on,
                                               Map<RealizationTarget, Place> fixing,
                                               Reachability.Reaching reaching, CandidateCheck check) {
         LocationWrites decided = new LocationWrites();
@@ -2270,9 +2272,6 @@ public final class Generator {
         // came back as one every value tried was refused at.
         Map<TermPath, Place> settled = new LinkedHashMap<>();
         Map<TermPath, UnresolvedCombination.Reason> heldBack = new LinkedHashMap<>();
-        // Per term, because a fixing names one order pair per position and a row is certified
-        // against the one its own value was built on.
-        Map<NumericTerm, souther.compiler.inputs.TermOrders> builtOn = new LinkedHashMap<>();
         // Where every position of this row stands: the item's, and the ones the way to it bounds.
         // One map, because a row is one row — walked as two, the second was chosen from what the
         // declarations leave and the first from what reaches the border, and only one of them was
@@ -2280,25 +2279,11 @@ public final class Generator {
         Standing where = alsoOnTheWay(subject, fixing, reaching);
         Map<RealizationTarget, Place> standing = where.at();
         for (Map.Entry<RealizationTarget, Place> each : standing.entrySet()) {
-            // The order this position is written back on, which is the position's own. Handed one
-            // order for the whole fixing, a form over positions written back differently wrote each
-            // of them as a value of whichever order the quantity happened to answer with.
-            //
-            // The item's positions are the quantity's to answer for and the way's are not: a
-            // condition above the line is over positions the quantity is not taken of, and each of
-            // those is read and written on its own order like any other.
-            Carrier carrier = fixing.containsKey(each.getKey())
-                    ? on.apply(each.getKey().term())
-                    : subject.quantities().ordersOf(each.getKey().term()).answered();
-            if (carrier == null) {
-                throw new IllegalStateException("a row is owed at " + each.getKey()
-                        + " and the quantity it is owed for is over no such position");
-            }
             // Beside another where the item fixes more than one position. The way's are not counted
             // in: what that limit is about is a number met by several values being asked to stand
             // beside a second position of the same item, and a position bounded on the way is one
             // this could leave to its own range without the row stopping being a row at the item.
-            Edge edge = edgeAt(subject, carrier, each.getKey(), each.getValue(),
+            Edge edge = edgeAt(subject, each.getKey(), each.getValue(),
                     fixing.size() > 1, reaching.region());
             if (edge.values().isEmpty()) {
                 return new BoundaryAttempt.Unresolved(
@@ -2329,9 +2314,6 @@ public final class Generator {
                         UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE),
                         where.unrepresented());
             }
-            // The orders the value was built against, kept so that reading it back asks the
-            // question building it asked rather than a second reading of the same position.
-            builtOn.put(each.getKey().term(), edge.on());
             if (edge.settledAt() != null) {
                 settled.put(at, edge.settledAt());
             }
@@ -2346,7 +2328,7 @@ public final class Generator {
             // candidate turned away under one parameter would name the reason another failed for.
             boolean[] uncertified = {false};
             CandidateCheck certified =
-                    certifying(check, subject, p, standing, builtOn, uncertified);
+                    certifying(check, subject, p, standing, uncertified);
             Map<TermPath, List<FixtureTemplate>> here = new LinkedHashMap<>();
             for (RealizationTarget target : standing.keySet()) {
                 // A position the way also narrows is not fixed at a value here. What has to hold of
@@ -2523,7 +2505,6 @@ public final class Generator {
      */
     private static CandidateCheck certifying(CandidateCheck check, MeasuredInput subject, int parameter,
                                              Map<RealizationTarget, Place> fixing,
-                                             Map<NumericTerm, souther.compiler.inputs.TermOrders> builtOn,
                                              boolean[] refused) {
         return (at, candidate) -> {
             CandidateCheck.Built built = check.build(at, candidate);
@@ -2537,7 +2518,7 @@ public final class Generator {
                     continue;
                 }
                 String elsewhere = readsElsewhere(subject, parameter, observed, each.getKey(),
-                        each.getValue(), builtOn.get(each.getKey().term()));
+                        each.getValue());
                 if (elsewhere != null) {
                     refused[0] = true;
                     return new CandidateCheck.Built.Refused(elsewhere);
@@ -2564,11 +2545,11 @@ public final class Generator {
      */
     private static String readsElsewhere(MeasuredInput subject, int parameter,
                                          souther.compiler.observe.ObservedValue observed,
-                                         RealizationTarget target, Place at,
-                                         souther.compiler.inputs.TermOrders on) {
-        if (on == null) {
-            return null;
-        }
+                                         RealizationTarget target, Place at) {
+        // The orders to read it back on, asked of the reading that answered them when the value was
+        // built. Carried over from there instead, the two ends of one question would be two values
+        // free to part, and a row would be read back on an order nothing composed it against.
+        souther.compiler.inputs.TermOrders on = subject.quantities().ordersOf(target.term());
         // Only this parameter's value is filled in: the walk reads the one the path names, and the
         // others are not this candidate's to say anything about.
         List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
@@ -2617,7 +2598,7 @@ public final class Generator {
      *                      collapsing the two searches into one changed nothing, and removing it is
      *                      its own answer to give
      */
-    private static Edge edgeAt(MeasuredInput subject, Carrier carrier, RealizationTarget target, Place at,
+    private static Edge edgeAt(MeasuredInput subject, RealizationTarget target, Place at,
                                boolean besideAnother,
                                souther.compiler.inputs.SearchRegion within) {
         // A number met by several values can offer only one of them beside a second position being
@@ -2627,15 +2608,7 @@ public final class Generator {
         if (besideAnother && !TermRealizations.onlyOneValueAnswersIt(target)) {
             return Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        for (Axis axis : subject.axes()) {
-            if (axis.term().equals(target.term())) {
-                return edgeOf(axis, carrier, at, within, subject.symbols(),
-                        subject.inputs().policy());
-            }
-        }
-        // No axis here, which a behavior whose inputs nothing bounds has none of while its body
-        // still draws lines between them. What is written is the value the target's root holds, and
-        // which value answers the number is `TermRealizations`' one answer — asked of it whatever
+        // Which value answers the number is `TermRealizations`' one answer — asked of it whatever
         // kind of number this is, so that what can be built is settled in one place. Read off the
         // kind of term here as well, an operation would gain a value nothing writes for it on the
         // day the arm for it was written, with nothing failing to say so.
@@ -2643,19 +2616,21 @@ public final class Generator {
         // Where the value is written, which is the traversal that follows one. It stops where a
         // value is built rather than where a name is read, and that is the answer this question
         // wants: a name every case of a sum spreads is readable on a value of the sum and is not a
-        // place a value is composed for.
+        // place a value is composed for. Asked here whether or not the number is one a measure was
+        // drawn on: a measure says where the model divides a number and not where a value of it can
+        // be put, so a search reading the second off a measure would be composing at a place this
+        // walk says nothing is written.
         Type writtenAt = subject.inputs().typeAtWrittenPath(target.writeRoot());
         if (writtenAt == null) {
             return Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        // And the order the value is read back on, which is the reading's. Taken off the type above,
-        // the walk that answers where a value is written would be answering what a number there is
-        // measured on as well, and the two are one value only for as long as no term arrives where
-        // they part.
-        souther.compiler.inputs.TermOrders on = new souther.compiler.inputs.TermOrders(
-                subject.quantities().ordersOf(target.term()).observed(), carrier);
+        // And both orders the value is read back on, which are the reading's. Taken off the type
+        // above, the walk that answers where a value is written would be answering what a number
+        // there is measured on as well, and the two are one value only for as long as no term
+        // arrives where they part.
+        souther.compiler.inputs.TermOrders on = subject.quantities().ordersOf(target.term());
         return edgeFrom(TermRealizations.at(target, writtenAt, on, at, within, subject.symbols(),
-                subject.inputs().policy()), target, at, on);
+                subject.inputs().policy()), target, at);
     }
 
     /**
@@ -4050,22 +4025,19 @@ public final class Generator {
      * a line on a count taken of a location settles no number inside it, and saying it did would tell
      * the rest of the row that a string's length is the number the string holds.
      *
-     * @param on the pair of orders the values here were built against: the one a value at the
-     *           position is written on, and the one the number it answers is measured on. Carried
-     *           rather than worked out again by whoever wants it — reading a value back is asking
-     *           the same question building it asked, and a second answer to it is two readings of
-     *           one position free to disagree about which order the number is on
+     * <p>The orders the values were built against are not among them. Reading a value back asks the
+     * same question building it asked, and the reading is what answers it both times — kept here,
+     * an answer would travel from the one to the other and the two would be free to part.
      */
     private record Edge(List<FixtureTemplate> values, UnresolvedCombination.Reason reason,
-                        Place settledAt, UnresolvedCombination.Reason heldBack,
-                        souther.compiler.inputs.TermOrders on) {
+                        Place settledAt, UnresolvedCombination.Reason heldBack) {
 
         Edge {
             values = List.copyOf(values);
         }
 
         static Edge none(UnresolvedCombination.Reason why) {
-            return new Edge(List.of(), why, null, null, null);
+            return new Edge(List.of(), why, null, null);
         }
 
         /**
@@ -4081,27 +4053,6 @@ public final class Generator {
     }
 
     /**
-     * The values that stand on {@code value}'s edge of {@code axis}.
-     *
-     * <p>Which values those are is the term's question. The content of a location is the number
-     * written at it; a count taken of a location is met by whatever carries that count, and what
-     * carries a count is {@link Witnesses}'s to answer — asked rather than decided here, so that a
-     * value it learns to build is a boundary this reaches without being told again.
-     */
-    private static Edge edgeOf(Axis axis, Carrier carrier, Place at,
-                               souther.compiler.inputs.SearchRegion within, Symbols symbols,
-                               ReadingPolicy policy) {
-        // The order the line was drawn on is the caller's — a cut carries the one the rule was read
-        // on — and the order the value at the position is written on is the position's. Both, so
-        // neither stands in for the other.
-        souther.compiler.inputs.TermOrders on = new souther.compiler.inputs.TermOrders(
-                axis.term().observedOn(axis.type(), symbols), carrier);
-        RealizationTarget target = new RealizationTarget.AtOnePosition(axis.term());
-        return edgeFrom(TermRealizations.at(target, axis.type(), on, at, within, symbols, policy),
-                target, at, on);
-    }
-
-    /**
      * One realization as an edge of the search.
      *
      * <p>Where the root itself is settled, and where it is not. A term that is a location's content
@@ -4111,7 +4062,7 @@ public final class Generator {
      * asked of the variant.
      */
     private static Edge edgeFrom(TermRealizations.Realization made, RealizationTarget target,
-                                 Place at, souther.compiler.inputs.TermOrders on) {
+                                 Place at) {
         Place settled = switch (target.term()) {
             case NumericTerm.ValueOf _ -> at;
             // What an operation answered is not what its root holds — three characters is not the
@@ -4121,7 +4072,7 @@ public final class Generator {
         return switch (made) {
             case TermRealizations.Realization.BuiltNone none -> Edge.none(none.why());
             case TermRealizations.Realization.Built built ->
-                    new Edge(built.values(), null, settled, built.heldBack(), on);
+                    new Edge(built.values(), null, settled, built.heldBack());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -562,10 +562,18 @@ public final class GuardThresholds {
     /**
      * The number an expression names and the order that number is read and written on.
      *
-     * @param term  what the expression names
-     * @param order what it is counted on
+     * <p>One component, because the orders say which number they are of. Held beside them, the
+     * number would be a second answer to that, and a reader could be handed a pair built for
+     * another expression with nothing refusing it.
+     *
+     * @param orders what the expression names, and what it is counted on
      */
-    record Named(NumericTerm term, TermOrders orders) {
+    record Named(TermOrders orders) {
+
+        /** What the expression names. */
+        NumericTerm term() {
+            return orders.term();
+        }
 
         /** What a line on it is measured on, which is what most readers of a pair want. */
         Carrier order() {
@@ -594,7 +602,7 @@ public final class GuardThresholds {
             return null;
         }
         TermOrders orders = read.quantities().ordersOf(term);
-        return orders.answered() == null ? null : new Named(term, orders);
+        return orders.answered() == null ? null : new Named(orders);
     }
 
     private GuardThresholds() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -5,6 +5,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.CountDomain;
 import souther.compiler.numeric.Endpoint;
@@ -179,18 +180,22 @@ final class Intervals {
     /**
      * The classes those ranges are, on the term {@code of} at a position of {@code type}.
      *
-     * <p>The term says how a row's value is read into a number and how its numbers are spaced; the
+     * <p>The orders say how a row's value is read into a number and how its numbers are spaced; the
      * type says what a value written at one of them looks like. A range of lengths has the first and
      * not the second: five is not what is written at the position, a string of five characters is,
      * and which values carry a count is asked of what builds them rather than settled here.
+     *
+     * <p>The orders are handed in and not worked out from the type. Which order a number is
+     * measured on follows from where the reading has its term standing, and a caller deriving it
+     * from whatever type reached it would be answering about wherever that type came from.
      */
     static List<PartitionClass> classesOf(List<Band> runs, NumericTerm.FromOnePosition of,
-                                          Type type,
+                                          Type type, TermOrders orders,
                                           ReadingPolicy policy,
                                           Symbols symbols, Endpoint min, Endpoint max) {
         // What the counts in a label stand for. A day count is a carrier and never a name for the
         // line, so the class an author reads is spelled in dates where the position holds them.
-        Carrier carrier = of.answeredOn(type, symbols);
+        Carrier carrier = orders.answered();
         List<PartitionClass> classes = new ArrayList<>();
         for (Band run : runs) {
             String label = rangeOf(run, min, max).label(carrier);
@@ -199,7 +204,7 @@ final class Intervals {
             // The run's own answer about what is in it. Read off a range of the position's counts,
             // a class whose line falls at a place the position has no value for had no end to state
             // — so it held every value, and two such classes each held everything the other did.
-            Recognition is = new Recognition.OfACount(of, of.ordersAt(type, symbols),
+            Recognition is = new Recognition.OfACount(of, orders,
                     new Recognition.CountIs.InARun(run));
             if (inside == null) {
                 classes.add(PartitionClass.ungeneratable(id, label, is,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -5,6 +5,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.Quantities;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.CountDomain;
@@ -185,14 +186,17 @@ final class Intervals {
      * not the second: five is not what is written at the position, a string of five characters is,
      * and which values carry a count is asked of what builds them rather than settled here.
      *
-     * <p>The orders are handed in and not worked out from the type. Which order a number is
-     * measured on follows from where the reading has its term standing, and a caller deriving it
-     * from whatever type reached it would be answering about wherever that type came from.
+     * <p>The orders are asked of the reading rather than handed in beside the term. Which order a
+     * number is measured on follows from where the reading has that term standing, so a caller
+     * working it out from whatever type reached it would be answering about wherever that type came
+     * from — and a caller handing the answer over is handing two arguments that can be about two
+     * terms.
      */
     static List<PartitionClass> classesOf(List<Band> runs, NumericTerm.FromOnePosition of,
-                                          Type type, TermOrders orders,
+                                          Type type, Quantities reading,
                                           ReadingPolicy policy,
                                           Symbols symbols, Endpoint min, Endpoint max) {
+        TermOrders orders = reading.ordersOf(of);
         // What the counts in a label stand for. A day count is a carrier and never a name for the
         // line, so the class an author reads is spelled in dates where the position holds them.
         Carrier carrier = orders.answered();

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -195,7 +195,7 @@ public final class LinesWhereTheyFall {
      */
     private static LineDrawn lineAt(LineDrawn line, NumericTerm moves, NumericTerm to,
                                     Quantities quantities) {
-        Cutting cut = line.cuts().movedTo(moves, to, quantities.ordersOf(to), quantities);
+        Cutting cut = line.cuts().movedTo(moves, to, quantities);
         if (cut == null) {
             throw new IllegalStateException(
                     "`" + moves + "` was filed at " + to + " and the line on it cannot be taken "

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -856,13 +856,13 @@ public final class Partitions {
         for (Place value : values) {
             String written = carrier.written(value);
             classes.add(classAt(term + "/= " + written, "= " + written,
-                    holding(term, orders, new Recognition.CountIs.At(value)),
+                    holding(orders, new Recognition.CountIs.At(value)),
                     standing(type, carrier, value, symbols)));
         }
         Place other = carrier.somethingOtherThan(values, within);
         String label = "/= " + String.join(", ",
                 values.stream().map(carrier::written).toList());
-        Recognition away = holding(term, orders,
+        Recognition away = holding(orders,
                 new Recognition.CountIs.AwayFrom(values));
         classes.add(other == null
                 ? PartitionClass.ungeneratable(term + "/" + label, label, away,
@@ -889,11 +889,11 @@ public final class Partitions {
         return Witnesses.wrapped(type, FixtureTemplate.on(carrier, at, symbols.scope()::reach), symbols);
     }
 
-    /** A class that reads the term's count out of a row and answers about it. */
-    private static Recognition holding(NumericTerm.FromOnePosition term,
-                                          souther.compiler.inputs.TermOrders on,
-                                          Recognition.CountIs is) {
-        return new Recognition.OfACount(term, on, is);
+    /** A class that reads the count of the number {@code on} is of out of a row, and answers about
+     *  it. The number comes from the orders rather than beside them: a class of one number built on
+     *  another's order is what the pair naming its own number is here to stop. */
+    private static Recognition holding(TermOrders on, Recognition.CountIs is) {
+        return new Recognition.OfACount(on.term().atOnePosition(), on, is);
     }
 
     /** The cuts a position has, with the values a body singled out added as lines of their own. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -493,7 +493,7 @@ public final class Partitions {
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
             mine.forEach(each -> account.measured(each, id));
-            return made(out, at, behavior, term, type,
+            return made(out, at, behavior, term,
                     classesOf(axis, () -> singledClasses(points, term, type, orders, domain,
                             symbols)),
                     mergedPoints(cutsOf(axis), points, carrier),
@@ -537,7 +537,7 @@ public final class Partitions {
         // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
         // written about the position rather than everything that came to nothing.
         NumericDomain.Bounds within = domain;
-        return made(out, at, behavior, term, type,
+        return made(out, at, behavior, term,
                 classesOf(axis, () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
@@ -561,7 +561,7 @@ public final class Partitions {
      * the measures — which is what a measure of nothing was.
      */
     private static BodyCutInspection made(List<Axis> out, PositionMeasurements at, String behavior,
-                                          NumericTerm.FromOnePosition term, Type type,
+                                          NumericTerm.FromOnePosition term,
                                           List<PartitionClass> classes, List<Cut> cuts,
                                           List<Parting> parted, NarrowedBounds narrowed,
                                           BodyCutInspection drew, List<RuleWithoutALine> rules) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -494,7 +494,7 @@ public final class Partitions {
             // sides of a value the behavior treats alike.
             mine.forEach(each -> account.measured(each, id));
             return made(out, at, behavior, term,
-                    classesOf(axis, () -> singledClasses(points, term, type, orders, domain,
+                    classesOf(axis, () -> singledClasses(points, term, type, reading, domain,
                             symbols)),
                     mergedPoints(cutsOf(axis), points, carrier),
                     partedOf(axis), narrowedOf(axis),
@@ -541,7 +541,7 @@ public final class Partitions {
                 classesOf(axis, () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
-                        term, type, orders, policy, symbols,
+                        term, type, reading, policy, symbols,
                         within == null ? null : within.min(),
                         within == null ? null : within.max())),
                 mergedPoints(merged(cutsOf(axis), reachable, carrier), points, carrier),
@@ -839,8 +839,12 @@ public final class Partitions {
      */
     private static List<PartitionClass> singledClasses(List<GuardThresholds.Guards.Singled> points,
                                                        NumericTerm.FromOnePosition term, Type type,
-                                                       TermOrders orders,
+                                                       Quantities reading,
                                                        NumericDomain.Bounds within, Symbols symbols) {
+        // Asked here rather than handed in beside the term. A term and a pair of orders are two
+        // arguments, and two arguments can be about two terms; the reading is one argument that
+        // answers about whichever term it is asked.
+        TermOrders orders = reading.ordersOf(term);
         Carrier carrier = orders.answered();
         List<Place> values = new ArrayList<>();
         for (GuardThresholds.Guards.Singled each : points) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -19,6 +19,7 @@ import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TypeBounds;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.RuleWithoutALine;
+import souther.compiler.inputs.TermOrders;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
@@ -482,14 +483,19 @@ public final class Partitions {
         // the record it sits in says about it. Reading the type again here would put a threshold
         // back inside a range the record has no values in.
         NumericDomain.Bounds domain = domainOf(reading, term);
-        Carrier carrier = term.answeredOn(type, symbols);
+        // Both orders as the reading has them. Worked out here from the type this reader happens
+        // to hold, the answer would be about wherever that type came from rather than about where
+        // the reading has this term standing.
+        TermOrders orders = reading.ordersOf(term);
+        Carrier carrier = orders.answered();
         if (here.isEmpty() && !points.isEmpty()) {
             // Nothing orders this position, so its classes are the values singled out and
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
             mine.forEach(each -> account.measured(each, id));
             return made(out, at, behavior, term, type,
-                    classesOf(axis, () -> singledClasses(points, term, type, domain, symbols)),
+                    classesOf(axis, () -> singledClasses(points, term, type, orders, domain,
+                            symbols)),
                     mergedPoints(cutsOf(axis), points, carrier),
                     partedOf(axis), narrowedOf(axis),
                     new BodyCutInspection.Evidence(), rules);
@@ -535,7 +541,7 @@ public final class Partitions {
                 classesOf(axis, () -> Intervals.classesOf(
                         Intervals.of(reachable, within == null ? null : within.min(),
                                 within == null ? null : within.max(), carrier),
-                        term, type, policy, symbols,
+                        term, type, orders, policy, symbols,
                         within == null ? null : within.min(),
                         within == null ? null : within.max())),
                 mergedPoints(merged(cutsOf(axis), reachable, carrier), points, carrier),
@@ -817,7 +823,7 @@ public final class Partitions {
         for (Axis axis : axes) {
             if (axis.asksForARow()) {
                 out.put(axis.id(),
-                        bordersOf(axis, symbols, reading.runsBetween(axis.term()), read));
+                        bordersOf(axis, reading, reading.runsBetween(axis.term()), read));
             }
         }
         return out;
@@ -833,8 +839,8 @@ public final class Partitions {
      */
     private static List<PartitionClass> singledClasses(List<GuardThresholds.Guards.Singled> points,
                                                        NumericTerm.FromOnePosition term, Type type,
+                                                       TermOrders orders,
                                                        NumericDomain.Bounds within, Symbols symbols) {
-        souther.compiler.inputs.TermOrders orders = term.ordersAt(type, symbols);
         Carrier carrier = orders.answered();
         List<Place> values = new ArrayList<>();
         for (GuardThresholds.Guards.Singled each : points) {
@@ -974,8 +980,13 @@ public final class Partitions {
      * what the rules leave the term, which is a reading of the declarations — so a caller that could
      * assemble them would be deciding, from a reading of its own, which lines exist to be measured.
      */
-    static List<Border> bordersOf(Axis axis, Symbols symbols, NumericDomain.Bounds within,
+    static List<Border> bordersOf(Axis axis, Quantities reading, NumericDomain.Bounds within,
                                   LinesRead read) {
+        // Both orders of the number this axis measures, as the reading has them. A pair put
+        // together here out of the position's order and the carrier a cut was drawn on is a pair
+        // whose two halves came from two places, and the day they part is the day a row is decoded
+        // on a count the value is not written in.
+        TermOrders orders = reading.ordersOf(axis.term());
         List<Border> out = new ArrayList<>();
         // Every place the rules part this position's values, collected before any border is built.
         // What each border owes away from its line is a run of the arrangement they make together,
@@ -987,9 +998,7 @@ public final class Partitions {
         List<Parting> parted = new ArrayList<>(axis.parted());
         for (Cut cut : axis.cuts()) {
             BoundaryTarget where = BoundaryTarget.at(
-                    new BorderQuantity.OfACoordinate(axis.id(), axis.term(),
-                            new souther.compiler.inputs.TermOrders(
-                                    axis.term().observedOn(axis.type(), symbols), cut.carrier())),
+                    new BorderQuantity.OfACoordinate(axis.id(), axis.term(), orders),
                     new Level.OnACarrier(cut.carrier(), cut.at()));
             for (OriginRef origin : cut.origins()) {
                 // Every rule that drew a line here, as it was read. Which of them fall in one place
@@ -999,13 +1008,12 @@ public final class Partitions {
             }
         }
         for (Cut cut : axis.cuts()) {
-            // The carrier is the cut's, which is the one the rule was read on. Asked of the axis
-            // instead, a line drawn on a count taken of a position would be written back as a value
-            // of the position.
+            // The level is on the cut's carrier, which is the one the rule was read on. What the
+            // quantity is measured on is the reading's answer and not read off the line: a line
+            // drawn on a count taken of a position would otherwise be written back as a value of
+            // the position.
             BoundaryTarget target = BoundaryTarget.at(
-                    new BorderQuantity.OfACoordinate(axis.id(), axis.term(),
-                            new souther.compiler.inputs.TermOrders(
-                                    axis.term().observedOn(axis.type(), symbols), cut.carrier())),
+                    new BorderQuantity.OfACoordinate(axis.id(), axis.term(), orders),
                     new Level.OnACarrier(cut.carrier(), cut.at()));
             for (OriginRef origin : cut.origins()) {
                 // One cut, one border. Whether the quantity reaches the line is settled where the

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -568,7 +568,7 @@ public final class Partitions {
         if (classes.isEmpty() && cuts.isEmpty() && parted.isEmpty()) {
             return cameTo(term, at.position().path(), rules);
         }
-        out.add(Axis.of(behavior, term, type, classes, cuts, parted, narrowed));
+        out.add(Axis.of(behavior, term, classes, cuts, parted, narrowed));
         return drew != null ? drew : cameTo(term, at.position().path(), rules);
     }
 
@@ -1082,7 +1082,7 @@ public final class Partitions {
                 // (issue #1084).
                 PositionAccount at = PositionAccount.of(behavior, position, null, null);
                 drawn.add(new Drawn(at,
-                        List.of(Axis.of(behavior, term, at.type(), divided.classes(),
+                        List.of(Axis.of(behavior, term, divided.classes(),
                                 divided.cuts().cuts(), List.of(), position.narrowedEnds()))));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.

--- a/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PositionMeasurements.java
@@ -69,10 +69,6 @@ public record PositionMeasurements(PositionAccount position, List<Axis> axes,
             throw new IllegalArgumentException("`" + axis.id() + "` measures a number of "
                     + axis.term().position() + ", and is held under " + position.path());
         }
-        if (!axis.type().equals(position.type())) {
-            throw new IllegalArgumentException("`" + axis.id() + "` reads a value of "
-                    + axis.type() + " where " + position.path() + " holds " + position.type());
-        }
         if (!axis.id().behavior().equals(position.behavior())) {
             throw new IllegalArgumentException("`" + axis.id() + "` is a measure of another"
                     + " behavior's input than " + position.path() + " of " + position.behavior());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Recognition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Recognition.java
@@ -67,6 +67,14 @@ public sealed interface Recognition {
                     souther.compiler.inputs.TermOrders orders, CountIs is)
             implements Recognition {
 
+        public OfACount {
+            // The term is here because a class of one position's count is asked about a position,
+            // which is the narrower of the two kinds of term; the orders say which number they are
+            // of. Two spellings of one thing, so the second is refused here rather than read as a
+            // class of a number the row is not asked about.
+            orders.areOf(term);
+        }
+
         /** What the count is compared on, which is what the class was written in. */
         public Carrier carrier() {
             return orders.answered();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
@@ -107,7 +107,7 @@ public final class Recognitions {
     private static Membership counted(Recognition.OfACount count, ObservedValue value) {
         // Read on the order the value is written on; asked on the order the count is compared
         // on. One carrier for both was right while the two could not differ (#1027).
-        return switch (count.term().read(value, count.orders())) {
+        return switch (count.orders().read(value)) {
             case NumericTerm.Reading.Number number -> Membership.of(
                     holds(count.is(), number.value(), count.carrier()));
             case NumericTerm.Reading.Missing missing -> new Membership.Incomplete(missing.code());

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -110,13 +110,17 @@ final class TermRealizations {
      * of them are said here. {@link RealizationTarget} answers the first for every number there is;
      * a {@link Realization.BuiltNone} is the second.
      */
-    static Realization at(RealizationTarget target, Type sourceType, TermOrders orders,
+    static Realization at(Type sourceType, TermOrders orders,
                           Place answer, souther.compiler.inputs.SearchRegion within,
                           Symbols symbols, ReadingPolicy policy) {
         if (sourceType == null) {
             return new Realization.BuiltNone(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
+        // Which number is being written for, read off the answer that says which number it is of.
+        // Handed in beside it, it was a second name for the same thing and a caller could give two
+        // — and this would then write a value for one number on the order of another.
+        RealizationTarget target = RealizationTarget.of(orders.term());
         return switch (target.term()) {
             // Written by the carrier the line was drawn on, and wearing every name the position
             // declares. Read off the boundary's own shape instead, a count on one carrier could be
@@ -126,9 +130,9 @@ final class TermRealizations {
             case NumericTerm.ValueOf _ ->
                     oneValue(FixtureTemplate.on(orders.answered(), answer, symbols.scope()::reach),
                             sourceType, symbols);
-            case NumericTerm.TakenOf taken -> taken(taken.takenAs(), target, sourceType, orders,
+            case NumericTerm.TakenOf taken -> taken(taken.takenAs(), sourceType, orders,
                     answer, within, symbols, policy);
-            case NumericTerm.TakenOver over -> overARun(over.takenAs(), target, sourceType, orders,
+            case NumericTerm.TakenOver over -> overARun(over.takenAs(), sourceType, orders,
                     answer, within, symbols, policy);
         };
     }
@@ -142,7 +146,7 @@ final class TermRealizations {
      * agree, an operation would have gained a boundary nobody could write a row for, and the report
      * would have said only that every value tried was refused.
      */
-    private static Realization taken(TakenAs how, RealizationTarget target, Type sourceType,
+    private static Realization taken(TakenAs how, Type sourceType,
                                      TermOrders orders, Place answer,
                                      souther.compiler.inputs.SearchRegion within,
                                      Symbols symbols, ReadingPolicy policy) {
@@ -154,7 +158,7 @@ final class TermRealizations {
             // this number to be there. What that takes is choosing how many elements and what each
             // of them holds — one question whether the number is added up out of the container
             // itself or out of a path inside its elements, and answered for both in one place.
-            case TakenAs.TheSumOfWhatItHolds _ -> ContainersAddingUp.to(answer, target, sourceType,
+            case TakenAs.TheSumOfWhatItHolds _ -> ContainersAddingUp.to(answer, sourceType,
                     orders, within, symbols, policy);
             // And this one writes on the order the value is written on. Written on the order the
             // answer is measured on, the thirteenth hour would be offered as the thirteenth second —
@@ -180,12 +184,12 @@ final class TermRealizations {
      * reading answers that this is no number of theirs, and nothing composes a container for a
      * number nothing reads.
      */
-    private static Realization overARun(TakenAs how, RealizationTarget target, Type sourceType,
+    private static Realization overARun(TakenAs how, Type sourceType,
                                         TermOrders orders, Place answer,
                                         souther.compiler.inputs.SearchRegion within,
                                         Symbols symbols, ReadingPolicy policy) {
         return switch (how) {
-            case TakenAs.TheSumOfWhatItHolds _ -> ContainersAddingUp.to(answer, target, sourceType,
+            case TakenAs.TheSumOfWhatItHolds _ -> ContainersAddingUp.to(answer, sourceType,
                     orders, within, symbols, policy);
             case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ ->
                     new Realization.BuiltNone(

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1486,13 +1486,11 @@ public final class Adequacy {
 
                 @Override
                 public Generator.BoundaryAttempt attempt(String label,
-                        java.util.function.Function<souther.compiler.inputs.NumericTerm,
-                                souther.compiler.check.Carrier> carrier,
                         java.util.Map<souther.compiler.partition.RealizationTarget,
                                 souther.compiler.numeric.Place> fixing,
                         souther.compiler.partition.Reachability.Reaching reaching) {
                     return built(() ->
-                            Generator.probeFixing(subject, label, carrier, fixing, reaching, check));
+                            Generator.probeFixing(subject, label, fixing, reaching, check));
                 }
 
                 @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -520,6 +520,10 @@ final class Coverages {
          * by a row anywhere in it, so a row labelled by the places a search happened to compose
          * would name a witness as though it were the item.
          *
+         * <p>What each position's number is measured on is not among the arguments. That is the
+         * reading the row is composed against, which the generator holds; passed in, a caller would
+         * be answering a question about where a term stands from wherever it found the term.
+         *
          * @param reaching what the row has to be to arrive at the border at all. Handed in beside
          *                 the placement rather than left out: the placement is about the positions
          *                 the item names and a condition above the line is about the others, and a
@@ -527,8 +531,6 @@ final class Coverages {
          */
         souther.compiler.partition.Generator.BoundaryAttempt attempt(
                 String label,
-                java.util.function.Function<souther.compiler.inputs.NumericTerm,
-                        souther.compiler.check.Carrier> on,
                 Map<souther.compiler.partition.RealizationTarget, Place> fixing,
                 souther.compiler.partition.Reachability.Reaching reaching);
 
@@ -830,7 +832,7 @@ final class Coverages {
                 return switch (realizer.realize(quantity.standingAt(criterion), able.region())) {
                     case Realization.Found found -> whatCameOfIt(
                             standingThere(probe, quantity, where, criterion, site, label,
-                                    probe.attempt(label, quantity::carrierOf, found.fixing(), able)),
+                                    probe.attempt(label, found.fixing(), able)),
                             label, within);
                     // And the two ways of finding nothing are not one answer. A walk of the whole
                     // of what the rules leave that reaches no value settles the point; a search

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AReadingAnswersAboutItsOwnTermsAndNoOthersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AReadingAnswersAboutItsOwnTermsAndNoOthersTest.java
@@ -115,10 +115,11 @@ class AReadingAnswersAboutItsOwnTermsAndNoOthersTest {
     /** What the answer would have been, which is what makes the refusal load-bearing. */
     @Test
     void theAnswerItWouldHaveGivenIsHalfOne() {
-        assertEquals(souther.compiler.check.Carrier.WHOLE,
-                lengthOfS().answeredOn(null, SYMBOLS),
+        TermOrders would = TermOrdering.of(lengthOfS(), null, SYMBOLS);
+
+        assertEquals(souther.compiler.check.Carrier.WHOLE, would.answered(),
                 "the operation answers with a whole number wherever it was applied");
-        assertEquals(null, lengthOfS().observedOn(null, SYMBOLS),
+        assertEquals(null, would.observed(),
                 "and nothing says what a value at the position is read on, since there is none");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NothingTakesANumberAndAnotherNumbersOrdersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NothingTakesANumberAndAnotherNumbersOrdersTest.java
@@ -1,0 +1,184 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ClassDesc;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A number and a pair of orders do not travel as two things anybody can choose.
+ *
+ * <p>{@link TermOrders} says which number it is of, so a reader that has one needs nothing else to
+ * know what it is an answer about. What it does not stop by itself is a caller writing the number
+ * down beside it: two arguments are two things to get right, and {@code f(termA, ordersOfB)}
+ * compiles wherever the two are taken apart — which is the defect this reading exists to stop, said
+ * one call along.
+ *
+ * <p>So the rule is about every place that takes both, whether it is a constructor, a factory or a
+ * reader: either it does not take both, or it proves they agree. Proving is
+ * {@link TermOrders#areOf}, and a method that takes both without calling it is what this reports.
+ *
+ * <p><b>Enumerated by the machine and not by a reader.</b> The three rounds of review this rule went
+ * through each found another spelling of it — a record here, a signature there, a package-private
+ * entry that came in with a refactor — because the population was read off the sources by whoever
+ * was looking. What a class file carries is every method that takes the two, whatever it is called
+ * and wherever it was written.
+ */
+class NothingTakesANumberAndAnotherNumbersOrdersTest {
+
+    private static final String ORDERS = "souther.compiler.inputs.TermOrders";
+
+    /**
+     * What names a number: the term itself, its cases, and the values built around one.
+     *
+     * <p>A wrapper counts. What makes two arguments a pairing is that each says which number it is
+     * about, and {@code RealizationTarget} says it as plainly as a term does — so a reader handed
+     * one of those and a pair of orders has the same two things to get right.
+     */
+    private static final List<String> TERM = List.of(
+            "souther.compiler.inputs.NumericTerm",
+            "souther.compiler.partition.RealizationTarget");
+
+    /**
+     * The one place the two are meant to be about two numbers, and it says so by its shape.
+     *
+     * <p>Moving a quantity is asked which number it is over and handed the answer for the one it
+     * lands on, and those are two numbers on purpose. Everything else that takes both is a pairing
+     * a caller chose. Named by what it is rather than by which classes do it, so an implementation
+     * added is covered and a second reader of two numbers is not.
+     */
+    private static final String MOVES = "movedTo";
+
+    @Test
+    void nothingTakesBothWithoutProvingTheyAgree() throws IOException {
+        Set<String> takesBoth = new TreeSet<>();
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            String from = model.thisClass().asInternalName().replace('/', '.');
+            if (from.equals(ORDERS)) {
+                continue;   // what the pair says about itself is its own business
+            }
+            for (MethodModel method : model.methods()) {
+                String named = method.methodName().stringValue();
+                if (!takesBoth(method) || proves(method) || moves(named)) {
+                    continue;
+                }
+                takesBoth.add(from + "#" + named);
+            }
+        }
+
+        assertEquals(Set.of(), takesBoth,
+                "a number and a pair of orders taken as two arguments are two arguments that can"
+                        + " be about two numbers; take the pair, which names its number, or hold"
+                        + " the two to each other");
+    }
+
+    /**
+     * And the exception keeps the shape it was allowed for.
+     *
+     * <p>One number and one answer. A second number beside them would be the pairing again, under
+     * the one name this does not report.
+     */
+    @Test
+    void movingAQuantityIsAskedOneNumberAndHandedOneAnswer() throws IOException {
+        Set<String> shapes = new TreeSet<>();
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            for (MethodModel method : model.methods()) {
+                // The declared move, not the lambdas inside one: a lambda's parameters are what it
+                // captured, which is not a shape anybody wrote.
+                if (method.methodName().stringValue().equals(MOVES) && takesBoth(method)) {
+                    shapes.add(method.methodTypeSymbol().parameterList().stream()
+                            .map(ClassDesc::displayName).toList().toString());
+                }
+            }
+        }
+
+        assertEquals(Set.of("[NumericTerm, TermOrders]"), shapes,
+                "moving is asked the number it is over and handed the answer for the one it lands"
+                        + " on, and nothing else");
+    }
+
+    /** Whether this is the move, including the lambdas written inside one. */
+    private static boolean moves(String method) {
+        return method.equals(MOVES) || method.startsWith("lambda$" + MOVES + "$");
+    }
+
+    /** That the scan is reading methods at all, so an empty answer means what it says. */
+    @Test
+    void theScanReadsTheMethodsItIsAbout() throws IOException {
+        int found = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            for (MethodModel method : model.methods()) {
+                if (mentions(method, ORDERS)) {
+                    found++;
+                }
+            }
+        }
+
+        int carrying = found;
+        assertTrue(carrying > 20,
+                () -> "the scan found only " + carrying + " methods taking a pair of orders,"
+                        + " which is not this compiler");
+    }
+
+    /** Whether {@code method} is handed a number and a pair of orders as separate arguments. */
+    private static boolean takesBoth(MethodModel method) {
+        return mentions(method, ORDERS) && TERM.stream().anyMatch(each -> mentions(method, each));
+    }
+
+    /** Whether it holds the two to each other, which is what {@link TermOrders#areOf} is. */
+    private static boolean proves(MethodModel method) {
+        CodeModel code = method.code().orElse(null);
+        if (code == null) {
+            return false;
+        }
+        for (var element : code) {
+            if (element instanceof InvokeInstruction call
+                    && call.owner().asInternalName().replace('/', '.').equals(ORDERS)
+                    && call.name().stringValue().equals("areOf")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** A parameter of that type, or of one of its cases: a term arrives under several names. */
+    private static boolean mentions(MethodModel method, String type) {
+        for (ClassDesc each : method.methodTypeSymbol().parameterList()) {
+            String named = each.isClassOrInterface()
+                    ? each.packageName() + "." + each.displayName() : each.displayName();
+            // A case of a term is written with a dollar in a class file, which is the spelling that
+            // let this scan report nothing about the records holding one.
+            if (named.equals(type) || named.startsWith(type + "$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(new LinkedHashSet<>(
+                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -90,9 +90,10 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
      * A line added to any class here would be a pair about no reading, made where the compiler has
      * nothing left to refuse, and both other checks would stay green.
      *
-     * <p>Both ways in are counted, and separately: a constructor and a factory that calls it are
-     * two things a reader can reach for, and a check that added them up would go on passing while
-     * one moved to the other.
+     * <p>Both ways in are counted, and separately: a constructor and a factory beside it are two
+     * things a reader can reach for, and a check that added them up would go on passing while one
+     * moved to the other. There is no factory today, which is the stronger of the two states and is
+     * held to here rather than left to be noticed.
      */
     @Test
     void oneProductionPlaceMakesAPair() throws IOException {
@@ -126,8 +127,8 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
         assertEquals(Set.of(DERIVES), built,
                 "a pair of orders is put together where a term's orders are worked out, and"
                         + " a second place is a pair about no reading in particular");
-        assertEquals(Set.of(DERIVES), named,
-                "and the same of the factory beside the constructor");
+        assertEquals(Set.of(), named,
+                "and nothing hands a pair back beside the constructor, so there is one way in");
     }
 
     /** The nest a class belongs to: a lambda written inside a reader is that reader. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.RepositoryLayout;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which orders a term stands on is worked out in one place, from what one reading resolved.
+ *
+ * <p>A term is a value that travels and a type is in every reader's hand, so anything that can put
+ * the two together can answer what a number is measured on — about wherever that type came from,
+ * and about no reading in particular. The answer is right only while the type the caller holds and
+ * the type the reading resolved agree, and nothing says when they stop agreeing.
+ *
+ * <p>Which is why the derivation is package-private here and the way to it is
+ * {@link Quantities#ordersOf}. Visibility settles who may call it; it does not settle how many
+ * places inside this package do, and a second one is the same defect written where the compiler
+ * cannot see it. So this counts them.
+ *
+ * <p><b>Counted in the sources rather than declared in a list.</b> A list of allowed callers is a
+ * thing to keep up to date, and the first person to add one keeps it up to date by adding
+ * themselves. The count is what the rule says.
+ */
+class OneReadingAnswersWhatATermIsMeasuredOnTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** Where both orders of a term are worked out from a type. */
+    private static final String DERIVED = "TermOrdering.of(";
+
+    @Test
+    void oneProductionPlaceDerivesATermsOrders() throws IOException {
+        List<Path> sources = REPOSITORY.mainJavaSources();
+        assertTrue(sources.size() > 20,
+                () -> "the scan found only " + sources.size() + " sources, which is not the tree");
+
+        List<String> derives = new ArrayList<>();
+        for (Path source : sources) {
+            String text = code(Files.readString(source, StandardCharsets.UTF_8));
+            if (text.contains(DERIVED) && !source.getFileName().toString().equals("TermOrdering.java")) {
+                derives.add(source.getParent().getFileName() + "/" + source.getFileName());
+            }
+        }
+
+        assertEquals(List.of("inputs/ReadQuantities.java"), derives,
+                "a term's orders are worked out where the reading that resolved its subject is,"
+                        + " and a second place is a reader answering for a reading of its own");
+    }
+
+    /**
+     * And the way in stays shut, which is what makes the count above the whole of the rule.
+     *
+     * <p>Asked of the class rather than of the sources. What stops a reader elsewhere from pairing
+     * two carriers of its own is that it cannot name the constructor, and that is a property of
+     * {@link TermOrders} rather than of anything written at a call site — widen either of these and
+     * every source in the compiler may make one, with nothing else here failing.
+     */
+    @Test
+    void theWayToMakeAPairIsNotOpenToOtherPackages() {
+        for (java.lang.reflect.Constructor<?> made : TermOrders.class.getDeclaredConstructors()) {
+            assertTrue(!java.lang.reflect.Modifier.isPublic(made.getModifiers()),
+                    () -> "a term's orders are made from what a reading resolved, and " + made
+                            + " lets any caller pair two carriers it happens to hold");
+        }
+        assertTrue(java.util.Arrays.stream(TermOrders.class.getDeclaredMethods())
+                        .filter(each -> each.getReturnType() == TermOrders.class)
+                        .noneMatch(each ->
+                                java.lang.reflect.Modifier.isPublic(each.getModifiers())),
+                "and no factory beside it is open either");
+    }
+
+    /** {@code source} with its comments taken out, which is what this reads: a file may say what
+     *  the rule is without being a place that does it. */
+    private static String code(String source) {
+        return source.replaceAll("(?s)/\\*.*?\\*/", " ").replaceAll("//[^\n]*", " ");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -42,6 +42,9 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
     /** Where both orders of a term are worked out from a type. */
     private static final String DERIVES = "souther.compiler.inputs.TermOrdering";
 
+    /** The pair itself, whose constructor and factory are the two ways to make one. */
+    private static final String MADE = "souther.compiler.inputs.TermOrders";
+
     /**
      * Read off what was compiled rather than off the sources.
      *
@@ -77,6 +80,54 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
         assertEquals(Set.of("souther.compiler.inputs.ReadQuantities"), derives,
                 "a term's orders are worked out where the reading that resolved its subject is,"
                         + " and a second place is a reader answering for a reading of its own");
+    }
+
+    /**
+     * And one place makes one, which is not the same question.
+     *
+     * <p>Closing the constructor says who may make a pair and the count above says who works one
+     * out from a type; neither says how many places inside this package put two carriers together.
+     * A line added to any class here would be a pair about no reading, made where the compiler has
+     * nothing left to refuse, and both other checks would stay green.
+     *
+     * <p>Both ways in are counted, and separately: a constructor and a factory that calls it are
+     * two things a reader can reach for, and a check that added them up would go on passing while
+     * one moved to the other.
+     */
+    @Test
+    void oneProductionPlaceMakesAPair() throws IOException {
+        Set<String> built = new TreeSet<>();
+        Set<String> named = new TreeSet<>();
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            String from = nestOf(model.thisClass().asInternalName().replace('/', '.'));
+            if (from.equals(MADE)) {
+                continue;   // what the pair does with itself is its own business
+            }
+            for (var method : model.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
+                    continue;
+                }
+                for (var element : code) {
+                    if (!(element instanceof InvokeInstruction call)
+                            || !call.owner().asInternalName().replace('/', '.').equals(MADE)) {
+                        continue;
+                    }
+                    if (call.name().stringValue().equals("<init>")) {
+                        built.add(from);
+                    } else if (call.typeSymbol().returnType().displayName().equals("TermOrders")) {
+                        named.add(from);
+                    }
+                }
+            }
+        }
+
+        assertEquals(Set.of(DERIVES), built,
+                "a pair of orders is put together where a term's orders are worked out, and"
+                        + " a second place is a pair about no reading in particular");
+        assertEquals(Set.of(DERIVES), named,
+                "and the same of the factory beside the constructor");
     }
 
     /** The nest a class belongs to: a lambda written inside a reader is that reader. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -160,10 +160,11 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
                     () -> "a term's orders are made from what a reading resolved, and " + made
                             + " lets any caller pair two carriers it happens to hold");
         }
-        assertTrue(java.util.Arrays.stream(TermOrders.class.getDeclaredMethods())
+        assertEquals(List.of(), java.util.Arrays.stream(TermOrders.class.getDeclaredMethods())
                         .filter(each -> each.getReturnType() == TermOrders.class)
-                        .noneMatch(each ->
-                                java.lang.reflect.Modifier.isPublic(each.getModifiers())),
-                "and no factory beside it is open either");
+                        .map(java.lang.reflect.Method::getName).sorted().toList(),
+                "and there is no factory beside it at all, open or not: a second way to make one is"
+                        + " a second place to count, and the count above reads calls rather than"
+                        + " declarations");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingAnswersWhatATermIsMeasuredOnTest.java
@@ -2,16 +2,22 @@ package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
 
-import souther.test.RepositoryLayout;
-
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.instruction.InvokeInstruction;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -33,28 +39,58 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class OneReadingAnswersWhatATermIsMeasuredOnTest {
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
-
     /** Where both orders of a term are worked out from a type. */
-    private static final String DERIVED = "TermOrdering.of(";
+    private static final String DERIVES = "souther.compiler.inputs.TermOrdering";
 
+    /**
+     * Read off what was compiled rather than off the sources.
+     *
+     * <p>A check on the spelling reads what a call looks like, and a call can look like anything: a
+     * static import drops the class name, and a lambda that derives puts the call in a class of its
+     * own. What the class files carry is the call, whatever it was written as.
+     */
     @Test
     void oneProductionPlaceDerivesATermsOrders() throws IOException {
-        List<Path> sources = REPOSITORY.mainJavaSources();
-        assertTrue(sources.size() > 20,
-                () -> "the scan found only " + sources.size() + " sources, which is not the tree");
-
-        List<String> derives = new ArrayList<>();
-        for (Path source : sources) {
-            String text = code(Files.readString(source, StandardCharsets.UTF_8));
-            if (text.contains(DERIVED) && !source.getFileName().toString().equals("TermOrdering.java")) {
-                derives.add(source.getParent().getFileName() + "/" + source.getFileName());
+        Set<String> derives = new TreeSet<>();
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            String from = nestOf(model.thisClass().asInternalName().replace('/', '.'));
+            if (from.equals(DERIVES)) {
+                continue;   // what the derivation does with itself is its own business
+            }
+            for (var method : model.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
+                    continue;
+                }
+                for (var element : code) {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().replace('/', '.').equals(DERIVES)) {
+                        derives.add(from);
+                    }
+                }
             }
         }
 
-        assertEquals(List.of("inputs/ReadQuantities.java"), derives,
+        assertFalse(derives.isEmpty(),
+                "nothing works a term's orders out at all; this check is reading no calls");
+        assertEquals(Set.of("souther.compiler.inputs.ReadQuantities"), derives,
                 "a term's orders are worked out where the reading that resolved its subject is,"
                         + " and a second place is a reader answering for a reading of its own");
+    }
+
+    /** The nest a class belongs to: a lambda written inside a reader is that reader. */
+    private static String nestOf(String binaryName) {
+        int nested = binaryName.indexOf('$');
+        return nested < 0 ? binaryName : binaryName.substring(0, nested);
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(new LinkedHashSet<>(
+                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
+        }
     }
 
     /**
@@ -77,11 +113,5 @@ class OneReadingAnswersWhatATermIsMeasuredOnTest {
                         .noneMatch(each ->
                                 java.lang.reflect.Modifier.isPublic(each.getModifiers())),
                 "and no factory beside it is open either");
-    }
-
-    /** {@code source} with its comments taken out, which is what this reads: a file may say what
-     *  the rule is without being a place that does it. */
-    private static String code(String source) {
-        return source.replaceAll("(?s)/\\*.*?\\*/", " ").replaceAll("//[^\n]*", " ");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
@@ -1,0 +1,40 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.Carrier;
+
+/**
+ * Synthetic orders for a test that describes a term rather than reading one.
+ *
+ * <p>Here because a package is what package-private means, and a test source set is what says this
+ * is not production. What it opens is open to tests and to nothing that ships: production reaches
+ * {@link TermOrders} through {@link Quantities#ordersOf} and has no way to mint one, which is the
+ * whole point of closing the constructor, and a test writing a border by hand still needs to say
+ * what its number is counted on.
+ */
+public final class TermOrdersFixtures {
+
+    private TermOrdersFixtures() { }
+
+    /** A term whose value is the number it answers. */
+    public static TermOrders itself(Carrier carrier) {
+        return TermOrders.itself(carrier);
+    }
+
+    /** A term read on one order and answering on another, which is every taking of an operation. */
+    public static TermOrders orders(Carrier observed, Carrier answered) {
+        return new TermOrders(observed, answered);
+    }
+
+    /**
+     * What the derivation answers for a term at a type, which is the derivation itself.
+     *
+     * <p>For the tests that are about it: what an operation answers with, and what a value at the
+     * position it was taken of is read on. Production reaches this only through a reading, which is
+     * what settles which type to ask about; a test naming the type is asking the narrower question
+     * of what follows from a type once one is chosen.
+     */
+    public static TermOrders at(NumericTerm term, souther.compiler.types.Type positionType,
+                                souther.compiler.check.Symbols symbols) {
+        return TermOrdering.of(term, positionType, symbols);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TermOrdersFixtures.java
@@ -16,13 +16,13 @@ public final class TermOrdersFixtures {
     private TermOrdersFixtures() { }
 
     /** A term whose value is the number it answers. */
-    public static TermOrders itself(Carrier carrier) {
-        return TermOrders.itself(carrier);
+    public static TermOrders itself(NumericTerm term, Carrier carrier) {
+        return new TermOrders(term, carrier, carrier);
     }
 
     /** A term read on one order and answering on another, which is every taking of an operation. */
-    public static TermOrders orders(Carrier observed, Carrier answered) {
-        return new TermOrders(observed, answered);
+    public static TermOrders orders(NumericTerm term, Carrier observed, Carrier answered) {
+        return new TermOrders(term, observed, answered);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -205,7 +205,7 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                 new BorderQuantity.OfACoordinate(axis,
                         new souther.compiler.inputs.NumericTerm.ValueOf(
                                 souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrders.itself(carrier)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
                 new Level.OnACarrier(carrier, souther.compiler.numeric.Count.of(at)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -404,8 +404,9 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Axis axis = partitioning.axes().stream()
                 .filter(a -> a.path().toString().equals(path)).findFirst().orElseThrow();
-        return Partitions.bordersOf(axis, symbols,
-                domain.quantities(symbols).runsBetween(axis.term()), new LinesRead());
+        souther.compiler.inputs.Quantities reading = domain.quantities(symbols);
+        return Partitions.bordersOf(axis, reading,
+                reading.runsBetween(axis.term()), new LinesRead());
     }
 
     /** A newtype's own clause, reached through the record that holds it. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -201,11 +201,12 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
     private static BoundaryTarget aLineAt(int at) {
         souther.compiler.check.Carrier carrier = new souther.compiler.check.Carrier.Whole();
         AxisId axis = new AxisId("twice", "a.value");
+        souther.compiler.inputs.NumericTerm.ValueOf term =
+                new souther.compiler.inputs.NumericTerm.ValueOf(
+                        souther.compiler.inputs.TermPath.of(axis.term()));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(axis,
-                        new souther.compiler.inputs.NumericTerm.ValueOf(
-                                souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
+                new BorderQuantity.OfACoordinate(axis, term,
+                        souther.compiler.inputs.TermOrdersFixtures.itself(term, carrier)),
                 new Level.OnACarrier(carrier, souther.compiler.numeric.Count.of(at)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -295,7 +295,7 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
         return BoundaryTarget.at(new BorderQuantity.OfACoordinate(axis,
                         new souther.compiler.inputs.NumericTerm.ValueOf(
                                 souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrders.itself(carrier)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
                 new Level.OnACarrier(carrier, at));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -292,10 +292,11 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     /** A line on one position's own values, at a place of its carrier. */
     private static BoundaryTarget lineAt(AxisId axis, Carrier carrier,
                                          souther.compiler.numeric.Place at) {
-        return BoundaryTarget.at(new BorderQuantity.OfACoordinate(axis,
-                        new souther.compiler.inputs.NumericTerm.ValueOf(
-                                souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
+        souther.compiler.inputs.NumericTerm.ValueOf term =
+                new souther.compiler.inputs.NumericTerm.ValueOf(
+                        souther.compiler.inputs.TermPath.of(axis.term()));
+        return BoundaryTarget.at(new BorderQuantity.OfACoordinate(axis, term,
+                        souther.compiler.inputs.TermOrdersFixtures.itself(term, carrier)),
                 new Level.OnACarrier(carrier, at));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
@@ -161,7 +161,7 @@ class ABoundSaysWhichSideItKeepsTest {
                 new BorderQuantity.OfACoordinate(axis,
                         new souther.compiler.inputs.NumericTerm.ValueOf(
                                 souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrders.itself(carrier)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
                 new Level.OnACarrier(carrier, Count.of(at)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
@@ -157,11 +157,12 @@ class ABoundSaysWhichSideItKeepsTest {
     private static BoundaryTarget aLineAt(int at) {
         Carrier carrier = new Carrier.Whole();
         AxisId axis = new AxisId("f", "n");
+        souther.compiler.inputs.NumericTerm.ValueOf term =
+                new souther.compiler.inputs.NumericTerm.ValueOf(
+                        souther.compiler.inputs.TermPath.of(axis.term()));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(axis,
-                        new souther.compiler.inputs.NumericTerm.ValueOf(
-                                souther.compiler.inputs.TermPath.of(axis.term())),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(carrier)),
+                new BorderQuantity.OfACoordinate(axis, term,
+                        souther.compiler.inputs.TermOrdersFixtures.itself(term, carrier)),
                 new Level.OnACarrier(carrier, Count.of(at)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -116,7 +116,6 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
                 }
                 out.add(role + " -> "
                         + (Generator.probeFixing(subject, border.label(role),
-                                ignored -> axis.term().answeredOn(axis.type(), symbols),
                                 java.util.Map.of(
                                         new RealizationTarget.AtOnePosition(axis.term()),
                                         ((Level.OnACarrier) each.at()).at()),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -108,7 +108,7 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
         List<String> out = new ArrayList<>();
         for (Axis axis : p.axes()) {
             for (Border border
-                    : Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()), new LinesRead())) {
+                    : Partitions.bordersOf(axis, reading, reading.runsBetween(axis.term()), new LinesRead())) {
               for (PointRole role : List.of(PointRole.ON, PointRole.OFF)) {
                 if (!(border.demand(role).criterion()
                         instanceof Criterion.AtTheLevel each)) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
@@ -104,7 +104,7 @@ class ACarrierNothingReadsUnmeasuresItsSiblingsTest {
                 .filter(a -> a.path().toString().equals(path)).findFirst().orElseThrow();
         String standing = read.partitioning().edgeIsKnownWritable(axis.term())
                 ? " writable" : " not known to be writable";
-        return Partitions.bordersOf(axis, read.symbols(),
+        return Partitions.bordersOf(axis, read.reading(),
                         read.reading().runsBetween(axis.term()), new LinesRead()).stream()
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -9,7 +9,7 @@ import souther.compiler.check.ClauseName;
 import souther.compiler.check.MatchedEndAttribution;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
@@ -169,7 +169,7 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
         return BoundaryTarget.at(
                 new BorderQuantity.OfACoordinate(axis,
                         new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrders.itself(WHOLE)),
+                        TermOrdersFixtures.itself(WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(value)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -166,10 +166,10 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
 
     private static BoundaryTarget aLineAt(int value) {
         AxisId axis = new AxisId("weigh", "w.a");
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(TermPath.of(axis.term()));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(axis,
-                        new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrdersFixtures.itself(WHOLE)),
+                new BorderQuantity.OfACoordinate(axis, term,
+                        TermOrdersFixtures.itself(term, WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(value)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -156,7 +156,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     }
 
     private static Axis anAxis() {
-        return new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")), Type.INT,
+        return new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")),
                 List.of(), List.of(Cut.at(Carrier.WHOLE, Count.of(5), bound("cap"))));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -37,6 +37,10 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
 
     private static final AxisId AT = new AxisId("take", "h.a");
 
+    /** The number that measure is of, which its orders are the orders of. */
+    private static final NumericTerm.ValueOf AT_A =
+            new NumericTerm.ValueOf(TermPath.of("h").then("a"));
+
     /** A reading of one line that drew it, which is what a closed one is. */
     @Test
     void aReadingThatDrewItsLineMayBeClosed() {
@@ -156,15 +160,14 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     }
 
     private static Axis anAxis() {
-        return new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")),
+        return new Axis(AT, AT_A,
                 List.of(), List.of(Cut.at(Carrier.WHOLE, Count.of(5), bound("cap"))));
     }
 
     private static BoundaryTarget aLine() {
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(AT,
-                        new NumericTerm.ValueOf(TermPath.of("h").then("a")),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
+                new BorderQuantity.OfACoordinate(AT, AT_A,
+                        souther.compiler.inputs.TermOrdersFixtures.itself(AT_A, Carrier.WHOLE)),
                 new Level.OnACarrier(Carrier.WHOLE, Count.of(5)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -164,7 +164,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
         return BoundaryTarget.at(
                 new BorderQuantity.OfACoordinate(AT,
                         new NumericTerm.ValueOf(TermPath.of("h").then("a")),
-                        souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
                 new Level.OnACarrier(Carrier.WHOLE, Count.of(5)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOverASharedNameIsOneTheComposerCanPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOverASharedNameIsOneTheComposerCanPlaceTest.java
@@ -110,7 +110,6 @@ class AConditionOverASharedNameIsOneTheComposerCanPlaceTest {
     private static Generator.BoundaryAttempt composing(Count at) {
         Axis fixed = axisAt("n");
         return Generator.probeFixing(subject(), "n = " + at,
-                _ -> fixed.term().answeredOn(fixed.type(), symbols()),
                 Map.of(new RealizationTarget.AtOnePosition(fixed.term()), at),
                 new Reachability.Reaching(domain().quantities(symbols()).region(),
                         Requirements.NONE,

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
@@ -216,7 +216,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
         Partitions.Partitioning p =
                 Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         return p.axes().stream()
-                .flatMap(axis -> Partitions.bordersOf(axis, symbols,
+                .flatMap(axis -> Partitions.bordersOf(axis, reading,
                         reading.runsBetween(axis.term()), new LinesRead()).stream())
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
@@ -44,7 +44,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     private static Cutting onThePosition(String t) {
         return new Cutting(
                 new BorderQuantity.OfACoordinate(AxisId.of("f", term("n")), term("n"),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(term("n"), WHOLE)),
                 new Level.OnACarrier(WHOLE, new Count(new BigDecimal(t))),
                 new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
@@ -52,7 +52,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     /** {@code k * n > t}, read as an arithmetic form over a multiple of that position. */
     private static Cutting overAMultiple(String k, String t) {
         return new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", k), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", k), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(term("n"), WHOLE))),
                 new Level.ACount(new Count(new BigDecimal(t))),
                 new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
@@ -94,7 +94,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void aRuleThatSinglesAValueOutSinglesOutAValueOrNoneAtAll() {
         Cutting names = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(term("n"), WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("9"))),
                 new ComparisonClaim.Singled(true), null);
 
@@ -108,7 +108,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void andWhereTheLineIsAValueOfThePositionThatIsTheOneItNames() {
         Cutting names = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(term("n"), WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("8"))),
                 new ComparisonClaim.Singled(true), null);
 
@@ -125,7 +125,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void aThresholdTheWrittenFormNeverReachesStillPartsTheValues() {
         Cutting closed = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(term("n"), WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("9"))),
                 new ComparisonClaim.Cut(Towards.BELOW, true), null);
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACutSaysWhatItDividesAndWhereTest.java
@@ -44,7 +44,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     private static Cutting onThePosition(String t) {
         return new Cutting(
                 new BorderQuantity.OfACoordinate(AxisId.of("f", term("n")), term("n"),
-                        souther.compiler.inputs.TermOrders.itself(WHOLE)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE)),
                 new Level.OnACarrier(WHOLE, new Count(new BigDecimal(t))),
                 new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
@@ -52,7 +52,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     /** {@code k * n > t}, read as an arithmetic form over a multiple of that position. */
     private static Cutting overAMultiple(String k, String t) {
         return new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", k), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", k), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal(t))),
                 new ComparisonClaim.Cut(Towards.BELOW, false), null);
     }
@@ -94,7 +94,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void aRuleThatSinglesAValueOutSinglesOutAValueOrNoneAtAll() {
         Cutting names = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("9"))),
                 new ComparisonClaim.Singled(true), null);
 
@@ -108,7 +108,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void andWhereTheLineIsAValueOfThePositionThatIsTheOneItNames() {
         Cutting names = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("8"))),
                 new ComparisonClaim.Singled(true), null);
 
@@ -125,7 +125,7 @@ class ACutSaysWhatItDividesAndWhereTest {
     @Test
     void aThresholdTheWrittenFormNeverReachesStillPartsTheValues() {
         Cutting closed = new Cutting(
-                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrders.itself(WHOLE))),
+                new BorderQuantity.OverAForm("f", form("n", "2"), Map.of(term("n"), souther.compiler.inputs.TermOrdersFixtures.itself(WHOLE))),
                 new Level.ACount(new Count(new BigDecimal("9"))),
                 new ComparisonClaim.Cut(Towards.BELOW, true), null);
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest.java
@@ -141,7 +141,6 @@ class ACutTheComposerCannotPlaceIsSaidAndNotHalfAppliedTest {
     /** A row composed with {@code axis} at {@code at}, and {@code taken} on the way to it. */
     private static Generator.BoundaryAttempt composing(Axis axis, Place at, OnTheWay.TakenIn taken) {
         return Generator.probeFixing(subject(), axis.path() + " = " + at,
-                _ -> axis.term().answeredOn(axis.type(), symbols()),
                 Map.of(new RealizationTarget.AtOnePosition(axis.term()), at),
                 new Reachability.Reaching(domain().quantities(symbols()).region(),
                         Requirements.NONE, List.of(taken)),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
@@ -163,7 +163,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
         souther.compiler.inputs.NumericTerm.ValueOf atDays =
                 new souther.compiler.inputs.NumericTerm.ValueOf(
                         souther.compiler.inputs.TermPath.of("days"));
-        Axis days = new Axis(new AxisId("fee", "days"), atDays, Type.INT,
+        Axis days = new Axis(new AxisId("fee", "days"), atDays,
                 List.of(divided("days/low", 1).ofTheNumber(atDays),
                         divided("days/high", 9).ofTheNumber(atDays)),
                 List.of());

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
@@ -96,8 +96,8 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
                                 value("n"), BigDecimal.ONE.negate()));
 
         BorderQuantity.OverAForm over = new BorderQuantity.OverAForm("take", daysBetweenLessN,
-                Map.of(value("to"), on(Carrier.DATE), value("from"), on(Carrier.DATE),
-                        value("n"), on(Carrier.WHOLE)));
+                Map.of(value("to"), on("to", Carrier.DATE), value("from"), on("from", Carrier.DATE),
+                        value("n"), on("n", Carrier.WHOLE)));
 
         assertEquals(Carrier.DATE, over.carrierOf(value("to")));
         assertEquals(Carrier.WHOLE, over.carrierOf(value("n")));
@@ -107,8 +107,8 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
 
     /** A position read and written on one order, which is every position here: what an operation
      *  answered of one is not what these tests are about. */
-    private static souther.compiler.inputs.TermOrders on(Carrier carrier) {
-        return souther.compiler.inputs.TermOrdersFixtures.itself(carrier);
+    private static souther.compiler.inputs.TermOrders on(String field, Carrier carrier) {
+        return souther.compiler.inputs.TermOrdersFixtures.itself(value(field), carrier);
     }
 
     /** And a position with no number under it is one a sum has nothing to add. */
@@ -116,7 +116,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     void aPositionWithNoCountIsRefused() {
         assertTrue(assertThrows(IllegalArgumentException.class,
                 () -> new BorderQuantity.OverAForm("take", aDecimalLessAnInt(),
-                        Map.of(value("d"), on(Carrier.TEXT), value("n"), on(Carrier.WHOLE))))
+                        Map.of(value("d"), on("d", Carrier.TEXT), value("n"), on("n", Carrier.WHOLE))))
                 .getMessage().contains("no number under it"));
     }
 
@@ -125,7 +125,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     void aFormOverTwoDifferentOrdersIsAQuantity() {
         BorderQuantity.OverAForm over = new BorderQuantity.OverAForm("take",
                 aDecimalLessAnInt(),
-                Map.of(value("d"), on(Carrier.DENSE), value("n"), on(Carrier.WHOLE)));
+                Map.of(value("d"), on("d", Carrier.DENSE), value("n"), on("n", Carrier.WHOLE)));
 
         assertEquals(Carrier.DENSE, over.carrierOf(value("d")),
                 "the decimal position is read and written as a decimal");
@@ -146,10 +146,10 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     void whatTheSumStepsByIsWhatItsPositionsStepByTogether() {
         BorderQuantity.OverAForm mixed = new BorderQuantity.OverAForm("take",
                 aDecimalLessAnInt(),
-                Map.of(value("d"), on(Carrier.DENSE), value("n"), on(Carrier.WHOLE)));
+                Map.of(value("d"), on("d", Carrier.DENSE), value("n"), on("n", Carrier.WHOLE)));
         BorderQuantity.OverAForm whole = new BorderQuantity.OverAForm("take",
                 aDecimalLessAnInt(),
-                Map.of(value("d"), on(Carrier.WHOLE), value("n"), on(Carrier.WHOLE)));
+                Map.of(value("d"), on("d", Carrier.WHOLE), value("n"), on("n", Carrier.WHOLE)));
 
         assertEquals(souther.compiler.numeric.Granularity.DENSE, mixed.spacing(),
                 "one dense position makes the sum dense");
@@ -170,12 +170,12 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     void aFormAndItsOrdersAreOverTheSamePositions() {
         assertTrue(assertThrows(IllegalArgumentException.class,
                 () -> new BorderQuantity.OverAForm("take", aDecimalLessAnInt(),
-                        Map.of(value("d"), on(Carrier.DENSE))))
+                        Map.of(value("d"), on("d", Carrier.DENSE))))
                 .getMessage().contains("read on one order"));
         assertTrue(assertThrows(IllegalArgumentException.class,
                 () -> new BorderQuantity.OverAForm("take", aDecimalLessAnInt(),
-                        Map.of(value("d"), on(Carrier.DENSE), value("n"), on(Carrier.WHOLE),
-                                value("from"), on(Carrier.DATE))))
+                        Map.of(value("d"), on("d", Carrier.DENSE), value("n"), on("n", Carrier.WHOLE),
+                                value("from"), on("from", Carrier.DATE))))
                 .getMessage().contains("read on one order"));
     }
 
@@ -192,7 +192,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     void aLevelOfSuchAFormIsReached() {
         BorderQuantity.OverAForm over = new BorderQuantity.OverAForm("take",
                 aDecimalLessAnInt(),
-                Map.of(value("d"), on(Carrier.DENSE), value("n"), on(Carrier.WHOLE)));
+                Map.of(value("d"), on("d", Carrier.DENSE), value("n"), on("n", Carrier.WHOLE)));
 
         Standing standing = over.standingAt(
                 new Criterion.AtTheLevel(new Level.ACount(Count.of(new BigDecimal("2.5")))));
@@ -226,7 +226,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
                 BigDecimal.ZERO,
                 Map.of(value("d"), new BigDecimal("3"), value("n"), BigDecimal.ONE));
         BorderQuantity.OverAForm over = new BorderQuantity.OverAForm("take", thriceD,
-                Map.of(value("d"), on(Carrier.DENSE), value("n"), on(Carrier.WHOLE)));
+                Map.of(value("d"), on("d", Carrier.DENSE), value("n"), on("n", Carrier.WHOLE)));
 
         Realization made = new LevelRealizer().realize(
                 over.standingAt(

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFormAddsPositionsWrittenBackDifferentlyTest.java
@@ -108,7 +108,7 @@ class AFormAddsPositionsWrittenBackDifferentlyTest {
     /** A position read and written on one order, which is every position here: what an operation
      *  answered of one is not what these tests are about. */
     private static souther.compiler.inputs.TermOrders on(Carrier carrier) {
-        return souther.compiler.inputs.TermOrders.itself(carrier);
+        return souther.compiler.inputs.TermOrdersFixtures.itself(carrier);
     }
 
     /** And a position with no number under it is one a sum has nothing to add. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineFallsInAClassOnTheOrderItWasDrawnOnTest.java
@@ -85,8 +85,8 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
             }
             """;
 
-    /** A model's one measure, with the symbols its carrier is read against. */
-    private record Measured(Axis axis, Symbols symbols) {
+    /** A model's one measure, with the orders the reading of its input came to for that number. */
+    private record Measured(Axis axis, souther.compiler.inputs.TermOrders orders) {
 
         Cut line() {
             assertEquals(1, axis.cuts().size(), "the model draws the one line");
@@ -94,7 +94,7 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
         }
 
         Carrier carrier() {
-            return axis.term().answeredOn(axis.type(), symbols);
+            return orders.answered();
         }
 
         List<PartitionClass> holding(Cut line) {
@@ -115,7 +115,11 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
                 .findFirst().orElse(null);
         assertNotNull(axis, "the model is measured at " + id + ", among "
                 + read.axes().stream().map(each -> each.id().toString()).toList());
-        return new Measured(axis, Scopes.derived(compilation.db(), module).value());
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        souther.compiler.inputs.InputDomain domain = compilation.db()
+                .ask(new Adequacy.Inputs(module)).value().get("gate");
+        assertNotNull(domain, "the input of the behavior under test was read");
+        return new Measured(axis, domain.quantities(symbols).ordersOf(axis.term()));
     }
 
     /** The line the rules drew on a number taken of a location falls in one of that number's runs. */
@@ -143,7 +147,7 @@ class ALineFallsInAClassOnTheOrderItWasDrawnOnTest {
         Measured minute = measured(TAKEN, "gate/Time.minute(slot.at)");
         Cut line = minute.line();
 
-        assertNotEquals(minute.carrier(), minute.axis().type(),
+        assertNotEquals(minute.orders().answered(), minute.orders().observed(),
                 "the number is counted on an order of its own");
         assertTrue(minute.axis().classes().stream().allMatch(each ->
                         !(each.classifier().membershipOf(minute.carrier().valueOf(line.at()))

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsHeldUnderThePositionItMeasuresTest.java
@@ -9,7 +9,6 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Towards;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
-import souther.compiler.types.Type;
 
 import java.util.List;
 
@@ -81,8 +80,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
         NumericTerm.ValueOf term = new NumericTerm.ValueOf(at);
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new Axis(AxisId.of("gate", term), term, Type.STRING,
-                        List.of(), List.of()));
+                () -> new Axis(AxisId.of("gate", term), term, List.of(), List.of()));
 
         assertTrue(refused.getMessage().contains("measures a number of no")
                         || refused.getMessage().contains("at nothing"),
@@ -132,7 +130,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
         PositionMeasurements n = at("slot.n");
         Axis reading = n.axes().get(0);
         Carrier whole = new Carrier.Whole();
-        Axis partsOnly = new Axis(reading.id(), reading.term(), reading.type(), List.of(),
+        Axis partsOnly = new Axis(reading.id(), reading.term(), List.of(),
                 List.of(),
                 List.of(Parting.by(
                         Seam.of(LevelSpace.onACarrier(whole),
@@ -163,28 +161,14 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
     void aMeasureOfAnotherLocationIsNotHeldUnderThisOne() {
         PositionMeasurements n = at("slot.n");
         Axis ofAnother = at("slot.m").axes().get(0);
-        assertEquals(n.position().type(), ofAnother.type(), "the two hold the same type");
+        assertEquals(n.position().type(), at("slot.m").position().type(),
+                "the two locations hold the same type, so what refuses this is the path");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new PositionMeasurements(n.position(), List.of(ofAnother), READ_TO_THE_END));
 
         assertTrue(refused.getMessage().contains("slot.m")
                 && refused.getMessage().contains("slot.n"), refused.getMessage());
-    }
-
-    /** Nor a measure that reads a value of another type, whatever it is called. */
-    @Test
-    void aMeasureThatReadsAnotherTypeIsNotHeldHere() {
-        PositionMeasurements n = at("slot.n");
-        Axis reading = n.axes().get(0);
-        Axis ofAString = new Axis(reading.id(), reading.term(), Type.STRING,
-                List.of(), reading.cuts());
-
-        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new PositionMeasurements(n.position(), List.of(ofAString), READ_TO_THE_END));
-
-        assertTrue(refused.getMessage().contains(Type.STRING.toString())
-                && refused.getMessage().contains(Type.INT.toString()), refused.getMessage());
     }
 
     /**
@@ -201,7 +185,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new Axis(AxisId.of("gate", at("slot.m").axes().get(0).term()),
-                        reading.term(), reading.type(), reading.classes(), reading.cuts()));
+                        reading.term(), reading.classes(), reading.cuts()));
 
         assertTrue(refused.getMessage().contains("slot.m")
                 && refused.getMessage().contains("slot.n"), refused.getMessage());
@@ -237,7 +221,7 @@ class AMeasureIsHeldUnderThePositionItMeasuresTest {
         PositionMeasurements n = at("slot.n");
         Axis reading = n.axes().get(0);
         Axis elsewhere = new Axis(AxisId.of("other", reading.term()), reading.term(),
-                reading.type(), reading.classes(), reading.cuts());
+                reading.classes(), reading.cuts());
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new PositionMeasurements(n.position(), List.of(elsewhere), READ_TO_THE_END));

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
@@ -154,10 +154,10 @@ class ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest {
 
     private static BoundaryTarget aLineAt(int value) {
         AxisId axis = new AxisId("weigh", "w.a");
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(TermPath.of(axis.term()));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(axis,
-                        new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrdersFixtures.itself(WHOLE)),
+                new BorderQuantity.OfACoordinate(axis, term,
+                        TermOrdersFixtures.itself(term, WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(value)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest.java
@@ -10,7 +10,7 @@ import souther.compiler.check.MatchedEndAttribution;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
@@ -157,7 +157,7 @@ class ANarrowingIsToldOnlyAboutTheEndItWasReadAtTest {
         return BoundaryTarget.at(
                 new BorderQuantity.OfACoordinate(axis,
                         new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrders.itself(WHOLE)),
+                        TermOrdersFixtures.itself(WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(value)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.RunSource;
 import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
@@ -44,7 +45,7 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
             souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
 
     private static final TermOrders WHOLE =
-            TermOrders.itself(new Carrier.Whole());
+            TermOrdersFixtures.itself(new Carrier.Whole());
 
     /** The capability question, which is the one every reader that would act on a place asks. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
@@ -45,7 +45,7 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
             souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
 
     private static final TermOrders WHOLE =
-            TermOrdersFixtures.itself(new Carrier.Whole());
+            TermOrdersFixtures.itself(TOTAL, new Carrier.Whole());
 
     /** The capability question, which is the one every reader that would act on a place asks. */
     @Test
@@ -67,15 +67,15 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
     /** The number is what the values come to, not what any one of them is. */
     @Test
     void theNumberIsWhatTheValuesAddUpTo() {
-        assertEquals(Count.of(100000), number(TOTAL.readOver(
-                List.of(whole(60000), whole(40000)), WHOLE)),
+        assertEquals(Count.of(100000),
+                number(WHOLE.readOver(List.of(whole(60000), whole(40000)))),
                 "sixty thousand and forty thousand come to the hundred thousand a rule compares");
     }
 
     /** A container holding nothing comes to what the walk starts from. */
     @Test
     void anEmptyRunComesToWhatTheWalkStartsFrom() {
-        assertEquals(Count.of(0), number(TOTAL.readOver(List.of(), WHOLE)),
+        assertEquals(Count.of(0), number(WHOLE.readOver(List.of())),
                 "a row writing no element is a row an author can write, and its total is nought");
     }
 
@@ -83,7 +83,7 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
     @Test
     void aValueThatCouldNotBeReadLeavesTheTotalUnread() {
         assertInstanceOf(NumericTerm.Reading.Missing.class,
-                TOTAL.readOver(List.of(whole(1), new ObservedValue.Unknown("not read")), WHOLE),
+                WHOLE.readOver(List.of(whole(1), new ObservedValue.Unknown("not read"))),
                 "a total is over every value, so one that could not be read is not a total short"
                         + " of a part");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
@@ -190,7 +190,6 @@ class ARowIsOfferedForAPointOnlyWhereItStandsThereTest {
         Axis axis = partitioning.axes().stream()
                 .filter(each -> each.path().toString().equals("r.cost")).findFirst().orElseThrow();
         return Generator.probeFixing(subject, "r.cost = " + at,
-                _ -> axis.term().answeredOn(axis.type(), symbols),
                 Map.of(new RealizationTarget.AtOnePosition(axis.term()), at),
                 Reachability.untouched(domain.quantities(symbols).region()), check);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASubjectNamesTheBehaviorItsAxesAreOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASubjectNamesTheBehaviorItsAxesAreOfTest.java
@@ -72,6 +72,6 @@ class ASubjectNamesTheBehaviorItsAxesAreOfTest {
 
     private static Axis axisOf(String behavior, String position) {
         return new Axis(new AxisId(behavior, position),
-                new NumericTerm.ValueOf(TermPath.of(position)), Type.INT, List.of(), List.of());
+                new NumericTerm.ValueOf(TermPath.of(position)), List.of(), List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATermSaysWhyItHasNoNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATermSaysWhyItHasNoNumberTest.java
@@ -43,20 +43,20 @@ class ATermSaysWhyItHasNoNumberTest {
 
     /** The two orders a whole-number position stands on, which are one order. */
     private static final souther.compiler.inputs.TermOrders AS_A_NUMBER =
-            souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.itself(VALUE, Carrier.WHOLE);
 
     /** And the two a length stands on: the string is read as text, the count as a whole number. */
     private static final souther.compiler.inputs.TermOrders AS_A_LENGTH =
-            souther.compiler.inputs.TermOrdersFixtures.orders(Carrier.TEXT, Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.orders(LENGTH, Carrier.TEXT, Carrier.WHOLE);
 
     @Test
     void anObservationThatDidNotArriveIsMissing() {
         assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
-                ((NumericTerm.Reading.Missing) VALUE.read(new ObservedValue.Truncated(), AS_A_NUMBER)).code());
+                ((NumericTerm.Reading.Missing) AS_A_NUMBER.read(new ObservedValue.Truncated())).code());
         assertInstanceOf(NumericTerm.Reading.Missing.class,
-                LENGTH.read(new ObservedValue.Truncated(), AS_A_LENGTH));
+                AS_A_LENGTH.read(new ObservedValue.Truncated()));
         assertInstanceOf(NumericTerm.Reading.Missing.class,
-                VALUE.read(new ObservedValue.Unknown("gone"), AS_A_NUMBER));
+                AS_A_NUMBER.read(new ObservedValue.Unknown("gone")));
     }
 
     /** One layer in, which is where a newtype puts it. The construction reads perfectly well and the
@@ -66,31 +66,31 @@ class ATermSaysWhyItHasNoNumberTest {
     void anObservationCutShortInsideANewtypeIsMissingToo() {
         ObservedValue wrapped = new ObservedValue.Constructed(WRAPPER,
                 Map.of("value", new ObservedValue.Truncated()));
-        assertInstanceOf(NumericTerm.Reading.Missing.class, VALUE.read(wrapped, AS_A_NUMBER));
-        assertInstanceOf(NumericTerm.Reading.Missing.class, LENGTH.read(wrapped, AS_A_LENGTH));
+        assertInstanceOf(NumericTerm.Reading.Missing.class, AS_A_NUMBER.read(wrapped));
+        assertInstanceOf(NumericTerm.Reading.Missing.class, AS_A_LENGTH.read(wrapped));
     }
 
     /** A value that was read, and that this term is not a number of. Not the same answer. */
     @Test
     void aValueThatWasReadAndIsNotThisTermsNumberIsNotMissing() {
         assertInstanceOf(NumericTerm.Reading.NotNumber.class,
-                VALUE.read(new ObservedValue.Text("abc"), AS_A_NUMBER));
+                AS_A_NUMBER.read(new ObservedValue.Text("abc")));
         assertInstanceOf(NumericTerm.Reading.NotNumber.class,
-                LENGTH.read(new ObservedValue.Integer(3), AS_A_LENGTH));
+                AS_A_LENGTH.read(new ObservedValue.Integer(3)));
         assertInstanceOf(NumericTerm.Reading.NotNumber.class,
-                LENGTH.read(new ObservedValue.Bool(true), AS_A_LENGTH));
+                AS_A_LENGTH.read(new ObservedValue.Bool(true)));
     }
 
     /** And what each term does read, so that none of the above passes by reading nothing at all. */
     @Test
     void eachTermReadsItsOwnNumber() {
         assertEquals(Count.of(3),
-                ((NumericTerm.Reading.Number) VALUE.read(new ObservedValue.Integer(3), AS_A_NUMBER)).value());
+                ((NumericTerm.Reading.Number) AS_A_NUMBER.read(new ObservedValue.Integer(3))).value());
         assertEquals(Count.of(3),
-                ((NumericTerm.Reading.Number) LENGTH.read(new ObservedValue.Text("abc"), AS_A_LENGTH)).value());
+                ((NumericTerm.Reading.Number) AS_A_LENGTH.read(new ObservedValue.Text("abc"))).value());
         assertEquals(Count.of(3),
-                ((NumericTerm.Reading.Number) LENGTH.read(new ObservedValue.Constructed(
-                        WRAPPER, Map.of("value", new ObservedValue.Text("abc"))), AS_A_LENGTH)).value());
+                ((NumericTerm.Reading.Number) AS_A_LENGTH.read(new ObservedValue.Constructed(
+                        WRAPPER, Map.of("value", new ObservedValue.Text("abc"))))).value());
     }
 
     /** A string counts in code points, as `Strings.length` does. Counted in UTF-16 units this is 2,
@@ -98,7 +98,7 @@ class ATermSaysWhyItHasNoNumberTest {
     @Test
     void aStringIsCountedTheWayTheLanguageCountsIt() {
         assertEquals(Count.of(1),
-                ((NumericTerm.Reading.Number) LENGTH.read(new ObservedValue.Text("😀"), AS_A_LENGTH))
+                ((NumericTerm.Reading.Number) AS_A_LENGTH.read(new ObservedValue.Text("😀")))
                         .value());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATermSaysWhyItHasNoNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATermSaysWhyItHasNoNumberTest.java
@@ -43,11 +43,11 @@ class ATermSaysWhyItHasNoNumberTest {
 
     /** The two orders a whole-number position stands on, which are one order. */
     private static final souther.compiler.inputs.TermOrders AS_A_NUMBER =
-            souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE);
 
     /** And the two a length stands on: the string is read as text, the count as a whole number. */
     private static final souther.compiler.inputs.TermOrders AS_A_LENGTH =
-            new souther.compiler.inputs.TermOrders(Carrier.TEXT, Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.orders(Carrier.TEXT, Carrier.WHOLE);
 
     @Test
     void anObservationThatDidNotArriveIsMissing() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
@@ -92,7 +92,8 @@ class ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest {
             Symbols.none(souther.compiler.DefaultStdlib.get()));
 
     /** A container is on no order of its own, and the total it answers is counted by one. */
-    private static final TermOrders A_CONTAINERS_ORDERS = new TermOrders(null, Carrier.WHOLE);
+    private static final TermOrders A_CONTAINERS_ORDERS =
+            souther.compiler.inputs.TermOrdersFixtures.orders(null, Carrier.WHOLE);
 
     private static Count numberOf(NumericTerm.Reading read) {
         return (Count) ((NumericTerm.Reading.Number) read).value();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest.java
@@ -73,10 +73,10 @@ class ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest {
     void aTotalOfAContainerAndATotalOverARunReadOneOrder() {
         List<ObservedValue> elements = List.of(new ObservedValue.Integer(1),
                 new ObservedValue.Integer(5));
-        assertEquals(Count.of(6), numberOf(AT_A_POSITION.read(new ObservedValue.Sequence(elements),
-                        A_CONTAINERS_ORDERS)),
+        assertEquals(Count.of(6),
+                numberOf(AT_A_POSITIONS_ORDERS.read(new ObservedValue.Sequence(elements))),
                 "the total of what the place holds");
-        assertEquals(Count.of(6), numberOf(OVER_A_RUN.readOver(elements, A_CONTAINERS_ORDERS)),
+        assertEquals(Count.of(6), numberOf(OVER_A_RUNS_ORDERS.readOver(elements)),
                 "and the total over the values of a run, which are the same values");
     }
 
@@ -92,8 +92,13 @@ class ATotalReadsItsElementsOnOneOrderWhereverItIsReadTest {
             Symbols.none(souther.compiler.DefaultStdlib.get()));
 
     /** A container is on no order of its own, and the total it answers is counted by one. */
-    private static final TermOrders A_CONTAINERS_ORDERS =
-            souther.compiler.inputs.TermOrdersFixtures.orders(null, Carrier.WHOLE);
+    private static final TermOrders AT_A_POSITIONS_ORDERS =
+            souther.compiler.inputs.TermOrdersFixtures.orders(AT_A_POSITION, null, Carrier.WHOLE);
+
+    /** The same two orders, of the number over the run — which is the point: one operation, one
+     *  account of what its elements are places of, whichever of the two names it. */
+    private static final TermOrders OVER_A_RUNS_ORDERS =
+            souther.compiler.inputs.TermOrdersFixtures.orders(OVER_A_RUN, null, Carrier.WHOLE);
 
     private static Count numberOf(NumericTerm.Reading read) {
         return (Count) ((NumericTerm.Reading.Number) read).value();

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -53,7 +53,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     private static final BodyCutInspection READ_TO_THE_END = new BodyCutInspection.Exhausted();
 
     private static PositionMeasurements measured() {
-        return at(new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
+        return at(new Axis(ID, new NumericTerm.ValueOf(AT),
                 List.of(PartitionClass.of("true", "true", new Recognition.Nothing(),
                                 RepresentativeSource.of(FixtureTemplate.bool(true)))
                         .ofTheNumber(new NumericTerm.ValueOf(AT))),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -67,7 +67,7 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
         account.measured(one, new AxisId("f", AT.toString()));
 
         account.everyPieceWasDisposedOf(List.of(new Axis(new AxisId("f", AT.toString()), AT,
-                souther.compiler.types.Type.INT, List.of(),
+                List.of(),
                 List.of(Cut.at(new Carrier.Whole(),
                         new Count(new java.math.BigDecimal("10")), origin())))));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest.java
@@ -70,7 +70,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
 
     /** The same measure, offered another run of classes and another set of lines. */
     private static Axis carrying(Axis axis, List<PartitionClass> classes, List<Cut> cuts) {
-        return new Axis(axis.id(), axis.term(), axis.type(), classes, cuts);
+        return new Axis(axis.id(), axis.term(), classes, cuts);
     }
 
     private static Axis axisOf(Partitions.Partitioning read, String id) {
@@ -350,8 +350,7 @@ class AnAxisHoldsOnlyClassesOfTheNumberItMeasuresTest {
         assertNotSame(length.term(), again, "a second naming, built here");
         assertEquals(length.term(), again, "of the number the reading already named");
 
-        Axis measuring = new Axis(length.id(), again, length.type(),
-                length.classes(), length.cuts());
+        Axis measuring = new Axis(length.id(), again, length.classes(), length.cuts());
 
         assertSame(again, measuring.term(),
                 "so the classes of that number are the classes of an axis measuring it");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -87,7 +87,8 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
                 ValueName.Stdlib.operation("List", "sum"), TermPath.of("ns"), OF_WHOLE_NUMBERS,
                 SYMBOLS);
         assertNotNull(total, "a walk that adds up a list of whole numbers is a number of it");
-        TermOrders orders = total.ordersAt(OF_WHOLE_NUMBERS, SYMBOLS);
+        TermOrders orders = souther.compiler.inputs.TermOrdersFixtures
+                .at(total, OF_WHOLE_NUMBERS, SYMBOLS);
         assertTrue(orders.answered() != null, "and the order it answers on is the elements'");
         return TermRealizations.at(new RealizationTarget.AtOnePosition(total), OF_WHOLE_NUMBERS,
                 orders, SIX, NothingTheRulesSay.REGION, SYMBOLS, POLICY);

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -90,7 +90,7 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
         TermOrders orders = souther.compiler.inputs.TermOrdersFixtures
                 .at(total, OF_WHOLE_NUMBERS, SYMBOLS);
         assertTrue(orders.answered() != null, "and the order it answers on is the elements'");
-        return TermRealizations.at(new RealizationTarget.AtOnePosition(total), OF_WHOLE_NUMBERS,
+        return TermRealizations.at(OF_WHOLE_NUMBERS,
                 orders, SIX, NothingTheRulesSay.REGION, SYMBOLS, POLICY);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -196,8 +196,8 @@ class GeneratorTest {
                                                 List<PartitionClass> right) {
         NumericTerm.ValueOf atA = new NumericTerm.ValueOf(TermPath.of("a"));
         NumericTerm.ValueOf atB = new NumericTerm.ValueOf(TermPath.of("b"));
-        Axis a = new Axis(new AxisId("f", "a"), atA, Type.INT, classesOf(left, atA), List.of());
-        Axis b = new Axis(new AxisId("f", "b"), atB, Type.INT, classesOf(right, atB), List.of());
+        Axis a = new Axis(new AxisId("f", "a"), atA, classesOf(left, atA), List.of());
+        Axis b = new Axis(new AxisId("f", "b"), atB, classesOf(right, atB), List.of());
         // Axes written here rather than read off a model, so nothing counts a container of this
         // input. The reading is still the input's own: what a number at one of these positions is
         // measured on is what the declarations say, and the subject asks it for that.
@@ -403,7 +403,7 @@ class GeneratorTest {
     void onePositionHasNoPairsAndItsClassesStillOweRows() {
         Symbols symbols = modelOf(TRIP, "submit").symbols();
         NumericTerm.ValueOf atA = new NumericTerm.ValueOf(TermPath.of("a"));
-        Axis only = new Axis(new AxisId("f", "a"), atA, Type.INT,
+        Axis only = new Axis(new AxisId("f", "a"), atA,
                 classesOf(List.of(number("low", 1), number("high", 9)), atA), List.of());
         MeasuredInput subject = MeasuredInput.of("f", readingOf(symbols, "a"), List.of(only));
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
@@ -242,7 +242,8 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
             case BorderQuantity.OfACoordinate one -> one.term() + " on " + one.of();
             case BorderQuantity.OverAForm form -> form.form() + " on " + form.on();
             case BorderQuantity.Apart apart ->
-                    apart.on() + " vs " + apart.against() + " on " + apart.carriers();
+                    apart.onTerm() + " vs " + apart.againstTerm()
+                            + " on " + apart.on() + ", " + apart.against();
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
@@ -10,7 +10,7 @@ import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.EndSide;
@@ -178,7 +178,7 @@ class OneBorderReadTwiceIsOneReadingTest {
         return Border.at(BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(axis,
                                 new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                                TermOrders.itself(WHOLE)),
+                                TermOrdersFixtures.itself(WHOLE)),
                         new Level.OnACarrier(WHOLE, at)),
                 aBound(),
                 new NumericDomain.Bounds(Endpoint.inclusive(at),
@@ -203,7 +203,7 @@ class OneBorderReadTwiceIsOneReadingTest {
         return BoundaryTarget.at(
                 new BorderQuantity.OfACoordinate(axis,
                         new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrders.itself(WHOLE)),
+                        TermOrdersFixtures.itself(WHOLE)),
                 at(value));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneBorderReadTwiceIsOneReadingTest.java
@@ -175,10 +175,10 @@ class OneBorderReadTwiceIsOneReadingTest {
     /** The same bound, with its line written as {@code at}. */
     private static Border boundAt(Count at) {
         AxisId axis = new AxisId("weigh", "w.a");
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(TermPath.of(axis.term()));
         return Border.at(BoundaryTarget.at(
-                        new BorderQuantity.OfACoordinate(axis,
-                                new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                                TermOrdersFixtures.itself(WHOLE)),
+                        new BorderQuantity.OfACoordinate(axis, term,
+                                TermOrdersFixtures.itself(term, WHOLE)),
                         new Level.OnACarrier(WHOLE, at)),
                 aBound(),
                 new NumericDomain.Bounds(Endpoint.inclusive(at),
@@ -200,10 +200,10 @@ class OneBorderReadTwiceIsOneReadingTest {
 
     private static BoundaryTarget aLineAt(String path, int value) {
         AxisId axis = new AxisId("weigh", path);
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(TermPath.of(axis.term()));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(axis,
-                        new NumericTerm.ValueOf(TermPath.of(axis.term())),
-                        TermOrdersFixtures.itself(WHOLE)),
+                new BorderQuantity.OfACoordinate(axis, term,
+                        TermOrdersFixtures.itself(term, WHOLE)),
                 at(value));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OrdersAreHeldBesideTheNumberTheyAreOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OrdersAreHeldBesideTheNumberTheyAreOfTest.java
@@ -49,6 +49,14 @@ class OrdersAreHeldBesideTheNumberTheyAreOfTest {
     }
 
     @Test
+    void norIsALineAComparisonDrew() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ComparedLine(CHARGE, Count.of(1), OF_THE_CEILING,
+                        new souther.compiler.check.ComparisonClaim.Cut(
+                                souther.compiler.numeric.Towards.BELOW, true)));
+    }
+
+    @Test
     void norIsACoordinateOfABorder() {
         assertThrows(IllegalArgumentException.class,
                 () -> new BorderQuantity.OfACoordinate(

--- a/souther-compiler/src/test/java/souther/compiler/partition/OrdersAreHeldBesideTheNumberTheyAreOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OrdersAreHeldBesideTheNumberTheyAreOfTest.java
@@ -1,0 +1,85 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A pair of orders held beside a number is held beside the number it is of.
+ *
+ * <p>Some readers cannot drop the number: a class of a count and a coordinate of a border are about
+ * a position's own number, which is the narrower kind of term, and the orders say which number they
+ * are of without saying that. Two components are two things to get right, and what this holds them
+ * to is that the second is refused where the value is made rather than carried into a document that
+ * reads one number against the order of another.
+ *
+ * <p>Where the number can be dropped it has been, and there is nothing to check: a reader holding
+ * only the orders is one this cannot be asked of.
+ */
+class OrdersAreHeldBesideTheNumberTheyAreOfTest {
+
+    private static final NumericTerm.ValueOf CHARGE =
+            new NumericTerm.ValueOf(TermPath.of("r").then("charge"));
+
+    private static final NumericTerm.ValueOf CEILING =
+            new NumericTerm.ValueOf(TermPath.of("r").then("ceiling"));
+
+    private static final TermOrders OF_THE_CEILING =
+            TermOrdersFixtures.itself(CEILING, Carrier.WHOLE);
+
+    @Test
+    void aClassOfACountIsNotBuiltOnAnotherNumbersOrders() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Recognition.OfACount(CHARGE, OF_THE_CEILING,
+                        new Recognition.CountIs.At(Count.of(1))));
+
+        assertTrue(refused.getMessage().contains("charge")
+                && refused.getMessage().contains("ceiling"), refused.getMessage());
+    }
+
+    @Test
+    void norIsACoordinateOfABorder() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BorderQuantity.OfACoordinate(
+                        AxisId.of("weigh", CHARGE), CHARGE, OF_THE_CEILING));
+    }
+
+    /**
+     * And a table from a number to its orders is one whose entries are about their own keys.
+     *
+     * <p>The key set agreeing says the table is about the right numbers and says nothing about
+     * which of them each answer came from: a table with two ends swapped has exactly the same keys,
+     * and every check the form and the key set can make passes.
+     */
+    @Test
+    void norAreTheEntriesOfAFormsTable() {
+        Map<NumericTerm, TermOrders> swapped = Map.of(
+                CHARGE, OF_THE_CEILING,
+                CEILING, TermOrdersFixtures.itself(CHARGE, Carrier.WHOLE));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new BorderQuantity.OverAForm("weigh",
+                        new souther.compiler.numeric.NumericDomain.LinearForm<>(
+                                java.math.BigDecimal.ZERO,
+                                Map.of(CHARGE, java.math.BigDecimal.ONE,
+                                        CEILING, java.math.BigDecimal.ONE.negate())),
+                        swapped));
+    }
+
+    /** And the pair says which number it is of, which is what all of the above read. */
+    @Test
+    void theOrdersSayWhichNumberTheyAreOf() {
+        assertEquals(CEILING, OF_THE_CEILING.term());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -229,7 +229,7 @@ class ThresholdNormalizationTest {
 
         NumericDomain.Bounds within = read.reading().runsBetween(cost.term());
         assertNotNull(within, "the invariant's domain is what this asks the obligations about");
-        List<String> described = pointsAgainstTheLines(cost, read.symbols(), within);
+        List<String> described = pointsAgainstTheLines(cost, read.reading(), within);
 
         assertTrue(described.contains("ON 100000"), described.toString());
         assertTrue(described.contains("OFF 100001"), described.toString());
@@ -274,7 +274,7 @@ class ThresholdNormalizationTest {
         assertEquals(List.of("Prospecting", "Qualified", "Won"), labels(stage),
                 "the cut is the coarser partition, so the classes stay the cases");
 
-        List<String> described = pointsAgainstTheLines(stage, read.symbols(),
+        List<String> described = pointsAgainstTheLines(stage, read.reading(),
                 read.reading().runsBetween(stage.term()));
         assertEquals(List.of("ON Prospecting", "OFF Qualified"), described);
     }
@@ -306,15 +306,16 @@ class ThresholdNormalizationTest {
 
         NumericDomain.Bounds within = read.reading().runsBetween(amount.term());
         assertNotNull(within, "the invariant's domain is what this asks the obligations about");
-        List<String> described = pointsAgainstTheLines(amount, read.symbols(), within);
+        List<String> described = pointsAgainstTheLines(amount, read.reading(), within);
         assertTrue(described.contains("OFF 3000"), described.toString());
         assertTrue(described.contains("ON 2999"), described.toString());
     }
 
     /** The points against each of {@code axis}'s borders, as {@code role value}. */
-    private static List<String> pointsAgainstTheLines(Axis axis, Symbols symbols,
+    private static List<String> pointsAgainstTheLines(Axis axis,
+                                                      souther.compiler.inputs.Quantities reading,
                                                       NumericDomain.Bounds within) {
-        return Partitions.bordersOf(axis, symbols, within, new LinesRead()).stream()
+        return Partitions.bordersOf(axis, reading, within, new LinesRead()).stream()
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)
                         .map(role -> role + " "

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -34,6 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhatAClauseDrawsALineOnTest {
 
+    /** The number the line below is on, which its orders are the orders of. */
+    private static final souther.compiler.inputs.NumericTerm.ValueOf AT_ID =
+            new souther.compiler.inputs.NumericTerm.ValueOf(
+                    souther.compiler.inputs.TermPath.of("id"));
+
     /** The lines one behavior's clauses draw, through the readings a report is built from. */
     private static EnsuresThresholds.Clauses drawn(String source, String behavior) {
         Compilation compilation = Compilation.ofSource(source, "Main");
@@ -280,10 +285,9 @@ class WhatAClauseDrawsALineOnTest {
         assertEquals(1, clauses.singled().size(), clauses.singled().toString());
         Border singled = Border.at(BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(
-                                new AxisId("findTodo", "id"),
-                                new souther.compiler.inputs.NumericTerm.ValueOf(
-                                        souther.compiler.inputs.TermPath.of("id")),
-                                souther.compiler.inputs.TermOrdersFixtures.itself(new Carrier.Whole())),
+                                new AxisId("findTodo", "id"), AT_ID,
+                                souther.compiler.inputs.TermOrdersFixtures
+                                        .itself(AT_ID, new Carrier.Whole())),
                         new Level.OnACarrier(new Carrier.Whole(),
                                 clauses.singled().get(0).value())),
                 clauses.singled().get(0).origin(), null);

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -283,7 +283,7 @@ class WhatAClauseDrawsALineOnTest {
                                 new AxisId("findTodo", "id"),
                                 new souther.compiler.inputs.NumericTerm.ValueOf(
                                         souther.compiler.inputs.TermPath.of("id")),
-                                souther.compiler.inputs.TermOrders.itself(new Carrier.Whole())),
+                                souther.compiler.inputs.TermOrdersFixtures.itself(new Carrier.Whole())),
                         new Level.OnACarrier(new Carrier.Whole(),
                                 clauses.singled().get(0).value())),
                 clauses.singled().get(0).origin(), null);

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
@@ -193,7 +193,7 @@ class WhatARuleOnAStringIsMeasuredAtTest {
                         : made.stream().map(FixtureTemplate::text)
                                 .map(WhatARuleOnAStringIsMeasuredAtTest::bare).toList().toString());
             }
-            Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()), new LinesRead())
+            Partitions.bordersOf(axis, reading, reading.runsBetween(axis.term()), new LinesRead())
                     .forEach(border -> border.answers().keySet().stream()
                             .filter(DomainPoint::againstTheLine)
                             .filter(point -> border.demand(point).criterion() != null)

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
@@ -53,7 +53,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     /** The two orders an hour of a time stands on: seconds of a day at the position, a count by one
      *  for what the operation answers. */
     private static final souther.compiler.inputs.TermOrders AS_AN_HOUR =
-            new souther.compiler.inputs.TermOrders(Carrier.TIME, Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.orders(Carrier.TIME, Carrier.WHOLE);
 
     /**
      * Numbers the operation actually answers, which is where its own bound runs.
@@ -124,7 +124,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
             NumericTerm.TakenOf term = NumericTerm.TakenOf.of(
                     (ValueName.Stdlib) operation, AT, source, SYMBOLS);
             assertNotNull(term, operation + " is taken of what its own signature says it takes");
-            souther.compiler.inputs.TermOrders orders = term.ordersAt(source, SYMBOLS);
+            souther.compiler.inputs.TermOrders orders =
+                    souther.compiler.inputs.TermOrdersFixtures.at(term, source, SYMBOLS);
             assertNotNull(orders.answered(),
                     operation + " answers a number, so there is an order for it");
             for (long each : answerable(term)) {
@@ -170,7 +171,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
             NumericTerm.TakenOf term = NumericTerm.TakenOf.of(
                     (ValueName.Stdlib) operation, AT, source, SYMBOLS);
             assertNotNull(term, operation + " is taken of what its own signature says it takes");
-            souther.compiler.inputs.TermOrders orders = term.ordersAt(source, SYMBOLS);
+            souther.compiler.inputs.TermOrders orders =
+                    souther.compiler.inputs.TermOrdersFixtures.at(term, source, SYMBOLS);
             for (long each : answerable(term)) {
                 assertInstanceOf(TermRealizations.Realization.Built.class,
                         TermRealizations.at(new RealizationTarget.AtOnePosition(term), source,
@@ -194,7 +196,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     void whatEachAccountAnswersIsWhatTheLibraryAnswers() {
         assertEquals(Count.of(1),
                 number(term("String", "length").read(new ObservedValue.Text("😀"),
-                        new souther.compiler.inputs.TermOrders(Carrier.TEXT, Carrier.WHOLE))),
+                        souther.compiler.inputs.TermOrdersFixtures.orders(
+                                Carrier.TEXT, Carrier.WHOLE))),
                 "a string counts in code points, and one emoji is one of them");
         assertEquals(Count.of(13),
                 number(term("Time", "hour").read(
@@ -216,13 +219,17 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
      */
     @Test
     void whatATakenNumberIsMeasuredByIsTheOperationsResult() {
-        assertEquals(Carrier.WHOLE, term("Time", "hour").answeredOn(Type.Prim.TIME, SYMBOLS),
-                "an hour is counted by one");
-        assertEquals(Carrier.TIME, term("Time", "hour").observedOn(Type.Prim.TIME, SYMBOLS),
+        souther.compiler.inputs.TermOrders anHour = souther.compiler.inputs.TermOrdersFixtures
+                .at(term("Time", "hour"), Type.Prim.TIME, SYMBOLS);
+        souther.compiler.inputs.TermOrders aLength = souther.compiler.inputs.TermOrdersFixtures
+                .at(term("String", "length"), Type.STRING, SYMBOLS);
+
+        assertEquals(Carrier.WHOLE, anHour.answered(), "an hour is counted by one");
+        assertEquals(Carrier.TIME, anHour.observed(),
                 "while the value it is read off counts the seconds of its day");
-        assertEquals(Carrier.WHOLE, term("String", "length").answeredOn(Type.STRING, SYMBOLS),
+        assertEquals(Carrier.WHOLE, aLength.answered(),
                 "and a count is whole however the thing counted is ordered");
-        assertEquals(Carrier.TEXT, term("String", "length").observedOn(Type.STRING, SYMBOLS),
+        assertEquals(Carrier.TEXT, aLength.observed(),
                 "while what is read at the position is still a string");
     }
 
@@ -243,7 +250,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
                 number(hour.read(new ObservedValue.Temporal("13:00:00"), AS_AN_HOUR)));
         assertInstanceOf(NumericTerm.Reading.NotNumber.class,
                 hour.read(new ObservedValue.Temporal("13:00:00"),
-                        souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                        souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
                 "and read on the order the answer is measured on — which is what a caller handing"
                         + " one carrier used to be able to do — the same value reads as no number at"
                         + " all");
@@ -274,7 +281,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
         ValueName.Stdlib operation = DefaultStdlib.get().operation(qualified);
         NumericTerm.TakenOf term = NumericTerm.TakenOf.of(operation, AT, source, SYMBOLS);
         assertNotNull(term, qualified + " is taken of what its own signature says it takes");
-        souther.compiler.inputs.TermOrders orders = term.ordersAt(source, SYMBOLS);
+        souther.compiler.inputs.TermOrders orders =
+                    souther.compiler.inputs.TermOrdersFixtures.at(term, source, SYMBOLS);
         for (long each : numbers) {
             Place asked = Count.of(each);
             TermRealizations.Realization made =

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
@@ -53,7 +53,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     /** The two orders an hour of a time stands on: seconds of a day at the position, a count by one
      *  for what the operation answers. */
     private static final souther.compiler.inputs.TermOrders AS_AN_HOUR =
-            souther.compiler.inputs.TermOrdersFixtures.orders(Carrier.TIME, Carrier.WHOLE);
+            souther.compiler.inputs.TermOrdersFixtures.orders(
+                    term("Time", "hour"), Carrier.TIME, Carrier.WHOLE);
 
     /**
      * Numbers the operation actually answers, which is where its own bound runs.
@@ -140,7 +141,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
                 }
                 for (FixtureTemplate value : built.values()) {
                     assertEquals(new NumericTerm.Reading.Number(asked),
-                            term.read(observed(value), orders),
+                            orders.read(observed(value)),
                             operation + " built " + value.text() + " for " + each
                                     + ", and it does not read back as that");
                     checked++;
@@ -195,17 +196,15 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     @Test
     void whatEachAccountAnswersIsWhatTheLibraryAnswers() {
         assertEquals(Count.of(1),
-                number(term("String", "length").read(new ObservedValue.Text("😀"),
-                        souther.compiler.inputs.TermOrdersFixtures.orders(
-                                Carrier.TEXT, Carrier.WHOLE))),
+                number(souther.compiler.inputs.TermOrdersFixtures.orders(
+                        term("String", "length"), Carrier.TEXT, Carrier.WHOLE)
+                        .read(new ObservedValue.Text("😀"))),
                 "a string counts in code points, and one emoji is one of them");
         assertEquals(Count.of(13),
-                number(term("Time", "hour").read(
-                        new ObservedValue.Temporal("13:45:12"), AS_AN_HOUR)),
+                number(AS_AN_HOUR.read(new ObservedValue.Temporal("13:45:12"))),
                 "a quarter to two in the afternoon falls in the thirteenth hour");
         assertEquals(Count.of(0),
-                number(term("Time", "hour").read(
-                        new ObservedValue.Temporal("00:45:12"), AS_AN_HOUR)),
+                number(AS_AN_HOUR.read(new ObservedValue.Temporal("00:45:12"))),
                 "and three quarters of an hour past midnight falls in the noughth");
     }
 
@@ -247,10 +246,10 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     void theOrderAValueIsReadOnIsNotTheOrderItsAnswerIsMeasuredOn() {
         NumericTerm.FromOnePosition hour = term("Time", "hour");
         assertEquals(Count.of(13),
-                number(hour.read(new ObservedValue.Temporal("13:00:00"), AS_AN_HOUR)));
+                number(AS_AN_HOUR.read(new ObservedValue.Temporal("13:00:00"))));
         assertInstanceOf(NumericTerm.Reading.NotNumber.class,
-                hour.read(new ObservedValue.Temporal("13:00:00"),
-                        souther.compiler.inputs.TermOrdersFixtures.itself(Carrier.WHOLE)),
+                souther.compiler.inputs.TermOrdersFixtures.itself(hour, Carrier.WHOLE)
+                        .read(new ObservedValue.Temporal("13:00:00")),
                 "and read on the order the answer is measured on — which is what a caller handing"
                         + " one carrier used to be able to do — the same value reads as no number at"
                         + " all");
@@ -293,7 +292,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
                     qualified + " answers " + each + " of some date, so there is one to offer");
             for (FixtureTemplate value : built.values()) {
                 assertEquals(new NumericTerm.Reading.Number(asked),
-                        term.read(observed(value), orders),
+                        orders.read(observed(value)),
                         qualified + " built " + value.text() + " for " + each
                                 + ", and it does not read back as that");
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
@@ -132,7 +132,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
             for (long each : answerable(term)) {
                 Place asked = Count.of(each);
                 TermRealizations.Realization made =
-                        TermRealizations.at(new RealizationTarget.AtOnePosition(term), source,
+                        TermRealizations.at(source,
                                 orders, asked, NothingTheRulesSay.REGION, SYMBOLS, POLICY);
                 // An operation that builds nothing at a number is not a failure of this: whether
                 // anything answers it is `EveryAnswerItCanGiveHasASourceValue`, asked below.
@@ -176,7 +176,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
                     souther.compiler.inputs.TermOrdersFixtures.at(term, source, SYMBOLS);
             for (long each : answerable(term)) {
                 assertInstanceOf(TermRealizations.Realization.Built.class,
-                        TermRealizations.at(new RealizationTarget.AtOnePosition(term), source,
+                        TermRealizations.at(source,
                                 orders, Count.of(each), NothingTheRulesSay.REGION, SYMBOLS,
                                 POLICY),
                         operation + " says every number it answers is one some value answers, and"
@@ -285,7 +285,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
         for (long each : numbers) {
             Place asked = Count.of(each);
             TermRealizations.Realization made =
-                    TermRealizations.at(new RealizationTarget.AtOnePosition(term), source,
+                    TermRealizations.at(source,
                             orders, asked, NothingTheRulesSay.REGION, SYMBOLS, POLICY);
             TermRealizations.Realization.Built built = assertInstanceOf(
                     TermRealizations.Realization.Built.class, made,

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -271,9 +271,10 @@ class WhichReadingComposesTheRowALineIsOwedTest {
 
     /** Where a line was read: one position of one behavior, cut at one value. */
     private static BoundaryTarget aLineAt(String behavior, String path) {
+        NumericTerm.ValueOf term = new NumericTerm.ValueOf(TermPath.of(path));
         return BoundaryTarget.at(
-                new BorderQuantity.OfACoordinate(new AxisId(behavior, path),
-                        new NumericTerm.ValueOf(TermPath.of(path)), TermOrdersFixtures.itself(WHOLE)),
+                new BorderQuantity.OfACoordinate(new AxisId(behavior, path), term,
+                        TermOrdersFixtures.itself(term, WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(1)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.partition.AxisId;
@@ -273,7 +273,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     private static BoundaryTarget aLineAt(String behavior, String path) {
         return BoundaryTarget.at(
                 new BorderQuantity.OfACoordinate(new AxisId(behavior, path),
-                        new NumericTerm.ValueOf(TermPath.of(path)), TermOrders.itself(WHOLE)),
+                        new NumericTerm.ValueOf(TermPath.of(path)), TermOrdersFixtures.itself(WHOLE)),
                 new Level.OnACarrier(WHOLE, Count.of(1)));
     }
 


### PR DESCRIPTION
Closes #1198.

`NumericTerm` answered what a number is measured on for any type it was handed, so a term plus a
type a caller happened to hold compiled and answered — about wherever that type came from, and about
no reading in particular. #1190 made `Quantities.ordersOf` the one public answer; this takes away the
capability that let the defect be written, and then the capability behind it.

## Two halves of one invariant

Closing who may **derive** a pair of orders does not close who may **pair** one with a number. A
`TermOrders` was two carriers and said nothing about which term it was of, so every place it
travelled beside one was an association held by convention — nineteen declarations, at each of which
`Recognition.OfACount(termA, ordersOfTermB, is)` compiled.

**Deriving.** The derivation is now `TermOrdering` in `souther.compiler.inputs`, package-private,
with one production caller: the reading that resolved where the term stands. `NumericTerm` loses
`answeredOn`, `observedOn`, `ordersAt` and `intervals`.

**Pairing.** `TermOrders` carries its term. The mint already had it — one construction — so the
value costs nothing there, and `itself` goes with the arm it existed for. Where the number was a
second spelling it is gone: `GuardThresholds.Named` holds the orders and reads the term off them,
and `BorderQuantity.Apart` and `ComparedTerms` hold two of them and no parallel table, which is what
had let a map's keys name the right pair with its values the other way round. Where the shape needs
the narrower kind of term, the constructor refuses a pair of another number's. Equality takes the
term in: two carriers that come to the same pair are answers to two questions.

Reading moves off the term for the same reason — it takes a term and orders, so an entry taking both
is the same pairing one layer along. The machinery is package-private and the way in is
`TermOrders.read`, asked of an answer that already says which term it is of.

## What the consumers do

Every consumer that can reach the reading asks it. `Partitions`, `Intervals`, `Cutting.movedTo` and
`Generator` did not need a new value to be handed one — each already held the reading it belongs to.
`Cutting.movedTo` was being handed the reading and the answer in the same call.

`Axis` loses its `Type`. Both places that built one took it from the position account they were
already holding, and `PositionMeasurements` checked the copy against that same account. The check
goes with the field, and so does the test for it.

`Generator`'s two edge arms are one. Nothing carries an order to the search any more — `Edge.on`,
`builtOn`, the `Carrier` argument of `edgeAt`, the per-term carrier function of `probeFixing` and
`Coverages.Probe.attempt`, and the orders argument of `readsElsewhere` are gone. Unifying the arms
also stops a measure standing in for the walk that says where a value can be written:
`typeAtWrittenPath` returning null is now `NOTHING_COMPOSES_ONE` whether or not the number has an
axis.

## Measured before flipping

Every flip was measured over the whole suite first, each with a negative control that fed the same
comparison a value known to be wrong and saw it reported.

| what | population | disagreements |
| --- | --- | --- |
| the type a measure holds vs the type the reading resolved | 1,826 measures / 5,785 axes | 0 |
| a cut's carrier vs the order the reading answers with | 10,312 cuts | 0 |
| the axis's type vs the write walk | 13,002 searches / 5,785 axes | 0 null, 0 differ |
| the carrier handed to `probeFixing` vs the reading's | 5,095 pairs, 17,369 calls | 0 |
| the orders handed to `readsElsewhere` vs the reading's | 5,039 pairs, 17,608 calls | 0, and the lookup never missed |

## What holds it

`OneReadingAnswersWhatATermIsMeasuredOnTest` counts, off the class files, the production places that
work a term's orders out from a type and the places that make a pair — the constructor and any
factory beside it, separately, so one moved to the other does not go on passing — and asks the class
whether the way in is still shut. Three checks because none covers the others: visibility says who
may call, not how many places inside the package do; a count of the derivation says nothing about a
constructor somebody widened. Each was confirmed by writing the second place and watching the right
one fail, including a call split across lines that a search of the sources cannot see.

`OrdersAreHeldBesideTheNumberTheyAreOfTest` holds the constructors that still carry a term to
refusing another number's orders, and a form's table to its entries rather than only its keys.

The conformance corpus answers are the ones checked in, unchanged.

## Beside it

The tests that describe a synthetic border reach the constructor through a bridge in the same
package under their own source set — one in `souther-compiler`, one in `souther-cli`. A Maven module
is not a package boundary, so this needs no test-jar dependency, and nothing that ships can mint a
pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
