### PR TITLE
Answer a condition connective with what it composes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,18 +55,17 @@ sealed interface ClauseExpr {
         }
     }
 
-    /** Both of them holding. */
-    record Both(List<Core> spelled, ClauseExpr left, ClauseExpr right) implements ClauseExpr {
+    /**
+     * Two parts and what holding this one says of them.
+     *
+     * @param how what the connective composes, with the denial the tree was read under already
+     *            applied: what is left holds no {@code not}, so a reader below asks this and never
+     *            the operator the clause was written with
+     */
+    record Joined(List<Core> spelled, ConditionJoin how, ClauseExpr left, ClauseExpr right)
+            implements ClauseExpr {
 
-        public Both {
-            spelled = named(spelled);
-        }
-    }
-
-    /** Either of them holding. */
-    record Either(List<Core> spelled, ClauseExpr left, ClauseExpr right) implements ClauseExpr {
-
-        public Either {
+        public Joined {
             spelled = named(spelled);
         }
     }
@@ -96,14 +95,16 @@ sealed interface ClauseExpr {
         if (under != null) {
             return of(under, !positive, spelled);
         }
-        if (clause instanceof Core.Binary bin && bin.op().joinsTwoConditions()) {
+        if (clause instanceof Core.Binary bin) {
             // Stated, a conjunction gives both sides; denied, it gives the choice between their
             // denials. And the same the other way round, which is the whole of what a denial does
-            // to a connective.
-            ClauseExpr left = of(bin.left(), positive, List.of());
-            ClauseExpr right = of(bin.right(), positive, List.of());
-            return (bin.op() == BinOp.AND) == positive
-                    ? new Both(spelled, left, right) : new Either(spelled, left, right);
+            // to a connective, and is why the denial is applied to what the connective composes.
+            ConditionJoin joined = ConditionJoin.of(bin.op()).map(one -> one.under(positive))
+                    .orElse(null);
+            if (joined != null) {
+                return new Joined(spelled, joined, of(bin.left(), positive, List.of()),
+                        of(bin.right(), positive, List.of()));
+            }
         }
         return new Leaf(spelled, positive);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -1,6 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
@@ -170,7 +170,8 @@ public final class ClauseHelpers {
     /** The conjuncts of a clause, flattened, in the order they are written — what a reader sees as
      * separate clauses. */
     public static List<Hir.Expr> conjunctsOf(Hir.Expr e) {
-        if (e instanceof Hir.Binary b && b.op() == BinOp.AND) {
+        if (e instanceof Hir.Binary b
+                && ConditionJoin.of(b.op()).orElse(null) == ConditionJoin.BOTH) {
             List<Hir.Expr> out = new ArrayList<>(conjunctsOf(b.left()));
             out.addAll(conjunctsOf(b.right()));
             return out;

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -82,8 +82,10 @@ interface ClauseReading<S> {
     private S over(ClauseExpr shape, java.util.function.BiConsumer<Core, S> per) {
         S out = switch (shape) {
             case ClauseExpr.Leaf it -> leaf(it.of(), it.positive());
-            case ClauseExpr.Both it -> both(over(it.left(), per), over(it.right(), per));
-            case ClauseExpr.Either it -> either(over(it.left(), per), over(it.right(), per));
+            case ClauseExpr.Joined it -> switch (it.how()) {
+                case BOTH -> both(over(it.left(), per), over(it.right(), per));
+                case EITHER -> either(over(it.left(), per), over(it.right(), per));
+            };
         };
         // Every node that was written as this shape, so a reader asking about the node it is
         // holding finds what this made of it — the denial as well as what is under it, since the

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -7,6 +7,7 @@ import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.numeric.Towards;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.semantics.ResultRange;
 import souther.compiler.types.BinOp;
@@ -148,7 +149,8 @@ final class Conditions {
             return;
         }
         if (cond instanceof Core.Binary b
-                && (b.op() == BinOp.AND && positive || b.op() == BinOp.OR && !positive)) {
+                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
+                        == ConditionJoin.BOTH) {
             stating(terms, b.left(), at, positive, out);
             stating(terms, b.right(), at, positive, out);
             return;

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1,6 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Endpoint;
@@ -1464,7 +1464,8 @@ public final class FieldDomains {
                 // the conjunction as well, a rule whose halves are each held in a language of their
                 // own — a date bounded at both ends, read by the comparison rather than by the
                 // interval algebra — answers for neither half and fails on the node above them.
-                if (part instanceof Core.Binary b && b.op() == BinOp.AND
+                if (part instanceof Core.Binary b
+                        && ConditionJoin.of(b.op()).orElse(null) == ConditionJoin.BOTH
                         && byPart.containsKey(b.left()) && byPart.containsKey(b.right())) {
                     return;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,6 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Combinators.Handed;
@@ -1361,7 +1361,8 @@ public final class InvariantChecker {
                         Map<RuleRef, Map<Core, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing) {
-        if (clause instanceof Core.Binary and && and.op() == BinOp.AND) {
+        if (clause instanceof Core.Binary and
+                && ConditionJoin.of(and.op()).orElse(null) == ConditionJoin.BOTH) {
             // One rule the author wrote, so what it raises is what its conjuncts raise together.
             // Left before right, which is the order the clause was written in and the order
             // {@code ClauseHelpers.conjunctsOf} reads it in: the two readings of one clause number

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -1,6 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.DischargeRules.Carrying;
 import souther.compiler.check.DischargeRules.Projection;
@@ -91,14 +91,17 @@ final class Predicates {
     }
 
     /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
-     * Mirrors {@link #obligations}: a conjunction states each of its sides, and a negation flips the
-     * polarity. Only a stated quantifier is recorded — denying one says some element fails the
-     * predicate, and which one is not something this check can name. */
+     * Mirrors {@link #obligations}: a connective that composes both halves under the polarity in
+     * force states each of them under it, and a negation turns the polarity over. Only a stated
+     * quantifier is recorded — denying one says some element fails the predicate, and which one is
+     * not something this check can name. */
     void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
         Core e = Conditions.asSizeComparison(raw);
-        if (e instanceof Core.Binary b && b.op() == BinOp.AND && positive) {
-            quantifiedBy(b.left(), at, true, out);
-            quantifiedBy(b.right(), at, true, out);
+        if (e instanceof Core.Binary b
+                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
+                        == ConditionJoin.BOTH) {
+            quantifiedBy(b.left(), at, positive, out);
+            quantifiedBy(b.right(), at, positive, out);
             return;
         }
         Core under = Conditions.negated(e);
@@ -615,13 +618,16 @@ final class Predicates {
     private Owed read(Core inv, Denotations at, Set<Core> unnamed,
                       boolean positive, boolean decidesFalse, Discharge discharge,
                       PerPart per) {
-        if (inv instanceof Core.Binary b && b.op() == BinOp.AND && positive) {
-            // Each conjunct on its own: an invariant is a set of things that hold, and one the check
+        if (inv instanceof Core.Binary b
+                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
+                        == ConditionJoin.BOTH) {
+            // Each half on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
-            // That it stands is carried rather than dropped — the other conjunct being discharged is
+            // That it stands is carried rather than dropped — the other half being discharged is
             // not the invariant proven.
-            return obligations(b.left(), at, unnamed, true, decidesFalse, discharge, per)
-                    .and(obligations(b.right(), at, unnamed, true, decidesFalse, discharge, per));
+            return obligations(b.left(), at, unnamed, positive, decidesFalse, discharge, per)
+                    .and(obligations(b.right(), at, unnamed, positive, decidesFalse, discharge,
+                            per));
         }
         Core under = Conditions.negated(inv);
         if (under != null) {
@@ -792,9 +798,11 @@ final class Predicates {
             taken = first.taken();
             shapeRead = first.shapeRead();
         }
-        // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
+        // A connective composing both halves under the polarity in force gives each of them under
+        // that polarity.
         if (cond instanceof Core.Binary b
-                && (b.op() == BinOp.AND && positive || b.op() == BinOp.OR && !positive)) {
+                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
+                        == ConditionJoin.BOTH) {
             Assumed left = assumeCond(b.left(), k, at, positive);
             // Either side taken in is the condition taken in. A conjunction one half of which reads
             // is not one nothing was read of, and calling it that would name this compiler's limit

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -5,7 +5,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.ReadMeaning;
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 
 /**
  * What a condition of a body is made of.
@@ -26,11 +26,10 @@ import souther.compiler.types.BinOp;
  * establishes. All from moving a comparison into a {@code let}, which changes nothing about what the
  * model says.
  *
- * <p>So the vocabulary is here and the readers fold over it. Four shapes:
+ * <p>So the vocabulary is here and the readers fold over it. Three shapes:
  *
  * <ul>
- *   <li>{@link Both} and {@link Either} — the two operators a condition is built from, each of
- *       which stops as soon as it is settled;
+ *   <li>{@link Joined} — two conditions put together, with what their connective makes of them;
  *   <li>{@link Compares} — one comparison, with the reading of the names in force where it stands;
  *   <li>{@link NotRead} — where this stops. A condition can be anything a {@code Bool} is, and what
  *       is not one of the shapes above says nothing here rather than being guessed at.
@@ -62,11 +61,16 @@ sealed interface Condition {
      */
     Core at();
 
-    /** Both, and the right one runs only where the left held. */
-    record Both(Core.Binary at, Condition left, Condition right) implements Condition {}
-
-    /** Either, and the right one runs only where the left did not hold. */
-    record Either(Core.Binary at, Condition left, Condition right) implements Condition {}
+    /**
+     * Two conditions put together, and what the connective makes of them.
+     *
+     * @param how what the connective composes, which is read off the operator where this is made
+     *            and is what a reader asks rather than the operator: a reader holding the operator
+     *            reads it again for the same answer, and the two readings can be taught different
+     *            ones
+     */
+    record Joined(Core.Binary at, ConditionJoin how, Condition left, Condition right)
+            implements Condition {}
 
     /**
      * One comparison, and where the names in it point.
@@ -116,13 +120,12 @@ sealed interface Condition {
                 && reads.meaningOf(name, symbols) instanceof ReadMeaning.Through through) {
             return of(through.denotes().value(), through.denotes().at(), symbols);
         }
-        if (e instanceof Core.Binary binary && binary.op().joinsTwoConditions()) {
-            Condition left = of(binary.left(), reads, symbols);
-            Condition right = of(binary.right(), reads, symbols);
-            return binary.op() == BinOp.AND
-                    ? new Both(binary, left, right) : new Either(binary, left, right);
-        }
         if (e instanceof Core.Binary binary) {
+            ConditionJoin joined = ConditionJoin.of(binary.op()).orElse(null);
+            if (joined != null) {
+                return new Joined(binary, joined, of(binary.left(), reads, symbols),
+                        of(binary.right(), reads, symbols));
+            }
             Comparison comparison = Comparison.of(binary).orElse(null);
             if (comparison != null) {
                 return new Compares(comparison, reads);

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -1,6 +1,6 @@
 package souther.compiler.partition;
 
-import souther.compiler.types.BinOp;
+import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
@@ -172,11 +172,6 @@ public final class EnsuresThresholds {
                               InputReading read, InputReads reads,
                               Drawn out) {
         Symbols symbols = read.symbols();
-        if (e instanceof Core.Binary both && both.op() == BinOp.AND) {
-            return stated(both.right(), rule, clause,
-                    stated(both.left(), rule, clause, line, read, reads, out),
-                    read, reads, out);
-        }
         // Through what a `let` binds, which is not a choice: what the expression comes to is its
         // body, so the body states whatever the rule states. This is the shape a helper called from
         // a clause arrives in — the call is expanded and its argument bound to the helper's own
@@ -186,11 +181,22 @@ public final class EnsuresThresholds {
             return stated(let.body(), rule, clause, line, read,
                     reads.and(let.binder(), let.value()), out);
         }
-        // A disjunction was read, and what it states is not what either side of it states. Said as
-        // nothing rather than as a rule this could not read: reporting it would send an author after
-        // a limit of this compiler that is not there.
-        if (e instanceof Core.Binary or && or.op() == BinOp.OR) {
-            return line + 1;
+        if (e instanceof Core.Binary binary) {
+            // Asked once of the connective this is, and both answers read off that. Asked again
+            // below for the other one, the second question would be free to come to a different
+            // answer about the very operator the first one has already been read for.
+            ConditionJoin joined = ConditionJoin.of(binary.op()).orElse(null);
+            if (joined == ConditionJoin.BOTH) {
+                return stated(binary.right(), rule, clause,
+                        stated(binary.left(), rule, clause, line, read, reads, out),
+                        read, reads, out);
+            }
+            if (joined == ConditionJoin.EITHER) {
+                // What such a rule states is not what either side of it states. Said as nothing
+                // rather than as a rule this could not read: reporting it would send an author
+                // after a limit of this compiler that is not there.
+                return line + 1;
+            }
         }
         // Anything else is a form this walk does not read. Which positions it is about is still
         // said, because a position left out of every answer is reported as one the model draws no

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -13,6 +13,7 @@ import souther.compiler.inputs.SearchRegion;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.semantics.ConditionJoin;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -92,31 +93,27 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
      * derived alike, and the day one of them learned to read a new shape of condition would be the
      * day they stopped agreeing.
      *
-     * <p>A conjunction coming out true is both its operands true, and a disjunction coming out false
-     * is both false. The other two ways round say a disjunction of things, which is not a list of
-     * cuts and is not approximated into one: {@code A && B} being false says one of them failed and
-     * names neither, and narrowing on either would exclude rows that arrive. So those two are
-     * declined whole, at the condition rather than at an operand — neither operand is what could
+     * <p>A joined condition that came out the way its connective gives both halves is both halves
+     * having come out that way, and which way that is comes from the composition under the outcome
+     * rather than from the operator. The other composition says a disjunction of things, which is
+     * not a list of cuts and is not approximated into one: {@code A && B} being false says one of
+     * them failed and names neither, and narrowing on either would exclude rows that arrive. So it
+     * is declined whole, at the condition rather than at an operand — neither operand is what could
      * not be carried.
      */
     static List<OnTheWay> stating(Condition node, InputDomain inputs, boolean holding,
                                   Symbols symbols) {
         return switch (node) {
-            // A conjunction coming out true is both its operands true, and a disjunction coming out
-            // false is both false. The other two ways round say a disjunction of things, which is
-            // not a list of cuts and is not approximated into one: `A && B` being false says one of
-            // them failed and names neither, and narrowing on either would exclude rows that arrive.
-            // So the whole node is declined, at the whole node's place.
-            case Condition.Both both -> holding
-                    ? and(stating(both.left(), inputs, true, symbols),
-                            stating(both.right(), inputs, true, symbols))
-                    : List.of(new OnTheWay.Declined(Citation.of(both.at().pos()),
+            // Coming out the way that gives both halves, each of them came out that way too. The
+            // other composition says a disjunction of things, which is not a list of cuts and is
+            // not approximated into one: `A && B` being false says one of them failed and names
+            // neither, and narrowing on either would exclude rows that arrive. So the whole node is
+            // declined, at the whole node's place.
+            case Condition.Joined joined -> joined.how().under(holding) == ConditionJoin.BOTH
+                    ? and(stating(joined.left(), inputs, holding, symbols),
+                            stating(joined.right(), inputs, holding, symbols))
+                    : List.of(new OnTheWay.Declined(Citation.of(joined.at().pos()),
                             new OnTheWay.Why.OneOfTwoThings()));
-            case Condition.Either either -> holding
-                    ? List.of(new OnTheWay.Declined(Citation.of(either.at().pos()),
-                            new OnTheWay.Why.OneOfTwoThings()))
-                    : and(stating(either.left(), inputs, false, symbols),
-                            stating(either.right(), inputs, false, symbols));
             case Condition.Compares one -> List.of(of(one, inputs, holding, symbols));
             case Condition.NotRead not -> List.of(new OnTheWay.Declined(
                     Citation.of(not.at().pos()), new OnTheWay.Why.NoWordsForTheShape()));

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ConditionJoin.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ConditionJoin.java
@@ -1,0 +1,71 @@
+package souther.compiler.semantics;
+
+import souther.compiler.types.BinOp;
+
+import java.util.Optional;
+
+/**
+ * What a connective makes of the two conditions it stands between.
+ *
+ * <p>The answer a reader takes away from recognising a connective. Recognition answered as a
+ * membership says that two conditions were joined and not which way, so what a reader held
+ * afterwards was the operator, and it read the operator again where the meaning was wanted. The
+ * rule that a stated conjunction gives both halves and a denied disjunction gives both halves was
+ * then written out at each of those places, and each of them could be taught a different one.
+ *
+ * <p><b>What a denial does is here and not in any of them.</b> Denying a condition exchanges the
+ * two answers, which is the whole of what a denial does to a connective, and a reader carrying a
+ * polarity asks for the answer under it rather than working the exchange out beside the operator.
+ *
+ * <p>Nothing here is about how the two halves run. Which operand runs when is
+ * {@link BinOp#rightRunsWhenLeftIs}, and the two questions are told apart by the same two operators
+ * today — a connective composing without stopping early would part them, and reading either answer
+ * off the other is a coupling between facts that do not decide each other.
+ */
+public enum ConditionJoin {
+
+    /** Both of the halves. */
+    BOTH,
+
+    /** One of the halves, or both of them. */
+    EITHER;
+
+    /**
+     * What {@code op} composes where it is stated, which is nothing where it joins no two
+     * conditions.
+     *
+     * <p>Which operators join two conditions is {@link BinOp#joinsTwoConditions}'s answer and this
+     * asks it rather than listing them again. Two lists can be given different answers about one
+     * operator added later, and a reader would then be told that something states a composition
+     * where the language says it is not a connective at all.
+     */
+    public static Optional<ConditionJoin> of(BinOp op) {
+        if (!op.joinsTwoConditions()) {
+            return Optional.empty();
+        }
+        return switch (op) {
+            case AND -> Optional.of(BOTH);
+            case OR -> Optional.of(EITHER);
+            // Refused above and written out here so the switch stays exhaustive: an operator added
+            // to the language stops the compile here and is decided about rather than falling in.
+            // The arms answer the absence the refusal above answered, and are no second say in
+            // which operators join two conditions.
+            case EQ, NE, LT, LE, GT, GE, ADD, SUB, MUL, DIV, CONCAT -> Optional.empty();
+        };
+    }
+
+    /** What the connective composes where the condition it joins is denied: both halves where
+     *  either of them would have done, and either of them where both would have. */
+    public ConditionJoin denied() {
+        return switch (this) {
+            case BOTH -> EITHER;
+            case EITHER -> BOTH;
+        };
+    }
+
+    /** What the connective composes where the condition it joins is stated with polarity
+     *  {@code positive}, which is what it composes denied where it is not. */
+    public ConditionJoin under(boolean positive) {
+        return positive ? this : denied();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/semantics/package-info.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/package-info.java
@@ -1,11 +1,12 @@
 /**
- * What the language's own operations are, as propositions about the operations.
+ * What the language's own constructs are, as propositions about them.
  *
  * <p>Nothing here is about a reader. What {@code Date.daysBetween} answers, that
  * {@code Int.abs} is never negative, that {@code Date.addMonths} moves a date by no
- * fixed number of days: each is true of the operation whether or not anything in this
- * compiler asks. This package holds those, once, and the checks that hold each of them
- * to the declaration it was written for.
+ * fixed number of days, that a conjunction states both of the conditions it joins: each
+ * is true of the construct whether or not anything in this compiler asks. This package
+ * holds those, once, and the checks that hold each of them to the declaration it was
+ * written for.
  *
  * <h2>Why it is not owned by whoever asks first</h2>
  *
@@ -21,8 +22,8 @@
  * needed it second, so the same repair is owed again every time. What removes the repair
  * is the ownership rule, held from the first reader rather than the second:
  *
- * <p><b>An intrinsic fact about an operation never belongs to a consumer.</b> A
- * proposition true of the operation is declared here. A rule about what a procedure does
+ * <p><b>An intrinsic fact about a construct never belongs to a consumer.</b> A
+ * proposition true of the construct is declared here. A rule about what a procedure does
  * with such a proposition — which of them it enforces, what it reports when it cannot —
  * belongs to that procedure.
  *

--- a/souther-compiler/src/test/java/souther/compiler/ADeniedDisjunctionStatesBothOfItsHalvesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADeniedDisjunctionStatesBothOfItsHalvesTest.java
@@ -1,0 +1,115 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a rule written as a denied disjunction states, which is both of its halves denied.
+ *
+ * <p>One connective and one polarity say what a condition gives its reader, and the answer does not
+ * depend on which of the two ways round they arrive: a conjunction stated and a disjunction denied
+ * each give both halves. A reading that takes a conjunction apart and stops at a disjunction states
+ * nothing about a rule an author wrote the other way round, and the rule is then owed a run-time
+ * check where the values already settle it.
+ *
+ * <p>What is asked here is the polarity as much as the connective. A disjunction denied gives both
+ * halves <em>denied</em>, so a quantifier under one is a quantifier said to fail of some element,
+ * which names no element and is not recorded — and a denial inside one of the halves states the
+ * quantifier again.
+ */
+class ADeniedDisjunctionStatesBothOfItsHalvesTest {
+
+    private static long warnings(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    /** A rule of a type, written as a denied disjunction of two orders. Each half denied is an
+     *  order the guards settle, so nothing is left for a run-time check. */
+    @Test
+    void aDeniedDisjunctionOwesBothOfItsHalvesDenied() {
+        String m = """
+                module demo
+                data TooSmall
+                data Qty = Int
+                    invariant Bool.not(value < 1 || value > 10)
+                behavior toQty : (n: Int) -> Qty | TooSmall
+                    constructs Qty
+                let toQty (n) = {
+                    guard n >= 1
+                        else TooSmall
+                    guard n <= 10
+                        else TooSmall
+                    Qty(n)
+                }
+                """;
+        assertEquals(0, warnings(m),
+                "both halves denied are the two orders the guards settle");
+    }
+
+    /** The same rule written as the conjunction it means, which is the reading the one above has to
+     *  agree with. Two ways of writing one rule are one rule. */
+    @Test
+    void theConjunctionItMeansIsOwedTheSame() {
+        String m = """
+                module demo
+                data TooSmall
+                data Qty = Int
+                    invariant value >= 1 && value <= 10
+                behavior toQty : (n: Int) -> Qty | TooSmall
+                    constructs Qty
+                let toQty (n) = {
+                    guard n >= 1
+                        else TooSmall
+                    guard n <= 10
+                        else TooSmall
+                    Qty(n)
+                }
+                """;
+        assertEquals(0, warnings(m), "the two orders the guards settle");
+    }
+
+    /** A denied disjunction of two quantifiers records neither of them: what it states is that each
+     *  fails of some element, and which element is not something this check can name. */
+    @Test
+    void aDeniedDisjunctionOfQuantifiersRecordsNeitherOfThem() {
+        String m = """
+                module demo
+                data Pos = Int
+                    invariant value >= 1
+                data Line = { qty: Int, price: Int }
+                data Cart = { items: List<Line> }
+                    invariant Bool.not(List.all(x -> x.qty >= 1, items)
+                        || List.all(x -> x.price >= 1, items))
+                behavior toPos : (cart: Cart) -> List<Pos>
+                    constructs Pos
+                let toPos (cart) = List.map(i -> Pos(i.qty), cart.items)
+                """;
+        assertEquals(1, warnings(m),
+                "a quantifier said to fail of some element states nothing of the element built from");
+    }
+
+    /** And a denied disjunction of two denied quantifiers records both: the denial inside each half
+     *  meets the denial the disjunction carries into it, and what is left is the quantifier. */
+    @Test
+    void aDeniedDisjunctionOfDeniedQuantifiersRecordsBothOfThem() {
+        String m = """
+                module demo
+                data Pos = Int
+                    invariant value >= 1
+                data Line = { qty: Int, price: Int }
+                data Cart = { items: List<Line> }
+                    invariant Bool.not(Bool.not(List.all(x -> x.qty >= 1, items))
+                        || Bool.not(List.all(x -> x.price >= 1, items)))
+                behavior toPos : (cart: Cart) -> List<Pos>
+                    constructs Pos
+                let toPos (cart) = List.map(i -> Pos(i.qty), cart.items)
+                """;
+        assertEquals(0, warnings(m), "every element's qty is at least one, which the rule states");
+        assertEquals(0, warnings(m.replace("Pos(i.qty)", "Pos(i.price)")),
+                "and so is every element's price, which is the other half of the same rule");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -103,6 +103,8 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
 
             new Held("souther.compiler.check.ComparisonPlacement.of",
                     "the one reading of an operator for what it places"),
+            new Held("souther.compiler.semantics.ConditionJoin.of",
+                    "the one reading of an operator for what a connective composes"),
 
             new Held("souther.compiler.check.ArithmeticCheck.of",
                     "which operands an operator takes and what it answers, which is a question"
@@ -219,33 +221,38 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " operator that fact holds: what is written there is read back as a"
                             + " comparison by everything downstream, and nothing recognised it"),
 
-            // Which operators put conditions together, and what each says about its two halves.
+            // Handing the operator to the one reading of what a connective composes. Each of these
+            // has the operator only as far as that call: what it asks afterwards is of the
+            // composition, and where a polarity is carried it is applied to the composition.
             new Held("souther.compiler.check.ClauseExpr.of",
-                    "a conjunction asserted true and a disjunction asserted false each state both"
-                            + " halves"),
+                    "the composition under the polarity the tree is read with, which the shape it"
+                            + " makes carries so that nothing below it holds the operator"),
             new Held("souther.compiler.check.ClauseHelpers.conjunctsOf",
-                    "the conjuncts of a clause, which is walking into a conjunction"),
+                    "the conjuncts of a clause, which is walking into what composes both halves"),
             new Held("souther.compiler.check.Conditions.stating",
-                    "the same, for what a condition states on its own"),
+                    "the same under a polarity, for what a condition states on its own"),
             new Held("souther.compiler.check.FieldDomains.lambda$projection$2",
-                    "walks into a conjunction for the clause that bounds a field"),
+                    "walks into both halves for the clause that bounds a field"),
             new Held("souther.compiler.check.InvariantChecker.direct",
-                    "walks into a conjunction for the clauses an invariant states"),
+                    "walks into both halves for the clauses an invariant states"),
             new Held("souther.compiler.check.Predicates.assumeCond",
-                    "a conjunction asserted true gives both sides, a disjunction asserted false"
-                            + " gives both denied"),
+                    "walks into both halves under the polarity in force, for what a condition"
+                            + " taken in makes known"),
             new Held("souther.compiler.check.Predicates.quantifiedBy",
-                    "walks into a conjunction for what it quantifies over"),
+                    "the same, for what it quantifies over"),
             new Held("souther.compiler.check.Predicates.read",
-                    "walks into a conjunction for the clauses a rule owes"),
+                    "the same, for the clauses a rule owes"),
+            new Held("souther.compiler.partition.Condition.of",
+                    "the composition, which the shape it makes carries"),
+            new Held("souther.compiler.partition.EnsuresThresholds.stated",
+                    "walks into both halves, and stops where the connective composes either of"
+                            + " them because what such a rule states is neither of its sides"),
+
+            // Which operand runs when, asked of the operator itself rather than of what it
+            // composes: the two are answered by the same two operators and are not one question.
             new Held("souther.compiler.partition.ComparisonReadings.walk",
                     "walks both sides of a conjunction and of a disjunction, each under what the"
                             + " other side leaves"),
-            new Held("souther.compiler.partition.Condition.of",
-                    "whether the operator joins two conditions, and which of the two it is"),
-            new Held("souther.compiler.partition.EnsuresThresholds.stated",
-                    "walks into a conjunction, and stops at a disjunction because what one states"
-                            + " is neither of its sides"),
 
             // Which operand runs when, which is the enum's own answer.
             new Held("souther.compiler.core.Evaluated.inOrder",

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.semantics;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Who reads an operator for what a connective composes, and how often.
+ *
+ * <p>Beside {@link souther.compiler.check.AnOperatorIsAskedWhatItPlacesInOnePlaceTest}, which holds
+ * the recognition of a comparison to one call each. This holds the other recognition an operator is
+ * read for, and for the same reason: below the point where a binary was recognised as a connective
+ * a reader holds {@link ConditionJoin}, which has no case for an operator that composes nothing, and
+ * that stands only while nothing down there goes back to the operator.
+ *
+ * <p><b>How often, and not only where.</b> A method is licensed here for the question it asks, and
+ * a second call inside it is that same node recognised twice — a walk with an arm per composition
+ * asks the operator once per arm, which is the arrangement this value exists to end, one method
+ * further in. So the count is part of what is declared.
+ *
+ * <p>What is not counted is what a reader does with the answer afterwards. Denying it and asking
+ * for it under a polarity are operations on the value, and a reader may do either as often as it
+ * meets a negation — that is the value being carried, which is the point.
+ *
+ * <p>Read off the compiled classes, because what a method calls is what the class file says. A
+ * reading of the sources would answer the same question a second way, and would not see a call
+ * written inside a lambda as the method that holds it.
+ */
+class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
+
+    private static final String JOIN = "souther/compiler/semantics/ConditionJoin";
+
+    /** A method that may read an operator for what it composes, how many times it does, and why. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_ASK = List.of(
+            new Licence("souther.compiler.partition.Condition.of", 1,
+                    "the one place a condition of a body becomes a shape, which carries the"
+                            + " composition to every reader of that shape"),
+            new Licence("souther.compiler.check.ClauseExpr.of", 1,
+                    "the same for a clause, with the denial the tree is read under applied as the"
+                            + " shape is made"),
+
+            new Licence("souther.compiler.check.Conditions.stating", 1,
+                    "what a condition states on its own, walked into where the composition under"
+                            + " the polarity in force gives both halves"),
+            new Licence("souther.compiler.check.Predicates.assumeCond", 1,
+                    "the same, for what a condition taken in makes known"),
+            new Licence("souther.compiler.check.Predicates.quantifiedBy", 1,
+                    "the same, for what a rule says of every element of a container"),
+            new Licence("souther.compiler.check.Predicates.read", 1,
+                    "the same, for the clauses a rule owes"),
+
+            new Licence("souther.compiler.check.ClauseHelpers.conjunctsOf", 1,
+                    "the conjuncts of a clause as a reader sees them, which is walking into what"
+                            + " composes both halves"),
+            new Licence("souther.compiler.check.InvariantChecker.direct", 1,
+                    "the clauses an invariant states, numbered as that same walk numbers them"),
+            new Licence("souther.compiler.check.FieldDomains.lambda$projection$2", 1,
+                    "the clause that bounds a field, whose halves are answered beside it"),
+            new Licence("souther.compiler.partition.EnsuresThresholds.stated", 1,
+                    "the comparisons a rule states outright: one recognition, and both of what a"
+                            + " connective can compose read off it"));
+
+    @Test
+    void onlyARecognitionReadsAnOperatorForWhatItComposes() throws IOException {
+        assertEquals(declared(MAY_ASK), callsTo(JOIN, "of"),
+                "a reader that has recognised a connective and asks the operator again has"
+                        + " somewhere in it that could disagree with itself, and a second call in a"
+                        + " licensed reader is that same recognition made twice. What each of these"
+                        + " may ask, and why: " + why(MAY_ASK));
+    }
+
+    private static Map<String, Integer> declared(List<Licence> licences) {
+        Map<String, Integer> out = new TreeMap<>();
+        licences.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why(List<Licence> licences) {
+        Map<String, String> out = new LinkedHashMap<>();
+        licences.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler calls {@code owner.name}. */
+    private static Map<String, Integer> callsTo(String owner, String name) throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(owner)
+                            && call.name().stringValue().equals(name)) {
+                        calls.merge(from + "." + method.methodName().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/semantics/WhatAConnectiveComposesIsOneAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/WhatAConnectiveComposesIsOneAnswerTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.semantics;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.types.BinOp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The algebra of what a connective composes, which is what lets a reader stop holding the operator.
+ *
+ * <p>Each law is what some reading rests on. That the composition and
+ * {@link BinOp#joinsTwoConditions} agree is what makes a composition the evidence that an operator
+ * joins two conditions. That denying it exchanges the two answers is what lets a reader meeting a
+ * negation deny what it holds rather than working out which operator would have been written. And
+ * that a composition under a polarity is that same exchange is what lets a reader carry a polarity
+ * without an operator table of its own.
+ */
+class WhatAConnectiveComposesIsOneAnswerTest {
+
+    /** What each connective composes where it is stated. Written out here and nowhere else in the
+     *  compiler: every reader asks for this, and this is the table that says which answer it is. */
+    private static final Map<BinOp, ConditionJoin> STATED = stated();
+
+    /** What each composition comes to where the condition it joins is denied. Written out here and
+     *  nowhere in the compiler: what a reading does under a negation is deny the composition, and
+     *  this is the table that says the two are one. */
+    private static final Map<ConditionJoin, ConditionJoin> DENIED = denied();
+
+    private static Map<BinOp, ConditionJoin> stated() {
+        Map<BinOp, ConditionJoin> composed = new LinkedHashMap<>();
+        composed.put(BinOp.AND, ConditionJoin.BOTH);
+        composed.put(BinOp.OR, ConditionJoin.EITHER);
+        return composed;
+    }
+
+    private static Map<ConditionJoin, ConditionJoin> denied() {
+        Map<ConditionJoin, ConditionJoin> pairs = new LinkedHashMap<>();
+        pairs.put(ConditionJoin.BOTH, ConditionJoin.EITHER);
+        pairs.put(ConditionJoin.EITHER, ConditionJoin.BOTH);
+        return pairs;
+    }
+
+    /** An operator composes something exactly where it joins two conditions. Two spellings of one
+     *  membership drift, and an operator added to the language would land in them differently. */
+    @Test
+    void whatComposesSomethingIsWhatJoinsTwoConditions() {
+        Map<BinOp, Boolean> composes = new LinkedHashMap<>();
+        Map<BinOp, Boolean> joins = new LinkedHashMap<>();
+        for (BinOp op : BinOp.values()) {
+            composes.put(op, ConditionJoin.of(op).isPresent());
+            joins.put(op, op.joinsTwoConditions());
+        }
+        assertEquals(joins, composes,
+                "what an operator composes and whether it joins two conditions are one question");
+    }
+
+    /**
+     * What each connective composes where it is stated, written out so that the two are the
+     * specification.
+     *
+     * <p>The one crossing from how a condition is written to what it says of its two halves. Every
+     * reader that had a table from the operator to a composition is asking for this, and where a
+     * table and this part, the reader takes a condition apart the source did not write.
+     */
+    @Test
+    void whatEachConnectiveStatesIsOneComposition() {
+        Map<BinOp, ConditionJoin> composed = new LinkedHashMap<>();
+        for (BinOp op : STATED.keySet()) {
+            composed.put(op, ConditionJoin.of(op).orElseThrow());
+        }
+        assertEquals(STATED, composed, "what each connective makes of the two conditions it joins");
+    }
+
+    /** An operator that joins no two conditions composes nothing, which is what lets a reading of
+     *  any binary ask before it knows whether it is a connective. */
+    @Test
+    void anOperatorThatJoinsNoConditionsComposesNothing() {
+        for (BinOp op : BinOp.values()) {
+            if (op.joinsTwoConditions()) {
+                continue;
+            }
+            assertEquals(Optional.empty(), ConditionJoin.of(op),
+                    () -> op + " joins no two conditions, so it composes nothing");
+        }
+    }
+
+    /** Denying a condition exchanges the two answers, which is the whole of what a denial does to a
+     *  connective and the reason no reader works it out beside the operator. */
+    @Test
+    void denyingAConditionExchangesWhatItsConnectiveComposes() {
+        for (Map.Entry<ConditionJoin, ConditionJoin> each : DENIED.entrySet()) {
+            assertEquals(each.getValue(), each.getKey().denied(),
+                    () -> each.getKey() + " denied composes " + each.getValue());
+        }
+    }
+
+    /** Denying twice is the composition, which is what lets a reading deny wherever it meets a
+     *  negation rather than counting how many it is under. */
+    @Test
+    void denyingTwiceLeavesTheComposition() {
+        for (ConditionJoin join : ConditionJoin.values()) {
+            assertEquals(join, join.denied().denied(),
+                    () -> "denying " + join + " twice composes what it composed");
+        }
+    }
+
+    /** A stated condition composes what its connective composes, and a denied one composes the
+     *  denial of it. The polarity a reader carries is applied to the composition and nowhere to the
+     *  operator. */
+    @Test
+    void aCompositionUnderAPolarityIsTheStatementOrItsDenial() {
+        for (ConditionJoin join : ConditionJoin.values()) {
+            assertEquals(join, join.under(true),
+                    () -> join + " stated composes what it composes");
+            assertEquals(join.denied(), join.under(false),
+                    () -> join + " denied composes the other one");
+        }
+    }
+}


### PR DESCRIPTION
Closes #1227.

## What was wrong

Recognising a condition connective answered with a membership (`BinOp.joinsTwoConditions`), and a membership cannot say which of the two was recognised. What a reader held afterwards was the operator, so it read the operator again where the meaning was wanted. Ten places spelled out the same rule — a stated conjunction gives both halves, a denied disjunction gives both halves — and each of them could be taught a different one. The comparison side has had `ComparisonPlacement` / `ComparisonClaim` since #1215 and #1217; the condition side had no such value.

## The answer

`souther.compiler.semantics.ConditionJoin` — `BOTH` / `EITHER`, with:

* `of(BinOp)`: the family gate above one exhaustive switch with no `default`. Which operators join two conditions stays the family's answer and is asked rather than listed again. The arms below the refusal answer the absence the gate answered and are no second say in it; they are there so an operator added to the language stops the compile and is decided about.
* `denied()`: the exchange, which is the whole of what a denial does to a connective.
* `under(boolean)`: the composition with the polarity in force applied, defined by `denied()`.

It is in `semantics` because a proposition about a language construct belongs to no consumer and the package's dependency direction (language only, never a reader) is exactly what this value needs. The package doc's subject is widened from operations to constructs; nothing else about it changes.

## What moved

Both condition trees are one shape carrying the composition — `partition.Condition.Joined(at, how, left, right)` and `ClauseExpr.Joined(spelled, how, left, right)`, with no adapter left behind. Kept as a pair of shapes, the mint would be a second table per tree and a reader of one would write the exchange out again — which is what `ReachingCuts` did, four arms of connective against outcome for what is now `how.under(holding) == BOTH`.

Ten readers ask `ConditionJoin.of`. The six that carry a polarity apply it with `under(positive)`; the four that read a clause as written take the positive answer directly, since applying an identity there would put a polarity where the reader has none. `BinaryElaborator` keeps `joinsTwoConditions()`: it needs the operator family for typing and not what the connective composes.

Nothing here reads `rightRunsWhenLeftIs()`. The two questions are answered by the same two operators today and are not one question, so `ConstEval` and `ComparisonReadings` keep asking the operator about short-circuiting.

## A defect the value exposed

Two readings of an invariant took a conjunction apart and stopped at a disjunction. So a rule written as a denied disjunction owed a run-time check where the values already settle it, and a quantifier under two denials was never recorded — while `Conditions.stating`, reading the same trees, took both halves. Reading the composition makes the three agree. Both are fixtures in `ADeniedDisjunctionStatesBothOfItsHalvesTest`, written before the change and red then:

| fixture | before |
| --- | --- |
| `Bool.not(value < 1 \|\| value > 10)` settled by two guards | 1 warning |
| the same rule written `value >= 1 && value <= 10` (control) | 0 warnings |
| `Bool.not(all(p, items) \|\| all(q, items))` records no quantifier | 1 warning |
| `Bool.not(Bool.not(all(p, items)) \|\| Bool.not(all(q, items)))` records both | 1 warning |

The third is green either way and is here with the fourth on purpose: a reading that expanded a denied disjunction without carrying the polarity into the halves would record quantifiers that state nothing, and only the pair tells the two apart.

## Measured

* Mutating the positive mapping (`AND -> EITHER`): 231 failures, 20 errors. No second table produces the old result.
* Mutating `denied()` to the identity: 12 failures in 6 classes — the laws, both polarity fixtures, the fold over a clause, the walk that reaches `ReachingCuts`, and the reading of an operation case by case. Nothing the four positive-only readers reach fails, and that is mechanical rather than read off which tests failed: `denied()` has no caller but `under(boolean)`, and the four never call it. The two decisions are separately observed.
* `ConditionJoin.of` is called ten times in ten readers, one each, and `AnOperatorIsAskedWhatItComposesInOnePlaceTest` counts that off the class files beside the licence test that holds the recognition of a comparison to one call. A walk with an arm per composition asks the operator once per arm — the answer read where it is used rather than where the node is met, which is this PR's own defect one method further in — so `EnsuresThresholds.stated` recognises where the binary is met and both arms read that. Adding a second call anywhere fails the licence test, measured. The only `BinOp.AND` / `BinOp.OR` left in main are the parser's translation into the operator and the two short-circuit readers.
* `WhereAnOperatorMayStillBeHeldIsWrittenDownTest` gains `semantics.ConditionJoin.of` and has the reason rewritten for each reader that moved.
* `mvn -o test`: 7,925 tests in souther-compiler, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

