### PR TITLE
Say what an observation could not keep, and never that the model admits no row

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/Membership.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Membership.java
@@ -40,12 +40,20 @@ public sealed interface Membership {
      * <p>Null where there is a value to look at, so a classifier can go on to its own question. Here
      * rather than at each classifier because it is one fact about the observation and not a
      * judgement any class makes — and by the same reading it is not this layer's to state either, so
-     * which cases are a reason instead of a value is {@link ObservedValue#unread()}'s to say. What
-     * is left here is the absence a walk answers with, which is not an observation at all.
+     * which cases are a reason instead of a value is {@link ObservedValue#unread()}'s to say.
+     *
+     * <p><b>Of a value, and refused of nothing.</b> The absence a walk answers with is not an
+     * observation at all, so there is no observation's word for it and this does not reach for the
+     * nearest one. A caller that may arrive with nothing says what nothing means to its own
+     * question, where that is known: for a term reading a number it is that the walk had no value,
+     * and for a classifier it is that no class holds what is not there.
      */
     static Incomplete unread(ObservedValue value) {
-        Incompleteness.Code why = value == null
-                ? Incompleteness.Code.VALUE_UNREADABLE : value.unread();
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "no value arrived, which is not something an observation of one says");
+        }
+        Incompleteness.Code why = value.unread();
         return why == null ? null : new Incomplete(why);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -404,8 +404,27 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
 
         record Number(Place value) implements Reading {}
 
-        /** There was no value to read, and this is what stopped there being one. */
+        /**
+         * A value was there and the observation of it did not come back whole.
+         *
+         * <p>What {@link Incompleteness.Code} names is what an observation met, so only an
+         * observation may put one here. A walk that arrived at no value at all has met nothing and
+         * says {@link NoValue}: given a code instead, the nearest one is borrowed, and a reader
+         * downstream that words a code as what an observation did then says an observation did
+         * something that never happened.
+         */
         record Missing(Incompleteness.Code code) implements Reading {}
+
+        /**
+         * The walk answered with no value here, which is not an observation of one.
+         *
+         * <p>Apart from {@link Missing} because what a reader may do with it is not the same. A
+         * value the observation shortened is a value that exists and this compiler declined to
+         * keep; nothing arriving is this compiler unable to walk to a place, or a place that holds
+         * nothing under the reading being tried. Neither says anything about the number, and only
+         * the first is something a wider budget would have kept.
+         */
+        record NoValue() implements Reading {}
 
         /** The value was read and this term is not a number of it. An answer about the value and not
          * about the observation: a {@code Text} where a number was expected is a class nothing holds,

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -82,10 +82,11 @@ final class TermReading {
      */
     static Reading over(TermOrders on, java.util.List<ObservedValue> values) {
         NumericTerm.TakenOver term = (NumericTerm.TakenOver) on.term();
-        // Nothing to read, which a caller that could not walk to the run answers with. Said as
-        // "this is no number of that" rather than as a total over the values it did find.
+        // Nothing to read, which a caller that could not walk to the run answers with. The absence
+        // a walk answers with and not the values being no number of this term: said as the second,
+        // a run this compiler could not reach comes out as the model putting the row elsewhere.
         if (values == null) {
-            return new Reading.NotNumber();
+            return new Reading.NoValue();
         }
         for (ObservedValue each : values) {
             // An element the walk arrived at nothing for, which is not an observation of one. Said

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -41,6 +41,12 @@ final class TermReading {
     static Reading at(TermOrders on, ObservedValue at) {
         NumericTerm.FromOnePosition term = on.term().atOnePosition();
         Carrier observed = on.observed();
+        // Nothing arrived, which is the walk saying it has no value here rather than an observation
+        // saying it could not keep one. Named apart, because the reader that words an observation's
+        // code says what an observation did — and here there was none.
+        if (at == null) {
+            return new Reading.NoValue();
+        }
         Membership.Incomplete unread = Membership.unread(at);
         if (unread != null) {
             return new Reading.Missing(unread.code());
@@ -82,6 +88,12 @@ final class TermReading {
             return new Reading.NotNumber();
         }
         for (ObservedValue each : values) {
+            // An element the walk arrived at nothing for, which is not an observation of one. Said
+            // apart for the reason the one value a place holds is, since a total over a run is over
+            // whatever the run holds and one of them being nothing is not a limit having fired.
+            if (each == null) {
+                return new Reading.NoValue();
+            }
             Membership.Incomplete unread = Membership.unread(each);
             if (unread != null) {
                 return new Reading.Missing(unread.code());
@@ -184,6 +196,9 @@ final class TermReading {
         }
         java.math.BigDecimal total = java.math.BigDecimal.ZERO;
         for (ObservedValue each : values) {
+            if (each == null) {
+                return new Reading.NoValue();
+            }
             Membership.Incomplete unread = Membership.unread(each);
             if (unread != null) {
                 return new Reading.Missing(unread.code());

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -7,10 +7,14 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.Place;
+import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * What a border is a border <em>of</em>: the quantity a rule cuts.
@@ -91,7 +95,7 @@ public sealed interface BorderQuantity {
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
             return switch (of.read(row.at(term.position()))) {
-                case NumericTerm.Reading.Missing _ -> Stands.UNREADABLE;
+                case NumericTerm.Reading.Missing missing -> Stands.unreadable(missing.code());
                 case NumericTerm.Reading.NotNumber _ -> Stands.NO;
                 case NumericTerm.Reading.Number number ->
                         where.holds(new Level.OnACarrier(of.answered(), number.value()))
@@ -303,9 +307,18 @@ public sealed interface BorderQuantity {
             // whole number is no number at all, and the row stood at nothing (#1018).
             NumericTerm.Reading here = on.read(row.at(on.term().subjectPath()));
             NumericTerm.Reading there = against.read(row.at(against.term().subjectPath()));
-            if (here instanceof NumericTerm.Reading.Missing
-                    || there instanceof NumericTerm.Reading.Missing) {
-                return Stands.UNREADABLE;
+            // Both sides, and not the first of them. The pair is unreadable for whatever stopped
+            // either, and a reader told about one end is being told which end this happened to
+            // look at first.
+            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
+            if (here instanceof NumericTerm.Reading.Missing missing) {
+                stopped.add(missing.code());
+            }
+            if (there instanceof NumericTerm.Reading.Missing missing) {
+                stopped.add(missing.code());
+            }
+            if (!stopped.isEmpty()) {
+                return new Stands.Unreadable(stopped);
             }
             if (!(here instanceof NumericTerm.Reading.Number onAt)
                     || !(there instanceof NumericTerm.Reading.Number againstAt)) {
@@ -521,6 +534,15 @@ public sealed interface BorderQuantity {
         @Override
         public Stands standsAt(Criterion where, Observation row) {
             java.math.BigDecimal at = java.math.BigDecimal.ZERO;
+            // Every term before anything is concluded. What stopped a reading is collected over the
+            // whole form rather than taken from whichever term the map handed over first: the form
+            // is unreadable for whatever stopped any of it, and stopping at the first said which
+            // term this walk happened to begin with. A term that read as no number at all is held
+            // until then for the same reason — a form with one of each is one nothing could read,
+            // and answering that it does not stand would be this compiler's own gap said as the
+            // model's answer.
+            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
+            boolean noNumber = false;
             for (Map.Entry<NumericTerm, java.math.BigDecimal> each : form.coefs().entrySet()) {
                 // Each on its own order. Read on one order for the whole form, a position written
                 // back differently from its neighbour was read as a value it does not hold.
@@ -534,13 +556,21 @@ public sealed interface BorderQuantity {
                     case NumericTerm.TakenOver over ->
                             orders.readOver(row.everyValueAt(over.subjectPath()));
                 };
-                if (read instanceof NumericTerm.Reading.Missing) {
-                    return Stands.UNREADABLE;
+                if (read instanceof NumericTerm.Reading.Missing missing) {
+                    stopped.add(missing.code());
+                    continue;
                 }
                 if (!(read instanceof NumericTerm.Reading.Number number)) {
-                    return Stands.NO;
+                    noNumber = true;
+                    continue;
                 }
                 at = at.add(Count.number(number.value()).at().multiply(each.getValue()));
+            }
+            if (!stopped.isEmpty()) {
+                return new Stands.Unreadable(stopped);
+            }
+            if (noNumber) {
+                return Stands.NO;
             }
             return where.holds(new Level.ACount(new Count(at)))
                     ? Stands.YES : Stands.NO;
@@ -748,11 +778,48 @@ public sealed interface BorderQuantity {
      */
     BoundaryTarget.Shape shape();
 
-    /** Whether a row is at an item, where a row that could not be read is neither. */
-    enum Stands {
-        YES,
-        NO,
-        UNREADABLE
+    /**
+     * Whether a row is at an item, where a row that could not be read is neither.
+     *
+     * <p>The third carries what stopped the reading, because that is a fact about this compiler's
+     * observation and never one about the model. Answered without it, a reader is left to work out
+     * from what it has why there was nothing to compare — and what it has is the absence of a
+     * number, which reads exactly like a number that did not match.
+     */
+    sealed interface Stands {
+
+        /** The values stand at the item. */
+        record Yes() implements Stands {}
+
+        /** They were read, and they do not. */
+        record No() implements Stands {}
+
+        /**
+         * There was no number to compare, and this is what there was instead.
+         *
+         * <p>More than one where the quantity reads more than one term: a rule relating two
+         * positions and a form over several are each unreadable for whatever stopped any of them,
+         * and naming one would be picking which of them a reader is told about.
+         */
+        record Unreadable(Set<Incompleteness.Code> causes) implements Stands {
+
+            public Unreadable {
+                if (causes == null || causes.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a reading nothing could be made of says what stopped it");
+                }
+                causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+            }
+        }
+
+        Stands YES = new Yes();
+
+        Stands NO = new No();
+
+        /** Unreadable for one reason, which is what a quantity reading one term has. */
+        static Stands unreadable(Incompleteness.Code code) {
+            return new Unreadable(EnumSet.of(code));
+        }
     }
 
     /** What one row holds at each of a behavior's positions, for a quantity reading its own value

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -7,11 +7,8 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.Place;
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,8 +92,9 @@ public sealed interface BorderQuantity {
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
             return switch (of.read(row.at(term.position()))) {
-                case NumericTerm.Reading.Missing missing -> Stands.unreadable(missing.code());
-                case NumericTerm.Reading.NoValue _ -> Stands.NOTHING_TO_READ;
+                case NumericTerm.Reading.Missing missing ->
+                        Stands.couldNotTell(ReadingGap.of(missing.code()));
+                case NumericTerm.Reading.NoValue _ -> Stands.couldNotTell(ReadingGap.NO_VALUE);
                 case NumericTerm.Reading.NotNumber _ -> Stands.NO;
                 case NumericTerm.Reading.Number number ->
                         where.holds(new Level.OnACarrier(of.answered(), number.value()))
@@ -311,15 +309,16 @@ public sealed interface BorderQuantity {
             // Both sides, and not the first of them. The pair is unreadable for whatever stopped
             // either, and a reader told about one end is being told which end this happened to
             // look at first.
-            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
-            boolean nothing = false;
+            Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             for (NumericTerm.Reading end : List.of(here, there)) {
                 if (end instanceof NumericTerm.Reading.Missing missing) {
-                    stopped.add(missing.code());
+                    stopped.add(ReadingGap.of(missing.code()));
                 }
-                nothing |= end instanceof NumericTerm.Reading.NoValue;
+                if (end instanceof NumericTerm.Reading.NoValue) {
+                    stopped.add(ReadingGap.NO_VALUE);
+                }
             }
-            Stands unread = Stands.unreadable(stopped, nothing);
+            Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
                 return unread;
             }
@@ -544,9 +543,8 @@ public sealed interface BorderQuantity {
             // until then for the same reason — a form with one of each is one nothing could read,
             // and answering that it does not stand would be this compiler's own gap said as the
             // model's answer.
-            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
+            Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             boolean noNumber = false;
-            boolean nothing = false;
             for (Map.Entry<NumericTerm, java.math.BigDecimal> each : form.coefs().entrySet()) {
                 // Each on its own order. Read on one order for the whole form, a position written
                 // back differently from its neighbour was read as a value it does not hold.
@@ -561,11 +559,11 @@ public sealed interface BorderQuantity {
                             orders.readOver(row.everyValueAt(over.subjectPath()));
                 };
                 if (read instanceof NumericTerm.Reading.Missing missing) {
-                    stopped.add(missing.code());
+                    stopped.add(ReadingGap.of(missing.code()));
                     continue;
                 }
                 if (read instanceof NumericTerm.Reading.NoValue) {
-                    nothing = true;
+                    stopped.add(ReadingGap.NO_VALUE);
                     continue;
                 }
                 if (!(read instanceof NumericTerm.Reading.Number number)) {
@@ -574,7 +572,7 @@ public sealed interface BorderQuantity {
                 }
                 at = at.add(Count.number(number.value()).at().multiply(each.getValue()));
             }
-            Stands unread = Stands.unreadable(stopped, nothing);
+            Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
                 return unread;
             }
@@ -804,57 +802,37 @@ public sealed interface BorderQuantity {
         record No() implements Stands {}
 
         /**
-         * There was no number to compare, and this is what there was instead.
+         * There was no number to compare, and this is every reason there was none.
          *
          * <p>More than one where the quantity reads more than one term: a rule relating two
-         * positions and a form over several are each unreadable for whatever stopped any of them,
-         * and naming one would be picking which of them a reader is told about.
+         * positions and a form over several come to nothing for whatever stopped any of them, and
+         * naming one would be picking which of them a reader is told about. Which is as true of the
+         * two kinds of reason as it is of two observations, so both kinds are in the set and
+         * neither is chosen over the other ({@link ReadingGap}).
          */
-        record Unreadable(Set<Incompleteness.Code> causes) implements Stands {
+        record CouldNotTell(Set<ReadingGap> why) implements Stands {
 
-            public Unreadable {
-                if (causes == null || causes.isEmpty()) {
+            public CouldNotTell {
+                if (why == null || why.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a reading nothing could be made of says what stopped it");
                 }
-                causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+                why = Set.copyOf(why);
             }
         }
-
-        /**
-         * The walk arrived at no value, so there was nothing for an observation to be of.
-         *
-         * <p>Beside {@link Unreadable} and not among its causes. A value the observation shortened
-         * exists and a wider budget would have kept it; a walk that reached nothing has met no
-         * value, and no number of nodes changes that. Held as one case, the second borrows the
-         * first's word and every reader that says what an observation did says it of a walk that
-         * made no observation.
-         */
-        record NothingToRead() implements Stands {}
 
         Stands YES = new Yes();
 
         Stands NO = new No();
 
-        Stands NOTHING_TO_READ = new NothingToRead();
-
-        /** Unreadable for one reason, which is what a quantity reading one term has. */
-        static Stands unreadable(Incompleteness.Code code) {
-            return new Unreadable(EnumSet.of(code));
+        /** Come to nothing for one reason, which is what a quantity reading one term has. */
+        static Stands couldNotTell(ReadingGap why) {
+            return new CouldNotTell(Set.of(why));
         }
 
-        /**
-         * What a quantity over several terms came to, given what each of them did.
-         *
-         * <p>An observation that stopped outranks a walk that reached nothing: the first names
-         * something a wider budget would have kept and is the more specific news, and a form
-         * stopped in both ways is stopped in the way somebody can do something about.
-         */
-        static Stands unreadable(Set<Incompleteness.Code> causes, boolean nothingToRead) {
-            if (!causes.isEmpty()) {
-                return new Unreadable(causes);
-            }
-            return nothingToRead ? NOTHING_TO_READ : null;
+        /** The same over several terms, or null where nothing stopped any of them. */
+        static Stands couldNotTell(Set<ReadingGap> why) {
+            return why.isEmpty() ? null : new CouldNotTell(why);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -96,6 +96,7 @@ public sealed interface BorderQuantity {
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
             return switch (of.read(row.at(term.position()))) {
                 case NumericTerm.Reading.Missing missing -> Stands.unreadable(missing.code());
+                case NumericTerm.Reading.NoValue _ -> Stands.NOTHING_TO_READ;
                 case NumericTerm.Reading.NotNumber _ -> Stands.NO;
                 case NumericTerm.Reading.Number number ->
                         where.holds(new Level.OnACarrier(of.answered(), number.value()))
@@ -311,14 +312,16 @@ public sealed interface BorderQuantity {
             // either, and a reader told about one end is being told which end this happened to
             // look at first.
             Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
-            if (here instanceof NumericTerm.Reading.Missing missing) {
-                stopped.add(missing.code());
+            boolean nothing = false;
+            for (NumericTerm.Reading end : List.of(here, there)) {
+                if (end instanceof NumericTerm.Reading.Missing missing) {
+                    stopped.add(missing.code());
+                }
+                nothing |= end instanceof NumericTerm.Reading.NoValue;
             }
-            if (there instanceof NumericTerm.Reading.Missing missing) {
-                stopped.add(missing.code());
-            }
-            if (!stopped.isEmpty()) {
-                return new Stands.Unreadable(stopped);
+            Stands unread = Stands.unreadable(stopped, nothing);
+            if (unread != null) {
+                return unread;
             }
             if (!(here instanceof NumericTerm.Reading.Number onAt)
                     || !(there instanceof NumericTerm.Reading.Number againstAt)) {
@@ -543,6 +546,7 @@ public sealed interface BorderQuantity {
             // model's answer.
             Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
             boolean noNumber = false;
+            boolean nothing = false;
             for (Map.Entry<NumericTerm, java.math.BigDecimal> each : form.coefs().entrySet()) {
                 // Each on its own order. Read on one order for the whole form, a position written
                 // back differently from its neighbour was read as a value it does not hold.
@@ -560,14 +564,19 @@ public sealed interface BorderQuantity {
                     stopped.add(missing.code());
                     continue;
                 }
+                if (read instanceof NumericTerm.Reading.NoValue) {
+                    nothing = true;
+                    continue;
+                }
                 if (!(read instanceof NumericTerm.Reading.Number number)) {
                     noNumber = true;
                     continue;
                 }
                 at = at.add(Count.number(number.value()).at().multiply(each.getValue()));
             }
-            if (!stopped.isEmpty()) {
-                return new Stands.Unreadable(stopped);
+            Stands unread = Stands.unreadable(stopped, nothing);
+            if (unread != null) {
+                return unread;
             }
             if (noNumber) {
                 return Stands.NO;
@@ -812,13 +821,40 @@ public sealed interface BorderQuantity {
             }
         }
 
+        /**
+         * The walk arrived at no value, so there was nothing for an observation to be of.
+         *
+         * <p>Beside {@link Unreadable} and not among its causes. A value the observation shortened
+         * exists and a wider budget would have kept it; a walk that reached nothing has met no
+         * value, and no number of nodes changes that. Held as one case, the second borrows the
+         * first's word and every reader that says what an observation did says it of a walk that
+         * made no observation.
+         */
+        record NothingToRead() implements Stands {}
+
         Stands YES = new Yes();
 
         Stands NO = new No();
 
+        Stands NOTHING_TO_READ = new NothingToRead();
+
         /** Unreadable for one reason, which is what a quantity reading one term has. */
         static Stands unreadable(Incompleteness.Code code) {
             return new Unreadable(EnumSet.of(code));
+        }
+
+        /**
+         * What a quantity over several terms came to, given what each of them did.
+         *
+         * <p>An observation that stopped outranks a walk that reached nothing: the first names
+         * something a wider budget would have kept and is the more specific news, and a form
+         * stopped in both ways is stopped in the way somebody can do something about.
+         */
+        static Stands unreadable(Set<Incompleteness.Code> causes, boolean nothingToRead) {
+            if (!causes.isEmpty()) {
+                return new Unreadable(causes);
+            }
+            return nothingToRead ? NOTHING_TO_READ : null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -817,7 +817,9 @@ public sealed interface BorderQuantity {
                     throw new IllegalArgumentException(
                             "a reading nothing could be made of says what stopped it");
                 }
-                why = Set.copyOf(why);
+                // In the order they were met, because a report prints them and a report that
+                // changes between runs cannot be compared between runs.
+                why = java.util.Collections.unmodifiableSet(new java.util.LinkedHashSet<>(why));
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2576,6 +2576,7 @@ public final class Generator {
         // readings does; a number over a run is read of all of them at once, since that is what the
         // walk was given and any one of them is not it.
         Set<Incompleteness.Code> unread = EnumSet.noneOf(Incompleteness.Code.class);
+        boolean nothing = false;
         boolean stands = switch (target) {
             case RealizationTarget.AtOnePosition _ -> {
                 boolean any = false;
@@ -2584,6 +2585,10 @@ public final class Generator {
                         case NumericTerm.Reading.Number number ->
                                 any |= number.value().compareTo(at) == 0;
                         case NumericTerm.Reading.Missing missing -> unread.add(missing.code());
+                        // Nothing at this occurrence, which the walk answers with and another
+                        // occurrence may not. Neither placed nor elsewhere, and not something an
+                        // observation stopped either.
+                        case NumericTerm.Reading.NoValue _ -> nothing = true;
                         case NumericTerm.Reading.NotNumber _ -> { }
                     }
                 }
@@ -2595,6 +2600,10 @@ public final class Generator {
                     unread.add(missing.code());
                     yield false;
                 }
+                case NumericTerm.Reading.NoValue _ -> {
+                    nothing = true;
+                    yield false;
+                }
                 case NumericTerm.Reading.NotNumber _ -> false;
             };
         };
@@ -2603,6 +2612,9 @@ public final class Generator {
         }
         if (!unread.isEmpty()) {
             return new RealizationReadback.CouldNotTell(new ReadbackGap.Observation(unread));
+        }
+        if (nothing) {
+            return new RealizationReadback.CouldNotTell(new ReadbackGap.NoValueAtThePosition());
         }
         return new RealizationReadback.Elsewhere("it was composed to put " + target.term()
                 + " at " + at + " and does not stand there");

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -13,6 +13,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.observe.Classification;
+import souther.compiler.observe.Incompleteness;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeReachName;
@@ -21,6 +22,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -2517,11 +2519,15 @@ public final class Generator {
                 if (!subject.parameters().get(parameter).equals(each.getKey().writeRoot().head())) {
                     continue;
                 }
-                String elsewhere = readsElsewhere(subject, parameter, observed, each.getKey(),
-                        each.getValue());
-                if (elsewhere != null) {
+                // Only a reading that placed the value somewhere else turns a candidate away. A
+                // reading that could not be made says nothing about where the value is, and a
+                // search that pruned on it would be spending this compiler's own limit as though
+                // it were an answer about the value. The whole-row reading that follows is where
+                // not being able to tell is recorded.
+                if (readsBackAt(subject, parameter, observed, each.getKey(), each.getValue())
+                        instanceof RealizationReadback.Elsewhere(String why)) {
                     refused[0] = true;
-                    return new CandidateCheck.Built.Refused(elsewhere);
+                    return new CandidateCheck.Built.Refused(why);
                 }
             }
             return built;
@@ -2529,27 +2535,29 @@ public final class Generator {
     }
 
     /**
-     * Where the row reads at the term's position, said only where that is not {@code at}.
+     * What reading one candidate back at the term's position came to.
      *
-     * <p>Null where nothing here can say. A fixing whose edge kept no orders, a position the row
-     * wrote no value at, a walk the value and the type disagree about — none of them is the row
-     * standing somewhere else, and refusing a candidate for one would turn what this compiler
-     * cannot see into a row the model does not have.
+     * <p><b>Three answers, and the third is not the second.</b> A value read where it was built for
+     * and a value read somewhere else are what this walk can establish; everything else is the walk
+     * unable to look, and this compiler being unable to look is not the model putting the value
+     * elsewhere. Held as a {@code null} beside a sentence, the two are one — the sentence is
+     * written whenever a number does not come back, so a value whose observation a limit cut short
+     * is refused with a sentence saying it does not stand where it plainly does.
      *
      * <p>One occurrence is enough, as it is for a row that was written: a row stands at a point
-     * where one of its readings does.
-     *
-     * @param on the orders the value was built against, carried from the edge that built it. Read
-     *           back on anything else, this would be a second reading of the position free to
-     *           disagree with the one the value came from
+     * where one of its readings does. And a reading that could not be made at one occurrence does
+     * not take back another that placed the value — the answers are looked at in that order.
      */
-    private static String readsElsewhere(MeasuredInput subject, int parameter,
-                                         souther.compiler.observe.ObservedValue observed,
-                                         RealizationTarget target, Place at) {
+    private static RealizationReadback readsBackAt(MeasuredInput subject, int parameter,
+                                                   souther.compiler.observe.ObservedValue observed,
+                                                   RealizationTarget target, Place at) {
         // The orders to read it back on, asked of the reading that answered them when the value was
         // built. Carried over from there instead, the two ends of one question would be two values
         // free to part, and a row would be read back on an order nothing composed it against.
         souther.compiler.inputs.TermOrders on = subject.quantities().ordersOf(target.term());
+        if (on == null) {
+            return new RealizationReadback.CouldNotTell(new ReadbackGap.NoOrdersOnTheEdge());
+        }
         // Only this parameter's value is filled in: the walk reads the one the path names, and the
         // others are not this candidate's to say anything about.
         List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
@@ -2557,29 +2565,92 @@ public final class Generator {
         row.set(parameter, observed);
         List<souther.compiler.observe.ObservedValue> values =
                 subject.inputs().valuesAt(row, target.term().subjectPath());
-        if (values == null || values.isEmpty()) {
-            return null;
+        if (values == null) {
+            return new RealizationReadback.CouldNotTell(new ReadbackGap.WalkAndTypeDisagree());
+        }
+        if (values.isEmpty()) {
+            return new RealizationReadback.CouldNotTell(new ReadbackGap.NoValueAtThePosition());
         }
         // What the number is of, asked the way the term's own reader asks it. A number one position
         // answers is read at each value standing there, and a row stands at a point where one of its
         // readings does; a number over a run is read of all of them at once, since that is what the
         // walk was given and any one of them is not it.
+        Set<Incompleteness.Code> unread = EnumSet.noneOf(Incompleteness.Code.class);
         boolean stands = switch (target) {
             case RealizationTarget.AtOnePosition _ -> {
                 boolean any = false;
                 for (souther.compiler.observe.ObservedValue value : values) {
-                    any |= on.read(value) instanceof NumericTerm.Reading.Number number
-                            && number.value().compareTo(at) == 0;
+                    switch (on.read(value)) {
+                        case NumericTerm.Reading.Number number ->
+                                any |= number.value().compareTo(at) == 0;
+                        case NumericTerm.Reading.Missing missing -> unread.add(missing.code());
+                        case NumericTerm.Reading.NotNumber _ -> { }
+                    }
                 }
                 yield any;
             }
-            case RealizationTarget.OverARun _ ->
-                    on.readOver(values) instanceof NumericTerm.Reading.Number number
-                            && number.value().compareTo(at) == 0;
+            case RealizationTarget.OverARun _ -> switch (on.readOver(values)) {
+                case NumericTerm.Reading.Number number -> number.value().compareTo(at) == 0;
+                case NumericTerm.Reading.Missing missing -> {
+                    unread.add(missing.code());
+                    yield false;
+                }
+                case NumericTerm.Reading.NotNumber _ -> false;
+            };
         };
-        return stands ? null
-                : "it was composed to put " + target.term() + " at " + at
-                        + " and does not stand there";
+        if (stands) {
+            return new RealizationReadback.AtRequestedPlace();
+        }
+        if (!unread.isEmpty()) {
+            return new RealizationReadback.CouldNotTell(new ReadbackGap.Observation(unread));
+        }
+        return new RealizationReadback.Elsewhere("it was composed to put " + target.term()
+                + " at " + at + " and does not stand there");
+    }
+
+    /**
+     * What reading a candidate back said about where it stands.
+     *
+     * <p>This walk's own vocabulary and not the one an account is written in. What is asked here is
+     * one parameter's value against one place, which is a cheap prune of the search — a candidate
+     * this lets through is one worth going on with, and never one this has declared to be a row at
+     * the point. What settles that is the whole row, read after it is composed, and what the
+     * <em>account</em> then says is written in the account's words.
+     */
+    private sealed interface RealizationReadback {
+
+        /** The value reads back as the number it was built for. */
+        record AtRequestedPlace() implements RealizationReadback {}
+
+        /** It reads back as some other number, and this is how that is said. */
+        record Elsewhere(String why) implements RealizationReadback {}
+
+        /** Nothing here could say where it reads, and this is what stopped the saying. */
+        record CouldNotTell(ReadbackGap why) implements RealizationReadback {}
+    }
+
+    /**
+     * What stopped one candidate being read back where it was built for.
+     *
+     * <p>Kept apart from what an account calls a gap. The cases here are this walk's own — an edge
+     * that carried no orders, a path the walk and the type disagree about — and only one of them is
+     * about the observation. Shared with the account's vocabulary, a prune's reasons would be
+     * offered as reasons a point cannot be shown writable, and three of these have nothing to do
+     * with that.
+     */
+    private sealed interface ReadbackGap {
+
+        /** The fixing's edge kept no orders, so there is nothing to read the value on. */
+        record NoOrdersOnTheEdge() implements ReadbackGap {}
+
+        /** The walk and the declared type disagree about the path, which the quantity reports. */
+        record WalkAndTypeDisagree() implements ReadbackGap {}
+
+        /** The row wrote no value at the position the term names. */
+        record NoValueAtThePosition() implements ReadbackGap {}
+
+        /** The observation of the value did not come back whole. */
+        record Observation(Set<Incompleteness.Code> causes) implements ReadbackGap {}
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
@@ -1,0 +1,41 @@
+package souther.compiler.partition;
+
+import souther.compiler.observe.Incompleteness;
+
+/**
+ * Why a reading of a number came to none.
+ *
+ * <p>Two kinds and neither outranks the other. A value the observation did not keep whole is a value
+ * that is there, named by the code an observation writes; a walk that arrived at no value met none,
+ * and has no such code. What a reader does about them differs — the first is something a wider
+ * budget keeps and the second is not — so both travel, and a quantity stopped in both ways says
+ * both.
+ *
+ * <p><b>Collected and never chosen between.</b> A rule over several terms is read once per term and
+ * a point is tried against several readings of several rows, so the reasons arrive a few at a time
+ * and are put together. Ranked instead, every place that folds them writes a precedence, every
+ * precedence throws one away, and which one a report says comes out of the order a map or a list
+ * happened to be walked in.
+ */
+public sealed interface ReadingGap {
+
+    /** The observation of a value did not come back whole, and this is what it met. */
+    record Observation(Incompleteness.Code code) implements ReadingGap {
+
+        public Observation {
+            if (code == null) {
+                throw new IllegalArgumentException("an observation that stopped says what it met");
+            }
+        }
+    }
+
+    /** The walk arrived at no value, so there was none to observe. */
+    record NoValue() implements ReadingGap {}
+
+    ReadingGap NO_VALUE = new NoValue();
+
+    /** The gap an observation's code is, for a reader holding one. */
+    static ReadingGap of(Incompleteness.Code code) {
+        return new Observation(code);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.inputs.Membership;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.numeric.Place;
+import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.values.Value;
 
@@ -60,6 +61,12 @@ public final class Recognitions {
     /** One told apart by looking at the value, which there has to be one of to look at. */
     private static Membership byShape(ObservedValue value,
                                       java.util.function.Predicate<ObservedValue> holds) {
+        // No class holds what is not there, and which class it is in is what nothing can say. The
+        // word is this classifier's own: what a walk arrived at is not an observation, and the
+        // sentence read off this code is about placing a value rather than about a limit.
+        if (value == null) {
+            return new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
+        }
         Membership.Incomplete unread = Membership.unread(value);
         return unread != null ? unread : Membership.of(holds.test(value));
     }
@@ -111,6 +118,10 @@ public final class Recognitions {
             case NumericTerm.Reading.Number number -> Membership.of(
                     holds(count.is(), number.value(), count.carrier()));
             case NumericTerm.Reading.Missing missing -> new Membership.Incomplete(missing.code());
+            // Nothing to place, which no class holds and none refuses either. Said in this
+            // classifier's word for it, as the value that never arrived is above.
+            case NumericTerm.Reading.NoValue _ ->
+                    new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
             case NumericTerm.Reading.NotNumber _ -> Membership.NO_MATCH;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -81,7 +81,18 @@ public final class StandingAtAPoint {
             }
         }
 
+        /**
+         * The walk reached no value to compare, which is not an observation of one.
+         *
+         * <p>Apart from {@link CouldNotTell} because the two leave different work. A value a budget
+         * shortened is one a wider budget keeps; a place this compiler could not get a value out of
+         * is not, and reporting it as the first sends a reader after a limit that never fired.
+         */
+        record NothingToRead() implements Met {}
+
         Met REACHED = new Reached();
+
+        Met NOTHING_TO_READ = new NothingToRead();
 
         Met NOT_WATCHED = new NotWatched();
 
@@ -98,6 +109,7 @@ public final class StandingAtAPoint {
     public static Met met(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
                           Criterion criterion, Optional<ComparisonOccurrence> site) {
         Set<Incompleteness.Code> unreadable = EnumSet.noneOf(Incompleteness.Code.class);
+        boolean nowhereToLook = false;
         boolean unwatched = false;
         for (ObservedInputs row : rows) {
             // A row has more than one value at a position inside a sequence, and standing at a point
@@ -109,6 +121,7 @@ public final class StandingAtAPoint {
             Map<TermPath, Integer> held = new LinkedHashMap<>();
             OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
             boolean stands = false;
+            boolean walkedToNothing = false;
             Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
             for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
                 switch (quantity.standsAt(criterion, reading)) {
@@ -119,6 +132,15 @@ public final class StandingAtAPoint {
                     case BorderQuantity.Stands.Unreadable it -> {
                         if (!reading.wroteNothing()) {
                             stopped.addAll(it.causes());
+                        }
+                    }
+                    // The walk reached no value under this reading. Which is not an observation of
+                    // one, so nothing here is recorded as a limit having stopped anything: another
+                    // reading of the same row may reach the point, and where none does the row is
+                    // one this could not read a value off rather than one a budget shortened.
+                    case BorderQuantity.Stands.NothingToRead _ -> {
+                        if (!reading.wroteNothing()) {
+                            walkedToNothing = true;
                         }
                     }
                     case BorderQuantity.Stands.No _ -> { }
@@ -145,9 +167,16 @@ public final class StandingAtAPoint {
                 }
             }
             unreadable.addAll(stopped);
+            nowhereToLook |= walkedToNothing;
         }
+        // An observation that stopped outranks a walk that reached nothing, the way it does at one
+        // reading: the first names something a wider budget would have kept, and the second names
+        // a place this compiler could not get a value out of at all.
         if (!unreadable.isEmpty()) {
             return new Met.CouldNotTell(unreadable);
+        }
+        if (nowhereToLook) {
+            return Met.NOTHING_TO_READ;
         }
         return unwatched ? Met.NOT_WATCHED : Met.NOT_AT_POINT;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -2,13 +2,17 @@ package souther.compiler.partition;
 
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
+import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Whether a tuple of values stands at one point of a border.
@@ -35,8 +39,54 @@ public final class StandingAtAPoint {
      * read leaves the point undecided; a tuple that stands at the level and has no account of its
      * run is one nothing can say reached the comparison, which is not the same as one that ran and
      * did not reach it. Which of them a caller may treat as a miss is the caller's to say.
+     *
+     * <p><b>And the two that found the values are a case of their own.</b> A caller that wants to
+     * know whether the values were seen where the line is asks {@link AtPoint}, and one that wants
+     * to know whether anything watched the run tells its two arms apart — so which readers those
+     * two answers are alike to is settled here, once, rather than by each of them writing the pair
+     * into an arm of its own switch. A caller free to write its own pair is free to write any pair,
+     * and the pair that costs something is a walk that could not look put beside a walk that looked
+     * and found nothing.
      */
-    public enum Met { YES, NO, NOT_WATCHED, UNREADABLE }
+    public sealed interface Met {
+
+        /** The values stand where the line is. */
+        sealed interface AtPoint extends Met {}
+
+        /** And something watched the run reach the comparison, where reaching it was asked. */
+        record Reached() implements AtPoint {}
+
+        /** And nothing watched it get there, which this found out rather than concluded. */
+        record NotWatched() implements AtPoint {}
+
+        /** The values were read, and they are not where the line is. */
+        record NotAtPoint() implements Met {}
+
+        /**
+         * There was nothing at the point to compare, and this is what stopped there being one.
+         *
+         * <p>Carries the causes rather than the fact of there being some. What a limit met is about
+         * this compiler's observation, and a reader handed the case alone can say only that
+         * something went unread — which is the distinction {@code Observed} from
+         * {@code TruncatedByLimit} from {@code Absent} being lost one layer before anybody needs it.
+         */
+        record CouldNotTell(Set<Incompleteness.Code> causes) implements Met {
+
+            public CouldNotTell {
+                if (causes == null || causes.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a point nothing could be told about says what stopped the telling");
+                }
+                causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+            }
+        }
+
+        Met REACHED = new Reached();
+
+        Met NOT_WATCHED = new NotWatched();
+
+        Met NOT_AT_POINT = new NotAtPoint();
+    }
 
     /**
      * The first of {@code rows} that stands there, or why none was found.
@@ -47,7 +97,7 @@ public final class StandingAtAPoint {
      */
     public static Met met(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
                           Criterion criterion, Optional<ComparisonOccurrence> site) {
-        boolean unreadable = false;
+        Set<Incompleteness.Code> unreadable = EnumSet.noneOf(Incompleteness.Code.class);
         boolean unwatched = false;
         for (ObservedInputs row : rows) {
             // A row has more than one value at a position inside a sequence, and standing at a point
@@ -59,16 +109,20 @@ public final class StandingAtAPoint {
             Map<TermPath, Integer> held = new LinkedHashMap<>();
             OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
             boolean stands = false;
-            boolean stopped = false;
+            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
             for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
                 switch (quantity.standsAt(criterion, reading)) {
                     // A reading that could not look, unless what it could not find was an element
                     // the row wrote none of — that is a row that was read and does not stand, and
                     // said of the reading it happened in rather than of the row, since another
                     // reading of the same row may reach the point.
-                    case UNREADABLE -> stopped = stopped || !reading.wroteNothing();
-                    case NO -> { }
-                    case YES -> stands = true;
+                    case BorderQuantity.Stands.Unreadable it -> {
+                        if (!reading.wroteNothing()) {
+                            stopped.addAll(it.causes());
+                        }
+                    }
+                    case BorderQuantity.Stands.No _ -> { }
+                    case BorderQuantity.Stands.Yes _ -> stands = true;
                 }
                 if (stands) {
                     break;
@@ -76,12 +130,12 @@ public final class StandingAtAPoint {
             }
             if (stands) {
                 if (site.isEmpty()) {
-                    return Met.YES;   // writing the value is the whole of what there is to reach
+                    return Met.REACHED;   // writing the value is the whole of what there is to reach
                 }
                 switch (row.watched()) {
                     case Generator.Watched.Ran(var account) -> {
                         if (site.stream().allMatch(account::reached)) {
-                            return Met.YES;
+                            return Met.REACHED;
                         }
                     }
                     // It stands where the line is and nothing watched it get there. Said rather
@@ -90,12 +144,12 @@ public final class StandingAtAPoint {
                     case Generator.Watched.NoAccount _ -> unwatched = true;
                 }
             }
-            unreadable = unreadable || stopped;
+            unreadable.addAll(stopped);
         }
-        if (unreadable) {
-            return Met.UNREADABLE;
+        if (!unreadable.isEmpty()) {
+            return new Met.CouldNotTell(unreadable);
         }
-        return unwatched ? Met.NOT_WATCHED : Met.NO;
+        return unwatched ? Met.NOT_WATCHED : Met.NOT_AT_POINT;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -74,7 +74,8 @@ public final class StandingAtAPoint {
                     throw new IllegalArgumentException(
                             "a point nothing could be told about says what stopped the telling");
                 }
-                why = Set.copyOf(why);
+                // In the order they were met, for the reason a report keeps any order.
+                why = java.util.Collections.unmodifiableSet(new java.util.LinkedHashSet<>(why));
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -2,12 +2,9 @@ package souther.compiler.partition;
 
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,34 +62,23 @@ public final class StandingAtAPoint {
         /**
          * There was nothing at the point to compare, and this is what stopped there being one.
          *
-         * <p>Carries the causes rather than the fact of there being some. What a limit met is about
-         * this compiler's observation, and a reader handed the case alone can say only that
-         * something went unread — which is the distinction {@code Observed} from
-         * {@code TruncatedByLimit} from {@code Absent} being lost one layer before anybody needs it.
+         * <p>Carries every reason rather than the fact of there being some, and never one of them
+         * over another. A reader handed the case alone can say only that something went unread —
+         * which is {@code Observed} from {@code TruncatedByLimit} from {@code Absent} being lost one
+         * layer before anybody needs it; handed the strongest, it is lost wherever a point met both.
          */
-        record CouldNotTell(Set<Incompleteness.Code> causes) implements Met {
+        record CouldNotTell(Set<ReadingGap> why) implements Met {
 
             public CouldNotTell {
-                if (causes == null || causes.isEmpty()) {
+                if (why == null || why.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a point nothing could be told about says what stopped the telling");
                 }
-                causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+                why = Set.copyOf(why);
             }
         }
 
-        /**
-         * The walk reached no value to compare, which is not an observation of one.
-         *
-         * <p>Apart from {@link CouldNotTell} because the two leave different work. A value a budget
-         * shortened is one a wider budget keeps; a place this compiler could not get a value out of
-         * is not, and reporting it as the first sends a reader after a limit that never fired.
-         */
-        record NothingToRead() implements Met {}
-
         Met REACHED = new Reached();
-
-        Met NOTHING_TO_READ = new NothingToRead();
 
         Met NOT_WATCHED = new NotWatched();
 
@@ -108,8 +94,7 @@ public final class StandingAtAPoint {
      */
     public static Met met(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
                           Criterion criterion, Optional<ComparisonOccurrence> site) {
-        Set<Incompleteness.Code> unreadable = EnumSet.noneOf(Incompleteness.Code.class);
-        boolean nowhereToLook = false;
+        Set<ReadingGap> unreadable = new java.util.LinkedHashSet<>();
         boolean unwatched = false;
         for (ObservedInputs row : rows) {
             // A row has more than one value at a position inside a sequence, and standing at a point
@@ -121,26 +106,16 @@ public final class StandingAtAPoint {
             Map<TermPath, Integer> held = new LinkedHashMap<>();
             OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
             boolean stands = false;
-            boolean walkedToNothing = false;
-            Set<Incompleteness.Code> stopped = EnumSet.noneOf(Incompleteness.Code.class);
+            Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
                 switch (quantity.standsAt(criterion, reading)) {
                     // A reading that could not look, unless what it could not find was an element
                     // the row wrote none of — that is a row that was read and does not stand, and
                     // said of the reading it happened in rather than of the row, since another
                     // reading of the same row may reach the point.
-                    case BorderQuantity.Stands.Unreadable it -> {
+                    case BorderQuantity.Stands.CouldNotTell it -> {
                         if (!reading.wroteNothing()) {
-                            stopped.addAll(it.causes());
-                        }
-                    }
-                    // The walk reached no value under this reading. Which is not an observation of
-                    // one, so nothing here is recorded as a limit having stopped anything: another
-                    // reading of the same row may reach the point, and where none does the row is
-                    // one this could not read a value off rather than one a budget shortened.
-                    case BorderQuantity.Stands.NothingToRead _ -> {
-                        if (!reading.wroteNothing()) {
-                            walkedToNothing = true;
+                            stopped.addAll(it.why());
                         }
                     }
                     case BorderQuantity.Stands.No _ -> { }
@@ -167,16 +142,12 @@ public final class StandingAtAPoint {
                 }
             }
             unreadable.addAll(stopped);
-            nowhereToLook |= walkedToNothing;
         }
-        // An observation that stopped outranks a walk that reached nothing, the way it does at one
-        // reading: the first names something a wider budget would have kept, and the second names
-        // a place this compiler could not get a value out of at all.
+        // Every reason any row met, the way one reading collects every reason its terms met. A
+        // point tried against several rows is one this could not tell about for whatever stopped
+        // any of them, and taking the strongest would say which row this walk began with.
         if (!unreadable.isEmpty()) {
             return new Met.CouldNotTell(unreadable);
-        }
-        if (nowhereToLook) {
-            return Met.NOTHING_TO_READ;
         }
         return unwatched ? Met.NOT_WATCHED : Met.NOT_AT_POINT;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -387,7 +387,11 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                         "a reading owing nothing at a point it owes one at: " + role);
             }
             coverage.add(owed.coverage());
-            if (built == null && owed.attempt() instanceof ItemAssessment.Attempt.Built) {
+            // The strongest of them and not the first. A row read back where it was built for is
+            // grounds that a row can be written at the point; one nothing could place is not, and
+            // taking whichever reading came first would let the second stand in for the first and
+            // decide what the account says by the order the readings were walked in.
+            if (outranks(owed.attempt(), built)) {
                 built = owed.attempt();
             }
             if (owed.projection().proves()) {
@@ -399,6 +403,26 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
         }
         return new ObligationAssessment(asked.criterion(),
                 ObligationCoverage.acrossTheReadings(coverage), projection, built);
+    }
+
+    /**
+     * Whether {@code made} says more about a row at the point than {@code held} does.
+     *
+     * <p>Existential over the readings, the way a row that was found is: what one reading of a line
+     * established, another reading of the same line does not take back. Which leaves an order among
+     * what a search may come back with — a row that was placed, a row nothing could place, and
+     * nothing — and it is the same order everywhere the readings of one line are folded.
+     */
+    private static boolean outranks(ItemAssessment.Attempt made, ItemAssessment.Attempt held) {
+        return says(made) > says(held);
+    }
+
+    private static int says(ItemAssessment.Attempt attempt) {
+        return switch (attempt) {
+            case ItemAssessment.Attempt.Certified _ -> 2;
+            case ItemAssessment.Attempt.Unverified _ -> 1;
+            case null, default -> 0;
+        };
     }
 
     /** The measured half, which a point owed a row always has. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -33,7 +33,6 @@ import souther.compiler.partition.BehaviorInputs;
 import souther.compiler.partition.InputClassifications;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -980,12 +979,13 @@ final class Coverages {
         souther.compiler.partition.ObservedInputs read =
                 probe.read(built.row().inputs()).asInputs();
         if (read == null) {
-            // Nothing came back to read, so nothing here can say where the value went. Which is
-            // this walk unable to look and not this walk having looked — the row was composed and
-            // taken by the decoders either way, and the case that says so is the one for a reading
-            // that did not happen.
-            return new StandingAtAPoint.Met.CouldNotTell(
-                    EnumSet.of(Incompleteness.Code.VALUE_UNREADABLE));
+            // Nothing came back to read the row off, which is not an observation of it. What did
+            // not happen here is the running: the values would not build a second time, or the
+            // model refused them, or the classes would not link — and every one of those is
+            // something this run did rather than a value a limit shortened. Named as the second, a
+            // linkage failure arrives at the account as an observation that was stopped, and the
+            // report says a limit did something that never fired.
+            return StandingAtAPoint.Met.NOTHING_TO_READ;
         }
         return StandingAtAPoint.met(quantity, where, List.of(read), criterion, site);
     }
@@ -1057,6 +1057,18 @@ final class Coverages {
                                 new ItemAssessment.Attempt.Unverified(built.row(), within,
                                         built.unrepresented(),
                                         new EstablishmentGap.Observation(it.causes()));
+                        // And a walk that reached no value made no observation, so there is no
+                        // observation to have been stopped. What this run did is the search's own
+                        // to say, in the generator's words: a gap here would put a limit's name on
+                        // something no limit did, which is the trade this whole reading refuses.
+                        case StandingAtAPoint.Met.NothingToRead _ ->
+                                new ItemAssessment.Attempt.Unresolved(
+                                        new souther.compiler.partition.Generator
+                                                .UnresolvedCombination(List.of(subject),
+                                                souther.compiler.partition.Generator
+                                                        .UnresolvedCombination.Reason
+                                                        .NO_CERTIFIED_WITNESS),
+                                        within, built.unrepresented());
                     };
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
                     new ItemAssessment.Attempt.Unresolved(left.why(), within,
@@ -1116,10 +1128,18 @@ final class Coverages {
         // nothing read at all, which may be the row that is at this value; and, for a line a fork
         // drew, a row that never finished and so never reached the comparison.
         Set<Weakening> by = new LinkedHashSet<>();
+        // Each in its own words. What the rows leave open is the same either way — no row of
+        // theirs settles the point — and why there was nothing to read is not, so the two are
+        // carried apart even where this block treats them alike.
         if (met instanceof StandingAtAPoint.Met.CouldNotTell it) {
             for (Incompleteness.Code cause : it.causes()) {
-                by.add(new Weakening.BorderValueUnreadable(border, cause));
+                by.add(new Weakening.BorderValueUnreadable(border,
+                        new Weakening.WhyNoValue.AnObservationStopped(cause)));
             }
+        }
+        if (met instanceof StandingAtAPoint.Met.NothingToRead) {
+            by.add(new Weakening.BorderValueUnreadable(border,
+                    new Weakening.WhyNoValue.TheWalkReachedNoValue()));
         }
         for (Incompleteness gap : observed.gaps()) {
             // Rows nothing read at all bear on every line. Rows that were read and did not finish

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -905,10 +905,25 @@ final class Coverages {
         return composed(a) >= composed(b);
     }
 
-    /** Whether the search of this reading's own region built a row to offer. */
+    /**
+     * How much the search of this reading's own region came back with.
+     *
+     * <p>A row read back where it was built for outranks one nothing could place, which outranks
+     * none at all. The first is grounds that a row can be written at the point and the second is
+     * not, so a reading holding the second cannot be the one that is kept where another holds the
+     * first — the grounds are read off whichever reading this keeps, and taking them from the
+     * reading that happened to come first would lose them to the order two call sites of one helper
+     * were walked in.
+     */
     private static int composed(ItemAssessment item) {
-        return item instanceof ItemAssessment.Owed owed
-                && owed.attempt() instanceof ItemAssessment.Attempt.Built ? 1 : 0;
+        if (!(item instanceof ItemAssessment.Owed owed)) {
+            return 0;
+        }
+        return switch (owed.attempt()) {
+            case ItemAssessment.Attempt.Certified _ -> 2;
+            case ItemAssessment.Attempt.Unverified _ -> 1;
+            case null, default -> 0;
+        };
     }
 
     private static int rank(ItemAssessment item) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -33,11 +33,13 @@ import souther.compiler.partition.BehaviorInputs;
 import souther.compiler.partition.InputClassifications;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Measuring one behavior's rows against the distinctions its model draws.
@@ -830,10 +832,14 @@ final class Coverages {
                 // in the same side is at the point as much as this one would be, so what the row is
                 // offered for goes in beside it rather than being read back off it.
                 return switch (realizer.realize(quantity.standingAt(criterion), able.region())) {
-                    case Realization.Found found -> whatCameOfIt(
-                            standingThere(probe, quantity, where, criterion, site, label,
-                                    probe.attempt(label, found.fixing(), able)),
-                            label, within);
+                    case Realization.Found found -> {
+                        souther.compiler.partition.Generator.BoundaryAttempt made =
+                                probe.attempt(label, found.fixing(), able);
+                        yield whatCameOfIt(made, label, within,
+                                () -> standingThere(probe, quantity, where, criterion, site,
+                                        (souther.compiler.partition.Generator.BoundaryAttempt.Built)
+                                                made));
+                    }
                     // And the two ways of finding nothing are not one answer. A walk of the whole
                     // of what the rules leave that reaches no value settles the point; a search
                     // that stopped, or one that composed no candidate at all, settles nothing
@@ -952,30 +958,21 @@ final class Coverages {
      * stand at the point says the way to the border was not composed against in full; the point is
      * owed the same row it was owed before, and nothing here says one cannot be written.
      */
-    private static souther.compiler.partition.Generator.BoundaryAttempt standingThere(
+    private static StandingAtAPoint.Met standingThere(
             Probe probe, BorderQuantity quantity, BehaviorInputs where, Criterion criterion,
-            java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> site, String label,
-            souther.compiler.partition.Generator.BoundaryAttempt made) {
-        if (!(made instanceof souther.compiler.partition.Generator.BoundaryAttempt.Built built)) {
-            return made;
-        }
+            java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> site,
+            souther.compiler.partition.Generator.BoundaryAttempt.Built built) {
         souther.compiler.partition.ObservedInputs read =
                 probe.read(built.row().inputs()).asInputs();
         if (read == null) {
-            return made;   // nothing built it, so nothing here can say where it went
+            // Nothing came back to read, so nothing here can say where the value went. Which is
+            // this walk unable to look and not this walk having looked — the row was composed and
+            // taken by the decoders either way, and the case that says so is the one for a reading
+            // that did not happen.
+            return new StandingAtAPoint.Met.CouldNotTell(
+                    EnumSet.of(Incompleteness.Code.VALUE_UNREADABLE));
         }
-        return switch (StandingAtAPoint.met(quantity, where, List.of(read), criterion, site)) {
-            case YES, NOT_WATCHED -> made;
-            // Carrying what the composer could not compose against. This is the outcome that most
-            // needs it: a row was built and was not seen reaching the point, and whether some
-            // condition above the line went unused is the first thing that would explain it.
-            case NO, UNREADABLE -> new souther.compiler.partition.Generator.BoundaryAttempt.Unresolved(
-                    new souther.compiler.partition.Generator.UnresolvedCombination(
-                            List.of(label),
-                            souther.compiler.partition.Generator.UnresolvedCombination.Reason
-                                    .NO_CERTIFIED_WITNESS),
-                    built.unrepresented());
-        };
+        return StandingAtAPoint.met(quantity, where, List.of(read), criterion, site);
     }
 
     /** A search that came to nothing at {@code subject}, which is what a point is written as. */
@@ -1004,7 +1001,8 @@ final class Coverages {
      */
     private static ItemAssessment.Attempt.Searched whatCameOfIt(
             souther.compiler.partition.Generator.BoundaryAttempt made, String subject,
-            souther.compiler.partition.WayToTheBorder within) {
+            souther.compiler.partition.WayToTheBorder within,
+            Supplier<StandingAtAPoint.Met> standing) {
         return switch (made) {
             case null -> new ItemAssessment.Attempt.Unresolved(
                     new souther.compiler.partition.Generator.UnresolvedCombination(
@@ -1015,8 +1013,36 @@ final class Coverages {
             // stages and two answers: a condition the walk stated stays stated, and writing the
             // composer's own failure onto the way would have one condition wearing two of the
             // walk's words.
+            //
+            // And the row read back, which is where a composed value becomes a value at the point
+            // or stops short of being one. The three answers of that reading are the three this
+            // hands on, and this is the only place they are turned into what a search came to.
             case souther.compiler.partition.Generator.BoundaryAttempt.Built built ->
-                    new ItemAssessment.Attempt.Built(built.row(), within, built.unrepresented());
+                    switch (standing.get()) {
+                        case StandingAtAPoint.Met.AtPoint _ ->
+                                new ItemAssessment.Attempt.Certified(built.row(), within,
+                                        built.unrepresented());
+                        // Composed and not seen where it was composed for. Which says the way to
+                        // the border was not composed against in full and never that the point is
+                        // unwritable, and it carries what the composer could not act on because
+                        // that is the first thing that would explain it.
+                        case StandingAtAPoint.Met.NotAtPoint _ ->
+                                new ItemAssessment.Attempt.Unresolved(
+                                        new souther.compiler.partition.Generator
+                                                .UnresolvedCombination(List.of(subject),
+                                                souther.compiler.partition.Generator
+                                                        .UnresolvedCombination.Reason
+                                                        .NO_CERTIFIED_WITNESS),
+                                        within, built.unrepresented());
+                        // And a reading that could not look is not a reading that looked. The value
+                        // was built and the decoders took it; what did not happen is the reading
+                        // back. Said as the answer above, a point a value was just built at is
+                        // reported as one nothing can write a row at.
+                        case StandingAtAPoint.Met.CouldNotTell it ->
+                                new ItemAssessment.Attempt.Unverified(built.row(), within,
+                                        built.unrepresented(),
+                                        new EstablishmentGap.Observation(it.causes()));
+                    };
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
                     new ItemAssessment.Attempt.Unresolved(left.why(), within,
                             left.unrepresented());
@@ -1066,7 +1092,7 @@ final class Coverages {
             StandingAtAPoint.Met met, boolean guard, souther.compiler.partition.Border border,
             souther.compiler.query.Adequacy.RowReading observed) {
         List<RowOutcome> rows = observed.rowsSeen();
-        if (met == StandingAtAPoint.Met.YES) {
+        if (met instanceof StandingAtAPoint.Met.Reached) {
             // Found is found: a row settles this whatever else went unread, so nothing weakens it.
             return new Measurement.Complete<>(new ItemAssessment.Coverage.Hit());
         }
@@ -1075,8 +1101,10 @@ final class Coverages {
         // nothing read at all, which may be the row that is at this value; and, for a line a fork
         // drew, a row that never finished and so never reached the comparison.
         Set<Weakening> by = new LinkedHashSet<>();
-        if (met == StandingAtAPoint.Met.UNREADABLE) {
-            by.add(new Weakening.BorderValueUnreadable(border));
+        if (met instanceof StandingAtAPoint.Met.CouldNotTell it) {
+            for (Incompleteness.Code cause : it.causes()) {
+                by.add(new Weakening.BorderValueUnreadable(border, cause));
+            }
         }
         for (Incompleteness gap : observed.gaps()) {
             // Rows nothing read at all bear on every line. Rows that were read and did not finish

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -985,9 +985,33 @@ final class Coverages {
             // something this run did rather than a value a limit shortened. Named as the second, a
             // linkage failure arrives at the account as an observation that was stopped, and the
             // report says a limit did something that never fired.
-            return StandingAtAPoint.Met.NOTHING_TO_READ;
+            return new StandingAtAPoint.Met.CouldNotTell(
+                    Set.of(souther.compiler.partition.ReadingGap.NO_VALUE));
         }
         return StandingAtAPoint.met(quantity, where, List.of(read), criterion, site);
+    }
+
+    /** Whether an observation is among the reasons a reading came to nothing. */
+    private static boolean observed(StandingAtAPoint.Met.CouldNotTell why) {
+        return why.why().stream()
+                .anyMatch(each -> each instanceof souther.compiler.partition.ReadingGap.Observation);
+    }
+
+    /**
+     * The observations among them, which is what a gap about an observation may hold.
+     *
+     * <p>Only those. A walk that reached no value is a reason the reading came to nothing and is
+     * not a thing an observation did, so it travels as far as the account's own reasons go and no
+     * further.
+     */
+    private static EstablishmentGap stopped(StandingAtAPoint.Met.CouldNotTell why) {
+        Set<Incompleteness.Code> codes = new LinkedHashSet<>();
+        for (souther.compiler.partition.ReadingGap each : why.why()) {
+            if (each instanceof souther.compiler.partition.ReadingGap.Observation it) {
+                codes.add(it.code());
+            }
+        }
+        return new EstablishmentGap.Observation(codes);
     }
 
     /** A search that came to nothing at {@code subject}, which is what a point is written as. */
@@ -1053,22 +1077,21 @@ final class Coverages {
                         // was built and the decoders took it; what did not happen is the reading
                         // back. Said as the answer above, a point a value was just built at is
                         // reported as one nothing can write a row at.
+                        // And only the observations among the reasons make an observation's gap. A
+                        // walk that reached no value made no observation, so there is none to have
+                        // been stopped, and a gap built from it would put a limit's name on
+                        // something no limit did. Where that is all there was, what this run did is
+                        // the search's own to say, in the generator's words.
                         case StandingAtAPoint.Met.CouldNotTell it ->
-                                new ItemAssessment.Attempt.Unverified(built.row(), within,
-                                        built.unrepresented(),
-                                        new EstablishmentGap.Observation(it.causes()));
-                        // And a walk that reached no value made no observation, so there is no
-                        // observation to have been stopped. What this run did is the search's own
-                        // to say, in the generator's words: a gap here would put a limit's name on
-                        // something no limit did, which is the trade this whole reading refuses.
-                        case StandingAtAPoint.Met.NothingToRead _ ->
-                                new ItemAssessment.Attempt.Unresolved(
-                                        new souther.compiler.partition.Generator
-                                                .UnresolvedCombination(List.of(subject),
-                                                souther.compiler.partition.Generator
-                                                        .UnresolvedCombination.Reason
-                                                        .NO_CERTIFIED_WITNESS),
-                                        within, built.unrepresented());
+                                observed(it) ? new ItemAssessment.Attempt.Unverified(built.row(),
+                                        within, built.unrepresented(), stopped(it))
+                                        : new ItemAssessment.Attempt.Unresolved(
+                                                new souther.compiler.partition.Generator
+                                                        .UnresolvedCombination(List.of(subject),
+                                                        souther.compiler.partition.Generator
+                                                                .UnresolvedCombination.Reason
+                                                                .NO_CERTIFIED_WITNESS),
+                                                within, built.unrepresented());
                     };
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
                     new ItemAssessment.Attempt.Unresolved(left.why(), within,
@@ -1128,18 +1151,13 @@ final class Coverages {
         // nothing read at all, which may be the row that is at this value; and, for a line a fork
         // drew, a row that never finished and so never reached the comparison.
         Set<Weakening> by = new LinkedHashSet<>();
-        // Each in its own words. What the rows leave open is the same either way — no row of
-        // theirs settles the point — and why there was nothing to read is not, so the two are
-        // carried apart even where this block treats them alike.
+        // One per reason, each in its own words. What the rows leave open is the same whichever it
+        // was — no row of theirs settles the point — and why there was nothing to read is not, so
+        // every reason travels even where this block treats them alike.
         if (met instanceof StandingAtAPoint.Met.CouldNotTell it) {
-            for (Incompleteness.Code cause : it.causes()) {
-                by.add(new Weakening.BorderValueUnreadable(border,
-                        new Weakening.WhyNoValue.AnObservationStopped(cause)));
+            for (souther.compiler.partition.ReadingGap why : it.why()) {
+                by.add(new Weakening.BorderValueUnreadable(border, why));
             }
-        }
-        if (met instanceof StandingAtAPoint.Met.NothingToRead) {
-            by.add(new Weakening.BorderValueUnreadable(border,
-                    new Weakening.WhyNoValue.TheWalkReachedNoValue()));
         }
         for (Incompleteness gap : observed.gaps()) {
             // Rows nothing read at all bear on every line. Rows that were read and did not finish

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -1,0 +1,49 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.Incompleteness;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * What stopped this compiler establishing that a row can be written at a point.
+ *
+ * <p>Not a reason a row cannot be written. Every case here is a budget of this compiler's own
+ * reached on the way to an answer, so what it licenses is that the question is open — and a reader
+ * that turned one of these into a statement about the model would be reporting a policy as a
+ * property of what somebody wrote.
+ *
+ * <p><b>Made where the establishing stopped, and never worked out afterwards.</b> The outcome a
+ * search comes back with says that nothing came of it; which budget ran out is known only where it
+ * ran out, and a reader recovering it from the outcome would be recovering it from something that
+ * has already lost it — one reason a search comes back with is written wherever a search can stop,
+ * by files that stop for nothing like each other. So a producer that stops hands this over, and one
+ * that has nothing to hand over says so by there being no gap rather than by a gap nobody made.
+ *
+ * <p>One case today. A candidate this compiler declined to compose leaves the same question open
+ * for the same kind of reason, and it is not here: what stops that composing is a different budget
+ * in a different stage, and the value that would have been read back was never built. A case for it
+ * arrives beside this one, and every reader that has to tell them apart is a reader an exhaustive
+ * switch already stops.
+ */
+public sealed interface EstablishmentGap {
+
+    /**
+     * An observation of the value did not come back whole, so where it stands could not be read.
+     *
+     * <p>The value was built and the module's own decoders took it. What did not happen is the
+     * reading back, and {@link Incompleteness.Code} is what says whether a limit shortened the
+     * observation or nothing could be made of the value at all.
+     */
+    record Observation(Set<Incompleteness.Code> causes) implements EstablishmentGap {
+
+        public Observation {
+            if (causes == null || causes.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "an observation that stopped something says what stopped it");
+            }
+            causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -7,6 +7,7 @@ import souther.compiler.partition.NotOwedReason;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -57,15 +58,32 @@ public sealed interface ItemAssessment {
          * <p>Which is why the two used to be attempts and are not. "A row is already there" and
          * "this was never measured" are things the measurement says, and a search that reported them
          * was repeating what its own input already held.
+         *
+         * <p><b>Read over the states and not off a list of the ones that qualify.</b> The question
+         * is whether anything is left to find out here, and a measurement that is short of
+         * something is the case that most needs a candidate — it is the one where this compiler
+         * cannot say whether a row exists. Named the other way round, as a list of the shapes worth
+         * searching, a reading weakened by what went unread falls through to {@code false} and the
+         * point is never searched at all; nothing is then built, nothing shows the point writable,
+         * and the account says the model admits no row there. A state added to {@link Measurement}
+         * arrives here as a compile error rather than as that silence.
          */
         public boolean worthSearching() {
             if (hasRowWitness()) {
                 return false;
             }
-            return coverage instanceof Measurement.Complete<Coverage> whole
-                            && whole.value() instanceof Coverage.NoHit
-                    || coverage instanceof Measurement.NotMeasured<Coverage> none
-                            && none.why() == Coverage.NotAsked.NO_ROWS;
+            return switch (coverage) {
+                // Read to the end and no row at it, or read as far as it got and no row at it: both
+                // are points where a candidate tells somebody something.
+                case Measurement.Complete<Coverage> it -> it.value() instanceof Coverage.NoHit;
+                case Measurement.Partial<Coverage> it -> it.value() instanceof Coverage.NoHit;
+                // No rows to look at is a point worth building one for. The other reasons nobody
+                // measured are not: a question this compilation was not put is not work to hand to
+                // an author.
+                case Measurement.NotMeasured<Coverage> it -> it.why() == Coverage.NotAsked.NO_ROWS;
+                // Nothing to build against, which the search would find out again.
+                case Measurement.FailedToMeasure<Coverage> _ -> false;
+            };
         }
 
         /**
@@ -116,8 +134,13 @@ public sealed interface ItemAssessment {
          * true of whether anything was known, and false of what was doing the knowing.
          */
         public WritabilityEvidence writabilityEvidence() {
+            // The certified arm and not `Built`. What grounds this is a value shown to be at the
+            // point, and a row whose read-back never came back has not been shown to be anywhere —
+            // counted here, an observation this compiler cut short would be reported as the model
+            // admitting a row, which is the same trade as the one it is here to stop, made the
+            // other way round. What that row does license is said by `WritabilityKnowledge`.
             return WritabilityEvidence.of(projection, hasRowWitness(),
-                    attempt instanceof Attempt.Built);
+                    attempt instanceof Attempt.Certified);
         }
     }
 
@@ -368,20 +391,65 @@ public sealed interface ItemAssessment {
             List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed();
         }
 
-        /** A value at the point, built and accepted by the module's own decoders. */
-        record Built(Generator.GeneratedRow row,
-                     souther.compiler.partition.WayToTheBorder way,
-                     List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed)
-                implements Searched {
+        /**
+         * A value at the point, built and accepted by the module's own decoders.
+         *
+         * <p><b>What was built, and whether it was read back where it was built for, are two
+         * things.</b> Composing a value that the decoders take does not say the value lands at the
+         * point — a rule the composer could not act on refuses a candidate the composer thought it
+         * had placed — so the row is read again after it is built. Which leaves three outcomes and
+         * not two: the reading agreed, the reading disagreed, and the reading did not happen.
+         *
+         * <p>Held as one case, the third can only be said as the second: a value whose read-back a
+         * limit cuts short is filed as a search that composed nothing, and the point it stands at
+         * is then reported as one nothing can write a row at. Held as a boolean beside the row,
+         * every reader decides again what the boolean licenses.
+         *
+         * <p>So this is what the two share — a row was built, and whoever wants it can have it —
+         * and the arms below are what only one of them may say. A reader asking for the row asks
+         * for {@link Built}; a reader asking whether anything showed the point writable asks for
+         * {@link Certified}, and gets a compile error rather than a silent yes if a third way of
+         * being built arrives.
+         */
+        sealed interface Built extends Searched {
 
-            public Built {
-                uncomposed = List.copyOf(uncomposed);
-            }
+            /** The value this search composed, whichever of the two this is. */
+            Generator.GeneratedRow row();
 
             /** A row composed where the whole way was stated and used. */
-            public Built(Generator.GeneratedRow row,
-                         souther.compiler.partition.WayToTheBorder way) {
-                this(row, way, List.of());
+            static Built certified(Generator.GeneratedRow row,
+                                   souther.compiler.partition.WayToTheBorder way) {
+                return new Certified(row, way, List.of());
+            }
+        }
+
+        /** Built, and read back standing where it was built for. */
+        record Certified(Generator.GeneratedRow row,
+                         souther.compiler.partition.WayToTheBorder way,
+                         List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed)
+                implements Built {
+
+            public Certified {
+                uncomposed = List.copyOf(uncomposed);
+            }
+        }
+
+        /**
+         * Built, and the reading that would have said where it stands did not come back.
+         *
+         * <p>Nothing here is about the model. The row is as much a row as {@link Certified}'s and is
+         * offered as one; what is missing is this compiler's own confirmation, and {@code why} is
+         * what stopped it.
+         */
+        record Unverified(Generator.GeneratedRow row,
+                          souther.compiler.partition.WayToTheBorder way,
+                          List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
+                          EstablishmentGap why)
+                implements Built {
+
+            public Unverified {
+                uncomposed = List.copyOf(uncomposed);
+                Objects.requireNonNull(why, "a row nothing certified says what stopped it");
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -59,14 +59,11 @@ public sealed interface ItemAssessment {
          * "this was never measured" are things the measurement says, and a search that reported them
          * was repeating what its own input already held.
          *
-         * <p><b>Read over the states and not off a list of the ones that qualify.</b> The question
-         * is whether anything is left to find out here, and a measurement that is short of
-         * something is the case that most needs a candidate — it is the one where this compiler
-         * cannot say whether a row exists. Named the other way round, as a list of the shapes worth
-         * searching, a reading weakened by what went unread falls through to {@code false} and the
-         * point is never searched at all; nothing is then built, nothing shows the point writable,
-         * and the account says the model admits no row there. A state added to {@link Measurement}
-         * arrives here as a compile error rather than as that silence.
+         * <p><b>Read over the states rather than off a list of the ones that qualify.</b> Every
+         * state says here what it means, so a state added to {@link Measurement} arrives as a
+         * compile error rather than as a silent {@code false} — which is the difference between a
+         * point nobody searched because nothing would come of it and one nobody searched because
+         * the list was written before the state existed.
          */
         public boolean worthSearching() {
             if (hasRowWitness()) {
@@ -76,7 +73,12 @@ public sealed interface ItemAssessment {
                 // Read to the end and no row at it, or read as far as it got and no row at it: both
                 // are points where a candidate tells somebody something.
                 case Measurement.Complete<Coverage> it -> it.value() instanceof Coverage.NoHit;
-                case Measurement.Partial<Coverage> it -> it.value() instanceof Coverage.NoHit;
+                // A measurement short of something is not work to hand to anybody. Nobody can say
+                // whether a row is at such a point, so no finding is made of it and an author is
+                // not behind on it; a candidate built there answers a question the measurement did
+                // not ask, and building one costs a composed row run and read back at every point
+                // of every line the reading fell short at.
+                case Measurement.Partial<Coverage> _ -> false;
                 // No rows to look at is a point worth building one for. The other reasons nobody
                 // measured are not: a question this compilation was not put is not work to hand to
                 // an author.
@@ -392,7 +394,11 @@ public sealed interface ItemAssessment {
         }
 
         /**
-         * A value at the point, built and accepted by the module's own decoders.
+         * A value composed for the point and accepted by the module's own decoders.
+         *
+         * <p>Composed <em>for</em> it and not established to be at it, which is the whole of what
+         * this word promises: {@link Unverified} is the case where nothing placed the value, so a
+         * contract saying a value at the point would be false of one of its own arms.
          *
          * <p><b>What was built, and whether it was read back where it was built for, are two
          * things.</b> Composing a value that the decoders take does not say the value lands at the

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -73,12 +73,7 @@ public sealed interface ItemAssessment {
                 // Read to the end and no row at it, or read as far as it got and no row at it: both
                 // are points where a candidate tells somebody something.
                 case Measurement.Complete<Coverage> it -> it.value() instanceof Coverage.NoHit;
-                // A measurement short of something is not work to hand to anybody. Nobody can say
-                // whether a row is at such a point, so no finding is made of it and an author is
-                // not behind on it; a candidate built there answers a question the measurement did
-                // not ask, and building one costs a composed row run and read back at every point
-                // of every line the reading fell short at.
-                case Measurement.Partial<Coverage> _ -> false;
+                case Measurement.Partial<Coverage> it -> it.value() instanceof Coverage.NoHit;
                 // No rows to look at is a point worth building one for. The other reasons nobody
                 // measured are not: a question this compilation was not put is not work to hand to
                 // an author.

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
@@ -69,7 +69,18 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
      */
     public ItemAssessment.WritabilityEvidence writabilityEvidence() {
         return ItemAssessment.WritabilityEvidence.of(projection, hasRowWitness(),
-                attempt instanceof ItemAssessment.Attempt.Built);
+                attempt instanceof ItemAssessment.Attempt.Certified);
+    }
+
+    /**
+     * The same, and where the knowing stopped where there are no grounds.
+     *
+     * <p>What an account reads. The grounds alone answer one question and leave two situations
+     * looking alike — nothing has shown a row can be written, and the showing of it was stopped —
+     * and an account acts on those differently.
+     */
+    public WritabilityKnowledge writabilityKnowledge() {
+        return WritabilityKnowledge.of(writabilityEvidence(), attempt);
     }
 
     /** What the readings behind this went without. */
@@ -84,6 +95,6 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
      * to the two answers this holds, and {@link ObligationDisposition} is that question asked once.
      */
     public ObligationDisposition disposition() {
-        return ObligationDisposition.of(coverage, writabilityEvidence());
+        return ObligationDisposition.of(coverage, writabilityKnowledge());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
@@ -36,13 +36,42 @@ public sealed interface ObligationDisposition {
     record Unmet() implements Counted {}
 
     /**
-     * No row was seen and a reading that could have been holding one did not run to the end.
+     * No row was seen, and something this compiler could not do is why nobody can say more.
      *
      * <p>Counted and never a finding. Whether a row is at the point is what nobody can say, so an
      * author told to write one may be told to write one they have written; and left out of the
      * count, an obligation the rows may already answer would go unsaid.
+     *
+     * <p><b>Two questions can be the one nobody can answer, and they are told apart.</b> A reading
+     * that could have been holding a row did not run to the end; or the rows were read to the end
+     * and it was the showing that a row can be written here that was stopped. Both leave the point
+     * undecided and they leave different work: the first is answered by reading more of what is
+     * written, the second by this compiler being able to keep more of what it builds. Held as one
+     * state, a reader is told a verdict and left to work out which question it is about — from the
+     * verdict, which is the one thing that does not say.
+     *
+     * <p>A set, because one obligation can be both, and either one alone would be a choice of which
+     * to tell.
      */
-    record Undecided() implements Counted {}
+    record Undecided(Set<Uncertainty> because) implements Counted {
+
+        public Undecided {
+            if (because == null || because.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "an obligation nobody can decide says which question is open");
+            }
+            because = Collections.unmodifiableSet(EnumSet.copyOf(because));
+        }
+    }
+
+    /** Which question about an obligation is the one nothing answered. */
+    enum Uncertainty {
+        /** Whether a row that is written stands at the point: a reading of the rows stopped short. */
+        COVERAGE,
+        /** Whether a row can be written at the point: the showing of it stopped short. What
+         *  stopped it is the point's own to say ({@link WritabilityKnowledge.Prevented}). */
+        WRITABILITY
+    }
 
     /** One this account does not count, with every reason it does not. */
     record NotCounted(Set<Reason> because) implements ObligationDisposition {
@@ -66,35 +95,60 @@ public sealed interface ObligationDisposition {
     }
 
     /**
-     * Where {@code coverage} and {@code writable} put the obligation.
+     * Where {@code coverage} and {@code knowledge} put the obligation.
      *
-     * <p>The one place the pair is read. A row found answers first and on its own — it is what the
-     * point asked for, and it proves the point can be written at, so nothing beside it can take it
-     * back. Below that the two reasons for not counting are collected together, and only a counted
-     * obligation is told apart by what the readings found.
+     * <p>The one place the pair is read, and read coverage first. What the rows came to is what
+     * decides which question is even open: a row found is met whatever else is so, a reading that
+     * stopped leaves the point undecided whatever anybody built, and a point nothing was read
+     * against is out of the count however well the rules prove a value could stand there.
+     *
+     * <p><b>What has shown a row can be written is a refinement of one of those and not a gate over
+     * all of them.</b> It is what tells a miss the rows ran out on from a finding — an author told
+     * to write a row at a point nothing promises may be told to write one that cannot exist. Asked
+     * before the coverage instead, it takes an obligation nobody could decide out of the count as
+     * well, and the account then says the model admits no row at a point where the rows simply went
+     * unread.
+     *
+     * <p>And the middle answer of the three is why that refinement has three arms rather than two.
+     * A point where the showing was stopped by a budget of this compiler's is not one where nothing
+     * promises a row: it is one where the promise was being made and did not arrive. Counted, and
+     * never a finding.
      */
-    static ObligationDisposition of(ObligationCoverage coverage,
-                                    ItemAssessment.WritabilityEvidence writable) {
-        if (coverage.hasRowWitness()) {
-            return new Met();
-        }
-        Set<Reason> because = EnumSet.noneOf(Reason.class);
-        if (!coverage.hasAnswer()) {
-            because.add(Reason.NOTHING_WAS_READ);
-        }
-        if (!writable.known()) {
-            because.add(Reason.NOT_KNOWN_TO_BE_WRITABLE);
-        }
-        if (!because.isEmpty()) {
-            return new NotCounted(because);
-        }
+    static ObligationDisposition of(ObligationCoverage coverage, WritabilityKnowledge knowledge) {
         return switch (coverage) {
-            case ObligationCoverage.Missed _ -> new Unmet();
-            case ObligationCoverage.Undecided _ -> new Undecided();
-            // Both are answered above: a witness is met, and nothing read is not counted.
-            case ObligationCoverage.Witnessed _, ObligationCoverage.NotMeasured _ ->
-                    throw new IllegalStateException(
-                            "an obligation counted and neither missed nor undecided: " + coverage);
+            case ObligationCoverage.Witnessed _ -> new Met();
+            // What the rows left open, and beside it whatever else is open about the same point. A
+            // reading that stopped and a showing that was stopped are two questions, and a point
+            // where both happened is undecided about both.
+            case ObligationCoverage.Undecided _ -> {
+                Set<Uncertainty> open = EnumSet.of(Uncertainty.COVERAGE);
+                if (knowledge instanceof WritabilityKnowledge.Prevented) {
+                    open.add(Uncertainty.WRITABILITY);
+                }
+                yield new Undecided(open);
+            }
+            case ObligationCoverage.Missed _ -> switch (knowledge) {
+                case WritabilityKnowledge.Established _ -> new Unmet();
+                // The rows are read out and no row is at the point, and what would have shown a row
+                // can be written was stopped on the way. The obligation stays in the count — a
+                // budget of this compiler's is not the model refusing anything — and no finding is
+                // made of it, because nothing here can say the row an author would write is one
+                // that exists.
+                case WritabilityKnowledge.Prevented _ ->
+                        new Undecided(EnumSet.of(Uncertainty.WRITABILITY));
+                case WritabilityKnowledge.NoEvidence _ ->
+                        new NotCounted(EnumSet.of(Reason.NOT_KNOWN_TO_BE_WRITABLE));
+            };
+            // Nothing was read against it, so there is nothing to have found. What is known about a
+            // row being writable there is said beside that rather than instead of it: the two are
+            // independent facts about the point and a reader is owed both.
+            case ObligationCoverage.NotMeasured _ -> {
+                Set<Reason> because = EnumSet.of(Reason.NOTHING_WAS_READ);
+                if (!(knowledge instanceof WritabilityKnowledge.Established)) {
+                    because.add(Reason.NOT_KNOWN_TO_BE_WRITABLE);
+                }
+                yield new NotCounted(because);
+            }
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -105,11 +105,14 @@ public final class PointResolver {
                         walked.put(reading, new SearchCoverage.ReadingSearch.Unavailable());
                 case ReadingEvidence.Searched(ItemAssessment.Attempt attempt) -> {
                     switch (attempt) {
-                        case ItemAssessment.Attempt.Built(var row, var _, var _) ->
+                        // A row was built, whether or not the reading back placed it. What this
+                        // hands over is the row, and an author holding one this compiler could not
+                        // read back has the same row it composed.
+                        case ItemAssessment.Attempt.Built built ->
                                 // The line is answered. Which reading answered it is where the row
                                 // goes, and what a reader asking about one coordinate compares
                                 // against — so the position is carried and not the behavior alone.
-                                { return new PointResolution.Generated(reading, row); }
+                                { return new PointResolution.Generated(reading, built.row()); }
                         case ItemAssessment.Attempt.Unresolved(var why, var _, var _) ->
                                 walked.put(reading,
                                         new SearchCoverage.ReadingSearch.Attempted(why));

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -97,6 +97,7 @@ public final class PointResolver {
                     : PointResolution.Cause.NOTHING_MEASURED);
         }
         SequencedMap<Reading, SearchCoverage.ReadingSearch> walked = new LinkedHashMap<>();
+        PointResolution.Generated offered = null;
         for (Reading reading : readings) {
             switch (held.apply(reading)) {
                 case ReadingEvidence.OutOfScope _ ->
@@ -105,14 +106,21 @@ public final class PointResolver {
                         walked.put(reading, new SearchCoverage.ReadingSearch.Unavailable());
                 case ReadingEvidence.Searched(ItemAssessment.Attempt attempt) -> {
                     switch (attempt) {
-                        // A row was built, whether or not the reading back placed it. What this
-                        // hands over is the row, and an author holding one this compiler could not
-                        // read back has the same row it composed.
-                        case ItemAssessment.Attempt.Built built ->
-                                // The line is answered. Which reading answered it is where the row
-                                // goes, and what a reader asking about one coordinate compares
-                                // against — so the position is carried and not the behavior alone.
-                                { return new PointResolution.Generated(reading, built.row()); }
+                        // A row read back where it was built for. Which reading composed it is
+                        // where the row goes, and what a reader asking about one coordinate
+                        // compares against — so the position is carried and not the behavior alone.
+                        case ItemAssessment.Attempt.Certified made ->
+                                { return new PointResolution.Generated(reading, made.row()); }
+                        // And one nothing could place, which is a row an author may still want and
+                        // is not one this settles the point with. Kept in case no reading of the
+                        // line has better, and answered only after every one of them has been
+                        // asked: taken as soon as it is met, a reading that could not read its
+                        // candidate back would stand in for one that could.
+                        case ItemAssessment.Attempt.Unverified made -> {
+                            if (offered == null) {
+                                offered = new PointResolution.Generated(reading, made.row());
+                            }
+                        }
                         case ItemAssessment.Attempt.Unresolved(var why, var _, var _) ->
                                 walked.put(reading,
                                         new SearchCoverage.ReadingSearch.Attempted(why));
@@ -140,7 +148,11 @@ public final class PointResolver {
                 }
             }
         }
-        return new PointResolution.Unresolved(new SearchCoverage(readings, walked));
+        // A row nothing placed, where no reading of the line placed one. It is what a search came
+        // back with and an author asked for a row is owed it; what it is not is the point settled,
+        // and nothing here says it is.
+        return offered != null ? offered
+                : new PointResolution.Unresolved(new SearchCoverage(readings, walked));
     }
 
     private PointResolver() {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -494,11 +494,11 @@ public record Settlements(List<OfferItem> requested,
             for (AtAPoint one : here) {
                 Settlement said = switch (StandingAtAPoint.met(one.line().cut().of(), where,
                         List.of(row), one.criterion(), one.line().origin().comparisonAt())) {
-                    case YES -> new Settlement.Settles();
-                    case NO -> new Settlement.DoesNotSettle();
-                    case NOT_WATCHED ->
+                    case StandingAtAPoint.Met.Reached _ -> new Settlement.Settles();
+                    case StandingAtAPoint.Met.NotAtPoint _ -> new Settlement.DoesNotSettle();
+                    case StandingAtAPoint.Met.NotWatched _ ->
                             new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
-                    case UNREADABLE -> new Settlement.Undetermined(
+                    case StandingAtAPoint.Met.CouldNotTell _ -> new Settlement.Undetermined(
                             Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
                 };
                 if (said.settles()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -500,6 +500,11 @@ public record Settlements(List<OfferItem> requested,
                             new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
                     case StandingAtAPoint.Met.CouldNotTell _ -> new Settlement.Undetermined(
                             Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
+                    // A walk that reached no value, which settles nothing for the same reason and
+                    // by a different route. What this reader is deciding is whether the row before
+                    // it answers the point, and neither of them lets it say so.
+                    case StandingAtAPoint.Met.NothingToRead _ -> new Settlement.Undetermined(
+                            Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
                 };
                 if (said.settles()) {
                     return said;

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -498,12 +498,9 @@ public record Settlements(List<OfferItem> requested,
                     case StandingAtAPoint.Met.NotAtPoint _ -> new Settlement.DoesNotSettle();
                     case StandingAtAPoint.Met.NotWatched _ ->
                             new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);
+                    // Whichever reason there was none, this reader is deciding whether the row
+                    // before it answers the point, and none of them lets it say so.
                     case StandingAtAPoint.Met.CouldNotTell _ -> new Settlement.Undetermined(
-                            Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
-                    // A walk that reached no value, which settles nothing for the same reason and
-                    // by a different route. What this reader is deciding is whether the row before
-                    // it answers the point, and neither of them lets it say so.
-                    case StandingAtAPoint.Met.NothingToRead _ -> new Settlement.Undetermined(
                             Settlement.Reason.THE_VALUES_COULD_NOT_BE_READ);
                 };
                 if (said.settles()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -68,37 +68,16 @@ public sealed interface Weakening {
      * A row's value at one border could not be read, so what is not found at that border is
      * undecided rather than absent.
      *
-     * <p>With what stopped the reading, since a value a limit shortened and one nothing could
-     * decode leave the same hole and are not the same news: the first is what this compiler chose
-     * not to keep and the second is a value it met and could make nothing of. One of these per
-     * cause, so that a border stopped in two ways says both — which a set does for free, and a
-     * record holding the causes would leave to whoever wrote the sentence.
+     * <p>With what stopped the reading, one of these per reason, so that a border stopped in two
+     * ways says both — which a set does for free, and a record holding the reasons would leave to
+     * whoever wrote the sentence. The reasons are the reading's own ({@link
+     * souther.compiler.partition.ReadingGap}) and are carried rather than folded: a value a limit
+     * shortened, a value nothing could decode and a place the walk never reached leave the same
+     * hole and are three different pieces of news.
      */
-    record BorderValueUnreadable(souther.compiler.partition.Border border, WhyNoValue why)
+    record BorderValueUnreadable(souther.compiler.partition.Border border,
+                                 souther.compiler.partition.ReadingGap why)
             implements Weakening {}
-
-    /**
-     * Why there was no value at a border to read.
-     *
-     * <p>Two, and only one of them is an observation. A value this compiler chose not to keep is a
-     * value that is there, named by the code an observation writes; a walk that arrived at no value
-     * met none, and has no such code — so it does not borrow one. Held as a code either way, the
-     * second wears the first's word, and a reader that says what an observation did says it of a
-     * walk that made none ({@link EstablishmentGap}).
-     *
-     * <p>What a report calls this is one word for both, because what a reader does about them is
-     * the same: the point is undecided and no row of theirs settles it. The two are apart so that
-     * the next reader to want more than that word cannot take the wrong half of it.
-     */
-    sealed interface WhyNoValue {
-
-        /** An observation of the value did not come back whole. */
-        record AnObservationStopped(souther.compiler.observe.Incompleteness.Code code)
-                implements WhyNoValue {}
-
-        /** The walk arrived at no value, so there was none to observe. */
-        record TheWalkReachedNoValue() implements WhyNoValue {}
-    }
 
     /** The reading of the model that a measure depends on did not run out. */
     record ModelReadingIncomplete(ClosureGap cause) implements Weakening {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -74,9 +74,31 @@ public sealed interface Weakening {
      * cause, so that a border stopped in two ways says both — which a set does for free, and a
      * record holding the causes would leave to whoever wrote the sentence.
      */
-    record BorderValueUnreadable(souther.compiler.partition.Border border,
-                                 souther.compiler.observe.Incompleteness.Code why)
+    record BorderValueUnreadable(souther.compiler.partition.Border border, WhyNoValue why)
             implements Weakening {}
+
+    /**
+     * Why there was no value at a border to read.
+     *
+     * <p>Two, and only one of them is an observation. A value this compiler chose not to keep is a
+     * value that is there, named by the code an observation writes; a walk that arrived at no value
+     * met none, and has no such code — so it does not borrow one. Held as a code either way, the
+     * second wears the first's word, and a reader that says what an observation did says it of a
+     * walk that made none ({@link EstablishmentGap}).
+     *
+     * <p>What a report calls this is one word for both, because what a reader does about them is
+     * the same: the point is undecided and no row of theirs settles it. The two are apart so that
+     * the next reader to want more than that word cannot take the wrong half of it.
+     */
+    sealed interface WhyNoValue {
+
+        /** An observation of the value did not come back whole. */
+        record AnObservationStopped(souther.compiler.observe.Incompleteness.Code code)
+                implements WhyNoValue {}
+
+        /** The walk arrived at no value, so there was none to observe. */
+        record TheWalkReachedNoValue() implements WhyNoValue {}
+    }
 
     /** The reading of the model that a measure depends on did not run out. */
     record ModelReadingIncomplete(ClosureGap cause) implements Weakening {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -64,9 +64,19 @@ public sealed interface Weakening {
     /** The same at one of a behavior's inputs, counted from zero. */
     record InputCasesUnreadable(String behavior, int at) implements Weakening {}
 
-    /** A row's value at one border could not be read, so what is not found at that border is
-     *  undecided rather than absent. */
-    record BorderValueUnreadable(souther.compiler.partition.Border border) implements Weakening {}
+    /**
+     * A row's value at one border could not be read, so what is not found at that border is
+     * undecided rather than absent.
+     *
+     * <p>With what stopped the reading, since a value a limit shortened and one nothing could
+     * decode leave the same hole and are not the same news: the first is what this compiler chose
+     * not to keep and the second is a value it met and could make nothing of. One of these per
+     * cause, so that a border stopped in two ways says both — which a set does for free, and a
+     * record holding the causes would leave to whoever wrote the sentence.
+     */
+    record BorderValueUnreadable(souther.compiler.partition.Border border,
+                                 souther.compiler.observe.Incompleteness.Code why)
+            implements Weakening {}
 
     /** The reading of the model that a measure depends on did not run out. */
     record ModelReadingIncomplete(ClosureGap cause) implements Weakening {}

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import java.util.Objects;
+
 /**
  * What this compilation knows about a row being writable at one point, and where the knowing
  * stopped.
@@ -24,12 +26,31 @@ package souther.compiler.query;
  */
 public sealed interface WritabilityKnowledge {
 
-    /** Something has shown a row can be written here, and this is what. */
+    /**
+     * Something has shown a row can be written here, and this is what.
+     *
+     * <p>Never nothing. An empty set of grounds is what {@link NoEvidence} is, and holding one here
+     * would put the two states one field apart — a point with nothing behind it wearing the word
+     * for a point with something, which is what an account reads to tell a finding from a gap.
+     */
     record Established(ItemAssessment.WritabilityEvidence evidence)
-            implements WritabilityKnowledge {}
+            implements WritabilityKnowledge {
+
+        public Established {
+            if (evidence == null || !evidence.known()) {
+                throw new IllegalArgumentException(
+                        "a point something has shown writable says what showed it");
+            }
+        }
+    }
 
     /** A budget of this compiler's stopped the establishing, and this is which. */
-    record Prevented(EstablishmentGap by) implements WritabilityKnowledge {}
+    record Prevented(EstablishmentGap by) implements WritabilityKnowledge {
+
+        public Prevented {
+            Objects.requireNonNull(by, "a showing that was stopped says what stopped it");
+        }
+    }
 
     /** Nothing has shown a row can be written here, and nothing was stopped from showing it. */
     record NoEvidence() implements WritabilityKnowledge {}

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -1,0 +1,62 @@
+package souther.compiler.query;
+
+/**
+ * What this compilation knows about a row being writable at one point, and where the knowing
+ * stopped.
+ *
+ * <p>Beside {@link ItemAssessment.WritabilityEvidence} and not instead of it. That collects the
+ * grounds and holds nothing else, which is what makes an empty set the absence of evidence rather
+ * than evidence of absence — and leaves the reader of the empty set with one answer for two
+ * situations. Nothing has been shown, and nothing was tried, are alike only in what they lack.
+ *
+ * <p>So this is the projection an account reads: whether there are grounds, whether a budget of
+ * this compiler's stopped the establishing of any, or whether there is simply nothing. The middle
+ * one is the whole of what {@link #of} adds, and it is narrow — a value was composed and the
+ * reading that would have placed it did not come back. A search that ran and found nothing, a
+ * search nobody could run, and a point nobody asked about are all the third case: none of them met
+ * a budget on the way to an answer, and calling them prevented would say this compiler was stopped
+ * where it was not.
+ *
+ * <p><b>Nothing here says a row can be written.</b> {@link Prevented} is the question left open and
+ * never the answer yes — a reader that took it for one would be turning an observation this
+ * compiler cut short into the model admitting a row, which is the mistake it exists to name, made
+ * backwards.
+ */
+public sealed interface WritabilityKnowledge {
+
+    /** Something has shown a row can be written here, and this is what. */
+    record Established(ItemAssessment.WritabilityEvidence evidence)
+            implements WritabilityKnowledge {}
+
+    /** A budget of this compiler's stopped the establishing, and this is which. */
+    record Prevented(EstablishmentGap by) implements WritabilityKnowledge {}
+
+    /** Nothing has shown a row can be written here, and nothing was stopped from showing it. */
+    record NoEvidence() implements WritabilityKnowledge {}
+
+    /**
+     * Where the grounds and the attempt beside them put the point.
+     *
+     * <p>Derived here and held nowhere, for the reason the evidence is: both are answers to
+     * questions the assessment already carries, and a copy kept beside them is a state somebody can
+     * build in which they disagree.
+     *
+     * <p>Grounds first. A point something has shown writable is established whatever a later search
+     * made of it — a value built and not read back does not take back what the rules already prove,
+     * and the order says so rather than leaving it to whichever the caller looked at.
+     */
+    static WritabilityKnowledge of(ItemAssessment.WritabilityEvidence evidence,
+                                   ItemAssessment.Attempt attempt) {
+        if (evidence.known()) {
+            return new Established(evidence);
+        }
+        // The one thing that was stopped rather than absent. Read off the attempt's own case and
+        // never off the reason inside an unresolved one: a search that came back with nothing has
+        // already lost which budget it was, so a reader rebuilding that from the word left over is
+        // rebuilding what the word does not hold.
+        if (attempt instanceof ItemAssessment.Attempt.Unverified it) {
+            return new Prevented(it.why());
+        }
+        return new NoEvidence();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -35,6 +35,7 @@ import souther.compiler.query.ObligationDisposition;
 import souther.compiler.query.ObligationSummary;
 import souther.compiler.query.EstablishmentGap;
 import souther.compiler.query.WritabilityKnowledge;
+import souther.compiler.partition.ReadingGap;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.BehaviorEvidence;
 import souther.compiler.query.PartitionEvidence;
@@ -1707,7 +1708,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         List<String> said = new ArrayList<>();
         for (ObligationDisposition.Uncertainty each : it.because()) {
             said.add(switch (each) {
-                case COVERAGE -> "undecided whether a row is at the " + point;
+                // And what the rows went without, which is what makes it undecided rather than
+                // missed. The reading carried whether a value was stopped or never arrived all the
+                // way here, and a sentence that stopped at "undecided" would be the last step of
+                // the carrying dropping it.
+                case COVERAGE -> "undecided whether a row is at the " + point
+                        + whatTheRowsWentWithout(owed);
                 // Named for what happened and not for the limit's number. Which budget it was is
                 // the observation's own word, and what an author is told is that the row this
                 // compiler composed is not evidence of anything until it can be read back.
@@ -1716,6 +1722,33 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             });
         }
         return said;
+    }
+
+    /**
+     * What the readings of a point went without at the border, said after the verdict.
+     *
+     * <p>Empty where they went without nothing there — a point left undecided by a row that never
+     * ran has its reason said elsewhere, and repeating it here would be one gap wearing two
+     * sentences.
+     */
+    private static String whatTheRowsWentWithout(ObligationAssessment owed) {
+        List<String> said = new ArrayList<>();
+        for (Weakening each : owed.weakening().causes()) {
+            if (each instanceof Weakening.BorderValueUnreadable it) {
+                said.add(atTheBorder(it.why()));
+            }
+        }
+        return said.isEmpty() ? "" : ", and " + String.join(", and ", said);
+    }
+
+    /** What one reading met at a border instead of a number, in the reading's own words. */
+    private static String atTheBorder(ReadingGap why) {
+        return switch (why) {
+            case ReadingGap.Observation(Incompleteness.Code code) -> whatStopped(code);
+            // Nothing was observed here, so nothing about an observation is said. What a reader is
+            // owed is that no value arrived at all, which no budget would have changed.
+            case ReadingGap.NoValue _ -> "the walk reached no value there to read";
+        };
     }
 
     /** Why nothing could confirm the row a search composed, in the observation's own words. */
@@ -3250,7 +3283,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     throw new IllegalArgumentException("an observation writes its own code");
             case Weakening.OutputCasesUnreadable _ -> WeakeningWord.OUTPUT_CASES_UNREADABLE;
             case Weakening.InputCasesUnreadable _ -> WeakeningWord.INPUT_CASES_UNREADABLE;
-            case Weakening.BorderValueUnreadable _ -> WeakeningWord.BORDER_VALUE_UNREADABLE;
+            // Read through to what the reading met. Both of these leave a point undecided and a
+            // reader acts on them differently, so a projection that answered one word for the pair
+            // would take the difference back out one step after the reading carried it here.
+            case Weakening.BorderValueUnreadable it -> switch (it.why()) {
+                case ReadingGap.Observation _ -> WeakeningWord.BORDER_VALUE_UNREADABLE;
+                case ReadingGap.NoValue _ -> WeakeningWord.BORDER_VALUE_ABSENT;
+            };
             case Weakening.ModelReadingIncomplete it -> switch (it.cause()) {
                 case souther.compiler.partition.ClosureGap.RuleUnread _ ->
                         WeakeningWord.RULE_UNREAD;

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -33,6 +33,8 @@ import souther.compiler.query.ObligationAssessment;
 import souther.compiler.query.ObligationCoverage;
 import souther.compiler.query.ObligationDisposition;
 import souther.compiler.query.ObligationSummary;
+import souther.compiler.query.EstablishmentGap;
+import souther.compiler.query.WritabilityKnowledge;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.BehaviorEvidence;
 import souther.compiler.query.PartitionEvidence;
@@ -49,6 +51,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * How well a model's {@code example}s cover it, as something a person reads and a build reads.
@@ -500,8 +503,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // numbers is a difference a reader can walk. A point nobody can say is missed is not a gap
         // and is under no finding, and this is the only place it can be said at all.
         for (Adequacy.DeclaredDebt each : account.undecided()) {
-            out.append(String.format("      ? undecided whether a row is at the %s point %s (%s)%n",
-                    each.debt().role(), each.said(), each.debt().describe(names, null)));
+            for (String said : undecidedBecause(each.debt().owed(),
+                    each.debt().role() + " point " + each.said()
+                            + " (" + each.debt().describe(names, null) + ")")) {
+                out.append(String.format("      ? %s%n", said));
+            }
             readings(out, each.debt(), _ -> true, _ -> "");
         }
         // And the ones the count leaves out, said here for the reason it counts them here: a line
@@ -1224,8 +1230,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // a point nobody can say is missed is not a gap and is no finding, and left to the number
         // alone a reader is told a difference with nothing under it to act on.
         for (BorderObligationPointAssessment point : owed.undecided()) {
-            out.append(String.format("      ? undecided whether a row is at the %s point (%s)%n",
-                    point.role(), point.describe(names, declaredIn)));
+            for (String said : undecidedBecause(point.owed(),
+                    point.role() + " point (" + point.describe(names, declaredIn) + ")")) {
+                out.append(String.format("      ? %s%n", said));
+            }
             readings(out, point, _ -> true, _ -> "");
         }
         // A border the model drew that nothing here answered for, said whether or not one came of
@@ -1677,6 +1685,66 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return switch (reason) {
             case NOTHING_WAS_READ -> Surface.UNDER_THE_COUNT;
             case NOT_KNOWN_TO_BE_WRITABLE -> Surface.ON_ITS_OWN_LINE;
+        };
+    }
+
+    /**
+     * What is undecided about one obligation, a sentence per open question.
+     *
+     * <p>Two questions wear one verdict, and an author acts on them differently. Whether a row that
+     * is written stands at the point is answered by reading more of what the rows hold; whether a
+     * row can be written there at all is answered by this compiler keeping more of what it builds,
+     * and the second is not work an author can do. Said in one sentence, the second reads as the
+     * first and sends a reader to look through their own rows for something that is not there.
+     *
+     * <p>Read off the disposition rather than off what is beside it. Which questions are open is
+     * what the disposition was made to say, and a second reading here would be a second answer.
+     */
+    private static List<String> undecidedBecause(ObligationAssessment owed, String point) {
+        if (!(owed.disposition() instanceof ObligationDisposition.Undecided it)) {
+            return List.of();
+        }
+        List<String> said = new ArrayList<>();
+        for (ObligationDisposition.Uncertainty each : it.because()) {
+            said.add(switch (each) {
+                case COVERAGE -> "undecided whether a row is at the " + point;
+                // Named for what happened and not for the limit's number. Which budget it was is
+                // the observation's own word, and what an author is told is that the row this
+                // compiler composed is not evidence of anything until it can be read back.
+                case WRITABILITY -> "a row was built for the " + point
+                        + ", and " + why(owed.writabilityKnowledge());
+            });
+        }
+        return said;
+    }
+
+    /** Why nothing could confirm the row a search composed, in the observation's own words. */
+    private static String why(WritabilityKnowledge knowledge) {
+        if (!(knowledge instanceof WritabilityKnowledge.Prevented(EstablishmentGap by))) {
+            // Only a point whose showing was stopped is written this way, and what stopped it is
+            // what this exists to say.
+            throw new IllegalStateException("a point undecided about being writable was not "
+                    + "stopped from being shown so: " + knowledge);
+        }
+        return switch (by) {
+            case EstablishmentGap.Observation(Set<Incompleteness.Code> causes) -> causes.stream()
+                    .map(AdequacyReport::whatStopped)
+                    .collect(Collectors.joining(", and "));
+        };
+    }
+
+    /** What one observation gap cost, said as what it stopped rather than as its code. */
+    private static String whatStopped(Incompleteness.Code code) {
+        return switch (code) {
+            case VALUE_TRUNCATED -> "the observation of it was stopped by a limit, "
+                    + "so where it stands could not be read";
+            case VALUE_UNREADABLE -> "nothing could read it back, "
+                    + "so where it stands could not be read";
+            // Nothing else stops a value being read back at a point: the rest are about a row that
+            // did not run or a module nothing observed, and neither reaches a value just composed.
+            default -> throw new IllegalStateException(
+                    "an observation of a composed value stopped for a reason it cannot have: "
+                            + code);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
@@ -26,8 +26,19 @@ public enum WeakeningWord {
     /** The same at one of the inputs. */
     INPUT_CASES_UNREADABLE,
 
-    /** A row's value at one border could not be read. */
+    /** A row's value at one border was observed and the observation did not come back whole. */
     BORDER_VALUE_UNREADABLE,
+
+    /**
+     * The walk arrived at no value at one border, so there was none to observe.
+     *
+     * <p>Its own word beside the one above. Both leave a point undecided and they are not the same
+     * news: a value an observation stopped is one a wider budget keeps, and a place this compiler
+     * could not get a value out of is not. Said with one word, a reader acting on the report cannot
+     * tell which of the two they are looking at, and the difference is the whole of what the reading
+     * beneath it was built to carry.
+     */
+    BORDER_VALUE_ABSENT,
 
     /** A rule of the model that a reader set aside. */
     RULE_UNREAD,

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-10.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-10.json
@@ -69,6 +69,7 @@
           "input_cases_unreadable",
           "row_did_not_finish",
           "border_value_unreadable",
+          "border_value_absent",
           "rule_unread",
           "position_not_read",
           "question_unanswered",

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -428,7 +428,10 @@ class EverySchemaWordIsAccountedForTest {
         return List.of(
                 new ObligationDisposition.Met(),
                 new ObligationDisposition.Unmet(),
-                new ObligationDisposition.Undecided(),
+                new ObligationDisposition.Undecided(
+                        Set.of(ObligationDisposition.Uncertainty.COVERAGE)),
+                new ObligationDisposition.Undecided(
+                        Set.of(ObligationDisposition.Uncertainty.WRITABILITY)),
                 new ObligationDisposition.NotCounted(
                         Set.of(ObligationDisposition.Reason.NOTHING_WAS_READ)));
     }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
@@ -1,0 +1,199 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.Carrier;
+import souther.compiler.check.CheckedDeclarations;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.RunSource;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.observe.FieldTypes;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.Limits;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.partition.BorderQuantity;
+import souther.compiler.partition.Criterion;
+import souther.compiler.partition.Level;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A limit that fired is not a limit the term read, and the two are joined here.
+ *
+ * <p>Whether an observation stopped and whether the number a rule is about was one of the things it
+ * stopped at are different facts. A count taken at a container's root survives a walk that ran out
+ * of nodes inside it — the elements arrive stopped and there are still as many of them — so a walk
+ * under a budget and a reading that met the budget do not follow from one another.
+ *
+ * <p>Which is why the two halves are joined by a value and not by argument. Above this, a producer
+ * test holds that each budget stops a walk; below it, a reading test holds that a stopped value
+ * never reads as a row that does not stand. Neither says that what the first produces arrives where
+ * the second is asked, and a model was met that crossed a budget by two thousand nodes and read
+ * back a perfectly good number.
+ *
+ * <p>Under limits of its own, so the join is a few values wide rather than a compilation deep. What
+ * is being held is the path from a walk to a term, and the numbers a shipped observation happens to
+ * use are not part of it.
+ */
+class ALimitThatFiredIsNotALimitTheTermReadTest {
+
+    private static final TermPath UNDER = TermPath.of("lines").element();
+
+    private static final NumericTerm.TakenOver TOTAL = NumericTerm.TakenOver.of(
+            ValueName.Stdlib.operation("List", "sum"),
+            new RunSource.ProjectedOccurrences(UNDER),
+            souther.compiler.types.Type.Prim.INT,
+            Symbols.none(DefaultStdlib.get()));
+
+    private static final TermOrders ON_THE_TOTAL =
+            TermOrdersFixtures.itself(TOTAL, new Carrier.Whole());
+
+    /** Room for the container and a few of its elements, and no more. */
+    private static final Limits FOUR_NODES = new Limits(12, 4, 64, 1024);
+
+    /**
+     * A run whose later elements the node budget stopped reads as a reading that was stopped.
+     *
+     * <p>The whole path in one value: the walk is run under a budget it cannot meet, and what comes
+     * out of it is handed to the term the rule is about.
+     */
+    @Test
+    void aRunTheNodeBudgetStoppedInsideReadsAsStopped() {
+        ObservedValue observed = observed(FOUR_NODES, longs(6));
+
+        assertEquals(new BorderQuantity.Stands.Unreadable(
+                        EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+                form().standsAt(atTheLevel(15), run(observed)),
+                "the elements the walk stopped at are the ones the total is over");
+    }
+
+    /**
+     * And one the same budget kept whole reads as the number it holds.
+     *
+     * <p>The control. Without it every reading of this passes for a walk that stops at everything.
+     */
+    @Test
+    void aRunTheSameBudgetKeptReadsAsItsTotal() {
+        ObservedValue observed = observed(FOUR_NODES, longs(3));
+
+        assertEquals(BorderQuantity.Stands.YES,
+                form().standsAt(atTheLevel(6), run(observed)),
+                "three elements fit the budget, and their total is what the run comes to");
+    }
+
+    /**
+     * A budget that fired somewhere the term does not read leaves the reading whole.
+     *
+     * <p>The case the two halves apart cannot see. The walk stopped — the elements inside each
+     * entry are gone — and the number this rule is about is how many entries there are, which the
+     * container still says. A test that watched only for a limit to fire would call this covered.
+     */
+    @Test
+    void aBudgetThatFiredWhereTheTermDoesNotReadLeavesItReadable() {
+        ObservedValue observed = observed(FOUR_NODES, nested(6));
+
+        assertInstanceOf(ObservedValue.Sequence.class, observed,
+                "the container survives a walk that ran out inside it");
+        assertEquals(6, ((ObservedValue.Sequence) observed).elements().size(),
+                "and still holds as many elements as were written");
+        assertEquals(BorderQuantity.Stands.YES, howMany().standsAt(atTheLevel(6), at(observed)),
+                "so a count of them is a number, though a limit fired inside every one");
+    }
+
+    private static Criterion atTheLevel(long at) {
+        return new Criterion.AtTheLevel(new Level.ACount(Count.of(at)));
+    }
+
+    private static BorderQuantity.OverAForm form() {
+        return new BorderQuantity.OverAForm("decide",
+                LinearForm.atom((NumericTerm) TOTAL), Map.of(TOTAL, ON_THE_TOTAL));
+    }
+
+    /**
+     * The same container, counted rather than added up.
+     *
+     * <p>A number read at the container's own root, which is what makes it the other half of the
+     * pair: the walk stops in the same places and this term never looks at any of them.
+     */
+    private static BorderQuantity.OverAForm howMany() {
+        NumericTerm.TakenOf counted = NumericTerm.TakenOf.of(
+                ValueName.Stdlib.operation("List", "length"),
+                TermPath.of("lines"),
+                new souther.compiler.types.Type.ListOf(souther.compiler.types.Type.Prim.INT),
+                Symbols.none(DefaultStdlib.get()));
+        return new BorderQuantity.OverAForm("decide", LinearForm.atom((NumericTerm) counted),
+                Map.of(counted, TermOrdersFixtures.itself(counted, new Carrier.Whole())));
+    }
+
+    /** A row whose only readable place is the container itself. */
+    private static BorderQuantity.Observation at(ObservedValue observed) {
+        return new BorderQuantity.Observation() {
+
+            @Override
+            public ObservedValue at(TermPath path) {
+                assertEquals(TermPath.of("lines"), path, "read at the container the count is of");
+                return observed;
+            }
+
+            @Override
+            public List<ObservedValue> everyValueAt(TermPath path) {
+                throw new AssertionError("a count of a container is not read over a run");
+            }
+        };
+    }
+
+    /** A row whose only readable place is the run, holding what {@code observed} came to. */
+    private static BorderQuantity.Observation run(ObservedValue observed) {
+        return new BorderQuantity.Observation() {
+
+            @Override
+            public ObservedValue at(TermPath path) {
+                throw new AssertionError("a number over a run is not read from one value");
+            }
+
+            @Override
+            public List<ObservedValue> everyValueAt(TermPath path) {
+                return observed instanceof ObservedValue.Sequence held ? held.elements()
+                        : List.of(observed);
+            }
+        };
+    }
+
+    private static ObservedValue observed(Limits limits, Object live) {
+        Symbols symbols = Symbols.none(DefaultStdlib.get());
+        // No module is being read, so nothing here declares a data whose fields could be asked for.
+        return ObservedValues.of(live, symbols,
+                new NeutralForm(symbols,
+                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), limits);
+    }
+
+    private static List<Object> longs(int count) {
+        List<Object> out = new ArrayList<>();
+        for (long i = 1; i <= count; i++) {
+            out.add(i);
+        }
+        return out;
+    }
+
+    /** A list of {@code count} lists, so a budget runs out inside the elements and not at them. */
+    private static List<Object> nested(int count) {
+        List<Object> out = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            out.add(longs(3));
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
@@ -20,10 +20,10 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.partition.BorderQuantity;
 import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Level;
+import souther.compiler.partition.ReadingGap;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -74,8 +74,8 @@ class ALimitThatFiredIsNotALimitTheTermReadTest {
     void aRunTheNodeBudgetStoppedInsideReadsAsStopped() {
         ObservedValue observed = observed(FOUR_NODES, longs(6));
 
-        assertEquals(new BorderQuantity.Stands.Unreadable(
-                        EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+        assertEquals(BorderQuantity.Stands.couldNotTell(
+                        ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)),
                 form().standsAt(atTheLevel(15), run(observed)),
                 "the elements the walk stopped at are the ones the total is over");
     }

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhicheverBudgetStopsAWalkItStopsItWithOneWordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhicheverBudgetStopsAWalkItStopsItWithOneWordTest.java
@@ -1,0 +1,178 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.CheckedDeclarations;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.Membership;
+import souther.compiler.observe.FieldTypes;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.Limits;
+import souther.compiler.observe.ObservedValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whichever of an observation's budgets runs out, what the walk hands back is the same word.
+ *
+ * <p>There are four numbers and one thing they do. A walk that goes too deep, one that has held too
+ * many nodes, one at a collection longer than it keeps and one at a text longer than it keeps all
+ * stop, and what stands where the value would have been says that a limit stopped there — not which
+ * limit, and nothing about the value. So a reading written for one of them is a reading for all
+ * four, and this is what says so.
+ *
+ * <p><b>Each number with its two neighbours.</b> A budget tested with a value well past it passes
+ * for a walk that stops one early or one late, and one early is a value the report says nothing can
+ * be read of when it plainly can. So each of these is the largest value the budget keeps and the
+ * smallest it does not.
+ *
+ * <p>Held here rather than by a model apiece. What a rule downstream does with the word is the
+ * reading's own law and is held where the reading is; four models saying it again would be the same
+ * law written four times, at the cost of a compilation each and with three of them measuring
+ * whichever budget the model happened to cross first.
+ */
+class WhicheverBudgetStopsAWalkItStopsItWithOneWordTest {
+
+    private static final Limits DEFAULT = Limits.DEFAULT;
+
+    /** A subtree past the depth the walk goes to is stopped, and the one at it is not. */
+    @Test
+    void aWalkTooDeepStops() {
+        assertEquals(new ObservedValue.Truncated(), deepest(nested(DEFAULT.maxDepth() + 1)),
+                "one step past the depth is where the walk stops");
+        assertNotEquals(new ObservedValue.Truncated(), deepest(nested(DEFAULT.maxDepth())),
+                "and the value standing at the depth is read");
+    }
+
+    /**
+     * A walk that has held as many nodes as it may stops at the next one.
+     *
+     * <p>Shaped so that no other budget is anywhere near it. A flat list of two thousand values is
+     * a collection past its count long before it is a walk out of nodes, and would measure that
+     * instead — so the nodes are spread over collections each well inside what one may hold.
+     */
+    @Test
+    void aWalkOutOfNodesStops() {
+        assertTrue(stopsSomewhere(observed(nodes(DEFAULT.maxNodes() + 1))),
+                "the node after the last one the budget holds is where the walk stops");
+        assertFalse(stopsSomewhere(observed(nodes(DEFAULT.maxNodes()))),
+                "and a value of exactly the budget is read whole");
+    }
+
+    /** A collection longer than the walk keeps is stopped whole. */
+    @Test
+    void aCollectionPastItsCountStops() {
+        assertEquals(new ObservedValue.Truncated(), observed(longs(DEFAULT.maxElements() + 1)),
+                "one element past the count is a collection the walk does not keep");
+        assertNotEquals(new ObservedValue.Truncated(), observed(longs(DEFAULT.maxElements())),
+                "and one of exactly the count is kept");
+    }
+
+    /** And a text longer than the walk keeps, the same way. */
+    @Test
+    void aTextPastItsLengthStops() {
+        assertEquals(new ObservedValue.Truncated(), observed("x".repeat(DEFAULT.maxText() + 1)),
+                "one character past the length is a text the walk does not keep");
+        assertNotEquals(new ObservedValue.Truncated(), observed("x".repeat(DEFAULT.maxText())),
+                "and one of exactly the length is kept");
+    }
+
+    /**
+     * And every one of them reads as the same reason, which is what a rule downstream is handed.
+     *
+     * <p>The word a walk hands back carries no budget, so nothing further on can tell the four
+     * apart — which is the point. A reading that answered differently for one of them would be a
+     * reading with a fifth case nothing produces.
+     */
+    @Test
+    void allFourReadAsOneReason() {
+        for (ObservedValue stopped : List.of(deepest(nested(DEFAULT.maxDepth() + 1)),
+                stopped(observed(nodes(DEFAULT.maxNodes() + 1))),
+                observed(longs(DEFAULT.maxElements() + 1)),
+                observed("x".repeat(DEFAULT.maxText() + 1)))) {
+            assertEquals(new Membership.Incomplete(Incompleteness.Code.VALUE_TRUNCATED),
+                    Membership.unread(stopped),
+                    "a value a budget stopped is one reason, whichever budget it was");
+        }
+    }
+
+    /** A list nested {@code deep} times around a whole number. */
+    private static Object nested(int deep) {
+        Object at = 1L;
+        for (int i = 0; i < deep; i++) {
+            at = List.of(at);
+        }
+        return at;
+    }
+
+    /** What stands at the bottom of a nest of sequences. */
+    private static ObservedValue deepest(Object live) {
+        ObservedValue at = observed(live);
+        while (at instanceof ObservedValue.Sequence held && !held.elements().isEmpty()) {
+            at = held.elements().get(0);
+        }
+        return at;
+    }
+
+    /**
+     * A live value of exactly {@code total} observed nodes, held under every other budget.
+     *
+     * <p>One list of lists. Each holds at most what a collection may hold, and the whole is two
+     * deep, so the only number this can run out of is the one for how many nodes an observation
+     * keeps.
+     */
+    private static Object nodes(int total) {
+        List<Object> out = new ArrayList<>();
+        int left = total - 1;   // the list itself is a node
+        while (left > 0) {
+            int here = Math.min(1 + DEFAULT.maxElements(), left);
+            out.add(longs(here - 1));
+            left -= here;
+        }
+        return out;
+    }
+
+    /** Whether the walk stopped anywhere inside {@code at}. */
+    private static boolean stopsSomewhere(ObservedValue at) {
+        return stopped(at) != null;
+    }
+
+    /** The first stopped value inside {@code at}, or null where the walk kept all of it. */
+    private static ObservedValue stopped(ObservedValue at) {
+        if (at instanceof ObservedValue.Truncated) {
+            return at;
+        }
+        if (at instanceof ObservedValue.Sequence held) {
+            for (ObservedValue each : held.elements()) {
+                ObservedValue found = stopped(each);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static ObservedValue observed(Object live) {
+        Symbols symbols = Symbols.none(DefaultStdlib.get());
+        // No module is being read, so nothing here declares a data whose fields could be asked for.
+        return ObservedValues.of(live, symbols,
+                new NeutralForm(symbols,
+                        FieldTypes.over(new CheckedDeclarations(symbols, _ -> null))), DEFAULT);
+    }
+
+    private static List<Object> longs(int count) {
+        List<Object> out = new ArrayList<>();
+        for (long i = 0; i < count; i++) {
+            out.add(i);
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
@@ -66,11 +66,14 @@ class ARunBoundedAtBothEndsIsLookedInsideTest {
      */
     @Test
     void aRunHoldingNoWholeMultipleOfTheGeneratorIsStillLookedIn() {
-        assertEquals(souther.compiler.query.ItemAssessment.Attempt.Built.class,
-                attemptAt(cut("10"), "3 * n = 1", PointRole.IN).getClass(),
+        // A row was offered, which is what looking inside the run produces. Which of the ways of
+        // having been built it is is a second question and not this one's: the run is looked in or
+        // it is not, and a candidate that came out of it settles that either way.
+        assertInstanceOf(souther.compiler.query.ItemAssessment.Attempt.Built.class,
+                attemptAt(cut("10"), "3 * n = 1", PointRole.IN),
                 "a run from one to ten holds three, which anything could name");
-        assertEquals(souther.compiler.query.ItemAssessment.Attempt.Built.class,
-                attemptAt(cut("2"), "3 * n = 1", PointRole.IN).getClass(),
+        assertInstanceOf(souther.compiler.query.ItemAssessment.Attempt.Built.class,
+                attemptAt(cut("2"), "3 * n = 1", PointRole.IN),
                 "and one from one to two holds 1.5, which only looking inside it finds");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.RunSource;
 import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain.LinearForm;
@@ -54,7 +55,11 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
             souther.compiler.types.Type.Prim.INT,
             souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
 
-    private static final TermOrders WHOLE = TermOrders.itself(new Carrier.Whole());
+    private static final TermOrders ON_THE_TOTAL =
+            TermOrdersFixtures.itself(TOTAL, new Carrier.Whole());
+
+    private static final TermOrders ON_THE_OTHER =
+            TermOrdersFixtures.itself(OTHER_TOTAL, new Carrier.Whole());
 
     private static final Criterion AT_A_HUNDRED =
             new Criterion.AtTheLevel(new Level.ACount(Count.of(100)));
@@ -114,7 +119,7 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
         BorderQuantity.OverAForm both = new BorderQuantity.OverAForm("decide",
                 LinearForm.atom((NumericTerm) TOTAL)
                         .plus(LinearForm.atom((NumericTerm) OTHER_TOTAL)),
-                Map.of(TOTAL, WHOLE, OTHER_TOTAL, WHOLE));
+                Map.of(TOTAL, ON_THE_TOTAL, OTHER_TOTAL, ON_THE_OTHER));
 
         BorderQuantity.Stands stands = both.standsAt(AT_A_HUNDRED,
                 new BorderQuantity.Observation() {
@@ -138,9 +143,37 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
                 "a reading stopped in two ways is stopped in both of them");
     }
 
+    /**
+     * A walk that arrived at no value says that, and not that an observation stopped.
+     *
+     * <p>The two leave different work and only one of them names a budget. A reader that words a
+     * code as what an observation did — and something downstream does, since that is what the code
+     * is for — then says a limit did something where no limit fired: the value it would have
+     * stopped was never met.
+     */
+    @Test
+    void aWalkThatReachedNoValueIsNotAnObservationThatStopped() {
+        BorderQuantity.Stands stands = form().standsAt(AT_A_HUNDRED,
+                new BorderQuantity.Observation() {
+
+                    @Override
+                    public ObservedValue at(TermPath path) {
+                        return null;
+                    }
+
+                    @Override
+                    public List<ObservedValue> everyValueAt(TermPath path) {
+                        return java.util.Collections.singletonList(null);
+                    }
+                });
+
+        assertEquals(BorderQuantity.Stands.NOTHING_TO_READ, stands,
+                "nothing arrived, which is not a value an observation could not keep");
+    }
+
     private static BorderQuantity.OverAForm form() {
         return new BorderQuantity.OverAForm("decide",
-                LinearForm.atom((NumericTerm) TOTAL), Map.of(TOTAL, WHOLE));
+                LinearForm.atom((NumericTerm) TOTAL), Map.of(TOTAL, ON_THE_TOTAL));
     }
 
     /** A row whose only readable place is the run, holding these values. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
@@ -14,7 +14,6 @@ import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.ValueName;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,8 +71,8 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
      */
     @Test
     void aRunHoldingAValueALimitStoppedIsUnreadableAndSaysSo() {
-        assertEquals(new BorderQuantity.Stands.Unreadable(
-                        EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+        assertEquals(BorderQuantity.Stands.couldNotTell(
+                        ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)),
                 form().standsAt(AT_A_HUNDRED,
                         run(new ObservedValue.Integer(40), new ObservedValue.Truncated())),
                 "a total over a value the limits stopped is not a total that missed the line");
@@ -82,8 +81,8 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
     /** And one holding a value nothing could decode says that instead, which is the other word. */
     @Test
     void aRunHoldingAValueNothingCouldDecodeSaysThatInstead() {
-        assertEquals(new BorderQuantity.Stands.Unreadable(
-                        EnumSet.of(Incompleteness.Code.VALUE_UNREADABLE)),
+        assertEquals(BorderQuantity.Stands.couldNotTell(
+                        ReadingGap.of(Incompleteness.Code.VALUE_UNREADABLE)),
                 form().standsAt(AT_A_HUNDRED,
                         run(new ObservedValue.Integer(40), new ObservedValue.Unknown("no"))),
                 "what a limit shortened and what nothing could read are two things to tell a"
@@ -137,9 +136,9 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
                     }
                 });
 
-        assertEquals(Set.of(Incompleteness.Code.VALUE_TRUNCATED,
-                        Incompleteness.Code.VALUE_UNREADABLE),
-                assertInstanceOf(BorderQuantity.Stands.Unreadable.class, stands).causes(),
+        assertEquals(Set.of(ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED),
+                        ReadingGap.of(Incompleteness.Code.VALUE_UNREADABLE)),
+                assertInstanceOf(BorderQuantity.Stands.CouldNotTell.class, stands).why(),
                 "a reading stopped in two ways is stopped in both of them");
     }
 
@@ -167,8 +166,35 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
                     }
                 });
 
-        assertEquals(BorderQuantity.Stands.NOTHING_TO_READ, stands,
+        assertEquals(BorderQuantity.Stands.couldNotTell(ReadingGap.NO_VALUE), stands,
                 "nothing arrived, which is not a value an observation could not keep");
+    }
+
+    /**
+     * And a run the walk never reached says the same, rather than that the row does not stand.
+     *
+     * <p>The other way nothing arrives. A caller that could not walk to the run hands over no list
+     * at all, and answering "this is no number of that" would make a place this compiler could not
+     * reach into the model putting the row somewhere else — {@code Stands.No}, and a point missed.
+     */
+    @Test
+    void aRunTheWalkNeverReachedIsNotARunThatMissedTheLine() {
+        BorderQuantity.Stands stands = form().standsAt(AT_A_HUNDRED,
+                new BorderQuantity.Observation() {
+
+                    @Override
+                    public ObservedValue at(TermPath path) {
+                        return null;
+                    }
+
+                    @Override
+                    public List<ObservedValue> everyValueAt(TermPath path) {
+                        return null;
+                    }
+                });
+
+        assertEquals(BorderQuantity.Stands.couldNotTell(ReadingGap.NO_VALUE), stands,
+                "the walk did not reach the run, which says nothing about where the row stands");
     }
 
     private static BorderQuantity.OverAForm form() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.RunSource;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.types.ValueName;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A value an observation could not keep is not a value standing somewhere else.
+ *
+ * <p>Every limit an observation is walked under produces one word — the value is not there and the
+ * walk stopped — and what the word is <em>of</em> travels with it. From there the reading has one
+ * job: to arrive at the border still saying that nothing could be read, rather than that the row
+ * does not stand at the point. The two are a number that did not come back and a number that came
+ * back wrong, and only the second is about what somebody wrote.
+ *
+ * <p>Written by hand, so what is held is the reading and not a model's answer. Which budget stopped
+ * the walk is the observation's own question and is settled where the limits are; every one of them
+ * hands over the same {@link ObservedValue.Truncated}, so a reading that keeps the word for one
+ * keeps it for all four, and holding this against four models would be holding the same law four
+ * times.
+ */
+class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
+
+    private static final TermPath UNDER = TermPath.of("lines").element().then("amount");
+
+    private static final NumericTerm.TakenOver TOTAL = NumericTerm.TakenOver.of(
+            ValueName.Stdlib.operation("List", "sum"),
+            new RunSource.ProjectedOccurrences(UNDER),
+            souther.compiler.types.Type.Prim.INT,
+            souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
+
+    private static final TermPath BESIDE = TermPath.of("fees").element().then("amount");
+
+    private static final NumericTerm.TakenOver OTHER_TOTAL = NumericTerm.TakenOver.of(
+            ValueName.Stdlib.operation("List", "sum"),
+            new RunSource.ProjectedOccurrences(BESIDE),
+            souther.compiler.types.Type.Prim.INT,
+            souther.compiler.check.Symbols.none(souther.compiler.DefaultStdlib.get()));
+
+    private static final TermOrders WHOLE = TermOrders.itself(new Carrier.Whole());
+
+    private static final Criterion AT_A_HUNDRED =
+            new Criterion.AtTheLevel(new Level.ACount(Count.of(100)));
+
+    /**
+     * A run holding a value the limits stopped is unreadable, and says which stopped it.
+     *
+     * <p>The value the run would come to is not this compiler's to guess: the elements it can see
+     * add up to less than the total, which is exactly what a row below the line looks like.
+     */
+    @Test
+    void aRunHoldingAValueALimitStoppedIsUnreadableAndSaysSo() {
+        assertEquals(new BorderQuantity.Stands.Unreadable(
+                        EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+                form().standsAt(AT_A_HUNDRED,
+                        run(new ObservedValue.Integer(40), new ObservedValue.Truncated())),
+                "a total over a value the limits stopped is not a total that missed the line");
+    }
+
+    /** And one holding a value nothing could decode says that instead, which is the other word. */
+    @Test
+    void aRunHoldingAValueNothingCouldDecodeSaysThatInstead() {
+        assertEquals(new BorderQuantity.Stands.Unreadable(
+                        EnumSet.of(Incompleteness.Code.VALUE_UNREADABLE)),
+                form().standsAt(AT_A_HUNDRED,
+                        run(new ObservedValue.Integer(40), new ObservedValue.Unknown("no"))),
+                "what a limit shortened and what nothing could read are two things to tell a"
+                        + " person");
+    }
+
+    /**
+     * A run whose values are all there answers the question, which is the control.
+     *
+     * <p>Without it every reading of this passes for a quantity that never answers anything.
+     */
+    @Test
+    void aRunWhoseValuesAreAllThereStillAnswers() {
+        assertEquals(BorderQuantity.Stands.YES,
+                form().standsAt(AT_A_HUNDRED,
+                        run(new ObservedValue.Integer(60), new ObservedValue.Integer(40))),
+                "a row whose values come to the level stands on the line");
+        assertEquals(BorderQuantity.Stands.NO,
+                form().standsAt(AT_A_HUNDRED,
+                        run(new ObservedValue.Integer(60), new ObservedValue.Integer(39))),
+                "and one that comes to anything else does not");
+    }
+
+    /**
+     * A form stopped at two of its terms says both.
+     *
+     * <p>The form is unreadable for whatever stopped any of it. Answered from the first term the
+     * walk reaches, what a reader is told is which term the map handed over first — and a map's
+     * order is not something a report may turn on.
+     */
+    @Test
+    void aFormStoppedAtTwoOfItsTermsSaysBoth() {
+        BorderQuantity.OverAForm both = new BorderQuantity.OverAForm("decide",
+                LinearForm.atom((NumericTerm) TOTAL)
+                        .plus(LinearForm.atom((NumericTerm) OTHER_TOTAL)),
+                Map.of(TOTAL, WHOLE, OTHER_TOTAL, WHOLE));
+
+        BorderQuantity.Stands stands = both.standsAt(AT_A_HUNDRED,
+                new BorderQuantity.Observation() {
+
+                    @Override
+                    public ObservedValue at(TermPath path) {
+                        throw new AssertionError("a number over a run is not read from one value");
+                    }
+
+                    @Override
+                    public List<ObservedValue> everyValueAt(TermPath path) {
+                        return UNDER.equals(path)
+                                ? List.of(new ObservedValue.Truncated())
+                                : List.of(new ObservedValue.Unknown("no"));
+                    }
+                });
+
+        assertEquals(Set.of(Incompleteness.Code.VALUE_TRUNCATED,
+                        Incompleteness.Code.VALUE_UNREADABLE),
+                assertInstanceOf(BorderQuantity.Stands.Unreadable.class, stands).causes(),
+                "a reading stopped in two ways is stopped in both of them");
+    }
+
+    private static BorderQuantity.OverAForm form() {
+        return new BorderQuantity.OverAForm("decide",
+                LinearForm.atom((NumericTerm) TOTAL), Map.of(TOTAL, WHOLE));
+    }
+
+    /** A row whose only readable place is the run, holding these values. */
+    private static BorderQuantity.Observation run(ObservedValue... values) {
+        return new BorderQuantity.Observation() {
+
+            @Override
+            public ObservedValue at(TermPath path) {
+                throw new AssertionError("a number over a run is not read from one value");
+            }
+
+            @Override
+            public List<ObservedValue> everyValueAt(TermPath path) {
+                assertEquals(UNDER, path, "read from where the run says its values are");
+                return List.of(values);
+            }
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -1,0 +1,197 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.Incompleteness;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A budget of this compiler's may leave an obligation undecided and may never take it out of the
+ * count.
+ *
+ * <p>What the account is for is telling an author what the model owes. A row the rows do not answer
+ * and nothing shows can be written is left out of it, because asking for a row that may not exist
+ * is asking for work nobody can do — and that is a statement about the model. A row this compiler
+ * composed and could not read back is not: the value went through the module's own decoders, and
+ * what is missing is the reading. Counted the same way, the numbers a report prints move with how
+ * much of a value an observation happens to keep.
+ *
+ * <p>Put to the fold directly and not through a model. Reaching every row of the table from source
+ * takes a model per row, and the one for a point whose showing was stopped takes a value of about
+ * two thousand nodes — which is minutes of composing to establish one arm of a switch. The models
+ * that are cheap are elsewhere; what is held here is the rule they are read by.
+ */
+class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
+
+    /**
+     * A point the rows ran out on, where the value built for it could not be read back.
+     *
+     * <p>The row the table exists for. Nothing has shown the point writable — the reading that
+     * would have is the one that did not come back — and the obligation stays counted all the same,
+     * because what stopped the showing is this compiler's own budget and not the model refusing a
+     * row.
+     */
+    @Test
+    void aShowingStoppedByALimitLeavesTheObligationCountedAndUndecided() {
+        ObligationDisposition disposition =
+                ObligationDisposition.of(new ObligationCoverage.Missed(), prevented());
+
+        assertInstanceOf(ObligationDisposition.Counted.class, disposition,
+                "a point whose showing a limit stopped is one the model still owes a row at");
+        assertEquals(new ObligationDisposition.Undecided(
+                        EnumSet.of(ObligationDisposition.Uncertainty.WRITABILITY)),
+                disposition,
+                "and the question left open is whether a row can be written, not whether one is");
+    }
+
+    /**
+     * The same coverage with nothing behind it at all, which is the row beside it.
+     *
+     * <p>The pair is the measurement. Both are points every row was read against and none is at;
+     * they differ in whether anything was stopped from showing a row could be written there. Held
+     * on one of them alone, a fold that ignored the difference would pass.
+     */
+    @Test
+    void aShowingNothingEverMadeLeavesTheObligationOutOfTheCount() {
+        ObligationDisposition disposition = ObligationDisposition.of(
+                new ObligationCoverage.Missed(), new WritabilityKnowledge.NoEvidence());
+
+        assertEquals(new ObligationDisposition.NotCounted(
+                        Set.of(ObligationDisposition.Reason.NOT_KNOWN_TO_BE_WRITABLE)),
+                disposition,
+                "a point nothing promises a row at is not one an author is behind on");
+    }
+
+    /** And the same coverage where something did show it, which is the only finding of the three. */
+    @Test
+    void aShowingThatArrivedIsTheOneThatMakesAFinding() {
+        assertEquals(new ObligationDisposition.Unmet(),
+                ObligationDisposition.of(new ObligationCoverage.Missed(), established()),
+                "a point the rules prove and no row is at is a row somebody owes");
+    }
+
+    /**
+     * Both questions open at one point are both said.
+     *
+     * <p>A reading that stopped short and a showing that was stopped are about different things,
+     * and either one alone is a choice of which to tell.
+     */
+    @Test
+    void twoOpenQuestionsAtOnePointAreBothSaid() {
+        ObligationDisposition disposition = ObligationDisposition.of(
+                new ObligationCoverage.Undecided(WeakeningSet.of(
+                        new Weakening.BorderValueUnreadable(null,
+                                Incompleteness.Code.VALUE_TRUNCATED))),
+                prevented());
+
+        assertEquals(new ObligationDisposition.Undecided(EnumSet.of(
+                        ObligationDisposition.Uncertainty.COVERAGE,
+                        ObligationDisposition.Uncertainty.WRITABILITY)),
+                disposition,
+                "the rows left one question open and the search left the other");
+    }
+
+    /**
+     * A point nothing was read against keeps both reasons it is out of the count.
+     *
+     * <p>They are independent facts about the point and a reader is owed both: one says there was
+     * nothing to find, the other says nothing promises there is anything to find.
+     */
+    @Test
+    void aPointNothingWasReadAgainstKeepsEveryReasonItIsOut() {
+        ObligationDisposition disposition = ObligationDisposition.of(
+                new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS),
+                new WritabilityKnowledge.NoEvidence());
+
+        assertEquals(new ObligationDisposition.NotCounted(Set.of(
+                        ObligationDisposition.Reason.NOTHING_WAS_READ,
+                        ObligationDisposition.Reason.NOT_KNOWN_TO_BE_WRITABLE)),
+                disposition,
+                "nothing was read and nothing promises a row, and both are true of it");
+    }
+
+    /**
+     * Tightening what an observation keeps may weaken what is known and may not empty the count.
+     *
+     * <p>The law the table is for, said over the states rather than over one pair. A budget of this
+     * compiler's turns what was established into what was prevented; every disposition that was
+     * counted under the first is counted under the second.
+     */
+    @Test
+    void everyObligationCountedWithGroundsIsStillCountedWhenALimitStopsThem() {
+        for (ObligationCoverage coverage : everyCoverage()) {
+            ObligationDisposition withGrounds = ObligationDisposition.of(coverage, established());
+            if (!(withGrounds instanceof ObligationDisposition.Counted)) {
+                continue;
+            }
+            assertInstanceOf(ObligationDisposition.Counted.class,
+                    ObligationDisposition.of(coverage, prevented()),
+                    () -> "a limit took " + coverage + " out of the count");
+        }
+    }
+
+    /**
+     * And it may not turn one verdict into the other, which is what a resource policy cannot say.
+     *
+     * <p>What a limit may do is take knowledge away, and the states are ordered by how much they
+     * claim: a row is there, no row is there, nobody can say. Moving along that order downwards is
+     * a limit doing its job; moving across it — a miss becoming a hit, or either becoming a point
+     * the account no longer holds — is the policy answering a question about the model.
+     */
+    @Test
+    void aLimitDoesNotTurnAMissIntoAHitOrBack() {
+        for (ObligationCoverage coverage : everyCoverage()) {
+            ObligationDisposition withGrounds = ObligationDisposition.of(coverage, established());
+            ObligationDisposition stopped = ObligationDisposition.of(coverage, prevented());
+            assertTrue(weakensTo(withGrounds, stopped),
+                    () -> "a limit moved " + coverage + " from " + withGrounds + " to " + stopped
+                            + ", which is a verdict and not a loss of knowledge");
+        }
+    }
+
+    /**
+     * Whether {@code after} claims no more than {@code before}.
+     *
+     * <p>A verdict may stand or become the one that claims nothing; a point already outside the
+     * count stays outside it, and may be outside it for more reasons than before, since a reason is
+     * something known about the point rather than a claim about the model.
+     */
+    private static boolean weakensTo(ObligationDisposition before, ObligationDisposition after) {
+        return switch (before) {
+            case ObligationDisposition.Met _, ObligationDisposition.Unmet _ ->
+                    after.equals(before) || after instanceof ObligationDisposition.Undecided;
+            case ObligationDisposition.Undecided it ->
+                    after instanceof ObligationDisposition.Undecided then
+                            && then.because().containsAll(it.because());
+            case ObligationDisposition.NotCounted it ->
+                    after instanceof ObligationDisposition.NotCounted then
+                            && then.because().containsAll(it.because());
+        };
+    }
+
+    private static List<ObligationCoverage> everyCoverage() {
+        return List.of(new ObligationCoverage.Witnessed(),
+                new ObligationCoverage.Missed(),
+                new ObligationCoverage.Undecided(WeakeningSet.of(
+                        new Weakening.BorderValueUnreadable(null,
+                                Incompleteness.Code.VALUE_TRUNCATED))),
+                new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS));
+    }
+
+    private static WritabilityKnowledge established() {
+        return new WritabilityKnowledge.Established(new ItemAssessment.WritabilityEvidence(
+                Set.of(ItemAssessment.WritabilityEvidence.Ground.THE_RULES_PROVE_IT)));
+    }
+
+    private static WritabilityKnowledge prevented() {
+        return new WritabilityKnowledge.Prevented(new EstablishmentGap.Observation(
+                EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -88,7 +88,8 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
         ObligationDisposition disposition = ObligationDisposition.of(
                 new ObligationCoverage.Undecided(WeakeningSet.of(
                         new Weakening.BorderValueUnreadable(null,
-                                Incompleteness.Code.VALUE_TRUNCATED))),
+                                new Weakening.WhyNoValue.AnObservationStopped(
+                                        Incompleteness.Code.VALUE_TRUNCATED)))),
                 prevented());
 
         assertEquals(new ObligationDisposition.Undecided(EnumSet.of(
@@ -181,7 +182,8 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
                 new ObligationCoverage.Missed(),
                 new ObligationCoverage.Undecided(WeakeningSet.of(
                         new Weakening.BorderValueUnreadable(null,
-                                Incompleteness.Code.VALUE_TRUNCATED))),
+                                new Weakening.WhyNoValue.AnObservationStopped(
+                                        Incompleteness.Code.VALUE_TRUNCATED)))),
                 new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.partition.ReadingGap;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -88,8 +89,7 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
         ObligationDisposition disposition = ObligationDisposition.of(
                 new ObligationCoverage.Undecided(WeakeningSet.of(
                         new Weakening.BorderValueUnreadable(null,
-                                new Weakening.WhyNoValue.AnObservationStopped(
-                                        Incompleteness.Code.VALUE_TRUNCATED)))),
+                                ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)))),
                 prevented());
 
         assertEquals(new ObligationDisposition.Undecided(EnumSet.of(
@@ -182,8 +182,7 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
                 new ObligationCoverage.Missed(),
                 new ObligationCoverage.Undecided(WeakeningSet.of(
                         new Weakening.BorderValueUnreadable(null,
-                                new Weakening.WhyNoValue.AnObservationStopped(
-                                        Incompleteness.Code.VALUE_TRUNCATED)))),
+                                ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)))),
                 new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest.java
@@ -1,0 +1,143 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.Limits;
+import souther.compiler.partition.PointRole;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a search composed stays composed, whatever an observation of it kept.
+ *
+ * <p>A value built for a point goes through the module's own decoders and is then read back, to see
+ * that it landed where it was built for. That reading is walked under the limits an observation is
+ * held to, so a value the limits stop is a value nothing can place — and the row is as built as it
+ * ever was. What the search may report is that it could not confirm the row; what it may not report
+ * is that it composed nothing, which is the sentence an author reads as the model refusing a row.
+ *
+ * <p><b>The pair is the measurement, and it is one character wide.</b> Both models ask for a row at
+ * a length; they differ in whether that length is one an observation keeps. Held on the far side
+ * alone, a reading that never composes anything at all passes.
+ *
+ * <p>And what fired is asserted beside what came of it. The same two words come back whichever
+ * budget an observation ran out of, so a test reading the outcome alone would go green on a model
+ * that crossed some other limit — or on one that this compiler declined to compose a value for at
+ * all, which is a different thing to fix.
+ */
+class ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest {
+
+    /**
+     * A rule on the length of a text, with one short row written.
+     *
+     * <p>The text budget and no other. A row at the point is one string, so nothing here composes a
+     * collection, nests anything, or holds more than a handful of nodes — the other three limits
+     * are nowhere near, and the one being measured is crossed by the value the point asks for.
+     */
+    private static String model(int length) {
+        return """
+                module example.text
+
+                data 長い
+                data 短い
+
+                behavior 判定する : (文字: String) -> 長い | 短い
+
+                let 判定する (文字) =
+                    if String.length(文字) >= %d
+                    then 長い else 短い
+
+                example 判定する
+                    | "短いなら短い" : ("abc") -> 短い
+                """.formatted(length);
+    }
+
+    /**
+     * A point at exactly what the limits keep is confirmed, which is the near side of the pair.
+     *
+     * <p>{@link Limits#DEFAULT} keeps a text of {@code maxText} characters and stops at one more, so
+     * this is the longest row the reading back can place.
+     */
+    @Test
+    void aRowTheObservationKeepsIsConfirmedWhereItWasBuilt() {
+        ItemAssessment.Attempt at = attemptAt(Limits.DEFAULT.maxText(), PointRole.ON);
+
+        assertInstanceOf(ItemAssessment.Attempt.Certified.class, at,
+                "a row of exactly what the limits keep is read back where it was built for");
+    }
+
+    /**
+     * One character more, and the row is built and unconfirmed rather than never composed.
+     *
+     * <p>The whole of the difference between the two is the limit. The search did the same work,
+     * the decoders took the same kind of value, and what changed is that the walk that reads it
+     * back stopped.
+     */
+    @Test
+    void oneCharacterMoreLeavesTheRowBuiltAndUnconfirmed() {
+        ItemAssessment.Attempt at = attemptAt(Limits.DEFAULT.maxText() + 1, PointRole.ON);
+
+        ItemAssessment.Attempt.Unverified unverified = assertInstanceOf(
+                ItemAssessment.Attempt.Unverified.class, at,
+                "a value the limits stopped is a row this compiler could not place, not one it"
+                        + " never composed");
+        assertNotNull(unverified.row(),
+                "and the row is offered, since composing it is what happened");
+        assertEquals(new EstablishmentGap.Observation(
+                        Set.of(Incompleteness.Code.VALUE_TRUNCATED)),
+                unverified.why(),
+                "what stopped the placing is the observation, and it says which way");
+    }
+
+    /**
+     * And the point beside it in the same model is confirmed.
+     *
+     * <p>The control that says the model is not simply broken past the threshold: the row for the
+     * point one below the line is a text of {@code maxText} characters, and it is placed.
+     */
+    @Test
+    void thePointBesideItInTheSameModelIsStillConfirmed() {
+        assertInstanceOf(ItemAssessment.Attempt.Certified.class,
+                attemptAt(Limits.DEFAULT.maxText() + 1, PointRole.OFF),
+                "the row one character shorter is the one the limits keep, and it is placed");
+    }
+
+    /**
+     * And nothing about the point's grounds is invented from the row that was not placed.
+     *
+     * <p>A row built and not read back has shown nothing about the model. Counted as though it
+     * had, the account would say a row can be written here because an observation was cut short,
+     * which is this reading's own mistake made the other way round.
+     */
+    @Test
+    void aRowNothingPlacedIsNotGroundsForAnything() {
+        assertEquals(Set.of(ItemAssessment.WritabilityEvidence.Ground.THE_RULES_PROVE_IT),
+                line(Limits.DEFAULT.maxText() + 1).owedAt(PointRole.ON)
+                        .writabilityEvidence().grounds(),
+                "the rules still prove it; the row that was not placed adds nothing");
+    }
+
+    private static ItemAssessment.Attempt attemptAt(int length, PointRole role) {
+        return line(length).owedAt(role).attempt();
+    }
+
+    private static BorderAssessment line(int length) {
+        Compilation compilation = Compilation.ofSource(model(length), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.errors().stream()
+                        .map(each -> each.diagnostic().code()).toList(),
+                () -> "the model under test compiles at " + length);
+        List<BorderAssessment> lines =
+                Adequacy.readingsOf(compilation.db(), "example.text").get("判定する");
+        assertNotNull(lines, () -> "the threshold draws a line at " + length);
+        assertEquals(1, lines.size(), () -> "one line at " + length + ": " + lines);
+        return lines.get(0);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
@@ -86,7 +86,7 @@ class ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest {
      */
     @Test
     void anAnsweredPointAndAnUnmadeSearchOweNothing() {
-        assertEquals(List.of(), new ItemAssessment.Attempt.Built(
+        assertEquals(List.of(), ItemAssessment.Attempt.Built.certified(
                 new Generator.GeneratedRow(
                         new Generator.Purpose.ForAPoint("p.x = 11"), List.of()), way())
                 .unaccountedFor());

--- a/souther-compiler/src/test/java/souther/compiler/query/AnObservationThisCompilerStoppedIsNotAPointNothingWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnObservationThisCompilerStoppedIsNotAPointNothingWritesTest.java
@@ -1,0 +1,150 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule whose values this compilation could not read whole still owes the rows it owes.
+ *
+ * <p>How much of a value an observation keeps is a policy about what an answer may hold. It decides
+ * nothing about the model, so the account of what an author owes is the same account whether or not
+ * the walk that reads a row got to the end of it: the same rule is written, the same four points
+ * are on its line, and what changes is only whether anybody can say a row is at one of them.
+ *
+ * <p><b>Held over the length of the reading, and not against one model.</b> A name standing for
+ * another is the one thing a model may have any number of, so a wrapper added is not a statement
+ * about anything — and every number an observation could stop at is a model somebody may write.
+ * A regression for the model that was reported would go green again under a larger budget; this
+ * would not.
+ */
+class AnObservationThisCompilerStoppedIsNotAPointNothingWritesTest {
+
+    private static final String LINE = "List.sum(明細[*].金額) = 100000";
+
+    /**
+     * The same rule with {@code names} wrappers around the list.
+     *
+     * <p>Every wrapper is one more name between the total and the values it is over. None of them
+     * says anything about the rule, and past a dozen of them the walk that reads a row hands back a
+     * value it stopped at rather than the list.
+     */
+    private static String model(int names) {
+        StringBuilder out = new StringBuilder("""
+                module example.through
+
+                data 金額 = Int
+
+                data 明細 = { 金額: 金額 }
+
+                data 高額
+                data 少額
+
+                data 束1 = List<明細>
+                """);
+        for (int n = 2; n <= names; n++) {
+            out.append("data 束%d = 束%d%n".formatted(n, n - 1));
+        }
+        out.append("%nbehavior 判定する : (明細: 束%d) -> 高額 | 少額%n".formatted(names));
+        StringBuilder taken = new StringBuilder("件");
+        for (int n = 1; n <= names; n++) {
+            taken.insert(0, "束%d(".formatted(n)).append(")");
+        }
+        out.append("""
+
+                let 判定する (%s) =
+                    if List.sum(List.map(一件 -> 一件.金額.value, 件)) >= 100000
+                    then 高額 else 少額
+
+                example 判定する
+                    | "ちょうど10万円なら高額" : (%s) -> 高額
+                    | "1000円なら少額"        : (%s) -> 少額
+                """.formatted(taken, wrapped(names, 100000), wrapped(names, 1000)));
+        return out.toString();
+    }
+
+    /** One list of one detail of {@code amount}, under every wrapper the model declares. */
+    private static String wrapped(int names, int amount) {
+        StringBuilder out = new StringBuilder("[ 明細 { 金額 = 金額(%d) } ]".formatted(amount));
+        for (int n = 1; n <= names; n++) {
+            out.insert(0, "束%d(".formatted(n)).append(")");
+        }
+        return out.toString();
+    }
+
+    /**
+     * One name between, or sixteen: the line owes four rows either way.
+     *
+     * <p>What the rows then answer is a second question and is allowed to differ — a reading that
+     * stopped finds nothing, which is what it means to have stopped. What may not differ is how
+     * many rows the model is asking for.
+     */
+    @Test
+    void theSameFourRowsAreOwedHoweverManyNamesStandBetween() {
+        Map<Integer, String> owed = new LinkedHashMap<>();
+        for (int names : new int[] {1, 8, 12, 16}) {
+            owed.put(names, counted(names));
+        }
+
+        assertEquals(Map.of(1, "4", 8, "4", 12, "4", 16, "4"), owed,
+                () -> "one account however many names stand between: " + owed);
+    }
+
+    /**
+     * And a reading that stopped is said as one, not as a point nothing can write a row at.
+     *
+     * <p>The two sentences send an author to different places. One says the rows do not settle a
+     * point they are owed at; the other says to stop looking, because nothing here could write a
+     * row there at all — and an author who reads the second goes looking for a model that admits no
+     * such row. There is one, and they wrote it.
+     */
+    @Test
+    void whatStoppedIsSaidAsUndecidedAndNotAsUnwritable() {
+        String said = report(16);
+
+        assertFalse(said.contains("not known to be writable"),
+                () -> "a value this compiler declined to keep is not a point nothing writes:\n"
+                        + said);
+        assertTrue(said.contains("undecided whether a row is at the ON point"),
+                () -> "what the rows left open is what an author is told:\n" + said);
+    }
+
+    /**
+     * How many obligations the behavior's border account counts, as the report prints it.
+     *
+     * <p>Read off the account and not off how many points the line has. Every line has four, owed
+     * or not; the number a reader acts on is the denominator of what the rows are held to, and it
+     * is the one an observation must not move.
+     */
+    private static String counted(int names) {
+        Matcher said = Pattern.compile("obligations \\d+/(\\d+)").matcher(report(names));
+        assertTrue(said.find(), () -> "the border block prints an account at " + names + " names");
+        return said.group(1);
+    }
+
+    private static String report(int names) {
+        return AdequacyReport.of(compiled(names)).only("example.through", "判定する")
+                .human(SourceNameResolver.identity());
+    }
+
+    private static Compilation compiled(int names) {
+        Compilation compilation = Compilation.ofSource(model(names), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.errors().stream()
+                        .map(each -> each.diagnostic().code()).toList(),
+                () -> "the model under test compiles at " + names + " names");
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -291,7 +291,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     }
 
     private static ItemAssessment.Attempt built(String carrier) {
-        return new ItemAssessment.Attempt.Built(new Generator.GeneratedRow(
+        return ItemAssessment.Attempt.Built.certified(new Generator.GeneratedRow(
                 new Generator.Purpose.ForAPoint(carrier + ": " + SAID), List.of()), null);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -70,6 +70,40 @@ class WhichReadingComposesTheRowALineIsOwedTest {
                 "and the reading past it was never asked: a row anywhere settles the line");
     }
 
+    /**
+     * A row read back where it was built for outranks one nothing could place.
+     *
+     * <p>Both are rows a search composed and an author may be handed either, so a walk stopping at
+     * the first of them stops at whichever reading the module happened to declare first. What tells
+     * them apart is that only one has been seen at the point — which is what a reader asking
+     * whether a row can be written there is asking about, and it is not something the order of two
+     * call sites of one helper may decide.
+     */
+    @Test
+    void aRowThatWasPlacedOutranksOneNothingCouldPlace() {
+        PointResolution resolved = PointResolver.resolveAt(owed(),
+                List.of(at("unplaced"), at("placed")),
+                reading -> searched(reading.behavior().equals("unplaced")
+                        ? unverified(reading.behavior()) : built(reading.behavior())));
+
+        assertEquals("placed", assertInstanceOf(PointResolution.Generated.class, resolved)
+                        .composedBy(),
+                "the reading whose row was read back where it was built for is the one kept");
+    }
+
+    /** And where no reading placed one, the row nothing placed is still a row to offer. */
+    @Test
+    void aRowNothingPlacedIsStillOfferedWhereNothingBetterWas() {
+        PointResolution resolved = PointResolver.resolveAt(owed(),
+                List.of(at("unplaced"), at("neither")),
+                reading -> searched(reading.behavior().equals("unplaced")
+                        ? unverified(reading.behavior()) : notComposed()));
+
+        assertEquals("unplaced", assertInstanceOf(PointResolution.Generated.class, resolved)
+                        .composedBy(),
+                "a row this compiler could not read back is a row an author asked for");
+    }
+
     /** In the order the readings were handed over, which is the order the module declares them. */
     @Test
     void theReadingsAreWalkedInTheOrderTheyWereGiven() {
@@ -293,6 +327,15 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     private static ItemAssessment.Attempt built(String carrier) {
         return ItemAssessment.Attempt.Built.certified(new Generator.GeneratedRow(
                 new Generator.Purpose.ForAPoint(carrier + ": " + SAID), List.of()), null);
+    }
+
+    /** The same row, with nothing having read it back where it was built for. */
+    private static ItemAssessment.Attempt unverified(String carrier) {
+        return new ItemAssessment.Attempt.Unverified(new Generator.GeneratedRow(
+                new Generator.Purpose.ForAPoint(carrier + ": " + SAID), List.of()), null,
+                List.of(), new EstablishmentGap.Observation(
+                        java.util.Set.of(souther.compiler.observe.Incompleteness.Code
+                                .VALUE_TRUNCATED)));
     }
 
     /** The same, as what a reading holds at the point. */

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
@@ -1,0 +1,72 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.partition.ReadingGap;
+import souther.compiler.query.Weakening;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every reason a reading of a border came to no number reaches the report as a word of its own.
+ *
+ * <p>The reading tells a value an observation stopped from a place the walk never reached, and
+ * carries the pair through the quantity, the point and the weakening. What it is carried <em>for</em>
+ * is that a reader is told which one happened; a projection answering one word for both takes the
+ * difference out at the last step, and everything upstream of it becomes a distinction nobody can
+ * see.
+ *
+ * <p><b>Over the cases and not over a list somebody wrote.</b> The reasons are asked of the sealed
+ * type, so a reason added to {@link ReadingGap} arrives here as a case with no word rather than as a
+ * word it quietly shares — which is how the last one arrived. What the words are is not this test's
+ * to say; that they are as many as the reasons is.
+ */
+class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
+
+    /**
+     * As many words as there are reasons, and no two reasons under one word.
+     *
+     * <p>Both halves. Equal counts alone pass for a projection that answers one word twice and
+     * another never, and distinctness alone passes for one that leaves a reason out.
+     */
+    @Test
+    void eachReasonHasAWordAndNoTwoShareOne() {
+        List<ReadingGap> reasons = everyReason();
+        Set<WeakeningWord> words = new LinkedHashSet<>();
+        for (ReadingGap each : reasons) {
+            words.add(AdequacyReport.wordFor(new Weakening.BorderValueUnreadable(null, each)));
+        }
+
+        assertEquals(reasons.size(), words.size(),
+                () -> "two reasons a reading met came out as one word: " + reasons + " to " + words);
+    }
+
+    /**
+     * One of each, taken from what the type permits rather than from what a reader remembers.
+     *
+     * <p>An observation carries a code, and the codes an observation of a value can meet are the
+     * two it can meet — the rest of {@link Incompleteness.Code} is about rows and modules and
+     * reaches no border. They are one reason here all the same: what the word says is that an
+     * observation stopped, and which one it met is said under it.
+     */
+    private static List<ReadingGap> everyReason() {
+        List<ReadingGap> out = new ArrayList<>();
+        for (Class<?> permitted : ReadingGap.class.getPermittedSubclasses()) {
+            out.add(switch (permitted.getSimpleName()) {
+                case "Observation" -> ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED);
+                case "NoValue" -> ReadingGap.NO_VALUE;
+                // A reason added to the type and not to this list. Written as a failure rather than
+                // skipped: a reason nothing here can build is one nothing here is checking.
+                default -> throw new IllegalStateException(
+                        "a reason a reading can meet that this test cannot make: " + permitted);
+            });
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
Closes #1212.

An observation is walked under four budgets so that a memoised answer cannot hold an unbounded
value. What a budget stops is a fact about this compiler. Four places turned it into a fact about
the model, and each was enough on its own to leave the reported symptom in place:

```
Generator.readsElsewhere      a candidate whose read-back stopped is refused,
                              with a sentence saying it does not stand there

Coverages.standingThere       `case NO, UNREADABLE ->`: a walk that could not
                              look in the arm for a walk that looked

ObligationDisposition.of      `!writable.known()` asked before the coverage,
                              so a point nobody could decide leaves the count

Attempt.Built                 one case for a row that was placed and a row
                              nothing placed, so the second reads as the first
```

`ObligationDisposition` is what prints `not known to be writable` and `obligations 0/0`. Sixteen
wrappers around a list now reads:

```
border      borders 1   obligations 0/4
  ? undecided whether a row is at the ON point (comparison@30:49)
      · read as 判定する/List.sum(明細[*].金額): = 100000
  ? undecided whether a row is at the OFF point (comparison@30:49)
  ? undecided whether a row is at the IN point (comparison@30:49)
  ? undecided whether a row is at the OUT point (comparison@30:49)
```

and a point whose candidate could not be read back reads:

```
  ? a row was built for the ON point (comparison@14:50), and the observation of it was
    stopped by a limit, so where it stands could not be read
```

## What carries the fact

```
ObservedValue.Truncated / Unknown            the only thing that is an observation stopping
  └─ NumericTerm.Reading   Missing(code) | NoValue | NotNumber | Number
        └─ ReadingGap            Observation(code) | NoValue      collected, never ranked
              ├─ Generator.RealizationReadback  AtRequestedPlace | Elsewhere | CouldNotTell(gap)
              └─ BorderQuantity.Stands          Yes | No | CouldNotTell(Set<ReadingGap>)
                    └─ StandingAtAPoint.Met     AtPoint(Reached | NotWatched) | NotAtPoint
                                                | CouldNotTell(Set<ReadingGap>)
                          ├─ Weakening.BorderValueUnreadable(border, ReadingGap)   one per reason
                          │     └─ border_value_unreadable | border_value_absent
                          └─ Attempt.Built     Certified | Unverified(EstablishmentGap)
                                ├─ WritabilityEvidence   only Certified grounds A_VALUE_WAS_BUILT
                                └─ WritabilityKnowledge  Established | Prevented | NoEvidence
                                      └─ ObligationDisposition   coverage first, exhaustively
```

Collected and never ranked. Two observations were already gathered into a set; a walk that reached
no value is another reason and not a competing case, so it goes in the same set. Ranked instead,
every fold writes a precedence, every precedence throws one away, and which one a report says comes
out of the order a map was walked in.

Two readings and not one. The generator's is a prune of one parameter's value against one place and
says so; the whole row is read after it is composed, and that is the only place a `Certified` or an
`Unverified` is decided.

`Unverified` is not evidence. A row nothing placed has shown nothing about the model, and counting
it would turn an observation this compiler cut short into the model admitting a row — the same
trade the other way round. What it does license is that the question is open, which is
`WritabilityKnowledge.Prevented`, and a point there stays counted and makes no finding.

`ObligationDisposition` reads the coverage first. What promises a row is a refinement of one of its
answers — the one that tells a miss from a finding — and not a gate over all of them.

**And only an observation makes an observation's gap.** Several distinct facts arrived as one
`null` — a walk the type and the path disagree about, a place a reading holds nothing at, a row
that would not run back — and the first reader that needed a reason took the nearest word, which
was an observation's. Harmless while what that word carried was "the value could not be read, so
which class it is in is unknown"; not harmless once a reader says which budget stopped what, since
a linkage failure then arrives at the account as a limit that never fired. So `Membership.unread`
is asked of a value and refuses nothing, and each caller says what nothing means to its own
question.

## Tests

| layer | test | what it holds |
| --- | --- | --- |
| producer | `WhicheverBudgetStopsAWalkItStopsItWithOneWord` | each budget at the largest value it keeps and the smallest it does not, and all four read as one reason |
| bridge | `ALimitThatFiredIsNotALimitTheTermRead` | a walk run under a budget, handed to the term the rule is about — including a budget that fired everywhere the term does not read, which leaves the number readable |
| propagation | `WhatAnObservationCouldNotKeepIsNotWhereARowStands` | a stopped value never reads as a row that does not stand; a walk that reached nothing is not a stopped observation; a form says every cause |
| account | `ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCount` | the table, and the order: a limit may weaken a verdict to undecided and may not move it across or out |
| end to end | `ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKept` | `maxText` at 1024 and 1025, asserting which budget fired as well as what came of it |
| end to end | `AnObservationThisCompilerStoppedIsNotAPointNothingWrites` | one wrapper or sixteen, the same four rows are owed, and what stopped is said as undecided |
| projection | `EveryReasonAReadingMetIsSaidByAWordOfItsOwn` | as many report words as the reading has reasons, asked of what the type permits |

Three times in this branch a distinction was carried further than anything read it: a state the
search could no longer reach, an entry that never produced one of its two cases, and a projection
that answered one word for both. The last test is over that shape rather than over the instance —
a reason added to `ReadingGap` arrives as a case with no word rather than as a word it shares.

The bridge exists because a limit firing and the term meeting it are different facts: a count taken
at a container's root survives a walk that ran out of nodes inside it. A model was measured that
crossed the node budget by six hundred and read back a perfectly good number.

Four budgets, one reading. A model apiece would state one law four times, and three of them would
measure whichever budget the fixture crossed first — three constants are `64` (`Limits.maxElements`,
`ContainersAddingUp.MOST_ELEMENTS_A_ROW_CARRIES`, `Witnesses.MOST_ELEMENTS`), and for a collection
the observation is not the one that binds.

## What a point whose measurement fell short costs

Such a point is searched. Without it nothing is ever built there, so the writability half of an
undecided obligation is a state nothing reaches — and a state nothing reaches is a lie in the type.

It costs a composed row run at 212 points across the suite, of which 16 come back unplaced and say
what no other reading can; the rest change no output. Concentrated in the two classes written for
exactly this shape: `CompilePartialAdequacyTest` 1.1s → 34.6s, and
`AdequacyNeverAssertsFromPartOfTheRowsTest` 1.2s → 11.6s. The suite's wall clock is unchanged —
another class is the critical path — so the cost is CPU rather than time here, and will show
differently on a runner with fewer cores.

The switch over `Measurement` is exhaustive, so a state added to it arrives as a compile error
rather than as a silent `false`.

## Left out

#1232. A point this compiler declined to compose a value for meets the same sentence through a
different budget, in a different stage, and with no value built to read back. The vocabulary here
takes it as a case beside `EstablishmentGap.Observation` and a row of the table that already
exists.

The `maxNodes` end-to-end model is in #1212 rather than in the suite. It is the one axis that
reaches a plain miss whose showing was stopped, and crossing a two-thousand node budget costs about
two minutes a threshold. That row of the table is held by the account test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
