### PR TITLE
Derive what a comparison states from what it placed

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CanonicalComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CanonicalComparison.java
@@ -4,18 +4,18 @@ package souther.compiler.check;
  * The canonical statement a comparison comes to, over two values of whatever a reader holds them
  * as.
  *
- * <p>Six ways to compare two values state three things between them: that the two are the same
- * value, that one stands below the other, and the denial of either. Which of the three a comparison
- * states is decided from what it placed ({@link ComparisonClaim}), and it is decided once — a
- * reader that worked it out from the operator would be a second answer, and the two agree only for
- * as long as somebody keeps them so.
+ * <p>Two statements carry the six ways to compare two values: that the two are the same value, and
+ * that one stands below the other. Each of them and its denial is four, and the two sides of an
+ * order are six. Which of them a comparison states is decided from what it placed
+ * ({@link ComparisonClaim}), and it is decided once — a reader that worked it out from the operator
+ * would be a second answer, and the two agree only for as long as somebody keeps them so.
  *
  * <p><b>A proposition and not a record of one.</b> Nothing here can be taken apart. Which of the
- * three this is, which side each value is on, and whether it is denied are what a reader would have
- * to put back together, and putting them back together is the derivation this type exists to hold:
- * a reader that switched on the first fact and forgot the last would state the comparison that
- * holds exactly where this one does not. So the only way to read one is {@link #expressedAs}, which
- * hands the reader its own three constructors and assembles the answer here.
+ * two it is, which side each value is on, and whether it is denied are what a reader would have to
+ * put back together, and putting them back together is the derivation this type exists to hold: a
+ * reader that switched on the first fact and forgot the last would state the comparison that holds
+ * exactly where this one does not. So the only way to read one is {@link #expressedAs}, which hands
+ * the reader its own way of writing each and assembles the answer here.
  *
  * <p><b>Over any two values.</b> A comparison of two terms and a comparison of two expressions
  * state the same thing about their sides, and what differs is only what a side is and what a
@@ -24,7 +24,7 @@ package souther.compiler.check;
  */
 final class CanonicalComparison<A> {
 
-    /** How a reader writes the three statements in its own representation. */
+    /** How a reader writes the two statements, and a denial, in its own representation. */
     interface Expression<A, T> {
 
         /** The two sides are the same value. */

--- a/souther-compiler/src/main/java/souther/compiler/check/CanonicalComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CanonicalComparison.java
@@ -1,0 +1,95 @@
+package souther.compiler.check;
+
+/**
+ * The canonical statement a comparison comes to, over two values of whatever a reader holds them
+ * as.
+ *
+ * <p>Six ways to compare two values state three things between them: that the two are the same
+ * value, that one stands below the other, and the denial of either. Which of the three a comparison
+ * states is decided from what it placed ({@link ComparisonClaim}), and it is decided once — a
+ * reader that worked it out from the operator would be a second answer, and the two agree only for
+ * as long as somebody keeps them so.
+ *
+ * <p><b>A proposition and not a record of one.</b> Nothing here can be taken apart. Which of the
+ * three this is, which side each value is on, and whether it is denied are what a reader would have
+ * to put back together, and putting them back together is the derivation this type exists to hold:
+ * a reader that switched on the first fact and forgot the last would state the comparison that
+ * holds exactly where this one does not. So the only way to read one is {@link #expressedAs}, which
+ * hands the reader its own three constructors and assembles the answer here.
+ *
+ * <p><b>Over any two values.</b> A comparison of two terms and a comparison of two expressions
+ * state the same thing about their sides, and what differs is only what a side is and what a
+ * statement about two of them is written as. So the values are the reader's, and so is what comes
+ * back.
+ */
+final class CanonicalComparison<A> {
+
+    /** How a reader writes the three statements in its own representation. */
+    interface Expression<A, T> {
+
+        /** The two sides are the same value. */
+        T theSameValue(A left, A right);
+
+        /** The left side stands below the right. */
+        T below(A left, A right);
+
+        /** What holds exactly where {@code statement} does not. */
+        T denied(T statement);
+    }
+
+    private final Statement<A> statement;
+
+    private CanonicalComparison(Statement<A> statement) {
+        this.statement = statement;
+    }
+
+    /** The statement that the two sides are the same value. */
+    static <A> CanonicalComparison<A> theSameValue(A left, A right) {
+        return new CanonicalComparison<>(new Same<>(left, right));
+    }
+
+    /** The statement that {@code left} stands below {@code right}. */
+    static <A> CanonicalComparison<A> below(A left, A right) {
+        return new CanonicalComparison<>(new Below<>(left, right));
+    }
+
+    /** What holds exactly where this does not. */
+    CanonicalComparison<A> denied() {
+        return new CanonicalComparison<>(new Denied<>(statement));
+    }
+
+    /** This statement, written by {@code expression} in the reader's own representation. */
+    <T> T expressedAs(Expression<A, T> expression) {
+        return statement.expressedAs(expression);
+    }
+
+    /** What is stated, kept where no reader can name it. */
+    private sealed interface Statement<A> {
+
+        <T> T expressedAs(Expression<A, T> expression);
+    }
+
+    private record Same<A>(A left, A right) implements Statement<A> {
+
+        @Override
+        public <T> T expressedAs(Expression<A, T> expression) {
+            return expression.theSameValue(left, right);
+        }
+    }
+
+    private record Below<A>(A left, A right) implements Statement<A> {
+
+        @Override
+        public <T> T expressedAs(Expression<A, T> expression) {
+            return expression.below(left, right);
+        }
+    }
+
+    private record Denied<A>(Statement<A> of) implements Statement<A> {
+
+        @Override
+        public <T> T expressedAs(Expression<A, T> expression) {
+            return expression.denied(of.expressedAs(expression));
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
@@ -56,6 +56,22 @@ public sealed interface ComparisonClaim
      */
     Rel statedRelation();
 
+    /**
+     * The canonical statement this claim makes of {@code left} and {@code right}.
+     *
+     * <p>The one derivation from what a comparison placed to what it states. Two facts decide it
+     * and neither decides the other: which class the value named is in says which side of the
+     * canonical order each of the two goes on, and whether the comparison holds at the value says
+     * whether the canonical statement is denied. The two shapes read the second fact opposite ways,
+     * because an order does not hold at the value it names and an equality does.
+     *
+     * <p>Here rather than wherever a reader wants it, because a reader that pairs the two facts
+     * itself remembers the pairing in as many places as there are readers, and one that pairs them
+     * the other way round states the comparison that holds exactly where this one does not while
+     * answering every one of its own questions consistently.
+     */
+    <A> CanonicalComparison<A> canonical(A left, A right);
+
     @Override
     ComparisonClaim turned();
 
@@ -109,6 +125,18 @@ public sealed interface ComparisonClaim
         @Override
         public Cut denied() {
             return new Cut(valueBelongs, !holdsAtTheValue);
+        }
+
+        /** The canonical order, taken with the value named above the other — which is the side the
+         *  canonical form wants it on, so a cut that puts it below states the same thing with its
+         *  sides exchanged — and denied where the comparison holds at the value, because the
+         *  canonical order does not hold there. */
+        @Override
+        public <A> CanonicalComparison<A> canonical(A left, A right) {
+            boolean exchanged = valueBelongs == Towards.BELOW;
+            CanonicalComparison<A> order = CanonicalComparison.below(
+                    exchanged ? right : left, exchanged ? left : right);
+            return holdsAtTheValue ? order.denied() : order;
         }
 
         /** Which way the values it admits lie, and whether the number named is one of them: the
@@ -177,6 +205,16 @@ public sealed interface ComparisonClaim
         @Override
         public Singled denied() {
             return new Singled(!holdsAtTheValue);
+        }
+
+        /** The two sides being the same value, denied where the comparison does not hold at the
+         *  value it names — which is the canonical equality read the way round it is stated, and
+         *  the opposite of how an order reads that same fact. Nothing is exchanged: an equality
+         *  orders nothing, so neither side is the one the canonical form wants. */
+        @Override
+        public <A> CanonicalComparison<A> canonical(A left, A right) {
+            CanonicalComparison<A> equality = CanonicalComparison.theSameValue(left, right);
+            return holdsAtTheValue ? equality : equality.denied();
         }
 
         /** An equality or its denial, which is the whole of what singling a value out states. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -6,7 +6,6 @@ import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
-import souther.compiler.numeric.Towards;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.semantics.ResultRange;
@@ -308,29 +307,47 @@ final class Conditions {
     /**
      * The one of the two canonical comparisons {@code placed} is, and which way it is asserted.
      *
-     * <p>Two independent things are done to get there, each of them one fact of what was placed.
-     * Which sides the canonical form wants is which class the value named is in: the canonical
-     * order names it above, so a comparison that names it below is the same statement with its
-     * sides exchanged. Whether the assertion turns over is whether the comparison holds at the
-     * value: the canonical order does not hold there and the canonical equality does, which is why
-     * the two shapes read that fact opposite ways.
-     *
-     * <p>Written as the two rather than as the four comparisons it comes to, because the four are
-     * a table of what these two facts say together — and a table is a thing to keep in step with
-     * the classification it was copied from.
+     * <p>Which of the two it is, which side of it each value goes on and whether it is denied are
+     * what {@code placed} states ({@link ComparisonClaim#canonical}). What is here is the rest:
+     * that a canonical comparison of this compiler's own is written as an operator between the two
+     * sides, and that its denial is carried by the polarity beside it rather than by a node.
      */
     private static Polar canonical(Core.Binary b, ComparisonClaim placed, boolean positive) {
-        return switch (placed) {
-            case ComparisonClaim.Singled singled ->
-                    new Polar(comparison(BinOp.EQ, b.left(), b.right(), b),
-                            singled.holdsAtTheValue() == positive);
-            case ComparisonClaim.Cut cut -> {
-                boolean exchanged = cut.valueBelongs() == Towards.BELOW;
-                yield new Polar(comparison(BinOp.LT,
-                        exchanged ? b.right() : b.left(), exchanged ? b.left() : b.right(), b),
-                        cut.holdsAtTheValue() != positive);
-            }
-        };
+        AsPolar as = new AsPolar(b);
+        Polar stated = placed.canonical(b.left(), b.right()).expressedAs(as);
+        return positive ? stated : as.denied(stated);
+    }
+
+    /**
+     * A canonical comparison, written as a node standing where {@code of} did with what is asserted
+     * of it held beside it.
+     *
+     * <p>{@code of} is here because a node is more than its two sides and its operator: where it
+     * came from, what it answers and where it stands are what the readings below it file the fact
+     * under, and a comparison put in its place that said any of them differently would be a fact
+     * about somewhere else. What is written is the reader's own business and is no part of what the
+     * comparison states, which is why the node is held here and not carried in the statement.
+     */
+    private record AsPolar(Core.Binary of)
+            implements CanonicalComparison.Expression<Core, Polar> {
+
+        @Override
+        public Polar theSameValue(Core left, Core right) {
+            return new Polar(comparison(BinOp.EQ, left, right, of), true);
+        }
+
+        @Override
+        public Polar below(Core left, Core right) {
+            return new Polar(comparison(BinOp.LT, left, right, of), true);
+        }
+
+        /** Carried beside the node, which is what a polarity is for: a denial written as a node
+         *  would be a second shape for the readings below to take apart before they could read the
+         *  comparison under it. */
+        @Override
+        public Polar denied(Polar statement) {
+            return new Polar(statement.expr(), !statement.positive());
+        }
     }
 
     static Core.Binary comparison(BinOp op, Core left, Core right, Core.Binary of) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericMeaning.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericMeaning.java
@@ -36,7 +36,24 @@ sealed interface NumericMeaning {
      * (spec §stdlib-decimal), which is a different operation from the one
      * {@link RoundedQuotient} states. Nothing derives a range from it, as nothing did before.
      */
-    record Operator(BinOp op, Core left, Core right) implements NumericMeaning {}
+    record Operator(BinOp op, Core left, Core right) implements NumericMeaning {
+
+        /**
+         * Which operators this is about, said where one arrives rather than left to the readings
+         * that meet it.
+         *
+         * <p>An operator answering something else is not arithmetic the language wrote, and a
+         * reader of this holds one that is: everything below takes the operator as naming a number
+         * two operands come to, and a comparison arriving here would be named as though it were
+         * one.
+         */
+        public Operator {
+            if (!op.answersANumber()) {
+                throw new IllegalArgumentException(
+                        "arithmetic is what this is about, and this answers no number: " + op);
+            }
+        }
+    }
 
     /** A division of whole numbers, truncated toward zero (spec §stdlib-int). */
     record TruncatingQuotient(Core dividend, Core divisor) implements NumericMeaning {}

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -711,24 +711,58 @@ final class Term {
         }
 
         /**
-         * The operator over its two operands.
+         * The operator over its two operands, in the order written.
          *
-         * <p>Six comparisons are three: {@code >} is {@code <} the other way round, and {@code >=}
-         * and {@code <=} are the denials of the other two. So two clauses comparing the same two
-         * terms are one term however the author reached for it, which matters wherever the
-         * comparison is not the whole condition — only there can the denial not be carried by the
-         * polarity instead.
+         * <p>Knows nothing about comparisons and refuses one. What a comparison of two values comes
+         * to is decided from what it placed and reaches here as a statement
+         * ({@link #comparison}); an operator arriving here is what is left, which is arithmetic,
+         * a join of two conditions, or a concatenation. Answered here as well, the six ways to
+         * compare two values would be read a second time out of the operator, below the point where
+         * what they state was already settled.
          */
         Term operator(BinOp op, Term left, Term right) {
-            return switch (op) {
-                case EQ -> of(Shape.EQ, null, List.of(left, right));
-                case NE -> not(of(Shape.EQ, null, List.of(left, right)));
-                case LT -> of(Shape.OP, BinOp.LT, List.of(left, right));
-                case GT -> of(Shape.OP, BinOp.LT, List.of(right, left));
-                case GE -> not(of(Shape.OP, BinOp.LT, List.of(left, right)));
-                case LE -> not(of(Shape.OP, BinOp.LT, List.of(right, left)));
-                default -> of(Shape.OP, op, List.of(left, right));
-            };
+            if (op.compares()) {
+                throw new IllegalArgumentException(
+                        "what a comparison names is decided from what it placed: " + op);
+            }
+            return of(Shape.OP, op, List.of(left, right));
+        }
+
+        /**
+         * The term {@code canonical} names.
+         *
+         * <p>Two clauses comparing the same two terms are one term however the author reached for
+         * the comparison, which matters wherever the comparison is not the whole condition — only
+         * there can the denial not be carried by the polarity instead. What each spelling states is
+         * the claim's answer, and this says what a term for each of the three is.
+         */
+        Term comparison(CanonicalComparison<Term> canonical) {
+            return canonical.expressedAs(asTerms);
+        }
+
+        private final AsTerms asTerms = new AsTerms();
+
+        /** Which term each of the three canonical statements is. */
+        private final class AsTerms implements CanonicalComparison.Expression<Term, Term> {
+
+            /** Whose two parts are unordered, because which side of an equality a value was written
+             *  on says nothing about it ({@link Shape#EQ}). */
+            @Override
+            public Term theSameValue(Term left, Term right) {
+                return of(Shape.EQ, null, List.of(left, right));
+            }
+
+            /** The one order the terms are written in, so a comparison written the other way round
+             *  is the same term with its two operands exchanged. */
+            @Override
+            public Term below(Term left, Term right) {
+                return of(Shape.OP, BinOp.LT, List.of(left, right));
+            }
+
+            @Override
+            public Term denied(Term statement) {
+                return not(statement);
+            }
         }
 
         Term list(List<Term> elements) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -734,7 +734,7 @@ final class Term {
          * <p>Two clauses comparing the same two terms are one term however the author reached for
          * the comparison, which matters wherever the comparison is not the whole condition — only
          * there can the denial not be carried by the polarity instead. What each spelling states is
-         * the claim's answer, and this says what a term for each of the three is.
+         * the claim's answer, and this says which term states it.
          */
         Term comparison(CanonicalComparison<Term> canonical) {
             return canonical.expressedAs(asTerms);
@@ -742,7 +742,7 @@ final class Term {
 
         private final AsTerms asTerms = new AsTerms();
 
-        /** Which term each of the three canonical statements is. */
+        /** Which term a canonical statement is written as. */
         private final class AsTerms implements CanonicalComparison.Expression<Term, Term> {
 
             /** Whose two parts are unordered, because which side of an equality a value was written

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2098,8 +2098,7 @@ final class Terms {
             case Core.UnitValue u -> new Naming.Named(interned.unit(u.data()));
             case Core.Neg n -> over(List.of(n.operand()), at, bound, depth, leaf,
                     ps -> interned.negated(ps.get(0)));
-            case Core.Binary b -> over(List.of(b.left(), b.right()), at, bound, depth, leaf,
-                    ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));
+            case Core.Binary b -> binary(b, at, bound, depth, leaf);
             case Core.ListLit l -> over(l.elements(), at, bound, depth, leaf, interned::list);
             case Core.Tuple t -> over(t.elements(), at, bound, depth, leaf, interned::tuple);
             case Core.TupleGet g -> over(List.of(g.tuple()), at, bound, depth, leaf,
@@ -2245,6 +2244,28 @@ final class Terms {
     private Naming named(Naming naming, java.util.function.UnaryOperator<Term> made) {
         return naming instanceof Naming.Unnamed absent ? absent
                 : new Naming.Named(made.apply(naming.term()));
+    }
+
+    /**
+     * What a binary is named by: what the comparison it is states, or the operator over its two
+     * operands.
+     *
+     * <p>Recognised here, where the node is. A comparison of two values is named by what it placed
+     * ({@link ComparisonClaim#canonical}), so the six ways to write one come to the three things
+     * they state and two clauses comparing the same two values meet as one term. Handed the
+     * operator instead, what a comparison states would be read a second time below the point where
+     * it was already settled. What is left is an operator the interner takes as written.
+     */
+    private Naming binary(Core.Binary b, Denotations at, Map<BindingId, Term> bound, int depth,
+                          Leaf leaf) {
+        List<Core> sides = List.of(b.left(), b.right());
+        Comparison compared = Comparison.of(b).orElse(null);
+        if (compared != null) {
+            return over(sides, at, bound, depth, leaf,
+                    ps -> interned.comparison(compared.claim().canonical(ps.get(0), ps.get(1))));
+        }
+        return over(sides, at, bound, depth, leaf,
+                ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));
     }
 
     /** {@code made} of the terms {@code parts} are, or null where any of them is named by nothing. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2251,18 +2251,18 @@ final class Terms {
      * operands.
      *
      * <p>Recognised here, where the node is. A comparison of two values is named by what it placed
-     * ({@link ComparisonClaim#canonical}), so the six ways to write one come to the three things
-     * they state and two clauses comparing the same two values meet as one term. Handed the
+     * ({@link ComparisonClaim#canonical}), so the six ways to write one come to what they state and
+     * two clauses comparing the same two values meet as one term. Handed the
      * operator instead, what a comparison states would be read a second time below the point where
      * it was already settled. What is left is an operator the interner takes as written.
      */
     private Naming binary(Core.Binary b, Denotations at, Map<BindingId, Term> bound, int depth,
                           Leaf leaf) {
         List<Core> sides = List.of(b.left(), b.right());
-        Comparison compared = Comparison.of(b).orElse(null);
-        if (compared != null) {
+        ComparisonClaim placed = Comparison.of(b).map(Comparison::claim).orElse(null);
+        if (placed != null) {
             return over(sides, at, bound, depth, leaf,
-                    ps -> interned.comparison(compared.claim().canonical(ps.get(0), ps.get(1))));
+                    ps -> interned.comparison(placed.canonical(ps.get(0), ps.get(1))));
         }
         return over(sides, at, bound, depth, leaf,
                 ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));

--- a/souther-compiler/src/main/java/souther/compiler/semantics/Arithmetic.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/Arithmetic.java
@@ -41,8 +41,19 @@ public sealed interface Arithmetic {
      */
     record TheOperator(BinOp op) implements Arithmetic {
 
+        /**
+         * Which operators a row may state, said here rather than trusted of the rows.
+         *
+         * <p>What this declares is that a library operation computes what an operator computes,
+         * and every reader of it takes the operation to answer a number. A row naming an operator
+         * that answers something else would put that operation's value where a number is read.
+         */
         public TheOperator {
             java.util.Objects.requireNonNull(op, "this one names an operator");
+            if (!op.answersANumber()) {
+                throw new IllegalArgumentException(
+                        "an operation computing what an operator computes answers a number: " + op);
+            }
         }
 
         @Override

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -124,8 +124,7 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                 interned.unit(data),
                 interned.negated(one),
                 interned.not(interned.written(true)),
-                interned.comparison(
-                        ((ComparisonClaim) ComparisonPlacement.of(BinOp.EQ)).canonical(one, one)),
+                interned.comparison(AsPlaced.claim(BinOp.EQ).canonical(one, one)),
                 interned.operator(BinOp.ADD, one, one),
                 interned.list(List.of(one)),
                 interned.tuple(List.of(one)),

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -124,7 +124,8 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                 interned.unit(data),
                 interned.negated(one),
                 interned.not(interned.written(true)),
-                interned.operator(BinOp.EQ, one, one),
+                interned.comparison(
+                        ((ComparisonClaim) ComparisonPlacement.of(BinOp.EQ)).canonical(one, one)),
                 interned.operator(BinOp.ADD, one, one),
                 interned.list(List.of(one)),
                 interned.tuple(List.of(one)),

--- a/souther-compiler/src/test/java/souther/compiler/check/ArithmeticIsKeyedByAnOperatorThatAnswersANumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ArithmeticIsKeyedByAnOperatorThatAnswersANumberTest.java
@@ -1,0 +1,62 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.semantics.Arithmetic;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.Type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Which operators the two values keyed by one may be keyed by.
+ *
+ * <p>Both say that an operator is what computes a number: {@link NumericMeaning.Operator} of an
+ * expression the check read, and {@link Arithmetic.TheOperator} of an operation the library
+ * declared. Every reader of either takes the operator that way — the term a value is named by is
+ * built from it, and the recipe a bound is proved in is keyed by it — so one keyed by an operator
+ * answering something else would put a comparison where a number is read.
+ *
+ * <p><b>The set the type admits, not the set anything happens to make.</b> The library states three
+ * arithmetic operations and none of them is a divide, and a row for one is writable: the divides it
+ * declares today are a truncating quotient and a quotient rounded to a scale, which are arithmetic
+ * of their own rather than what the operator computes. So what is refused here is an operator that
+ * answers no number, and a divide is not one of those.
+ */
+class ArithmeticIsKeyedByAnOperatorThatAnswersANumberTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static Core number(long value) {
+        return new Core.Int(value, Type.INT, POS);
+    }
+
+    @Test
+    void anExpressionsArithmeticIsKeyedByOneThatAnswersANumber() {
+        for (BinOp op : BinOp.values()) {
+            if (op.answersANumber()) {
+                assertEquals(op, new NumericMeaning.Operator(op, number(1), number(2)).op(),
+                        "arithmetic the language writes as an operator is keyed by it: " + op);
+            } else {
+                assertThrows(IllegalArgumentException.class,
+                        () -> new NumericMeaning.Operator(op, number(1), number(2)),
+                        "what this is about is arithmetic, and this answers no number: " + op);
+            }
+        }
+    }
+
+    @Test
+    void aLibraryOperationComputesWhatAnOperatorAnsweringANumberComputes() {
+        for (BinOp op : BinOp.values()) {
+            if (op.answersANumber()) {
+                assertEquals(op, new Arithmetic.TheOperator(op).op(),
+                        "an operation stating this computes what the operator computes: " + op);
+            } else {
+                assertThrows(IllegalArgumentException.class, () -> new Arithmetic.TheOperator(op),
+                        "an operation computing what an operator computes answers a number: " + op);
+            }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AsPlaced.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AsPlaced.java
@@ -1,0 +1,27 @@
+package souther.compiler.check;
+
+import souther.compiler.types.BinOp;
+
+/**
+ * What an operator placed, for a test that names the operator rather than a node.
+ *
+ * <p>{@link Comparison} is how a reader comes by a claim, and it wants a node — so a test whose
+ * subject is the operator itself has to narrow {@link ComparisonPlacement} instead. Here rather
+ * than wherever such a test stands, because narrowing the wide answer in each of them is the shape
+ * the readings below a recognition stopped having: one of them holding an operator that placed
+ * nothing would answer for a case the test meant to exclude, and it would say so as a class cast
+ * somewhere in the middle of what it was checking.
+ */
+final class AsPlaced {
+
+    private AsPlaced() {
+    }
+
+    /** What {@code op} placed, where the test's own subject is that it places something. */
+    static ComparisonClaim claim(BinOp op) {
+        if (ComparisonPlacement.of(op) instanceof ComparisonClaim placed) {
+            return placed;
+        }
+        throw new IllegalArgumentException("this places nothing, so there is no claim: " + op);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,29 +30,71 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * the answer is a different matter — a reader that has to write a comparison down asks, and one
  * more of them is one more consumer and not one more derivation.
  *
+ * <p><b>What is watched is not written here.</b> Everything that hands back a
+ * {@link CanonicalComparison} is read off the compiled classes, and the two questions are the two
+ * halves of that: what is declared on the value is how one is assembled, and what is declared
+ * anywhere else is how one is asked for. A list of methods written out instead would have a
+ * complement — an operation added to the value, an override reached through the arm that declares
+ * it rather than through the interface — and what falls in the complement is answered by silence.
+ * So the way in is enumerated and then declared, and a way in that nobody has written down is
+ * itself the finding.
+ *
  * <p><b>What the visibility does not do.</b> {@link CanonicalComparison} is this package's, which
  * keeps it out of the vocabulary anything outside reads. It does not decide who calls what: a
  * method whose answer nothing outside can name is still a method anything can call, so both
  * questions are answered here rather than by the language.
  *
  * <p>Read off the compiled classes, because what a method calls is what the class file says. A
- * reading of the sources would answer the same question a second way, and would not see a call
- * written inside a lambda as the method that holds it.
+ * reading of the sources would answer the same question a second way, would not see a call written
+ * inside a lambda as the method that holds it, and would not see which of an override and the
+ * method it overrides a call names.
  */
 class OnlyAClaimSaysWhatAComparisonStatesTest {
 
     private static final String CANONICAL = "souther/compiler/check/CanonicalComparison";
 
-    private static final String CLAIM = "souther/compiler/check/ComparisonClaim";
+    /** What hands back a canonical comparison: the class it is declared on, and its name. */
+    private record Producer(String owner, String name) implements Comparable<Producer> {
 
-    /** Everything a canonical comparison is put together out of. A licence for one of these is a
-     *  licence for none of the others: a reader allowed to deny a statement it did not make is a
-     *  reader stating the comparison that holds exactly where the claim's does not. */
-    private static final Set<String> ASSEMBLED =
-            Set.of("theSameValue", "below", "denied");
+        /** As a reader of a failure reads it, and as a licence below names it. */
+        String shown() {
+            return owner.replace('/', '.').replace('$', '.') + "." + name;
+        }
 
-    /** A method that may do this, and why it is the one that may. */
+        /** Assembled where it is declared on the value itself, and asked for anywhere else. */
+        boolean assembles() {
+            return owner.equals(CANONICAL);
+        }
+
+        @Override
+        public int compareTo(Producer other) {
+            return shown().compareTo(other.shown());
+        }
+    }
+
+    /** A method that may call one, and why it is one that may. */
     private record Licence(String who, String why) { }
+
+    /**
+     * Every way to come by a canonical comparison, and what each is for.
+     *
+     * <p>Declared because the two tests below are only as wide as this is. An operation added to
+     * the value, or a second method on a claim answering the same question, lands here first and is
+     * said to be one of the two things before anything asks who may call it.
+     */
+    private static final List<Licence> WAYS_IN = List.of(
+            new Licence("souther.compiler.check.CanonicalComparison.theSameValue",
+                    "assembles the statement that the two sides are the same value"),
+            new Licence("souther.compiler.check.CanonicalComparison.below",
+                    "assembles the statement that the left side stands below the right"),
+            new Licence("souther.compiler.check.CanonicalComparison.denied",
+                    "assembles what holds exactly where a statement does not"),
+            new Licence("souther.compiler.check.ComparisonClaim.canonical",
+                    "what a claim states, asked of a claim whichever of the two it is"),
+            new Licence("souther.compiler.check.ComparisonClaim.Cut.canonical",
+                    "the same, reached through the arm an order is"),
+            new Licence("souther.compiler.check.ComparisonClaim.Singled.canonical",
+                    "the same, reached through the arm a value singled out is"));
 
     private static final List<Licence> MAY_ASSEMBLE = List.of(
             new Licence("souther.compiler.check.ComparisonClaim.Cut.canonical",
@@ -69,6 +112,40 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
                     "names the value a comparison in a body is, which is written as a term"));
 
     /**
+     * Every way to come by one, which is what the two tests below are asked about.
+     *
+     * <p>A way in that nobody wrote down is not covered by either of them, and a check whose reach
+     * is a list somebody keeps in step is a check that goes quiet exactly when the thing it guards
+     * grows.
+     */
+    @Test
+    void everyWayToComeByACanonicalComparisonIsWrittenDown() throws IOException {
+        assertEquals(declared(WAYS_IN), shown(producers()),
+                "a method handing back a canonical comparison is a way to come by one, and what"
+                        + " may call it is decided below. What each of these is for: "
+                        + why(WAYS_IN));
+    }
+
+    /**
+     * And that the ways in are all of them, which is what makes the two below say what they claim.
+     *
+     * <p>Every one of these values comes from the one constructor, so a method that makes one and
+     * hands it back as something else — inside an optional, inside a list — would be a way in that
+     * the enumeration above cannot see, its own type having been erased from what it returns. It
+     * would be seen here, as a maker that is not one of the ways in.
+     *
+     * <p>Both sides are read off the classes, so this says the two agree and not what either is.
+     * What they are is said above.
+     */
+    @Test
+    void nothingMakesOneExceptTheWaysInToMakingOne() throws IOException {
+        assertEquals(shown(assembling()),
+                callers(Set.of(new Producer(CANONICAL, "<init>"))),
+                "a canonical comparison made anywhere else is one whose making nothing decided,"
+                        + " and it is made where the derivation is not");
+    }
+
+    /**
      * The derivation from what a comparison placed to what it states, which is the claim's own.
      *
      * <p>Two facts decide it and neither decides the other, so a reader putting them together is a
@@ -78,7 +155,7 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      */
     @Test
     void onlyTheTwoClaimsPutACanonicalComparisonTogether() throws IOException {
-        assertEquals(declared(MAY_ASSEMBLE), callsTo(CANONICAL, ASSEMBLED),
+        assertEquals(declared(MAY_ASSEMBLE), callersOf(Producer::assembles),
                 "what a comparison states is derived where what it placed is held, and nowhere"
                         + " else. What each of these assembles: " + why(MAY_ASSEMBLE));
     }
@@ -92,8 +169,9 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
      */
     @Test
     void onlyAReaderWritingAComparisonDownAsksForOne() throws IOException {
-        assertEquals(declared(MAY_ASK), callsTo(CLAIM, Set.of("canonical")),
-                "asking a claim what it states is asking to write the comparison down somewhere."
+        assertEquals(declared(MAY_ASK), callersOf(producer -> !producer.assembles()),
+                "asking a claim what it states is asking to write the comparison down somewhere,"
+                        + " through the interface or through the arm that declares the answer."
                         + " What each of these writes it into: " + why(MAY_ASK));
     }
 
@@ -103,38 +181,74 @@ class OnlyAClaimSaysWhatAComparisonStatesTest {
         return out;
     }
 
+    private static Map<String, String> shown(Set<Producer> producers) {
+        Map<String, String> out = new TreeMap<>();
+        producers.forEach(each -> out.put(each.shown(), ""));
+        return out;
+    }
+
     private static Map<String, String> why(List<Licence> licences) {
         Map<String, String> out = new LinkedHashMap<>();
         licences.forEach(each -> out.put(each.who(), each.why()));
         return out;
     }
 
-    /** Which methods of the compiler call any of {@code names} on {@code owner}. */
-    private static Map<String, String> callsTo(String owner, Set<String> names) throws IOException {
+    /** Everything the compiler declares that hands one back. */
+    private static Set<Producer> producers() throws IOException {
+        Set<Producer> out = new TreeSet<>();
+        for (ClassModel model : compiled()) {
+            String owner = model.thisClass().asInternalName();
+            for (MethodModel method : model.methods()) {
+                if (method.methodTypeSymbol().returnType().descriptorString()
+                        .equals("L" + CANONICAL + ";")) {
+                    out.add(new Producer(owner, method.methodName().stringValue()));
+                }
+            }
+        }
+        assertFalse(out.isEmpty(), "nothing hands one back at all, so this says nothing");
+        return out;
+    }
+
+    /** The ways in that are declared on the value itself, which is how one is made. */
+    private static Set<Producer> assembling() throws IOException {
+        return new TreeSet<>(producers().stream().filter(Producer::assembles).toList());
+    }
+
+    /** Which methods call any producer {@code wanted} admits, whichever way its receiver is
+     *  typed. */
+    private static Map<String, String> callersOf(java.util.function.Predicate<Producer> wanted)
+            throws IOException {
+        return callers(new TreeSet<>(producers().stream().filter(wanted).toList()));
+    }
+
+    /** Which methods call any of {@code watched}. */
+    private static Map<String, String> callers(Set<Producer> watched) throws IOException {
+        assertFalse(watched.isEmpty(), "no producer was watched, so this says nothing");
         Map<String, String> calls = new TreeMap<>();
-        int read = 0;
-        for (Path each : classes()) {
-            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-            read++;
+        for (ClassModel model : compiled()) {
             String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
             for (MethodModel method : model.methods()) {
                 method.code().ifPresent(code -> code.forEach(element -> {
                     if (element instanceof InvokeInstruction call
-                            && call.owner().asInternalName().equals(owner)
-                            && names.contains(call.name().stringValue())) {
+                            && watched.contains(new Producer(call.owner().asInternalName(),
+                                    call.name().stringValue()))) {
                         calls.put(from + "." + method.methodName().stringValue(), "");
                     }
                 }));
             }
         }
-        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
         return calls;
     }
 
-    private static List<Path> classes() throws IOException {
+    private static List<ClassModel> compiled() throws IOException {
         Path root = Path.of("target", "classes").toAbsolutePath();
+        List<ClassModel> out = new ArrayList<>();
         try (Stream<Path> walk = Files.walk(root)) {
-            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
+                out.add(ClassFile.of().parse(Files.readAllBytes(each)));
+            }
         }
+        assertFalse(out.isEmpty(), "no compiled class was read at all, so this says nothing");
+        return out;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAClaimSaysWhatAComparisonStatesTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Who puts a canonical comparison together, and who asks for one.
+ *
+ * <p>Two questions, and they break differently. What a comparison of two values states is derived
+ * from the two facts a claim holds, and that derivation is the claim's: a second one is a table of
+ * six that agrees with this one only for as long as somebody keeps it so. Who may ask a claim for
+ * the answer is a different matter — a reader that has to write a comparison down asks, and one
+ * more of them is one more consumer and not one more derivation.
+ *
+ * <p><b>What the visibility does not do.</b> {@link CanonicalComparison} is this package's, which
+ * keeps it out of the vocabulary anything outside reads. It does not decide who calls what: a
+ * method whose answer nothing outside can name is still a method anything can call, so both
+ * questions are answered here rather than by the language.
+ *
+ * <p>Read off the compiled classes, because what a method calls is what the class file says. A
+ * reading of the sources would answer the same question a second way, and would not see a call
+ * written inside a lambda as the method that holds it.
+ */
+class OnlyAClaimSaysWhatAComparisonStatesTest {
+
+    private static final String CANONICAL = "souther/compiler/check/CanonicalComparison";
+
+    private static final String CLAIM = "souther/compiler/check/ComparisonClaim";
+
+    /** Everything a canonical comparison is put together out of. A licence for one of these is a
+     *  licence for none of the others: a reader allowed to deny a statement it did not make is a
+     *  reader stating the comparison that holds exactly where the claim's does not. */
+    private static final Set<String> ASSEMBLED =
+            Set.of("theSameValue", "below", "denied");
+
+    /** A method that may do this, and why it is the one that may. */
+    private record Licence(String who, String why) { }
+
+    private static final List<Licence> MAY_ASSEMBLE = List.of(
+            new Licence("souther.compiler.check.ComparisonClaim.Cut.canonical",
+                    "an order, with the sides the way the canonical form wants them and denied"
+                            + " where the comparison holds at the value it names"),
+            new Licence("souther.compiler.check.ComparisonClaim.Singled.canonical",
+                    "an equality, denied where the comparison does not hold at the value it"
+                            + " names — which is the same fact read the other way round"));
+
+    private static final List<Licence> MAY_ASK = List.of(
+            new Licence("souther.compiler.check.Conditions.canonical",
+                    "keys a fact by the comparison a condition states, which is written as a node"
+                            + " with what is asserted of it carried beside"),
+            new Licence("souther.compiler.check.Terms.lambda$binary$0",
+                    "names the value a comparison in a body is, which is written as a term"));
+
+    /**
+     * The derivation from what a comparison placed to what it states, which is the claim's own.
+     *
+     * <p>Two facts decide it and neither decides the other, so a reader putting them together is a
+     * reader that remembers the pairing — and one that pairs them the other way round answers every
+     * one of its own questions consistently about the comparison that holds where this one does
+     * not.
+     */
+    @Test
+    void onlyTheTwoClaimsPutACanonicalComparisonTogether() throws IOException {
+        assertEquals(declared(MAY_ASSEMBLE), callsTo(CANONICAL, ASSEMBLED),
+                "what a comparison states is derived where what it placed is held, and nowhere"
+                        + " else. What each of these assembles: " + why(MAY_ASSEMBLE));
+    }
+
+    /**
+     * And who asks for one, which is a consumer boundary and not the derivation.
+     *
+     * <p>Written down for the same reason the readers of an operator are: a reader appearing here
+     * is one more place a comparison has to be written down in some representation, and what it
+     * writes has to be a comparison of this compiler's own rather than one the source never wrote.
+     */
+    @Test
+    void onlyAReaderWritingAComparisonDownAsksForOne() throws IOException {
+        assertEquals(declared(MAY_ASK), callsTo(CLAIM, Set.of("canonical")),
+                "asking a claim what it states is asking to write the comparison down somewhere."
+                        + " What each of these writes it into: " + why(MAY_ASK));
+    }
+
+    private static Map<String, String> declared(List<Licence> licences) {
+        Map<String, String> out = new TreeMap<>();
+        licences.forEach(each -> out.put(each.who(), ""));
+        return out;
+    }
+
+    private static Map<String, String> why(List<Licence> licences) {
+        Map<String, String> out = new LinkedHashMap<>();
+        licences.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** Which methods of the compiler call any of {@code names} on {@code owner}. */
+    private static Map<String, String> callsTo(String owner, Set<String> names) throws IOException {
+        Map<String, String> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(owner)
+                            && names.contains(call.name().stringValue())) {
+                        calls.put(from + "." + method.methodName().stringValue(), "");
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoWritingsOfOneComparisonAreOneTermTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoWritingsOfOneComparisonAreOneTermTest.java
@@ -46,11 +46,7 @@ class TwoWritingsOfOneComparisonAreOneTermTest {
     }
 
     private Term comparing(BinOp op, Term left, Term right) {
-        return interned.comparison(placed(op).canonical(left, right));
-    }
-
-    private static ComparisonClaim placed(BinOp op) {
-        return (ComparisonClaim) ComparisonPlacement.of(op);
+        return interned.comparison(AsPlaced.claim(op).canonical(left, right));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoWritingsOfOneComparisonAreOneTermTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoWritingsOfOneComparisonAreOneTermTest.java
@@ -1,0 +1,101 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.types.BinOp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What term each of the six ways to compare two values is named by.
+ *
+ * <p>A fact is settled by the term it is about, so two clauses comparing the same two values have
+ * to name one term however the author reached for the comparison. Six terms for six spellings would
+ * leave a guard written one way and a clause written the other talking about different values.
+ *
+ * <p><b>The terms themselves, written out.</b> What is fixed here is which term each spelling comes
+ * to and not that the six come to fewer than six: a reading that answered one term for all of them
+ * would satisfy the second and be wrong. So each row says what is built, down to which side of the
+ * order each operand is on and whether the term is a denial.
+ */
+class TwoWritingsOfOneComparisonAreOneTermTest {
+
+    private final Term.Interner interned = new Term.Interner();
+
+    private final Term one = interned.written(1L);
+
+    private final Term two = interned.written(2L);
+
+    /** What each comparison of {@code 1} against {@code 2} is named by. */
+    private static Map<BinOp, String> named() {
+        Map<BinOp, String> out = new LinkedHashMap<>();
+        out.put(BinOp.EQ, "(1 == 2)");
+        out.put(BinOp.NE, "!(1 == 2)");
+        out.put(BinOp.LT, "(1 LT 2)");
+        out.put(BinOp.GE, "!(1 LT 2)");
+        out.put(BinOp.GT, "(2 LT 1)");
+        out.put(BinOp.LE, "!(2 LT 1)");
+        return out;
+    }
+
+    private Term comparing(BinOp op) {
+        return comparing(op, one, two);
+    }
+
+    private Term comparing(BinOp op, Term left, Term right) {
+        return interned.comparison(placed(op).canonical(left, right));
+    }
+
+    private static ComparisonClaim placed(BinOp op) {
+        return (ComparisonClaim) ComparisonPlacement.of(op);
+    }
+
+    @Test
+    void eachComparisonIsNamedByTheCanonicalTermItStates() {
+        Map<BinOp, String> built = new LinkedHashMap<>();
+        named().keySet().forEach(op -> built.put(op, comparing(op).rendered()));
+
+        assertEquals(named(), built,
+                "the term a comparison is named by is what everything said about it is filed"
+                        + " under, so a spelling that comes to a different one is a spelling"
+                        + " nothing else can meet");
+    }
+
+    @Test
+    void anOrderWrittenEitherWayRoundIsOneTerm() {
+        assertEquals(comparing(BinOp.LT, one, two), comparing(BinOp.GT, two, one),
+                "a < b and b > a state one thing");
+        assertEquals(comparing(BinOp.LE, one, two), comparing(BinOp.GE, two, one),
+                "a <= b and b >= a state one thing");
+    }
+
+    /**
+     * And the operator has no way in.
+     *
+     * <p>Where a comparison could also be named from the operator it was written with, the six
+     * would come to what they state twice: once from what the comparison placed, and once here from
+     * an operator read below the point where that was settled. The two agree only for as long as
+     * somebody keeps them so.
+     */
+    @Test
+    void anOperatorCannotNameWhatAComparisonStates() {
+        for (BinOp op : BinOp.values()) {
+            if (!op.compares()) {
+                continue;
+            }
+            assertThrows(IllegalArgumentException.class, () -> interned.operator(op, one, two),
+                    "what a comparison states is not read off the operator: " + op);
+        }
+    }
+
+    @Test
+    void anEqualityWrittenEitherWayRoundIsOneTerm() {
+        assertEquals(comparing(BinOp.EQ, one, two), comparing(BinOp.EQ, two, one),
+                "which side of an equality a value was written on says nothing about it");
+        assertEquals(comparing(BinOp.NE, one, two), comparing(BinOp.NE, two, one),
+                "nor about its denial");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAComparisonStatesIsDerivedFromWhatItPlacedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAComparisonStatesIsDerivedFromWhatItPlacedTest.java
@@ -1,0 +1,125 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.types.BinOp;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What each way of comparing two values states, out of the two facts a claim holds.
+ *
+ * <p>Six ways to compare state three things between them, and which of the three is not read off
+ * the operator: which class the value named is in says which side of the canonical order each of
+ * the two goes on, and whether the comparison holds at the value says whether the statement is
+ * denied. The two shapes read the second fact opposite ways, because an order does not hold at the
+ * value it names and an equality does.
+ *
+ * <p><b>Against an algebra of its own.</b> What is fixed here is the derivation and not any
+ * writing of it: the statements are read into three values this test declares, so a term and a
+ * node that both got the derivation wrong the same way would not agree with what is written below.
+ * The two writings are fixed where each of them is
+ * ({@link TwoWritingsOfOneComparisonAreOneTermTest} and the readings of a condition).
+ */
+class WhatAComparisonStatesIsDerivedFromWhatItPlacedTest {
+
+    /** What a canonical comparison of two sides states, as a value with nothing else in it. */
+    private sealed interface Stated {
+
+        record TheSameValue(String left, String right) implements Stated {}
+
+        record Below(String left, String right) implements Stated {}
+
+        record Denied(Stated of) implements Stated {}
+    }
+
+    private static final CanonicalComparison.Expression<String, Stated> AS_STATED =
+            new CanonicalComparison.Expression<>() {
+
+                @Override
+                public Stated theSameValue(String left, String right) {
+                    return new Stated.TheSameValue(left, right);
+                }
+
+                @Override
+                public Stated below(String left, String right) {
+                    return new Stated.Below(left, right);
+                }
+
+                @Override
+                public Stated denied(Stated statement) {
+                    return new Stated.Denied(statement);
+                }
+            };
+
+    /** What each of the six states of a left side {@code l} and a right side {@code r}. */
+    private static Map<BinOp, Stated> stated() {
+        Map<BinOp, Stated> out = new LinkedHashMap<>();
+        out.put(BinOp.EQ, new Stated.TheSameValue("l", "r"));
+        out.put(BinOp.NE, new Stated.Denied(new Stated.TheSameValue("l", "r")));
+        out.put(BinOp.LT, new Stated.Below("l", "r"));
+        out.put(BinOp.GE, new Stated.Denied(new Stated.Below("l", "r")));
+        out.put(BinOp.GT, new Stated.Below("r", "l"));
+        out.put(BinOp.LE, new Stated.Denied(new Stated.Below("r", "l")));
+        return out;
+    }
+
+    private static Stated canonical(BinOp op) {
+        ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
+        return placed.canonical("l", "r").expressedAs(AS_STATED);
+    }
+
+    @Test
+    void eachComparisonStatesOneOfTheThree() {
+        Map<BinOp, Stated> derived = new LinkedHashMap<>();
+        stated().keySet().forEach(op -> derived.put(op, canonical(op)));
+
+        assertEquals(stated(), derived,
+                "which of the three a comparison states, which side of it each value goes on and"
+                        + " whether it is denied are one derivation from what the comparison"
+                        + " placed, and a reader that pairs those facts for itself pairs them"
+                        + " somewhere");
+    }
+
+    /**
+     * A reader holding the two sides the other way round states the same thing, so long as it turns
+     * the claim with them.
+     *
+     * <p>The one law that catches an order taken the wrong way round. The others hold of a
+     * derivation that exchanged the sides of every order, or of none of them, because at the value
+     * a comparison names both conventions agree — the difference shows only where one side really
+     * is below the other.
+     *
+     * <p>Of the orders, because only they have sides to turn. An equality's two sides are one pair
+     * and which of them was written first says nothing about it: that is answered where the
+     * equality is written, and here it would be this test declaring it a second time.
+     */
+    @Test
+    void aTurnedOrderStatesTheSameThingOfTheSidesTurnedWithIt() {
+        stated().keySet().stream()
+                .filter(op -> ComparisonPlacement.of(op) instanceof ComparisonClaim.Cut)
+                .forEach(op -> {
+                    ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
+                    assertEquals(placed.canonical("l", "r").expressedAs(AS_STATED),
+                            placed.turned().canonical("r", "l").expressedAs(AS_STATED),
+                            "turning the claim and the two sides together leaves the statement"
+                                    + " alone: " + op);
+                });
+    }
+
+    /** And a denied claim states the denial of what it stated. */
+    @Test
+    void aDeniedClaimStatesTheDenialOfWhatItStated() {
+        stated().forEach((op, was) -> {
+            ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
+            assertEquals(denial(was), placed.denied().canonical("l", "r").expressedAs(AS_STATED),
+                    "what holds where a comparison does not is what it states, denied: " + op);
+        });
+    }
+
+    private static Stated denial(Stated stated) {
+        return stated instanceof Stated.Denied denied ? denied.of() : new Stated.Denied(stated);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAComparisonStatesIsDerivedFromWhatItPlacedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAComparisonStatesIsDerivedFromWhatItPlacedTest.java
@@ -67,8 +67,7 @@ class WhatAComparisonStatesIsDerivedFromWhatItPlacedTest {
     }
 
     private static Stated canonical(BinOp op) {
-        ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
-        return placed.canonical("l", "r").expressedAs(AS_STATED);
+        return AsPlaced.claim(op).canonical("l", "r").expressedAs(AS_STATED);
     }
 
     @Test
@@ -99,9 +98,9 @@ class WhatAComparisonStatesIsDerivedFromWhatItPlacedTest {
     @Test
     void aTurnedOrderStatesTheSameThingOfTheSidesTurnedWithIt() {
         stated().keySet().stream()
-                .filter(op -> ComparisonPlacement.of(op) instanceof ComparisonClaim.Cut)
+                .filter(op -> AsPlaced.claim(op) instanceof ComparisonClaim.Cut)
                 .forEach(op -> {
-                    ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
+                    ComparisonClaim placed = AsPlaced.claim(op);
                     assertEquals(placed.canonical("l", "r").expressedAs(AS_STATED),
                             placed.turned().canonical("r", "l").expressedAs(AS_STATED),
                             "turning the claim and the two sides together leaves the statement"
@@ -109,17 +108,27 @@ class WhatAComparisonStatesIsDerivedFromWhatItPlacedTest {
                 });
     }
 
-    /** And a denied claim states the denial of what it stated. */
-    @Test
-    void aDeniedClaimStatesTheDenialOfWhatItStated() {
-        stated().forEach((op, was) -> {
-            ComparisonClaim placed = (ComparisonClaim) ComparisonPlacement.of(op);
-            assertEquals(denial(was), placed.denied().canonical("l", "r").expressedAs(AS_STATED),
-                    "what holds where a comparison does not is what it states, denied: " + op);
-        });
+    /** Which comparison holds exactly where each of them does not. Written out, because the two
+     *  sides of a denial are both rows of the table above and neither is worked out from the
+     *  other: the statement of a denied claim is read off this table and not by wrapping what the
+     *  claim stated, which for half of them would be a denial of a denial and is a shape nothing
+     *  here makes. */
+    private static Map<BinOp, BinOp> refuting() {
+        Map<BinOp, BinOp> out = new LinkedHashMap<>();
+        out.put(BinOp.EQ, BinOp.NE);
+        out.put(BinOp.NE, BinOp.EQ);
+        out.put(BinOp.LT, BinOp.GE);
+        out.put(BinOp.GE, BinOp.LT);
+        out.put(BinOp.GT, BinOp.LE);
+        out.put(BinOp.LE, BinOp.GT);
+        return out;
     }
 
-    private static Stated denial(Stated stated) {
-        return stated instanceof Stated.Denied denied ? denied.of() : new Stated.Denied(stated);
+    /** And a denied claim states what the comparison holding where it does not states. */
+    @Test
+    void aDeniedClaimStatesWhatRefusesIt() {
+        refuting().forEach((op, refusing) -> assertEquals(stated().get(refusing),
+                AsPlaced.claim(op).denied().canonical("l", "r").expressedAs(AS_STATED),
+                "what holds where a comparison does not is what its denial states: " + op));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -129,13 +129,17 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " means, in a table nothing recognises a comparison out of"),
 
             new Held("souther.compiler.check.NumericMeaning.Operator#op",
-                    "an arithmetic expression keyed by the operator written in it"),
+                    "an arithmetic expression keyed by the operator written in it — an operator"
+                            + " answering no number is refused where one of these is made, so a"
+                            + " comparison is not among the operators this holds"),
             new Held("souther.compiler.check.Terms.written",
-                    "makes the term a written binary is, off the operator it was written with"),
+                    "makes the term a written binary is, off the operator it was written with,"
+                            + " which is an arithmetic one: what reaches it is a divide it names"
+                            + " itself and the operator a NumericMeaning.Operator was made with"),
             new Held("souther.compiler.check.Term.Interner.operator",
-                    "which of the canonical terms a comparison is: the same six-into-three the"
-                            + " reading of a guard now takes from what was placed, kept here in the"
-                            + " operator's own words"),
+                    "makes the term an operator over two operands is, and refuses a comparison:"
+                            + " what a comparison of two values comes to is decided from what it"
+                            + " placed and arrives already stated"),
             new Held("souther.compiler.coverage.SourceOutcome.Compared#op",
                     "the operator an outcome was written with, which is what a report shows"),
 
@@ -146,11 +150,13 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.core.Core.Binary.<init>",
                     "makes the node a check produces"),
             new Held("souther.compiler.check.NumericMeaning.Operator.<init>",
-                    "makes the arithmetic meaning keyed by an operator"),
+                    "makes the arithmetic meaning keyed by an operator, and is what limits which"
+                            + " operators one of them may be keyed by to those answering a number"),
             new Held("souther.compiler.coverage.SourceOutcome.Compared.<init>",
                     "makes the outcome a report shows an operator for"),
             new Held("souther.compiler.semantics.Arithmetic.TheOperator.<init>",
-                    "makes the fact that a library operation computes what an operator computes"),
+                    "makes the fact that a library operation computes what an operator computes,"
+                            + " and is what limits that to the operators answering a number"),
             new Held("souther.compiler.semantics.NumericResult.TheOtherCaseWhen.<init>",
                     "makes the fact stating an operation's other case as a comparison"));
 
@@ -195,8 +201,9 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.Terms.numericMeaningOf",
                     "asks whether it computes a number, and keys the meaning by it"),
             new Held("souther.compiler.check.Terms.namedByRule", "asks whether it computes a number"),
-            new Held("souther.compiler.check.Terms.lambda$naming$1",
-                    "hands it to the interner, which says which canonical term the comparison is"),
+            new Held("souther.compiler.check.Terms.lambda$binary$1",
+                    "hands it to the interner, for a binary the recognition beside it found to be"
+                            + " no comparison"),
             new Held("souther.compiler.check.Terms.asOperator",
                     "reads the operator an arithmetic meaning was keyed by"),
             new Held("souther.compiler.check.Terms.theOneOf", "the same, for the meaning it interns"),
@@ -330,9 +337,14 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " composed comparison is said in the language's own operators"),
             new Held("souther.compiler.check.Conditions.asSizeComparison",
                     "writes the equality an emptiness check means: a size stood against nought"),
-            new Held("souther.compiler.check.Conditions.canonical",
-                    "writes the two comparisons a fact is keyed by, which what was placed says"
-                            + " which of and which way round"),
+            new Held("souther.compiler.check.Conditions.AsPolar.theSameValue",
+                    "writes the equality a fact is keyed by, which the claim said this comparison"
+                            + " states"),
+            new Held("souther.compiler.check.Conditions.AsPolar.below",
+                    "writes the order a fact is keyed by, with the sides the way the claim wanted"
+                            + " them"),
+            new Held("souther.compiler.check.Term.Interner.AsTerms.below",
+                    "the one order a term is written in, which the claim exchanged the sides for"),
             new Held("souther.compiler.check.Terms.repeating",
                     "writes the multiplication a repeated accumulation comes to"),
             new Held("souther.compiler.semantics.OperationFacts.declared",


### PR DESCRIPTION
Closes #1223.

## The defect

The six ways to compare two values state three things between them, and which of
the three was worked out in two places:

- `Conditions.canonical`, in the words of what the comparison placed;
- `Term.Interner.operator`, in the operator's own words.

The interner could do it because `Terms.naming`'s `Core.Binary` arm handed it a
raw `BinOp` — the walk never asked whether the binary was a comparison — which is
the boundary #1215 set: `BinOp` does not flow below the point where what a
comparison states is settled. #1215 also said the derivation from a claim's facts
is not the consumer's to write, and both of these wrote it: `exchanged` from
`valueBelongs`, and the denial from `holdsAtTheValue`, which the two shapes read
opposite ways.

Removing the operator table alone would have left that derivation in two places.

## What was measured before deciding

Every call into `Term.Interner.operator` over the whole suite, with its caller:

| entry | operators reaching it |
|---|---|
| `Terms.naming`'s `Core.Binary` arm | 134 — all six comparisons, and the arithmetic, the connectives and `CONCAT` |
| `Terms.written` | 1, and it was `DIV` |
| `Terms.repeating` | `MUL`, written there |

So the issue's question — how far `Terms.written`'s entry can be narrowed — has a
different answer than the issue supposed: it is not on the comparison path at
all. Its operator comes from a `DIV` it names itself and from
`NumericMeaning.Operator`, which is guarded at `Terms.numericMeaningOf` by
`answersANumber()` and built from library rows that are `ADD`/`SUB`/`MUL`. Nothing
said so in a type, which is what the first commit fixes.

`NumericMeaning.Operator` never carries a comparison either, so the walk over
`Core.Binary` was the only place a recognition could go.

## The shape

```
Core.Binary ──Comparison.of──▶ ComparisonClaim ──canonical(l,r)──▶ CanonicalComparison<A>
                                                                        ├──▶ Polar  (Conditions.AsPolar)
                                                                        └──▶ Term   (Term.Interner.AsTerms)
```

`CanonicalComparison` is what a claim states, over two values of whatever a reader
holds them as. Nothing about it can be taken apart — a reader that switched on
which of the three it is and forgot the denial would state the comparison that
holds exactly where this one does not — so the only way to read one is
`expressedAs`, which takes the reader's own `theSameValue` / `below` / `denied`.

Each reader keeps what is its own. A condition writes the comparison as a node
standing where the one it read did, with the denial carried by the polarity
beside it; the interner writes it as a term, whose equality has its two parts
unordered. The node a condition needs is held by its `Expression` and not by the
statement: where a comparison came from, what it answers and where it stands are
the representation's business.

`Term.Interner.operator` now knows nothing about comparisons and refuses one. No
name of any of the six appears in its body.

## Invariants

| what | how |
|---|---|
| what a comparison states is derived where what it placed is held | `OnlyAClaimSaysWhatAComparisonStatesTest`: only `Singled.canonical` and `Cut.canonical` call `theSameValue` / `below` / `denied` |
| who may ask a claim for it | the same test: only `Conditions.canonical` and the walk that names a binary |
| the operator has no way in | `Term.Interner.operator` refuses an operator that compares |
| arithmetic is keyed by an operator answering a number | the two constructors |

Both tripwires read the compiled classes. `CanonicalComparison` is this package's,
which keeps it out of the vocabulary anything outside reads — it does not decide
who calls what, since a method whose answer nothing outside can name is still a
method anything can call, so both questions are answered by the tripwires rather
than by the language.

`AnOperatorIsAskedWhatItPlacesInOnePlaceTest` is unchanged: the new recognition
goes through `Comparison.of`, which already holds its licence.

## Tests, and what each catches

Three layers. The first fixes the derivation against an algebra of its own, so a
term and a node that both got it wrong the same way would still not agree with
what is written down.

| mutation | what went red |
|---|---|
| `Cut.canonical` stops exchanging the sides | layer 1 (3), layer 2 (2), and 15 existing tests |
| `Cut.canonical` denies the other way round | layer 1 (2), layer 2 (1), **and nothing else** |
| `Singled.canonical` denies the other way round | layer 1 (2), layer 2 (2) |
| the interner stops refusing a comparison | layer 3 (1) |
| `answersANumber()` weakened to `!compares()` | red at `AND` |
| an unlicensed `denied()` call | construction tripwire |
| an unlicensed `canonical` call | canonicalization tripwire |

The second row is the one worth reading. A polarity keys a fact and is read from a
guard, so inverting it everywhere at once leaves the matching intact — before this
change the same error in `Conditions.canonical` would have been caught by nothing.

Layer 2's expected values were pinned as literals against `develop` and run green
there before the implementation was swapped, so the two implementations do not
share a rule.

The turn law is stated of the orders only. An equality's claim does not turn, and
`canonical` puts the sides down in the order it was given, so turning both gives
the same statement with its two sides written the other way round. That those two
are one thing is answered where the equality is written (`Shape.EQ` is unordered),
not by what it states.

`mvn -o test`: 7948 tests, green. The first commit alone is green too (7939).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
