### PR TITLE
Give every operator one family, and make each phase decide for itself

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -44,7 +44,7 @@ public final class BinaryElaborator {
         if (read.type() instanceof Type.Erroneous) {
             throw new Unanswerable(bin.pos());
         }
-        if (bin.op() == BinOp.AND || bin.op() == BinOp.OR) {
+        if (bin.op().joinsTwoConditions()) {
             Elaborator.requireType(e, read.type(), Type.BOOL, ctx.symbols(),
                     "operand of logical operator");
         }
@@ -255,7 +255,7 @@ public final class BinaryElaborator {
      * answer is null.
      */
     static Type operandBeside(BinOp op, Type other, boolean onTheRight, Symbols symbols) {
-        if (op == BinOp.AND || op == BinOp.OR) {
+        if (op.joinsTwoConditions()) {
             return Type.BOOL;
         }
         if (other == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -96,8 +96,7 @@ sealed interface ClauseExpr {
         if (under != null) {
             return of(under, !positive, spelled);
         }
-        if (clause instanceof Core.Binary bin
-                && (bin.op() == BinOp.AND || bin.op() == BinOp.OR)) {
+        if (clause instanceof Core.Binary bin && bin.op().joinsTwoConditions()) {
             // Stated, a conjunction gives both sides; denied, it gives the choice between their
             // denials. And the same the other way round, which is the whole of what a denial does
             // to a connective.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
@@ -359,13 +358,13 @@ public final class PathReachability {
             // its own over a fork's condition: a chain is a chain wherever it is written, and one
             // read only under the fork it was written into left the same operators unread a line
             // above.
-            case Core.Binary binary when binary.op() == BinOp.AND
-                    || binary.op() == BinOp.OR -> {
+            case Core.Binary binary when binary.op().stopsWhenItsAnswerIsSettled() -> {
                 walk(binary.left(), k, at, reads, decided, nothingAbove);
-                // `&&` gets to its right side having held, `||` having failed. Read the other way
-                // round, a comparison guarded by its neighbour would be read against conditions
-                // nothing on the way to it established.
-                boolean reachedWhen = binary.op() == BinOp.AND;
+                // Which way the left has to come out for the right to run is the operator's own
+                // answer, and the same answer says there is a right side that runs only sometimes.
+                // Read the other way round, a comparison guarded by its neighbour would be read
+                // against conditions nothing on the way to it established.
+                boolean reachedWhen = binary.op().rightRunsWhenLeftIs();
                 Predicates.Assumed reaching = engine.assuming(binary.left(), k, at, reachedWhen);
                 walk(binary.right(), reaching.known(), at, reads,
                         with(decided, reaching, binary.left().pos(), reachedWhen), nothingAbove);

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1768,7 +1768,7 @@ final class Terms {
         if (result != null && answersIn(result, answered)) {
             return computedBy(result, argsOf(e), answered);
         }
-        if (e instanceof Core.Binary b && isArith(b.op())) {
+        if (e instanceof Core.Binary b && b.op().answersANumber()) {
             return theOneOf(new NumericMeaning.Operator(b.op(), b.left(), b.right()), b.type());
         }
         return null;
@@ -2577,7 +2577,7 @@ final class Terms {
         // what a clause is read against; where it declines to — a variable product, an integer divide
         // — declining is a decision about what this check reasons over, and reporting a construction
         // it has decided not to reason over would be reporting the decision as the author's to fix.
-        if (read instanceof Core.Binary bin && isArith(bin.op())) {
+        if (read instanceof Core.Binary bin && bin.op().answersANumber()) {
             return false;
         }
         // A conditional is one of its branches and which one is not decided here. Saying only that it
@@ -2740,10 +2740,6 @@ final class Terms {
                 .orElse(null);
     }
 
-
-    static boolean isArith(BinOp op) {
-        return op == BinOp.ADD || op == BinOp.SUB || op == BinOp.MUL || op == BinOp.DIV;
-    }
     /** How a preserved call's operation is reached: it is the library's, named under the alias the
      * library publishes it under. A call this representation kept standing applies an operation —
      * the namespace applied is a construction, and is written back as one. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1,6 +1,5 @@
 package souther.compiler.codegen;
 
-import souther.compiler.types.BinOp;
 import souther.compiler.check.Scope;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
@@ -13,6 +12,7 @@ import souther.compiler.check.ReqSig;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Ordering;
@@ -1799,9 +1799,8 @@ final class BodyGen {
          */
         private void emitComparison(Comparison comparison) {
             switch (comparison.claim()) {
-                case ComparisonClaim.Cut _ -> ordered(comparison.at());
-                case ComparisonClaim.Singled(boolean holdsAtTheValue) ->
-                        same(comparison.at(), holdsAtTheValue);
+                case ComparisonClaim.Cut cut -> ordered(comparison.at(), cut);
+                case ComparisonClaim.Singled singled -> same(comparison.at(), singled);
             }
         }
 
@@ -1812,7 +1811,7 @@ final class BodyGen {
          * {@code StageN < StageN} fall past every ordering arm into an equality test, and an order
          * added to {@link Ordering} would fall the same way through an {@code instanceof} chain.
          */
-        private void ordered(Core.Binary bin) {
+        private void ordered(Core.Binary bin, ComparisonClaim.Cut cut) {
             // Whether the two may be compared at all was settled by BinaryElaborator against the
             // types as written; this reads what they open to.
             Ordering how = Ordering.ofComparison(bin.left().type(), bin.right().type(), symbols);
@@ -1824,7 +1823,7 @@ final class BodyGen {
                 case Ordering.Longs _ -> {
                     unwrapNewtypeValue(genExpr(bin.left()));
                     unwrapNewtypeValue(genExpr(bin.right()));
-                    comparisonMaterialize(bin.op(), true);
+                    comparisonMaterialize(cut.statedRelation(), true);
                 }
                 case Ordering.Natural _ -> {
                     // These all carry as Comparable — String, BigDecimal, LocalDate, LocalTime,
@@ -1835,7 +1834,7 @@ final class BodyGen {
                     unwrapNewtypeValue(genExpr(bin.right()));
                     code.invokeinterface(CD_Comparable, "compareTo", MTD_compareTo_Object);
                     code.iconst_0();
-                    comparisonMaterialize(bin.op(), false);
+                    comparisonMaterialize(cut.statedRelation(), false);
                 }
                 case Ordering.Places places -> {
                     // An enumeration compares by where its case stands in the declaration, which
@@ -1845,7 +1844,7 @@ final class BodyGen {
                     code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
                     unwrapNewtypeValue(genExpr(bin.right()));
                     code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
-                    comparisonMaterialize(bin.op(), false);
+                    comparisonMaterialize(cut.statedRelation(), false);
                 }
                 // `opened` answers for the value the operands are opened to, which is never one a
                 // name is still worn over.
@@ -1857,19 +1856,17 @@ final class BodyGen {
         /**
          * A value singled out, tested for sameness.
          *
-         * <p>{@code holdsAtTheValue} says which of the two classes the comparison selects, so a
-         * comparison met where the value is not the one named is this test inverted.
+         * <p>{@link ComparisonClaim.Singled#holdsAtTheValue} says which of the two classes the
+         * comparison selects, so a comparison met where the value is not the one named is this test
+         * inverted.
          */
-        private void same(Core.Binary bin, boolean holdsAtTheValue) {
+        private void same(Core.Binary bin, ComparisonClaim.Singled singled) {
             Type lt = unwrapNewtypeValue(genExpr(bin.left()));
             unwrapNewtypeValue(genExpr(bin.right()));
             if (lt == Type.STRING) {
                 code.invokevirtual(CD_String, "equals",
                         MethodTypeDesc.of(ConstantDescs.CD_boolean, CD_Object));
-                if (!holdsAtTheValue) {
-                    code.iconst_1();
-                    code.ixor();
-                }
+                selecting(singled);
                 return;
             }
             if (isReference(lt)) {
@@ -1877,13 +1874,19 @@ final class BodyGen {
                 // amount ignores its scale, a collection asks that of what it holds (spec
                 // §equality). A pair of Decimals takes the overload for them.
                 emitValueEquals(code, lt == Type.DECIMAL);
-                if (!holdsAtTheValue) {
-                    code.iconst_1();
-                    code.ixor();
-                }
+                selecting(singled);
                 return;
             }
-            comparisonMaterialize(bin.op(), lt == Type.INT);
+            comparisonMaterialize(singled.statedRelation(), lt == Type.INT);
+        }
+
+        /** Turns a test of sameness into the class the comparison selects: the one it is met at is
+         *  what was emitted, and the other is its denial. */
+        private void selecting(ComparisonClaim.Singled singled) {
+            if (!singled.holdsAtTheValue()) {
+                code.iconst_1();
+                code.ixor();
+            }
         }
 
         /** The enumeration a list's elements are ordered by, or null when they are ordered otherwise
@@ -1916,12 +1919,24 @@ final class BodyGen {
             };
         }
 
-        private void comparisonMaterialize(BinOp op, boolean isLong) {
+        /**
+         * The relation the comparison states, brought to a boolean on the stack.
+         *
+         * <p>Taken as what the comparison states rather than as the operator it was written with:
+         * the claim is what a reader holds below a recognition, and reaching back for the operator
+         * to emit it would be the last step of an emission asking the question the recognition
+         * settled.
+         *
+         * <p>The {@code default} is here though the six arms are the whole of {@link Rel} today. An
+         * enum switch statement is not held to covering its type, so a relation added later would
+         * emit no branch at all and leave the stack to the {@code iconst_0} below.
+         */
+        private void comparisonMaterialize(Rel rel, boolean isLong) {
             Label t = code.newLabel();
             Label end = code.newLabel();
             if (isLong) {
                 code.lcmp();
-                switch (op) {
+                switch (rel) {
                     case LT -> code.iflt(t);
                     case LE -> code.ifle(t);
                     case GT -> code.ifgt(t);
@@ -1931,7 +1946,7 @@ final class BodyGen {
                     default -> throw new IllegalStateException();
                 }
             } else {
-                switch (op) {
+                switch (rel) {
                     case LT -> code.if_icmplt(t);
                     case LE -> code.if_icmple(t);
                     case GT -> code.if_icmpgt(t);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -13,6 +13,8 @@ import souther.compiler.check.ReqSig;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.check.Comparison;
+import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Ordering;
 import souther.compiler.core.Core;
 import souther.compiler.core.Kernel;
@@ -599,11 +601,11 @@ final class BodyGen {
          * <p>Absent is ordinary here, unlike an arm's: what has a site is every comparison of a
          * condition this plan instruments, and the emitter walks comparisons everywhere else too.
          */
-        private void comparisonProbe(Core.Binary comparison) {
+        private void comparisonProbe(Comparison comparison) {
             if (!armsAreCounted || !ctx.measuring()) {
                 return;
             }
-            ctx.comparisonSiteOf(comparison).ifPresent(site -> {
+            ctx.comparisonSiteOf(comparison.at()).ifPresent(site -> {
                 ctx.emitted(site);
                 code.dup();
                 code.loadConstant(site);
@@ -757,8 +759,10 @@ final class BodyGen {
                 case Core.Tuple t -> tuple(t);
                 case Core.TupleGet tg -> tupleGet(tg);
                 case Core.Binary bin -> {
-                    binary(bin);
-                    comparisonProbe(bin);
+                    Comparison comparison = binary(bin);
+                    if (comparison != null) {
+                        comparisonProbe(comparison);
+                    }
                 }
                 case Core.Construct nd -> construct(nd);
                 case Core.Match m -> match(m, expected);
@@ -1675,8 +1679,18 @@ final class BodyGen {
             }
         }
 
-        private void binary(Core.Binary bin) {
-            switch (bin.op()) {
+        /**
+         * The operator, emitted; and the comparison it was, where it was one.
+         *
+         * <p>A switch expression, because an enum switch statement is not held to covering its
+         * type. What is wanted here is that an operator added to the language stops the compile
+         * until this has decided what to emit for it, and only an expression asks javac for that.
+         *
+         * <p>What comes back is what a probe records, so a caller has the recognition rather than
+         * the node and a lookup that answers for everything else.
+         */
+        private Comparison binary(Core.Binary bin) {
+            return switch (bin.op()) {
                 // Left to right, stopping as soon as the answer is settled. Not an optimisation:
                 // `/` aborts on a zero divisor and `Int` overflows, so a left operand is how the
                 // domain the right one is evaluated in gets narrowed, and `x /= 0 && 100 / x > 1`
@@ -1692,6 +1706,7 @@ final class BodyGen {
                     code.labelBinding(settled);
                     code.iconst_0();
                     code.labelBinding(end);
+                    yield null;
                 }
                 case OR -> {
                     genExpr(bin.left());
@@ -1703,6 +1718,7 @@ final class BodyGen {
                     code.labelBinding(settled);
                     code.iconst_1();
                     code.labelBinding(end);
+                    yield null;
                 }
                 // `+ - * /` work on two Int or two Decimal operands (spec
                 // §an-operator-takes-the-types-it-is-defined-for). Int aborts on overflow, and `/`
@@ -1715,30 +1731,14 @@ final class BodyGen {
                 // BigDecimal here is what let a scale overflow leave a behavior as a
                 // java.lang.ArithmeticException (ADR-0112, issue #976). This said "Decimal does not
                 // overflow", which is not true of a sum, a difference or a product either.
-                case ADD, SUB, MUL, DIV -> {
-                    // The operands are numbers here: newtype arithmetic is a construction over the
-                    // values its operands wrap, and it was written as one where the tree was built
-                    // (spec §newtype-arithmetic), so nothing is opened or re-wrapped at the operator.
-                    Type t = genExpr(bin.left());
-                    genExpr(bin.right());
-                    if (t == Type.DECIMAL) {
-                        String m = switch (bin.op()) {
-                            case ADD -> "add";
-                            case SUB -> "subtract";
-                            case MUL -> "multiply";
-                            default  -> "divide";
-                        };
-                        code.invokestatic(CD_DecimalMath, m, MTD_bdArith);
-                    } else {
-                        String m = switch (bin.op()) {
-                            case ADD -> "addExact";
-                            case SUB -> "subtractExact";
-                            case MUL -> "multiplyExact";
-                            default  -> "divideExact";
-                        };
-                        code.invokestatic(CD_IntMath, m, MTD_intExact);
-                    }
-                }
+                //
+                // One arm each, and the runtime's method named in it. Read off the operator a
+                // second time inside a single arm, the last of the four is whatever is left over,
+                // and an arithmetic operator added to that arm takes the leftover's method.
+                case ADD -> { arithmetic(bin, "add", "addExact"); yield null; }
+                case SUB -> { arithmetic(bin, "subtract", "subtractExact"); yield null; }
+                case MUL -> { arithmetic(bin, "multiply", "multiplyExact"); yield null; }
+                case DIV -> { arithmetic(bin, "divide", "divideExact"); yield null; }
                 case CONCAT -> {
                     Type lt = genExpr(bin.left());
                     // `++` over two strings is Elm's appendable on String; the checker guarantees both
@@ -1758,99 +1758,132 @@ final class BodyGen {
                         genExpr(bin.right());
                         code.invokestatic(CD_Lists, "concat", MTD_Lists_concat);
                     }
+                    yield null;
                 }
-                default -> {
-                    // A single-value newtype compares by its underlying value, so each operand is
-                    // opened to that value right after it is pushed (金額 <= 金額, 金額 <= 100 — the
-                    // checker allows only same newtype or a bare literal).
-                    //
-                    // An ordering is emitted from the order the operands open to and from nothing
-                    // else, and the switch below carries no `default`: reading the representation
-                    // instead is what let `StageN < StageN` fall past every ordering arm into the
-                    // equality test at the bottom, and an order added to {@link Ordering} would
-                    // fall the same way through an `instanceof` chain (issue #856). An equality is
-                    // the representation's own question and stays below.
-                    if (orderingOf(bin) instanceof Ordering how) {
-                        switch (how) {
-                            case Ordering.Longs _ -> {
-                                unwrapNewtypeValue(genExpr(bin.left()));
-                                unwrapNewtypeValue(genExpr(bin.right()));
-                                comparisonMaterialize(bin.op(), true);
-                            }
-                            case Ordering.Natural _ -> {
-                                // These all carry as Comparable — String, BigDecimal, LocalDate,
-                                // LocalTime, LocalDateTime, Instant — so one compareTo reduces the
-                                // order to its sign against 0. BigDecimal.compareTo ignores scale,
-                                // which matches Decimal equality (spec §equality); the others order
-                                // lexicographically / in time.
-                                unwrapNewtypeValue(genExpr(bin.left()));
-                                unwrapNewtypeValue(genExpr(bin.right()));
-                                code.invokeinterface(CD_Comparable, "compareTo", MTD_compareTo_Object);
-                                code.iconst_0();
-                                comparisonMaterialize(bin.op(), false);
-                            }
-                            case Ordering.Places places -> {
-                                // An enumeration compares by where its case stands in the
-                                // declaration, which the sum answers for both operands —
-                                // `stage < Won` pairs a sum with one of its cases, and
-                                // `x < StageN(Qualified)` two wrappers over one sum.
-                                unwrapNewtypeValue(genExpr(bin.left()));
-                                code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
-                                unwrapNewtypeValue(genExpr(bin.right()));
-                                code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
-                                comparisonMaterialize(bin.op(), false);
-                            }
-                            // `opened` answers for the value the operands are opened to, which is
-                            // never one a name is still worn over.
-                            case Ordering.Wrapped _ -> throw new IllegalStateException(
-                                    "an opened order is never a wrapped one: " + bin.left().type());
-                        }
-                        return;
-                    }
-                    Type lt = unwrapNewtypeValue(genExpr(bin.left()));
-                    unwrapNewtypeValue(genExpr(bin.right()));
-                    if (lt == Type.STRING) {
-                        code.invokevirtual(CD_String, "equals",
-                                MethodTypeDesc.of(ConstantDescs.CD_boolean, CD_Object));
-                        if (bin.op() == BinOp.NE) {
-                            code.iconst_1();
-                            code.ixor();
-                        }
-                        return;
-                    }
-                    if (isReference(lt)) {
-                        // What sameness is, is the runtime's to say: a data compares by its fields,
-                        // an amount ignores its scale, a collection asks that of what it holds
-                        // (spec §equality). A pair of Decimals takes the overload for them.
-                        emitValueEquals(code, lt == Type.DECIMAL);
-                        if (bin.op() == BinOp.NE) {
-                            code.iconst_1();
-                            code.ixor();
-                        }
-                        return;
-                    }
-                    comparisonMaterialize(bin.op(), lt == Type.INT);
+                case EQ, NE, LT, LE, GT, GE -> {
+                    Comparison comparison = Comparison.of(bin).orElseThrow(
+                            () -> new IllegalStateException(
+                                    "an operator that compares placed nothing: " + bin.op()));
+                    emitComparison(comparison);
+                    yield comparison;
                 }
+            };
+        }
+
+        /** What the operator computes of two numbers, through the runtime that owns the arithmetic
+         *  — {@code IntMath} and {@code DecimalMath} — rather than a host method. The operands are
+         *  numbers here: newtype arithmetic is a construction over the values its operands wrap,
+         *  and it was written as one where the tree was built (spec §newtype-arithmetic), so
+         *  nothing is opened or re-wrapped at the operator. */
+        private void arithmetic(Core.Binary bin, String onDecimal, String onInt) {
+            Type t = genExpr(bin.left());
+            genExpr(bin.right());
+            if (t == Type.DECIMAL) {
+                code.invokestatic(CD_DecimalMath, onDecimal, MTD_bdArith);
+            } else {
+                code.invokestatic(CD_IntMath, onInt, MTD_intExact);
             }
         }
 
-        /** How a {@code <}/{@code <=}/{@code >}/{@code >=} compares its operands, or null when this
-         * is not that comparison. Whether the two may be compared at all was settled by
-         * {@code BinaryElaborator} against the types as written; this reads what they open to. */
-        private Ordering orderingOf(Core.Binary bin) {
-            boolean ordering = switch (bin.op()) {
-                case LT, LE, GT, GE -> true;
-                default -> false;
-            };
-            if (!ordering) {
-                return null;
+        /**
+         * The comparison, emitted from what it placed.
+         *
+         * <p>An order and a value singled out are the two things a comparison places, and which of
+         * the two this is comes from the claim the recognition carries. Read off the operator here
+         * instead, the same six would be divided a second time and the two divisions would agree
+         * only for as long as somebody kept them so.
+         *
+         * <p>A single-value newtype compares by its underlying value, so each operand is opened to
+         * that value right after it is pushed (金額 &lt;= 金額, 金額 &lt;= 100 — the checker allows
+         * only same newtype or a bare literal).
+         */
+        private void emitComparison(Comparison comparison) {
+            switch (comparison.claim()) {
+                case ComparisonClaim.Cut _ -> ordered(comparison.at());
+                case ComparisonClaim.Singled(boolean holdsAtTheValue) ->
+                        same(comparison.at(), holdsAtTheValue);
             }
+        }
+
+        /**
+         * An order, emitted from the order the operands open to and from nothing else.
+         *
+         * <p>The switch carries no {@code default}: reading the representation instead is what let
+         * {@code StageN < StageN} fall past every ordering arm into an equality test, and an order
+         * added to {@link Ordering} would fall the same way through an {@code instanceof} chain.
+         */
+        private void ordered(Core.Binary bin) {
+            // Whether the two may be compared at all was settled by BinaryElaborator against the
+            // types as written; this reads what they open to.
             Ordering how = Ordering.ofComparison(bin.left().type(), bin.right().type(), symbols);
             if (how == null) {
                 throw new IllegalStateException("a comparison the checker admitted has no order: "
                         + bin.left().type() + " " + bin.op() + " " + bin.right().type());
             }
-            return how.opened();
+            switch (how.opened()) {
+                case Ordering.Longs _ -> {
+                    unwrapNewtypeValue(genExpr(bin.left()));
+                    unwrapNewtypeValue(genExpr(bin.right()));
+                    comparisonMaterialize(bin.op(), true);
+                }
+                case Ordering.Natural _ -> {
+                    // These all carry as Comparable — String, BigDecimal, LocalDate, LocalTime,
+                    // LocalDateTime, Instant — so one compareTo reduces the order to its sign
+                    // against 0. BigDecimal.compareTo ignores scale, which matches Decimal equality
+                    // (spec §equality); the others order lexicographically / in time.
+                    unwrapNewtypeValue(genExpr(bin.left()));
+                    unwrapNewtypeValue(genExpr(bin.right()));
+                    code.invokeinterface(CD_Comparable, "compareTo", MTD_compareTo_Object);
+                    code.iconst_0();
+                    comparisonMaterialize(bin.op(), false);
+                }
+                case Ordering.Places places -> {
+                    // An enumeration compares by where its case stands in the declaration, which
+                    // the sum answers for both operands — `stage < Won` pairs a sum with one of its
+                    // cases, and `x < StageN(Qualified)` two wrappers over one sum.
+                    unwrapNewtypeValue(genExpr(bin.left()));
+                    code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
+                    unwrapNewtypeValue(genExpr(bin.right()));
+                    code.invokestatic(cd(places.enumeration()), ORDER_METHOD, MTD_order, true);
+                    comparisonMaterialize(bin.op(), false);
+                }
+                // `opened` answers for the value the operands are opened to, which is never one a
+                // name is still worn over.
+                case Ordering.Wrapped _ -> throw new IllegalStateException(
+                        "an opened order is never a wrapped one: " + bin.left().type());
+            }
+        }
+
+        /**
+         * A value singled out, tested for sameness.
+         *
+         * <p>{@code holdsAtTheValue} says which of the two classes the comparison selects, so a
+         * comparison met where the value is not the one named is this test inverted.
+         */
+        private void same(Core.Binary bin, boolean holdsAtTheValue) {
+            Type lt = unwrapNewtypeValue(genExpr(bin.left()));
+            unwrapNewtypeValue(genExpr(bin.right()));
+            if (lt == Type.STRING) {
+                code.invokevirtual(CD_String, "equals",
+                        MethodTypeDesc.of(ConstantDescs.CD_boolean, CD_Object));
+                if (!holdsAtTheValue) {
+                    code.iconst_1();
+                    code.ixor();
+                }
+                return;
+            }
+            if (isReference(lt)) {
+                // What sameness is, is the runtime's to say: a data compares by its fields, an
+                // amount ignores its scale, a collection asks that of what it holds (spec
+                // §equality). A pair of Decimals takes the overload for them.
+                emitValueEquals(code, lt == Type.DECIMAL);
+                if (!holdsAtTheValue) {
+                    code.iconst_1();
+                    code.ixor();
+                }
+                return;
+            }
+            comparisonMaterialize(bin.op(), lt == Type.INT);
         }
 
         /** The enumeration a list's elements are ordered by, or null when they are ordered otherwise

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1761,6 +1761,10 @@ final class BodyGen {
                     yield null;
                 }
                 case EQ, NE, LT, LE, GT, GE -> {
+                    // These six are the six a placement answers a claim for, so the recognition is
+                    // here whenever this arm is. Asked for rather than assumed: what holds it is
+                    // two lists in two files agreeing, and the day they do not this says so rather
+                    // than emitting against a claim nobody made.
                     Comparison comparison = Comparison.of(bin).orElseThrow(
                             () -> new IllegalStateException(
                                     "an operator that compares placed nothing: " + bin.op()));

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1761,10 +1761,11 @@ final class BodyGen {
                     yield null;
                 }
                 case EQ, NE, LT, LE, GT, GE -> {
-                    // These six are the six a placement answers a claim for, so the recognition is
-                    // here whenever this arm is. Asked for rather than assumed: what holds it is
-                    // two lists in two files agreeing, and the day they do not this says so rather
-                    // than emitting against a claim nobody made.
+                    // The recognition is here whenever this arm is, because what an operator places
+                    // is a claim exactly where it compares — which is a law and not an agreement
+                    // between two lists ({@code WhatAnOperatorPlacesIsOneAnswerTest}). Asked for
+                    // rather than assumed all the same, so that a comparison this arm names and
+                    // that law stops holding for is said rather than emitted against.
                     Comparison comparison = Comparison.of(bin).orElseThrow(
                             () -> new IllegalStateException(
                                     "an operator that compares placed nothing: " + bin.op()));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -116,7 +116,7 @@ sealed interface Condition {
                 && reads.meaningOf(name, symbols) instanceof ReadMeaning.Through through) {
             return of(through.denotes().value(), through.denotes().at(), symbols);
         }
-        if (e instanceof Core.Binary binary && combines(binary.op())) {
+        if (e instanceof Core.Binary binary && binary.op().joinsTwoConditions()) {
             Condition left = of(binary.left(), reads, symbols);
             Condition right = of(binary.right(), reads, symbols);
             return binary.op() == BinOp.AND
@@ -129,11 +129,6 @@ sealed interface Condition {
             }
         }
         return new NotRead(e);
-    }
-
-    /** Whether an operator joins two conditions rather than comparing two values. */
-    static boolean combines(BinOp op) {
-        return op == BinOp.AND || op == BinOp.OR;
     }
 
     // Which binaries are comparisons is `Comparison#of`'s answer and is asked rather than spelled

--- a/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
@@ -11,35 +11,92 @@ package souther.compiler.types;
  * reads.
  *
  * <p>The parsed tree keeps its own, which is what the parser produced before anything was resolved.
+ *
+ * <p><b>What is answered here is what an operator is on its own.</b> Which family it belongs to and
+ * which of its operands run are settled by the operator and by nothing else — not by the types it
+ * was written between, not by the polarity it is read under, not by which phase is reading. A
+ * reader that works either out for itself is a second answer to one question, and two answers to
+ * one question are two questions an operator added later can be given different answers to.
+ *
+ * <p><b>And what a phase does with one is that phase's.</b> How an operator is elaborated,
+ * evaluated as a constant or emitted is a decision about the phase and not about the operator, so
+ * it stays where it is made and is exhaustive there. An operator added to the language is then
+ * classified once, here, and decided about once in each phase that has to do something with it.
  */
 public enum BinOp {
-    EQ, NE, LT, LE, GT, GE, AND, OR, ADD, SUB, MUL, DIV, CONCAT;
+    EQ(Family.COMPARISON),
+    NE(Family.COMPARISON),
+    LT(Family.COMPARISON),
+    LE(Family.COMPARISON),
+    GT(Family.COMPARISON),
+    GE(Family.COMPARISON),
+
+    AND(Family.CONDITION_COMBINATION),
+    OR(Family.CONDITION_COMBINATION),
+
+    ADD(Family.ARITHMETIC),
+    SUB(Family.ARITHMETIC),
+    MUL(Family.ARITHMETIC),
+    DIV(Family.ARITHMETIC),
+
+    CONCAT(Family.CONCATENATION);
 
     /**
-     * Whether this settles a comparison, which is the one place that says so.
+     * What an operator does with the two values it stands between.
      *
-     * <p>Read by everything that has to tell a comparison from what is written the same way.
-     * {@code &&} and {@code ||} put comparisons together rather than being ones; the arithmetic
-     * operators answer a number. Each reader used to spell the membership out for itself — one
-     * as "not {@code &&} or {@code ||}", one as "places something on an order" — and two
-     * spellings of one set are two sets an operator added later can land in differently.
+     * <p>Given where the constant is declared, so a constant cannot be written without saying which
+     * of these it is, and the memberships below cannot disagree: an operator is in exactly one
+     * family, and each question about which operators are which is that one classification read
+     * another way.
+     *
+     * <p><b>Private, because a partition is not a vocabulary.</b> A reader asks the question it has,
+     * and hands on what it established rather than the family it established it from.
+     *
+     * <p>{@link #CONCATENATION} is here for the same reason the others are, though nothing asks for
+     * it by name yet. Left out, joining two sequences would be what is left over from three sets
+     * rather than a family somebody declared, and an operator arriving later could be left over
+     * from four.
      */
+    private enum Family {
+        COMPARISON,
+        CONDITION_COMBINATION,
+        ARITHMETIC,
+        CONCATENATION
+    }
+
+    private final Family family;
+
+    BinOp(Family family) {
+        this.family = family;
+    }
+
+    /** Whether this settles a comparison, which is what everything that has to tell one from what
+     *  is written the same way reads. */
     public boolean compares() {
-        return switch (this) {
-            case EQ, NE, LT, LE, GT, GE -> true;
-            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
-        };
+        return family == Family.COMPARISON;
+    }
+
+    /** Whether this answers a number of its two operands. */
+    public boolean answersANumber() {
+        return family == Family.ARITHMETIC;
+    }
+
+    /** Whether this puts two conditions together rather than being one. */
+    public boolean joinsTwoConditions() {
+        return family == Family.CONDITION_COMBINATION;
     }
 
     /**
      * Which way the left operand has to come out for the right one to run, or null where both
      * always run (spec §a-condition-stops-when-its-answer-is-settled).
      *
-     * <p>Here for the reason {@link #compares} is here. Which operands run is part of what the
-     * operator means, and every reader that has to know it was spelling it out again — a reading of
-     * what arrives, a reading of what an expression evaluates, a reading of what a row interacts
-     * with. Three spellings of one rule are three rules an operator added later can land in
-     * differently.
+     * <p>Here for the reason the family is here, and beside it rather than out of it: which
+     * operands run is part of what the operator means, and a reader that works it out for itself is
+     * a second rule an operator added later can land in differently. It is not read off the family.
+     * {@code &&} and {@code ||} are the two that join conditions and the two that stop early, and
+     * those are one set answering two questions rather than one question — an operator joining two
+     * conditions without stopping early would part them, and a reader taking either answer for the
+     * other would be reading a decision nobody made.
      *
      * <p>The polarity and not the membership, because the membership follows from it and the
      * polarity does not follow from anything. Read as "which operators stop early", every reader

--- a/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
@@ -51,13 +51,14 @@ public enum BinOp {
      * classification read another way, and there is no second list to keep in step with this one.
      *
      * <p>Three things hold that between them, and no one of them holds all of it. javac requires
-     * the argument. Being private, these four are what a declaration in this file can name. And a
-     * {@code null} reaching the constructor is refused there, which is the part neither of the
-     * others sees — an operator in no family answers every membership below with "not this one",
-     * which is what an operator outside the language would answer.
+     * the argument. A {@code Family} that is not null is one of these four, which is what being an
+     * enum is. And a {@code null} reaching the constructor is refused there — an operator in no
+     * family answers every membership below with "not this one", which is what an operator outside
+     * the language would answer.
      *
-     * <p><b>Private, because a partition is not a vocabulary.</b> A reader asks the question it has,
-     * and hands on what it established rather than the family it established it from.
+     * <p><b>Private is none of the three: it is what keeps a partition from becoming a
+     * vocabulary.</b> A reader asks the question it has, and hands on what it established rather
+     * than the family it established it from.
      *
      * <p>{@link #CONCATENATION} is here for the same reason the others are, though nothing asks for
      * it by name yet. Left out, joining two sequences would be what is left over from three sets

--- a/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
@@ -99,9 +99,9 @@ public enum BinOp {
      * other would be reading a decision nobody made.
      *
      * <p>The polarity and not the membership, because the membership follows from it and the
-     * polarity does not follow from anything. Read as "which operators stop early", every reader
-     * still had to work out which way, and every one of them wrote {@code == AND} — which is right
-     * while {@code ||} is the only other one and reads {@code ||}'s answer for a third.
+     * polarity does not follow from anything. Answered as "which operators stop early", a reader is
+     * left to work out which way for itself, and the answer it arrives at — the right side is
+     * reached having held — is right only while {@code ||} is the only other one.
      */
     public Boolean rightRunsWhenLeftIs() {
         return switch (this) {

--- a/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BinOp.java
@@ -1,5 +1,7 @@
 package souther.compiler.types;
 
+import java.util.Objects;
+
 /**
  * A binary operator of the language.
  *
@@ -44,10 +46,15 @@ public enum BinOp {
     /**
      * What an operator does with the two values it stands between.
      *
-     * <p>Given where the constant is declared, so a constant cannot be written without saying which
-     * of these it is, and the memberships below cannot disagree: an operator is in exactly one
-     * family, and each question about which operators are which is that one classification read
-     * another way.
+     * <p>Each constant declaration supplies one of these, and the declarations here supply one of
+     * the four. So the memberships below cannot disagree with each other: each is that one
+     * classification read another way, and there is no second list to keep in step with this one.
+     *
+     * <p>Three things hold that between them, and no one of them holds all of it. javac requires
+     * the argument. Being private, these four are what a declaration in this file can name. And a
+     * {@code null} reaching the constructor is refused there, which is the part neither of the
+     * others sees — an operator in no family answers every membership below with "not this one",
+     * which is what an operator outside the language would answer.
      *
      * <p><b>Private, because a partition is not a vocabulary.</b> A reader asks the question it has,
      * and hands on what it established rather than the family it established it from.
@@ -67,7 +74,7 @@ public enum BinOp {
     private final Family family;
 
     BinOp(Family family) {
-        this.family = family;
+        this.family = Objects.requireNonNull(family, "the family an operator belongs to");
     }
 
     /** Whether this settles a comparison, which is what everything that has to tell one from what

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -268,8 +268,8 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.BinaryElaborator.elaborateBinary",
                     "what the operator makes of its operands' types"),
             new Held("souther.compiler.check.BinaryElaborator.operand",
-                    "the same asked of one operand: a scale takes the base a newtype wraps, and a"
-                            + " conjunction takes truths"),
+                    "asks whether the operator joins two conditions, which is the one thing an"
+                            + " operand can be held to before the one beside it has been read"),
             new Held("souther.compiler.check.ConstEval.binary",
                     "what the operator computes of two constants, and which operand it needs to"
                             + " compute it"),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -114,8 +114,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.ConstEval.arith",
                     "what the operator computes of two constants"),
             new Held("souther.compiler.check.ConstEval.compare", "the same for a comparison"),
-            new Held("souther.compiler.codegen.BodyGen.comparisonMaterialize",
-                    "which instructions an operator is emitted as"),
             new Held("souther.compiler.check.Conditions.comparison",
                     "builds a node from the operator it is handed"),
             new Held("souther.compiler.reading.Meetings.run",
@@ -287,10 +285,9 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.codegen.BodyGen.lambda$binary$0",
                     "names the operator in what it says of a comparison that placed nothing"),
             new Held("souther.compiler.codegen.BodyGen.ordered",
-                    "which instructions an order is emitted as, and which order the checker"
-                            + " admitted where it turns out there is none"),
-            new Held("souther.compiler.codegen.BodyGen.same",
-                    "which instructions a value singled out is tested with"),
+                    "names the operator in what it says of an order the checker admitted and the"
+                            + " types turn out not to have: the emission itself is off what the"
+                            + " comparison stated"),
 
             // And whether it compares at all, asked of the one place that says so.
             new Held("souther.compiler.check.InvariantChecker.arithmeticOf",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -282,11 +282,15 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.examples.FixtureReader.fold",
                     "what the operator computes of two numbers a fixture wrote"),
             new Held("souther.compiler.codegen.BodyGen.binary",
-                    "which instructions the operator is emitted as"),
-            new Held("souther.compiler.codegen.BodyGen.orderingOf",
-                    "which operators are orderings, spelled as four cases rather than asked: a"
-                            + " membership the enum does not own, beside the two others spelled"
-                            + " outside it"),
+                    "which instructions the operator is emitted as, and — for the six it emits a"
+                            + " comparison for — the recognition everything below it holds"),
+            new Held("souther.compiler.codegen.BodyGen.lambda$binary$0",
+                    "names the operator in what it says of a comparison that placed nothing"),
+            new Held("souther.compiler.codegen.BodyGen.ordered",
+                    "which instructions an order is emitted as, and which order the checker"
+                            + " admitted where it turns out there is none"),
+            new Held("souther.compiler.codegen.BodyGen.same",
+                    "which instructions a value singled out is tested with"),
 
             // And whether it compares at all, asked of the one place that says so.
             new Held("souther.compiler.check.InvariantChecker.arithmeticOf",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -116,14 +116,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.ConstEval.compare", "the same for a comparison"),
             new Held("souther.compiler.codegen.BodyGen.comparisonMaterialize",
                     "which instructions an operator is emitted as"),
-            new Held("souther.compiler.check.Terms.isArith",
-                    "which operators compute a number, spelled as four equalities rather than"
-                            + " asked of the operator: a membership the enum does not own, and one"
-                            + " an operator added later falls quietly outside of"),
-            new Held("souther.compiler.partition.Condition.combines",
-                    "which operators put conditions together, spelled as two equalities — the same"
-                            + " set the enum already answers for, under another name"),
-
             new Held("souther.compiler.check.Conditions.comparison",
                     "builds a node from the operator it is handed"),
             new Held("souther.compiler.reading.Meetings.run",
@@ -241,8 +233,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "walks into a conjunction for the clause that bounds a field"),
             new Held("souther.compiler.check.InvariantChecker.direct",
                     "walks into a conjunction for the clauses an invariant states"),
-            new Held("souther.compiler.check.PathReachability.walk",
-                    "which way an operator has to come out for the arm under it to be reached"),
             new Held("souther.compiler.check.Predicates.assumeCond",
                     "a conjunction asserted true gives both sides, a disjunction asserted false"
                             + " gives both denied"),
@@ -270,6 +260,9 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.reading.CoverageRead.rightOf", "and which way it runs under"),
             new Held("souther.compiler.reading.Meetings.meetingAt",
                     "asks the enum whether the operator stops early"),
+            new Held("souther.compiler.check.PathReachability.walk",
+                    "asks the enum whether there is a right side that runs on some runs and not"
+                            + " others, and which way the left has to come out for it to"),
 
             // What the operator computes, is typed as, or is emitted as.
             new Held("souther.compiler.check.AffineForms.composed",
@@ -339,13 +332,7 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.ArithmeticCheck.of",
                     "names the constants it has rules for, against the operator it was handed"),
             new Held("souther.compiler.check.BinaryElaborator.operandBeside",
-                    "names the two that take truths and the two that scale a newtype"),
-            new Held("souther.compiler.check.Terms.isArith",
-                    "names the four constants it calls arithmetic, which is a membership the enum"
-                            + " does not own"),
-            new Held("souther.compiler.partition.Condition.combines",
-                    "names the two constants it calls joining, which is a membership the enum"
-                            + " already answers for under another name"),
+                    "names the two that scale a newtype"),
             new Held("souther.compiler.check.Term.Interner.operator",
                     "names the constants the canonical terms are keyed by, which is the"
                             + " six-into-three the reading of a guard now takes from what was"


### PR DESCRIPTION
Closes #1225.

`BinOp` answered two questions about what an operator is and left the rest to be answered wherever they were first needed. Which operators compute a number was four equalities in a reading of terms; which join two conditions was two equalities in a reading of conditions and the same two again in three more readers. An equality chain answers false for an operator added later; the exhaustive switch beside it stops the compile. One enum failed in both directions for one edit.

What is one here is the classification, not the switch. A constant is declared with the family it belongs to, and the three memberships are that one answer read three ways. Three things hold that between them: javac requires the argument, a `Family` that is not null is one of four because `Family` is an enum, and a null reaching the constructor is refused there. `Family` being private is none of the three — that is what keeps the partition from becoming a second vocabulary. Moving each membership to its own exhaustive switch would have made them all loud and left three classifications free to disagree.

## What each commit does

**Give every operator one family where it is declared.** `Family` is a private nested enum supplied at each constant's declaration. `compares()`, `answersANumber()` and `joinsTwoConditions()` read it. `CONCATENATION` is a family though nothing asks for it by name: left out, joining two sequences is what is left over from three sets rather than something somebody declared. `Terms.isArith` and `Condition.combines` are gone and their callers ask the operator. `BinaryElaborator` (two sites), `ClauseExpr` and `Condition.of` ask it too. `PathReachability` was rebuilding short-circuit polarity from the operator — the gate and the polarity both — and takes them from `stopsWhenItsAnswerIsSettled` / `rightRunsWhenLeftIs`.

Which operands run stays beside the family and is not read off it. `&&` and `||` are the two that join conditions and the two that stop early, and that is one set answering two questions.

**Make the backend say what it emits for an operator it has not met.** `BodyGen.binary` sent everything it did not name through a `default` as a comparison. Writing the six comparisons out would not have fixed that: an enum switch *statement* is not held to covering its type, so nothing was going to ask. It is a switch expression now, answering with the comparison it emitted, which is what `comparisonProbe` records — the caller had the node and a lookup that answers for every binary, and now has the recognition.

Which of the two things a comparison places is emitted comes from the claim that recognition carries. The recognition is `Comparison.of`, not `ComparisonPlacement.of`: reading an operator for what it places is licensed to three recognitions, and a fourth call would be a fourth of them.

The arithmetic operators take an arm each, which removes two inner switches whose `default` named `divide`. Those were guarded by the outer arm and by nothing else: an arithmetic operator added there would have taken the leftover's method.

**Emit a comparison from what it states, not from what it was written with.** The emission had come down to the claim and then reached back past it for the operator to pick the branch instruction. The six instructions are chosen by `Rel` now. The `default` stays, for the same reason the outer switch had to become an expression: a statement is not held to covering its type, so a relation added later would emit no branch at all.

## Measured

**Two-stage probe, on clean builds.** `XOR` with no family: `BinOp.java:[43,5] constructor BinOp cannot be applied to given types` — the declaration itself.

`XOR(Family.CONDITION_COMBINATION)` and `mvn -o clean test-compile`, one arm added per round:

```
BinOp.rightRunsWhenLeftIs
ComparisonPlacement.of
BinaryElaborator.elaborateBinary
ConstEval.binary
BodyGen.binary
```

and then BUILD SUCCESS. Exactly five, no equality-chain membership and no backend `default` consuming it silently. The semantic rereads of `op == AND` that #1227 holds are still there and are meant to be. None of the five stops because it classifies the operator again; each has a different behavior to decide. `BodyGen.binary` is the fifth only because it is an expression — measured on javac 25 under this build's `-Xlint:all -Werror`, a statement missing a constant compiles with no error and no warning.

**Mutations.** javac proves a family was chosen; only the suite says whether it was the right one, and only the suite says the emission reads the claim.

Misclassifying `ADD` as `CONDITION_COMBINATION`: 421 failures, 522 errors. Swapping the `Cut` and `Singled` arms of `emitComparison`: 37 failures, 26 errors.

**The inventory, predicted and then measured.** Removing the two membership methods took exactly their four declared lines and added nothing. The backend commit lost `orderingOf` and gained `ordered`, `same` and the lambda that names the operator in an impossible state; the relation commit took `comparisonMaterialize` and `same` back out, neither naming an operator any more. `ComparisonPlacement.of` still has its three licensed callers.

## Left out

`Term.Interner.operator`'s `default` is #1223. The readings that derive what a connective states under a polarity — `(op == AND) == positive` in four places, and `Condition.of` choosing `Both` or `Either` — are #1227. `Resolve.expr`'s `BinOp.valueOf(x.op().name())` is #1228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
