### PR TITLE
Say what a parsed operator denotes, rather than share its name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -1086,7 +1086,7 @@ public final class Resolve {
                     stmts.add(new Hir.Let(a.binder(), value, let.pos()));
                     bound = a.bound();
                 }
-                yield new Hir.PrimDecoder(Hir.RawKind.valueOf(p.from().name()), input.binder(), stmts,
+                yield new Hir.PrimDecoder(rawKind(p.from()), input.binder(), stmts,
                         construct(p.result(), bound), p.pos());
             }
             case Ast.ObjectDecoder o -> {
@@ -1104,6 +1104,31 @@ public final class Resolve {
                 yield new Hir.NewtypeDecoder(decRef(n.inner()), input.binder(),
                         construct(n.result(), input.bound()), n.pos());
             }
+        };
+    }
+
+    /**
+     * Which kind of primitive Raw a written one reads, in the vocabulary below this boundary.
+     *
+     * <p>The parsed tree and what this pass answers hold the kinds as separate types, so crossing
+     * between them is a decision and this is where it is made. Written out on both sides rather
+     * than taken from a spelling: a kind added to what the parser can write then has no translation
+     * until one says which kind below it means, and a name shared by the two enums is no answer to
+     * that.
+     *
+     * <p>The switch is an expression and has no {@code default} for that reason. A {@code default}
+     * would answer for a kind nobody had decided about, which is the whole of what this stops.
+     */
+    private static Hir.RawKind rawKind(Ast.RawKind kind) {
+        return switch (kind) {
+            case TEXT -> Hir.RawKind.TEXT;
+            case INT -> Hir.RawKind.INT;
+            case BOOL -> Hir.RawKind.BOOL;
+            case DECIMAL -> Hir.RawKind.DECIMAL;
+            case DATE -> Hir.RawKind.DATE;
+            case TIME -> Hir.RawKind.TIME;
+            case DATETIME -> Hir.RawKind.DATETIME;
+            case INSTANT -> Hir.RawKind.INSTANT;
         };
     }
 
