### PR TITLE
Reserve the bare name `row` for a row

### DIFF
--- a/souther-bench/src/test/java/souther/bench/OnlyARowIsCalledARowTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,47 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.TheBareRowNames;
+import souther.test.WhatAModuleDeclares;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The rule this repository holds every module to, said here about this one. This module drives
+ * the compiler to time it and generates the sources it drives it over; a row of an {@code example}
+ * is the compiler's, so the rule has no admitting side to state here and the prohibition is the
+ * whole of it.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
+                "the benchmarks hold no rows of their own, so a declaration of them named for one"
+                        + " is named for something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /** And both are over this module's classes rather than over nothing. */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(Bench.class);
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/WhatARowCameToIsReadInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhatARowCameToIsReadInOnePlaceTest.java
@@ -2,6 +2,8 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Adequacy;
+
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -32,6 +34,10 @@ class WhatARowCameToIsReadInOnePlaceTest {
 
     /** Where a row's outcome becomes a reason a measure could not read everything. */
     private static final String PRODUCER = "souther.compiler.examples.ExampleVerifier";
+
+    /** What every behavior's rows came to, named by its class so that renaming it is a thing javac
+     *  says here rather than something this goes on spelling. */
+    private static final String READINGS = Adequacy.RowReadings.class.getName();
 
     /**
      * Nothing but the producer asks whether a row did not come back.
@@ -88,15 +94,15 @@ class WhatARowCameToIsReadInOnePlaceTest {
     void whatTheSourcesSawIsGatheredWhereTheAnswerIsMade() throws IOException {
         Set<String> gathering = new LinkedHashSet<>();
         for (Compiled.Site site : Compiled.sites()) {
-            if (site.owner().equals("souther.compiler.query.Adequacy")
+            if (site.owner().equals(Adequacy.class.getName())
                     && site.member().equals("rowsOf")
-                    && !site.at().startsWith("souther.compiler.query.Adequacy$Rows#compute")) {
+                    && !site.at().startsWith(READINGS + "#compute")) {
                 gathering.add(site.at());
             }
         }
         assertEquals(Set.of(), gathering,
-                "a caller reached past `Adequacy.Rows` for the gathering under it, which is where"
-                        + " what a level asked for stops being one answer");
+                "a caller reached past `" + READINGS + "` for the gathering under it, which is"
+                        + " where what a level asked for stops being one answer");
     }
 
     /**
@@ -121,7 +127,7 @@ class WhatARowCameToIsReadInOnePlaceTest {
         }
         assertEquals(Set.of(), gathering,
                 "a reader outside the queries assembled what a module's sources saw. What every"
-                        + " behavior's rows came to is `Adequacy.Rows`, and a second assembly of it"
-                        + " is a second answer to keep agreeing");
+                        + " behavior's rows came to is `" + READINGS + "`, and a second assembly"
+                        + " of it is a second answer to keep agreeing");
     }
 }

--- a/souther-build-driver/pom.xml
+++ b/souther-build-driver/pom.xml
@@ -47,5 +47,10 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/souther-build-driver/src/test/java/souther/build/driver/OnlyARowIsCalledARowTest.java
+++ b/souther-build-driver/src/test/java/souther/build/driver/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,50 @@
+package souther.build.driver;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.TheBareRowNames;
+import souther.test.WhatAModuleDeclares;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The rule this repository holds every module to, said here about this one. What this module
+ * hands over is a compile and what it holds is the driving of one; a row of an {@code example} is
+ * the compiler's, so the rule has no admitting side to state here and the prohibition is the whole
+ * of it.
+ *
+ * <p>Written where nothing violates it, because where the next one will be written is not something
+ * a boundary predicts.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
+                "the build driver holds no rows, so a declaration of it named for one is named for"
+                        + " something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /** And both are over this module's classes rather than over nothing. */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(CompilerBuildDriver.class);
+    }
+}

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Test scope, and not part of what this jar bundles. `souther init` writes a build plugin
              version into a project, and a plugin drives a Souther over a numbered protocol; this is
              the artifact that states which number this Souther speaks, so it is what the pinned

