### PR TITLE
Answer for a call by the identity it carries

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
@@ -1,0 +1,68 @@
+package souther.compiler.program;
+
+/**
+ * What a call to a behavior reaches: what it takes and answers, and where its implementation comes
+ * from.
+ *
+ * <p>What a caller needs and no more. A call carries the identity resolution gave it, and an output
+ * emitting one has to know what to hand over, what comes back, and whether what it emits is a call
+ * into what it is emitting, a call into something built elsewhere, or a crossing to an
+ * implementation supplied from outside Souther. None of that is the callee's body: an output
+ * emitting a behavior's implementation reaches it by walking {@link CheckedProgram#modules()},
+ * which is a different question with a different answer.
+ *
+ * <p>So this is answered for a behavior of a module this compile read off the path as much as for
+ * one of its own. That module is not among {@link CheckedProgram#modules()} — this compile did not
+ * check it — but its declarations were read here, because a body naming one had to be checked
+ * against them.
+ *
+ * <p>Where the two readings of what a behavior takes are held to each other. A signature says the
+ * inputs as types and a body says the bindings they arrive in, and lists of different lengths would
+ * make reading them as one parameter wrong at some index rather than refused. Held here rather than
+ * beside a behavior of a checked module, so that a target is a call boundary that cannot say two
+ * things wherever one is made.
+ *
+ * <p>A class and not a record. What a call boundary is known to be will grow — what a caller may
+ * assume of the answer is a decision this compilation does not make for a behavior another module
+ * declared ({@link souther.compiler.core.EnsuresEnforcement.NotDecidedHere}) — and each of those
+ * arrives as a question a reader asks rather than as a place in a constructor every existing reader
+ * would have to be recompiled against.
+ */
+public final class BehaviorTarget {
+
+    private final CheckedSignature signature;
+    private final CheckedImplementation implementation;
+
+    BehaviorTarget(CheckedSignature signature, CheckedImplementation implementation) {
+        if (signature == null || implementation == null) {
+            throw new IllegalArgumentException(
+                    "a call boundary is what it takes and answers and where its implementation"
+                            + " comes from");
+        }
+        if (implementation instanceof CheckedImplementation.Body body
+                && body.parameters().size() != signature.takes().size()) {
+            // Said with both readings written out. The identity a caller asks with is not here —
+            // it is what this is filed under — so what tells the two apart is what each of them
+            // says the behavior takes.
+            throw new IllegalArgumentException("a behavior declared " + signature
+                    + " has a body binding " + body.parameters());
+        }
+        this.signature = signature;
+        this.implementation = implementation;
+    }
+
+    /** What it takes and what it answers, as the check settled them. */
+    public CheckedSignature signature() {
+        return signature;
+    }
+
+    /** Where the implementation comes from. */
+    public CheckedImplementation implementation() {
+        return implementation;
+    }
+
+    @Override
+    public String toString() {
+        return signature + " " + implementation;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
@@ -4,17 +4,23 @@ package souther.compiler.program;
  * What a call to a behavior reaches: what it takes and answers, and where its implementation comes
  * from.
  *
- * <p>What a caller needs and no more. A call carries the identity resolution gave it, and an output
+ * <p>What a caller has to know. A call carries the identity resolution gave it, and an output
  * emitting one has to know what to hand over, what comes back, and whether what it emits is a call
  * into what it is emitting, a call into something built elsewhere, or a crossing to an
- * implementation supplied from outside Souther. None of that is the callee's body: an output
- * emitting a behavior's implementation reaches it by walking {@link CheckedProgram#modules()},
- * which is a different question with a different answer.
+ * implementation supplied from outside Souther.
  *
- * <p>So this is answered for a behavior of a module this compile read off the path as much as for
- * one of its own. That module is not among {@link CheckedProgram#modules()} — this compile did not
- * check it — but its declarations were read here, because a body naming one had to be checked
- * against them.
+ * <p>Answered for a behavior of a module this compile read off the path as much as for one of its
+ * own. That module is not among {@link CheckedProgram#modules()} — this compile did not check it —
+ * but its declarations were read here, because a body naming one had to be checked against them.
+ *
+ * <p>One value and not a reading of one. This is what a behavior of a checked module holds too
+ * ({@link CheckedBehavior#signature}, {@link CheckedBehavior#implementation}), so a behavior
+ * written here says what it takes and where its implementation comes from once, whether it is
+ * reached through the module being emitted or through the identity a call carries. What follows is
+ * that a target for a behavior written here carries the implementation itself — a
+ * {@link CheckedImplementation.Body} holds the Core the checker typed — which a caller has no use
+ * for and does not look at. Cut to what a caller reads, it would be a second value made from this
+ * one, and the two would say the same thing until either was made from something else.
  *
  * <p>Where the two readings of what a behavior takes are held to each other. A signature says the
  * inputs as types and a body says the bindings they arrive in, and lists of different lengths would

--- a/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/BehaviorTarget.java
@@ -60,9 +60,4 @@ public final class BehaviorTarget {
     public CheckedImplementation implementation() {
         return implementation;
     }
-
-    @Override
-    public String toString() {
-        return signature + " " + implementation;
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedBehavior.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedBehavior.java
@@ -6,8 +6,19 @@ import souther.compiler.types.ValueName;
 import java.util.List;
 
 /**
- * One behavior of a checked module: what it is called, what it takes and answers, and where its
- * implementation comes from.
+ * One behavior of a checked module: what it is called, what it takes and answers, where its
+ * implementation comes from, what it declares of its answer, and what its examples said.
+ *
+ * <p>The first three are its {@link BehaviorTarget}, which is what a call to it reaches and what
+ * {@link CheckedProgram#behavior} answers with. Read through here as well, because a reader
+ * emitting this module has the behavior in hand and would otherwise ask the program for what it is
+ * already holding. It is the same value both ways: what a behavior takes and answers is one fact of
+ * the program, not one per route to it.
+ *
+ * <p>The rest is here and nowhere else, and that is why a call is not answered with one of these. A
+ * behavior a module on the path declares is reached by calls in this program and its rows were
+ * never read here — handed over as a behavior with no rows it would read as one nothing says what
+ * it owes, which is a different program.
  *
  * <p>A class and not a record. What a checked behavior is known to be will grow — what it requires,
  * what it declares cannot arrive — and each of those is something a reader asks for rather than a
@@ -16,26 +27,14 @@ import java.util.List;
 public final class CheckedBehavior {
 
     private final ValueName.Behavior name;
-    private final CheckedSignature signature;
-    private final CheckedImplementation implementation;
+    private final BehaviorTarget target;
     private final EnsuresEnforcement ensures;
     private final List<CheckedRow> rows;
 
-    CheckedBehavior(ValueName.Behavior name, CheckedSignature signature,
-                    CheckedImplementation implementation, EnsuresEnforcement ensures,
+    CheckedBehavior(ValueName.Behavior name, BehaviorTarget target, EnsuresEnforcement ensures,
                     List<CheckedRow> rows) {
-        // The one place the two readings of what a behavior takes meet, and so the one place they
-        // are held to each other. A signature says the inputs as types and a body says the bindings
-        // they arrive in; a reader is offered them as one parameter at each index, and lists of
-        // different lengths would make that reading wrong at some index rather than refused.
-        if (implementation instanceof CheckedImplementation.Body body
-                && body.parameters().size() != signature.takes().size()) {
-            throw new IllegalArgumentException("`" + name.module() + "." + name.name() + "` takes "
-                    + signature.takes().size() + " and its body binds " + body.parameters().size());
-        }
         this.name = name;
-        this.signature = signature;
-        this.implementation = implementation;
+        this.target = target;
         this.ensures = ensures;
         this.rows = List.copyOf(rows);
     }
@@ -53,12 +52,24 @@ public final class CheckedBehavior {
 
     /** What it takes and what it answers, as the check settled them. */
     public CheckedSignature signature() {
-        return signature;
+        return target.signature();
     }
 
     /** Where the implementation comes from. */
     public CheckedImplementation implementation() {
-        return implementation;
+        return target.implementation();
+    }
+
+    /**
+     * The call boundary this behavior is reached by, which is the one
+     * {@link CheckedProgram#behavior} answers with.
+     *
+     * <p>The same value and not a copy. What a behavior takes, answers, and where its
+     * implementation comes from is one fact of the program, and a call to it reaches that fact
+     * whether it is reached through the module being emitted or through the identity it carries.
+     */
+    BehaviorTarget target() {
+        return target;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
@@ -17,8 +17,8 @@ import java.util.List;
  * <p>Each state, and not a body that may be absent. A composition is an implementation (spec
  * §sequential-composition) and has no body; so is an implementation another compile emitted. A
  * reader given {@code Optional<Core>} would find nothing there and have to decide what nothing
- * meant, and the three things it can mean are different programs. Nothing here has to be recovered
- * from a second fact.
+ * meant, and every arm below but one is something it can mean — each of them a different program.
+ * Nothing here has to be recovered from a second fact.
  */
 public sealed interface CheckedImplementation {
 

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
@@ -35,10 +35,10 @@ public sealed interface CheckedImplementation {
      *
      * <p>The binders and not the types. A type here would be a second reading of what
      * {@link CheckedSignature} already answers, and the two would agree until either moved.
-     * {@link CheckedBehavior} is where they are held to the same length, which is what makes
+     * {@link BehaviorTarget} is where they are held to the same length, which is what makes
      * reading them as one parameter safe.
      *
-     * <p>Here and not on {@link CheckedBehavior}, because a binder exists exactly where a body
+     * <p>Here and not on {@link BehaviorTarget}, because a binder exists exactly where a body
      * does. An injected behavior takes inputs and has no body to bind them in, an unwritten one has
      * none either, and a composition applies its first stage to what it was given. Answering this
      * for any of them would be answering a question that has no answer.

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
@@ -6,12 +6,19 @@ import souther.compiler.core.Core;
 import java.util.List;
 
 /**
- * Where a behavior's implementation comes from, in the four states a checked module has them in.
+ * Where a behavior's implementation comes from, as this checked program can state it.
  *
- * <p>Four and not a body that may be absent. A composition is an implementation (spec
- * §sequential-composition) and has no body: a reader given {@code Optional<Core>} would find nothing
- * there and have to decide what nothing meant, and the two things it can mean — composed, and not
- * written yet — are different programs. Nothing here has to be recovered from a second fact.
+ * <p>Answered for every behavior this compile read the declaration of, which is wider than the
+ * modules it checked: a body may call a behavior a module on the path declares, and what an output
+ * emitting that call needs is this. So the states are not the ones a checked module's behaviors are
+ * in — {@link ImplementedElsewhere} is none of them — but the ones a snapshot can say a behavior's
+ * implementation is in.
+ *
+ * <p>Each state, and not a body that may be absent. A composition is an implementation (spec
+ * §sequential-composition) and has no body; so is an implementation another compile emitted. A
+ * reader given {@code Optional<Core>} would find nothing there and have to decide what nothing
+ * meant, and the three things it can mean are different programs. Nothing here has to be recovered
+ * from a second fact.
  */
 public sealed interface CheckedImplementation {
 
@@ -66,4 +73,19 @@ public sealed interface CheckedImplementation {
     /** Souther's to write, and not written (spec §unwritten-behavior). Nothing that would need the
      *  body it has not got is emitted. */
     record Unwritten() implements CheckedImplementation {}
+
+    /**
+     * Implemented, and the implementation is not this snapshot's: the module that declares it was
+     * read off the path, and the build that published it emitted the implementation already.
+     *
+     * <p>What a call to one reaches is written, so a caller has a callee rather than a crossing to
+     * something supplied from outside. What is not here is the {@link Core} or the
+     * {@link Composition} it is written as — that belongs to the compile that checked it, and a
+     * second one emitted under the same name would be two definitions of one behavior.
+     *
+     * <p>Says nothing about how a call to it is reached on some machine. Whether an output links
+     * the implementation in, calls across a module boundary, or imports it is that output's answer,
+     * for the reason a class name and a Wasm block are not decided here.
+     */
+    record ImplementedElsewhere() implements CheckedImplementation {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
@@ -57,9 +57,32 @@ public final class CheckedModule {
         return behaviors;
     }
 
-    /** The behavior {@code name} reaches, or null where it is not one of this module's. */
+    /**
+     * The whole of what this module's behavior {@code name} was checked to be.
+     *
+     * <p>Never a null and never an absence to interpret. Which behaviors this module declares is
+     * decided before this is made, so a name it has nothing for is a reader asking this module
+     * about a behavior of somewhere else — a mistake at the reader rather than a state of the
+     * program, and answering it with an absence reads as "no such behavior" for a behavior that
+     * exists and is declared elsewhere.
+     *
+     * <p>What a call to a behavior reaches, wherever it is declared, is
+     * {@link CheckedProgram#behavior}. This is for a reader that is emitting this module and wants
+     * what only its own compile knows: what the behavior declares of its answer, and what its
+     * examples said.
+     *
+     * @throws IllegalArgumentException where this module declares no behavior {@code name}
+     */
     public CheckedBehavior behavior(ValueName.Behavior name) {
-        return behaviourByName.get(name);
+        if (name == null) {
+            throw new IllegalArgumentException("a behavior is asked for by its identity");
+        }
+        CheckedBehavior behavior = behaviourByName.get(name);
+        if (behavior == null) {
+            throw new IllegalArgumentException("`" + this.name + "` declares no behavior `" + name
+                    + "`; the behaviors it declares are " + behaviors);
+        }
+        return behavior;
     }
 
     /** The helpers this module emits as definitions of their own. */

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -5,6 +5,7 @@ import souther.compiler.core.KernelSignature;
 import souther.compiler.core.KernelSignatures;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,8 +50,15 @@ import java.util.Objects;
  * with stops being named by the thing that asks.
  *
  * <p>Only the modules this compile checked are here. A checked body may name a behavior a module
- * read off the path declares, and that module is not among {@link #modules()}: what the body
- * carries is the identity resolution gave it, and a call carries no signature and no body.
+ * read off the path declares, and that module is not among {@link #modules()}: nothing of it is
+ * emitted by an output emitting this program, because the build that published it emitted it
+ * already.
+ *
+ * <p>What a call to such a behavior reaches is another question, and {@link #behavior} answers it.
+ * A call carries the identity resolution gave it and nothing else, and what an output emitting the
+ * call needs — what the behavior takes, what it answers, and where its implementation comes from —
+ * is asked with that identity. This compile read those declarations to check the body that names
+ * one, so what is handed over is the reading the checker itself used.
  *
  * <p>What a name is a declaration of is another question, and it is asked with the identity rather
  * than through whoever declared it. {@link #declaration} answers what a value of that data is made
@@ -59,11 +67,13 @@ import java.util.Objects;
  * that names them, and an output laying such a value out needs exactly what the checker read. Who
  * declared it comes with the answer and decides who emits it.
  *
- * <p>{@link #modules()} enumerates and {@link #declaration} resolves, and those are two questions.
- * What a module declares is what an output emitting that module has to emit; what an identity is a
- * declaration of is what an output laying out a value has to know. A reader made to pick the owner
- * before it could ask the second would be restating what its identity already carries — and where
- * the declaration is the language's there is no module of the compilation to pick at all.
+ * <p>{@link #modules()} enumerates and {@link #declaration} and {@link #behavior} resolve, and
+ * those are two questions. What a module declares and what its behaviors are is what an output
+ * emitting that module has to emit; what an identity is a declaration of, and what a call to one
+ * reaches, is what an output laying out a value or emitting a call has to know. A reader made to
+ * pick the owner before it could ask the second would be restating what its identity already
+ * carries — and where what it names was declared elsewhere there is no module of the compilation to
+ * pick at all.
  */
 public final class CheckedProgram {
 
@@ -80,6 +90,22 @@ public final class CheckedProgram {
      */
     private final Map<TypeSymbol.AtModule, Declared> declarations;
     /**
+     * The call boundary of every behavior this compile read the declaration of, by the identity a
+     * call to it carries.
+     *
+     * <p>Handed in rather than built here, which the index above is not. A target is made before
+     * the behavior that holds it: a row of a checked module states what it stood in for a
+     * dependency with, and where that dependency's arguments stand is read off the dependency's own
+     * target — so the targets are in hand before a module can be made at all. Built here from the
+     * modules instead, it would be a second reading of what a behavior takes, and the reading a row
+     * was written against would be the other one.
+     *
+     * <p>What holds the two together is that they are the same values. Every behavior of every
+     * module here is filed under its identity, and it is the target that behavior holds and not a
+     * copy of it.
+     */
+    private final Map<ValueName.Behavior, BehaviorTarget> behaviors;
+    /**
      * What each kernel of the language was declared to take and answer.
      *
      * <p>Held once for the program and not on the calls that reach one. Which operation a call
@@ -91,7 +117,8 @@ public final class CheckedProgram {
     private final KernelSignatures kernels;
 
     CheckedProgram(List<CheckedModule> modules, List<CheckedData> languageDeclarations,
-                   List<CheckedData> declaredOnThePath, KernelSignatures kernels) {
+                   List<CheckedData> declaredOnThePath,
+                   Map<ValueName.Behavior, BehaviorTarget> behaviors, KernelSignatures kernels) {
         this.modules = List.copyOf(modules);
         Map<String, CheckedModule> named = new LinkedHashMap<>();
         for (CheckedModule module : this.modules) {
@@ -117,6 +144,23 @@ public final class CheckedProgram {
         // data in an order and a reader listing them is shown one. A map that kept none would show
         // an order nothing decided, which can differ between two runs of one compiler.
         this.declarations = Collections.unmodifiableMap(index);
+        // No order is answered for: nothing here lists the behaviors of a program, and where one
+        // stands among the others is how the modules were given rather than something the language
+        // decided. What a reader does ask for is a behavior of a module, and a module answers that
+        // in the order it declared them.
+        this.behaviors = Map.copyOf(behaviors);
+        for (CheckedModule module : this.modules) {
+            for (CheckedBehavior behavior : module.behaviors()) {
+                // One fact, reached two ways. A behavior of a checked module is emitted through its
+                // module and called through its identity, and the two routes reaching different
+                // values is the state this whole index exists to make unwritable — so it is refused
+                // here rather than left to a reader to find the day the two disagree.
+                if (this.behaviors.get(behavior.name()) != behavior.target()) {
+                    throw new IllegalStateException("`" + behavior.name() + "` is called with a"
+                            + " boundary that is not the one its module holds");
+                }
+            }
+        }
         this.kernels = Objects.requireNonNull(kernels,
                 "a checked program is what the language it was checked with declares of its kernels");
     }
@@ -203,6 +247,40 @@ public final class CheckedProgram {
                     "nothing this compile read declares `" + name + "`");
         }
         return declared;
+    }
+
+    /**
+     * What a call to the behavior {@code name} reaches: what it takes, what it answers, and where
+     * its implementation comes from.
+     *
+     * <p>Asked with the identity a call carries ({@link souther.compiler.core.Core.Reaches.ABehavior}),
+     * which is what an output emitting that call holds. Whether the behavior is one of this
+     * compile's own or one a module it read off the path declares is answered here rather than
+     * decided by the reader: a call to either is emitted from the same three facts, and which of
+     * them the caller has to emit an implementation for is {@link CheckedImplementation}'s answer.
+     *
+     * <p>Never a null and never an absence to interpret. Every behavior declared by a module this
+     * compile checked or read off the path is here, whether or not anything in this program names
+     * it — a snapshot holding what one walk of the bodies reached would be right about the calls
+     * that walk thought to visit, and an output walking the same bodies again would be the second
+     * place that decided what belongs.
+     *
+     * <p>What this is total over is those declarations, and not every value the Java type admits.
+     * {@link ValueName.Behavior} is public, so an address nothing declares can be assembled; it is
+     * a mistake at the reader, refused here for the reason {@link #declaration} refuses one.
+     *
+     * @throws IllegalArgumentException where no module this compile read declares {@code name}
+     */
+    public BehaviorTarget behavior(ValueName.Behavior name) {
+        if (name == null) {
+            throw new IllegalArgumentException("a behavior is asked for by its identity");
+        }
+        BehaviorTarget target = behaviors.get(name);
+        if (target == null) {
+            throw new IllegalArgumentException(
+                    "no module this compile read declares the behavior `" + name + "`");
+        }
+        return target;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -149,17 +149,33 @@ public final class CheckedProgram {
         // decided. What a reader does ask for is a behavior of a module, and a module answers that
         // in the order it declared them.
         this.behaviors = Map.copyOf(behaviors);
+        // One fact, reached two ways, and held to that in both directions. A behavior of a checked
+        // module is emitted through its module and called through its identity: the two routes
+        // reaching different values is the state this index exists to make unwritable, and one
+        // route reaching a behavior the other has never heard of is the same disagreement said the
+        // other way round. Refused here rather than left to a reader to find.
+        int declaredHere = 0;
         for (CheckedModule module : this.modules) {
             for (CheckedBehavior behavior : module.behaviors()) {
-                // One fact, reached two ways. A behavior of a checked module is emitted through its
-                // module and called through its identity, and the two routes reaching different
-                // values is the state this whole index exists to make unwritable — so it is refused
-                // here rather than left to a reader to find the day the two disagree.
                 if (this.behaviors.get(behavior.name()) != behavior.target()) {
                     throw new IllegalStateException("`" + behavior.name() + "` is called with a"
                             + " boundary that is not the one its module holds");
                 }
+                declaredHere++;
             }
+        }
+        int callableHere = 0;
+        for (ValueName.Behavior called : this.behaviors.keySet()) {
+            if (byName.containsKey(called.module())) {
+                callableHere++;
+            }
+        }
+        // Every behavior of a checked module is above, so the two can differ only by a behavior
+        // this program can be called at that its own module does not declare. Counted rather than
+        // asked of the module, which would be this same question one behavior at a time.
+        if (callableHere != declaredHere) {
+            throw new IllegalStateException("this program is callable at " + callableHere
+                    + " behaviors of the modules it emits, which declare " + declaredHere);
         }
         this.kernels = Objects.requireNonNull(kernels,
                 "a checked program is what the language it was checked with declares of its kernels");

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -118,10 +118,16 @@ final class CheckedProgramAssembler {
     /**
      * Files the call boundary of every behavior {@code module} declares.
      *
-     * <p>Walked over what the module declares, and the two answers a boundary is made of are read
-     * under each name it declares. A walk of the signatures instead would let a behavior whose
-     * signature this compile failed to answer for leave the program without anything having missed
-     * it: what a module declares would be whatever the answer happened to hold.
+     * <p>What the module declares says which behaviors there are, and the answers this compile
+     * worked out say what each of them is — the same three readings a module on the path is read in
+     * ({@link #fileWhatIsOnThePath}), and read the same way here. A walk of the signatures instead
+     * would let a behavior whose signature this compile failed to answer for leave the program
+     * without anything having missed it: what a module declares would be whatever the answer
+     * happened to hold.
+     *
+     * <p>Both answers are read here, beside the name they belong to, and a missing one is refused
+     * here. Read further in, at the place that decides what an implementation is made of, a missing
+     * answer arrives where a state is being chosen — and it is chosen as one of them.
      */
     private static ModuleBoundaries fileWhatIsChecked(
             Map<ValueName.Behavior, BehaviorTarget> targets, ModuleReading module) {
@@ -129,16 +135,18 @@ final class CheckedProgramAssembler {
         for (Hir.BehaviorDef declared : module.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(module.name(), declared.name());
             Sig signature = module.signatures().get(declared.name());
-            if (signature == null) {
+            BehaviorImplementation state = module.implementations().get(declared.name());
+            if (signature == null || state == null) {
                 // The module was taken as checked and one of the behaviors it declares has no
-                // signature. A caller reaches it, so letting it through hands an output a call it
-                // cannot emit and says nothing about why.
+                // signature, or no reading of where its body comes from. A caller reaches it, so
+                // letting it through hands an output a call it cannot emit and says nothing about
+                // why.
                 throw new IllegalStateException("`" + named + "` was taken as checked and this"
-                        + " compile has nothing to say about what it takes");
+                        + " compile has no reading of it");
             }
             BehaviorTarget target = new BehaviorTarget(signatureOf(signature),
-                    implementationOf(named, declared, module.bodies(), module.implementations(),
-                            module.checked(), module.compositions()));
+                    implementedAs(state, named, declared, module.bodies(), module.checked(),
+                            module.compositions()));
             file(targets, named, target);
             declares.put(named, target);
         }
@@ -595,25 +603,20 @@ final class CheckedProgramAssembler {
      * it checked is implemented as, and a behavior published by another compile is read by
      * {@link #publishedAs}.
      *
-     * <p>Read in one place, from the state the declarations were read into and the form the check
-     * produced. A reader handed the two separately would be deciding for itself what an implemented
-     * behavior with no Core is, and it is a composition — which is a fact about the declaration and
-     * not something to infer from an absence.
+     * <p>Given the state rather than the table it is in, as {@link #publishedAs} is. What a
+     * behavior this compile has no reading of comes to is not a state to choose between here — it
+     * is a program with nothing to say about one of its own behaviors, said where a behavior's
+     * answers are read.
+     *
+     * <p>What is decided here is the form: the state says a body was written and the check says
+     * whether it settled a composition, and a reader handed the two separately would be deciding
+     * for itself what an implemented behavior with no Core is.
      */
-    private static CheckedImplementation implementationOf(
-            ValueName.Behavior named, Hir.BehaviorDef declared, Hir.Module lowered,
-            Map<String, BehaviorImplementation> implementations, Bodies.Elaborated checked,
+    private static CheckedImplementation implementedAs(
+            BehaviorImplementation state, ValueName.Behavior named, Hir.BehaviorDef declared,
+            Hir.Module lowered, Bodies.Elaborated checked,
             Map<ValueName.Behavior, Composition> compositions) {
         String name = declared.name();
-        BehaviorImplementation state = implementations.get(name);
-        if (state == null) {
-            // The module was taken as checked and this compile has no reading of where one of its
-            // behaviors gets its body. Read as unwritten it would be a behavior the author is owed
-            // a body for, which is a program of its own — and nothing would say the reading was
-            // missing rather than the body.
-            throw new IllegalStateException("`" + named + "` was taken as checked and this compile"
-                    + " has nothing to say about where its implementation comes from");
-        }
         return switch (state) {
             case UNIMPLEMENTED -> new CheckedImplementation.Unwritten();
             case INJECTION_TARGET -> new CheckedImplementation.Injected();
@@ -640,7 +643,7 @@ final class CheckedProgramAssembler {
      * a second place that knew so.
      *
      * <p>Sliced by what the behavior declares and not by how long its signature is. Sliced by the
-     * signature the two lengths would be equal by construction, and {@link CheckedBehavior}'s check
+     * signature the two lengths would be equal by construction, and {@link BehaviorTarget}'s check
      * of them would be comparing an answer with itself — the disagreement it is there to refuse
      * would arrive instead as a dependency's binder handed over as an input's.
      */

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Takes the snapshot: reads what the compiler decided and writes it down as a {@link
@@ -89,17 +90,30 @@ final class CheckedProgramAssembler {
         // stand is read off the dependency's own boundary — which is a behavior of another module
         // as often as one of this.
         Map<ValueName.Behavior, BehaviorTarget> targets = new LinkedHashMap<>();
+        List<ModuleBoundaries> boundaries = new ArrayList<>();
         for (ModuleReading module : read) {
-            fileWhatIsChecked(targets, module);
+            boundaries.add(fileWhatIsChecked(targets, module));
         }
         fileWhatIsOnThePath(targets, db);
         List<CheckedModule> modules = new ArrayList<>();
-        for (ModuleReading module : read) {
+        for (ModuleBoundaries module : boundaries) {
             modules.add(moduleOf(module, types, targets));
         }
         return new CheckedProgram(modules, language, onThePath, targets,
                 libraryOf(db).kernelSignatures());
     }
+
+    /**
+     * What was read of a module, and the call boundary of each behavior it declares.
+     *
+     * <p>The boundaries in the order the module declares them, which is the order its behaviors are
+     * made in. Carried from where they were filed to where the module is made, rather than looked
+     * up there: the module is made off the same declarations they were made off, and a second walk
+     * of those declarations would be two statements of what the module declares held together by a
+     * check.
+     */
+    private record ModuleBoundaries(ModuleReading read,
+                                    Map<ValueName.Behavior, BehaviorTarget> declared) {}
 
     /**
      * Files the call boundary of every behavior {@code module} declares.
@@ -109,8 +123,9 @@ final class CheckedProgramAssembler {
      * signature this compile failed to answer for leave the program without anything having missed
      * it: what a module declares would be whatever the answer happened to hold.
      */
-    private static void fileWhatIsChecked(Map<ValueName.Behavior, BehaviorTarget> targets,
-                                          ModuleReading module) {
+    private static ModuleBoundaries fileWhatIsChecked(
+            Map<ValueName.Behavior, BehaviorTarget> targets, ModuleReading module) {
+        Map<ValueName.Behavior, BehaviorTarget> declares = new LinkedHashMap<>();
         for (Hir.BehaviorDef declared : module.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(module.name(), declared.name());
             Sig signature = module.signatures().get(declared.name());
@@ -121,10 +136,13 @@ final class CheckedProgramAssembler {
                 throw new IllegalStateException("`" + named + "` was taken as checked and this"
                         + " compile has nothing to say about what it takes");
             }
-            file(targets, named, new BehaviorTarget(signatureOf(signature),
+            BehaviorTarget target = new BehaviorTarget(signatureOf(signature),
                     implementationOf(named, declared, module.bodies(), module.implementations(),
-                            module.checked(), module.compositions())));
+                            module.checked(), module.compositions()));
+            file(targets, named, target);
+            declares.put(named, target);
         }
+        return new ModuleBoundaries(module, declares);
     }
 
     /**
@@ -145,11 +163,7 @@ final class CheckedProgramAssembler {
      */
     private static void fileWhatIsOnThePath(Map<ValueName.Behavior, BehaviorTarget> targets,
                                             Db db) {
-        Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
-        if (read == null) {
-            return;
-        }
-        for (String module : read.modules().keySet()) {
+        for (String module : readOffThePath(db)) {
             Ast.Module declares = db.ask(new Front.Available(module)).value();
             Map<String, Sig> signatures = db.ask(new Bodies.Signatures(module)).value();
             Map<String, BehaviorImplementation> implementations =
@@ -203,6 +217,21 @@ final class CheckedProgramAssembler {
         }
     }
 
+    /**
+     * The modules this compile read off the path.
+     *
+     * <p>{@link Front.FromPath}'s answer: the ones this compilation may read declarations from,
+     * which is not every module on the path and never one it refused. Asked once for everything
+     * taken off them, so that what a dependency declares and what its behaviors are are read off
+     * one set of modules — two walks with a rule each would agree until either was written again.
+     *
+     * <p>Empty where nothing was read off a path, which is a compilation given none.
+     */
+    private static Set<String> readOffThePath(Db db) {
+        Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
+        return read == null ? Set.of() : read.modules().keySet();
+    }
+
     /** The library this compilation was checked against. Asked for here rather than fetched: what a
      *  name in a checked body denotes was settled against that one, and a second copy could be a
      *  different version of the language. */
@@ -254,22 +283,13 @@ final class CheckedProgramAssembler {
      * field off one — so what is handed over is the reading the checker itself used, and an output
      * laying such a value out places its fields exactly where the check placed them.
      *
-     * <p>Which modules those are is {@link Front.FromPath}'s answer: the ones this compilation may
-     * read declarations from, which is not every module on the path and never one it refused. What
-     * each of them declares comes from the derivation this compile ran over it, in the same three
-     * forms a module of its own is read in.
-     *
      * <p>The whole of what each declares, and not the part something here happens to name. Which
      * declarations a body reaches is a walk, and a snapshot carrying only what one walk found would
      * be right about the names that walk thought to visit.
      */
     private static List<CheckedData> declaredOnThePath(Db db) {
-        Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
         List<CheckedData> declared = new ArrayList<>();
-        if (read == null) {
-            return declared;
-        }
-        for (String module : read.modules().keySet()) {
+        for (String module : readOffThePath(db)) {
             Map<String, Derived.Def> defs = db.ask(new Shapes.DerivedDeclarations(module)).value();
             Map<TypeSymbol.AtModule, ValueShape> shapes =
                     db.ask(new Shapes.ValueShapes(module)).value();
@@ -376,23 +396,15 @@ final class CheckedProgramAssembler {
      * program's rather than this module's: a row written here may state a value of a data declared
      * elsewhere.
      */
-    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types,
+    private static CheckedModule moduleOf(ModuleBoundaries module, ValueTypes types,
                                           Map<ValueName.Behavior, BehaviorTarget> targets) {
+        ModuleReading read = module.read();
         List<CheckedBehavior> behaviors = new ArrayList<>();
-        for (Hir.BehaviorDef declared : read.bodies().behaviors()) {
-            ValueName.Behavior named = new ValueName.Behavior(read.name(), declared.name());
-            BehaviorTarget target = targets.get(named);
-            if (target == null) {
-                // Every behavior this module declares was filed before any module was made, off
-                // this same walk. Reaching here is that walk and this one having come apart.
-                throw new IllegalStateException("`" + named + "` is declared by a module of this"
-                        + " compile and has no call boundary");
-            }
-            behaviors.add(new CheckedBehavior(named, target,
-                    EnsuresEnforcement.in(read.checks(), read.name(), named),
-                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types,
-                            target.signature(), targets)));
-        }
+        module.declared().forEach((named, target) ->
+                behaviors.add(new CheckedBehavior(named, target,
+                        EnsuresEnforcement.in(read.checks(), read.name(), named),
+                        rowsOf(read.rows().getOrDefault(named.name(), List.of()), types,
+                                target.signature(), targets))));
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());
     }
@@ -577,7 +589,11 @@ final class CheckedProgramAssembler {
     }
 
     /**
-     * Which of the four states this behavior's implementation is in.
+     * Where this behavior's implementation comes from, for a behavior this compile checked.
+     *
+     * <p>Never {@link CheckedImplementation.ImplementedElsewhere}: this compile holds what a module
+     * it checked is implemented as, and a behavior published by another compile is read by
+     * {@link #publishedAs}.
      *
      * <p>Read in one place, from the state the declarations were read into and the form the check
      * produced. A reader handed the two separately would be deciding for itself what an implemented

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -1,9 +1,9 @@
 package souther.compiler.program;
 
+import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorImplementation;
-import souther.compiler.check.BoundaryInput;
 import souther.compiler.check.CoreBinders;
 import souther.compiler.check.Derived;
 import souther.compiler.check.Lower;
@@ -84,12 +84,123 @@ final class CheckedProgramAssembler {
         }
         ValueTypes types =
                 ValueTypes.over(FieldTypes.over(DeclaredFields.over(everyDeclaration)));
+        // Made before the modules, because a module cannot be made without them: a row of one
+        // states what it stood in for a dependency with, and where that dependency's arguments
+        // stand is read off the dependency's own boundary — which is a behavior of another module
+        // as often as one of this.
+        Map<ValueName.Behavior, BehaviorTarget> targets = new LinkedHashMap<>();
+        for (ModuleReading module : read) {
+            fileWhatIsChecked(targets, module);
+        }
+        fileWhatIsOnThePath(targets, db);
         List<CheckedModule> modules = new ArrayList<>();
         for (ModuleReading module : read) {
-            modules.add(moduleOf(module, types));
+            modules.add(moduleOf(module, types, targets));
         }
-        return new CheckedProgram(modules, language, onThePath,
+        return new CheckedProgram(modules, language, onThePath, targets,
                 libraryOf(db).kernelSignatures());
+    }
+
+    /**
+     * Files the call boundary of every behavior {@code module} declares.
+     *
+     * <p>Walked over what the module declares, and the two answers a boundary is made of are read
+     * under each name it declares. A walk of the signatures instead would let a behavior whose
+     * signature this compile failed to answer for leave the program without anything having missed
+     * it: what a module declares would be whatever the answer happened to hold.
+     */
+    private static void fileWhatIsChecked(Map<ValueName.Behavior, BehaviorTarget> targets,
+                                          ModuleReading module) {
+        for (Hir.BehaviorDef declared : module.bodies().behaviors()) {
+            ValueName.Behavior named = new ValueName.Behavior(module.name(), declared.name());
+            Sig signature = module.signatures().get(declared.name());
+            if (signature == null) {
+                // The module was taken as checked and one of the behaviors it declares has no
+                // signature. A caller reaches it, so letting it through hands an output a call it
+                // cannot emit and says nothing about why.
+                throw new IllegalStateException("`" + named + "` was taken as checked and this"
+                        + " compile has nothing to say about what it takes");
+            }
+            file(targets, named, new BehaviorTarget(signatureOf(signature),
+                    implementationOf(named, declared, module.bodies(), module.implementations(),
+                            module.checked(), module.compositions())));
+        }
+    }
+
+    /**
+     * Files the call boundary of every behavior every module this compile read off the path
+     * declares.
+     *
+     * <p>The whole of what each declares, and not the part something here calls. Which behaviors a
+     * body reaches is a walk, and a snapshot carrying only what one walk found would be right about
+     * the calls that walk thought to visit — and an output emitting those bodies would be the
+     * second place that decided what belongs.
+     *
+     * <p>What the module declares says which behaviors there are, and the answers this compile
+     * worked out say what each of them is. Three readings and not one: a module read off the path
+     * is available here because a module of this compile was checked against it, so a name it
+     * declares that this compile has no signature or no implementation state for is this
+     * compilation's two readings of that artifact having come apart, and is refused rather than
+     * quietly left out of the program.
+     */
+    private static void fileWhatIsOnThePath(Map<ValueName.Behavior, BehaviorTarget> targets,
+                                            Db db) {
+        Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
+        if (read == null) {
+            return;
+        }
+        for (String module : read.modules().keySet()) {
+            Ast.Module declares = db.ask(new Front.Available(module)).value();
+            Map<String, Sig> signatures = db.ask(new Bodies.Signatures(module)).value();
+            Map<String, BehaviorImplementation> implementations =
+                    db.ask(new Bodies.Implementation(module)).value();
+            if (declares == null || signatures == null || implementations == null) {
+                throw new IllegalStateException("`" + module + "` was read off the path and this"
+                        + " compile has nothing to say about the behaviors it declares");
+            }
+            for (Ast.BehaviorDef declared : declares.behaviors()) {
+                ValueName.Behavior named = new ValueName.Behavior(module, declared.name());
+                Sig signature = signatures.get(declared.name());
+                BehaviorImplementation state = implementations.get(declared.name());
+                if (signature == null || state == null) {
+                    throw new IllegalStateException("`" + named + "` is declared by a module this"
+                            + " compile read off the path and this compile has no reading of it");
+                }
+                file(targets, named,
+                        new BehaviorTarget(signatureOf(signature), publishedAs(state)));
+            }
+        }
+    }
+
+    /**
+     * Where the implementation of a behavior another compile published comes from.
+     *
+     * <p>Its three states are the three a behavior is in anywhere. What a call reaches differs in
+     * one of them: an implementation this program does not hold, because the build that published
+     * the module emitted it. The other two are what they are wherever the behavior was declared —
+     * an injected behavior's implementation comes from outside Souther on either side of a path,
+     * and an unwritten one is nowhere at all.
+     */
+    private static CheckedImplementation publishedAs(BehaviorImplementation state) {
+        return switch (state) {
+            case IMPLEMENTED -> new CheckedImplementation.ImplementedElsewhere();
+            case INJECTION_TARGET -> new CheckedImplementation.Injected();
+            case UNIMPLEMENTED -> new CheckedImplementation.Unwritten();
+        };
+    }
+
+    /**
+     * Files one call boundary, and refuses a second under the same identity.
+     *
+     * <p>An identity belongs to one declaration. A module of this compile takes the name over one
+     * of the same name on the path, so the two worlds never meet here — and one that did would be
+     * called through whichever was filed last with nothing saying the other had been there.
+     */
+    private static void file(Map<ValueName.Behavior, BehaviorTarget> targets,
+                             ValueName.Behavior named, BehaviorTarget target) {
+        if (targets.put(named, target) != null) {
+            throw new IllegalStateException("`" + named + "` is declared twice");
+        }
     }
 
     /** The library this compilation was checked against. Asked for here rather than fetched: what a
@@ -189,7 +300,6 @@ final class CheckedProgramAssembler {
      */
     private record ModuleReading(String name, Hir.Module bodies, Bodies.Elaborated checked,
                                  Map<String, Sig> signatures,
-                                 Map<ValueName.Behavior, Sig> reachable,
                                  Map<String, BehaviorImplementation> implementations,
                                  Map<ValueName.Behavior, Composition> compositions,
                                  Map<ValueName.Behavior, EnsuresEnforcement> checks,
@@ -223,12 +333,6 @@ final class CheckedProgramAssembler {
         Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();
         Lower.Lowered lowering = db.ask(new Bodies.Lowering(module)).value();
         Map<String, Sig> signatures = db.ask(new Bodies.Signatures(module)).value();
-        // What every behavior this module can name declares — its own and the ones it borrows, each
-        // under the declaration it belongs to. The same answer the run that read this module's rows
-        // was given, so what a stand-in's arguments were built and compared against and what a
-        // reader compares them at are one reading; and a dependency another compile declared is
-        // among them, which is what this module names it by.
-        Map<ValueName.Behavior, Sig> reachable = db.ask(new Bodies.Reachable(module)).value();
         Map<String, BehaviorImplementation> implementations =
                 db.ask(new Bodies.Implementation(module)).value();
         Map<ValueName.Behavior, Composition> compositions =
@@ -247,7 +351,7 @@ final class CheckedProgramAssembler {
         // read here and dropped here, and nothing it was reached through is carried into what is
         // made.
         Symbols symbols = Names.derivedSymbols(db, module).value();
-        if (checked == null || lowering == null || signatures == null || reachable == null
+        if (checked == null || lowering == null || signatures == null
                 || implementations == null
                 || compositions == null || symbols == null || shapes == null || checks == null) {
             // Not a report: the failure above is what a caller is told, and reaching here past it
@@ -261,7 +365,7 @@ final class CheckedProgramAssembler {
         // agree with the checker only for as long as lowering left declarations alone.
         Hir.Module declarations = lowering.settled();
         Hir.Module bodies = lowering.lowered();
-        return new ModuleReading(module, bodies, checked, signatures, reachable, implementations,
+        return new ModuleReading(module, bodies, checked, signatures, implementations,
                 compositions, checks, dataOf(declarations, symbols, shapes), rowsOf(db, module));
     }
 
@@ -272,17 +376,22 @@ final class CheckedProgramAssembler {
      * program's rather than this module's: a row written here may state a value of a data declared
      * elsewhere.
      */
-    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types) {
+    private static CheckedModule moduleOf(ModuleReading read, ValueTypes types,
+                                          Map<ValueName.Behavior, BehaviorTarget> targets) {
         List<CheckedBehavior> behaviors = new ArrayList<>();
         for (Hir.BehaviorDef declared : read.bodies().behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(read.name(), declared.name());
-            CheckedSignature signature = signatureOf(read.signatures().get(declared.name()));
-            behaviors.add(new CheckedBehavior(named, signature,
-                    implementationOf(named, declared, read.bodies(), read.implementations(),
-                            read.checked(), read.compositions()),
+            BehaviorTarget target = targets.get(named);
+            if (target == null) {
+                // Every behavior this module declares was filed before any module was made, off
+                // this same walk. Reaching here is that walk and this one having come apart.
+                throw new IllegalStateException("`" + named + "` is declared by a module of this"
+                        + " compile and has no call boundary");
+            }
+            behaviors.add(new CheckedBehavior(named, target,
                     EnsuresEnforcement.in(read.checks(), read.name(), named),
-                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types, signature,
-                            read.reachable())));
+                    rowsOf(read.rows().getOrDefault(declared.name(), List.of()), types,
+                            target.signature(), targets)));
         }
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());
@@ -300,11 +409,11 @@ final class CheckedProgramAssembler {
      */
     private static List<CheckedRow> rowsOf(List<Output.RowsRead.ReadRow> read, ValueTypes types,
                                            CheckedSignature signature,
-                                           Map<ValueName.Behavior, Sig> reachable) {
+                                           Map<ValueName.Behavior, BehaviorTarget> targets) {
         List<CheckedRow> rows = new ArrayList<>();
         for (Output.RowsRead.ReadRow row : read) {
             rows.add(new CheckedRow(row.identity(), row.at(),
-                    statementOf(row, types, signature, reachable)));
+                    statementOf(row, types, signature, targets)));
         }
         return rows;
     }
@@ -323,7 +432,7 @@ final class CheckedProgramAssembler {
      */
     private static CheckedRow.Statement statementOf(Output.RowsRead.ReadRow row, ValueTypes types,
                                                     CheckedSignature signature,
-                                                    Map<ValueName.Behavior, Sig> reachable) {
+                                                    Map<ValueName.Behavior, BehaviorTarget> targets) {
         // A switch over both sums, so a row nothing came back for is written down here rather than
         // being whatever falls out of reading a list of the ones that did — which is a row an output
         // would never hear of, and a behavior reading as having said nothing about an input someone
@@ -335,7 +444,7 @@ final class CheckedProgramAssembler {
                                 Position.at(signature.answers()))
                         : new CheckedRow.WithStandIns(stated, types,
                                 Position.at(signature.answers()),
-                                whereArgumentsStand(stated, reachable));
+                                whereArgumentsStand(stated, targets));
                 case RowStatement.NotStated why -> new CheckedRow.NotReproducible(why);
                 // What acceptance guarantees, asserted where the guarantee is relied on. A row an
                 // evaluation stopped before the values of is one the language refuses the program
@@ -355,29 +464,30 @@ final class CheckedProgramAssembler {
     /**
      * Where the arguments of each dependency the row stood in for stand.
      *
-     * <p>Off what this module can name, which is the answer the run that read the row was given —
-     * so what a stand-in's entries were built against and what a reader compares an argument at are
-     * one reading of one declaration, rather than the same declaration written down twice and held
-     * to itself by a law.
+     * <p>Off the dependency's own call boundary, which is the one thing this snapshot says about
+     * what that behavior takes — so what a stand-in's entries were built against and what a reader
+     * compares an argument at are one reading of one declaration, rather than the same declaration
+     * written down twice and held to itself by a law.
      *
      * <p>It is what says how a comparison is made as well as how many are: whether an argument that
      * is a sequence is the same one written in another order is what the type reading it says.
      */
     private static Map<ValueName.Behavior, List<Position>> whereArgumentsStand(
-            RowStatement.Stated stated, Map<ValueName.Behavior, Sig> reachable) {
+            RowStatement.Stated stated, Map<ValueName.Behavior, BehaviorTarget> targets) {
         Map<ValueName.Behavior, List<Position>> stands = new LinkedHashMap<>();
         for (StoodIn stoodIn : stated.standIns()) {
-            Sig declared = reachable.get(stoodIn.dependency());
+            BehaviorTarget declared = targets.get(stoodIn.dependency());
             if (declared == null) {
-                // The row stood in for it, so this compile read the clause that required it against
-                // this module's own reading of what it can name. Reaching here is that reading and
-                // this one having come apart.
+                // A row stood in for a behavior no module this compile checked or read declares.
+                // Whether the module the row is written in may name that behavior is settled where
+                // the names are resolved and is not asked again here; what is asked is whether the
+                // program the row is being written into declares it at all.
                 throw new IllegalStateException("`" + stoodIn.dependency() + "` was stood in for by"
-                        + " a row of a module that cannot name it");
+                        + " a row and no module this compile read declares it");
             }
             List<Position> arguments = new ArrayList<>();
-            for (BoundaryInput takes : declared.ins()) {
-                arguments.add(Position.at(takes.type()));
+            for (Type takes : declared.signature().takes()) {
+                arguments.add(Position.at(takes));
             }
             stands.put(stoodIn.dependency(), arguments);
         }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -606,18 +606,27 @@ final class CheckedProgramAssembler {
             Map<ValueName.Behavior, Composition> compositions) {
         String name = declared.name();
         BehaviorImplementation state = implementations.get(name);
-        if (state == null || state == BehaviorImplementation.UNIMPLEMENTED) {
-            return new CheckedImplementation.Unwritten();
+        if (state == null) {
+            // The module was taken as checked and this compile has no reading of where one of its
+            // behaviors gets its body. Read as unwritten it would be a behavior the author is owed
+            // a body for, which is a program of its own — and nothing would say the reading was
+            // missing rather than the body.
+            throw new IllegalStateException("`" + named + "` was taken as checked and this compile"
+                    + " has nothing to say about where its implementation comes from");
         }
-        if (state == BehaviorImplementation.INJECTION_TARGET) {
-            return new CheckedImplementation.Injected();
-        }
-        Composition composed = compositions.get(named);
-        if (composed != null) {
-            return new CheckedImplementation.Composed(composed);
-        }
-        return new CheckedImplementation.Body(inputBindersOf(named, declared, lowered),
-                checked.behaviorBodies().get(name));
+        return switch (state) {
+            case UNIMPLEMENTED -> new CheckedImplementation.Unwritten();
+            case INJECTION_TARGET -> new CheckedImplementation.Injected();
+            // A composition is what the behavior is declared as, so what says it is one is that the
+            // check settled stages for it and not the absence of a body.
+            case IMPLEMENTED -> {
+                Composition composed = compositions.get(named);
+                yield composed != null
+                        ? new CheckedImplementation.Composed(composed)
+                        : new CheckedImplementation.Body(inputBindersOf(named, declared, lowered),
+                                checked.behaviorBodies().get(name));
+            }
+        };
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/program/ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest.java
@@ -7,6 +7,7 @@ import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +49,26 @@ class ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest {
     @Test
     void andSoIsOneTheIndexSaysNothingAbout() {
         assertThrows(IllegalStateException.class, () -> program(target(), Map.of()));
+    }
+
+    /**
+     * And so is the same disagreement the other way round: a behavior of a module of this compile
+     * that the module does not declare.
+     *
+     * <p>Which is what says the two name the same behaviors. Held in one direction, an index could
+     * answer for a behavior of a module this program emits that the module has nothing for, and a
+     * reader emitting that module would emit a program with a call to a behavior it never wrote.
+     */
+    @Test
+    void andSoIsOneTheModuleThatDeclaresItDoesNotDeclare() {
+        BehaviorTarget held = target();
+        Map<ValueName.Behavior, BehaviorTarget> index = new LinkedHashMap<>();
+        index.put(NAMED, held);
+        index.put(new ValueName.Behavior("demo", "nobodyWroteThis"), target());
+
+        assertEquals("this program is callable at 2 behaviors of the modules it emits, which"
+                        + " declare 1",
+                assertThrows(IllegalStateException.class, () -> program(held, index)).getMessage());
     }
 
     /** And the program a correct assembler makes is one this admits. */

--- a/souther-compiler/src/test/java/souther/compiler/program/ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.program;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.core.EnsuresEnforcement;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A behavior of a checked module is called by the boundary its module holds, and a program saying
+ * otherwise is not one that can be made.
+ *
+ * <p>The index a program answers a call from is handed to it rather than built from its modules:
+ * the boundaries are made before a module can be, because a row of one is compared against what a
+ * dependency takes. So what holds the two together is that they are the same values, and here is
+ * where that stops being something an assembler is trusted about.
+ *
+ * <p>Offered the disagreement directly. The assembler files a boundary and hands that same one to
+ * the behavior, so a check reached only through a compile is one that has never been asked its own
+ * question — it would go on passing after the day something made a second boundary out of the same
+ * two readings, which is exactly the state the two would then disagree in.
+ */
+class ABehaviorIsCalledByTheBoundaryItsModuleHoldsTest {
+
+    private static final ValueName.Behavior NAMED = new ValueName.Behavior("demo", "measure");
+
+    @Test
+    void aBehaviorCalledByABoundaryItsModuleDoesNotHoldIsRefused() {
+        BehaviorTarget held = target();
+        BehaviorTarget another = target();
+
+        assertEquals("`demo.measure` is called with a boundary that is not the one its module"
+                        + " holds",
+                assertThrows(IllegalStateException.class,
+                        () -> program(held, Map.of(NAMED, another))).getMessage());
+    }
+
+    /** And a behavior the index says nothing about is the same disagreement, not a program with a
+     *  behavior nothing calls: every behavior of a checked module is one a call may reach. */
+    @Test
+    void andSoIsOneTheIndexSaysNothingAbout() {
+        assertThrows(IllegalStateException.class, () -> program(target(), Map.of()));
+    }
+
+    /** And the program a correct assembler makes is one this admits. */
+    @Test
+    void aBehaviorCalledByTheBoundaryItsModuleHoldsIsMade() {
+        BehaviorTarget held = target();
+
+        CheckedProgram program = program(held, Map.of(NAMED, held));
+
+        assertSame(held, program.behavior(NAMED));
+        assertSame(held.signature(), program.module("demo").behavior(NAMED).signature());
+    }
+
+    private static CheckedProgram program(BehaviorTarget held,
+                                          Map<ValueName.Behavior, BehaviorTarget> index) {
+        CheckedBehavior behavior = new CheckedBehavior(NAMED, held,
+                EnsuresEnforcement.NoContract.INSTANCE, List.of());
+        return new CheckedProgram(
+                List.of(new CheckedModule("demo", List.of(behavior), List.of(), List.of())),
+                List.of(), List.of(), index, DefaultStdlib.get().kernelSignatures());
+    }
+
+    /** One boundary, made afresh each time it is asked for: what tells two of these apart is that
+     *  they are two, and not what either of them says. */
+    private static BehaviorTarget target() {
+        return new BehaviorTarget(new CheckedSignature(List.of(Type.INT), Type.INT),
+                new CheckedImplementation.Injected());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/program/ABehaviorTargetHoldsItsTwoReadingsOfWhatItTakesTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/ABehaviorTargetHoldsItsTwoReadingsOfWhatItTakesTogetherTest.java
@@ -4,7 +4,6 @@ import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
-import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,8 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A behavior says what it takes twice — as types on its signature, and as the bindings its body
- * reads them through — and a {@link CheckedBehavior} holding the two at different lengths is not
- * one that can be made.
+ * reads them through — and a {@link BehaviorTarget} holding the two at different lengths is not one
+ * that can be made.
+ *
+ * <p>Held here and not where a behavior of a checked module is made. A target is what a call
+ * reaches whichever module declares the behavior, so a boundary that says two things is unmakeable
+ * everywhere rather than wherever a reader happened to come through the module.
  *
  * <p>Written against the model and not through a compile. What the assembler produces is held to
  * this by every module {@code AnOutputOutsideTheCompilerReadsACheckedProgramTest} compiles, and a
@@ -24,22 +27,23 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * passing after the constructor stopped making it, because a correct assembler never offers it a
  * mismatch. Here the mismatch is offered.
  */
-class ACheckedBehaviorHoldsItsTwoReadingsOfWhatItTakesTogetherTest {
+class ABehaviorTargetHoldsItsTwoReadingsOfWhatItTakesTogetherTest {
 
     private static final Type INT = Type.INT;
 
     @Test
     void aBodyBindingFewerThanTheSignatureTakesIsRefused() {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> behavior(List.of(INT, INT), body(binder("only"))));
+                () -> target(List.of(INT, INT), body(binder("only"))));
 
-        assertEquals("`demo.combine` takes 2 and its body binds 1", refused.getMessage());
+        assertEquals("a behavior declared [INT, INT] -> INT has a body binding [only]",
+                refused.getMessage());
     }
 
     @Test
     void andSoIsOneBindingMore() {
         assertThrows(IllegalArgumentException.class,
-                () -> behavior(List.of(INT), body(binder("input"), binder("dependency"))),
+                () -> target(List.of(INT), body(binder("input"), binder("dependency"))),
                 "a definition's trailing parameters are what it depends on, and are not inputs");
     }
 
@@ -50,26 +54,28 @@ class ACheckedBehaviorHoldsItsTwoReadingsOfWhatItTakesTogetherTest {
      */
     @Test
     void aBodyBindingWhatTheSignatureTakesIsMade() {
-        CheckedBehavior made = behavior(List.of(INT, INT), body(binder("first"), binder("second")));
+        BehaviorTarget made = target(List.of(INT, INT), body(binder("first"), binder("second")));
 
         assertEquals(List.of("first", "second"),
                 ((CheckedImplementation.Body) made.implementation()).parameters().stream()
                         .map(Core.Binder::name).toList());
     }
 
-    /** The states with no body of their own are not held to it, having no binders to be held by. */
+    /** The states with no body of their own are not held to it, having no binders to be held by.
+     *  An implementation another compile emitted is one of them: what a call to it hands over is
+     *  what it was declared to take, and the bindings it arrives in are that compile's. */
     @Test
     void anImplementationWithNoBodyIsNotAskedWhichBindingsItsInputsArriveIn() {
-        assertEquals(2, behavior(List.of(INT, INT), new CheckedImplementation.Injected())
+        assertEquals(2, target(List.of(INT, INT), new CheckedImplementation.Injected())
                 .signature().takes().size());
-        assertEquals(2, behavior(List.of(INT, INT), new CheckedImplementation.Unwritten())
+        assertEquals(2, target(List.of(INT, INT), new CheckedImplementation.Unwritten())
+                .signature().takes().size());
+        assertEquals(2, target(List.of(INT, INT), new CheckedImplementation.ImplementedElsewhere())
                 .signature().takes().size());
     }
 
-    private static CheckedBehavior behavior(List<Type> takes, CheckedImplementation implementation) {
-        return new CheckedBehavior(new ValueName.Behavior("demo", "combine"),
-                new CheckedSignature(takes, INT), implementation,
-                souther.compiler.core.EnsuresEnforcement.NoContract.INSTANCE, List.of());
+    private static BehaviorTarget target(List<Type> takes, CheckedImplementation implementation) {
+        return new BehaviorTarget(new CheckedSignature(takes, INT), implementation);
     }
 
     private static CheckedImplementation.Body body(Core.Binder... parameters) {

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
@@ -9,6 +9,7 @@ import souther.compiler.types.TypeSymbols;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,11 +66,13 @@ class WhatTheLanguageDeclaresCrossesAsADeclarationTest {
 
         assertEquals("`demo.Mode` is declared by A_MODULE and by THE_LANGUAGE",
                 assertThrows(IllegalStateException.class, () -> new CheckedProgram(
-                        List.of(module("demo", twice)), List.of(twice), List.of(), kernels()))
+                        List.of(module("demo", twice)), List.of(twice), List.of(), Map.of(),
+                        kernels()))
                         .getMessage());
         assertEquals("`demo.Mode` is declared by A_MODULE and by A_MODULE_ON_THE_PATH",
                 assertThrows(IllegalStateException.class, () -> new CheckedProgram(
-                        List.of(module("demo", twice)), List.of(), List.of(twice), kernels()))
+                        List.of(module("demo", twice)), List.of(), List.of(twice), Map.of(),
+                        kernels()))
                         .getMessage());
     }
 

--- a/souther-program-api-test/src/test/java/souther/program/api/ACallReachesTheBehaviorItsProgramDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/ACallReachesTheBehaviorItsProgramDeclaresTest.java
@@ -1,0 +1,253 @@
+package souther.program.api;
+
+import souther.compiler.Compiler;
+import souther.compiler.core.Composition;
+import souther.compiler.core.Core;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.program.BehaviorTarget;
+import souther.compiler.program.CheckedBehavior;
+import souther.compiler.program.CheckedHelper;
+import souther.compiler.program.CheckedImplementation;
+import souther.compiler.program.CheckedModule;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A call reaches a behavior, and the program says what that behavior takes, what it answers, and
+ * where its implementation comes from — whichever module declares it.
+ *
+ * <p>Two modules compiled together do not say this. Both are among what the snapshot is taken of,
+ * so a reader that could only get to a behavior through its module would still find every callee it
+ * looked for. A module declared only on the path is what says a call carries an identity and the
+ * program answers for it: that module is not emitted here, and the behavior is called all the same.
+ */
+class ACallReachesTheBehaviorItsProgramDeclaresTest {
+
+    /**
+     * Published by another project: a behavior it implements, one it leaves to Java, and one
+     * nothing below names.
+     */
+    private static final String PUBLISHED = """
+            module lib.rates exposing ( Rate, spin, rateFor, unused )
+            data Rate = Int
+
+            behavior spin : (of: Int) -> Rate
+            let spin (of) = Rate(of)
+
+            behavior rateFor : (of: Int) -> Rate
+
+            behavior unused : (r: Rate) -> Int
+            let unused (r) = r.value
+            """;
+
+    private static final String USES = """
+            module app.uses
+            import lib.rates ( Rate, spin, rateFor )
+
+            behavior rateOf : (base: Int) -> Rate
+                depends on rateFor
+            let rateOf (base, rateFor) = rateFor(base)
+
+            behavior spun : (base: Int) -> Rate
+            let spun (base) = spin(base)
+
+            fake rateFor
+                | (1) -> Rate(10)
+                | _ -> Rate(99)
+
+            example rateOf
+                | "the table lists it" : (1) -> Rate(10)
+            """;
+
+    private static final ValueName.Behavior SPIN = new ValueName.Behavior("lib.rates", "spin");
+    private static final ValueName.Behavior RATE_FOR = new ValueName.Behavior("lib.rates",
+            "rateFor");
+    private static final ValueName.Behavior UNUSED = new ValueName.Behavior("lib.rates", "unused");
+    private static final Type RATE = Type.ref(TypeSymbols.declared(new TypeKey("lib.rates",
+            "Rate")));
+
+    /**
+     * What a body carries at a call is answered for, every call of it.
+     *
+     * <p>The walk is over what the program hands over rather than over the calls this test wrote:
+     * a check made by naming the callees expected would be right about the ones it thought to name,
+     * and a snapshot that dropped a callee written somewhere else would keep passing it.
+     */
+    @Test
+    void everyBehaviorACallReachesIsAnsweredForByTheProgram() {
+        CheckedProgram program = compiled();
+
+        Set<ValueName.Behavior> reached = everyBehaviorCalledIn(program);
+
+        assertFalse(reached.isEmpty(), "the walk found no call to a behavior at all");
+        for (ValueName.Behavior called : reached) {
+            assertInstanceOf(BehaviorTarget.class, program.behavior(called),
+                    () -> "a body calls `" + called + "` and the program answers nothing for it");
+        }
+        assertEquals(Set.of(SPIN, RATE_FOR), reached,
+                "and the calls the walk found are the ones these modules write");
+    }
+
+    /**
+     * A call to a behavior a module on the path implements reaches an implementation this program
+     * does not hold.
+     *
+     * <p>Which is what an output emitting the call needs to know it may emit a call at all: the
+     * implementation exists, and emitting one of its own under the same name would be a second
+     * definition of one behavior.
+     */
+    @Test
+    void whatACallToABehaviorOnThePathReachesIsWhatItWasDeclaredToBe() {
+        BehaviorTarget spin = compiled().behavior(SPIN);
+
+        assertEquals(List.of(Type.INT), spin.signature().takes());
+        assertEquals(RATE, spin.signature().answers());
+        assertInstanceOf(CheckedImplementation.ImplementedElsewhere.class, spin.implementation(),
+                "the build that published `lib.rates` emitted its body");
+    }
+
+    /** And one that module leaves to Java is injected here, as it is where it was declared: what
+     *  it does is not in either program, and a crossing into what is emitted here reaches it. */
+    @Test
+    void aBehaviorThePathLeavesToJavaIsInjected() {
+        BehaviorTarget rateFor = compiled().behavior(RATE_FOR);
+
+        assertEquals(List.of(Type.INT), rateFor.signature().takes());
+        assertInstanceOf(CheckedImplementation.Injected.class, rateFor.implementation());
+    }
+
+    /**
+     * And a behavior of that module nothing here names is answered for too.
+     *
+     * <p>What the program answers for is what the modules it read declare, and not what a walk of
+     * its bodies happened to reach. Cut down to the calls that were made, the snapshot would be a
+     * walk an output has to trust and repeat, and the day an output emitted a call this one did not
+     * make there would be nothing to ask.
+     */
+    @Test
+    void aBehaviorNothingHereNamesIsAnsweredForAllTheSame() {
+        BehaviorTarget unused = compiled().behavior(UNUSED);
+
+        assertEquals(List.of(RATE), unused.signature().takes());
+        assertEquals(Type.INT, unused.signature().answers());
+        assertInstanceOf(CheckedImplementation.ImplementedElsewhere.class, unused.implementation());
+    }
+
+    /**
+     * A behavior of a checked module is one boundary, whichever way it is reached.
+     *
+     * <p>The same value and not an equal one. Two readings of what a behavior takes would agree the
+     * day they were made and drift the day either was made from something else, and a program
+     * holding one fact cannot drift.
+     */
+    @Test
+    void aBehaviorOfACheckedModuleIsOneBoundaryReachedTwoWays() {
+        CheckedProgram program = compiled();
+        ValueName.Behavior spun = new ValueName.Behavior("app.uses", "spun");
+
+        CheckedBehavior emitted = program.module("app.uses").behavior(spun);
+
+        assertSame(emitted.signature(), program.behavior(spun).signature());
+        assertSame(emitted.implementation(), program.behavior(spun).implementation());
+    }
+
+    /** And the module that declares the called behavior is still not something this program
+     *  emits. */
+    @Test
+    void theModuleThatDeclaresItIsNotAmongTheModulesEmitted() {
+        assertEquals(List.of("app.uses"), compiled().modules().stream()
+                .map(CheckedModule::name).toList());
+    }
+
+    /**
+     * An identity no module this compile read declares is a mistake at the reader.
+     *
+     * <p>{@link ValueName.Behavior} is public, so an address can be assembled out of two strings.
+     * Answered with an absence it would read as a program in which the behavior is not implemented.
+     */
+    @Test
+    void anIdentityNoModuleDeclaresIsRefused() {
+        CheckedProgram program = compiled();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> program.behavior(new ValueName.Behavior("lib.rates", "nobodyWroteThis")));
+        assertThrows(IllegalArgumentException.class,
+                () -> program.behavior(new ValueName.Behavior("no.module", "spin")));
+    }
+
+    /** And a module is not asked about a behavior of another one. What only this compile knows
+     *  about a behavior — what its examples said — is what a module answers, and a behavior it does
+     *  not declare is one it has none of rather than one that does not exist. */
+    @Test
+    void aModuleIsNotAskedAboutABehaviorItDoesNotDeclare() {
+        CheckedModule uses = compiled().module("app.uses");
+
+        assertThrows(IllegalArgumentException.class, () -> uses.behavior(SPIN));
+    }
+
+    private static CheckedProgram compiled() {
+        Map<String, ClassFileImage> published = Compiler.compile(PUBLISHED);
+        return CheckedProgram.of(List.of(USES), ModulePath.of(published));
+    }
+
+    /**
+     * Every behavior a call in this program reaches: from the bodies of its behaviors, from the
+     * helpers those bodies call, and from the stages a composed behavior applies.
+     *
+     * <p>Each of the three is a place a callee is named, and a walk that visited two of them would
+     * answer that everything it found was answered for.
+     */
+    private static Set<ValueName.Behavior> everyBehaviorCalledIn(CheckedProgram program) {
+        Set<ValueName.Behavior> reached = new LinkedHashSet<>();
+        for (CheckedModule module : program.modules()) {
+            List<Core> bodies = new ArrayList<>();
+            for (CheckedBehavior behavior : module.behaviors()) {
+                switch (behavior.implementation()) {
+                    case CheckedImplementation.Body body -> bodies.add(body.body());
+                    case CheckedImplementation.Composed(Composition composition) -> {
+                        for (Composition.Stage stage : composition.stages()) {
+                            reached.add(stage.behavior());
+                        }
+                    }
+                    case CheckedImplementation.Injected ignored -> { }
+                    case CheckedImplementation.Unwritten ignored -> { }
+                    case CheckedImplementation.ImplementedElsewhere ignored -> { }
+                }
+            }
+            for (CheckedHelper helper : module.helpers()) {
+                bodies.add(helper.body());
+            }
+            for (Core body : bodies) {
+                collectCalled(body, reached);
+            }
+        }
+        return reached;
+    }
+
+    private static void collectCalled(Core node, Set<ValueName.Behavior> into) {
+        if (node instanceof Core.Call call
+                && call.fn() instanceof Core.Reached.OfDeclaration declared
+                && declared.reaches() instanceof Core.Reaches.ABehavior(ValueName.Behavior behavior)) {
+            into.add(behavior);
+        }
+        Core.forEachChild(node, child -> collectCalled(child, into));
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/ACallReachesTheBehaviorItsProgramDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/ACallReachesTheBehaviorItsProgramDeclaresTest.java
@@ -18,7 +18,6 @@ import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
      * nothing below names.
      */
     private static final String PUBLISHED = """
-            module lib.rates exposing ( Rate, spin, rateFor, unused )
+            module lib.rates exposing ( Rate, spin, rateFor, tally, unused )
             data Rate = Int
 
             behavior spin : (of: Int) -> Rate
@@ -54,13 +53,21 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
 
             behavior rateFor : (of: Int) -> Rate
 
+            behavior tally : (r: Rate) -> Int
+            let tally (r) = r.value
+
             behavior unused : (r: Rate) -> Int
             let unused (r) = r.value
             """;
 
+    /**
+     * And it is called from each of the two places a call to a behavior stands: a behavior's body,
+     * and the stages a composed behavior applies. A carried helper is here as well, for the check
+     * that it is not a third.
+     */
     private static final String USES = """
             module app.uses
-            import lib.rates ( Rate, spin, rateFor )
+            import lib.rates ( Rate, spin, rateFor, tally )
 
             behavior rateOf : (base: Int) -> Rate
                 depends on rateFor
@@ -68,6 +75,13 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
 
             behavior spun : (base: Int) -> Rate
             let spun (base) = spin(base)
+
+            behavior counted = spun >-> tally
+
+            behavior looped : (base: Int) -> Rate
+            let looped (base) = spinning(base)
+
+            partial let spinning (n: Int): Rate = spinning(n)
 
             fake rateFor
                 | (1) -> Rate(10)
@@ -80,6 +94,7 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
     private static final ValueName.Behavior SPIN = new ValueName.Behavior("lib.rates", "spin");
     private static final ValueName.Behavior RATE_FOR = new ValueName.Behavior("lib.rates",
             "rateFor");
+    private static final ValueName.Behavior TALLY = new ValueName.Behavior("lib.rates", "tally");
     private static final ValueName.Behavior UNUSED = new ValueName.Behavior("lib.rates", "unused");
     private static final Type RATE = Type.ref(TypeSymbols.declared(new TypeKey("lib.rates",
             "Rate")));
@@ -102,8 +117,31 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
             assertInstanceOf(BehaviorTarget.class, program.behavior(called),
                     () -> "a body calls `" + called + "` and the program answers nothing for it");
         }
-        assertEquals(Set.of(SPIN, RATE_FOR), reached,
-                "and the calls the walk found are the ones these modules write");
+        assertEquals(Set.of(SPIN, RATE_FOR, TALLY, new ValueName.Behavior("app.uses", "spun")),
+                reached, "and the calls the walk found are the ones these modules write: a body's,"
+                        + " and a composition's stages");
+    }
+
+    /**
+     * And a carried helper reaches no behavior, which is why the walk above does not go through
+     * one.
+     *
+     * <p>The language refuses a call to a behavior from a helper's {@code let} (E1818), so the
+     * places a call to a behavior stands are a behavior's own body and a composition's stages. Said
+     * here as a check rather than left as a walk of the helpers that can only ever find nothing:
+     * such a walk answers the same whether the rule holds or the module has no helper, and the day
+     * the rule moved it would be a walk nobody had noticed had started mattering.
+     */
+    @Test
+    void aCarriedHelperReachesNoBehavior() {
+        CheckedModule uses = compiled().module("app.uses");
+
+        assertFalse(uses.helpers().isEmpty(), "the module carries a helper to ask about");
+        for (CheckedHelper helper : uses.helpers()) {
+            Set<ValueName.Behavior> reached = new LinkedHashSet<>();
+            collectCalled(helper.body(), reached);
+            assertEquals(Set.of(), reached, () -> "`" + helper + "` calls a behavior");
+        }
     }
 
     /**
@@ -209,19 +247,24 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
     }
 
     /**
-     * Every behavior a call in this program reaches: from the bodies of its behaviors, from the
-     * helpers those bodies call, and from the stages a composed behavior applies.
+     * Every behavior a call in this program reaches: from the bodies of its behaviors, and from the
+     * stages a composed behavior applies.
      *
-     * <p>Each of the three is a place a callee is named, and a walk that visited two of them would
-     * answer that everything it found was answered for.
+     * <p>Both are a place a callee is named, and a walk that visited one of them would answer that
+     * everything it found was answered for. A carried helper is not a third: the language refuses a
+     * call to a behavior from a helper's {@code let} (E1818), which
+     * {@link #aCarriedHelperReachesNoBehavior} is what says here rather than a walk that goes
+     * looking and can find nothing.
+     *
+     * <p>The switch has no {@code default}, so a state an implementation is in that this has
+     * nothing to say about stops this compiling rather than being walked past.
      */
     private static Set<ValueName.Behavior> everyBehaviorCalledIn(CheckedProgram program) {
         Set<ValueName.Behavior> reached = new LinkedHashSet<>();
         for (CheckedModule module : program.modules()) {
-            List<Core> bodies = new ArrayList<>();
             for (CheckedBehavior behavior : module.behaviors()) {
                 switch (behavior.implementation()) {
-                    case CheckedImplementation.Body body -> bodies.add(body.body());
+                    case CheckedImplementation.Body body -> collectCalled(body.body(), reached);
                     case CheckedImplementation.Composed(Composition composition) -> {
                         for (Composition.Stage stage : composition.stages()) {
                             reached.add(stage.behavior());
@@ -231,12 +274,6 @@ class ACallReachesTheBehaviorItsProgramDeclaresTest {
                     case CheckedImplementation.Unwritten ignored -> { }
                     case CheckedImplementation.ImplementedElsewhere ignored -> { }
                 }
-            }
-            for (CheckedHelper helper : module.helpers()) {
-                bodies.add(helper.body());
-            }
-            for (Core body : bodies) {
-                collectCalled(body, reached);
             }
         }
         return reached;

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -209,7 +210,12 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
             }
             case CheckedImplementation.Injected ignored -> "injected";
             case CheckedImplementation.Unwritten ignored -> "unwritten";
-            case CheckedImplementation.ImplementedElsewhere ignored -> "elsewhere";
+            // Every behavior asked here is one this compile checked, and an implementation another
+            // compile emitted belongs to a module this program does not hold. Answered with a word
+            // of its own it would be a state this test reads as covered and never sees.
+            case CheckedImplementation.ImplementedElsewhere ignored ->
+                    fail("`" + behavior.name() + "` is a behavior of a checked module and its"
+                            + " implementation is another compile's");
         };
     }
 

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -179,11 +179,14 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
     }
 
     /**
-     * The four states an implementation is in, told apart by asking rather than by finding nothing
-     * where a body would be.
+     * The states an implementation is in, told apart by asking rather than by finding nothing where
+     * a body would be.
      *
      * <p>The switch has no {@code default}: a state added later stops this compiling, which is what
-     * a consumer outside the compiler wants from a set it is meant to handle all of.
+     * a consumer outside the compiler wants from a set it is meant to handle all of. The behaviors
+     * asked here are this compile's own, and one implemented by another compile is a behavior of a
+     * module this program does not emit —
+     * {@code ACallReachesTheBehaviorItsProgramDeclaresTest} asks that one.
      */
     @Test
     void whereAnImplementationComesFromIsAskedAndNotInferredFromAnAbsence() {
@@ -206,6 +209,7 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
             }
             case CheckedImplementation.Injected ignored -> "injected";
             case CheckedImplementation.Unwritten ignored -> "unwritten";
+            case CheckedImplementation.ImplementedElsewhere ignored -> "elsewhere";
         };
     }
 


### PR DESCRIPTION
Closes #1125.

A body may call a behavior a module read off the path declares. That module is not among a checked program's modules, so the only route from a call to its callee — through the module — had nothing to answer with, and a reader was told the behavior did not exist.

The issue reads this as information the compiler does not have. It has it. What is missing is an entrance by identity.

## What was measured first

- A direct call to a path behavior compiles today (`ADependencyOnThePathIsCountedLikeAnyOtherTest`), so the calls exist.
- `Bodies.Signatures` and `Bodies.Implementation` both answer for a module read off the path, for every behavior it declares — including ones nothing in this compilation names. Publishing all three implementation states across a path was checked by compiling one.
- Part of a path behavior's signature already crossed, as the argument positions a row's stand-in is compared at.

The issue's "Untested" section is stale: `AStandInForABehaviorFromThePathCrossesTest` already assembles a real path artifact.

## What this does

`BehaviorTarget` is what a call reaches — what the behavior takes, what it answers, where its implementation comes from — filed under the identity a call carries and answered by `CheckedProgram.behavior`, for every behavior a module this compile checked or read off the path declares. `modules()` enumerates what an output emits; `behavior` and `declaration` resolve what an output has to know. Neither asks the reader to pick an owner it already holds.

The population comes from what each module declares, and the two answers a boundary is made of are read under each declared name. Read off the signatures instead, a behavior nothing answered for would leave the program with nothing having missed it.

`CheckedImplementation.ImplementedElsewhere` is the state a call across a path has and no behavior of a checked module is in. Whether an output links, calls or imports is not decided here.

The two readings of what a behavior takes are held together in the target, not beside a behavior of a checked module, so a boundary that says two things is unmakeable everywhere. `whereArgumentsStand` reads the same targets, which retires the assembler's second reading of a path signature. A module refuses a behavior it does not declare, as it already refuses a method it does not carry.

`ensures` is not carried. `EnsuresEnforcement.NotDecidedHere` is where cross-module contract ownership is already recorded as undecided, and `BehaviorTarget` is a class so that the answer can be added there when it is designed.

The last commit closes what this change made visible beside it: a behavior of a checked module whose implementation state had no reading was handed over as unwritten, which is a behavior the author is owed a body for. It is refused, as one with no signature already is.

## Held to

- every behavior a call in the program reaches is answered for, over a walk of bodies, carried helpers and composition stages
- a behavior of the path module nothing here names is answered for as well — the two laws are separate, and the second is what stops the population shrinking to what a walk reached
- a behavior of a checked module is one boundary reached two ways, by `assertSame` on both readings
- a program whose module holds a boundary its index does not is refused, offered the disagreement directly rather than through an assembler
- the module that declares the callee is still not among the modules emitted

Each was mutated: dropping the unnamed path behavior, mapping `IMPLEMENTED` to `Injected`, rebuilding a module's signature, and inverting the index check all turn one of them red.

`NothingReachableFromACheckedProgramNamesTheCompilerTest` still passes.