@@ -1272,7 +1297,7 @@ public final class Resolve {
             case Ast.BoolLit x -> new Hir.BoolLit(x.value(), x.pos(), x.region());
             case Ast.Unreachable x -> new Hir.Unreachable(x.reason(), x.pos(), x.region());
             case Ast.Neg x -> new Hir.Neg(expr(x.operand(), bound), x.pos(), x.region());
-            case Ast.Binary x -> new Hir.Binary(BinOp.valueOf(x.op().name()),
+            case Ast.Binary x -> new Hir.Binary(binOp(x.op()),
                     expr(x.left(), bound), expr(x.right(), bound), x.origin(), x.pos(), x.region());
             case Ast.If x -> new Hir.If(expr(x.cond(), bound), expr(x.then(), bound),
                     expr(x.els(), bound), x.origin(), x.pos(), x.region());
@@ -1288,6 +1313,37 @@ public final class Resolve {
             // answers. One here is a tree that has been below this boundary and come back.
             case Ast.Expansion x -> throw new IllegalStateException(
                     "an expansion reached resolution at " + x.pos());
+        };
+    }
+
+    /**
+     * Which operator a written one is, in the vocabulary below this boundary.
+     *
+     * <p>An operator the parser can write and an operator the rest of the compiler gives a meaning
+     * to are separate types on purpose, and a written one becomes a meant one here or nowhere. Both
+     * sides are spelled out so that an operator added to what may be written stops the compile
+     * until somebody says which meaning it denotes — including when the two are given the same
+     * name, which says how they are typed and nothing about what they denote. The same reason
+     * {@code AstBuilder} writes out what each piece of syntax is an operator for.
+     *
+     * <p>The switch is an expression and has no {@code default} for that reason. A {@code default}
+     * would answer for an operator nobody had decided about, which is the whole of what this stops.
+     */
+    private static BinOp binOp(Ast.BinOp op) {
+        return switch (op) {
+            case EQ -> BinOp.EQ;
+            case NE -> BinOp.NE;
+            case LT -> BinOp.LT;
+            case LE -> BinOp.LE;
+            case GT -> BinOp.GT;
+            case GE -> BinOp.GE;
+            case AND -> BinOp.AND;
+            case OR -> BinOp.OR;
+            case ADD -> BinOp.ADD;
+            case SUB -> BinOp.SUB;
+            case MUL -> BinOp.MUL;
+            case DIV -> BinOp.DIV;
+            case CONCAT -> BinOp.CONCAT;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -1112,9 +1112,9 @@ public final class Resolve {
      *
      * <p>The parsed tree and what this pass answers hold the kinds as separate types, so crossing
      * between them is a decision and this is where it is made. Written out on both sides rather
-     * than taken from a spelling: a kind added to what the parser can write then has no translation
-     * until one says which kind below it means, and a name shared by the two enums is no answer to
-     * that.
+     * than taken from a spelling: a kind added to what the parsed tree may hold then has no
+     * translation until one says which kind below it means, and a name shared by the two enums is
+     * no answer to that.
      *
      * <p>The switch is an expression and has no {@code default} for that reason. A {@code default}
      * would answer for a kind nobody had decided about, which is the whole of what this stops.

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -1108,7 +1108,7 @@ public final class Resolve {
     }
 
     /**
-     * Which kind of primitive Raw a written one reads, in the vocabulary below this boundary.
+     * Which kind of primitive Raw a parsed kind denotes, in the vocabulary below this boundary.
      *
      * <p>The parsed tree and what this pass answers hold the kinds as separate types, so crossing
      * between them is a decision and this is where it is made. Written out on both sides rather

--- a/souther-compiler/src/test/java/souther/compiler/check/NothingCrossesThisBoundaryByItsSpellingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NothingCrossesThisBoundaryByItsSpellingTest.java
@@ -1,0 +1,59 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What one representation becomes in the next is written down, never read off a name.
+ *
+ * <p>{@code Resolve} is where the parsed tree becomes what the rest of the compiler gives a meaning
+ * to, and several of the vocabularies on the two sides are closed: an operator, the kind of a
+ * primitive Raw. Each such crossing is a decision about what a written thing denotes, and this pass
+ * makes it in an exhaustive switch that names both sides. Taking the answer from
+ * {@code valueOf(x.name())} instead makes it a shared spelling, and a spelling is not a decision:
+ * extend both enums with the same name and the translation goes on quietly, having decided nothing.
+ *
+ * <p>The rule this stands for is that this pass does not infer one closed representation from
+ * another one's spelling. What is checked is stricter: the word {@code valueOf(} does not appear in
+ * the pass at all. That catches the spelling written straight, the same call with the name held in
+ * a variable first, and {@code Enum.valueOf(BinOp.class, ...)}, and it costs nothing today, because
+ * translating by name was the only thing this pass used the word for.
+ *
+ * <p>Being stricter than the rule, it can refuse something the rule allows —
+ * {@code Denotations.valueOf(BindingId)}, next door in this package, is a lookup and no crossing at
+ * all. That is the check working as designed and not a miss in it. Should such a call become
+ * necessary here, decide about this check itself: narrowing it to the enums known today puts the
+ * hole back, since what it is here for is the crossing nobody has written yet.
+ */
+class NothingCrossesThisBoundaryByItsSpellingTest {
+
+    /** The pass that holds the boundary, and so the one this is about. */
+    private static final Path RESOLVE = Path.of("src/main/java/souther/compiler/check/Resolve.java");
+
+    @Test
+    void resolveTranslatesByDecidingRatherThanByReadingAName() throws IOException {
+        assertTrue(Files.isRegularFile(RESOLVE), () -> "no " + RESOLVE.toAbsolutePath());
+        String text = Files.readString(RESOLVE);
+
+        assertEquals(0, occurrences(text, "valueOf("),
+                "a closed vocabulary crosses this boundary in a switch that names both sides, so"
+                        + " that adding to what may be written stops the compile until somebody says"
+                        + " what it denotes; a name the two sides happen to share says nothing about"
+                        + " that. A valueOf that is a lookup rather than a crossing is refused here"
+                        + " too — decide about this check, do not narrow it to the enums of the day");
+    }
+
+    private static int occurrences(String text, String word) {
+        int count = 0;
+        for (int at = text.indexOf(word); at >= 0; at = text.indexOf(word, at + word.length())) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/NothingCrossesThisBoundaryByItsSpellingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NothingCrossesThisBoundaryByItsSpellingTest.java
@@ -20,10 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * extend both enums with the same name and the translation goes on quietly, having decided nothing.
  *
  * <p>The rule this stands for is that this pass does not infer one closed representation from
- * another one's spelling. What is checked is stricter: the word {@code valueOf(} does not appear in
- * the pass at all. That catches the spelling written straight, the same call with the name held in
- * a variable first, and {@code Enum.valueOf(BinOp.class, ...)}, and it costs nothing today, because
- * translating by name was the only thing this pass used the word for.
+ * another one's spelling. What is checked is stricter: the word {@code valueOf} does not appear in
+ * the pass at all. The word and not a call written a particular way — a call is one of the shapes
+ * the word comes in, beside {@code valueOf (x)}, beside {@code BinOp::valueOf} handed to something
+ * that applies it, and beside {@code Enum.valueOf(BinOp.class, ...)}. Each of those is the same
+ * thing asked for, and a check that named the shape in front of it would be one the next shape
+ * walks past. It costs nothing today, because translating by name was the only thing this pass used
+ * the word for.
  *
  * <p>Being stricter than the rule, it can refuse something the rule allows —
  * {@code Denotations.valueOf(BindingId)}, next door in this package, is a lookup and no crossing at
@@ -41,7 +44,7 @@ class NothingCrossesThisBoundaryByItsSpellingTest {
         assertTrue(Files.isRegularFile(RESOLVE), () -> "no " + RESOLVE.toAbsolutePath());
         String text = Files.readString(RESOLVE);
 
-        assertEquals(0, occurrences(text, "valueOf("),
+        assertEquals(0, occurrences(text, "valueOf"),
                 "a closed vocabulary crosses this boundary in a switch that names both sides, so"
                         + " that adding to what may be written stops the compile until somebody says"
                         + " what it denotes; a name the two sides happen to share says nothing about"

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -184,10 +184,12 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " the answer is a newtype"),
             new Held("souther.compiler.check.Terms.asWrittenValue",
                     "writes it back into the syntax a value is rendered as"),
+            new Held("souther.compiler.check.Resolve.binOp",
+                    "says which operator the parsed tree's own denotes, the one place the two are"
+                            + " held together: both sides written out, so an operator added to what"
+                            + " may be written stops the compile until somebody decides"),
             new Held("souther.compiler.check.Resolve.expr",
-                    "translates the parsed tree's own operator into this one, by the name each is"
-                            + " spelled with: two enums held together by a string rather than by"
-                            + " anything that would fail to compile"),
+                    "writes what that answered into the node the resolved tree holds"),
 
             // Handing it on to something that answers about it.
             new Held("souther.compiler.check.HelperParams.BodyTyping.visit",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -184,10 +184,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " the answer is a newtype"),
             new Held("souther.compiler.check.Terms.asWrittenValue",
                     "writes it back into the syntax a value is rendered as"),
-            new Held("souther.compiler.check.Resolve.binOp",
-                    "says which operator the parsed tree's own denotes, the one place the two are"
-                            + " held together: both sides written out, so an operator added to what"
-                            + " may be written stops the compile until somebody decides"),
             new Held("souther.compiler.check.Resolve.expr",
                     "writes what that answered into the node the resolved tree holds"),
 
@@ -317,6 +313,11 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "reads the operator a library operation is declared to compute"),
 
             // Naming a constant, which is the other way to come by one.
+            new Held("souther.compiler.check.Resolve.binOp",
+                    "names the constant the parsed tree's own operator denotes, which is the one"
+                            + " place the two vocabularies are held together: both sides written"
+                            + " out, so an operator added to what may be written stops the compile"
+                            + " until somebody says what it means here"),
             new Held("souther.compiler.check.ComparisonWriting.operatorStating",
                     "names the constant a relation is written as, which is the one place a"
                             + " composed comparison is said in the language's own operators"),


### PR DESCRIPTION
Closes #1228.

`Resolve` translated the parsed tree's operators into the semantic ones with
`BinOp.valueOf(x.op().name())`, and the kinds of a primitive Raw with
`Hir.RawKind.valueOf(p.from().name())`. Two representations kept apart on
purpose were held together by a spelling: name a constant alike on both sides
and the crossing succeeds without anyone having decided what the new written
form denotes.

Each crossing is now a `private static` switch expression over what may be
written, naming both sides, with no `default`. The `default` is the point and
not an afterthought — a switch statement over an enum is not held to
exhaustiveness, and a `default` arm would answer for the form nobody had
decided about.

## What was measured

All four with `mvn -o clean test-compile`, on this branch rebased onto
`d841b0937`:

| probe | where the compile stopped |
| --- | --- |
| `XOR` in `Ast.BinOp` only | `Resolve.binOp` |
| `XOR` in `BinOp` only | `BinOp.rightRunsWhenLeftIs` — not this boundary |
| `XOR` in both, each stop answered in turn | `BinOp.rightRunsWhenLeftIs` → `ComparisonPlacement.of` → `BinaryElaborator.elaborateBinary` → `ConstEval.binary` → **`Resolve.binOp`** |
| a constant added to `Ast.RawKind` | `Resolve.rawKind` |

The third is the hole this closes: sharing a name gets a written operator past
nothing. It takes four compiles to see, because javac stops the run at the
first file that has errors — the translation is the last of the five to be
reached and it is reached.

The fourth matters because `Ast.PrimDecoder` has no producer, so no run reaches
that translation. What is wanted of it is a brake on how the source may be
extended, and that does not depend on anything reaching it.

`Ast.BinOp.LT -> BinOp.GT` leaves 144 failures and 11 errors. That says the
translation of `LT` is observed by the suite; it is not a statement about the
other twelve arms.

## The check beside them

`NothingCrossesThisBoundaryByItsSpellingTest` keeps the word `valueOf` out of
`Resolve.java`, which today it is not otherwise used for. The word and not a call
written a particular way: `valueOf (x)` with a space and `BinOp::valueOf` handed
to something that applies it are the same thing asked for, and each of them
counts zero against `valueOf(`. Both were run against the check — under the word
they fail it. The rule it stands
for is that this pass does not infer one closed representation from another
one's spelling; what it checks is stricter, and on purpose, so that the same
crossing written through a variable or through `Enum.valueOf` is stopped too.
A `valueOf` that is a lookup rather than a crossing — `Denotations.valueOf` is
one, next door — would be refused here as well. Its message says what to do
then: decide about the check, rather than narrow it to the enums known today,
which is how the hole would come back.

No test says the two enums have the same names. That convention is what the
translation stops relying on.

`WhereAnOperatorMayStillBeHeldIsWrittenDownTest` gains the translation as a
line of its own, under naming a constant, beside the relation written as one.

## Not here

`Ast.DecoderDef` and its `Ast.RawKind` have no producer anywhere, so
`Resolve.decoder` is unreachable. Filed as #1235. Whether a representation is
translated soundly and whether anything writes one are separate questions.