--- a/souther-cli/src/test/java/souther/cli/OnlyARowIsCalledARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,46 @@
+package souther.cli;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.TheBareRowNames;
+import souther.test.WhatAModuleDeclares;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The rule this repository holds every module to, said here about this one. This module prints
+ * what a compile answered, rows among it; what it holds of its own is a command's, so the rule has
+ * no admitting side to state here and the prohibition is the whole of it.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
+                "the command line holds no rows of its own, so a declaration of it named for one is"
+                        + " named for something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /** And both are over this module's classes rather than over nothing. */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(CliCommand.class);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
@@ -44,7 +44,7 @@ public final class Prepared {
 
     private final Desugared.Module desugared;
     private final List<Desugared.Fn> fns;
-    private final List<Rows> examples;
+    private final List<Example> examples;
     private final List<FakeTable> fakes;
     private final List<Hir.FnDef> takenOn;
     /**
@@ -59,12 +59,12 @@ public final class Prepared {
     private final List<Hir.FnDef> rowDefs;
     /** Which method each row operand's value runs as, by the operand — the correspondence the
      *  emission constructed, held so the reader that invokes a method never counts the rows for
-     *  itself. Keyed on operand identity, over the very nodes {@link Rows#read} answers with. */
+     *  itself. Keyed on operand identity, over the very nodes {@link Example#read} answers with. */
     private final Map<Hir.Expr, String> operandMethods;
     /** Worked out once, as the rungs below work theirs out. */
     private volatile Hir.Module projected;
 
-    private Prepared(Desugared.Module desugared, List<Desugared.Fn> fns, List<Rows> examples,
+    private Prepared(Desugared.Module desugared, List<Desugared.Fn> fns, List<Example> examples,
                      List<FakeTable> fakes, List<Hir.FnDef> takenOn, List<Hir.FnDef> rowDefs,
                      Map<Hir.Expr, String> operandMethods) {
         this.desugared = desugared;
@@ -118,9 +118,9 @@ public final class Prepared {
         for (Desugared.Fn fn : desugared.fns()) {
             fns.add(Desugared.Fn.reestablish(HelperNames.qualifyImportsIn(fn.read(), self), scope));
         }
-        List<Rows> examples = new ArrayList<>();
+        List<Example> examples = new ArrayList<>();
         for (Hir.Example block : desugared.module().examples()) {
-            examples.add(new Rows(HelperNames.qualifyImportsIn(block, self)));
+            examples.add(new Example(HelperNames.qualifyImportsIn(block, self)));
         }
         List<FakeTable> fakes = new ArrayList<>();
         for (Hir.Fake table : desugared.module().fakes()) {
@@ -198,7 +198,7 @@ public final class Prepared {
 
     /** The example blocks attached to this module, from its own file and from every file naming
      * it, each of them read the way this module reaches its names. */
-    public List<Rows> rows() {
+    public List<Example> examples() {
         return examples;
     }
 
@@ -234,8 +234,8 @@ public final class Prepared {
     /**
      * This module's artifact with all of its rows — what an example run over the module is given.
      */
-    public Examples forExamples() {
-        return new Examples(this, examples);
+    public ForExamples forExamples() {
+        return new ForExamples(this, examples);
     }
 
     /**
@@ -250,14 +250,14 @@ public final class Prepared {
      * the same answer kept somewhere else, and a caller holding one that had fallen out of step had
      * no way to know.
      */
-    public Examples forExamplesWrittenIn(SourceId sourceId) {
-        List<Rows> mine = new ArrayList<>();
-        for (Rows block : examples) {
+    public ForExamples forExamplesWrittenIn(SourceId sourceId) {
+        List<Example> mine = new ArrayList<>();
+        for (Example block : examples) {
             if (block.read().pos().isIn(sourceId)) {
                 mine.add(block);
             }
         }
-        return new Examples(this, mine);
+        return new ForExamples(this, mine);
     }
 
     /**
@@ -272,11 +272,11 @@ public final class Prepared {
      *
      * <p>Reached from {@link #prepare} and from nothing else.
      */
-    public static final class Rows {
+    public static final class Example {
 
         private final Hir.Example block;
 
-        private Rows(Hir.Example block) {
+        private Example(Hir.Example block) {
             this.block = block;
         }
 
@@ -298,7 +298,7 @@ public final class Prepared {
 
         @Override
         public boolean equals(Object o) {
-            return o instanceof Rows other && block.equals(other.block);
+            return o instanceof Example other && block.equals(other.block);
         }
 
         @Override
@@ -309,7 +309,7 @@ public final class Prepared {
 
     /**
      * One fake table of this module, with every name in it that denotes another module's definition
-     * written qualified — the same claim {@link Rows} carries, about what stands in for an
+     * written qualified — the same claim {@link Example} carries, about what stands in for an
      * injected behavior while a row runs.
      */
     public static final class FakeTable {
@@ -348,24 +348,25 @@ public final class Prepared {
     }
 
     /**
-     * The rows an example run reads, and the artifact they are evaluated in.
+     * The module projected for an example run: the example blocks it reads, and the artifact their
+     * rows are evaluated in.
      *
      * <p>Its own type because that pairing is what an example run needs and neither half is enough:
-     * the rows say what to try and the artifact says what is there to try it against — a row's
-     * operand is a method because this module emitted one for it, and a run that was handed the rows
-     * alone would be looking for it in a class that does not carry it.
+     * the blocks say what to try and the artifact says what is there to try it against — a row's
+     * operand is a method because this module emitted one for it, and a run that was handed the
+     * blocks alone would be looking for it in a class that does not carry it.
      *
      * <p>What it claims is about its input and not about its outcome. Nothing here says a row
      * agreed with anything; that is what running them answers.
      */
-    public static final class Examples {
+    public static final class ForExamples {
 
         private final Prepared module;
-        private final List<Rows> rows;
+        private final List<Example> examples;
 
-        private Examples(Prepared module, List<Rows> rows) {
+        private ForExamples(Prepared module, List<Example> examples) {
             this.module = module;
-            this.rows = List.copyOf(rows);
+            this.examples = List.copyOf(examples);
         }
 
         /** What the module is called. */
@@ -403,9 +404,9 @@ public final class Prepared {
             return module.takenOn;
         }
 
-        /** The rows this run is over. */
-        public List<Rows> rows() {
-            return rows;
+        /** The example blocks this run is over. */
+        public List<Example> examples() {
+            return examples;
         }
 
         /** The fake tables its rows run against, which are the module's whole and not one file's:
@@ -479,13 +480,13 @@ public final class Prepared {
          *
          * <p>The module's, not one file's, as {@link #fakes} is: a module's stand-ins are what its
          * attached files' rows run against and the other way round, so which modules a reading has
-         * to take the rows of is a fact about the module. Read off {@link #rows} it would be one
+         * to take the rows of is a fact about the module. Read off {@link #examples} it would be one
          * file's {@code with}s wherever this is a projection of a source, and the modules the other
          * files reach would go unread — which is the reading this answer exists to complete.
          */
         public Set<ValueName.Behavior> standsInFor() {
             Set<ValueName.Behavior> named = new LinkedHashSet<>(tablesThatAnswer().keySet());
-            for (Rows block : module.examples) {
+            for (Example block : module.examples) {
                 for (Hir.ExampleRow row : block.read().rows()) {
                     for (Hir.With supplied : row.withs()) {
                         if (supplied.standsInFor() != null) {
@@ -528,7 +529,7 @@ public final class Prepared {
             definitions.add(fn.read());
         }
         List<Hir.Example> blocks = new ArrayList<>();
-        for (Rows block : examples) {
+        for (Example block : examples) {
             blocks.add(block.read());
         }
         List<Hir.Fake> tables = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
@@ -29,16 +29,16 @@ import java.util.List;
 public final class BoundExamples {
 
     private final String module;
-    private final Prepared.Examples rows;
+    private final Prepared.ForExamples forExamples;
     private final ExampleVerifier verifier;
 
     /** The behaviors the bound instance implements, worked out once from the instance. */
     private final List<String> bound;
 
-    BoundExamples(String module, Prepared.Examples rows, ExampleVerifier verifier,
+    BoundExamples(String module, Prepared.ForExamples forExamples, ExampleVerifier verifier,
                   List<String> bound) {
         this.module = module;
-        this.rows = rows;
+        this.forExamples = forExamples;
         this.verifier = verifier;
         this.bound = List.copyOf(bound);
     }
@@ -52,7 +52,7 @@ public final class BoundExamples {
      */
     public List<RecordedRow> rows() {
         List<RecordedRow> found = new ArrayList<>();
-        for (Prepared.Rows block : rows.rows()) {
+        for (Prepared.Example block : forExamples.examples()) {
             Hir.Example written = block.read();
             if (!bound.contains(written.target())) {
                 continue;
@@ -92,7 +92,7 @@ public final class BoundExamples {
      * silently never runs. What is resolved against is the rows as written, which the compiler holds
      * to carrying one name each within a behavior — so this finds one row or none, never two.
      */
-    public RowKey row(String behavior, String name) {
+    public RowKey rowKey(String behavior, String name) {
         for (RecordedRow candidate : rows()) {
             if (candidate.behavior().equals(behavior)
                     && candidate.identity() instanceof RowIdentity.Named named

--- a/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
@@ -39,9 +39,10 @@ public interface Deadline {
         /** Where the writing this is about starts, which says which source it is in. */
         SourcePos pos();
 
-        /** A row of an {@code example}, evaluated: its fixtures built, the behavior applied, the
-         * result compared. {@code identity} is what the row names itself. */
-        record Row(String target, SourcePos pos, RowIdentity identity) implements Work {}
+        /** A row of an {@code example}, evaluated whole: its fixtures built, the behavior applied,
+         * the result compared. What {@link Fixtures} is the first third of, and named for the
+         * difference. {@code identity} is what the row names itself. */
+        record WholeRow(String target, SourcePos pos, RowIdentity identity) implements Work {}
 
         /** The statements a row is read from, with no behavior applied. */
         record Fixtures(String target, SourcePos pos, RowIdentity identity) implements Work {}

--- a/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Deadline.java
@@ -40,8 +40,8 @@ public interface Deadline {
         SourcePos pos();
 
         /** A row of an {@code example}, evaluated whole: its fixtures built, the behavior applied,
-         * the result compared. What {@link Fixtures} is the first third of, and named for the
-         * difference. {@code identity} is what the row names itself. */
+         * the result compared. Named against {@link Fixtures}, which is the reading of the same
+         * row that stops before the behavior. {@code identity} is what the row names itself. */
         record WholeRow(String target, SourcePos pos, RowIdentity identity) implements Work {}
 
         /** The statements a row is read from, with no behavior applied. */

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleProvisioning.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleProvisioning.java
@@ -46,7 +46,7 @@ public final class ExampleProvisioning {
      * @param onTheRow the {@code with}s written on the row; empty for a row not written yet
      */
     public static Standin standingIn(List<Hir.With> onTheRow, ValueName.Behavior dependency,
-                                     Prepared.Examples module) {
+                                     Prepared.ForExamples module) {
         for (Hir.With written : onTheRow) {
             if (dependency.equals(written.standsInFor())) {
                 return new Standin.OnTheRow(written);
@@ -59,7 +59,7 @@ public final class ExampleProvisioning {
     /** Of {@code required}, the ones nothing stands in for, in the order they were required. */
     public static List<ValueName.Behavior> unsupplied(List<Hir.With> onTheRow,
                                                       List<ValueName.Behavior> required,
-                                                      Prepared.Examples module) {
+                                                      Prepared.ForExamples module) {
         List<ValueName.Behavior> owed = new ArrayList<>();
         for (ValueName.Behavior dependency : required) {
             if (standingIn(onTheRow, dependency, module) instanceof Standin.Nothing) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -72,10 +72,11 @@ public final class ExampleStatements {
      * what that behavior owes, and the scope they are read in. Not its execution — the values are
      * built and compared in the reading that holds this, so nothing crosses a loader.
      */
-    public record Declaring(souther.compiler.check.Prepared.Examples rows, Symbols symbols,
-                            FieldTypes fields, Map<String, Hir.FnDef> values) {}
+    public record Declaring(souther.compiler.check.Prepared.ForExamples forExamples,
+                            Symbols symbols, FieldTypes fields,
+                            Map<String, Hir.FnDef> values) {}
 
-    private final souther.compiler.check.Prepared.Examples module;
+    private final souther.compiler.check.Prepared.ForExamples module;
     private final Symbols symbols;
     /** What a value of a declaration is made of, as the check settled it. */
     private final FieldTypes fields;
@@ -104,7 +105,7 @@ public final class ExampleStatements {
     /** The modules whose behaviors this one writes stand-ins for, by name. */
     private final Map<String, Declaring> declaring;
 
-    private ExampleStatements(souther.compiler.check.Prepared.Examples module, Symbols symbols,
+    private ExampleStatements(souther.compiler.check.Prepared.ForExamples module, Symbols symbols,
                               FieldTypes fields,
                               Map<ValueName.Behavior, Sig> sigs,
                               MemoryClassLoader loader, Map<String, Hir.FnDef> values,
@@ -140,7 +141,7 @@ public final class ExampleStatements {
      * states no input, so there is no relation to hold its answer to.
      *
      * <p>{@code fk} is a table that answers for something — every caller reaches it through the one
-     * place that says which those are ({@code Prepared.Examples.tablesThatAnswer}) — so the behavior
+     * place that says which those are ({@code Prepared.ForExamples.tablesThatAnswer}) — so the behavior
      * it stands in for is there to be asked about.
      */
     static List<Diagnostic> notKept(EnsuresChecks ensures, Hir.Fake fk, BuiltTable built) {
@@ -209,7 +210,7 @@ public final class ExampleStatements {
             return this::newFixtureReader;
         }
         Declaring elsewhere = declaring.get(declaredIn);
-        return () -> new FixtureReader(elsewhere.rows(), elsewhere.symbols(),
+        return () -> new FixtureReader(elsewhere.forExamples(), elsewhere.symbols(),
                 elsewhere.fields(), elsewhere.values(), loader);
     }
 
@@ -231,7 +232,7 @@ public final class ExampleStatements {
      * itself dispatches with ({@link Standins#answering}) — the same rule, not a second reading of it — and
      * the two answers are compared as the written values they are built into.
      */
-    public static Readings disagreements(souther.compiler.check.Prepared.Examples module, Symbols symbols,
+    public static Readings disagreements(souther.compiler.check.Prepared.ForExamples module, Symbols symbols,
                                          FieldTypes fields,
                                          Map<ValueName.Behavior, Sig> sigs,
                                          Map<String, ClassFileImage> classes,
@@ -239,7 +240,7 @@ public final class ExampleStatements {
                                          Deadline deadline, EvaluationPolicy policy,
                                          Map<ValueName.Behavior, Contract> contracts,
                                          Map<String, Declaring> declaring) {
-        if (module.rows().isEmpty() && module.fakes().isEmpty()) {
+        if (module.examples().isEmpty() && module.fakes().isEmpty()) {
             return Readings.NONE;
         }
         // Which behaviors have both a stand-in and rows of their own, read off the text. Two written
@@ -285,7 +286,7 @@ public final class ExampleStatements {
      * in.
      */
     public static List<souther.compiler.check.Prepared.FakeTable> tablesBuiltIn(
-            souther.compiler.check.Prepared.Examples module, Map<ValueName.Behavior, Sig> sigs,
+            souther.compiler.check.Prepared.ForExamples module, Map<ValueName.Behavior, Sig> sigs,
             SourceId sourceId) {
         List<souther.compiler.check.Prepared.FakeTable> building = new ArrayList<>();
         module.tablesThatAnswer().forEach((dependency, table) -> {
@@ -325,7 +326,7 @@ public final class ExampleStatements {
      * on. Which of them a fake is written in is what its own place says, so the two are never out of
      * step.
      */
-    public static List<Diagnostic> fakeTables(souther.compiler.check.Prepared.Examples module, Symbols symbols,
+    public static List<Diagnostic> fakeTables(souther.compiler.check.Prepared.ForExamples module, Symbols symbols,
                                               FieldTypes fields,
                                               Map<ValueName.Behavior, Sig> sigs,
                                               Map<String, ClassFileImage> classes,
@@ -555,7 +556,7 @@ public final class ExampleStatements {
      * would put a table written for a borrowed dependency against the rows of a namesake here.
      */
     private static Set<ValueName.Behavior> contested(
-            souther.compiler.check.Prepared.Examples module, Map<ValueName.Behavior, Sig> sigs,
+            souther.compiler.check.Prepared.ForExamples module, Map<ValueName.Behavior, Sig> sigs,
             Map<String, Declaring> declaring) {
         Set<ValueName.Behavior> both = new LinkedHashSet<>();
         for (ValueName.Behavior each : module.standsInFor()) {
@@ -582,17 +583,17 @@ public final class ExampleStatements {
      * says so by having nothing rather than by taking silence for agreement.
      */
     private static List<Hir.Example> recordedFor(ValueName.Behavior behavior,
-                                                 souther.compiler.check.Prepared.Examples module,
+                                                 souther.compiler.check.Prepared.ForExamples module,
                                                  Map<String, Declaring> declaring) {
-        souther.compiler.check.Prepared.Examples where = behavior.module().equals(module.name())
+        souther.compiler.check.Prepared.ForExamples where = behavior.module().equals(module.name())
                 ? module
                 : declaring.containsKey(behavior.module())
-                        ? declaring.get(behavior.module()).rows() : null;
+                        ? declaring.get(behavior.module()).forExamples() : null;
         if (where == null) {
             return List.of();
         }
         List<Hir.Example> blocks = new ArrayList<>();
-        for (souther.compiler.check.Prepared.Rows block : where.rows()) {
+        for (souther.compiler.check.Prepared.Example block : where.examples()) {
             if (block.target().equals(behavior.name())) {
                 blocks.add(block.read());
             }
@@ -623,8 +624,8 @@ public final class ExampleStatements {
         // disagree with. What that second table is, is its own question.
         module.tablesThatAnswer().forEach((dependency, table) ->
                 againstFake(table.read(), recorded, found, timedOut));
-        for (int i = 0; i < module.rows().size(); i++) {
-            againstWiths(module.rows().get(i).read(), recorded, found);
+        for (int i = 0; i < module.examples().size(); i++) {
+            againstWiths(module.examples().get(i).read(), recorded, found);
         }
         return new Readings(found, timedOut);
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleStatements.java
@@ -924,12 +924,12 @@ public final class ExampleStatements {
 
         /** Whether a fake's row states the arguments a call arrived with, each by the language's
          * equality. A multi-input dependency is matched as a tuple (spec §example-fakes), so this walks them. */
-        private static boolean sameArguments(Object[] row, Object[] key) {
-            if (row.length != key.length) {
+        private static boolean sameArguments(Object[] arguments, Object[] key) {
+            if (arguments.length != key.length) {
                 return false;
             }
-            for (int i = 0; i < row.length; i++) {
-                if (!souther.runtime.Values.equal(row[i], key[i])) {
+            for (int i = 0; i < arguments.length; i++) {
+                if (!souther.runtime.Values.equal(arguments[i], key[i])) {
                     return false;
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -146,7 +146,7 @@ public final class ExampleVerifier {
      *
      * @throws IllegalArgumentException where the artifact is of another module
      */
-    public static Observations check(souther.compiler.check.Prepared.Examples module,
+    public static Observations check(souther.compiler.check.Prepared.ForExamples module,
                                      Symbols symbols,
                                      souther.compiler.observe.FieldTypes fields,
                                      Map<ValueName.Behavior, Sig> sigs,
@@ -162,7 +162,7 @@ public final class ExampleVerifier {
                     + "`'s and the artifact is `" + artifact.implementations().module()
                     + "`'s; what applies a behavior would be looked up in the wrong module");
         }
-        if (module.rows().isEmpty()) {
+        if (module.examples().isEmpty()) {
             return Observations.NONE;
         }
         ExampleVerifier v = evaluating(module, symbols, fields, sigs, artifact, declared,
@@ -170,7 +170,7 @@ public final class ExampleVerifier {
         List<Diagnostic> failures = new ArrayList<>();
         List<RowOutcome> rows = new ArrayList<>();
         List<Incompleteness> incompleteness = new ArrayList<>();
-        for (souther.compiler.check.Prepared.Rows block : module.rows()) {
+        for (souther.compiler.check.Prepared.Example block : module.examples()) {
             Hir.Example ex = block.read();
             try {
                 v.checkExample(ex, failures, rows);
@@ -206,7 +206,7 @@ public final class ExampleVerifier {
      * rows against it is what lets the loop belong to a caller — which is what it has to be when
      * what an implementation answers out of changes between one row and the next.
      */
-    public static ExampleVerifier evaluating(souther.compiler.check.Prepared.Examples module,
+    public static ExampleVerifier evaluating(souther.compiler.check.Prepared.ForExamples module,
                                       Symbols symbols,
                                       souther.compiler.observe.FieldTypes fields,
                                       Map<ValueName.Behavior, Sig> sigs,
@@ -342,7 +342,7 @@ public final class ExampleVerifier {
     private List<StatedRow> recordedRowsOf(BoundExamples of, String behavior,
                                            FixtureReader fixtures, Sig sig) {
         List<StatedRow> found = new ArrayList<>();
-        for (souther.compiler.check.Prepared.Rows block : module.rows()) {
+        for (souther.compiler.check.Prepared.Example block : module.examples()) {
             Hir.Example written = block.read();
             if (!written.target().equals(behavior)) {
                 continue;
@@ -433,7 +433,7 @@ public final class ExampleVerifier {
      * the binding meaning three things.
      */
     ContractObservation contractOnly(String behavior, Hir.ExampleRow row) {
-        switch (deadline.given(new Deadline.Work.Row(behavior, row.pos(), row.identity()),
+        switch (deadline.given(new Deadline.Work.WholeRow(behavior, row.pos(), row.identity()),
                 () -> checkingContract(behavior, row))) {
             case Deadline.Outcome.Finished(ContractObservation observed) -> {
                 return observed;
@@ -671,7 +671,7 @@ public final class ExampleVerifier {
         };
     }
 
-    private final souther.compiler.check.Prepared.Examples module;
+    private final souther.compiler.check.Prepared.ForExamples module;
     private final Symbols symbols;
     /** What a value of a declaration is made of, as the check settled it. */
     private final souther.compiler.observe.FieldTypes fields;
@@ -729,7 +729,7 @@ public final class ExampleVerifier {
     /** What holds a row's values to what the behavior declares of what it answers. */
     private final EnsuresChecks ensures;
 
-    private ExampleVerifier(souther.compiler.check.Prepared.Examples module,
+    private ExampleVerifier(souther.compiler.check.Prepared.ForExamples module,
                             Symbols symbols,
                             souther.compiler.observe.FieldTypes fields,
                             Map<ValueName.Behavior, Sig> sigs,
@@ -1338,7 +1338,7 @@ public final class ExampleVerifier {
                           List<Diagnostic> out, List<RowOutcome> rows) {
         RowWork evaluation = new RowWork(this, target, sig, outCases, row);
         switch (deadline.given(
-                new Deadline.Work.Row(target.name(), row.pos(), row.identity()),
+                new Deadline.Work.WholeRow(target.name(), row.pos(), row.identity()),
                 evaluation)) {
             case Deadline.Outcome.Finished(List<Diagnostic> found) -> {
                 out.addAll(found);

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -79,7 +79,7 @@ import java.util.function.Supplier;
  */
 public final class FixtureReader {
 
-    private final souther.compiler.check.Prepared.Examples module;
+    private final souther.compiler.check.Prepared.ForExamples module;
     private final Symbols symbols;
     /** The values a row may name: this module's own, and the ones its imports bring in. */
     private final Map<String, Hir.FnDef> values;
@@ -93,7 +93,7 @@ public final class FixtureReader {
     /** The same answer as the places a comparison reads a value's parts at. */
     private final ValueTypes types;
 
-    FixtureReader(souther.compiler.check.Prepared.Examples module, Symbols symbols,
+    FixtureReader(souther.compiler.check.Prepared.ForExamples module, Symbols symbols,
                   FieldTypes fields, Map<String, Hir.FnDef> values,
                   MemoryClassLoader loader) {
         this.module = module;
@@ -107,7 +107,7 @@ public final class FixtureReader {
     }
 
     /** A way to build values against this module's generated classes, without any rows to run. */
-    public static BoundaryValues constructing(souther.compiler.check.Prepared.Examples module, Symbols symbols,
+    public static BoundaryValues constructing(souther.compiler.check.Prepared.ForExamples module, Symbols symbols,
                                             FieldTypes fields,
                                             Map<String, ClassFileImage> classes, ClassLoader parent,
                                             Map<String, Hir.FnDef> values) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowKey.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowKey.java
@@ -7,7 +7,7 @@ import souther.compiler.observe.RowIdentity;
  *
  * <p>Two things it must be, and the type closes both. It holds a {@link RowIdentity.Named}, so a key
  * for a row that has no name cannot be written — #718 put the namespace on the behavior and this
- * finishes that decision. And it is made only by {@link BoundExamples#row(String, String)}, so a key
+ * finishes that decision. And it is made only by {@link BoundExamples#rowKey(String, String)}, so a key
  * naming a row nothing answers to cannot be written either. Left as a record, its canonical
  * constructor would be public and a name nothing answers to would be written straight past the
  * resolution: {@link #is} would answer {@code false} for every row and the setup guarded by it would
@@ -17,19 +17,19 @@ import souther.compiler.observe.RowIdentity;
  * needs an address to be associated with something outside the file, not to be evaluated — and
  * keyed evaluation would silently drop every unnamed row of the behavior.
  *
- * <p>Made through {@link BoundExamples#row(String, String)} so a name nothing answers to fails where
+ * <p>Made through {@link BoundExamples#rowKey(String, String)} so a name nothing answers to fails where
  * it is resolved, rather than as setup that silently never runs.
  */
 public final class RowKey {
 
     private final BoundExamples of;
     private final String behavior;
-    private final RowIdentity.Named row;
+    private final RowIdentity.Named identity;
 
-    RowKey(BoundExamples of, String behavior, RowIdentity.Named row) {
+    RowKey(BoundExamples of, String behavior, RowIdentity.Named identity) {
         this.of = of;
         this.behavior = behavior;
-        this.row = row;
+        this.identity = identity;
     }
 
     /** The behavior whose row this addresses. */
@@ -38,13 +38,13 @@ public final class RowKey {
     }
 
     /** What the row names itself. */
-    public RowIdentity.Named row() {
-        return row;
+    public RowIdentity.Named identity() {
+        return identity;
     }
 
     /** The name the row was written with. */
     public String name() {
-        return row.name();
+        return identity.name();
     }
 
     /**
@@ -62,22 +62,22 @@ public final class RowKey {
             throw new IllegalArgumentException("this key was resolved against another enumeration,"
                     + " so what it addresses is not among these rows");
         }
-        return behavior.equals(enumerated.behavior()) && row.equals(enumerated.identity());
+        return behavior.equals(enumerated.behavior()) && identity.equals(enumerated.identity());
     }
 
     @Override
     public String toString() {
-        return behavior + " " + row.shown();
+        return behavior + " " + identity.shown();
     }
 
     @Override
     public boolean equals(Object other) {
         return other instanceof RowKey key && of == key.of
-                && behavior.equals(key.behavior) && row.equals(key.row);
+                && behavior.equals(key.behavior) && identity.equals(key.identity);
     }
 
     @Override
     public int hashCode() {
-        return System.identityHashCode(of) * 31 + behavior.hashCode() * 31 + row.hashCode();
+        return System.identityHashCode(of) * 31 + behavior.hashCode() * 31 + identity.hashCode();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -59,7 +59,7 @@ public final class RowTrial {
      *              A composed row is not a row anyone wrote, so a model that loops on it is this
      *              search's problem to stop rather than an author's to be told about
      */
-    public static RowTrials over(souther.compiler.check.Prepared.Examples module,
+    public static RowTrials over(souther.compiler.check.Prepared.ForExamples module,
                               Symbols symbols, souther.compiler.observe.FieldTypes fields,
                               Map<String, ClassFileImage> classes,
                               ClassLoader parent,

--- a/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/SoutherExamples.java
@@ -200,7 +200,7 @@ public final class SoutherExamples {
         // them is this run's. A row driven from here reaches an implementation that answers out of
         // the caller's world, which the compile's own rows do not, and an arrangement is how a run
         // is run rather than what it is held to.
-        return new BoundExamples(module, asked.rows(),
+        return new BoundExamples(module, asked.forExamples(),
                 JvmExampleRuns.evaluating(compilation.jvmProgramImages(), asked,
                         new CallerCrossingDeadlines(JvmDeadlines.workerStackFromSettings())
                                 .forThisCompile(asked.policy().outerTimeout()),

--- a/souther-compiler/src/main/java/souther/compiler/execute/ExampleExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/ExampleExecution.java
@@ -76,13 +76,15 @@ public final class ExampleExecution {
         return prepared.name();
     }
 
-    /** Every row the module has, from its own file and from every file naming it. */
-    public Prepared.Examples rows() {
+    /** The module projected for its every example block, from its own file and from every file
+     *  naming it. */
+    public Prepared.ForExamples forExamples() {
         return prepared.forExamples();
     }
 
-    /** The rows written in one source, projected the way the preparation projects them. */
-    public Prepared.Examples rowsWrittenIn(SourceId source) {
+    /** The same over the blocks written in one source, projected the way the preparation projects
+     *  them. */
+    public Prepared.ForExamples forExamplesWrittenIn(SourceId source) {
         return prepared.forExamplesWrittenIn(source);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleRuns.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmExampleRuns.java
@@ -46,7 +46,7 @@ public final class JvmExampleRuns {
             throw new IllegalStateException("`" + asked.module() + "` emitted nothing to run its"
                     + " rows against");
         }
-        return ExampleVerifier.evaluating(asked.rows(), asked.symbols(), asked.fieldTypes(),
+        return ExampleVerifier.evaluating(asked.forExamples(), asked.symbols(), asked.fieldTypes(),
                 asked.signatures(),
                 image.program(), image.published(), asked.requirements(), image.around(),
                 asked.definitions(), deadline, asked.policy(), answering,

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
@@ -72,7 +72,8 @@ public final class JvmProgramExecution implements ProgramExecution {
         if (image == null) {
             return new RowRun.NotRunHere();
         }
-        Observations observed = ExampleVerifier.check(asked.rowsWrittenIn(source), asked.symbols(),
+        Observations observed = ExampleVerifier.check(asked.forExamplesWrittenIn(source),
+                asked.symbols(),
                 asked.fieldTypes(),
                 asked.signatures(), image.program(), image.published(), asked.requirements(),
                 image.around(), asked.definitions(), keeping(asked), asked.policy(),
@@ -85,7 +86,7 @@ public final class JvmProgramExecution implements ProgramExecution {
 
     @Override
     public TableBuild fakeTables(ExampleExecution asked, SourceId source) {
-        if (ExampleStatements.tablesBuiltIn(asked.rows(), asked.signatures(), source).isEmpty()) {
+        if (ExampleStatements.tablesBuiltIn(asked.forExamples(), asked.signatures(), source).isEmpty()) {
             // Nothing this source states is a table this source builds, so there is nothing here
             // that went unbuilt. Asked the other way round — is there a program to build against —
             // a file that wrote no fake at all would answer that its tables could not be built,
@@ -99,7 +100,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         }
         // The classes alone. Nothing here applies a behavior, so what the compile implemented is not
         // a question this asks.
-        return new TableBuild.Built(ExampleStatements.fakeTables(asked.rows(), asked.symbols(),
+        return new TableBuild.Built(ExampleStatements.fakeTables(asked.forExamples(), asked.symbols(),
                 asked.fieldTypes(),
                 asked.signatures(), image.program().classes(), image.around(), asked.definitions(),
                 source, keeping(asked), asked.policy(), asked.contracts()));
@@ -117,9 +118,9 @@ public final class JvmProgramExecution implements ProgramExecution {
         // execution and the equality that decides it is the language's own.
         Map<String, ExampleStatements.Declaring> declaring = new LinkedHashMap<>();
         asked.declaring().forEach((name, reading) -> declaring.put(name,
-                new ExampleStatements.Declaring(reading.rows(), reading.symbols(),
+                new ExampleStatements.Declaring(reading.forExamples(), reading.symbols(),
                         reading.fieldTypes(), reading.definitions())));
-        return new StatementReading.Read(ExampleStatements.disagreements(asked.rows(),
+        return new StatementReading.Read(ExampleStatements.disagreements(asked.forExamples(),
                 asked.symbols(), asked.fieldTypes(),
                 asked.signatures(), image.program().classes(), image.around(),
                 asked.definitions(), keeping(asked), asked.policy(), asked.contracts(),
@@ -138,7 +139,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         // line up, which is a fault in a measurement nothing here is making.
         JvmProgramImage image = images.evaluating(asked.module(), ArmObservation.OMIT);
         return image == null ? null
-                : FixtureReader.constructing(asked.rows(), asked.symbols(), asked.fieldTypes(),
+                : FixtureReader.constructing(asked.forExamples(), asked.symbols(), asked.fieldTypes(),
                         image.program().classes(), image.around(), asked.definitions());
     }
 
@@ -148,7 +149,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         if (image == null || image.program().implementations() == null) {
             return null;
         }
-        return RowTrial.over(asked.rows(), asked.symbols(), asked.fieldTypes(),
+        return RowTrial.over(asked.forExamples(), asked.symbols(), asked.fieldTypes(),
                 image.program().classes(),
                 image.around(), asked.definitions(), image.program().implementations(),
                 asked.policy());

--- a/souther-compiler/src/main/java/souther/compiler/observe/Target.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Target.java
@@ -174,11 +174,12 @@ public sealed interface Target {
      * behavior, they were one identity and the second was dropped wherever these are kept one per
      * identity (issue #996).
      */
-    record OfRow(RowRef row) implements Target {
+    record OfRow(RowRef rowRef) implements Target {
 
         @Override
         public String subject() {
-            return row.behavior() + "/" + row.source().value() + "/" + row.identity().shown();
+            return rowRef.behavior() + "/" + rowRef.source().value() + "/"
+                    + rowRef.identity().shown();
         }
 
         @Override
@@ -186,7 +187,7 @@ public sealed interface Target {
             // The row decides which of its parts a reader needs; the caller decides what its file
             // is called. Written the other way round, a renderer would be choosing how much of an
             // identity to show, which is the row's to say.
-            return row.shown(names.nameOf(row.source()));
+            return rowRef.shown(names.nameOf(rowRef.source()));
         }
 
         @Override
@@ -204,7 +205,7 @@ public sealed interface Target {
 
         @Override
         public java.util.Optional<String> onlyBehavior() {
-            return java.util.Optional.of(row.behavior());
+            return java.util.Optional.of(rowRef.behavior());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
@@ -54,7 +54,7 @@ public record AdequacyPolicy(OfTheMeasures measures, OfTheGeneration generation)
     /**
      * What composing rows for one behavior may spend.
      *
-     * @param rows         how many rows one call will write. Past this the output stops being
+     * @param rowLimit     how many rows one call will write. Past this the output stops being
      *                     something a person reads and pastes, and what the search did not reach is
      *                     written down rather than left absent
      * @param cellsPerGroup how many ways of choosing an outcome from each factor a group may have
@@ -73,13 +73,13 @@ public record AdequacyPolicy(OfTheMeasures measures, OfTheGeneration generation)
      *                     group there is — a single choice — is offered, which is what a limit of
      *                     one should admit
      */
-    public record OfTheGeneration(int rows, int cellsPerGroup) {
+    public record OfTheGeneration(int rowLimit, int cellsPerGroup) {
 
         public OfTheGeneration {
-            if (rows < 1) {
+            if (rowLimit < 1) {
                 throw new IllegalArgumentException(
                         "a generation writes at least one row, so a limit below one bounds nothing: "
-                                + rows);
+                                + rowLimit);
             }
             if (cellsPerGroup < 1) {
                 throw new IllegalArgumentException(

--- a/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
@@ -17,10 +17,10 @@ import java.util.List;
 public sealed interface ArmDisposition {
 
     /** A row was composed for a combination that takes it, or along the way into it. */
-    record Built(RowId row) implements ArmDisposition {
+    record Built(RowId rowId) implements ArmDisposition {
 
         public Built {
-            if (row == null) {
+            if (rowId == null) {
                 throw new IllegalArgumentException("an arm a row was composed for names the row");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -85,12 +85,12 @@ public sealed interface BorderQuantity {
         }
 
         @Override
-        public Stands standsAt(Criterion where, Observation row) {
+        public Stands standsAt(Criterion where, Observation observation) {
             // Read on the order the value is written on and asked on the order the answer is
             // measured on. The two are one carrier for a position's own content and part for a term
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
-            return switch (of.read(row.at(term.position()))) {
+            return switch (of.read(observation.at(term.position()))) {
                 case NumericTerm.Reading.Missing _ -> Stands.UNREADABLE;
                 case NumericTerm.Reading.NotNumber _ -> Stands.NO;
                 case NumericTerm.Reading.Number number ->
@@ -297,12 +297,12 @@ public sealed interface BorderQuantity {
          * decimals read as met by no row, including the rows that meet it.
          */
         @Override
-        public Stands standsAt(Criterion where, Observation row) {
+        public Stands standsAt(Criterion where, Observation observation) {
             // Each on its own order. Read on one order for the pair, a position written back
             // differently from the other was read as a value it does not hold — a date read as a
             // whole number is no number at all, and the row stood at nothing (#1018).
-            NumericTerm.Reading here = on.read(row.at(on.term().subjectPath()));
-            NumericTerm.Reading there = against.read(row.at(against.term().subjectPath()));
+            NumericTerm.Reading here = on.read(observation.at(on.term().subjectPath()));
+            NumericTerm.Reading there = against.read(observation.at(against.term().subjectPath()));
             if (here instanceof NumericTerm.Reading.Missing
                     || there instanceof NumericTerm.Reading.Missing) {
                 return Stands.UNREADABLE;
@@ -519,7 +519,7 @@ public sealed interface BorderQuantity {
         }
 
         @Override
-        public Stands standsAt(Criterion where, Observation row) {
+        public Stands standsAt(Criterion where, Observation observation) {
             java.math.BigDecimal at = java.math.BigDecimal.ZERO;
             for (Map.Entry<NumericTerm, java.math.BigDecimal> each : form.coefs().entrySet()) {
                 // Each on its own order. Read on one order for the whole form, a position written
@@ -530,9 +530,9 @@ public sealed interface BorderQuantity {
                 // a total would be read off whichever element the row's reading happened to pick.
                 TermOrders orders = on.get(each.getKey());
                 NumericTerm.Reading read = switch (each.getKey()) {
-                    case NumericTerm.FromOnePosition one -> orders.read(row.at(one.position()));
+                    case NumericTerm.FromOnePosition one -> orders.read(observation.at(one.position()));
                     case NumericTerm.TakenOver over ->
-                            orders.readOver(row.everyValueAt(over.subjectPath()));
+                            orders.readOver(observation.everyValueAt(over.subjectPath()));
                 };
                 if (read instanceof NumericTerm.Reading.Missing) {
                     return Stands.UNREADABLE;
@@ -683,7 +683,7 @@ public sealed interface BorderQuantity {
 
     /** Whether a row stands at one item of a border on this quantity, or whether it could not be
      *  read. */
-    Stands standsAt(Criterion where, Observation row);
+    Stands standsAt(Criterion where, Observation observation);
 
     /** What a search has to solve to put a row at one item. */
     Standing standingAt(Criterion where);

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
@@ -14,10 +14,10 @@ package souther.compiler.partition;
 public sealed interface ClassDisposition {
 
     /** A row was composed for it, which is this row. */
-    record Built(RowId row) implements ClassDisposition {
+    record Built(RowId rowId) implements ClassDisposition {
 
         public Built {
-            if (row == null) {
+            if (rowId == null) {
                 throw new IllegalArgumentException("a class a row was composed for names the row");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
@@ -62,12 +62,12 @@ public record FillResult(GenerationPlan plan, SequencedMap<RowId, ComposedRow> c
         Set<RowId> answered = new LinkedHashSet<>();
         for (ClassDisposition each : discharge.classes().values()) {
             if (each instanceof ClassDisposition.Built built) {
-                answered.add(built.row());
+                answered.add(built.rowId());
             }
         }
         for (ArmDisposition each : discharge.arms().values()) {
             if (each instanceof ArmDisposition.Built built) {
-                answered.add(built.row());
+                answered.add(built.rowId());
             }
         }
         if (!answered.equals(composed.keySet())) {
@@ -141,14 +141,14 @@ public record FillResult(GenerationPlan plan, SequencedMap<RowId, ComposedRow> c
         List<Generator.Purpose> purposes = new ArrayList<>();
         for (Generator.ClassOwed owed : plan.classesOwed()) {
             if (discharge.at(owed) instanceof ClassDisposition.Built built
-                    && built.row().equals(id)) {
+                    && built.rowId().equals(id)) {
                 purposes.add(new Generator.Purpose.ForAClass(owed.at(), owed.classId(),
                         Generator.labelOf(plan.subject(), owed)));
             }
         }
         for (Generator.ArmOwed owed : plan.armsOwed()) {
             if (discharge.at(owed) instanceof ArmDisposition.Built built
-                    && built.row().equals(id)) {
+                    && built.rowId().equals(id)) {
                 purposes.add(new Generator.Purpose.ForAnArm(owed.probe()));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -952,7 +952,7 @@ public final class Generator {
         int classesLeft = 0;
         for (int i = 0; i < owed.size(); i++) {
             int[] at = owed.get(i);
-            if (composed.size() >= budget.rows()) {
+            if (composed.size() >= budget.rowLimit()) {
                 classesLeft = owed.size() - i;
                 for (int cut = i; cut < owed.size(); cut++) {
                     Axis axis = axes.get(owed.get(cut)[0]);
@@ -1021,7 +1021,7 @@ public final class Generator {
                 continue;
             }
             for (WhereToLook place : whereToLookFor(probe, read, cells, axes)) {
-                if (composed.size() >= budget.rows()) {
+                if (composed.size() >= budget.rowLimit()) {
                     cutOff.add(probe);
                     break;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -45,11 +45,12 @@ public final class StandingAtAPoint {
      *             takes more than standing at the level. Empty where standing there is the whole
      *             of it
      */
-    public static Met met(BorderQuantity quantity, BehaviorInputs where, List<ObservedInputs> rows,
-                          Criterion criterion, Optional<ComparisonOccurrence> site) {
+    public static Met met(BorderQuantity quantity, BehaviorInputs where,
+                          List<ObservedInputs> observed, Criterion criterion,
+                          Optional<ComparisonOccurrence> site) {
         boolean unreadable = false;
         boolean unwatched = false;
-        for (ObservedInputs row : rows) {
+        for (ObservedInputs one : observed) {
             // A row has more than one value at a position inside a sequence, and standing at a point
             // is one element standing there. Asked for one value, such a row answered with none and
             // every point on such a line came back undecided — a measurement that could not look,
@@ -57,10 +58,10 @@ public final class StandingAtAPoint {
             // The first reading both answers the point and says which steps the line's positions
             // take; the rest are tried under each choice those steps allow.
             Map<TermPath, Integer> held = new LinkedHashMap<>();
-            OneReadingOfARow first = new OneReadingOfARow(where, row, Map.of(), held);
+            OneReadingOfARow first = new OneReadingOfARow(where, one, Map.of(), held);
             boolean stands = false;
             boolean stopped = false;
-            for (OneReadingOfARow reading : readings(where, row, quantity, criterion, first, held)) {
+            for (OneReadingOfARow reading : readings(where, one, quantity, criterion, first, held)) {
                 switch (quantity.standsAt(criterion, reading)) {
                     // A reading that could not look, unless what it could not find was an element
                     // the row wrote none of — that is a row that was read and does not stand, and
@@ -78,7 +79,7 @@ public final class StandingAtAPoint {
                 if (site.isEmpty()) {
                     return Met.YES;   // writing the value is the whole of what there is to reach
                 }
-                switch (row.watched()) {
+                switch (one.watched()) {
                     case Generator.Watched.Ran(var account) -> {
                         if (site.stream().allMatch(account::reached)) {
                             return Met.YES;
@@ -116,25 +117,25 @@ public final class StandingAtAPoint {
     private static final class OneReadingOfARow implements BorderQuantity.Observation {
 
         private final BehaviorInputs where;
-        private final ObservedInputs row;
+        private final ObservedInputs observedInputs;
         /** The element chosen at each step, for this reading. */
         private final Map<TermPath, Integer> chosen;
         /** How many elements each step was found to have, over every reading so far. */
         private final Map<TermPath, Integer> held;
         private boolean wroteNothing;
 
-        OneReadingOfARow(BehaviorInputs where, ObservedInputs row,
+        OneReadingOfARow(BehaviorInputs where, ObservedInputs observedInputs,
                          Map<TermPath, Integer> chosen,
                          Map<TermPath, Integer> held) {
             this.where = where;
-            this.row = row;
+            this.observedInputs = observedInputs;
             this.chosen = chosen;
             this.held = held;
         }
 
         @Override
         public ObservedValue at(TermPath path) {
-            List<BehaviorInputs.Occurrence> values = where.occurrencesAt(row.inputs(), path);
+            List<BehaviorInputs.Occurrence> values = where.occurrencesAt(observedInputs.inputs(), path);
             if (values == null) {
                 return null;   // the walk and the type disagree, which is the quantity's to report
             }
@@ -174,7 +175,7 @@ public final class StandingAtAPoint {
         public List<ObservedValue> everyValueAt(TermPath path) {
             // Null where the walk and the type disagree, which is the quantity's to report, as it
             // is for the one value a place holds.
-            return where.valuesAt(row.inputs(), path);
+            return where.valuesAt(observedInputs.inputs(), path);
         }
 
         /** Whether {@code each} was reached through the elements this reading chose. */
@@ -201,14 +202,14 @@ public final class StandingAtAPoint {
      * quantity's to say as it reads them, so it says so by being asked once. Every choice those
      * steps allow follows it.
      */
-    private static List<OneReadingOfARow> readings(BehaviorInputs where, ObservedInputs row,
+    private static List<OneReadingOfARow> readings(BehaviorInputs where, ObservedInputs observed,
                                                    BorderQuantity quantity, Criterion criterion,
                                                    OneReadingOfARow first,
                                                    Map<TermPath, Integer> held) {
         quantity.standsAt(criterion, first);
         List<OneReadingOfARow> out = new ArrayList<>();
         for (Map<TermPath, Integer> choice : readingsOver(held)) {
-            out.add(new OneReadingOfARow(where, row, choice, held));
+            out.add(new OneReadingOfARow(where, observed, choice, held));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -323,8 +323,8 @@ final class CheckedProgramAssembler {
      * <p>Read in one pass so that what a module declares is in hand before what its rows state is
      * written down: the two are made in that order and not in the order the modules were given.
      *
-     * @param rows what each of the module's behaviors' rows turned out to be, by behavior name, in
-     *             the order the sources were read and the rows written
+     * @param rowsByBehavior what each of the module's behaviors' rows turned out to be, by behavior
+     *             name, in the order the sources were read and the rows written
      */
     private record ModuleReading(String name, Hir.Module bodies, Bodies.Elaborated checked,
                                  Map<String, Sig> signatures,
@@ -332,7 +332,7 @@ final class CheckedProgramAssembler {
                                  Map<ValueName.Behavior, Composition> compositions,
                                  Map<ValueName.Behavior, EnsuresEnforcement> checks,
                                  List<CheckedData> data,
-                                 Map<String, List<Output.RowsRead.ReadRow>> rows) {}
+                                 Map<String, List<Output.RowsRead.ReadRow>> rowsByBehavior) {}
 
     /**
      * The rows this compile read for {@code module}, by the behavior each is a row of.
@@ -411,7 +411,7 @@ final class CheckedProgramAssembler {
         module.declared().forEach((named, target) ->
                 behaviors.add(new CheckedBehavior(named, target,
                         EnsuresEnforcement.in(read.checks(), read.name(), named),
-                        rowsOf(read.rows().getOrDefault(named.name(), List.of()), types,
+                        rowsOf(read.rowsByBehavior().getOrDefault(named.name(), List.of()), types,
                                 target.signature(), targets))));
         return new CheckedModule(read.name(), behaviors,
                 helpersOf(read.name(), read.bodies(), read.checked()), read.data());

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1090,7 +1090,7 @@ public final class Adequacy {
                 return Answer.absent();
             }
             Set<Integer> lit = new LinkedHashSet<>();
-            for (RowReading observed : db.ask(new Rows(name)).value().values()) {
+            for (RowReading observed : db.ask(new RowReadings(name)).value().values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
                     lit.addAll(seenBy(row).taken());
                 }
@@ -1117,7 +1117,7 @@ public final class Adequacy {
      * matters most for. What the level asked for is answered here as well — a build that does not
      * read rows gets a reading that says so, rather than every caller writing that gate again.
      */
-    public record Rows(String name) implements Key<Map<String, RowReading>> {
+    public record RowReadings(String name) implements Key<Map<String, RowReading>> {
 
         /**
          * The reading for one behavior of a module this answered for.
@@ -1192,7 +1192,7 @@ public final class Adequacy {
             // the answer: what the level decides is what work to do, and the work this measure does
             // is reading every row of the module (issue #955).
             boolean asked = levelOf(db).readsRows();
-            Map<String, RowReading> byTarget = db.ask(new Rows(name)).value();
+            Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             // What each body can answer with, so that a case only an unreachable arm produces is not
             // counted. Read from the same reachability the arms are counted by.
@@ -1217,7 +1217,7 @@ public final class Adequacy {
                                 SignatureEvidence.boundaryNotDerived(behavior);
                         case BoundaryForMeasurement.Derived(Sig sig) ->
                                 evidenceOf(behavior.name(), sig, scope.value(), asked,
-                                        Rows.readingFor(byTarget, behavior.name()),
+                                        RowReadings.readingFor(byTarget, behavior.name()),
                                         behavior instanceof Hir.SpecBehavior spec
                                                 ? spec.params().stream().map(Hir.Param::name).toList()
                                                 : List.of(),
@@ -1269,7 +1269,7 @@ public final class Adequacy {
                                     : checked.decisions(),
                             checked == null ? souther.compiler.coverage.SuppliedRules.NONE : checked.supplied());
             Level level = levelOf(db);
-            Map<String, RowReading> byTarget = db.ask(new Rows(name)).value();
+            Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             // What the guards above each place leave, asked once for the module and read by
             // every measure below — the same reason the reading of the input is.
@@ -1322,7 +1322,7 @@ public final class Adequacy {
                 throw new IllegalStateException("`" + spec.name() + "` has a signature and no"
                         + " reading of what the model divides it into");
             }
-            RowReading seen = Rows.readingFor(byTarget, spec.name());
+            RowReading seen = RowReadings.readingFor(byTarget, spec.name());
             if (lines == null) {
                 // Nothing came back about this behavior's lines, from a question that has
                 // everything it needs to answer. Read as no lines, a behavior whose measure
@@ -2046,7 +2046,7 @@ public final class Adequacy {
             Level level = levelOf(db);
             Symbols symbols = scope.value();
             return Answer.of(assess(spec, sig, symbols, db.ask(new Front.Reading()).value(),
-                    divided, Rows.readingFor(db.ask(new Rows(name)).value(), behavior), level));
+                    divided, RowReadings.readingFor(db.ask(new RowReadings(name)).value(), behavior), level));
         }
 
         /** Every line of one behavior, with what the rows and the decoder say about each. */
@@ -2498,7 +2498,7 @@ public final class Adequacy {
             // body holds could be read — and answering both from this map is what made a module the
             // compile stopped in report every behavior as one with no body (issue #996).
             boolean bodiesRead = db.ask(new Bodies.Checked(name)).value() != null;
-            Map<String, RowReading> byTarget = db.ask(new Rows(name)).value();
+            Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Set<Integer> lit = new LinkedHashSet<>();
             for (RowReading observed : byTarget.values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
@@ -2514,7 +2514,7 @@ public final class Adequacy {
                 // would report an arm the body does not have.
                 List<souther.compiler.coverage.CoverageSites.Site> arms =
                         plan.arms(behavior.name());
-                RowReading observed = Rows.readingFor(byTarget, behavior.name());
+                RowReading observed = RowReadings.readingFor(byTarget, behavior.name());
                 souther.compiler.check.PathReachability.Answers.AsRun arrives =
                         reachable == null ? NOTHING_PROVEN
                                 : reachable.getOrDefault(behavior.name(), NOTHING_PROVEN);
@@ -2665,11 +2665,11 @@ public final class Adequacy {
          *
          * <p>Not the same as {@link #NOT_ASKED}, and not the same as rows nothing came back from.
          *
-         * <p><b>An answer and not a default.</b> Both of these are things {@link Rows} says, and
-         * which of them a behavior gets is its answer to give — so a caller reaching for one where
-         * the map did not answer is deciding what the producer said from what it did not say.
-         * {@link Rows#readingFor} is how a caller gets one. What is left here is building a fixture,
-         * which has no producer to ask.
+         * <p><b>An answer and not a default.</b> Both of these are things {@link RowReadings}
+         * says, and which of them a behavior gets is its answer to give — so a caller reaching for
+         * one where the map did not answer is deciding what the producer said from what it did not
+         * say. {@link RowReadings#readingFor} is how a caller gets one. What is left here is
+         * building a fixture, which has no producer to ask.
          */
         public static final RowReading NONE =
                 new RowReading(new Measurement.Complete<>(Observed.NONE));
@@ -2930,7 +2930,7 @@ public final class Adequacy {
                                     ? souther.compiler.coverage.DecisionSources.NONE
                                     : checked.decisions(),
                             checked == null ? souther.compiler.coverage.SuppliedRules.NONE : checked.supplied());
-            Map<String, RowReading> byTarget = db.ask(new Rows(name)).value();
+            Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             // What the guards above each place leave, asked once for the module and read by
             // every measure below — the same reason the reading of the input is.
@@ -2990,7 +2990,7 @@ public final class Adequacy {
                                 // nothing about is a value this cannot reach rather than a fault.
                                 new souther.compiler.check.ResolvedFieldTypes(symbols)),
                         divided, bodies.get(behavior), plan,
-                        Rows.readingFor(byTarget, behavior),
+                        RowReadings.readingFor(byTarget, behavior),
                         constructing(db, name),
                         domainOf(readInputs, spec),
                         runningRowsOf(trialling(db, name),
@@ -3160,7 +3160,7 @@ public final class Adequacy {
             }
             return switch (answer) {
                 case souther.compiler.partition.ArmDisposition.Built built ->
-                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.row())));
+                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.rowId())));
                 // What every place a row was looked for came to, all of it. They are not one fact
                 // and they do not order against each other: one the model refuses says the arm may
                 // be unreachable, one the search stopped at says nothing at all, and a reader
@@ -3253,7 +3253,7 @@ public final class Adequacy {
             }
             return switch (answer) {
                 case souther.compiler.partition.ClassDisposition.Built built ->
-                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.row())));
+                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.rowId())));
                 case souther.compiler.partition.ClassDisposition.Unresolved none ->
                         new GenerationOutcome.CannotGenerate(none.why());
             };
@@ -3379,7 +3379,7 @@ public final class Adequacy {
             // values that go together, which is more than this can say of one value chosen per
             // position on its own — and it is the set they reached for, which is what makes a row
             // written against it read as one column moved.
-            for (souther.compiler.check.Prepared.Rows block : prepared.rows()) {
+            for (souther.compiler.check.Prepared.Example block : prepared.examples()) {
                 if (!block.target().equals(spec.name())) {
                     continue;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2375,13 +2375,13 @@ public final class Adequacy {
                                               List<souther.compiler.coverage.CoverageSites.Site> all,
                                               Set<Integer> covered,
                                               souther.compiler.check.PathReachability.Answers.AsRun reachable,
-                                              WeakeningSet rows) {
+                                              WeakeningSet weakenings) {
             List<souther.compiler.coverage.CoverageSites.Site> owed = owed(all, reachable);
             Set<Integer> counted = new LinkedHashSet<>(covered);
             counted.retainAll(owed.stream()
                     .map(souther.compiler.coverage.CoverageSites.Site::index).toList());
             Arms arms = new Arms(owed, counted);
-            WeakeningSet by = rows;
+            WeakeningSet by = weakenings;
             for (int probe : reachable.provedWrong()) {
                 by = by.union(WeakeningSet.of(new Weakening.ProofContradicted(behavior, probe)));
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Composition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Composition.java
@@ -26,17 +26,19 @@ import java.util.SequencedMap;
  * does the system answer? — and what it would settle if it were written is not something this says.
  *
  * @param request  what was asked for, which is what settles which rows are here
- * @param rows     one entry per behavior with rows, in the order they were asked about
+ * @param rowsByBehavior one entry per behavior with rows, in the order they were asked about
  * @param searched what each behavior's own search came to, keyed the way a report keys them
  * @param account every point of a line this request answers for, whosever it is — a body's own and
  *                 its declarations' alike — or null where the request asked for no boundary rows,
  *                 which is not the same as a request that asked and found none
  */
-public record Composition(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
+public record Composition(OfferingRequest request,
+                          SequencedMap<String, List<OfferedRow>> rowsByBehavior,
                           SequencedMap<String, Adequacy.Filling> searched, BorderAccount account) {
 
     public Composition {
-        rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
+        rowsByBehavior =
+                Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rowsByBehavior));
         searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
     }
 
@@ -123,7 +125,7 @@ public record Composition(OfferingRequest request, SequencedMap<String, List<Off
 
     /** How many pieces of work this holds, which is what a block says at the top of it. */
     public int count() {
-        return rows.values().stream().mapToInt(List::size).sum();
+        return rowsByBehavior.values().stream().mapToInt(List::size).sum();
     }
 
     /**
@@ -141,7 +143,7 @@ public record Composition(OfferingRequest request, SequencedMap<String, List<Off
      */
     Offering keeping(java.util.Set<RowKey> kept, java.util.Set<OfferItem> answered) {
         SequencedMap<String, List<OfferedRow>> out = new LinkedHashMap<>();
-        rows.forEach((behavior, here) -> {
+        rowsByBehavior.forEach((behavior, here) -> {
             List<OfferedRow> left = here.stream().filter(row -> kept.contains(row.key())).toList();
             if (!left.isEmpty()) {
                 out.put(behavior, left);

--- a/souther-compiler/src/main/java/souther/compiler/query/Offering.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Offering.java
@@ -33,14 +33,15 @@ import java.util.SequencedMap;
 public final class Offering {
 
     private final OfferingRequest request;
-    private final SequencedMap<String, List<OfferedRow>> rows;
+    private final SequencedMap<String, List<OfferedRow>> rowsByBehavior;
     private final SequencedMap<String, Adequacy.Filling> searched;
     private final BorderAccount account;
     private final Set<OfferItem> answered;
 
     /**
      * @param request  what was asked for, which is what settles which rows are here
-     * @param rows     one entry per behavior with rows to offer, in the order they were asked about
+     * @param rowsByBehavior one entry per behavior with rows to offer, in the order they were asked
+     *                 about
      * @param searched what each behavior's own search came to, keyed the way a report keys them
      * @param account every point of a line this request answers for, whosever it is — a body's own
      *                 and its declarations' alike — or null where the request asked for no boundary
@@ -48,11 +49,12 @@ public final class Offering {
      * @param answered what the rows here settle: every item one of them would answer if it were
      *                 written, whichever row it was composed for
      */
-    Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rows,
+    Offering(OfferingRequest request, SequencedMap<String, List<OfferedRow>> rowsByBehavior,
              SequencedMap<String, Adequacy.Filling> searched, BorderAccount account,
              Set<OfferItem> answered) {
         this.request = request;
-        this.rows = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rows));
+        this.rowsByBehavior =
+                Collections.unmodifiableSequencedMap(new LinkedHashMap<>(rowsByBehavior));
         this.searched = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(searched));
         this.account = account;
         this.answered = Collections.unmodifiableSet(new LinkedHashSet<>(answered));
@@ -64,8 +66,8 @@ public final class Offering {
     }
 
     /** The rows a person is handed, under the behavior each is written for. */
-    public SequencedMap<String, List<OfferedRow>> rows() {
-        return rows;
+    public SequencedMap<String, List<OfferedRow>> rowsByBehavior() {
+        return rowsByBehavior;
     }
 
     /** What each behavior's own search came to. */
@@ -86,6 +88,6 @@ public final class Offering {
 
     /** How many pieces of work this offers, which is what a block says at the top of it. */
     public int count() {
-        return rows.values().stream().mapToInt(List::size).sum();
+        return rowsByBehavior.values().stream().mapToInt(List::size).sum();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -832,9 +832,9 @@ public final class Output {
      * behavior, because which behaviors it wrote rows for is exactly what could not be read.
      *
      * <p>What is here are the rows as they were read and the reasons a reading fell short, and
-     * nothing made of either. What a measurement makes of them is {@link Adequacy.Rows}, which is
-     * asked only where a build measures; what a behavior owes is a fact about the model, and an
-     * output holding a checked program reads it whether or not anything was measured.
+     * nothing made of either. What a measurement makes of them is {@link Adequacy.RowReadings},
+     * which is asked only where a build measures; what a behavior owes is a fact about the model,
+     * and an output holding a checked program reads it whether or not anything was measured.
      */
     public record RowsRead(String name) implements Key<RowsRead.Of> {
 
@@ -1057,8 +1057,8 @@ public final class Output {
                 }
                 return;
             }
-            for (souther.compiler.check.Prepared.Rows block
-                    : prepared.value().forExamplesWrittenIn(sourceId).rows()) {
+            for (souther.compiler.check.Prepared.Example block
+                    : prepared.value().forExamplesWrittenIn(sourceId).examples()) {
                 souther.compiler.ast.Hir.Example written = block.read();
                 List<ReadRow> mine = into.computeIfAbsent(written.target(),
                         _ -> new ArrayList<>());
@@ -1254,7 +1254,7 @@ public final class Output {
             if (asked == null) {
                 return Answer.absent();   // nothing here can have its examples evaluated yet
             }
-            if (asked.rowsWrittenIn(sourceId).rows().isEmpty()) {
+            if (asked.forExamplesWrittenIn(sourceId).examples().isEmpty()) {
                 return Answer.of(Of.NONE);
             }
             List<Report> reports = new ArrayList<>(alreadyDeclared(db, name, sourceId));

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -586,18 +586,6 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         }
 
         /**
-         * The numbers, where a measurement was made.
-         *
-         * <p>Throws where none was. A measure with no number has none, and an accessor that answered
-         * zero would be the thing this type was introduced to remove — a reader would get an answer
-         * and no sign that nobody measured it.
-         */
-        public Reached rows() {
-            return reached.made().orElseThrow(() -> new IllegalStateException(
-                    "a position nobody measured was read for what the rows reached: " + path));
-        }
-
-        /**
          * The classes of this position no row is in, each knowing which position it is a class of.
          *
          * <p>A bare name used to be enough because one axis was read at a time. It is not enough to

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -46,11 +46,12 @@ public record Settlements(List<OfferItem> requested,
         byRow = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(byRow));
     }
 
-    /** What {@code row} would do about {@code item}, for a reader holding both. */
-    public Settlement at(RowKey row, OfferItem item) {
-        Map<OfferItem, Settlement> here = byRow.get(row);
+    /** What the row {@code rowKey} addresses would do about {@code item}, for a reader holding
+     *  both. */
+    public Settlement at(RowKey rowKey, OfferItem item) {
+        Map<OfferItem, Settlement> here = byRow.get(rowKey);
         if (here == null || !here.containsKey(item)) {
-            throw new IllegalArgumentException("no entry for " + row + " at " + item);
+            throw new IllegalArgumentException("no entry for " + rowKey + " at " + item);
         }
         return here.get(item);
     }
@@ -66,13 +67,13 @@ public record Settlements(List<OfferItem> requested,
      * <p>Written once because it is what {@link #keeping()} preserves. Said as two rules in two
      * places, the second is the one a later reader drops as an oversight.
      */
-    public boolean offers(Set<RowKey> rows, OfferItem item) {
-        for (RowKey row : rows) {
-            if (byRow.get(row).get(item).settles()) {
+    public boolean offers(Set<RowKey> rowKeys, OfferItem item) {
+        for (RowKey rowKey : rowKeys) {
+            if (byRow.get(rowKey).get(item).settles()) {
                 return true;
             }
         }
-        return rows.contains(composedFor.get(item));
+        return rowKeys.contains(composedFor.get(item));
     }
 
     /**
@@ -117,15 +118,15 @@ public record Settlements(List<OfferItem> requested,
         // way for every row, the walk would go over every item once per row to find the few that
         // name it.
         Map<RowKey, List<OfferItem>> composedHere = new LinkedHashMap<>();
-        composedFor.forEach((item, row) ->
-                composedHere.computeIfAbsent(row, _ -> new ArrayList<>()).add(item));
+        composedFor.forEach((item, rowKey) ->
+                composedHere.computeIfAbsent(rowKey, _ -> new ArrayList<>()).add(item));
         List<RowKey> inOrder = new ArrayList<>(byRow.keySet());
         Set<RowKey> kept = new LinkedHashSet<>(inOrder);
         for (int at = inOrder.size() - 1; at >= 0; at--) {
-            RowKey row = inOrder.get(at);
-            if (goes(row, composedHere.getOrDefault(row, List.of()), count)) {
-                kept.remove(row);
-                byRow.get(row).forEach((item, settlement) -> {
+            RowKey rowKey = inOrder.get(at);
+            if (goes(rowKey, composedHere.getOrDefault(rowKey, List.of()), count)) {
+                kept.remove(rowKey);
+                byRow.get(rowKey).forEach((item, settlement) -> {
                     if (settlement.settles()) {
                         count.merge(item, -1, Integer::sum);
                     }
@@ -137,8 +138,8 @@ public record Settlements(List<OfferItem> requested,
     }
 
     /**
-     * Whether the offering offers as much without {@code row} as with it — {@link #offers} for
-     * every item, read off the counts rather than walked again.
+     * Whether the offering offers as much without the row {@code rowKey} addresses as with it —
+     * {@link #offers} for every item, read off the counts rather than walked again.
      *
      * <p>The counts hold the kept rows and this one among them. So an item this row settles needs a
      * second settler to be left after it goes, and an item it was composed for and settles nothing
@@ -146,8 +147,9 @@ public record Settlements(List<OfferItem> requested,
      *
      * @param composedHere what this row was composed for
      */
-    private boolean goes(RowKey row, List<OfferItem> composedHere, Map<OfferItem, Integer> count) {
-        Map<OfferItem, Settlement> here = byRow.get(row);
+    private boolean goes(RowKey rowKey, List<OfferItem> composedHere,
+                         Map<OfferItem, Integer> count) {
+        Map<OfferItem, Settlement> here = byRow.get(rowKey);
         for (Map.Entry<OfferItem, Settlement> each : here.entrySet()) {
             if (each.getValue().settles() && count.get(each.getKey()) <= 1) {
                 return false;
@@ -417,11 +419,11 @@ public record Settlements(List<OfferItem> requested,
             return RowAsRead.of(sig, building, trial, inputs);
         }
 
-        Settlement settlementOf(RowAsRead row, OfferItem item) {
+        Settlement settlementOf(RowAsRead asRead, OfferItem item) {
             return switch (item) {
-                case OfferItem.AClass(var owed) -> inClass(row, owed);
-                case OfferItem.AnArm(var owed) -> throughArm(row, owed);
-                case OfferItem.APointOfALine at -> atThePoint(row, at);
+                case OfferItem.AClass(var owed) -> inClass(asRead, owed);
+                case OfferItem.AnArm(var owed) -> throughArm(asRead, owed);
+                case OfferItem.APointOfALine at -> atThePoint(asRead, at);
             };
         }
 
@@ -432,15 +434,15 @@ public record Settlements(List<OfferItem> requested,
          * another one is not something a row written here has a value at — which is a row that does
          * not settle it rather than one nothing could tell about.
          */
-        private Settlement inClass(RowAsRead row, Generator.ClassOwed owed) {
+        private Settlement inClass(RowAsRead asRead, Generator.ClassOwed owed) {
             if (!behavior.equals(owed.at().behavior())) {
                 return new Settlement.DoesNotSettle();
             }
-            if (row.values() == null) {
-                return undetermined(row);
+            if (asRead.values() == null) {
+                return undetermined(asRead);
             }
             Classification at =
-                    InputClassifications.of(row.values(), where, axes).get(owed.at());
+                    InputClassifications.of(asRead.values(), where, axes).get(owed.at());
             if (at == null) {
                 return new Settlement.DoesNotSettle();
             }
@@ -460,8 +462,8 @@ public record Settlements(List<OfferItem> requested,
          * — and where there is none, this says so rather than reading the absence as a row that
          * missed.
          */
-        private Settlement throughArm(RowAsRead row, Generator.ArmOwed owed) {
-            return switch (row.watched()) {
+        private Settlement throughArm(RowAsRead asRead, Generator.ArmOwed owed) {
+            return switch (asRead.watched()) {
                 case Generator.Watched.Ran(var account) -> account.taken().contains(owed.probe())
                         ? new Settlement.Settles() : new Settlement.DoesNotSettle();
                 case Generator.Watched.NoAccount _ ->
@@ -476,7 +478,7 @@ public record Settlements(List<OfferItem> requested,
          * behavior's readings do not meet is one a row written here does not settle. Where they do,
          * the walk that reads a written row against the point reads this one.
          */
-        private Settlement atThePoint(RowAsRead read, OfferItem.APointOfALine at) {
+        private Settlement atThePoint(RowAsRead asRead, OfferItem.APointOfALine at) {
             List<AtAPoint> here = reads.get(at);
             if (here == null || here.isEmpty()) {
                 // No reading of this line in this behavior. A row written here has no value on the
@@ -484,16 +486,17 @@ public record Settlements(List<OfferItem> requested,
                 // nothing could tell about.
                 return new Settlement.DoesNotSettle();
             }
-            if (read.values() == null) {
-                return undetermined(read);
+            if (asRead.values() == null) {
+                return undetermined(asRead);
             }
-            ObservedInputs row = read.asInputs();
+            ObservedInputs observed = asRead.asInputs();
             // Existential over the readings, the way a point met at one position of a behavior is
             // met: a row standing on the line anywhere the behavior reads it is a row at the point.
             Settlement answer = new Settlement.DoesNotSettle();
             for (AtAPoint one : here) {
                 Settlement said = switch (StandingAtAPoint.met(one.line().cut().of(), where,
-                        List.of(row), one.criterion(), one.line().origin().comparisonAt())) {
+                        List.of(observed), one.criterion(),
+                        one.line().origin().comparisonAt())) {
                     case YES -> new Settlement.Settles();
                     case NO -> new Settlement.DoesNotSettle();
                     case NOT_WATCHED ->
@@ -519,7 +522,7 @@ public record Settlements(List<OfferItem> requested,
                             souther.compiler.partition.Criterion criterion) {}
 
     /** What an item that needs the values is told, where they are not here. */
-    private static Settlement undetermined(RowAsRead row) {
-        return new Settlement.Undetermined(row.whyNotRead());
+    private static Settlement undetermined(RowAsRead asRead) {
+        return new Settlement.Undetermined(asRead.whyNotRead());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -207,7 +207,7 @@ public record Settlements(List<OfferItem> requested,
         // searches alone, such a row came back undetermined at every item, so nothing it stands at
         // could ever make another row redundant.
         Map<String, OneBehavior> reading = new LinkedHashMap<>();
-        Set<String> carriers = new LinkedHashSet<>(offering.rows().keySet());
+        Set<String> carriers = new LinkedHashSet<>(offering.rowsByBehavior().keySet());
         carriers.addAll(offering.searched().keySet());
         for (String behavior : carriers) {
             Adequacy.Filling filling = offering.searched().get(behavior);
@@ -245,7 +245,7 @@ public record Settlements(List<OfferItem> requested,
             });
         }
         List<OfferItem> items = List.copyOf(new LinkedHashSet<>(requested));
-        offering.rows().forEach((behavior, rows) -> {
+        offering.rowsByBehavior().forEach((behavior, rows) -> {
             OneBehavior read = reading.get(behavior);
             for (OfferedRow row : rows) {
                 // Read once for the row and asked of every item. What a row is — where its values
@@ -384,14 +384,14 @@ public record Settlements(List<OfferItem> requested,
                 if (filling.composed().discharge().at(each)
                         instanceof souther.compiler.partition.ClassDisposition.Built built) {
                     out.put(new OfferItem.AClass(each),
-                            RowKey.of(behavior, filling.composed().rowFor(built.row())));
+                            RowKey.of(behavior, filling.composed().rowFor(built.rowId())));
                 }
             }
             for (Generator.ArmOwed each : arms) {
                 if (filling.composed().discharge().at(each)
                         instanceof souther.compiler.partition.ArmDisposition.Built built) {
                     out.put(new OfferItem.AnArm(each),
-                            RowKey.of(behavior, filling.composed().rowFor(built.row())));
+                            RowKey.of(behavior, filling.composed().rowFor(built.rowId())));
                 }
             }
             return out;

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -317,14 +317,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
          * written, and a reader shown {@code 0} beside a source nobody evaluated is told the author
          * wrote no row — which sends them to write one that may already be there.
          */
-        public java.util.OptionalInt rows() {
+        public java.util.OptionalInt rowCount() {
             return reading().measured().made()
                     .map(seen -> java.util.OptionalInt.of(seen.rows().size()))
                     .orElseGet(java.util.OptionalInt::empty);
         }
 
         /** How many of those are recorded rather than evaluated. Absent for the reason
-         *  {@link #rows()} is. */
+         *  {@link #rowCount()} is. */
         public java.util.OptionalInt pending() {
             return reading().measured().made()
                     .map(seen -> java.util.OptionalInt.of((int) seen.rows().stream()
@@ -375,7 +375,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // it — so an absence here is this report and that query disagreeing about what a module is,
         // and there is no reading of it that is not a guess.
         Map<String, Adequacy.RowReading> readings = java.util.Objects.requireNonNull(
-                compilation.db().ask(new Adequacy.Rows(name)).value(),
+                compilation.db().ask(new Adequacy.RowReadings(name)).value(),
                 () -> "the rows of `" + name + "` were not read for or against");
         Map<String, Adequacy.SignatureEvidence> signatures =
                 compilation.db().ask(new Adequacy.Witnesses(name)).value();
@@ -403,7 +403,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // say. `NOT_ASKED` and `NONE` are both things the reading says — a build that reads no
             // rows, and a reading that finished and found none — so picking one from an absent key
             // is a reader deciding what the producer answered (issue #996).
-            Adequacy.RowReading reading = Adequacy.Rows.readingFor(readings, behavior.name());
+            Adequacy.RowReading reading =
+                    Adequacy.RowReadings.readingFor(readings, behavior.name());
             // Anything larger than a behavior holds this one: a source that could not be evaluated is
             Adequacy.SignatureEvidence signature =
                     signatures == null ? null : signatures.get(behavior.name());
@@ -858,9 +859,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 out.append(String.format("  %s %s %s%n",
                         DisplayColumns.padRight(behavior.name(), 24),
                         DisplayColumns.padRight(behavior.implementation().written(), 13),
-                        behavior.rows().isPresent()
+                        behavior.rowCount().isPresent()
                                 ? String.format("rows %-4d pending %d",
-                                        behavior.rows().getAsInt(), behavior.pending().getAsInt())
+                                        behavior.rowCount().getAsInt(),
+                                        behavior.pending().getAsInt())
                                 : "rows not read"));
                 signature(out, behavior);
                 partition(out, behavior, module.declaredIn(), names);
@@ -2361,7 +2363,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // Written where the rows were read, and left out where they were not. A zero here
                 // is a behavior whose rows were read and numbered none of them, which a consumer
                 // acts on differently from rows nobody read.
-                behavior.rows().ifPresent(count -> b.put("rows", count));
+                behavior.rowCount().ifPresent(count -> b.put("rows", count));
                 behavior.pending().ifPresent(count -> b.put("pending", count));
                 b.put("status", wire(behavior.status()));
                 weakening(b, behavior.weakenedBy());

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -46,21 +46,22 @@ public final class GeneratedRows {
      *
      * <p>Two answers because callers ask two different things of this. What to print is the text; a
      * block of notes and no rows is worth printing, and {@code souther examples --generate} prints
-     * it. Whether there is a row to write is {@link #rows}, and it is the generator's answer rather
-     * than something read off the text: an editor offering "write the rows this does not cover"
+     * it. Whether there is a row to write is {@link #rowCount}, and it is the generator's answer
+     * rather than something read off the text: an editor offering "write the rows this does not cover"
      * asked whether the block was blank, and a block that holds only the reason nothing was composed
      * is not blank — so the action appeared, a person took it, and what it wrote into their source
      * was a comment (issue #955).
      *
-     * @param rows how many rows the block offers, which is what a caller that is about to change
-     *             somebody's source has to ask
+     * @param rowCount how many rows the block offers, which is what a caller that is about to
+     *                 change somebody's source has to ask
      */
-    public record Block(String text, int rows) {
+    public record Block(String text, int rowCount) {
 
         public Block {
             java.util.Objects.requireNonNull(text, "a block is of something, even if it is empty");
-            if (rows < 0) {
-                throw new IllegalArgumentException("a block offering fewer than no rows: " + rows);
+            if (rowCount < 0) {
+                throw new IllegalArgumentException(
+                        "a block offering fewer than no rows: " + rowCount);
             }
         }
     }
@@ -97,7 +98,7 @@ public final class GeneratedRows {
             }
             Block one = of(offering, WrittenEnsures.of(compilation.db(), name), names);
             out.append(one.text());
-            rows += one.rows();
+            rows += one.rowCount();
         }
         return new Block(out.toString(), rows);
     }
@@ -356,7 +357,7 @@ public final class GeneratedRows {
      */
     private static Map<String, List<Offered>> named(Offering offering) {
         Map<String, List<Offered>> out = new LinkedHashMap<>();
-        offering.rows().forEach((behavior, rows) -> {
+        offering.rowsByBehavior().forEach((behavior, rows) -> {
             Map<Integer, String> arms = armNames(offering.searched().get(behavior));
             List<Offered> here = new ArrayList<>();
             for (souther.compiler.query.OfferedRow row : rows) {

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -469,7 +469,7 @@ class AMeasureWithNoNumberSaysWhyTest {
         // And the count says so rather than saying zero. `0` is a behavior whose rows were read and
         // numbered none of them, which is the other half of the pair this test is about: written
         // as a number, "nothing was read" and "nothing was written" were the same byte.
-        assertEquals(java.util.OptionalInt.empty(), reported.rows(), "nothing was read");
+        assertEquals(java.util.OptionalInt.empty(), reported.rowCount(), "nothing was read");
         assertTrue(AdequacyReport.of(compilation).modules().get(0).incompleteness().stream()
                         .anyMatch(gap -> gap.code() == Incompleteness.Code.OBSERVATION_ABSENT),
                 "and there may well have been something to read");
@@ -707,7 +707,7 @@ class AMeasureWithNoNumberSaysWhyTest {
     private static Map<String, Adequacy.RowReading> readings() {
         Compilation compilation = compiled();
         return compilation.db()
-                .ask(new Adequacy.Rows(compilation.modules().get(0))).value();
+                .ask(new Adequacy.RowReadings(compilation.modules().get(0))).value();
     }
 
     private static Map<String, Adequacy.BranchEvidence> branches() {

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsEvaluatedOncePerCompileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsEvaluatedOncePerCompileTest.java
@@ -77,7 +77,7 @@ class ARowIsEvaluatedOncePerCompileTest {
     }
 
     private static long rowsRunIn(Adequacy.Asked measure) {
-        return workOf(measure).stream().filter(w -> w instanceof Deadline.Work.Row).count();
+        return workOf(measure).stream().filter(w -> w instanceof Deadline.Work.WholeRow).count();
     }
 
     /** Two rows, two evaluations — not four. */

--- a/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowIsReadUnderWhateverBehaviorComposedItTest.java
@@ -72,8 +72,8 @@ class ARowIsReadUnderWhateverBehaviorComposedItTest {
         // `Composition.composed` is written for, and the one a reader off the searches cannot read.
         Composition composed = Composition.composed(
                 OfferingRequest.overTheModule("example.carried", true), Map.of(), declared);
-        assertFalse(composed.rows().isEmpty(), "the row is offered under its carrier: " + composed);
-        for (String carrier : composed.rows().keySet()) {
+        assertFalse(composed.rowsByBehavior().isEmpty(), "the row is offered under its carrier: " + composed);
+        for (String carrier : composed.rowsByBehavior().keySet()) {
             assertFalse(composed.searched().containsKey(carrier),
                     "and nothing was searched for that behavior: " + carrier);
         }

--- a/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEquivalencePartitionIsWhatTheModelDistinguishesTest.java
@@ -145,9 +145,9 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
                     | "under" : (0.30m) -> Yes { v = 1 }
                     | "over" : (0.34m) -> No { why = 0 }""");
 
-        assertEquals(2, measured.axes().get(0).rows().covered().size(),
+        assertEquals(2, WhatTheRowsReached.at(measured.axes().get(0)).covered().size(),
                 "three tenths is under a third and thirty-four hundredths is over it: "
-                        + measured.axes().get(0).rows().covered());
+                        + WhatTheRowsReached.at(measured.axes().get(0)).covered());
     }
 
     /**
@@ -160,14 +160,14 @@ class AnEquivalencePartitionIsWhatTheModelDistinguishesTest {
      */
     @Test
     void aClassStopsAtALineThePositionCannotName() {
-        List<String> covered = measured("Decimal", """
+        List<String> covered = WhatTheRowsReached.at(measured("Decimal", """
                     guard n > 0.2m else No { why = 0 }
                     guard 3m * n > 1m else No { why = 1 }""",
                 """
                     | "low" : (0.1m) -> No { why = 0 }
                     | "mid" : (0.3m) -> No { why = 1 }
                     | "high" : (0.5m) -> Yes { v = 1 }""")
-                .axes().get(0).rows().covered().stream().sorted().toList();
+                .axes().get(0)).covered().stream().sorted().toList();
 
         assertEquals(3, covered.size(), "one row in each of the three classes: " + covered);
         assertEquals(List.of("n/0.2 < x and 3 * x <= 1", "n/1 < 3 * x", "n/x <= 0.2"), covered,

--- a/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
+++ b/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
@@ -161,7 +161,7 @@ public final class DoesNotComeBack {
 
     /** Every row of {@code target}, evaluated — its fixtures built, the behavior applied. */
     static Predicate<Deadline.Work> everyRowOf(String target) {
-        return w -> w instanceof Deadline.Work.Row row && row.target().equals(target);
+        return w -> w instanceof Deadline.Work.WholeRow row && row.target().equals(target);
     }
 
     /** The statements every row of {@code target} is read from, with nothing applied. */
@@ -185,7 +185,7 @@ public final class DoesNotComeBack {
     static Predicate<Deadline.Work> everythingAboutTheRowNamed(String name) {
         RowIdentity named = new RowIdentity.Named(name);
         return w -> switch (w) {
-            case Deadline.Work.Row row -> named.equals(row.identity());
+            case Deadline.Work.WholeRow row -> named.equals(row.identity());
             case Deadline.Work.Fixtures f -> named.equals(f.identity());
             default -> false;
         };

--- a/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
@@ -15,7 +15,6 @@ import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.RecordAttribute;
 import java.lang.classfile.attribute.RecordComponentInfo;
 import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -89,15 +88,13 @@ class OnlyARowIsCalledARowTest {
     /**
      * What a plurality of rows is held in.
      *
-     * <p>A closed list, so that a shape nobody has decided about arrives here as a failure rather
-     * than as a pass. A map from something to rows is not on it: what its keys are is a second
-     * thing the value says, and a name that does not say it leaves the reader to find out.
+     * <p>What this compiler holds them in, and nothing else. A closed list is the point — a shape
+     * nobody has decided about arrives as a failure rather than as a pass — so a shape nobody has
+     * written yet is not admitted in advance either. A map from something to rows is the case that
+     * made this worth closing: what its keys are is a second thing the value says, and a name that
+     * does not say it leaves the reader to find out.
      */
-    private static final Set<String> CONTAINERS = Set.of(
-            "java/util/Collection",
-            "java/util/List",
-            "java/util/SequencedCollection",
-            "java/util/Set");
+    private static final Set<String> CONTAINERS = Set.of("java/util/List");
 
     private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
 
@@ -139,8 +136,13 @@ class OnlyARowIsCalledARowTest {
     @Test
     void bothOfThoseAreOverSomething() throws IOException, URISyntaxException {
         List<ClassModel> compiled = compiled();
-        assertTrue(compiled.size() > 100,
-                "the walk reads this module's classes, and read " + compiled.size());
+        // Named, rather than counted against a floor somebody chose: a walk that reached the
+        // classes the rule is written about is what this is asking, and a number would be met by
+        // any hundred of them.
+        List<String> internal = compiled.stream().map(OnlyARowIsCalledARowTest::internal).toList();
+        for (String each : ROWS) {
+            assertTrue(internal.contains(each), () -> "the walk did not reach " + each);
+        }
         List<String> allowed = new ArrayList<>();
         for (ClassModel each : compiled) {
             for (MethodModel method : each.methods()) {
@@ -159,6 +161,11 @@ class OnlyARowIsCalledARowTest {
      * <p>One name of one class is one finding. A record component, the field it writes and the
      * accessor that answers it are one thing the author wrote, and so are a field and the accessor
      * beside it; naming each of them would say the same finding three times over.
+     *
+     * <p>So a record whose component takes the reserved name and may hold it covers a second
+     * declaration of that name in the same record — a static field, which is the only way to write
+     * one. Nothing in this compiler does, and closing it would mean telling a component's own field
+     * and accessor from a member that merely shares its name, which a class file does not say.
      */
     private static List<String> membersOf(ClassModel of) {
         List<String> wrong = new ArrayList<>();
@@ -201,17 +208,17 @@ class OnlyARowIsCalledARowTest {
             case Signature.ArrayTypeSig array -> answersARow(array.componentSignature());
             case Signature.ClassTypeSig cls -> ROWS.contains(named(cls))
                     || CONTAINERS.contains(named(cls)) && cls.typeArgs().size() == 1
-                    && answersARow(argument(cls.typeArgs().getFirst()));
+                    && holdsARow(cls.typeArgs().getFirst());
             default -> false;
         };
     }
 
-    /** What a type argument stands for, or the type variable that stands for nothing here. */
-    private static Signature argument(Signature.TypeArg arg) {
-        return switch (arg) {
-            case Signature.TypeArg.Bounded bounded -> bounded.boundType();
-            case Signature.TypeArg.Unbounded _ -> Signature.of(ConstantDescs.CD_Object);
-        };
+    /** Whether a container's one type argument names a row. A wildcard does not: what a list of
+     *  something unsaid holds is not something this was told. */
+    private static boolean holdsARow(Signature.TypeArg arg) {
+        return arg instanceof Signature.TypeArg.Bounded bounded
+                && bounded.wildcardIndicator() == Signature.TypeArg.Bounded.WildcardIndicator.NONE
+                && answersARow(bounded.boundType());
     }
 
     private static String named(Signature.ClassTypeSig of) {
@@ -247,7 +254,19 @@ class OnlyARowIsCalledARowTest {
             case Signature.TypeVarSig var -> var.identifier();
             case Signature.ClassTypeSig cls -> cls.typeArgs().isEmpty() ? named(cls)
                     : named(cls) + "<" + String.join(", ",
-                            cls.typeArgs().stream().map(it -> shown(argument(it))).toList()) + ">";
+                            cls.typeArgs().stream().map(OnlyARowIsCalledARowTest::shown).toList())
+                            + ">";
+        };
+    }
+
+    private static String shown(Signature.TypeArg arg) {
+        return switch (arg) {
+            case Signature.TypeArg.Unbounded _ -> "?";
+            case Signature.TypeArg.Bounded bounded -> switch (bounded.wildcardIndicator()) {
+                case NONE -> shown(bounded.boundType());
+                case EXTENDS -> "? extends " + shown(bounded.boundType());
+                case SUPER -> "? super " + shown(bounded.boundType());
+            };
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
@@ -4,11 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Prepared;
 import souther.test.Signatures;
+import souther.test.TheBareRowNames;
 import souther.test.WhatAModuleDeclares;
 
-import java.lang.classfile.ClassModel;
 import java.lang.classfile.Signature;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,34 +90,20 @@ class OnlyARowIsCalledARowTest {
      */
     private static final Set<String> CONTAINERS = Set.of("java/util/List");
 
-    private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
-
-    private static final Set<String> RESERVED_TYPES = Set.of("Row", "Rows");
-
     /** A member called {@code row} or {@code rows} answers a row, or rows. */
     @Test
     void aMemberCalledRowAnswersARow() {
-        List<String> wrong = new ArrayList<>();
-        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
-            if (!answersARow(each.type())) {
-                wrong.add(each.shown());
-            }
-        }
-        assertEquals(List.of(), wrong,
+        assertEquals(List.of(),
+                TheBareRowNames.takenIn(compiled(), each -> answersARow(each.type())),
                 "a member called row or rows answers a row or rows, and these answer something else");
     }
 
     /** A type called {@code Row} or {@code Rows} is a row, or is rows. */
     @Test
     void aTypeCalledRowIsARow() {
-        List<String> wrong = new ArrayList<>();
-        for (ClassModel each : compiled().classes()) {
-            String internal = each.thisClass().asInternalName();
-            if (RESERVED_TYPES.contains(simple(internal)) && !ROWS.contains(internal)) {
-                wrong.add(internal);
-            }
-        }
-        assertEquals(List.of(), wrong,
+        assertEquals(List.of(),
+                TheBareRowNames.typesIn(compiled()).stream()
+                        .filter(each -> !ROWS.contains(each)).toList(),
                 "a type called Row or Rows is a row, and these are something else");
     }
 
@@ -176,7 +161,7 @@ class OnlyARowIsCalledARowTest {
         for (String each : ROWS) {
             assertTrue(internal.contains(each), () -> "the walk did not reach " + each);
         }
-        assertFalse(compiled().taking(RESERVED_MEMBERS).isEmpty(),
+        assertFalse(compiled().taking(TheBareRowNames.MEMBERS).isEmpty(),
                 "the reserved name is in use on what may hold it");
     }
 
@@ -216,11 +201,6 @@ class OnlyARowIsCalledARowTest {
                 && bounded.wildcardIndicator()
                         != Signature.TypeArg.Bounded.WildcardIndicator.SUPER
                 && isARow(bounded.boundType());
-    }
-
-    private static String simple(String internal) {
-        String last = internal.substring(internal.lastIndexOf('/') + 1);
-        return last.substring(last.lastIndexOf('$') + 1);
     }
 
     private static WhatAModuleDeclares compiled() {

--- a/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,278 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Prepared;
+
+import java.io.IOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.MethodSignature;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.RecordAttribute;
+import java.lang.classfile.attribute.RecordComponentInfo;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>A row is one line of an {@code example} or {@code fake} table. The things holding rows nest —
+ * a block holds rows, a module's preparation holds blocks, a report holds a number of them — and
+ * every one of those levels can be spelled {@code rows} without a reader being told which they have.
+ * A count taken off the wrong level is a count of blocks that reads as a count of rows, and the
+ * name is what produced the expectation.
+ *
+ * <p><b>Two prohibitions, because a level can be named twice.</b> A declaration names a level by
+ * what it calls the member that answers it, and by what it calls the type that is it. Closing only
+ * the member leaves a type free to be called {@code Rows} while holding blocks, which is where this
+ * was found.
+ *
+ * <p><b>What is reserved is the bare name.</b> {@code row} and {@code rows} exactly, and the types
+ * {@code Row} and {@code Rows} exactly. A compound name has a different head concept —
+ * {@code rowCount} is a number, {@code RowReading} is a reading, {@code RowsRead} is what was read
+ * — and a rule that took names apart into tokens would be a naming lint rather than this claim.
+ * Nothing here says a compound name holds rows; only that the bare name is not available to
+ * anything else.
+ *
+ * <p><b>What it is over is production declarations.</b> It reads the main class files of this
+ * module, which is where the row vocabulary is declared and where a reader of this compiler meets
+ * it. Test fixtures, local variables and parameters are not part of the surface it protects: a
+ * table-driven test's own {@code Row} is not a name any reader of the compiler resolves, and what a
+ * method calls a value inside its body is not a declaration. Serialized vocabulary is outside it
+ * too — a report's JSON key {@code "rows"} is a wire contract of its own and is not renamed by
+ * anything said here.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /**
+     * The rows of this compiler.
+     *
+     * <p>The declaration of what the word means. A value of one of these types is one row itself,
+     * at whichever stage the type belongs to — what an author wrote, what the check settled, what a
+     * run recorded, what a generator offered. A line stays a line all the way along, so the list is
+     * a chain and not a layer.
+     *
+     * <p>What is not on it is everything that is <em>about</em> a row. An identity, a reference, an
+     * id, a key, a reading, a verdict, a deadline and a unit of work each hold a row's whereabouts
+     * beside something else, and a reader handed one of them under the bare name would take it for
+     * the line.
+     */
+    private static final Set<String> ROWS = Set.of(
+            "souther/compiler/ast/Ast$ExampleRow",
+            "souther/compiler/ast/Ast$FakeRow",
+            "souther/compiler/ast/Hir$ExampleRow",
+            "souther/compiler/ast/Hir$FakeRow",
+            "souther/compiler/examples/RecordedRow",
+            "souther/compiler/observe/RowOutcome",
+            "souther/compiler/partition/Generator$GeneratedRow",
+            "souther/compiler/program/CheckedRow",
+            "souther/compiler/query/OfferedRow",
+            "souther/compiler/query/Output$RowsRead$ReadRow");
+
+    /**
+     * What a plurality of rows is held in.
+     *
+     * <p>A closed list, so that a shape nobody has decided about arrives here as a failure rather
+     * than as a pass. A map from something to rows is not on it: what its keys are is a second
+     * thing the value says, and a name that does not say it leaves the reader to find out.
+     */
+    private static final Set<String> CONTAINERS = Set.of(
+            "java/util/Collection",
+            "java/util/List",
+            "java/util/SequencedCollection",
+            "java/util/Set");
+
+    private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
+
+    private static final Set<String> RESERVED_TYPES = Set.of("Row", "Rows");
+
+    /** A member called {@code row} or {@code rows} answers a row, or rows. */
+    @Test
+    void aMemberCalledRowAnswersARow() throws IOException, URISyntaxException {
+        List<String> wrong = new ArrayList<>();
+        for (ClassModel each : compiled()) {
+            wrong.addAll(membersOf(each));
+        }
+        assertEquals(List.of(), wrong,
+                "a member called row or rows answers a row or rows, and these answer something else");
+    }
+
+    /** A type called {@code Row} or {@code Rows} is a row, or is rows. */
+    @Test
+    void aTypeCalledRowIsARow() throws IOException, URISyntaxException {
+        List<String> wrong = new ArrayList<>();
+        for (ClassModel each : compiled()) {
+            String internal = internal(each);
+            if (RESERVED_TYPES.contains(simple(internal)) && !ROWS.contains(internal)) {
+                wrong.add(internal);
+            }
+        }
+        assertEquals(List.of(), wrong,
+                "a type called Row or Rows is a row, and these are something else");
+    }
+
+    /**
+     * And both prohibitions are over something.
+     *
+     * <p>Both pass on the empty set, which is also what a walk that read nothing answers. The rows
+     * are the population the member rule is about — a name it lets through rather than one it never
+     * met — and the classes are what the type rule ranges over. Told neither, a walk that had lost
+     * its way would report this module clean.
+     */
+    @Test
+    void bothOfThoseAreOverSomething() throws IOException, URISyntaxException {
+        List<ClassModel> compiled = compiled();
+        assertTrue(compiled.size() > 100,
+                "the walk reads this module's classes, and read " + compiled.size());
+        List<String> allowed = new ArrayList<>();
+        for (ClassModel each : compiled) {
+            for (MethodModel method : each.methods()) {
+                if (RESERVED_MEMBERS.contains(method.methodName().stringValue())
+                        && answersARow(answeredBy(method))) {
+                    allowed.add(internal(each) + "." + method.methodName().stringValue());
+                }
+            }
+        }
+        assertFalse(allowed.isEmpty(), "the reserved name is in use on what may hold it");
+    }
+
+    /**
+     * Every declaration of one class that takes the reserved name.
+     *
+     * <p>One name of one class is one finding. A record component, the field it writes and the
+     * accessor that answers it are one thing the author wrote, and so are a field and the accessor
+     * beside it; naming each of them would say the same finding three times over.
+     */
+    private static List<String> membersOf(ClassModel of) {
+        List<String> wrong = new ArrayList<>();
+        Set<String> said = new LinkedHashSet<>();
+        Set<String> components = new LinkedHashSet<>();
+        for (RecordComponentInfo each : of.findAttribute(Attributes.record())
+                .map(RecordAttribute::components).orElse(List.of())) {
+            components.add(each.name().stringValue());
+            if (RESERVED_MEMBERS.contains(each.name().stringValue())
+                    && !answersARow(signatureOf(each)) && said.add(each.name().stringValue())) {
+                wrong.add(internal(of) + "." + each.name().stringValue()
+                        + " : " + shown(signatureOf(each)));
+            }
+        }
+        for (FieldModel each : of.fields()) {
+            String name = each.fieldName().stringValue();
+            if (RESERVED_MEMBERS.contains(name) && !components.contains(name)
+                    && !answersARow(signatureOf(each)) && said.add(name)) {
+                wrong.add(internal(of) + "." + name + " : " + shown(signatureOf(each)));
+            }
+        }
+        for (MethodModel each : of.methods()) {
+            String name = each.methodName().stringValue();
+            if (RESERVED_MEMBERS.contains(name) && !components.contains(name)
+                    && !answersARow(answeredBy(each)) && said.add(name)) {
+                wrong.add(internal(of) + "." + name + " : " + shown(answeredBy(each)));
+            }
+        }
+        return wrong;
+    }
+
+    /**
+     * Whether what a member answers is a row, or rows.
+     *
+     * <p>An array of rows is rows for the same reason a list of them is. A number is not: what it
+     * counts is not in it, which is how a count of blocks comes to be read as a count of rows.
+     */
+    private static boolean answersARow(Signature answered) {
+        return switch (answered) {
+            case Signature.ArrayTypeSig array -> answersARow(array.componentSignature());
+            case Signature.ClassTypeSig cls -> ROWS.contains(named(cls))
+                    || CONTAINERS.contains(named(cls)) && cls.typeArgs().size() == 1
+                    && answersARow(argument(cls.typeArgs().getFirst()));
+            default -> false;
+        };
+    }
+
+    /** What a type argument stands for, or the type variable that stands for nothing here. */
+    private static Signature argument(Signature.TypeArg arg) {
+        return switch (arg) {
+            case Signature.TypeArg.Bounded bounded -> bounded.boundType();
+            case Signature.TypeArg.Unbounded _ -> Signature.of(ConstantDescs.CD_Object);
+        };
+    }
+
+    private static String named(Signature.ClassTypeSig of) {
+        String descriptor = of.classDesc().descriptorString();
+        return descriptor.substring(1, descriptor.length() - 1);
+    }
+
+    /** What a method answers, generic where it was written generic. */
+    private static Signature answeredBy(MethodModel of) {
+        Optional<MethodSignature> generic = of.findAttribute(Attributes.signature())
+                .map(it -> MethodSignature.parseFrom(it.signature().stringValue()));
+        return generic.map(MethodSignature::result)
+                .orElseGet(() -> Signature.of(of.methodTypeSymbol().returnType()));
+    }
+
+    private static Signature signatureOf(FieldModel of) {
+        return of.findAttribute(Attributes.signature())
+                .map(it -> Signature.parseFrom(it.signature().stringValue()))
+                .orElseGet(() -> Signature.of(of.fieldTypeSymbol()));
+    }
+
+    private static Signature signatureOf(RecordComponentInfo of) {
+        return of.findAttribute(Attributes.signature())
+                .map(it -> Signature.parseFrom(it.signature().stringValue()))
+                .orElseGet(() -> Signature.of(of.descriptorSymbol()));
+    }
+
+    private static String shown(Signature of) {
+        return switch (of) {
+            case Signature.ArrayTypeSig array -> shown(array.componentSignature()) + "[]";
+            case Signature.BaseTypeSig base ->
+                    ClassDesc.ofDescriptor(String.valueOf(base.baseType())).displayName();
+            case Signature.TypeVarSig var -> var.identifier();
+            case Signature.ClassTypeSig cls -> cls.typeArgs().isEmpty() ? named(cls)
+                    : named(cls) + "<" + String.join(", ",
+                            cls.typeArgs().stream().map(it -> shown(argument(it))).toList()) + ">";
+        };
+    }
+
+    private static String internal(ClassModel of) {
+        return of.thisClass().asInternalName();
+    }
+
+    private static String simple(String internal) {
+        String last = internal.substring(internal.lastIndexOf('/') + 1);
+        return last.substring(last.lastIndexOf('$') + 1);
+    }
+
+    /** Every class this compiler was built into, found from where one of them is loaded from. */
+    private static List<ClassModel> compiled() throws IOException, URISyntaxException {
+        Path root = Path.of(Prepared.class.getResource("Prepared.class").toURI());
+        for (int up = 0; up <= "souther/compiler/check".chars().filter(it -> it == '/').count();
+                up++) {
+            root = root.getParent();
+        }
+        List<ClassModel> out = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(root)) {
+            for (Path each : walk.filter(it -> it.toString().endsWith(".class")).sorted().toList()) {
+                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
+            }
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
@@ -3,29 +3,16 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Prepared;
+import souther.test.Signatures;
+import souther.test.WhatAModuleDeclares;
 
-import java.io.IOException;
-import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
-import java.lang.classfile.FieldModel;
-import java.lang.classfile.MethodModel;
-import java.lang.classfile.MethodSignature;
 import java.lang.classfile.Signature;
-import java.lang.classfile.attribute.RecordAttribute;
-import java.lang.classfile.attribute.RecordComponentInfo;
-import java.lang.constant.ClassDesc;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,6 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the member leaves a type free to be called {@code Rows} while holding blocks, which is where this
  * was found.
  *
+ * <p><b>And one claim, because a prohibition alone cannot be held to.</b> Both prohibitions are
+ * over what this module holds, so widening what counts as rows moves the population with them and
+ * leaves nothing to report: a rule that admits more finds less. What the rule admits is said
+ * separately, against shapes rather than against the module.
+ *
  * <p><b>What is reserved is the bare name.</b> {@code row} and {@code rows} exactly, and the types
  * {@code Row} and {@code Rows} exactly. A compound name has a different head concept —
  * {@code rowCount} is a number, {@code RowReading} is a reading, {@code RowsRead} is what was read
@@ -54,7 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p><b>What it is over is production declarations.</b> It reads the main class files of this
  * module, which is where the row vocabulary is declared and where a reader of this compiler meets
- * it. Test fixtures, local variables and parameters are not part of the surface it protects: a
+ * it. The modules beside it hold the same rule and say it themselves, each over its own classes.
+ * Test fixtures, local variables and parameters are not part of the surface it protects: a
  * table-driven test's own {@code Row} is not a name any reader of the compiler resolves, and what a
  * method calls a value inside its body is not a declaration. Serialized vocabulary is outside it
  * too — a report's JSON key {@code "rows"} is a wire contract of its own and is not renamed by
@@ -104,10 +97,12 @@ class OnlyARowIsCalledARowTest {
 
     /** A member called {@code row} or {@code rows} answers a row, or rows. */
     @Test
-    void aMemberCalledRowAnswersARow() throws IOException, URISyntaxException {
+    void aMemberCalledRowAnswersARow() {
         List<String> wrong = new ArrayList<>();
-        for (ClassModel each : compiled()) {
-            wrong.addAll(membersOf(each));
+        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
+            if (!answersARow(each.type())) {
+                wrong.add(each.shown());
+            }
         }
         assertEquals(List.of(), wrong,
                 "a member called row or rows answers a row or rows, and these answer something else");
@@ -115,10 +110,10 @@ class OnlyARowIsCalledARowTest {
 
     /** A type called {@code Row} or {@code Rows} is a row, or is rows. */
     @Test
-    void aTypeCalledRowIsARow() throws IOException, URISyntaxException {
+    void aTypeCalledRowIsARow() {
         List<String> wrong = new ArrayList<>();
-        for (ClassModel each : compiled()) {
-            String internal = internal(each);
+        for (ClassModel each : compiled().classes()) {
+            String internal = each.thisClass().asInternalName();
             if (RESERVED_TYPES.contains(simple(internal)) && !ROWS.contains(internal)) {
                 wrong.add(internal);
             }
@@ -128,43 +123,12 @@ class OnlyARowIsCalledARowTest {
     }
 
     /**
-     * And both prohibitions are over something.
-     *
-     * <p>Both pass on the empty set, which is also what a walk that read nothing answers. The rows
-     * are the population the member rule is about — a name it lets through rather than one it never
-     * met — and the classes are what the type rule ranges over. Told neither, a walk that had lost
-     * its way would report this module clean.
-     */
-    @Test
-    void bothOfThoseAreOverSomething() throws IOException, URISyntaxException {
-        List<ClassModel> compiled = compiled();
-        // Named, rather than counted against a floor somebody chose: a walk that reached the
-        // classes the rule is written about is what this is asking, and a number would be met by
-        // any hundred of them.
-        List<String> internal = compiled.stream().map(OnlyARowIsCalledARowTest::internal).toList();
-        for (String each : ROWS) {
-            assertTrue(internal.contains(each), () -> "the walk did not reach " + each);
-        }
-        List<String> allowed = new ArrayList<>();
-        for (ClassModel each : compiled) {
-            for (MethodModel method : each.methods()) {
-                if (RESERVED_MEMBERS.contains(method.methodName().stringValue())
-                        && answersARow(answeredBy(method))) {
-                    allowed.add(internal(each) + "." + method.methodName().stringValue());
-                }
-            }
-        }
-        assertFalse(allowed.isEmpty(), "the reserved name is in use on what may hold it");
-    }
-
-    /**
      * And what the reserved name may answer is these shapes and no others.
      *
-     * <p>The two prohibitions above say what this module holds today, so an edit that widened what
-     * counts as rows would go on passing — the population would move with it and nothing would be
-     * left to report. What the rule admits is a claim of its own, and it is made here against
-     * shapes rather than against the module: each is written out and run, so widening the rule
-     * fails on the shape it newly admits and narrowing it fails on the shape it stops admitting.
+     * <p>The two prohibitions say what this module holds today, so an edit that widened what counts
+     * as rows would go on passing — the population would move with it and nothing would be left to
+     * report. So what the rule admits is claimed here against shapes: each is written out and run,
+     * and widening the rule fails on the shape it newly admits.
      *
      * <p>The refusals are the ones that cost something. A plurality of pluralities is the shape
      * this whole rule came from: {@code rows().size()} over one is a count of groups read as a
@@ -176,14 +140,14 @@ class OnlyARowIsCalledARowTest {
         Map<String, Boolean> shapes = new LinkedHashMap<>();
         shapes.put(row, true);                                  // a row
         shapes.put("Ljava/util/List<" + row + ">;", true);       // rows
-        shapes.put("[" + row, true);                            // rows, written as an array
         shapes.put("Ljava/util/List<+" + row + ">;", true);      // rows nothing writes to
         shapes.put("Ljava/util/List<Ljava/util/List<" + row + ">;>;", false);   // groups of rows
-        shapes.put("[[" + row, false);                          // the same, written as an array
+        shapes.put("[" + row, false);                           // a shape nobody has decided about
+        shapes.put("[[" + row, false);                          // groups of them, as an array
         shapes.put("[Ljava/util/List<" + row + ">;", false);     // and the same, mixed
         shapes.put("Ljava/util/Map<Ljava/lang/String;Ljava/util/List<" + row + ">;>;",
                 false);                                         // rows under a key
-        shapes.put("Ljava/util/Set<" + row + ">;", false);       // a shape nobody has decided about
+        shapes.put("Ljava/util/Set<" + row + ">;", false);       // another nobody has decided about
         shapes.put("Ljava/util/List<-" + row + ">;", false);     // rows go in, anything comes out
         shapes.put("Ljava/util/List<*>;", false);                // what it holds is unsaid
         shapes.put("Lsouther/compiler/check/Prepared$ForExamples;", false);   // what holds blocks
@@ -196,45 +160,24 @@ class OnlyARowIsCalledARowTest {
     }
 
     /**
-     * Every declaration of one class that takes the reserved name.
+     * And the prohibitions are over something.
      *
-     * <p>One name of one class is one finding. A record component, the field it writes and the
-     * accessor that answers it are one thing the author wrote, and so are a field and the accessor
-     * beside it; naming each of them would say the same finding three times over.
-     *
-     * <p>So a record whose component takes the reserved name and may hold it covers a second
-     * declaration of that name in the same record — a static field, which is the only way to write
-     * one. Nothing in this compiler does, and closing it would mean telling a component's own field
-     * and accessor from a member that merely shares its name, which a class file does not say.
+     * <p>Both pass on the empty set, which is also what a walk that read nothing answers. The rows
+     * are the population the member rule is about — names it lets through rather than ones it never
+     * met — and the classes are what the type rule ranges over.
      */
-    private static List<String> membersOf(ClassModel of) {
-        List<String> wrong = new ArrayList<>();
-        Set<String> said = new LinkedHashSet<>();
-        Set<String> components = new LinkedHashSet<>();
-        for (RecordComponentInfo each : of.findAttribute(Attributes.record())
-                .map(RecordAttribute::components).orElse(List.of())) {
-            components.add(each.name().stringValue());
-            if (RESERVED_MEMBERS.contains(each.name().stringValue())
-                    && !answersARow(signatureOf(each)) && said.add(each.name().stringValue())) {
-                wrong.add(internal(of) + "." + each.name().stringValue()
-                        + " : " + shown(signatureOf(each)));
-            }
+    @Test
+    void andTheProhibitionsAreOverSomething() {
+        List<String> internal = compiled().classes().stream()
+                .map(each -> each.thisClass().asInternalName()).toList();
+        // Named, rather than counted against a floor somebody chose: a walk that reached the
+        // classes the rule is written about is what this is asking, and a number would be met by
+        // any hundred of them.
+        for (String each : ROWS) {
+            assertTrue(internal.contains(each), () -> "the walk did not reach " + each);
         }
-        for (FieldModel each : of.fields()) {
-            String name = each.fieldName().stringValue();
-            if (RESERVED_MEMBERS.contains(name) && !components.contains(name)
-                    && !answersARow(signatureOf(each)) && said.add(name)) {
-                wrong.add(internal(of) + "." + name + " : " + shown(signatureOf(each)));
-            }
-        }
-        for (MethodModel each : of.methods()) {
-            String name = each.methodName().stringValue();
-            if (RESERVED_MEMBERS.contains(name) && !components.contains(name)
-                    && !answersARow(answeredBy(each)) && said.add(name)) {
-                wrong.add(internal(of) + "." + name + " : " + shown(answeredBy(each)));
-            }
-        }
-        return wrong;
+        assertFalse(compiled().taking(RESERVED_MEMBERS).isEmpty(),
+                "the reserved name is in use on what may hold it");
     }
 
     /**
@@ -245,22 +188,20 @@ class OnlyARowIsCalledARowTest {
      * under the reserved name it would be read as a count of rows, which is the reading this whole
      * rule exists to remove — the one that came off {@code rows().rows().size()}.
      *
-     * <p>An array of rows is rows for the same reason a list of them is, and stops at the same
-     * place. A number is not rows: what it counts is not in it.
+     * <p>A number is not rows: what it counts is not in it. Nor is an array of them — not because
+     * an array could not hold rows, but because nothing here writes one, and admitting a shape in
+     * advance is what {@link #CONTAINERS} is closed against.
      */
     private static boolean answersARow(Signature answered) {
-        return switch (answered) {
-            case Signature.ArrayTypeSig array -> isARow(array.componentSignature());
-            case Signature.ClassTypeSig cls -> isARow(cls)
-                    || CONTAINERS.contains(named(cls)) && cls.typeArgs().size() == 1
-                    && holdsARow(cls.typeArgs().getFirst());
-            default -> false;
-        };
+        return answered instanceof Signature.ClassTypeSig cls
+                && (isARow(cls)
+                        || CONTAINERS.contains(Signatures.named(cls)) && cls.typeArgs().size() == 1
+                        && holdsARow(cls.typeArgs().getFirst()));
     }
 
     /** Whether a type is one of the rows themselves. */
     private static boolean isARow(Signature type) {
-        return type instanceof Signature.ClassTypeSig cls && ROWS.contains(named(cls));
+        return type instanceof Signature.ClassTypeSig cls && ROWS.contains(Signatures.named(cls));
     }
 
     /**
@@ -277,77 +218,12 @@ class OnlyARowIsCalledARowTest {
                 && isARow(bounded.boundType());
     }
 
-    private static String named(Signature.ClassTypeSig of) {
-        String descriptor = of.classDesc().descriptorString();
-        return descriptor.substring(1, descriptor.length() - 1);
-    }
-
-    /** What a method answers, generic where it was written generic. */
-    private static Signature answeredBy(MethodModel of) {
-        Optional<MethodSignature> generic = of.findAttribute(Attributes.signature())
-                .map(it -> MethodSignature.parseFrom(it.signature().stringValue()));
-        return generic.map(MethodSignature::result)
-                .orElseGet(() -> Signature.of(of.methodTypeSymbol().returnType()));
-    }
-
-    private static Signature signatureOf(FieldModel of) {
-        return of.findAttribute(Attributes.signature())
-                .map(it -> Signature.parseFrom(it.signature().stringValue()))
-                .orElseGet(() -> Signature.of(of.fieldTypeSymbol()));
-    }
-
-    private static Signature signatureOf(RecordComponentInfo of) {
-        return of.findAttribute(Attributes.signature())
-                .map(it -> Signature.parseFrom(it.signature().stringValue()))
-                .orElseGet(() -> Signature.of(of.descriptorSymbol()));
-    }
-
-    private static String shown(Signature of) {
-        return switch (of) {
-            case Signature.ArrayTypeSig array -> shown(array.componentSignature()) + "[]";
-            case Signature.BaseTypeSig base ->
-                    ClassDesc.ofDescriptor(String.valueOf(base.baseType())).displayName();
-            case Signature.TypeVarSig var -> var.identifier();
-            case Signature.ClassTypeSig cls -> cls.typeArgs().isEmpty() ? named(cls)
-                    : named(cls) + "<" + String.join(", ",
-                            cls.typeArgs().stream().map(OnlyARowIsCalledARowTest::shown).toList())
-                            + ">";
-        };
-    }
-
-    private static String shown(Signature.TypeArg arg) {
-        return switch (arg) {
-            case Signature.TypeArg.Unbounded _ -> "?";
-            case Signature.TypeArg.Bounded bounded -> switch (bounded.wildcardIndicator()) {
-                case NONE -> shown(bounded.boundType());
-                case EXTENDS -> "? extends " + shown(bounded.boundType());
-                case SUPER -> "? super " + shown(bounded.boundType());
-            };
-        };
-    }
-
-    private static String internal(ClassModel of) {
-        return of.thisClass().asInternalName();
-    }
-
     private static String simple(String internal) {
         String last = internal.substring(internal.lastIndexOf('/') + 1);
         return last.substring(last.lastIndexOf('$') + 1);
     }
 
-    /** Every class this compiler was built into, found from where one of them is loaded from. */
-    private static List<ClassModel> compiled() throws IOException, URISyntaxException {
-        Path root = Path.of(Prepared.class.getResource("Prepared.class").toURI());
-        for (int up = 0; up <= "souther/compiler/check".chars().filter(it -> it == '/').count();
-                up++) {
-            root = root.getParent();
-        }
-        List<ClassModel> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(root)) {
-            for (Path each : walk.filter(it -> it.toString().endsWith(".class")).sorted().toList()) {
-                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
-            }
-        }
-        return out;
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(Prepared.class);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyARowIsCalledARowTest.java
@@ -19,8 +19,10 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -156,6 +158,44 @@ class OnlyARowIsCalledARowTest {
     }
 
     /**
+     * And what the reserved name may answer is these shapes and no others.
+     *
+     * <p>The two prohibitions above say what this module holds today, so an edit that widened what
+     * counts as rows would go on passing — the population would move with it and nothing would be
+     * left to report. What the rule admits is a claim of its own, and it is made here against
+     * shapes rather than against the module: each is written out and run, so widening the rule
+     * fails on the shape it newly admits and narrowing it fails on the shape it stops admitting.
+     *
+     * <p>The refusals are the ones that cost something. A plurality of pluralities is the shape
+     * this whole rule came from: {@code rows().size()} over one is a count of groups read as a
+     * count of rows.
+     */
+    @Test
+    void andTheReservedNameAnswersTheseShapesAndNoOthers() {
+        String row = "Lsouther/compiler/ast/Hir$ExampleRow;";
+        Map<String, Boolean> shapes = new LinkedHashMap<>();
+        shapes.put(row, true);                                  // a row
+        shapes.put("Ljava/util/List<" + row + ">;", true);       // rows
+        shapes.put("[" + row, true);                            // rows, written as an array
+        shapes.put("Ljava/util/List<+" + row + ">;", true);      // rows nothing writes to
+        shapes.put("Ljava/util/List<Ljava/util/List<" + row + ">;>;", false);   // groups of rows
+        shapes.put("[[" + row, false);                          // the same, written as an array
+        shapes.put("[Ljava/util/List<" + row + ">;", false);     // and the same, mixed
+        shapes.put("Ljava/util/Map<Ljava/lang/String;Ljava/util/List<" + row + ">;>;",
+                false);                                         // rows under a key
+        shapes.put("Ljava/util/Set<" + row + ">;", false);       // a shape nobody has decided about
+        shapes.put("Ljava/util/List<-" + row + ">;", false);     // rows go in, anything comes out
+        shapes.put("Ljava/util/List<*>;", false);                // what it holds is unsaid
+        shapes.put("Lsouther/compiler/check/Prepared$ForExamples;", false);   // what holds blocks
+        shapes.put("I", false);                                 // a number of them
+
+        Map<String, Boolean> answered = new LinkedHashMap<>();
+        shapes.keySet().forEach(shape ->
+                answered.put(shape, answersARow(Signature.parseFrom(shape))));
+        assertEquals(shapes, answered, "what the reserved name may answer");
+    }
+
+    /**
      * Every declaration of one class that takes the reserved name.
      *
      * <p>One name of one class is one finding. A record component, the field it writes and the
@@ -200,25 +240,41 @@ class OnlyARowIsCalledARowTest {
     /**
      * Whether what a member answers is a row, or rows.
      *
-     * <p>An array of rows is rows for the same reason a list of them is. A number is not: what it
-     * counts is not in it, which is how a count of blocks comes to be read as a count of rows.
+     * <p>One row, or one container of rows, and no further. What holds rows does not recur: a list
+     * of lists of rows is a plurality of pluralities, and its size is a count of groups. Answered
+     * under the reserved name it would be read as a count of rows, which is the reading this whole
+     * rule exists to remove — the one that came off {@code rows().rows().size()}.
+     *
+     * <p>An array of rows is rows for the same reason a list of them is, and stops at the same
+     * place. A number is not rows: what it counts is not in it.
      */
     private static boolean answersARow(Signature answered) {
         return switch (answered) {
-            case Signature.ArrayTypeSig array -> answersARow(array.componentSignature());
-            case Signature.ClassTypeSig cls -> ROWS.contains(named(cls))
+            case Signature.ArrayTypeSig array -> isARow(array.componentSignature());
+            case Signature.ClassTypeSig cls -> isARow(cls)
                     || CONTAINERS.contains(named(cls)) && cls.typeArgs().size() == 1
                     && holdsARow(cls.typeArgs().getFirst());
             default -> false;
         };
     }
 
-    /** Whether a container's one type argument names a row. A wildcard does not: what a list of
-     *  something unsaid holds is not something this was told. */
+    /** Whether a type is one of the rows themselves. */
+    private static boolean isARow(Signature type) {
+        return type instanceof Signature.ClassTypeSig cls && ROWS.contains(named(cls));
+    }
+
+    /**
+     * Whether a container's one type argument is a row.
+     *
+     * <p>What may be read out as a row. {@code ? extends} may — every element of it is one — and
+     * {@code ? super} may not: what comes out of a list something writes rows into is whatever the
+     * bound admits. A wildcard with no bound says nothing at all.
+     */
     private static boolean holdsARow(Signature.TypeArg arg) {
         return arg instanceof Signature.TypeArg.Bounded bounded
-                && bounded.wildcardIndicator() == Signature.TypeArg.Bounded.WildcardIndicator.NONE
-                && answersARow(bounded.boundType());
+                && bounded.wildcardIndicator()
+                        != Signature.TypeArg.Bounded.WildcardIndicator.SUPER
+                && isARow(bounded.boundType());
     }
 
     private static String named(Signature.ClassTypeSig of) {

--- a/souther-compiler/src/test/java/souther/compiler/WhatTheRowsReached.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatTheRowsReached.java
@@ -1,0 +1,27 @@
+package souther.compiler;
+
+import souther.compiler.query.PartitionEvidence;
+
+/**
+ * What the rows reached at a position a test has already measured.
+ *
+ * <p>Here rather than on {@link PartitionEvidence.AxisCoverage} because the unwrapping is a test's
+ * to do. The measurement is what the type answers, and a position nobody measured has no numbers;
+ * an accessor beside it that threw would be a second way in, and the caller that wanted the one
+ * answer would be choosing between them.
+ */
+public final class WhatTheRowsReached {
+
+    private WhatTheRowsReached() {
+    }
+
+    /**
+     * The numbers at {@code axis}.
+     *
+     * @throws java.util.NoSuchElementException where nothing measured it, which in a test is the
+     *                                          setup not having produced what the test is about
+     */
+    public static PartitionEvidence.AxisCoverage.Reached at(PartitionEvidence.AxisCoverage axis) {
+        return axis.reached().made().orElseThrow();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AStateIsReachedOnlyThroughWhatEstablishesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AStateIsReachedOnlyThroughWhatEstablishesItTest.java
@@ -165,12 +165,13 @@ class AStateIsReachedOnlyThroughWhatEstablishesItTest {
                 "the second map is what each behavior takes and answers with, which the rung that "
                         + "settles it worked out: a row's positions are read from it rather than "
                         + "off the forms this module wrote");
-        assertEquals(Set.of(), waysInto(Prepared.Rows.class),
+        assertEquals(Set.of(), waysInto(Prepared.Example.class),
                 "an example block is projected from the module it is one of");
         assertEquals(Set.of(), waysInto(Prepared.FakeTable.class),
                 "and so is a fake table");
-        assertEquals(Set.of(), waysInto(Prepared.Examples.class),
-                "a run is asked for of the module, which is what pairs the rows with the artifact");
+        assertEquals(Set.of(), waysInto(Prepared.ForExamples.class),
+                "a run is asked for of the module, which is what pairs the blocks with the "
+                        + "artifact");
     }
 
     /**
@@ -252,7 +253,7 @@ class AStateIsReachedOnlyThroughWhatEstablishesItTest {
             // which rows are reported on is `Output.Examples`' question and its key carries the
             // source. What must not take one is the way in, or a route to a part — either would be
             // a module whose contents are a function of which file is being reported on.
-            assertEquals(Prepared.Examples.class, m.getReturnType(),
+            assertEquals(Prepared.ForExamples.class, m.getReturnType(),
                     "Prepared." + signature(m) + " takes a name, and the only one it could be "
                             + "is an output's");
         }

--- a/souther-compiler/src/test/java/souther/compiler/examples/TheFaceReadsWhatAModelIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/TheFaceReadsWhatAModelIsWrittenAsTest.java
@@ -130,11 +130,11 @@ class TheFaceReadsWhatAModelIsWrittenAsTest {
         BoundExamples examples = bound();
 
         assertThrows(IllegalArgumentException.class,
-                () -> examples.row("findTodo", "a todo that was never written"));
+                () -> examples.rowKey("findTodo", "a todo that was never written"));
         assertEquals(0, RowKey.class.getConstructors().length,
                 "nothing outside the package makes one");
 
-        RowKey stored = examples.row("findTodo", "a todo that is stored");
+        RowKey stored = examples.rowKey("findTodo", "a todo that is stored");
         assertTrue(stored.is(examples.rows().get(0)));
         assertFalse(stored.is(examples.rows().get(1)));
     }
@@ -142,7 +142,7 @@ class TheFaceReadsWhatAModelIsWrittenAsTest {
     /** A key of one enumeration is refused by another rather than quietly matching nothing. */
     @Test
     void aKeyOfOneBindingIsRefusedByAnothersRows() throws Exception {
-        RowKey stored = bound().row("findTodo", "a todo that is stored");
+        RowKey stored = bound().rowKey("findTodo", "a todo that is stored");
         RecordedRow elsewhere = bound().rows().get(0);
 
         assertThrows(IllegalArgumentException.class, () -> stored.is(elsewhere));

--- a/souther-compiler/src/test/java/souther/compiler/examples/TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest.java
@@ -95,7 +95,7 @@ class TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest {
     @Test
     void oneRowEvaluatedUnderTwoWorldsIsTwoObservations() throws Exception {
         BoundExamples examples = bound();
-        RowKey key = examples.row("findTodo", "a todo that is stored");
+        RowKey key = examples.rowKey("findTodo", "a todo that is stored");
         RecordedRow stored = examples.rows().stream().filter(key::is).findFirst().orElseThrow();
 
         System.setProperty(STORED, "yes");
@@ -122,9 +122,9 @@ class TheLoopOverBoundRowsBelongsToWhoeverOwnsTheWorldTest {
     void anAddressIsResolvedAgainstTheRowsAsWritten() throws Exception {
         BoundExamples examples = bound();
 
-        assertEquals("a todo that is stored", examples.row("findTodo", "a todo that is stored").name());
+        assertEquals("a todo that is stored", examples.rowKey("findTodo", "a todo that is stored").name());
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> examples.row("findTodo", "a todo that was never written"));
+                () -> examples.rowKey("findTodo", "a todo that was never written"));
         assertTrue(refused.getMessage().contains("a todo that was never written"),
                 refused.getMessage());
     }

--- a/souther-compiler/src/test/java/souther/compiler/examples/TheRowStaysOnItsWorkerAndTheApplicationDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/TheRowStaysOnItsWorkerAndTheApplicationDoesNotTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TheRowStaysOnItsWorkerAndTheApplicationDoesNotTest {
 
     private static final Deadline.Work WORK =
-            new Deadline.Work.Row("findTodo", new SourcePos(1, 1), new RowIdentity.Unnamed(1));
+            new Deadline.Work.WholeRow("findTodo", new SourcePos(1, 1), new RowIdentity.Unnamed(1));
 
     /** The crossing arrangement, on a worker of {@code stackBytes}. What a compile says it gives a
      *  row is read and not kept here — there is no clock past the crossing — so which wait this is

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForARequirementIsAskedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForARequirementIsAskedInOnePlaceTest.java
@@ -145,7 +145,7 @@ class WhatStandsInForARequirementIsAskedInOnePlaceTest {
                         model.execution()));
     }
 
-    private record Model(String module, Hir.ExampleRow row, Prepared.Examples execution) {
+    private record Model(String module, Hir.ExampleRow row, Prepared.ForExamples execution) {
 
         /** One of the model's own behaviors, as the declaration a requirement is. */
         ValueName.Behavior of(String name) {
@@ -159,7 +159,7 @@ class WhatStandsInForARequirementIsAskedInOnePlaceTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         assertNotNull(prepared, "the model under test compiles");
-        Hir.ExampleRow row = prepared.rows().get(0).read().rows().get(0);
+        Hir.ExampleRow row = prepared.examples().get(0).read().rows().get(0);
         return new Model(module, row, prepared.forExamples());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/execute/NothingCrossingTheExecutionBoundaryIsTheMachinesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/NothingCrossingTheExecutionBoundaryIsTheMachinesTest.java
@@ -2,6 +2,9 @@ package souther.compiler.execute;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.Prepared;
+import souther.compiler.observe.Observations;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -98,9 +101,12 @@ class NothingCrossingTheExecutionBoundaryIsTheMachinesTest {
         List<String> reached = everythingCrossing(ProgramExecution.class).stream()
                 .map(each -> each.type().getName()).toList();
 
-        assertTrue(reached.contains("souther.compiler.check.Prepared$Examples"),
-                () -> "no prepared rows in " + reached);
-        assertTrue(reached.contains("souther.compiler.observe.Observations"),
+        // Named by their classes and not by how they are spelled: a rename would otherwise leave
+        // this looking for a type nothing declares any more, and a walk that had stopped reaching
+        // it would read the same as the rename.
+        assertTrue(reached.contains(Prepared.ForExamples.class.getName()),
+                () -> "no prepared examples in " + reached);
+        assertTrue(reached.contains(Observations.class.getName()),
                 () -> "no observations in " + reached);
         assertTrue(reached.size() > 30, () -> "the walk reached only " + reached.size());
     }

--- a/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
+++ b/souther-compiler/src/test/java/souther/compiler/execute/RecordingExecution.java
@@ -61,9 +61,9 @@ final class RecordingExecution implements ProgramExecution {
      */
     private static String read(ExampleExecution about) {
         EvaluationPolicy held = about.policy();
-        long written = Math.max(1, about.rows().rows().size());
+        long written = Math.max(1, about.forExamples().examples().size());
         return about.module()
-                + " (" + about.rows().rows().size() + " examples"
+                + " (" + about.forExamples().examples().size() + " examples"
                 + ", " + about.signatures().size() + " behaviors"
                 + ", " + about.requirements().size() + " requirement tables"
                 + ", " + about.definitions().size() + " definitions"
@@ -77,7 +77,7 @@ final class RecordingExecution implements ProgramExecution {
     @Override
     public TableBuild fakeTables(ExampleExecution about, SourceId source) {
         asked.add("fakes of " + read(about) + " written in " + source
-                + ", " + about.rowsWrittenIn(source).rows().size() + " of them here");
+                + ", " + about.forExamplesWrittenIn(source).examples().size() + " of them here");
         return new TableBuild.NotBuiltHere();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -189,7 +189,7 @@ class AGroupTooWideToWalkSaysSoTest {
 
 
     private static AdequacyPolicy.OfTheGeneration atMost(int cells) {
-        return new AdequacyPolicy.OfTheGeneration(Budgets.generation().rows(), cells);
+        return new AdequacyPolicy.OfTheGeneration(Budgets.generation().rowLimit(), cells);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.DefaultStdlib;
+import souther.compiler.WhatTheRowsReached;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Resolve;
@@ -187,7 +188,8 @@ class ANameGoesBackOnTheWayItCameOffTest {
         PartitionEvidence evidence = compilation.db()
                 .ask(new Adequacy.Coverage("demo")).value().get("run");
 
-        assertEquals(java.util.Set.of("Approved"), evidence.axes().get(0).rows().covered());
+        assertEquals(java.util.Set.of("Approved"),
+                WhatTheRowsReached.at(evidence.axes().get(0)).covered());
     }
 
     /** The observation of {@code value} written under {@code names}, outermost first. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/APairIsOneElementInTwoClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APairIsOneElementInTwoClassesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.WhatTheRowsReached;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
@@ -90,7 +91,7 @@ class APairIsOneElementInTwoClassesTest {
 
         assertEquals(List.of(Set.of("people[*].age/x < 18", "people[*].age/18 <= x"),
                         Set.of("Active", "Inactive")),
-                select.axes().stream().map(a -> a.rows().covered()).toList());
+                select.axes().stream().map(a -> WhatTheRowsReached.at(a).covered()).toList());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.WhatTheRowsReached;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
@@ -110,9 +111,10 @@ class APositionUnderANameIsReachedThroughItTest {
     void aRowWrittenUnderTheNameIsReadBackThroughIt() {
         Compilation compilation = measured(FLAGS);
 
-        assertEquals(Set.of("true"), evidence(compilation, "wrapped").axes().get(0).rows().covered());
-        assertEquals(evidence(compilation, "bare").axes().get(0).rows().covered(),
-                evidence(compilation, "wrapped").axes().get(0).rows().covered(),
+        assertEquals(Set.of("true"),
+                WhatTheRowsReached.at(evidence(compilation, "wrapped").axes().get(0)).covered());
+        assertEquals(WhatTheRowsReached.at(evidence(compilation, "bare").axes().get(0)).covered(),
+                WhatTheRowsReached.at(evidence(compilation, "wrapped").axes().get(0)).covered(),
                 "a name is how a value is written, not what it is");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowsElementsNeedNotFallTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowsElementsNeedNotFallTogetherTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.WhatTheRowsReached;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
@@ -75,7 +76,7 @@ class ARowsElementsNeedNotFallTogetherTest {
     @Test
     void aListOfOneCoversTheClassItsElementIsIn() {
         assertEquals(Set.of("people[*].age/18 <= x"),
-                elementAxis("[ Person { age = 20 } ]", "1").rows().covered());
+                WhatTheRowsReached.at(elementAxis("[ Person { age = 20 } ]", "1")).covered());
     }
 
     /**
@@ -89,8 +90,9 @@ class ARowsElementsNeedNotFallTogetherTest {
         PartitionEvidence.AxisCoverage axis =
                 elementAxis("[ Person { age = 20 }, Person { age = 10 } ]", "1");
 
-        assertEquals(Set.of("people[*].age/18 <= x", "people[*].age/x < 18"), axis.rows().covered());
-        assertEquals(0, axis.rows().unclassifiedRows(),
+        assertEquals(Set.of("people[*].age/18 <= x", "people[*].age/x < 18"),
+                WhatTheRowsReached.at(axis).covered());
+        assertEquals(0, WhatTheRowsReached.at(axis).unclassifiedRows(),
                 "and the row said where it was, at every element it wrote");
     }
 
@@ -105,10 +107,10 @@ class ARowsElementsNeedNotFallTogetherTest {
     void anEmptyListIsReadAndCoversNothing() {
         PartitionEvidence.AxisCoverage axis = elementAxis("[ ]", "0");
 
-        assertEquals(Set.of(), axis.rows().covered());
-        assertEquals(0, axis.rows().unclassifiedRows(),
+        assertEquals(Set.of(), WhatTheRowsReached.at(axis).covered());
+        assertEquals(0, WhatTheRowsReached.at(axis).unclassifiedRows(),
                 "the row was read: it wrote no element, which is not a value nothing could read");
-        assertTrue(axis.classes().size() > axis.rows().covered().size(),
+        assertTrue(axis.classes().size() > WhatTheRowsReached.at(axis).covered().size(),
                 "so the classes it did not reach are owed a row");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
@@ -86,7 +86,7 @@ class TheCompositionIsNotBehindTheBaselinesBudgetTest {
 
         ClassDisposition at = attemptAtTheLowerHi(filling);
         assertEquals(List.of("Request { lo = Amount(0), hi = Amount(0) }"),
-                filling.composed().rowFor(((ClassDisposition.Built) at).row()).inputs().stream()
+                filling.composed().rowFor(((ClassDisposition.Built) at).rowId()).inputs().stream()
                         .map(FixtureTemplate::text).toList(),
                 "composed from the classes, which is what a row is where none of the values the "
                         + "model states can be written for it: " + at);

--- a/souther-compiler/src/test/java/souther/compiler/program/EveryRowWrittenIsARowThatCrossesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/EveryRowWrittenIsARowThatCrossesTest.java
@@ -126,7 +126,7 @@ class EveryRowWrittenIsARowThatCrossesTest {
         int rows = 0;
         for (String module : compilation.modules()) {
             Prepared prepared = db.ask(new Shapes.Prepared(module)).value();
-            for (Prepared.Rows block : prepared.forExamples().rows()) {
+            for (Prepared.Example block : prepared.forExamples().examples()) {
                 rows += block.read().rows().size();
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
@@ -112,7 +112,7 @@ class ABudgetIsTheCompilationsToSetTest {
     @Test
     void theStandardBudgetIsWhatACompilationSets() {
         assertTrue(Budgets.measures().pairSpace() > 0);
-        assertTrue(Budgets.generation().rows() > 0);
+        assertTrue(Budgets.generation().rowLimit() > 0);
         assertTrue(Budgets.generation().cellsPerGroup() > 0);
     }
 
@@ -122,7 +122,7 @@ class ABudgetIsTheCompilationsToSetTest {
         Compilation compilation = Compilation.ofSource(TWO_DECISIONS, "Main")
                 .withAdequacyPolicy(new AdequacyPolicy(
                         Budgets.measures(),
-                        new AdequacyPolicy.OfTheGeneration(Budgets.generation().rows(), cells)));
+                        new AdequacyPolicy.OfTheGeneration(Budgets.generation().rowLimit(), cells)));
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filling =

--- a/souther-compiler/src/test/java/souther/compiler/query/AnAnsweredMeasureAnswersForEveryBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnAnsweredMeasureAnswersForEveryBehaviorTest.java
@@ -111,10 +111,10 @@ class AnAnsweredMeasureAnswersForEveryBehaviorTest {
     void theReadingOfTheRowsAnswersForEveryBehaviorToo() {
         Compilation compilation = measured();
         Map<String, Adequacy.RowReading> rows =
-                compilation.db().ask(new Adequacy.Rows("example.shapes")).value();
+                compilation.db().ask(new Adequacy.RowReadings("example.shapes")).value();
         assertNotNull(rows, "the rows were read for or against");
         for (String behavior : declared(compilation)) {
-            assertNotNull(Adequacy.Rows.readingFor(rows, behavior),
+            assertNotNull(Adequacy.RowReadings.readingFor(rows, behavior),
                     () -> "how far the rows of " + behavior + " were read");
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnswerClosure.java
@@ -625,10 +625,14 @@ final class AnswerClosure {
                 // what the JDK ships: two caches the language fills in and opens to nobody. The
                 // walk asks, is refused, and says so — reading it as one of the JDK's own maps
                 // instead would read it for its entries and never meet what it answers with.
-                fieldOfAJdkParent("Adequacy$Rows", "", "keySet", Scenario.VALID_CORPUS),
-                fieldOfAJdkParent("Adequacy$Rows", "", "keySet", Scenario.A_MODULE_SPOKEN_ABOUT),
-                fieldOfAJdkParent("Adequacy$Rows", "", "values", Scenario.VALID_CORPUS),
-                fieldOfAJdkParent("Adequacy$Rows", "", "values", Scenario.A_MODULE_SPOKEN_ABOUT),
+                fieldOfAJdkParent(Adequacy.RowReadings.class, "", "keySet",
+                        Scenario.VALID_CORPUS),
+                fieldOfAJdkParent(Adequacy.RowReadings.class, "", "keySet",
+                        Scenario.A_MODULE_SPOKEN_ABOUT),
+                fieldOfAJdkParent(Adequacy.RowReadings.class, "", "values",
+                        Scenario.VALID_CORPUS),
+                fieldOfAJdkParent(Adequacy.RowReadings.class, "", "values",
+                        Scenario.A_MODULE_SPOKEN_ABOUT),
                 // The correspondence between a row's operand and the method it runs as, keyed on
                 // the very nodes this answer hands out — so what it means it means inside the
                 // answer that holds it, and what the answer says it is leaves it out on purpose.
@@ -644,10 +648,15 @@ final class AnswerClosure {
                 operandMethodsOf("IdentityHashMap#table", Scenario.A_MODULE_SPOKEN_ABOUT));
     }
 
-    /** A field of what the JDK ships, under something of this compiler's own that holds it. */
-    private static String fieldOfAJdkParent(String question, String under, String named,
+    /**
+     * A field of what the JDK ships, under something of this compiler's own that holds it.
+     *
+     * <p>The question is named by its class rather than spelled, so that renaming it is a thing
+     * javac says here. Spelled, this would go on standing above a question nothing asks any more.
+     */
+    private static String fieldOfAJdkParent(Class<?> question, String under, String named,
                                             Scenario scenario) {
-        return "A_FIELD_THAT_WOULD_NOT_OPEN " + Q + question + ".Answer#value" + under
+        return "A_FIELD_THAT_WOULD_NOT_OPEN " + question.getName() + ".Answer#value" + under
                 + ".AbstractMap#" + named + " in " + scenario;
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryRowOfIt.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryRowOfIt.java
@@ -18,7 +18,7 @@ public final class EveryRowOfIt {
      *  what not having asked means. */
     public static Offering offered(Composition composed) {
         return composed.keeping(
-                composed.rows().values().stream().flatMap(java.util.List::stream)
+                composed.rowsByBehavior().values().stream().flatMap(java.util.List::stream)
                         .map(OfferedRow::key)
                         .collect(java.util.stream.Collectors.toCollection(
                                 java.util.LinkedHashSet::new)),

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
@@ -65,17 +65,17 @@ final class Columns {
         /** Where a fake row's output begins. */
         THE_RESULT_OF_A_FAKE(SyntaxKind.FAKE_ROW, SyntaxKind.ARROW);
 
-        private final SyntaxKind row;
+        private final SyntaxKind rowKind;
         private final SyntaxKind connector;
 
-        Stop(SyntaxKind row, SyntaxKind connector) {
-            this.row = row;
+        Stop(SyntaxKind rowKind, SyntaxKind connector) {
+            this.rowKind = rowKind;
             this.connector = connector;
         }
 
-        /** The row this is a stop of. */
-        SyntaxKind row() {
-            return row;
+        /** What the row this is a stop of is written as. */
+        SyntaxKind rowKind() {
+            return rowKind;
         }
 
         /** The token written at the column. */
@@ -85,10 +85,10 @@ final class Columns {
 
         /** What the rule says, for a reader who is being told their source does not. */
         String said() {
-            return "the rows of a " + switch (row) {
+            return "the rows of a " + switch (rowKind) {
                 case EXAMPLE_ROW -> "table of examples";
                 case FAKE_ROW -> "table of fakes";
-                default -> throw new IllegalStateException("no such table: " + row);
+                default -> throw new IllegalStateException("no such table: " + rowKind);
             } + " write their " + connector.fixedSpelling().orElseThrow()
                     + " at one column";
         }
@@ -114,7 +114,7 @@ final class Columns {
      */
     static Stop at(SyntaxKind joining, SyntaxKind right) {
         for (Stop stop : Stop.values()) {
-            if (stop.row() == joining && stop.connector() == right) {
+            if (stop.rowKind() == joining && stop.connector() == right) {
                 return stop;
             }
         }

--- a/souther-fmt/src/test/java/souther/compiler/fmt/OnlyARowIsCalledARowTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,89 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.WhatAModuleDeclares;
+
+import java.lang.classfile.ClassModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The same rule the compiler holds itself to, said here about this module: the bare names
+ * {@code row} and {@code rows}, and the bare types {@code Row} and {@code Rows}, are a row's.
+ * Everything that is merely about one — what a row is written as, where it starts, how wide it is —
+ * says what it is instead.
+ *
+ * <p><b>Nothing here may take them at all.</b> A row of an {@code example} is a compiler type, and
+ * this module does not depend on the compiler; there is nothing it could hold that is a row. So the
+ * rule has no admitting side to state, and the prohibition is the whole of it. Declaring a row here
+ * would mean saying which type that is, and then saying what may hold one — which is what the
+ * compiler's own copy of this does.
+ *
+ * <p><b>Its own module, not a walk over the reactor.</b> A check reaching across to a sibling's
+ * {@code target/classes} would be reading whatever a previous build left there: the reactor builds
+ * this module after the compiler and before nothing, so what exists beside it at any moment is not
+ * what this run compiled. Each module says this about itself, over the classes it was just built
+ * into.
+ */
+class OnlyARowIsCalledARowTest {
+
+    private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
+
+    private static final Set<String> RESERVED_TYPES = Set.of("Row", "Rows");
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        List<String> wrong = new ArrayList<>();
+        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
+            wrong.add(each.shown());
+        }
+        assertEquals(List.of(), wrong,
+                "the formatter holds no rows, so a declaration of it named for one is named for"
+                        + " something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        List<String> wrong = new ArrayList<>();
+        for (ClassModel each : compiled().classes()) {
+            String internal = each.thisClass().asInternalName();
+            if (RESERVED_TYPES.contains(simple(internal))) {
+                wrong.add(internal);
+            }
+        }
+        assertEquals(List.of(), wrong, "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /**
+     * And both are over this module's classes rather than over nothing.
+     *
+     * <p>The prohibition passes on an empty answer, which is also what a reading that found no
+     * declarations at all would give. So it is asked for a name this module does have — the other
+     * half of the stop that started this — and the two answers together say the reading works and
+     * the reserved name is not in it.
+     */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+        assertFalse(compiled().taking(Set.of("connector")).isEmpty(),
+                "and reads the declarations of them");
+    }
+
+    private static String simple(String internal) {
+        String last = internal.substring(internal.lastIndexOf('/') + 1);
+        return last.substring(last.lastIndexOf('$') + 1);
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(Columns.class);
+    }
+}

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -593,14 +593,14 @@ public final class Analyzer {
         // source that did not answer as one holding no rows, so a behavior whose file could not be
         // evaluated drew the same lens as one nobody has exampled — and drew none (issue #996).
         Map<String, Adequacy.RowReading> readings =
-                compilation.db().ask(new Adequacy.Rows(module)).value();
+                compilation.db().ask(new Adequacy.RowReadings(module)).value();
         if (readings == null) {
             // The compile did not get as far as the shapes, so there is nothing to draw a lens
             // from. Not a reading that found no rows, which is what an editor would show as one.
             return null;
         }
         List<souther.compiler.observe.RowOutcome> read =
-                Adequacy.Rows.readingFor(readings, behavior).measured().made()
+                Adequacy.RowReadings.readingFor(readings, behavior).measured().made()
                         .map(Adequacy.Observed::rows).orElse(null);
         if (read == null || read.isEmpty()) {
             // No numbers to show: either nobody has written a row here, or nothing read the ones
@@ -926,7 +926,7 @@ public final class Analyzer {
                 souther.compiler.report.GeneratedRows.of(compilation, offer.module(),
                         offer.behavior(), true,
                         souther.compiler.diag.SourceNameResolver.identity());
-        if (block.rows() == 0) {
+        if (block.rowCount() == 0) {
             return null;
         }
         // Inserted at the end of the document. Where rows belong is the author's choice — this

--- a/souther-lsp/src/test/java/souther/lsp/OnlyARowIsCalledARowTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,50 @@
+package souther.lsp;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.TheBareRowNames;
+import souther.test.WhatAModuleDeclares;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The rule this repository holds every module to, said here about this one. This module asks the
+ * compiler about rows and hands an editor what it answered; what it holds of its own is an
+ * editor's, so the rule has no admitting side to state here and the prohibition is the whole of it.
+ *
+ * <p>Which is the case the rule is most worth having in: a reader here meets both vocabularies at
+ * once, and a name that says row while holding an offer, a count or a position is read as the
+ * compiler's word for a line.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
+                "the language server holds no rows of its own, so a declaration of it named for one"
+                        + " is named for something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /** And both are over this module's classes rather than over nothing. */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(LspMethod.class);
+    }
+}

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- The nullness gate runs here in every build, `mvn test` included, because this is the module

--- a/souther-runtime/src/test/java/souther/runtime/OnlyARowIsCalledARowTest.java
+++ b/souther-runtime/src/test/java/souther/runtime/OnlyARowIsCalledARowTest.java
@@ -1,4 +1,4 @@
-package souther.compiler.fmt;
+package souther.runtime;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,15 +14,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Only a row is called a row.
  *
  * <p>The rule this repository holds every module to, said here about this one. A row of an
- * {@code example} is a compiler type and the formatter is not under the compiler, so there is
+ * {@code example} is a compiler type and the run time does not reach the compiler, so there is
  * nothing here that could be one: the rule has no admitting side to state and the prohibition is
- * the whole of it. Declaring a row here would mean saying which type that is and what may hold one,
- * which is what the compiler's own copy of this does.
+ * the whole of it.
+ *
+ * <p>Written where nothing violates it, because where the next one will be written is not something
+ * a boundary predicts. The two this branch found were in modules nobody had looked at, and guarding
+ * only the modules a census turned something up in is making the census the rule.
  *
  * <p><b>Its own module, not a walk over the reactor.</b> A check reaching across to a sibling's
- * {@code target/classes} would be reading whatever a previous build left there — the reactor builds
- * these in an order, so what is on disk beside a module at any moment is not what this run
- * compiled. Each module says this about itself, over the classes it was just built into.
+ * {@code target/classes} would be reading whatever a previous build left there. Each module says
+ * this about itself, over the classes it was just built into.
  */
 class OnlyARowIsCalledARowTest {
 
@@ -30,7 +32,7 @@ class OnlyARowIsCalledARowTest {
     @Test
     void nothingHereIsCalledARow() {
         assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
-                "the formatter holds no rows, so a declaration of it named for one is named for"
+                "the run time holds no rows, so a declaration of it named for one is named for"
                         + " something it is not");
     }
 
@@ -41,19 +43,13 @@ class OnlyARowIsCalledARowTest {
                 "a type called Row or Rows is a row, and none of these is");
     }
 
-    /**
-     * And both are over this module's classes rather than over nothing.
-     *
-     * <p>A prohibition passes on an empty answer, which is also what a reading that found no
-     * classes would give. That the reading names every declaration of a name is held to where the
-     * reading lives; what is asked here is that it was given this module to read.
-     */
+    /** And both are over this module's classes rather than over nothing. */
     @Test
     void andBothAreOverThisModule() {
         assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
     }
 
     private static WhatAModuleDeclares compiled() {
-        return WhatAModuleDeclares.of(Columns.class);
+        return WhatAModuleDeclares.of(Behavior.class);
     }
 }

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -31,5 +31,10 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/souther-syntax/src/test/java/souther/compiler/diag/OnlyARowIsCalledARowTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/diag/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.WhatAModuleDeclares;
+
+import java.lang.classfile.ClassModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The same rule the compiler holds itself to, said here about this module: the bare names
+ * {@code row} and {@code rows}, and the bare types {@code Row} and {@code Rows}, are a row's. A row
+ * of an {@code example} is a compiler type and this module is under the compiler, so there is
+ * nothing here that could be one — the rule has no admitting side to state and the prohibition is
+ * the whole of it.
+ *
+ * <p><b>Except what a message carries.</b> A {@link souther.compiler.diag.msg.Message} is a record
+ * whose component names are read back by name: they are the placeholders a catalog entry writes
+ * ({@code The row says {row}}), and they are the keys the JSON renderer puts a diagnostic's values
+ * under. So a component called {@code row} is not this module calling something a row — it is the
+ * word the sentence uses, in two languages and on a wire, and renaming it would move a published
+ * key to say something about Java. Serialized vocabulary is outside this rule wherever it appears,
+ * as a report's JSON key {@code "rows"} is.
+ *
+ * <p>Which is why the exception is taken from what a class implements rather than from a list of
+ * the ones there are today. A message written next year carries the same wire and would otherwise
+ * have to be remembered.
+ *
+ * <p><b>Its own module, not a walk over the reactor.</b> A check reaching across to a sibling's
+ * {@code target/classes} would be reading whatever a previous build left there. Each module says
+ * this about itself, over the classes it was just built into.
+ */
+class OnlyARowIsCalledARowTest {
+
+    private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
+
+    private static final Set<String> RESERVED_TYPES = Set.of("Row", "Rows");
+
+    private static final String MESSAGE = "souther/compiler/diag/msg/Message";
+
+    /** Nothing here is called {@code row} or {@code rows}, except what a message says. */
+    @Test
+    void nothingHereIsCalledARow() {
+        List<String> wrong = new ArrayList<>();
+        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
+            if (!isAMessage(each.owner())) {
+                wrong.add(each.shown());
+            }
+        }
+        assertEquals(List.of(), wrong,
+                "nothing under the compiler holds a row, so a declaration of it named for one is"
+                        + " named for something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        List<String> wrong = new ArrayList<>();
+        for (ClassModel each : compiled().classes()) {
+            String internal = each.thisClass().asInternalName();
+            if (RESERVED_TYPES.contains(simple(internal))) {
+                wrong.add(internal);
+            }
+        }
+        assertEquals(List.of(), wrong, "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /**
+     * And the exception is over something.
+     *
+     * <p>A prohibition with an exception nothing meets is a prohibition, and this one is written
+     * because messages do carry the word. Meeting nothing, it would be the wrong shape of rule and
+     * nobody would find out.
+     */
+    @Test
+    void andWhatAMessageSaysIsWhyThereIsAnException() {
+        List<String> excused = new ArrayList<>();
+        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
+            if (isAMessage(each.owner())) {
+                excused.add(each.shown());
+            }
+        }
+        assertFalse(excused.isEmpty(), "a message carries the word this rule reserves");
+    }
+
+    /** Whether {@code of} is a message, whose component names are a catalog's and a wire's. */
+    private static boolean isAMessage(ClassModel of) {
+        return of.interfaces().stream()
+                .anyMatch(each -> each.asInternalName().equals(MESSAGE)
+                        || each.asInternalName().startsWith(MESSAGE + "$")
+                        || implementsAMessage(each.asInternalName()));
+    }
+
+    private static boolean implementsAMessage(String internal) {
+        for (ClassModel each : compiled().classes()) {
+            if (each.thisClass().asInternalName().equals(internal)) {
+                return each.interfaces().stream()
+                        .anyMatch(one -> one.asInternalName().equals(MESSAGE));
+            }
+        }
+        return false;
+    }
+
+    private static String simple(String internal) {
+        String last = internal.substring(internal.lastIndexOf('/') + 1);
+        return last.substring(last.lastIndexOf('$') + 1);
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(Diagnostic.class);
+    }
+}

--- a/souther-syntax/src/test/java/souther/compiler/diag/OnlyARowIsCalledARowTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/diag/OnlyARowIsCalledARowTest.java
@@ -2,59 +2,50 @@ package souther.compiler.diag;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.TheBareRowNames;
 import souther.test.WhatAModuleDeclares;
 
 import java.lang.classfile.ClassModel;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Only a row is called a row.
  *
- * <p>The same rule the compiler holds itself to, said here about this module: the bare names
+ * <p>The rule this repository holds every module to, said here about this one: the bare names
  * {@code row} and {@code rows}, and the bare types {@code Row} and {@code Rows}, are a row's. A row
  * of an {@code example} is a compiler type and this module is under the compiler, so there is
  * nothing here that could be one — the rule has no admitting side to state and the prohibition is
  * the whole of it.
  *
- * <p><b>Except what a message carries.</b> A {@link souther.compiler.diag.msg.Message} is a record
+ * <p><b>Except a component of a message.</b> A {@link souther.compiler.diag.msg.Message} is a record
  * whose component names are read back by name: they are the placeholders a catalog entry writes
- * ({@code The row says {row}}), and they are the keys the JSON renderer puts a diagnostic's values
- * under. So a component called {@code row} is not this module calling something a row — it is the
- * word the sentence uses, in two languages and on a wire, and renaming it would move a published
- * key to say something about Java. Serialized vocabulary is outside this rule wherever it appears,
- * as a report's JSON key {@code "rows"} is.
+ * ({@code The row says {row}}), in every language it is written in, and the keys the JSON renderer
+ * puts a diagnostic's values under. So a component called {@code row} is not this module calling
+ * something a row — it is the word the sentence uses, on a wire, and renaming it would move a
+ * published key to say something about Java. Serialized vocabulary is outside this rule wherever it
+ * appears, as a report's JSON key {@code "rows"} is.
  *
- * <p>Which is why the exception is taken from what a class implements rather than from a list of
- * the ones there are today. A message written next year carries the same wire and would otherwise
- * have to be remembered.
+ * <p>Which is the component and nothing beside it. A field or a method of a message goes by no
+ * catalog and no wire, so the reason does not reach it, and excusing the class rather than the
+ * component would excuse what the reason does not cover.
  *
- * <p><b>Its own module, not a walk over the reactor.</b> A check reaching across to a sibling's
- * {@code target/classes} would be reading whatever a previous build left there. Each module says
- * this about itself, over the classes it was just built into.
+ * <p>The exception is taken from what a class implements rather than from a list of the messages
+ * there are today: one written next year carries the same wire and would otherwise have to be
+ * remembered.
  */
 class OnlyARowIsCalledARowTest {
-
-    private static final Set<String> RESERVED_MEMBERS = Set.of("row", "rows");
-
-    private static final Set<String> RESERVED_TYPES = Set.of("Row", "Rows");
 
     private static final String MESSAGE = "souther/compiler/diag/msg/Message";
 
     /** Nothing here is called {@code row} or {@code rows}, except what a message says. */
     @Test
     void nothingHereIsCalledARow() {
-        List<String> wrong = new ArrayList<>();
-        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
-            if (!isAMessage(each.owner())) {
-                wrong.add(each.shown());
-            }
-        }
-        assertEquals(List.of(), wrong,
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(),
+                        each -> each.kind() == WhatAModuleDeclares.Kind.RECORD_COMPONENT
+                                && isAMessage(each.owner())),
                 "nothing under the compiler holds a row, so a declaration of it named for one is"
                         + " named for something it is not");
     }
@@ -62,14 +53,8 @@ class OnlyARowIsCalledARowTest {
     /** And no type of it is called {@code Row} or {@code Rows}. */
     @Test
     void andNoTypeOfItIsCalledARow() {
-        List<String> wrong = new ArrayList<>();
-        for (ClassModel each : compiled().classes()) {
-            String internal = each.thisClass().asInternalName();
-            if (RESERVED_TYPES.contains(simple(internal))) {
-                wrong.add(internal);
-            }
-        }
-        assertEquals(List.of(), wrong, "a type called Row or Rows is a row, and none of these is");
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
     }
 
     /**
@@ -81,20 +66,16 @@ class OnlyARowIsCalledARowTest {
      */
     @Test
     void andWhatAMessageSaysIsWhyThereIsAnException() {
-        List<String> excused = new ArrayList<>();
-        for (WhatAModuleDeclares.Declared each : compiled().taking(RESERVED_MEMBERS)) {
-            if (isAMessage(each.owner())) {
-                excused.add(each.shown());
-            }
-        }
-        assertFalse(excused.isEmpty(), "a message carries the word this rule reserves");
+        assertTrue(compiled().taking(TheBareRowNames.MEMBERS).stream()
+                        .anyMatch(each -> each.kind() == WhatAModuleDeclares.Kind.RECORD_COMPONENT
+                                && isAMessage(each.owner())),
+                "a message carries the word this rule reserves");
     }
 
     /** Whether {@code of} is a message, whose component names are a catalog's and a wire's. */
     private static boolean isAMessage(ClassModel of) {
         return of.interfaces().stream()
                 .anyMatch(each -> each.asInternalName().equals(MESSAGE)
-                        || each.asInternalName().startsWith(MESSAGE + "$")
                         || implementsAMessage(each.asInternalName()));
     }
 
@@ -106,11 +87,6 @@ class OnlyARowIsCalledARowTest {
             }
         }
         return false;
-    }
-
-    private static String simple(String internal) {
-        String last = internal.substring(internal.lastIndexOf('/') + 1);
-        return last.substring(last.lastIndexOf('$') + 1);
     }
 
     private static WhatAModuleDeclares compiled() {

--- a/souther-test-support/src/main/java/souther/test/Signatures.java
+++ b/souther-test-support/src/main/java/souther/test/Signatures.java
@@ -1,0 +1,41 @@
+package souther.test;
+
+import java.lang.classfile.Signature;
+import java.lang.constant.ClassDesc;
+
+/** What a class file says a type is, written out for a reader of a failure. */
+public final class Signatures {
+
+    private Signatures() {
+    }
+
+    /** The internal name of a class type, as a class file spells it. */
+    public static String named(Signature.ClassTypeSig of) {
+        String descriptor = of.classDesc().descriptorString();
+        return descriptor.substring(1, descriptor.length() - 1);
+    }
+
+    /** {@code of}, as a failure would name it. */
+    public static String shown(Signature of) {
+        return switch (of) {
+            case Signature.ArrayTypeSig array -> shown(array.componentSignature()) + "[]";
+            case Signature.BaseTypeSig base ->
+                    ClassDesc.ofDescriptor(String.valueOf(base.baseType())).displayName();
+            case Signature.TypeVarSig var -> var.identifier();
+            case Signature.ClassTypeSig cls -> cls.typeArgs().isEmpty() ? named(cls)
+                    : named(cls) + "<" + String.join(", ",
+                            cls.typeArgs().stream().map(Signatures::shown).toList()) + ">";
+        };
+    }
+
+    private static String shown(Signature.TypeArg arg) {
+        return switch (arg) {
+            case Signature.TypeArg.Unbounded _ -> "?";
+            case Signature.TypeArg.Bounded bounded -> switch (bounded.wildcardIndicator()) {
+                case NONE -> shown(bounded.boundType());
+                case EXTENDS -> "? extends " + shown(bounded.boundType());
+                case SUPER -> "? super " + shown(bounded.boundType());
+            };
+        };
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/TheBareRowNames.java
+++ b/souther-test-support/src/main/java/souther/test/TheBareRowNames.java
@@ -1,0 +1,59 @@
+package souther.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * The names this repository keeps for a row.
+ *
+ * <p>One row is one line of an {@code example} or {@code fake} table. The things holding rows nest,
+ * and every level of them can be spelled {@code rows} without a reader being told which they have —
+ * a count taken off the wrong one is a count of groups that reads as a count of rows.
+ *
+ * <p>The spelling is here because it is the same in every module. What a row <em>is</em>, and what
+ * may hold one, is not: only the compiler declares a row type, so only its own check has an
+ * admitting side to state. Every other module has none, and says so by letting nothing take the
+ * name at all.
+ */
+public final class TheBareRowNames {
+
+    private TheBareRowNames() {
+    }
+
+    /** What a member may not be called unless it answers a row. */
+    public static final Set<String> MEMBERS = Set.of("row", "rows");
+
+    /** What a type may not be called unless it is one. */
+    public static final Set<String> TYPES = Set.of("Row", "Rows");
+
+    /**
+     * The declarations of {@code module} that take one of {@link #MEMBERS}, less those excused.
+     *
+     * @param excused what the rule does not reach here, which is a module's own to say
+     */
+    public static List<String> takenIn(WhatAModuleDeclares module,
+                                       Predicate<WhatAModuleDeclares.Declared> excused) {
+        List<String> found = new ArrayList<>();
+        for (WhatAModuleDeclares.Declared each : module.taking(MEMBERS)) {
+            if (!excused.test(each)) {
+                found.add(each.shown());
+            }
+        }
+        return found;
+    }
+
+    /** The types of {@code module} called {@code Row} or {@code Rows}. */
+    public static List<String> typesIn(WhatAModuleDeclares module) {
+        List<String> found = new ArrayList<>();
+        for (var each : module.classes()) {
+            String internal = each.thisClass().asInternalName();
+            String last = internal.substring(internal.lastIndexOf('/') + 1);
+            if (TYPES.contains(last.substring(last.lastIndexOf('$') + 1))) {
+                found.add(internal);
+            }
+        }
+        return found;
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
+++ b/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
@@ -15,7 +15,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -80,14 +79,14 @@ public final class WhatAModuleDeclares {
     /**
      * Every declaration of it that goes by one of {@code names}.
      *
-     * <p>One name of one class is one of these. A record component, the field it writes and the
-     * accessor that answers it are one thing the author wrote, and so are a field and the accessor
-     * beside it; naming each would say the same thing three times over.
-     *
-     * <p>So a record whose component takes one of the names covers a second declaration of that
-     * name in the same record — a static field, which is the only way to write one. Telling a
-     * component's own field and accessor from a member that merely shares its name is not something
-     * a class file says.
+     * <p>Every one of them, and not every name. A record's component, the field the compiler writes
+     * for it and the accessor that answers it are one thing the author wrote, and a class file says
+     * which two those are: the field goes by the component's name and descriptor, and the accessor
+     * goes by its name, takes nothing and answers its type. Those two are left out and everything
+     * else is here — a field and a method of one name are two declarations, and so are a component
+     * and an overload beside it. Collapsing them by the name they share would be answering about
+     * names while being asked about declarations, and a check reading this would stop at the first
+     * of them.
      */
     public List<Declared> taking(Set<String> names) {
         List<Declared> found = new ArrayList<>();
@@ -99,33 +98,53 @@ public final class WhatAModuleDeclares {
 
     private static List<Declared> takenIn(ClassModel of, Set<String> names) {
         List<Declared> found = new ArrayList<>();
-        Set<String> said = new LinkedHashSet<>();
-        Set<String> components = new LinkedHashSet<>();
-        for (RecordComponentInfo each : of.findAttribute(Attributes.record())
-                .map(RecordAttribute::components).orElse(List.of())) {
-            String name = each.name().stringValue();
-            components.add(name);
-            if (names.contains(name) && said.add(name)) {
-                found.add(new Declared(of, name, signatureOf(each)));
+        List<RecordComponentInfo> components = of.findAttribute(Attributes.record())
+                .map(RecordAttribute::components).orElse(List.of());
+        for (RecordComponentInfo each : components) {
+            if (names.contains(each.name().stringValue())) {
+                found.add(new Declared(of, each.name().stringValue(), signatureOf(each),
+                        Kind.RECORD_COMPONENT));
             }
         }
         for (FieldModel each : of.fields()) {
             String name = each.fieldName().stringValue();
-            if (names.contains(name) && !components.contains(name) && said.add(name)) {
-                found.add(new Declared(of, name, signatureOf(each)));
+            if (names.contains(name) && !writtenFor(components, name,
+                    each.fieldTypeSymbol().descriptorString())) {
+                found.add(new Declared(of, name, signatureOf(each), Kind.FIELD));
             }
         }
         for (MethodModel each : of.methods()) {
             String name = each.methodName().stringValue();
-            if (names.contains(name) && !components.contains(name) && said.add(name)) {
-                found.add(new Declared(of, name, answeredBy(each)));
+            boolean answersAComponent = each.methodTypeSymbol().parameterCount() == 0
+                    && writtenFor(components, name,
+                            each.methodTypeSymbol().returnType().descriptorString());
+            if (names.contains(name) && !answersAComponent) {
+                found.add(new Declared(of, name, answeredBy(each), Kind.METHOD));
             }
         }
         return found;
     }
 
+    /** Whether a record wrote a component of this name and type, which is what a field of the same
+     *  name and type, or an accessor answering it, belongs to. */
+    private static boolean writtenFor(List<RecordComponentInfo> components, String name,
+                                      String descriptor) {
+        return components.stream().anyMatch(each -> each.name().stringValue().equals(name)
+                && each.descriptorSymbol().descriptorString().equals(descriptor));
+    }
+
+    /** How a declaration was written, which is what tells a component from a member beside it. */
+    public enum Kind {
+        /** A record's component, whose name a reader of the record's own form may go by. */
+        RECORD_COMPONENT,
+        /** A field the author wrote. */
+        FIELD,
+        /** A method the author wrote. */
+        METHOD
+    }
+
     /** One declaration, and what it answers. */
-    public record Declared(ClassModel owner, String name, Signature type) {
+    public record Declared(ClassModel owner, String name, Signature type, Kind kind) {
 
         /** What the class holding it is called, as a class file spells it. */
         public String ownerName() {

--- a/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
+++ b/souther-test-support/src/main/java/souther/test/WhatAModuleDeclares.java
@@ -1,0 +1,158 @@
+package souther.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.MethodSignature;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.RecordAttribute;
+import java.lang.classfile.attribute.RecordComponentInfo;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * What one module compiled, read off its class files.
+ *
+ * <p>The mechanism a check on names needs, and none of the policy. Which names a module reserves
+ * and what they may answer is that module's to say; finding the classes and reading a declaration's
+ * type off them is the same work wherever it is asked, and written out per module it drifts — the
+ * copy that stops seeing record components goes on reporting a pass.
+ *
+ * <p><b>One module, found from a class of it.</b> Not a walk over whatever {@code target/classes}
+ * directories exist beside it: a module built earlier in the reactor may have last run's classes
+ * on disk and a module not built at all has none, so a check that swept the file system would prove
+ * something about a build nobody ran. A marker class is loaded from the classpath the test was
+ * given, which is the module as this run built it.
+ */
+public final class WhatAModuleDeclares {
+
+    private final List<ClassModel> classes;
+
+    private WhatAModuleDeclares(List<ClassModel> classes) {
+        this.classes = List.copyOf(classes);
+    }
+
+    /**
+     * The classes of the module {@code marker} was compiled into.
+     *
+     * @param marker any class of that module's main sources
+     */
+    public static WhatAModuleDeclares of(Class<?> marker) {
+        String binary = marker.getName();
+        String simple = binary.substring(binary.lastIndexOf('.') + 1);
+        Path root;
+        try {
+            root = Path.of(marker.getResource(simple + ".class").toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("a class of " + binary + " is not on a file system,"
+                    + " so this module's classes cannot be read", e);
+        }
+        for (int up = 0; up <= binary.chars().filter(each -> each == '.').count(); up++) {
+            root = root.getParent();
+        }
+        List<ClassModel> found = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(root)) {
+            for (Path each : walk.filter(one -> one.toString().endsWith(".class")).sorted()
+                    .toList()) {
+                found.add(ClassFile.of().parse(Files.readAllBytes(each)));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new WhatAModuleDeclares(found);
+    }
+
+    /** Every class of it. */
+    public List<ClassModel> classes() {
+        return classes;
+    }
+
+    /**
+     * Every declaration of it that goes by one of {@code names}.
+     *
+     * <p>One name of one class is one of these. A record component, the field it writes and the
+     * accessor that answers it are one thing the author wrote, and so are a field and the accessor
+     * beside it; naming each would say the same thing three times over.
+     *
+     * <p>So a record whose component takes one of the names covers a second declaration of that
+     * name in the same record — a static field, which is the only way to write one. Telling a
+     * component's own field and accessor from a member that merely shares its name is not something
+     * a class file says.
+     */
+    public List<Declared> taking(Set<String> names) {
+        List<Declared> found = new ArrayList<>();
+        for (ClassModel each : classes) {
+            found.addAll(takenIn(each, names));
+        }
+        return found;
+    }
+
+    private static List<Declared> takenIn(ClassModel of, Set<String> names) {
+        List<Declared> found = new ArrayList<>();
+        Set<String> said = new LinkedHashSet<>();
+        Set<String> components = new LinkedHashSet<>();
+        for (RecordComponentInfo each : of.findAttribute(Attributes.record())
+                .map(RecordAttribute::components).orElse(List.of())) {
+            String name = each.name().stringValue();
+            components.add(name);
+            if (names.contains(name) && said.add(name)) {
+                found.add(new Declared(of, name, signatureOf(each)));
+            }
+        }
+        for (FieldModel each : of.fields()) {
+            String name = each.fieldName().stringValue();
+            if (names.contains(name) && !components.contains(name) && said.add(name)) {
+                found.add(new Declared(of, name, signatureOf(each)));
+            }
+        }
+        for (MethodModel each : of.methods()) {
+            String name = each.methodName().stringValue();
+            if (names.contains(name) && !components.contains(name) && said.add(name)) {
+                found.add(new Declared(of, name, answeredBy(each)));
+            }
+        }
+        return found;
+    }
+
+    /** One declaration, and what it answers. */
+    public record Declared(ClassModel owner, String name, Signature type) {
+
+        /** What the class holding it is called, as a class file spells it. */
+        public String ownerName() {
+            return owner.thisClass().asInternalName();
+        }
+
+        /** What the declaration reads as, for a check saying which one it found. */
+        public String shown() {
+            return ownerName() + "." + name + " : " + Signatures.shown(type);
+        }
+    }
+
+    private static Signature answeredBy(MethodModel of) {
+        return of.findAttribute(Attributes.signature())
+                .map(it -> MethodSignature.parseFrom(it.signature().stringValue()).result())
+                .orElseGet(() -> Signature.of(of.methodTypeSymbol().returnType()));
+    }
+
+    private static Signature signatureOf(FieldModel of) {
+        return of.findAttribute(Attributes.signature())
+                .map(it -> Signature.parseFrom(it.signature().stringValue()))
+                .orElseGet(() -> Signature.of(of.fieldTypeSymbol()));
+    }
+
+    private static Signature signatureOf(RecordComponentInfo of) {
+        return of.findAttribute(Attributes.signature())
+                .map(it -> Signature.parseFrom(it.signature().stringValue()))
+                .orElseGet(() -> Signature.of(of.descriptorSymbol()));
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/ADeclarationIsWhatWasWrittenAndNotItsNameTest.java
+++ b/souther-test-support/src/test/java/souther/test/ADeclarationIsWhatWasWrittenAndNotItsNameTest.java
@@ -1,0 +1,53 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A declaration is what was written, and not the name it goes by.
+ *
+ * <p>{@link WhatAModuleDeclares#taking} is asked which declarations take a name, and a check
+ * reading it decides from every one of them. Answering one per name would let the second
+ * declaration of a name pass behind the first — and the one that passes is whichever the class file
+ * happens to list earlier, which is not a thing anybody chose.
+ *
+ * <p>What is left out is the two a record's component is written as. The compiler writes a field of
+ * the component's name and descriptor and an accessor that takes nothing and answers its type; a
+ * class file says which those are, so leaving them out is telling a component from a member rather
+ * than collapsing the two by their name. An overload beside the component is a member.
+ *
+ * <p>Held here rather than in each check that reads it. What a module's classes hold is that
+ * module's to say; that the reading names every declaration is the mechanism's, and a check made to
+ * prove it again would be proving it over whatever its module happened to hold.
+ */
+class ADeclarationIsWhatWasWrittenAndNotItsNameTest {
+
+    /** A field and a method of one name are two declarations. */
+    @Test
+    void aFieldAndAMethodOfOneNameAreTwo() {
+        assertEquals(List.of("FIELD", "METHOD"), kindsTaking("beside"));
+    }
+
+    /** A record component is one, and the field and accessor written for it are not beside it. */
+    @Test
+    void aComponentIsWrittenAsThreeThingsAndIsOne() {
+        assertEquals(List.of("RECORD_COMPONENT"), kindsTaking("stated"));
+    }
+
+    /** And an overload beside a component is a declaration of its own. */
+    @Test
+    void andAnOverloadBesideAComponentIsItsOwn() {
+        assertEquals(List.of("RECORD_COMPONENT", "METHOD"), kindsTaking("counted"));
+    }
+
+    private static List<String> kindsTaking(String name) {
+        return WhatAModuleDeclares.of(WhatWasWritten.class).taking(Set.of(name)).stream()
+                .filter(each -> each.ownerName().startsWith("souther/test/WhatWasWritten"))
+                .map(each -> each.kind().name())
+                .toList();
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/OnlyARowIsCalledARowTest.java
+++ b/souther-test-support/src/test/java/souther/test/OnlyARowIsCalledARowTest.java
@@ -1,0 +1,45 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Only a row is called a row.
+ *
+ * <p>The rule this repository holds every module to, said here about this one — including about the
+ * module the rule's own spelling lives in. What is checked is {@link TheBareRowNames} and what does
+ * the checking is {@link TheBareRowNames}, which is the same arrangement as a compiler compiling
+ * itself: it does not make the answer true, and it does mean the rule is not written somewhere it
+ * exempts.
+ */
+class OnlyARowIsCalledARowTest {
+
+    /** Nothing here is called {@code row} or {@code rows}, because nothing here is a row. */
+    @Test
+    void nothingHereIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.takenIn(compiled(), _ -> false),
+                "what a test is given holds no rows, so a declaration of it named for one is named"
+                        + " for something it is not");
+    }
+
+    /** And no type of it is called {@code Row} or {@code Rows}. */
+    @Test
+    void andNoTypeOfItIsCalledARow() {
+        assertEquals(List.of(), TheBareRowNames.typesIn(compiled()),
+                "a type called Row or Rows is a row, and none of these is");
+    }
+
+    /** And both are over this module's classes rather than over nothing. */
+    @Test
+    void andBothAreOverThisModule() {
+        assertFalse(compiled().classes().isEmpty(), "the walk reads this module's classes");
+    }
+
+    private static WhatAModuleDeclares compiled() {
+        return WhatAModuleDeclares.of(RepositoryLayout.class);
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/WhatWasWritten.java
+++ b/souther-test-support/src/test/java/souther/test/WhatWasWritten.java
@@ -1,0 +1,28 @@
+package souther.test;
+
+/**
+ * Declarations written the ways a reading of them has to tell apart.
+ *
+ * <p>A fixture, so that what the reading answers is held to shapes somebody wrote on purpose rather
+ * than to whatever a module happens to hold today.
+ */
+final class WhatWasWritten {
+
+    /** A field and a method of one name, which are two things the author wrote. */
+    private final String beside = "";
+
+    String beside() {
+        return beside + "!";
+    }
+
+    /** A component, written as itself, a field and an accessor. */
+    record Stating(String stated) {}
+
+    /** A component with an overload beside it, which is a second declaration of the name. */
+    record Counting(int counted) {
+
+        int counted(int by) {
+            return counted + by;
+        }
+    }
+}


### PR DESCRIPTION
Closes #1155.

`Prepared.Rows` was one `example` block and `Prepared.Examples.rows()` answered
blocks, so a count taken off either read as a count of rows. The issue names six
call sites. What it describes is one case of a wider defect, and the invariant
was written before the renames so that the population would come off the class
files rather than off whoever was looking.

## The rule

A member called `row` or `rows` answers a row, or rows. A type called `Row` or
`Rows` is a row. Everything that is merely *about* a row — an identity, a key, a
reference, an id, a reading, a count, a limit, a map indexed by behavior, a
measurement, a unit of work — is spelled as what it is.

`OnlyARowIsCalledARowTest` holds this compiler's main declarations to it. What
the rule *admits* is a claim of its own and is run rather than written down:
thirteen shapes, three admitted and ten refused, so an edit that widens the rule
fails on the shape it newly admits. A container holds rows and does not hold
containers — a list of lists of rows answers `size()` with a count of groups,
which is the reading this rule exists to remove.

Its javadoc says what it does not protect: compound names, whose head concept
is something else (`rowCount`, `RowReading`, `RowsRead`); local variables and
parameters, which are not declarations a reader resolves; test fixtures, which
are not production vocabulary; and the report's JSON key `rows`, which is a wire
contract of its own and does not move. A third check keeps both prohibitions
from passing on an empty walk.

## What the check named

Twenty-two declarations were initially named: six were the original collision,
fifteen were existing violations, and one established a missing row type in the
check's own declaration. That one, `Output.RowsRead.ReadRows.rows`, is a list of
rows — `ReadRow` is one written row and what became of reading it — and it was
named only because `ROWS` had not yet said so.

The twenty-one violations are two groups, because the reason differs.

**The collision the issue describes** — six declarations. The check names five of
them; `ExampleExecution.rowsWrittenIn()` is a compound name and outside the rule,
and moves with the accessor beside it.

| before | after |
| --- | --- |
| `Prepared.Rows` | `Prepared.Example` |
| `Prepared.rows()` | `Prepared.examples()` |
| `Prepared.Examples` | `Prepared.ForExamples` |
| `Prepared.ForExamples.rows()` | `examples()` |
| `ExampleExecution.rows()` | `forExamples()` |
| `ExampleExecution.rowsWrittenIn()` | `forExamplesWrittenIn()` |

`ForExamples` because the value is the module projected for an example run — the
blocks paired with the artifact their rows are evaluated in — and not a plurality
of anything. It is what `Prepared.forExamples()` already called it.

**Existing violations the invariant exposed** — fifteen declarations. Three
counts (`rowLimit` on the generation budget, `rowCount` on `GeneratedRows.Block`
and on `AdequacyReport.BehaviorReport`); three maps that now say what their keys
are (`rowsByBehavior` on `Offering`, `Composition` and
`CheckedProgramAssembler.ModuleReading`); six members holding something about a
row (`rowKey`, `rowRef`, `rowId` twice, `identity` on `RowKey`,
`observedInputs`); `Adequacy.Rows` → `Adequacy.RowReadings`, which is what its
`Map<String, RowReading>` answer is; `Deadline.Work.Row` → `WholeRow`, which is
named against `Fixtures`, which is the reading of the same row that stops before
the behavior; and
`PartitionEvidence.AxisCoverage.rows()`, which answered a measurement and is
gone rather than renamed — the record component `reached` is the way in, an
accessor beside it that threw was a second one, and unwrapping where a test has
already established the measurement is a test's to do.

## Two things found on the way

Three checks elsewhere had spelled a type rather than named it, and so would
have gone on standing above a type nothing declares. They take the class now,
which is a thing javac says.

The second commit is the source census the rule calls for over parameters and
locals. Sixteen named a key, a set of weakenings or an observation `row`; they
say what they hold. Eleven others are left alone: `Intrinsics.Emit`,
`ResultRange.ResultBound` and `Hir.RowCollection` each have a table with rows of
their own, and renaming those would reserve `row` across this compiler for an
`example` row, which is a wider rule than the one written here.

## Every module that could break it says it

The rule reaches every production declaration, and all nine modules with main
sources say it — not the three a census turned something up in. The two
violations this branch found were in modules nobody had looked at, so which
module the next one appears in is not something a boundary predicts.

Each holds itself to it over its own classes. Nothing walks across to a sibling's
`target/classes`: the reactor builds these in an order, and what is on disk
beside a module at any moment is not what this run compiled. Only the compiler
declares a row, so only its copy has an admitting side to state; the rest let
nothing take the name at all, and the spelling they share is declared once.

souther-fmt holds no rows — a row is a compiler type and the formatter is not
under the compiler — so its copy has no admitting side and the prohibition is the
whole of it. `Columns.Stop.row` was the `SyntaxKind` a row is written as and is
`rowKind`.

souther-syntax keeps its two `String row` components, and its copy says why. A
message's component names are read back by name: they are a catalog entry's
placeholders in two languages (`The row says {row}`) and the keys the JSON
renderer writes a diagnostic's values under. That is the sentence's word on a
wire, not this module calling something a row, and serialized vocabulary is
outside this rule wherever it appears — as the report's `"rows"` key is. The
exception is the component and nothing beside it: a field or a method of a
message goes by no catalog and no wire, so the reason does not reach it. It is
taken from what a class implements rather than from a list of today's messages,
and a third check holds it to meeting something.

The mechanism they share is in souther-test-support: finding a module's classes
from one of them, and reading which declarations take a name. That reading names
every declaration and not every name — a field and a method of one name are two
things the author wrote, and a record's component is told from the field and
accessor written for it by the descriptors a class file carries. What it answers
is pinned there, against a fixture written for it.

## Not done

`Deadline.Work.RowEvaluation` was the first candidate for the work of evaluating
a row and is not available: `souther.compiler.examples.RowEvaluation` is already
the *result* of evaluating one, in the same package. `WholeRow` avoids putting
two `RowEvaluation`s in one package while the change is about removing exactly
that kind of collision.

`mvn -o test` is green over all eleven modules from a fresh build of every
module's classes.
