### PR TITLE
A budget of this compiler's is not the model refusing a row

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -78,6 +78,13 @@ class AMeasureIsIntroducedInOnePlaceTest {
             Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/partition/StandingAtAPoint$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$RowReading;)Lsouther/compiler/query/Measurement;", 3),
             Map.entry("souther.compiler.query.Coverages#whyNoGuardLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 2),
             Map.entry("souther.compiler.query.Coverages#whyNoInvariantLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 1),
+            // Two searches of one reading of one line, as that reading's measurement. It makes
+            // states and decides none of them: what the pair comes to is asked of
+            // `acrossTheReadings`, and the three here are the measurements that say each of that
+            // one's answers back. A second reading of the same question would be a second coverage
+            // semantics, which is what this count exists to stop, so the answer is borrowed rather
+            // than worked out and only the writing back is here.
+            Map.entry("souther.compiler.query.ObligationCoverage#acrossOneReadingsSearches(Lsouther/compiler/query/Measurement;Lsouther/compiler/query/Measurement;)Lsouther/compiler/query/Measurement;", 3),
             // The reading of a behavior's rows, which is a measure like the ones counted over them
             // and is the one that can never be inapplicable. `of` chooses between the three states
             // a reading that was asked for comes to; the two constants are a behavior with no rows

--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -80,11 +80,17 @@ class AMeasureIsIntroducedInOnePlaceTest {
             Map.entry("souther.compiler.query.Coverages#whyNoInvariantLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 1),
             // Two searches of one reading of one line, as that reading's measurement. It makes
             // states and decides none of them: what the pair comes to is asked of
-            // `acrossTheReadings`, and the three here are the measurements that say each of that
+            // `acrossTheReadings`, and the five here are the measurements that say each of that
             // one's answers back. A second reading of the same question would be a second coverage
             // semantics, which is what this count exists to stop, so the answer is borrowed rather
             // than worked out and only the writing back is here.
-            Map.entry("souther.compiler.query.ObligationCoverage#acrossOneReadingsSearches(Lsouther/compiler/query/Measurement;Lsouther/compiler/query/Measurement;)Lsouther/compiler/query/Measurement;", 3),
+            //
+            // Five and not three, because a row one of the searches saw is written back with what
+            // both of them went without. Kept as whichever search saw it, the sentence a report
+            // prints about what the reading could not read moved with the order the searches were
+            // walked in — so the answer is written rather than picked, and a row seen is two shapes
+            // depending on whether there was anything to say beside it.
+            Map.entry("souther.compiler.query.ObligationCoverage#acrossOneReadingsSearches(Lsouther/compiler/query/Measurement;Lsouther/compiler/query/Measurement;)Lsouther/compiler/query/Measurement;", 5),
             // The reading of a behavior's rows, which is a measure like the ones counted over them
             // and is the one that can never be inapplicable. `of` chooses between the three states
             // a reading that was asked for comes to; the two constants are a behavior with no rows

--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -91,6 +91,8 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/inputs/SearchRegion;)"
                             + "Lsouther/compiler/partition/LevelRealizer$Reached;",
                     "walks a progression as far as this walks one, and says that is why"),
+            Map.entry("souther.compiler.partition.LevelCandidateSource#<clinit>()V",
+                    "how many levels a side is asked at"),
             Map.entry("souther.compiler.partition.NumericWitness#<clinit>()V",
                     "how many values a position on the way is tried at"),
             Map.entry("souther.compiler.partition.NumericWitness#walk("

--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -31,12 +31,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * it hand the budget over, or does it swallow it — and the answer belongs beside the code that
  * decides, which is why the list is here and not a count.
  *
- * <p><b>What this does not see.</b> A figure a class copies into a field of its own is reached once,
+ * <p><b>One of two sheets.</b> A figure a class copies into a field of its own is reached once,
  * where the field is set, and the walk that then stops at the field is not a reader of the figure
- * here. So this holds the inventory of figures and the places that hand one over; it does not catch
- * a walk that consults a copy and comes back with a word. What would catch that is a rule about the
- * constants themselves — every number of that kind in these classes being one of these figures —
- * and it is not written.
+ * here — so this holds the registered figures to being handed over, and
+ * {@link EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest} holds the classes to
+ * registering a figure at all. Neither is enough alone: that one sees a number written down and
+ * this one sees a figure that is the size of a walk.
+ *
+ * <p><b>And what neither sees is the predicate.</b> Each entry below says the place hands the
+ * figure over; that the place reaches it only where there was more to do is not something either
+ * sheet can read. What says that is the threshold tests, one either side of a figure and on it, and
+ * they exist for the walks that can be put there.
  */
 class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
 

--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -1,0 +1,174 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every figure this compiler stops a search at is read where a rule says it is read, and nowhere
+ * else.
+ *
+ * <p>What a budget is for is being carried: a search that stopped at one says which, and an account
+ * that reads it knows the point is open for a reason somebody could raise rather than because the
+ * model refuses a row. That only works while every place a figure is reached is a place that hands
+ * it over — a walk that consults one and comes back with a word alone is a stop that vanished, and
+ * the word it comes back with is written wherever a walk stops for any reason at all, so nothing
+ * downstream can tell that it happened.
+ *
+ * <p><b>So the places are counted rather than trusted.</b> Twice while this was written the list of
+ * budgets was taken from the constants that looked like budgets, and twice it was short — once by a
+ * figure spelled differently and once by a figure that is the size of a walk rather than a number
+ * anybody wrote down. A name is not what makes a budget; being reached and stopping something is.
+ *
+ * <p>Each entry below says what that place does with the figure. A place added is a question — does
+ * it hand the budget over, or does it swallow it — and the answer belongs beside the code that
+ * decides, which is why the list is here and not a count.
+ *
+ * <p><b>What this does not see.</b> A figure a class copies into a field of its own is reached once,
+ * where the field is set, and the walk that then stops at the field is not a reader of the figure
+ * here. So this holds the inventory of figures and the places that hand one over; it does not catch
+ * a walk that consults a copy and comes back with a word. What would catch that is a rule about the
+ * constants themselves — every number of that kind in these classes being one of these figures —
+ * and it is not written.
+ */
+class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
+
+    private static final String BUDGET = "souther.compiler.partition.CompositionBudget";
+
+    /**
+     * Where a figure is read, and what that place does with it.
+     *
+     * <p>By the method and not by the class. A helper beside one that reads a figure answers for
+     * nothing, and counting per class would let a second reader hide behind the first.
+     */
+    private static final Map<String, String> READ_AT = new LinkedHashMap<>(Map.ofEntries(
+            // The figures themselves. Every other place asks one of these for its number.
+            Map.entry("souther.compiler.partition.CompositionBudget#<clinit>()V",
+                    "the figures, which is where they are"),
+
+            // The stops. Each reaches a figure and hands it over as itself.
+            Map.entry("souther.compiler.partition.Witnesses#<clinit>()V",
+                    "how many elements and characters a proposal holds, and how many pairings"),
+            Map.entry("souther.compiler.partition.Witnesses#sized("
+                            + "Lsouther/compiler/types/Type;ILsouther/compiler/check/Symbols;"
+                            + "Lsouther/compiler/check/ReadingPolicy;Ljava/util/Set;)"
+                            + "Lsouther/compiler/partition/Witnesses$Built;",
+                    "stops at the elements and the characters, and says which"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp#<clinit>()V",
+                    "how many elements a total is spread over, and how many shapes are offered"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp#to("
+                            + "Lsouther/compiler/numeric/Place;Lsouther/compiler/types/Type;"
+                            + "Lsouther/compiler/inputs/TermOrders;"
+                            + "Lsouther/compiler/inputs/SearchRegion;"
+                            + "Lsouther/compiler/check/Symbols;"
+                            + "Lsouther/compiler/check/ReadingPolicy;)"
+                            + "Lsouther/compiler/partition/TermRealizations$Realization;",
+                    "records the three a total can be short of, where each decides not to go on"),
+            Map.entry("souther.compiler.partition.LevelRealizer#<clinit>()V",
+                    "the places a pair is tried at, the steps, the progression and the re-reads"),
+            Map.entry("souther.compiler.partition.LevelRealizer#ofTwo("
+                            + "Lsouther/compiler/partition/Standing$OfTwoOnOneCarrier;"
+                            + "Lsouther/compiler/inputs/SearchRegion;)"
+                            + "Lsouther/compiler/partition/Realization;",
+                    "stops walking a line at the places it tries and says which figure"),
+            Map.entry("souther.compiler.partition.LevelRealizer#ofAForm("
+                            + "Lsouther/compiler/partition/Standing$OfAForm;"
+                            + "Lsouther/compiler/inputs/SearchRegion;)"
+                            + "Lsouther/compiler/partition/Realization;",
+                    "collects what the level walks ran out of, and the levels it was offered"),
+            Map.entry("souther.compiler.partition.LevelRealizer$Search#stepsLeft()Z",
+                    "the steps a search may take, marked where there is no room for another"),
+            Map.entry("souther.compiler.partition.LevelRealizer$Search#outward("
+                            + "ILsouther/compiler/partition/CandidateDomain$Outward;"
+                            + "Ljava/math/BigDecimal;Ljava/math/BigDecimal;"
+                            + "Lsouther/compiler/inputs/SearchRegion;)"
+                            + "Lsouther/compiler/partition/LevelRealizer$Reached;",
+                    "walks a progression as far as this walks one, and says that is why"),
+            Map.entry("souther.compiler.partition.NumericWitness#<clinit>()V",
+                    "how many values a position on the way is tried at"),
+            Map.entry("souther.compiler.partition.NumericWitness#walk("
+                            + "Lsouther/compiler/inputs/SearchRegion;Ljava/util/List;I"
+                            + "Ljava/util/function/Function;Ljava/util/Map;Ljava/util/Set;)Z",
+                    "stops trying values of a position on the way and says which figure"),
+            Map.entry("souther.compiler.partition.Generator#<clinit>()V",
+                    "how many assignments a search composes"),
+            Map.entry("souther.compiler.partition.Generator#conditioned("
+                            + "Lsouther/compiler/partition/MeasuredInput;I"
+                            + "Lsouther/compiler/partition/ConstructionPlan;Ljava/util/Map;"
+                            + "Ljava/util/Map;"
+                            + "Lsouther/compiler/partition/Generator$CandidateCheck;)"
+                            + "Lsouther/compiler/partition/Generator$Outcome;",
+                    "the assignments a descent composes, marked where the bound is reached"),
+            Map.entry("souther.compiler.partition.Generator#over("
+                            + "Lsouther/compiler/partition/MeasuredInput;I"
+                            + "Lsouther/compiler/partition/ConstructionPlan;Ljava/util/List;"
+                            + "Ljava/util/List;"
+                            + "Lsouther/compiler/partition/Generator$CandidateCheck;)"
+                            + "Lsouther/compiler/partition/Generator$Outcome;",
+                    "the same bound over one pass of the assignments"),
+            Map.entry("souther.compiler.partition.ConstructionPlan#<clinit>()V",
+                    "how deep a plan descends, which nothing carries and which is named all the"
+                            + " same"),
+
+            // The readings. Each takes a figure that was handed over and says what it comes to.
+            Map.entry("souther.compiler.partition.Generator$UnresolvedCombination$Reason#wordFor("
+                            + "Ljava/util/Set;)"
+                            + "Lsouther/compiler/partition/Generator$UnresolvedCombination$Reason;",
+                    "the word a search stopped by these comes back with"),
+            Map.entry("souther.compiler.report.AdequacyReport#said(Ljava/util/Set;)"
+                            + "Ljava/lang/String;",
+                    "what a figure is called where a reader meets one")));
+
+    /**
+     * The places that read a figure are the places that say they do.
+     *
+     * <p>Both ways round. A place missing from the list is one nobody has said what it does with
+     * the figure it reached; a place in the list that reads none is a rule about code that has gone.
+     */
+    @Test
+    void aFigureIsReachedOnlyWhereSomethingSaysWhatItDoesWithIt() throws Exception {
+        Set<String> found = new LinkedHashSet<>();
+        for (Compiled.Site site : Compiled.sites()) {
+            if (site.owner().equals(BUDGET) && !site.member().equals("<init>")
+                    && !site.from().equals(BUDGET) && !javacsOwn(site.from())) {
+                found.add(site.at());
+            }
+        }
+        // The figures' own class reads itself, which is what an enum is; counted as a reader, every
+        // constant would be a place to explain.
+        found.add(BUDGET + "#<clinit>()V");
+
+        List<String> unsaid = new ArrayList<>(found);
+        unsaid.removeAll(READ_AT.keySet());
+        List<String> gone = new ArrayList<>(READ_AT.keySet());
+        gone.removeAll(found);
+
+        assertEquals(List.of(), unsaid,
+                "a figure of this compiler's reached where nothing says what it does with it."
+                        + " Either it hands the budget over, and the list says so, or it swallows"
+                        + " it — and a swallowed budget is a stop nothing downstream can see");
+        assertEquals(List.of(), gone,
+                "a rule about a place that no longer reads a figure");
+    }
+
+    /**
+     * A class javac wrote, which is not a place anybody decided anything.
+     *
+     * <p>A switch over the figures compiles to a table beside the class that switches, and the
+     * table reads every constant to number them. Counted as readers, every exhaustive switch would
+     * be a place to write a sentence about — and the sentence would be about the switch, which is
+     * already named here by the method that holds it.
+     */
+    private static boolean javacsOwn(String from) {
+        int nested = from.lastIndexOf('$');
+        return nested >= 0 && from.length() > nested + 1
+                && Character.isDigit(from.charAt(nested + 1));
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
@@ -1,0 +1,123 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every whole number the composing stage is written to stop at is one of this compiler's budgets, or
+ * is said here not to be.
+ *
+ * <p>The second sheet, beside the one that counts where a budget is read. That one holds the
+ * registered figures to being carried; this one holds the classes to registering a figure at all —
+ * and it is the sheet the population needed. Twice while #1232 was written the budgets were taken
+ * from the constants that looked like budgets, and twice the list was short. A name is not what
+ * makes a budget.
+ *
+ * <p><b>Told by how the number arrives and not by what it is called.</b> A figure that comes from
+ * {@link souther.compiler.partition.CompositionBudget} is worked out when the class is initialised
+ * and has no constant value in the class file; a number written into the source has one. So a
+ * constant that is a budget is one nobody wrote down twice, and this is what says so mechanically —
+ * a rule about spelling would be passed by the next figure spelled differently, which is the failure
+ * that made this necessary.
+ *
+ * <p>What it still does not see is a figure derived from something other than a number: how many
+ * ways a total is decomposed is the size of a walk, and no constant holds it. That one is caught by
+ * the other sheet, which sees the enum being read where the walk stops. Neither is enough alone.
+ */
+class EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest {
+
+    /** Where a row for a coverage item is composed, which is what a budget of this kind bounds. */
+    private static final String COMPOSING = "souther.compiler.partition.";
+
+    /**
+     * The whole numbers written into these classes, and why each is not a figure a search stops at.
+     *
+     * <p>One entry per constant, with what it is instead. A number added is a question — is this
+     * something this compiler stops at, and does what stops there carry it — and the answer belongs
+     * beside the code that stops.
+     */
+    private static final Map<String, String> NOT_A_BUDGET = new LinkedHashMap<>(Map.ofEntries(
+            // Numbers a value is written at, which are what a date or a time looks like and not how
+            // far this looks for one.
+            Map.entry("souther.compiler.partition.TermRealizations.A_YEAR",
+                    "the year a time of day is written in"),
+            Map.entry("souther.compiler.partition.TermRealizations.A_LONGEST_MONTH",
+                    "the month a day of the month is offered in"),
+            Map.entry("souther.compiler.partition.TermRealizations.FIRST_OF_THE_MONTH",
+                    "the day a date's other parts are offered at"),
+
+            // A place in a list rather than an amount of anything.
+            Map.entry("souther.compiler.partition.Generator.NOT_HERE",
+                    "no position, which is what an index that found none is"),
+
+            // How much of a number is written down, which bounds a value's shape and not a search:
+            // any length is sound while the rounding goes outward, so nothing is left unlooked at.
+            Map.entry("souther.compiler.partition.LevelRealizer.DIGITS_A_DERIVED_END_KEEPS",
+                    "how far a derived end is written out, which leaves nothing untried"),
+
+            // Budgets of walks that are not the composing of a row at a coverage item. Each bounds
+            // a search of its own, and what reaching one costs is that search's to carry — measured
+            // for #1232 and left where they are, which is why they are named rather than omitted.
+            Map.entry("souther.compiler.partition.Generator.MOST_REPAIRS",
+                    "the walk over which classes to settle a row at, not the row at an item"),
+            Map.entry("souther.compiler.partition.Generator.MOST_INTERPRETATIONS",
+                    "how many readings of a row's values one run tries"),
+            Map.entry("souther.compiler.partition.Generator.MOST_RUNS_PER_INTERPRETATION",
+                    "how many runs one reading of a row's values is given"),
+            Map.entry("souther.compiler.partition.StandingAtAPoint.MOST_READINGS",
+                    "the reading of a row that was built, which is where an observation stops")));
+
+    /**
+     * A number written into a composing class is a budget's, or is one of the above.
+     *
+     * <p>Both ways round, as the other sheet is. A number nobody has said anything about is one
+     * somebody has to decide about; an entry naming a constant that has gone is a rule about code
+     * that is not there.
+     */
+    @Test
+    void aFigureIsThisCompilersBudgetOrIsSaidToBeSomethingElse() throws IOException {
+        List<String> written = new ArrayList<>();
+        for (Path each : Reactor.classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            if (!from.startsWith(COMPOSING) || from.equals(COMPOSING + "CompositionBudget")) {
+                continue;
+            }
+            for (var field : model.fields()) {
+                if (!field.fieldTypeSymbol().descriptorString().equals("I")
+                        || field.findAttribute(java.lang.classfile.Attributes.constantValue())
+                                .isEmpty()) {
+                    continue;   // not a whole number, or worked out rather than written down
+                }
+                written.add(from + "." + field.fieldName().stringValue());
+            }
+        }
+
+        List<String> unsaid = new ArrayList<>(written);
+        unsaid.removeAll(NOT_A_BUDGET.keySet());
+        List<String> gone = new ArrayList<>(NOT_A_BUDGET.keySet());
+        gone.removeAll(written);
+
+        assertEquals(List.of(), NOT_A_BUDGET.isEmpty() || written.isEmpty()
+                        ? List.of("nothing was read, so this asserts nothing") : List.of(),
+                "the classes were read and hold whole numbers, or the census found none and"
+                        + " everything below passes by looking at nothing");
+        assertEquals(List.of(), unsaid,
+                "a whole number written into a composing class that nothing says anything about."
+                        + " Either a search stops at it — and then it is a CompositionBudget, whose"
+                        + " figure the class reads rather than writing its own — or it is something"
+                        + " else and the list above says what");
+        assertEquals(List.of(), gone, "a rule about a constant that is no longer written");
+    }
+}

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -173,7 +173,8 @@ final class AReportOfOneBorder {
             // was at the point while handing in a coverage that says none is.
             items.put(point, new ItemAssessment.Owed(border.demand(point).criterion(),
                     coverage.apply(border.roleOf(point)),
-                    ItemAssessment.WritabilityProjection.PROVEN, null));
+                    ItemAssessment.WritabilityProjection.PROVEN,
+                    souther.compiler.query.SearchOutcomes.none()));
         }
         return new BorderAssessment(border, items);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -68,7 +68,7 @@ public enum CompositionBudget {
     VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED(() -> 16),
 
     /** How many levels past the one a side starts from are asked for. */
-    LEVELS_A_SIDE_IS_ASKED_AT(LevelCandidateSource::levelsTried),
+    LEVELS_A_SIDE_IS_ASKED_AT(() -> 8),
 
     /** How often a walk re-reads the rules with the positions it has fixed. */
     TIMES_THE_RULES_ARE_ASKED_AGAIN(() -> 2_000),

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -1,0 +1,77 @@
+package souther.compiler.partition;
+
+import java.util.function.IntSupplier;
+
+/**
+ * How much of a search this compiler is willing to do before it stops.
+ *
+ * <p>One member per place that stops, and the figure it stops at is here rather than at the place.
+ * What a reader of a stopped search wants to know is which of these ran out, and a name written
+ * beside a number somewhere else is a second declaration of the same policy — the two part the
+ * first time one of them is raised.
+ *
+ * <p><b>A cause and not an outcome.</b> Reaching one of these says what this compiler declined to
+ * do and says nothing about the model: the value it did not build may be the easiest one in the
+ * file to write by hand. What the reaching did to the answer is a separate question, and it has two
+ * answers rather than one — a search that had produced nothing when it stopped leaves the point
+ * unestablished, and one that had produced something leaves an offer that is some of what there was.
+ * So the same member appears on both sides and is neither of them.
+ *
+ * <p>The figures are read through {@link #maximum()} and are not all written down. One of them is
+ * how many shapes a decomposition is offered in, which is how many the walk has — read off the walk,
+ * so that a shape added there is a budget raised here and not a number that stayed behind.
+ */
+public enum CompositionBudget {
+
+    /** How many elements a proposed collection is worth building. A row is offered for somebody to
+     *  read and complete, and a minimum past this asks for one nobody would. */
+    ELEMENTS_A_PROPOSAL_HOLDS(() -> 64),
+
+    /** How many characters a proposed string is worth building. Its own figure, because a string of
+     *  sixty-five is one literal where a collection of sixty-five is sixty-five values each built in
+     *  turn — holding the two to one number bounds a string by something about collections. */
+    CHARACTERS_A_PROPOSAL_HOLDS(() -> 4096),
+
+    /** How many pairings of what a map's key and value propose are built at once. Every pair is
+     *  built before any of them is tried, so this bounds what is allocated rather than what is
+     *  walked. */
+    PAIRINGS_BUILT_AT_ONCE(() -> 64),
+
+    /** How many elements a container built to reach a total is worth carrying. Its own figure and
+     *  not {@link #ELEMENTS_A_PROPOSAL_HOLDS}, though they agree: held as one, a change made for one
+     *  of them would move the other for no reason anybody could state. */
+    ELEMENTS_A_TOTAL_IS_SPREAD_OVER(() -> 64),
+
+    /** How many containers are offered for one total. They are alike to the total, so what a fifth
+     *  buys is another row reading like the last. */
+    SHAPES_OF_A_TOTAL_OFFERED(() -> 4),
+
+    /** How many ways the difference between a starting point and a total is spread over the
+     *  elements. Read off the walk that has them, so a third way of spreading is this budget
+     *  raised. */
+    DECOMPOSITIONS_OF_A_TOTAL_OFFERED(ContainersAddingUp::decompositionsOffered),
+
+    /** How many places along a line a pair is tried at. What a range cannot say is that one of its
+     *  values is missing, so what stepping past this walks over is holes, and there are as many of
+     *  those as the rules state. */
+    PLACES_A_PAIR_IS_TRIED_AT(() -> 64),
+
+    /** How many steps a walk over the positions of a form may take. A run without an end is not
+     *  walked to the end at any length. */
+    STEPS_A_SEARCH_MAY_TAKE(() -> 200_000),
+
+    /** How many assignments of one parameter's positions a search composes. A bound on the search
+     *  and not on any one position. */
+    ASSIGNMENTS_A_SEARCH_COMPOSES(() -> 256);
+
+    private final IntSupplier maximum;
+
+    CompositionBudget(IntSupplier maximum) {
+        this.maximum = maximum;
+    }
+
+    /** The figure this stops at. */
+    public int maximum() {
+        return maximum.getAsInt();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -62,7 +62,36 @@ public enum CompositionBudget {
 
     /** How many assignments of one parameter's positions a search composes. A bound on the search
      *  and not on any one position. */
-    ASSIGNMENTS_A_SEARCH_COMPOSES(() -> 256);
+    ASSIGNMENTS_A_SEARCH_COMPOSES(() -> 256),
+
+    /** How many values of a progression nothing bounds are tried. */
+    VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED(() -> 16),
+
+    /** How many levels past the one a side starts from are asked for. */
+    LEVELS_A_SIDE_IS_ASKED_AT(LevelCandidateSource::levelsTried),
+
+    /** How often a walk re-reads the rules with the positions it has fixed. */
+    TIMES_THE_RULES_ARE_ASKED_AGAIN(() -> 2_000),
+
+    /** How many values of one position on the way to a border are tried. Its outcome is not a
+     *  composing that stopped: the row is composed, and what was not composed against is one
+     *  condition on the way ({@link ReachabilityGap}). */
+    VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT(() -> 8),
+
+    /**
+     * How deep a construction plan descends.
+     *
+     * <p><b>Named here and carried by nothing.</b> Reaching it does not stop a composing and does
+     * not shorten an offer: the plan comes back with a position it has no fields for, the composing
+     * goes on against that plan, and what a failure afterwards says is what any refusal says. So
+     * there is no place on the way out for this to travel, and giving it one takes a shape the plan
+     * itself does not have — a plan that is complete and a plan that was cut are one word today.
+     *
+     * <p>Here all the same, because the inventory of what this compiler declines to do is what a
+     * reader of any of the others is entitled to, and a budget left out of it because its channel
+     * is missing is one nobody will find again. What is missing is the channel, not the name.
+     */
+    DEPTH_A_CONSTRUCTION_PLAN_DESCENDS(() -> 8);
 
     private final IntSupplier maximum;
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -66,7 +66,8 @@ final class ConstructionPlan {
      *  the declarations it opens ({@link souther.compiler.inputs.ExpansionTrace}), which answers a
      *  different question: a value has to be built at a position whether or not a report divides
      *  it. */
-    private static final int MAX_DEPTH = 8;
+    private static final int MAX_DEPTH =
+            CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS.maximum();
 
     /**
      * One position of the value being built.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -54,29 +54,22 @@ import java.util.List;
  */
 final class ContainersAddingUp {
 
-    /**
-     * How many elements a container this composes is worth carrying.
-     *
-     * <p>Its own figure and not {@link Witnesses}'s, though they agree: what bounds a container
-     * built to hold a count is how many a row is worth reading, and what bounds one built to reach a
-     * total is the same thing said of the same reader. Held as one constant, a change made for one
-     * of them would move the other for no reason anybody could state.
-     */
-    private static final int MOST_ELEMENTS_A_ROW_CARRIES = 64;
+    /** What this stops at, named where every budget of this compiler's is named. */
+    private static final int MOST_ELEMENTS_A_ROW_CARRIES =
+            CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER.maximum();
+
+    private static final int HOW_MANY_SHAPES_ARE_OFFERED =
+            CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED.maximum();
 
     /**
-     * How many containers are offered for one total.
+     * How many ways a difference is spread over the elements, which is how many this walk has.
      *
-     * <p>More than one, because the containers that reach a total are not alike to the rules the
-     * elements are under: a container of ten is refused by a rule about how many it holds while one
-     * of eleven is not, and one that put the whole difference on a single element is refused by a
-     * rule that takes that value out of the run while one that shared it is not. The search that
-     * puts them through the decoder has nothing else to try.
-     *
-     * <p>Small all the same. They are alike to the total, so what a fifth buys is another row
-     * reading like the last, and what is not made is said rather than made up for.
+     * <p>Read off {@link Spread} rather than written down beside it. A third way of spreading is a
+     * budget raised, and a figure of its own here would be a second declaration that stayed at two.
      */
-    private static final int HOW_MANY_SHAPES_ARE_OFFERED = 4;
+    static int decompositionsOffered() {
+        return Spread.values().length;
+    }
 
     /**
      * Containers whose occurrences of {@code target}'s path come to {@code answer}, or why there are

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -110,11 +110,14 @@ final class ContainersAddingUp {
         List<TermPath.Step> under = stepsInsideAnElement(target);
         List<FixtureTemplate> built = new ArrayList<>();
         int cap = Math.min(howMany.most(), MOST_ELEMENTS_A_ROW_CARRIES);
-        // What this walk did not do, recorded as it decides not to do it. Worked out afterwards from
-        // the ends, the two ways of leaving something unmade — a count never tried, and a count
-        // whose other decompositions were never made — cannot both be seen, and a container offered
-        // and refused was reported as every container having been refused.
-        boolean left = cap < howMany.most();
+        // What this walk did not do, recorded as it decides not to do it, and as which budget of
+        // this compiler's decided it. Held as one flag, the three ways of leaving something unmade
+        // were one fact and a reader was told a search stopped without being told what would let it
+        // go further — and worked out afterwards from the ends, they cannot all be seen at once.
+        java.util.Set<CompositionBudget> left = java.util.EnumSet.noneOf(CompositionBudget.class);
+        if (cap < howMany.most()) {
+            left.add(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER);
+        }
         // Asked where a container is added and nowhere else. What the budget counts is containers,
         // and a walk that asked at the top of the counts was asking about containers in a place that
         // steps by counts — so a count offering two of them stepped past the figure by one, and how
@@ -124,7 +127,9 @@ final class ContainersAddingUp {
             // More than one element is more than one decomposition, whether or not this made a
             // second: what is offered is two shapes of the many, and the many are what a rule taking
             // a value out of the middle of a run tells apart.
-            left |= many > 1;
+            if (many > 1) {
+                left.add(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED);
+            }
             for (Spread how : Spread.values()) {
                 List<BigDecimal> split = splitting(total.at(), many, ends, how, elements);
                 FixtureTemplate one = split == null ? null
@@ -133,18 +138,21 @@ final class ContainersAddingUp {
                     continue;
                 }
                 if (built.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
-                    left = true;
+                    left.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
                     break offering;
                 }
                 built.add(one);
             }
         }
-        Generator.UnresolvedCombination.Reason held =
-                left ? Generator.UnresolvedCombination.Reason.SEARCH_LIMIT : null;
-        return built.isEmpty()
-                ? none(held == null
-                        ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : held)
-                : new TermRealizations.Realization.Built(built, held);
+        if (!built.isEmpty()) {
+            return new TermRealizations.Realization.Built(built, left);
+        }
+        // Nothing was composed, so what the budgets stopped is the composing itself and not the rest
+        // of an offer. Where none of them ran out, this is a total nothing here writes a container
+        // for, which is a different thing to tell anybody.
+        return left.isEmpty()
+                ? none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                : new TermRealizations.Realization.Stopped(left);
     }
 
     /**
@@ -391,7 +399,7 @@ final class ContainersAddingUp {
 
     private static TermRealizations.Realization none(
             Generator.UnresolvedCombination.Reason why) {
-        return new TermRealizations.Realization.BuiltNone(why);
+        return new TermRealizations.Realization.None(why);
     }
 
     private ContainersAddingUp() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -54,11 +54,11 @@ import java.util.Set;
  */
 public final class Generator {
 
-    /** How many assignments of values one parameter is tried at in one pass. The choices multiply, so
-     * this is a bound on the search and not on any one position — and reaching it is reported as the
-     * search having stopped, which is a different thing from every assignment having been refused. A
-     * parameter with something held in reserve is walked twice, each pass under this bound. */
-    private static final int MAX_TUPLES = 256;
+    /** How many assignments of values one parameter is tried at in one pass. A parameter with
+     *  something held in reserve is walked twice, each pass under this bound. The figure is
+     *  {@link CompositionBudget}'s, where every budget of this compiler's is named. */
+    private static final int MAX_TUPLES =
+            CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES.maximum();
 
     /**
      * How many things one combination may be asking before the search gives up on it.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2278,6 +2278,38 @@ public final class Generator {
                 unrepresented = List.copyOf(unrepresented);
             }
         }
+
+        /**
+         * No row came of it, and a budget of this compiler's is why.
+         *
+         * <p>Beside {@link Unresolved} and not a field on it. A search that tried what it had and a
+         * search this compiler ended leave the reader different work — only the second has a figure
+         * somebody could raise — and every reader that has to tell them apart is one an exhaustive
+         * switch already stops.
+         *
+         * <p>{@code why} is the word such a search has always come back with, read off the budgets
+         * so that the two cannot part.
+         */
+        record Stopped(UnresolvedCombination why, java.util.Set<CompositionBudget> by,
+                       List<ReachabilityGap.Uncomposed> unrepresented)
+                implements BoundaryAttempt {
+
+            public Stopped {
+                unrepresented = List.copyOf(unrepresented);
+                by = java.util.Set.copyOf(by);
+                if (by.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a search this compiler stopped says which budget stopped it");
+                }
+            }
+
+            /** One at the label given, in the word its budgets come back with. */
+            static Stopped at(String label, java.util.Set<CompositionBudget> by,
+                              List<ReachabilityGap.Uncomposed> unrepresented) {
+                return new Stopped(new UnresolvedCombination(List.of(label),
+                        UnresolvedCombination.Reason.wordFor(by)), by, unrepresented);
+            }
+        }
     }
 
     /**
@@ -2322,7 +2354,10 @@ public final class Generator {
         // and taking the bottom of the type's range instead is how a boundary that can be written
         // came back as one every value tried was refused at.
         Map<TermPath, Place> settled = new LinkedHashMap<>();
-        Map<TermPath, UnresolvedCombination.Reason> heldBack = new LinkedHashMap<>();
+        // Which budgets each edge held values back at, and not the word for it. The word is one of
+        // two and says nothing about which figure; kept as the word, a refusal that turned out to
+        // be this compiler stopping could not say what stopping it cost.
+        Map<TermPath, java.util.Set<CompositionBudget>> heldBack = new LinkedHashMap<>();
         // Where every position of this row stands: the item's, and the ones the way to it bounds.
         // One map, because a row is one row — walked as two, the second was chosen from what the
         // declarations leave and the first from what reaches the border, and only one of them was
@@ -2337,9 +2372,15 @@ public final class Generator {
             Edge edge = edgeAt(subject, each.getKey(), each.getValue(),
                     fixing.size() > 1, reaching.region());
             if (edge.values().isEmpty()) {
-                return new BoundaryAttempt.Unresolved(
-                        new UnresolvedCombination(List.of(label), edge.reason()),
-                        where.unrepresented());
+                // What stopped the composing where a budget of this compiler's did, and the word
+                // for a search that came to nothing where none did. The two license different
+                // sentences and only the first names something anybody could raise.
+                return edge.stoppedBy().isEmpty()
+                        ? new BoundaryAttempt.Unresolved(
+                                new UnresolvedCombination(List.of(label), edge.reason()),
+                                where.unrepresented())
+                        : BoundaryAttempt.Stopped.at(label, edge.stoppedBy(),
+                                where.unrepresented());
             }
             TermPath at = each.getKey().writeRoot();
             // Two terms at one location is that location asked for two things at once — a string of
@@ -2368,7 +2409,7 @@ public final class Generator {
             if (edge.settledAt() != null) {
                 settled.put(at, edge.settledAt());
             }
-            heldBack.put(at, edge.refused());
+            heldBack.put(at, edge.stoppedBy());
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
@@ -2403,6 +2444,7 @@ public final class Generator {
                 // something this knows. Taken from whichever came first, the reason named the wrong
                 // position's search.
                 UnresolvedCombination.Reason why = tried.reason();
+                java.util.Set<CompositionBudget> stoppedBy = tried.stoppedBy();
                 // A search that offered candidates and certified none of them has not shown that
                 // every value the rules allow was refused: what it found out is that what it built
                 // did not stand where it was built for, which is its own answer.
@@ -2412,11 +2454,20 @@ public final class Generator {
                 }
                 if (here.size() == 1
                         && why == UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
-                    why = heldBack.getOrDefault(here.keySet().iterator().next(), why);
+                    java.util.Set<CompositionBudget> held =
+                            heldBack.getOrDefault(here.keySet().iterator().next(), java.util.Set.of());
+                    if (!held.isEmpty()) {
+                        stoppedBy = held;
+                        why = UnresolvedCombination.Reason.wordFor(held);
+                    }
                 }
-                return new BoundaryAttempt.Unresolved(
-                        new UnresolvedCombination(List.of(label), why, tried.detail()),
-                        where.unrepresented());
+                return stoppedBy.isEmpty()
+                        ? new BoundaryAttempt.Unresolved(
+                                new UnresolvedCombination(List.of(label), why, tried.detail()),
+                                where.unrepresented())
+                        : new BoundaryAttempt.Stopped(
+                                new UnresolvedCombination(List.of(label), why, tried.detail()),
+                                stoppedBy, where.unrepresented());
             }
             inputs.add(tried.value());
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -470,6 +470,37 @@ public final class Generator {
                 }
                 return word;
             }
+
+            /**
+             * The same answer in the words a walk of a coverage item comes back with.
+             *
+             * <p>Two vocabularies for one distinction, and this is the whole of what relates them.
+             * A walk says one of two things and a search says one of thirteen, so the projection
+             * runs this way and never the other — read back, eleven words would have to name a
+             * walk's answer and none of them does.
+             *
+             * <p>Exhaustive, with the eleven named. A word added is a word somebody has to decide
+             * about here, and deciding is what a {@code default} would do on their behalf: it would
+             * put the new word among the ones no walk says, which is the answer for eleven of them
+             * and is nobody's to assume for the twelfth.
+             */
+            public Realization.Unknown.Reason asAWalksAnswer() {
+                return switch (this) {
+                    case NOTHING_COMPOSES_ONE -> Realization.Unknown.Reason.NOTHING_COMPOSED_ONE;
+                    case SEARCH_LIMIT -> Realization.Unknown.Reason.THE_SEARCH_RAN_OUT;
+                    // What a walk of a coverage item comes back with is what it did, and these are
+                    // what somebody else did: the model settling the point, a candidate refused, a
+                    // module with no classes, a position held back, a group never offered.
+                    case ALL_CANDIDATES_REJECTED, THE_RULES_LEAVE_NOTHING_THERE,
+                         ONE_POSITION_CANNOT_BE_BOTH, NOTHING_TO_BUILD_AGAINST,
+                         NO_VALUES_WERE_ASKED_FOR, LINKAGE_FAILED, NO_CERTIFIED_WITNESS,
+                         THE_GROUP_WAS_NOT_OFFERED, THE_POSITION_WAS_WITHHELD,
+                         THE_ROWS_WERE_NOT_READ, THE_WAY_IN_PLACES_AT_NO_CLASS,
+                         NO_CANDIDATE_WAS_OFFERED, NO_READING_OF_THE_LINE_COULD_BE_SEARCHED ->
+                            throw new IllegalStateException(
+                                    "no walk of a coverage item comes back with this: " + this);
+                };
+            }
         }
 
         public UnresolvedCombination {
@@ -2301,13 +2332,26 @@ public final class Generator {
                     throw new IllegalArgumentException(
                             "a search this compiler stopped says which budget stopped it");
                 }
+                // The word is the budgets' to say, so this pair cannot be put here disagreeing.
+                // Left to whoever builds one, the two are a copy of one answer kept beside it —
+                // which is what a stop lost its budget to before it travelled at all.
+                if (why.reason() != UnresolvedCombination.Reason.wordFor(by)) {
+                    throw new IllegalArgumentException("a search stopped by " + by
+                            + " does not come back with " + why.reason());
+                }
             }
 
             /** One at the label given, in the word its budgets come back with. */
             static Stopped at(String label, java.util.Set<CompositionBudget> by,
                               List<ReachabilityGap.Uncomposed> unrepresented) {
+                return at(label, null, by, unrepresented);
+            }
+
+            /** The same, of a search that has something to say about where it stopped. */
+            static Stopped at(String label, String detail, java.util.Set<CompositionBudget> by,
+                              List<ReachabilityGap.Uncomposed> unrepresented) {
                 return new Stopped(new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.wordFor(by)), by, unrepresented);
+                        UnresolvedCombination.Reason.wordFor(by), detail), by, unrepresented);
             }
         }
     }
@@ -2465,9 +2509,8 @@ public final class Generator {
                         ? new BoundaryAttempt.Unresolved(
                                 new UnresolvedCombination(List.of(label), why, tried.detail()),
                                 where.unrepresented())
-                        : new BoundaryAttempt.Stopped(
-                                new UnresolvedCombination(List.of(label), why, tried.detail()),
-                                stoppedBy, where.unrepresented());
+                        : BoundaryAttempt.Stopped.at(label, tried.detail(), stoppedBy,
+                                where.unrepresented());
             }
             inputs.add(tried.value());
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -447,7 +447,16 @@ public final class Generator {
                              PLACES_A_PAIR_IS_TRIED_AT -> NOTHING_COMPOSES_ONE;
                         case PAIRINGS_BUILT_AT_ONCE, ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
                              SHAPES_OF_A_TOTAL_OFFERED, DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
-                             STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES -> SEARCH_LIMIT;
+                             STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES,
+                             VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
+                             LEVELS_A_SIDE_IS_ASKED_AT -> SEARCH_LIMIT;
+                        // Reaching these stops no composing, so no search comes back from one of
+                        // them and there is no word to give. Asked for one all the same, this says
+                        // so rather than lending a word from a budget that does stop something.
+                        case TIMES_THE_RULES_ARE_ASKED_AGAIN,
+                             VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT,
+                             DEPTH_A_CONSTRUCTION_PLAN_DESCENDS -> throw new IllegalArgumentException(
+                                "no search comes back from this budget, so it has no word: " + each);
                     };
                     if (word != null && word != here) {
                         throw new IllegalStateException("one search stopped by budgets that come"
@@ -2489,13 +2498,20 @@ public final class Generator {
             // pair: which values one of them may take depends on what the other took, and a value
             // chosen for the first without asking is right about its own run and wrong about the
             // pair as often as not.
-            Map<NumericTerm.FromOnePosition, Place> standing = shared || !placeable ? null
+            NumericWitness.Standing found = shared || !placeable ? null
                     : NumericWitness.of(here, owing,
                             term -> subject.quantities().ordersOf(term).answered());
+            Map<NumericTerm.FromOnePosition, Place> standing =
+                    found == null ? null : found.at();
             if (standing == null) {
+                // And where a budget of this compiler's is why the walk found nothing, that rather
+                // than the word for a walk that had everything and reached none of it.
                 unrepresented.add(new ReachabilityGap.Uncomposed(cut, shared
                         ? new ReachabilityGap.Why.TwoNumbersAtOneLocation()
-                        : new ReachabilityGap.Why.NoValueComposedForItsPositions()));
+                        : found != null && !found.stoppedBy().isEmpty()
+                                ? new ReachabilityGap.Why.TheWalkForItsPositionsWasStopped(
+                                        found.stoppedBy())
+                                : new ReachabilityGap.Why.NoValueComposedForItsPositions()));
                 continue;
             }
             for (Map.Entry<NumericTerm.FromOnePosition, Place> each : standing.entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -421,6 +421,46 @@ public final class Generator {
                          NO_READING_OF_THE_LINE_COULD_BE_SEARCHED -> false;
                 };
             }
+
+            /**
+             * The word a search these budgets stopped comes back with.
+             *
+             * <p>One way only. Which budget stopped a search is what the search hands over, and this
+             * is the word readers of the word have always had — read the other way round, a reader
+             * would be recovering a budget from something that never held one: two of these come
+             * back with the same word and one of them comes back with it without any budget having
+             * been reached at all.
+             *
+             * <p>The words are what each of these has always said, kept rather than tidied. A budget
+             * carries what stopped a search; what a report and a document say of it is a separate
+             * decision from this one, and moving a word here would move it for them.
+             *
+             * <p>Budgets that come back with different words are not one stop. Nothing composes such
+             * a set — a stop is one place — and this says so rather than choosing between them,
+             * which would be a precedence over causes at the one layer that has none.
+             */
+            public static Reason wordFor(java.util.Set<CompositionBudget> budgets) {
+                Reason word = null;
+                for (CompositionBudget each : budgets) {
+                    Reason here = switch (each) {
+                        case ELEMENTS_A_PROPOSAL_HOLDS, CHARACTERS_A_PROPOSAL_HOLDS,
+                             PLACES_A_PAIR_IS_TRIED_AT -> NOTHING_COMPOSES_ONE;
+                        case PAIRINGS_BUILT_AT_ONCE, ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
+                             SHAPES_OF_A_TOTAL_OFFERED, DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
+                             STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES -> SEARCH_LIMIT;
+                    };
+                    if (word != null && word != here) {
+                        throw new IllegalStateException("one search stopped by budgets that come"
+                                + " back with two words: " + budgets);
+                    }
+                    word = here;
+                }
+                if (word == null) {
+                    throw new IllegalArgumentException(
+                            "a search nothing stopped has no word to read off what stopped it");
+                }
+                return word;
+            }
         }
 
         public UnresolvedCombination {
@@ -3380,14 +3420,14 @@ public final class Generator {
         // and not something this fell short of — the same answer the class search gives when two
         // classes select different refinements of one position.
         if (planned instanceof ConstructionPlan.Result.Conflict against) {
-            return new Outcome(null, UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH,
+            return Outcome.none(UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH,
                     "`" + against.at() + "` would have to be both " + against.one().spelled()
                             + " and " + against.other().spelled());
         }
         ConstructionPlan plan = ((ConstructionPlan.Result.Planned) planned).plan();
         Choices choices = choicesOf(subject, p, plan, decided, settled);
         if (choices.missingAt() != null) {
-            return new Outcome(null, UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+            return Outcome.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                     choices.missingAt());
         }
         Outcome product = walk(subject, p, choices, check);
@@ -3406,16 +3446,26 @@ public final class Generator {
         // reported as though it had: `ALL_CANDIDATES_REJECTED` is what a reader is told nothing else
         // can be written at, and a search still holding assignments it never composed has not
         // established that.
-        if (product.reason() == UnresolvedCombination.Reason.SEARCH_LIMIT
-                || conditioned.reason() == UnresolvedCombination.Reason.SEARCH_LIMIT) {
-            return new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
+        if (!product.stoppedBy().isEmpty() || !conditioned.stoppedBy().isEmpty()) {
+            // Both passes' budgets and not one of them. Neither pass outranks the other here: each
+            // stopped where it stopped, and a reader wanting to know what would let this go further
+            // is owed every budget that would.
+            java.util.Set<CompositionBudget> both =
+                    java.util.EnumSet.noneOf(CompositionBudget.class);
+            both.addAll(product.stoppedBy());
+            both.addAll(conditioned.stoppedBy());
+            return Outcome.stoppedBy(both);
         }
         // Every value that was offered was refused, which is only the whole story where every value
         // the rules allow was offered. A position that read a count past what a row is built to carry,
         // or that has more pairings than are built at once, held something back, and saying so is the
         // difference between a fact about the model and a fact about this.
-        UnresolvedCombination.Reason held = heldBack(subject, p, plan, settled);
-        return held == null ? product : new Outcome(null, held, null);
+        return switch (heldBack(subject, p, plan, settled)) {
+            case HeldBack.Nothing _ -> product;
+            case HeldBack.NoRoomForOne _ -> Outcome.none(
+                    UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, null);
+            case HeldBack.ByABudget(var budgets) -> Outcome.stoppedBy(budgets);
+        };
     }
 
     /**
@@ -3470,37 +3520,52 @@ public final class Generator {
      * without them answers about a rule this row is no longer under — and would say "every value
      * tried was refused" of a position whose values were never built.
      */
-    private static UnresolvedCombination.Reason heldBack(MeasuredInput subject, int p,
-                                                         ConstructionPlan plan,
-                                                         Map<TermPath, Place> settled) {
+    private static HeldBack heldBack(MeasuredInput subject, int p, ConstructionPlan plan,
+                                     Map<TermPath, Place> settled) {
         TermPath root = TermPath.of(subject.parameters().get(p));
         Type declared = subject.types().get(p);
         FieldDomains rules = rulesOf(declared, subject.symbols(), subject.inputs().policy(),
                 under(root, settled));
-        UnresolvedCombination.Reason held = null;
         // A collection asked to hold a value in a class, whose rules say it holds fewer than that.
         // Nothing composes one: what the search would offer is a collection the rules refuse, and
         // saying every candidate was refused sends an author looking for a value where the rule
         // says there is no room for one.
         for (ConstructionPlan.Held each : plan.held()) {
             if (mostHeld(rules, each.at(), each.type(), subject.symbols()) < each.least()) {
-                return UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
+                return new HeldBack.NoRoomForOne();
             }
         }
+        // Every budget that held a position back, and not the first or the strongest. Two positions
+        // stopped by two budgets are two things this compiler declined to do, and a reader asking
+        // what would let the search go further is owed both — read as one, whichever the walk met
+        // last was the whole answer.
+        java.util.Set<CompositionBudget> budgets =
+                java.util.EnumSet.noneOf(CompositionBudget.class);
         for (ConstructionPlan.Slot each : plan.slots()) {
             RuleKey field = fieldUnder(each.at());
-            UnresolvedCombination.Reason here = Partitions.notBuilt(each.type(), subject.symbols(),
-                    subject.inputs().policy(), field == null ? null : rules.heldAt(field));
-            // Nothing of the shape having been built outranks some of it having been: the first says
-            // the search never had what the rule asks for, and a reader owed one sentence is owed that.
-            if (here == UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE) {
-                return here;
-            }
-            if (here != null) {
-                held = here;
+            budgets.addAll(Partitions.notBuilt(each.type(), subject.symbols(),
+                    subject.inputs().policy(), field == null ? null : rules.heldAt(field)));
+        }
+        return budgets.isEmpty() ? new HeldBack.Nothing() : new HeldBack.ByABudget(budgets);
+    }
+
+    /** Why a position of a parameter offered less than its rules allow. */
+    private sealed interface HeldBack {
+
+        /** Every position offered what its rules allow. */
+        record Nothing() implements HeldBack {}
+
+        /** A collection is asked to hold more than its rules leave room for, which is the model
+         *  settling it and not a budget of this compiler's. */
+        record NoRoomForOne() implements HeldBack {}
+
+        /** Budgets of this compiler's stopped positions offering the rest of what they had. */
+        record ByABudget(java.util.Set<CompositionBudget> budgets) implements HeldBack {
+
+            public ByABudget {
+                budgets = java.util.Set.copyOf(budgets);
             }
         }
-        return held;
     }
 
     /**
@@ -3531,11 +3596,12 @@ public final class Generator {
         FixtureTemplate built = descend(subject, p, plan, positions, 0, new LinkedHashMap<>(),
                 new LinkedHashMap<>(settled), decided, check, budget);
         if (built != null) {
-            return new Outcome(built, null, null);
+            return Outcome.built(built);
         }
-        return new Outcome(null, budget.cutShort
-                ? UnresolvedCombination.Reason.SEARCH_LIMIT
-                : UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+        return budget.cutShort
+                ? Outcome.stoppedBy(
+                        java.util.Set.of(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES))
+                : Outcome.none(UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
     }
 
     /**
@@ -3898,7 +3964,28 @@ public final class Generator {
 
     /** What came of trying the assignments for one parameter: its value, or why there is none. */
     private record Outcome(FixtureTemplate value, UnresolvedCombination.Reason reason,
-                           String detail) {}
+                           String detail, java.util.Set<CompositionBudget> stoppedBy) {
+
+        Outcome {
+            stoppedBy = java.util.Set.copyOf(stoppedBy);
+        }
+
+        /** A value was composed. */
+        static Outcome built(FixtureTemplate value) {
+            return new Outcome(value, null, null, java.util.Set.of());
+        }
+
+        /** None was, and no budget of this compiler's is why. */
+        static Outcome none(UnresolvedCombination.Reason why, String detail) {
+            return new Outcome(null, why, detail, java.util.Set.of());
+        }
+
+        /** None was, and these budgets of this compiler's are why. The word is read off them so
+         *  that the two cannot part; which budget it was is what the word does not hold. */
+        static Outcome stoppedBy(java.util.Set<CompositionBudget> budgets) {
+            return new Outcome(null, UnresolvedCombination.Reason.wordFor(budgets), null, budgets);
+        }
+    }
 
     /**
      * The assignments, nearest first, until one builds.
@@ -3939,7 +4026,15 @@ public final class Generator {
         seen.add(Arrays.toString(first));
 
         int tried = 0;
-        while (!next.isEmpty() && tried < MAX_TUPLES) {
+        // Recorded where the bound is reached rather than read afterwards off what was left behind.
+        // A walk that stopped and a walk that ran out are told apart by the queue today and would go
+        // on being told apart by it until the day a second thing empties it.
+        boolean stopped = false;
+        while (!next.isEmpty()) {
+            if (tried == MAX_TUPLES) {
+                stopped = true;
+                break;
+            }
             int[] assignment = next.poll();
             tried++;
             Map<TermPath, FixtureTemplate> chosen = new LinkedHashMap<>();
@@ -3948,7 +4043,7 @@ public final class Generator {
             }
             FixtureTemplate built = compose(plan.root(), chosen, subject.symbols(), subject.inputs().policy());
             if (built != null && check.refuse(p, built).isEmpty()) {
-                return new Outcome(built, null, null);
+                return Outcome.built(built);
             }
             for (int i = 0; i < positions; i++) {
                 if (assignment[i] + 1 >= values.get(i).size()) {
@@ -3961,13 +4056,14 @@ public final class Generator {
                 }
             }
         }
-        // Nothing left to try is every assignment refused; something left is the search having stopped,
-        // and the difference is what the reader is owed. Neither carries a detail: what these are
-        // about is the combination, and a detail is read as the position that is the fact behind
-        // several of them.
-        return next.isEmpty()
-                ? new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null)
-                : new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
+        // Nothing left to try is every assignment refused; a bound reached is the search having
+        // stopped, and the difference is what the reader is owed. Neither carries a detail: what
+        // these are about is the combination, and a detail is read as the position that is the fact
+        // behind several of them.
+        return stopped
+                ? Outcome.stoppedBy(
+                        java.util.Set.of(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES))
+                : Outcome.none(UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
     }
 
     /**
@@ -4111,15 +4207,37 @@ public final class Generator {
      * same question building it asked, and the reading is what answers it both times — kept here,
      * an answer would travel from the one to the other and the two would be free to part.
      */
-    private record Edge(List<FixtureTemplate> values, UnresolvedCombination.Reason reason,
-                        Place settledAt, UnresolvedCombination.Reason heldBack) {
-
-        Edge {
-            values = List.copyOf(values);
-        }
+    private record Edge(TermRealizations.Realization came, Place settledAt) {
 
         static Edge none(UnresolvedCombination.Reason why) {
-            return new Edge(List.of(), why, null, null);
+            return new Edge(new TermRealizations.Realization.None(why), null);
+        }
+
+        List<FixtureTemplate> values() {
+            return came instanceof TermRealizations.Realization.Built built
+                    ? built.values() : List.of();
+        }
+
+        /** Which budgets of this compiler's stopped this edge offering more than it did, and empty
+         *  where none did. The same set whether or not anything was offered: what a budget is, is
+         *  what this compiler declined to do, and that does not turn on what came of the rest. */
+        java.util.Set<CompositionBudget> stoppedBy() {
+            return switch (came) {
+                case TermRealizations.Realization.Built built -> built.heldBack();
+                case TermRealizations.Realization.Stopped stopped -> stopped.by();
+                case TermRealizations.Realization.None _ -> java.util.Set.of();
+            };
+        }
+
+        /** What to report where no value was offered here at all. */
+        UnresolvedCombination.Reason reason() {
+            return switch (came) {
+                case TermRealizations.Realization.None none -> none.why();
+                case TermRealizations.Realization.Stopped stopped ->
+                        UnresolvedCombination.Reason.wordFor(stopped.by());
+                case TermRealizations.Realization.Built _ -> throw new IllegalStateException(
+                        "an edge that offered values asked why it offered none");
+            };
         }
 
         /**
@@ -4130,7 +4248,8 @@ public final class Generator {
          * would act on: another value of this edge may be the one that builds.
          */
         UnresolvedCombination.Reason refused() {
-            return heldBack == null ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED : heldBack;
+            return stoppedBy().isEmpty() ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED
+                    : UnresolvedCombination.Reason.wordFor(stoppedBy());
         }
     }
 
@@ -4151,11 +4270,7 @@ public final class Generator {
             // position standing at three, and a hundred is not what the list adding up to it holds.
             case NumericTerm.TakenOf _, NumericTerm.TakenOver _ -> null;
         };
-        return switch (made) {
-            case TermRealizations.Realization.BuiltNone none -> Edge.none(none.why());
-            case TermRealizations.Realization.Built built ->
-                    new Edge(built.values(), null, settled, built.heldBack());
-        };
+        return new Edge(made, settled);
     }
 
     private Generator() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
@@ -35,13 +35,8 @@ public final class LevelCandidateSource {
      * of it; a box that holds none of the first few holds one only where the rules are shaped so that
      * the whole search is worth its own answer.
      */
-    private static final int LEVELS_TRIED = 8;
-
-    /** The same figure, for {@link CompositionBudget} to name it by. Read here rather than written
-     *  there, so that the bound and its name cannot part. */
-    static int levelsTried() {
-        return LEVELS_TRIED;
-    }
+    private static final int LEVELS_TRIED =
+            CompositionBudget.LEVELS_A_SIDE_IS_ASKED_AT.maximum();
 
     /**
      * The levels a row at this item could stand at, nearest the line first.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
@@ -112,15 +112,12 @@ public final class LevelCandidateSource {
                                      Towards towards) {
         List<Level> out = new ArrayList<>();
         Bound past = from == null ? null : Bound.at(from, false);
-        // Recorded where the figure is reached, so that a walk this stopped and a region with
-        // nothing further in it are told apart. Counted afterwards, a region holding exactly this
-        // many is the one that cannot be told from either.
+        // <b>A level found and not offered, never a count that came out even.</b> A region holding
+        // exactly this many and a region this stopped drawing from come back the same length, so
+        // the figure being reached says nothing on its own — what says this compiler declined to
+        // offer more is a level the region has that this did not take.
         boolean stoppedShort = false;
-        for (int step = 0; ; step++) {
-            if (step == LEVELS_TRIED) {
-                stoppedShort = true;
-                break;
-            }
+        while (true) {
             Level next = null;
             for (LevelInterval part : region.parts()) {
                 LevelInterval left = towards == Towards.ABOVE
@@ -135,6 +132,10 @@ public final class LevelCandidateSource {
                 }
             }
             if (next == null) {
+                break;   // nothing further in the region, so this drew the whole of it
+            }
+            if (out.size() == LEVELS_TRIED) {
+                stoppedShort = true;   // one the region has and this is not offering
                 break;
             }
             out.add(next);

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelCandidateSource.java
@@ -37,6 +37,12 @@ public final class LevelCandidateSource {
      */
     private static final int LEVELS_TRIED = 8;
 
+    /** The same figure, for {@link CompositionBudget} to name it by. Read here rather than written
+     *  there, so that the bound and its name cannot part. */
+    static int levelsTried() {
+        return LEVELS_TRIED;
+    }
+
     /**
      * The levels a row at this item could stand at, nearest the line first.
      *
@@ -46,12 +52,26 @@ public final class LevelCandidateSource {
      * for outward from what they are written against until the budget runs out. Which is why a run
      * that came back empty settles nothing while a point may.
      */
-    public static List<Level> forItem(Criterion where, LevelSpace levels) {
+    public static Offered forItem(Criterion where, LevelSpace levels) {
         Level from = where.anchor();
         return switch (where) {
-            case Criterion.AtTheLevel _ -> List.of(from);
+            case Criterion.AtTheLevel _ -> new Offered(List.of(from), false);
             case Criterion.Within within -> inside(levels, within);
         };
+    }
+
+    /**
+     * The levels offered, and whether there were more this stopped short of.
+     *
+     * <p>Two halves of one answer. A caller reading only the first says the levels are all the
+     * levels there were, which is what a run whose far end nothing reached looks like from here —
+     * and the difference is whether raising a figure of this compiler's would offer more.
+     */
+    public record Offered(List<Level> levels, boolean stoppedShort) {
+
+        public Offered {
+            levels = List.copyOf(levels);
+        }
     }
 
     /**
@@ -62,17 +82,18 @@ public final class LevelCandidateSource {
      * from the run's far end instead, a row well inside a wide run was offered where one just inside
      * it says the same thing and is the row an author would have written.
      */
-    private static List<Level> inside(LevelSpace levels, Criterion.Within within) {
+    private static Offered inside(LevelSpace levels, Criterion.Within within) {
         Level from = within.anchor();
         if (from == null) {
-            return List.of();
+            return new Offered(List.of(), false);
         }
         List<Level> out = new ArrayList<>();
         if (within.holds(from)) {
             out.add(from);
         }
-        out.addAll(drawnFrom(levels, within.region(), from, within.away()));
-        return out;
+        Offered drawn = drawnFrom(levels, within.region(), from, within.away());
+        out.addAll(drawn.levels());
+        return new Offered(out, drawn.stoppedShort());
     }
 
     /**
@@ -87,11 +108,19 @@ public final class LevelCandidateSource {
      * <p>Which part of the region a level comes from settles itself: every part on the wrong side of
      * what has already been offered has its ends crossed and is passed over.
      */
-    private static List<Level> drawnFrom(LevelSpace levels, LevelRegion region, Level from,
-                                         Towards towards) {
+    private static Offered drawnFrom(LevelSpace levels, LevelRegion region, Level from,
+                                     Towards towards) {
         List<Level> out = new ArrayList<>();
         Bound past = from == null ? null : Bound.at(from, false);
-        for (int step = 0; step < LEVELS_TRIED; step++) {
+        // Recorded where the figure is reached, so that a walk this stopped and a region with
+        // nothing further in it are told apart. Counted afterwards, a region holding exactly this
+        // many is the one that cannot be told from either.
+        boolean stoppedShort = false;
+        for (int step = 0; ; step++) {
+            if (step == LEVELS_TRIED) {
+                stoppedShort = true;
+                break;
+            }
             Level next = null;
             for (LevelInterval part : region.parts()) {
                 LevelInterval left = towards == Towards.ABOVE
@@ -111,7 +140,7 @@ public final class LevelCandidateSource {
             out.add(next);
             past = Bound.at(next, false);
         }
-        return out;
+        return new Offered(out, stoppedShort);
     }
 
     private LevelCandidateSource() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -61,7 +61,7 @@ public final class LevelRealizer {
     private Realization ofOne(Standing.OfOneCoordinate one,
                               souther.compiler.inputs.SearchRegion within) {
         Place at = placeMeeting(one.where(), one.of(), bounds(within, one.term()));
-        return at == null ? new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE)
+        return at == null ? Realization.Unknown.nothingComposedOne()
                 : found(Map.of(new RealizationTarget.AtOnePosition(one.term()), at), within);
     }
 
@@ -81,7 +81,8 @@ public final class LevelRealizer {
         NumericDomain.Bounds on = bounds(within, two.on());
         NumericDomain.Bounds together = commonRange(on, bounds(within, two.against()), two.of(),
                 two.where().anchor().asACount());
-        for (Place common : alongTheLine(together, two.of())) {
+        Outwards.Walked walked = alongTheLine(together, two.of());
+        for (Place common : walked) {
             // Where the first has to stand relative to the second: the place the level's distance
             // from it, and then whatever the item asks of that place. Arithmetic on the carrier's
             // counts and not a walk along it — a walk is an addition that only exists where the
@@ -102,7 +103,13 @@ public final class LevelRealizer {
                 return made;
             }
         }
-        return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
+        // Where the walk stopped at its figure, what came back empty is a walk this compiler cut
+        // short and not a line whose places were all tried. Said as the second, a pair the figure
+        // kept from being reached is reported as one nothing composes.
+        return walked.stoppedShort()
+                ? Realization.Unknown.stoppedBy(
+                        java.util.Set.of(CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT))
+                : Realization.Unknown.nothingComposedOne();
     }
 
     /**
@@ -131,10 +138,10 @@ public final class LevelRealizer {
      * <p>One place where the carrier's values do not count. There is no next place to step to, so
      * the one the ranges leave is the whole of what there is to try.
      */
-    private static List<Place> alongTheLine(NumericDomain.Bounds together, Carrier carrier) {
+    private static Outwards.Walked alongTheLine(NumericDomain.Bounds together, Carrier carrier) {
         // Nothing composed, which is this one's own answer and not something to ask a walk about.
         Place first = carrier.somethingInside(together.min(), together.max());
-        return first == null ? List.of()
+        return first == null ? new Outwards.Walked(List.of(), false)
                 : Outwards.from(first, Count.of(1), carrier, together,
                         HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT);
     }
@@ -199,9 +206,20 @@ public final class LevelRealizer {
             terms.add(Map.entry(RealizationTarget.of(each.getKey()), each.getValue()));
         }
         boolean bounded = true;
-        for (Level level : LevelCandidateSource.forItem(over.where(), levels)) {
+        // Every budget any of the level walks ran out of. Collected and not chosen between: two
+        // levels stopped by two figures are two things this compiler declined to do, and a reader
+        // asking what would let the search go further is owed both.
+        java.util.Set<CompositionBudget> stoppedBy =
+                java.util.EnumSet.noneOf(CompositionBudget.class);
+        LevelCandidateSource.Offered offered =
+                LevelCandidateSource.forItem(over.where(), levels);
+        if (offered.stoppedShort()) {
+            stoppedBy.add(CompositionBudget.LEVELS_A_SIDE_IS_ASKED_AT);
+        }
+        for (Level level : offered.levels()) {
             Search search = new Search(terms, over.on(), within);
             Reached reached = search.solve(level.asACount());
+            stoppedBy.addAll(search.stoppedBy());
             if (reached == Reached.FOUND) {
                 Realization made = found(search.fixing(), within);
                 if (made instanceof Realization.Found) {
@@ -219,9 +237,15 @@ public final class LevelRealizer {
         // be settled by looking: a walk of the whole box that reaches the level nothing else does is
         // a proof, and a side that none of the levels tried reached is a side this stopped looking
         // at.
-        return bounded && over.where() instanceof Criterion.AtTheLevel
-                ? new Realization.Impossible()
-                : new Realization.Unknown(Realization.Unknown.Reason.THE_SEARCH_RAN_OUT);
+        if (bounded && over.where() instanceof Criterion.AtTheLevel) {
+            return new Realization.Impossible();
+        }
+        // What kept this from settling it, where a figure of this compiler's did. Where none did,
+        // the walk reached the end of what it had and the answer is that nothing was composed —
+        // said in that word rather than in the one for a search that stopped, which would name a
+        // budget nobody reached.
+        return stoppedBy.isEmpty() ? Realization.Unknown.nothingComposedOne()
+                : Realization.Unknown.stoppedBy(stoppedBy);
     }
 
     /** How many assignments the search will try before it stops and says it did not settle it. */
@@ -252,7 +276,8 @@ public final class LevelRealizer {
      * the second value, and what would ask for a third is a run with two holes in it beside each
      * other.
      */
-    private static final int VALUES_A_PROGRESSION_WITHOUT_AN_END_IS_TRIED_AT = 16;
+    private static final int VALUES_A_PROGRESSION_WITHOUT_AN_END_IS_TRIED_AT =
+            CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED.maximum();
 
     /**
      * What a walk of one position came to.
@@ -280,7 +305,8 @@ public final class LevelRealizer {
      *  reading of every rule reaching the form's positions, and what it buys is skipping
      *  assignments the rules refuse — worth paying for a search that ends quickly and not for one
      *  walking a box a hundred thousand wide. */
-    private static final int HOW_OFTEN_THE_RULES_ARE_ASKED_AGAIN = 2_000;
+    private static final int HOW_OFTEN_THE_RULES_ARE_ASKED_AGAIN =
+            CompositionBudget.TIMES_THE_RULES_ARE_ASKED_AGAIN.maximum();
 
 
     /** How far a derived end is written out where the division that makes it does not end. Any
@@ -338,6 +364,23 @@ public final class LevelRealizer {
         private final AdditiveImage[] fromHere;
         private int taken;
         private int asked;
+        /** Which budgets of this compiler's this walk ran out of, recorded where each ran out. What
+         *  it came back with says that nothing was reached and not what kept it from reaching. */
+        private final java.util.Set<CompositionBudget> stoppedBy =
+                java.util.EnumSet.noneOf(CompositionBudget.class);
+
+        java.util.Set<CompositionBudget> stoppedBy() {
+            return stoppedBy;
+        }
+
+        /** Whether there is room for another assignment, marking the budget where there is not. */
+        private boolean stepsLeft() {
+            if (taken > STEPS_A_SEARCH_MAY_TAKE) {
+                stoppedBy.add(CompositionBudget.STEPS_A_SEARCH_MAY_TAKE);
+                return false;
+            }
+            return true;
+        }
 
         Search(List<Map.Entry<RealizationTarget, java.math.BigDecimal>> terms,
                Map<NumericTerm, Carrier> on, souther.compiler.inputs.SearchRegion within) {
@@ -400,7 +443,8 @@ public final class LevelRealizer {
          */
         private Reached walk(int i, java.math.BigDecimal owed,
                              souther.compiler.inputs.SearchRegion here) {
-            if (++taken > STEPS_A_SEARCH_MAY_TAKE) {
+            taken++;
+            if (!stepsLeft()) {
                 return Reached.INCOMPLETE;
             }
             java.math.BigDecimal coef = terms.get(i).getValue();
@@ -480,7 +524,7 @@ public final class LevelRealizer {
                 if (reached == Reached.INCOMPLETE) {
                     weakest = Reached.INCOMPLETE;
                 }
-                if (taken > STEPS_A_SEARCH_MAY_TAKE) {
+                if (!stepsLeft()) {
                     return Reached.INCOMPLETE;
                 }
             }
@@ -509,10 +553,13 @@ public final class LevelRealizer {
                 if (trying(i, Count.number(x).at(), owed, coef, here) == Reached.FOUND) {
                     return Reached.FOUND;
                 }
-                if (taken > STEPS_A_SEARCH_MAY_TAKE) {
+                if (!stepsLeft()) {
                     return Reached.INCOMPLETE;
                 }
             }
+            // A run without an end, walked as far as this compiler walks one. Never a proof, and
+            // the figure that decided how far is what a reader wanting more would raise.
+            stoppedBy.add(CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED);
             return Reached.INCOMPLETE;
         }
 
@@ -839,7 +886,7 @@ public final class LevelRealizer {
                               souther.compiler.inputs.SearchRegion within) {
         return theRulesHaveNotRefused(fixing, within)
                 ? new Realization.Found(fixing)
-                : new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
+                : Realization.Unknown.nothingComposedOne();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -103,13 +103,12 @@ public final class LevelRealizer {
                 return made;
             }
         }
-        // Where the walk stopped at its figure, what came back empty is a walk this compiler cut
-        // short and not a line whose places were all tried. Said as the second, a pair the figure
-        // kept from being reached is reported as one nothing composes.
-        return walked.stoppedShort()
-                ? Realization.Unknown.stoppedBy(
-                        java.util.Set.of(CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT))
-                : Realization.Unknown.nothingComposedOne();
+        // Nothing was composed, which is what a pair the ranges leave no place for comes to and
+        // what this has always said. Where the walk stopped at its figure, that is said beside the
+        // answer rather than in place of it.
+        return Realization.Unknown.nothingComposedOne(walked.stoppedShort()
+                ? java.util.Set.of(CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT)
+                : java.util.Set.of());
     }
 
     /**
@@ -240,12 +239,10 @@ public final class LevelRealizer {
         if (bounded && over.where() instanceof Criterion.AtTheLevel) {
             return new Realization.Impossible();
         }
-        // What kept this from settling it, where a figure of this compiler's did. Where none did,
-        // the walk reached the end of what it had and the answer is that nothing was composed —
-        // said in that word rather than in the one for a search that stopped, which would name a
-        // budget nobody reached.
-        return stoppedBy.isEmpty() ? Realization.Unknown.nothingComposedOne()
-                : Realization.Unknown.stoppedBy(stoppedBy);
+        // A side is never settled by looking, so what this comes back with is that the search ran
+        // out — which is what it has always come back with, whether or not a figure of this
+        // compiler's was reached. The figures are said beside that answer and do not choose it.
+        return Realization.Unknown.searchRanOut(stoppedBy);
     }
 
     /** How many assignments the search will try before it stops and says it did not settle it. */
@@ -548,8 +545,9 @@ public final class LevelRealizer {
         private Reached outward(int i, CandidateDomain.Outward on, java.math.BigDecimal owed,
                                 java.math.BigDecimal coef,
                                 souther.compiler.inputs.SearchRegion here) {
-            for (Place x : Outwards.from(new Count(on.from()), new Count(on.by()), carriers[i],
-                    on.within(), VALUES_A_PROGRESSION_WITHOUT_AN_END_IS_TRIED_AT)) {
+            Outwards.Walked walked = Outwards.from(new Count(on.from()), new Count(on.by()),
+                    carriers[i], on.within(), VALUES_A_PROGRESSION_WITHOUT_AN_END_IS_TRIED_AT);
+            for (Place x : walked) {
                 if (trying(i, Count.number(x).at(), owed, coef, here) == Reached.FOUND) {
                     return Reached.FOUND;
                 }
@@ -557,9 +555,14 @@ public final class LevelRealizer {
                     return Reached.INCOMPLETE;
                 }
             }
-            // A run without an end, walked as far as this compiler walks one. Never a proof, and
-            // the figure that decided how far is what a reader wanting more would raise.
-            stoppedBy.add(CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED);
+            // Never a proof either way: a run without an end is not walked to the end, and a walk
+            // of every value this had is still a walk of a progression. What the figure adds is
+            // only said where the run held one more and this did not take it — added whenever the
+            // walk came back empty, it would name a figure over a run that had nothing further in
+            // it, which is this compiler claiming to have been stopped where it was not.
+            if (walked.stoppedShort()) {
+                stoppedBy.add(CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED);
+            }
             return Reached.INCOMPLETE;
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -112,7 +112,8 @@ public final class LevelRealizer {
      * that takes a value away takes one — everything that moves an end is in the range already. So
      * what this steps past is holes, and there are as many of those as the rules state.
      */
-    private static final int HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT = 64;
+    private static final int HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT =
+            CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT.maximum();
 
     /**
      * The places to try the pair at, from the one the ranges leave outward.
@@ -224,7 +225,8 @@ public final class LevelRealizer {
     }
 
     /** How many assignments the search will try before it stops and says it did not settle it. */
-    private static final int STEPS_A_SEARCH_MAY_TAKE = 200_000;
+    private static final int STEPS_A_SEARCH_MAY_TAKE =
+            CompositionBudget.STEPS_A_SEARCH_MAY_TAKE.maximum();
 
     /**
      * How many values of a progression nothing bounds are tried.

--- a/souther-compiler/src/main/java/souther/compiler/partition/NumericWitness.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/NumericWitness.java
@@ -47,7 +47,8 @@ final class NumericWitness {
      * condition relating two positions gives that up within a step or two of the end it is written
      * against — past which the values being tried are ones the same condition already refused.
      */
-    private static final int VALUES_A_POSITION_IS_TRIED_AT = 8;
+    private static final int VALUES_A_POSITION_IS_TRIED_AT =
+            CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT.maximum();
 
     /**
      * Where each of {@code terms} may stand together inside {@code within}, or null where this found
@@ -57,11 +58,30 @@ final class NumericWitness {
      *           a position no value is chosen at here, and the whole assignment is refused rather
      *           than made without it
      */
-    static Map<NumericTerm.FromOnePosition, Place> of(
-            SearchRegion within, List<NumericTerm.FromOnePosition> terms,
-            Function<NumericTerm, Carrier> on) {
+    static Standing of(SearchRegion within, List<NumericTerm.FromOnePosition> terms,
+                       Function<NumericTerm, Carrier> on) {
         Map<NumericTerm.FromOnePosition, Place> standing = new LinkedHashMap<>();
-        return walk(within, terms, 0, on, standing) ? standing : null;
+        java.util.Set<CompositionBudget> stoppedBy =
+                java.util.EnumSet.noneOf(CompositionBudget.class);
+        return walk(within, terms, 0, on, standing, stoppedBy)
+                ? new Standing(standing, java.util.Set.of())
+                : new Standing(null, stoppedBy);
+    }
+
+    /**
+     * Where the positions may stand together, or nothing, and what stopped this looking further.
+     *
+     * <p>Two halves of one answer. A walk that tried every value it had and one that stopped at a
+     * figure of this compiler's both come back with nothing, and only the second names something a
+     * reader could raise.
+     */
+    record Standing(Map<NumericTerm.FromOnePosition, Place> at,
+                    java.util.Set<CompositionBudget> stoppedBy) {
+
+        Standing {
+            at = at == null ? null : Map.copyOf(at);
+            stoppedBy = java.util.Set.copyOf(stoppedBy);
+        }
     }
 
     /**
@@ -74,7 +94,8 @@ final class NumericWitness {
     private static boolean walk(SearchRegion within, List<NumericTerm.FromOnePosition> terms,
                                 int at,
                                 Function<NumericTerm, Carrier> on,
-                                Map<NumericTerm.FromOnePosition, Place> standing) {
+                                Map<NumericTerm.FromOnePosition, Place> standing,
+                                java.util.Set<CompositionBudget> stoppedBy) {
         if (at == terms.size()) {
             return true;
         }
@@ -88,8 +109,9 @@ final class NumericWitness {
         if (first == null) {
             return false;
         }
-        for (Place tried : Outwards.from(first, Count.of(1), carrier, runs,
-                VALUES_A_POSITION_IS_TRIED_AT)) {
+        Outwards.Walked walked =
+                Outwards.from(first, Count.of(1), carrier, runs, VALUES_A_POSITION_IS_TRIED_AT);
+        for (Place tried : walked) {
             if (!(tried instanceof Count count)) {
                 continue;
             }
@@ -98,10 +120,16 @@ final class NumericWitness {
                 continue;
             }
             standing.put(term, tried);
-            if (walk(next, terms, at + 1, on, standing)) {
+            if (walk(next, terms, at + 1, on, standing, stoppedBy)) {
                 return true;
             }
             standing.remove(term);
+        }
+        // Every value this position had to offer was tried and none of them led anywhere. Where
+        // there were more and a figure of this compiler's is why they were not tried, that is what
+        // the caller is owed beside the empty hand.
+        if (walked.stoppedShort()) {
+            stoppedBy.add(CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT);
         }
         return false;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Outwards.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Outwards.java
@@ -85,29 +85,33 @@ final class Outwards {
         }
         List<Place> out = new ArrayList<>();
         out.add(first);
-        // Recorded where the figure is reached rather than counted afterwards. A run holding exactly
-        // this many and a run this stopped walking come back the same length, and only one of them
-        // is a figure somebody could raise.
+        // <b>A value found and not taken, never a count that came out even.</b> A run holding
+        // exactly this many and a run this stopped walking come back the same length, so the figure
+        // being reached says nothing on its own — what says this compiler declined to go further is
+        // a value the run holds that this did not take. Read off the count instead, a run walked to
+        // its end reports a budget nobody reached, and a point nothing could stop is reported as one
+        // this stopped: the same trade this file is here to prevent, made the other way round.
         boolean stoppedShort = false;
+        outward:
         for (int step = 1; ; step++) {
-            if (out.size() == howManyValues) {
-                stoppedShort = true;
-                break;
-            }
             BigDecimal away = BigDecimal.valueOf(step);
-            Place above = carrier.onTheGrid(Count.number(first).plus(by.times(away)));
-            Place below = carrier.onTheGrid(Count.number(first).minus(by.times(away)));
+            Place[] neighbours = {
+                    carrier.onTheGrid(Count.number(first).plus(by.times(away))),
+                    carrier.onTheGrid(Count.number(first).minus(by.times(away)))};
             boolean took = false;
-            if (above != null && within.admits(above)) {
-                out.add(above);
-                took = true;
-            }
-            if (below != null && within.admits(below) && out.size() < howManyValues) {
-                out.add(below);
+            for (Place next : neighbours) {
+                if (next == null || !within.admits(next)) {
+                    continue;
+                }
+                if (out.size() == howManyValues) {
+                    stoppedShort = true;   // one the run holds and this is not taking
+                    break outward;
+                }
+                out.add(next);
                 took = true;
             }
             if (!took) {
-                break;
+                break;   // neither direction has a value left, so this walked the whole of it
             }
         }
         return new Walked(out, stoppedShort);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Outwards.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Outwards.java
@@ -33,6 +33,26 @@ final class Outwards {
     }
 
     /**
+     * The places walked, and whether there were more this stopped short of.
+     *
+     * <p>Two halves of one answer. A caller reading only the first cannot tell a run with nothing
+     * further in it from one this stopped walking, and only the second of those is a figure
+     * somebody could raise.
+     */
+    record Walked(List<Place> places, boolean stoppedShort) implements Iterable<Place> {
+
+        Walked {
+            places = List.copyOf(places);
+        }
+
+        /** The places, so that a caller wanting only those walks this. */
+        @Override
+        public java.util.Iterator<Place> iterator() {
+            return places.iterator();
+        }
+    }
+
+    /**
      * At most {@code howManyValues} values of {@code within}, from {@code first} outward, {@code by}
      * apart.
      *
@@ -45,8 +65,8 @@ final class Outwards {
      * @param by            the distance between neighbouring candidates, positive
      * @param howManyValues how many to yield, counting {@code first}
      */
-    static List<Place> from(Place first, Count by, Carrier carrier, NumericDomain.Bounds within,
-                            int howManyValues) {
+    static Walked from(Place first, Count by, Carrier carrier, NumericDomain.Bounds within,
+                       int howManyValues) {
         if (by == null || by.signum() <= 0) {
             throw new IllegalArgumentException(
                     "neighbouring candidates are a positive distance apart, or there is no outward:"
@@ -61,11 +81,19 @@ final class Outwards {
         // One place where the carrier's values do not count. There is no next place to step to, so
         // the one the caller started from is the whole of what there is to try.
         if (!carrier.counts()) {
-            return List.of(first);
+            return new Walked(List.of(first), false);
         }
         List<Place> out = new ArrayList<>();
         out.add(first);
-        for (int step = 1; out.size() < howManyValues; step++) {
+        // Recorded where the figure is reached rather than counted afterwards. A run holding exactly
+        // this many and a run this stopped walking come back the same length, and only one of them
+        // is a figure somebody could raise.
+        boolean stoppedShort = false;
+        for (int step = 1; ; step++) {
+            if (out.size() == howManyValues) {
+                stoppedShort = true;
+                break;
+            }
             BigDecimal away = BigDecimal.valueOf(step);
             Place above = carrier.onTheGrid(Count.number(first).plus(by.times(away)));
             Place below = carrier.onTheGrid(Count.number(first).minus(by.times(away)));
@@ -82,6 +110,6 @@ final class Outwards {
                 break;
             }
         }
-        return List.copyOf(out);
+        return new Walked(out, stoppedShort);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1449,9 +1449,9 @@ public final class Partitions {
      * reads is the floor that was built against, and a reading here that knew only the type would
      * say "every value tried was refused" of a position whose values were never built.
      */
-    static Generator.UnresolvedCombination.Reason notBuilt(Type type, Symbols symbols,
-                                                           ReadingPolicy policy,
-                                                            FieldDomains.Held held) {
+    static java.util.Set<CompositionBudget> notBuilt(Type type, Symbols symbols,
+                                                     ReadingPolicy policy,
+                                                     FieldDomains.Held held) {
         return Witnesses.heldBackFor(TypeOps.base(type, symbols), leastHeld(type, symbols, held),
                 symbols, policy);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachabilityGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachabilityGap.java
@@ -66,6 +66,31 @@ public sealed interface ReachabilityGap {
         record NoValueComposedForItsPositions() implements Why {}
 
         /**
+         * The same, where a budget of this compiler's is what stopped the walk that would have
+         * placed the positions.
+         *
+         * <p>A case beside the one above rather than a field on it. The two are different news: one
+         * says nothing was found in what was walked, the other says the walking stopped, and only
+         * the second names something a reader could raise. Held as a set that is sometimes empty,
+         * every reader would decide again which of the two it had.
+         *
+         * <p>Not an {@link souther.compiler.query.EstablishmentGap}. A row was composed here; what
+         * the budget cost is one condition on the way being composed against, and reporting it as a
+         * point nothing could be established at would say more than happened.
+         */
+        record TheWalkForItsPositionsWasStopped(java.util.Set<CompositionBudget> by)
+                implements Why {
+
+            public TheWalkForItsPositionsWasStopped {
+                by = java.util.Set.copyOf(by);
+                if (by.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a walk this compiler stopped says which budget stopped it");
+                }
+            }
+        }
+
+        /**
          * Two numbers taken at one location, one of which the row is already being written for.
          *
          * <p>A row writes one value where a location is, and that one value would have to answer

--- a/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
@@ -54,7 +54,43 @@ public sealed interface Realization {
      * <p>The item stays owed. What a report says of it is that it is not known to be writable, which
      * is the account any unpromised edge gets.
      */
-    record Unknown(Reason why) implements Realization {
+    record Unknown(Reason why, java.util.Set<CompositionBudget> stoppedBy)
+            implements Realization {
+
+        public Unknown {
+            stoppedBy = java.util.Set.copyOf(stoppedBy);
+        }
+
+        /** A walk that came to nothing without any budget of this compiler's having run out. */
+        public static Unknown nothingComposedOne() {
+            return new Unknown(Reason.NOTHING_COMPOSED_ONE, java.util.Set.of());
+        }
+
+        /**
+         * A walk these budgets of this compiler's stopped.
+         *
+         * <p>Which budget it was and the word it comes back with are made together here, and the
+         * word is never what the budget is read back from: one of these words is written wherever a
+         * walk of a side comes back empty, budget or no budget, so a reader recovering a budget
+         * from it would be recovering one that may never have been reached.
+         */
+        public static Unknown stoppedBy(java.util.Set<CompositionBudget> budgets) {
+            if (budgets.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a walk this compiler stopped says which budget stopped it");
+            }
+            // The word each of these has always come back with, and not one word for all of them.
+            // Which of the two a stopped walk says is the budget's, and a stop that said the other
+            // would move a sentence a reader has been reading for reasons of its own.
+            Reason why = switch (Generator.UnresolvedCombination.Reason.wordFor(budgets)) {
+                case NOTHING_COMPOSES_ONE -> Reason.NOTHING_COMPOSED_ONE;
+                case SEARCH_LIMIT -> Reason.THE_SEARCH_RAN_OUT;
+                default -> throw new IllegalStateException(
+                        "a budget that stopped a walk came back with a word no walk says: "
+                                + budgets);
+            };
+            return new Unknown(why, budgets);
+        }
 
         public enum Reason {
             /** This compiler composed no candidate — a position whose type it cannot write at, a

--- a/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
@@ -71,29 +71,37 @@ public sealed interface Realization {
             }
         }
 
-        /** A walk that came to nothing without any budget of this compiler's having run out. */
+        /**
+         * A walk that composed no candidate, and the budgets of this compiler's it ran out of.
+         *
+         * <p><b>The word is the walk's and the budgets are beside it.</b> What a walk came to and
+         * whether a figure of this compiler's stopped it are two questions, and only the first has
+         * ever decided which word this comes back with. Made from the budgets instead — one word
+         * where some were reached and another where none were — a walk changes what it says by
+         * acquiring a fact about this compiler, and a reader who has been reading that word for
+         * reasons of their own is told something else.
+         *
+         * <p>Empty is the ordinary case and says the same thing: nothing was composed, and nothing
+         * of this compiler's is why.
+         */
+        public static Unknown nothingComposedOne(java.util.Set<CompositionBudget> stoppedBy) {
+            return new Unknown(Reason.NOTHING_COMPOSED_ONE, stoppedBy);
+        }
+
+        /** The same, of a walk that composed no candidate and met no figure. */
         public static Unknown nothingComposedOne() {
-            return new Unknown(Reason.NOTHING_COMPOSED_ONE, java.util.Set.of());
+            return nothingComposedOne(java.util.Set.of());
         }
 
         /**
-         * A walk these budgets of this compiler's stopped.
+         * A walk that tried what it had and settled nothing, and the budgets it ran out of.
          *
-         * <p>Which budget it was and the word it comes back with are made together here, and the
-         * word is never what the budget is read back from: one of these words is written wherever a
-         * walk of a side comes back empty, budget or no budget, so a reader recovering a budget
-         * from it would be recovering one that may never have been reached.
+         * <p>Beside {@link #nothingComposedOne} for the reason above: which of the two a walk says
+         * is the walk's own answer, and this one is what a side comes back with whether or not a
+         * figure was reached.
          */
-        public static Unknown stoppedBy(java.util.Set<CompositionBudget> budgets) {
-            if (budgets.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "a walk this compiler stopped says which budget stopped it");
-            }
-            // The word each of these has always come back with, and not one word for all of them.
-            // Which of the two a stopped walk says is the budgets' to say, and a stop that said the
-            // other would move a sentence a reader has been reading for reasons of its own.
-            return new Unknown(Generator.UnresolvedCombination.Reason.wordFor(budgets)
-                    .asAWalksAnswer(), budgets);
+        public static Unknown searchRanOut(java.util.Set<CompositionBudget> stoppedBy) {
+            return new Unknown(Reason.THE_SEARCH_RAN_OUT, stoppedBy);
         }
 
         public enum Reason {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
@@ -59,6 +59,16 @@ public sealed interface Realization {
 
         public Unknown {
             stoppedBy = java.util.Set.copyOf(stoppedBy);
+            // What a walk stopped by these says is the budgets' to say, so the two cannot be put
+            // here disagreeing. A pair that could is a pair somebody has to keep in step, and
+            // keeping two spellings of one answer in step by hand is what a stopped walk lost its
+            // budget to in the first place.
+            if (!stoppedBy.isEmpty()
+                    && why != Generator.UnresolvedCombination.Reason.wordFor(stoppedBy)
+                            .asAWalksAnswer()) {
+                throw new IllegalArgumentException("a walk stopped by " + stoppedBy
+                        + " does not come back with " + why);
+            }
         }
 
         /** A walk that came to nothing without any budget of this compiler's having run out. */
@@ -80,16 +90,10 @@ public sealed interface Realization {
                         "a walk this compiler stopped says which budget stopped it");
             }
             // The word each of these has always come back with, and not one word for all of them.
-            // Which of the two a stopped walk says is the budget's, and a stop that said the other
-            // would move a sentence a reader has been reading for reasons of its own.
-            Reason why = switch (Generator.UnresolvedCombination.Reason.wordFor(budgets)) {
-                case NOTHING_COMPOSES_ONE -> Reason.NOTHING_COMPOSED_ONE;
-                case SEARCH_LIMIT -> Reason.THE_SEARCH_RAN_OUT;
-                default -> throw new IllegalStateException(
-                        "a budget that stopped a walk came back with a word no walk says: "
-                                + budgets);
-            };
-            return new Unknown(why, budgets);
+            // Which of the two a stopped walk says is the budgets' to say, and a stop that said the
+            // other would move a sentence a reader has been reading for reasons of its own.
+            return new Unknown(Generator.UnresolvedCombination.Reason.wordFor(budgets)
+                    .asAWalksAnswer(), budgets);
         }
 
         public enum Reason {

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -50,19 +50,47 @@ final class TermRealizations {
          * thing to tell an author.
          */
         record Built(List<FixtureTemplate> values,
-                     Generator.UnresolvedCombination.Reason heldBack) implements Realization {
+                     java.util.Set<CompositionBudget> heldBack) implements Realization {
 
             public Built {
                 values = List.copyOf(values);
+                heldBack = java.util.Set.copyOf(heldBack);
                 if (values.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a realization that built nothing is one that built none, and says why");
                 }
             }
+
+            static Built whole(List<FixtureTemplate> values) {
+                return new Built(values, java.util.Set.of());
+            }
         }
 
-        /** Nothing here writes a value answering it, and this is what stopped there being one. */
-        record BuiltNone(Generator.UnresolvedCombination.Reason why) implements Realization {}
+        /**
+         * A budget of this compiler's stopped the composing, and no value came of it.
+         *
+         * <p>Apart from {@link None} and the difference is the whole of why this is here. Both are
+         * nothing built; only this one is a policy of this compiler's having run out, and only a
+         * policy running out leaves the question of whether a value exists open in a way somebody
+         * could act on by raising it.
+         *
+         * <p>Never where a value was built. A budget that cut an offering short after something was
+         * composed is {@link Built#heldBack()}: what it stopped is the rest of the offer, and the
+         * point it was composed for has a value at it either way.
+         */
+        record Stopped(java.util.Set<CompositionBudget> by) implements Realization {
+
+            public Stopped {
+                by = java.util.Set.copyOf(by);
+                if (by.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a composing this compiler stopped says which budget stopped it");
+                }
+            }
+        }
+
+        /** Nothing here writes a value answering it, and no budget of this compiler's is why. */
+        record None(Generator.UnresolvedCombination.Reason why) implements Realization {}
     }
 
     /**
@@ -108,13 +136,13 @@ final class TermRealizations {
      *
      * <p>A target that exists and a target nothing writes at are two different sentences, and both
      * of them are said here. {@link RealizationTarget} answers the first for every number there is;
-     * a {@link Realization.BuiltNone} is the second.
+     * a {@link Realization.None} or a {@link Realization.Stopped} is the second.
      */
     static Realization at(Type sourceType, TermOrders orders,
                           Place answer, souther.compiler.inputs.SearchRegion within,
                           Symbols symbols, ReadingPolicy policy) {
         if (sourceType == null) {
-            return new Realization.BuiltNone(
+            return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         // Which number is being written for, read off the answer that says which number it is of.
@@ -192,7 +220,7 @@ final class TermRealizations {
             case TakenAs.TheSumOfWhatItHolds _ -> ContainersAddingUp.to(answer, sourceType,
                     orders, within, symbols, policy);
             case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ ->
-                    new Realization.BuiltNone(
+                    new Realization.None(
                             Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         };
     }
@@ -202,7 +230,7 @@ final class TermRealizations {
                                        ReadingPolicy policy) {
         int many = CountDomain.asCount(answer);
         if (many < 0) {
-            return new Realization.BuiltNone(
+            return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         Type holder = TypeOps.base(sourceType, symbols);
@@ -212,9 +240,10 @@ final class TermRealizations {
             // stopped as two halves of one answer for exactly this, and asking it again would be
             // the same decision taken twice — the two could not disagree today and there is no
             // reason to leave a second taking of it here.
-            return new Realization.BuiltNone(built.heldBack() == null
-                    ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE
-                    : built.heldBack());
+            return built.heldBack().isEmpty()
+                    ? new Realization.None(
+                            Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                    : new Realization.Stopped(built.heldBack());
         }
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : built.values()) {
@@ -244,7 +273,7 @@ final class TermRealizations {
             // Outside the parts a day has. Not this reader's to report as a refusal: what a part
             // runs between is the operation's declared bound, and a number outside it is a number
             // nothing answers.
-            return new Realization.BuiltNone(
+            return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         Place seconds = Count.of(count.at()
@@ -252,9 +281,9 @@ final class TermRealizations {
         FixtureTemplate standing = Witnesses.wrapped(sourceType,
                 FixtureTemplate.on(observed, seconds, symbols.scope()::reach), symbols);
         return standing == null
-                ? new Realization.BuiltNone(
+                ? new Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
-                : new Realization.Built(List.of(standing), null);
+                : Realization.Built.whole(List.of(standing));
     }
 
     /**
@@ -279,22 +308,22 @@ final class TermRealizations {
     private static Realization onThatPart(TakenAs.DatePart part, Type sourceType, Carrier observed,
                                           Place answer, Symbols symbols) {
         if (observed == null || !(answer instanceof Count count) || !count.whole()) {
-            return new Realization.BuiltNone(
+            return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         java.time.LocalDate on = dateOn(part, count.at());
         if (on == null) {
             // Outside the parts a date has. Not this reader's to report as a refusal: a number no
             // date answers is a number nothing composes one for.
-            return new Realization.BuiltNone(
+            return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         FixtureTemplate standing = Witnesses.wrapped(sourceType,
                 FixtureTemplate.on(observed, Dates.dayOf(on), symbols.scope()::reach), symbols);
         return standing == null
-                ? new Realization.BuiltNone(
+                ? new Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
-                : new Realization.Built(List.of(standing), null);
+                : Realization.Built.whole(List.of(standing));
     }
 
     /**
@@ -356,9 +385,9 @@ final class TermRealizations {
     private static Realization oneValue(FixtureTemplate bare, Type sourceType, Symbols symbols) {
         FixtureTemplate standing = Witnesses.wrapped(sourceType, bare, symbols);
         return standing == null
-                ? new Realization.BuiltNone(
+                ? new Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
-                : new Realization.Built(List.of(standing), null);
+                : Realization.Built.whole(List.of(standing));
     }
 
     private TermRealizations() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -49,18 +49,17 @@ import java.util.Set;
  */
 final class Witnesses {
 
-    /** How many elements a proposed collection is worth building. A row is offered for somebody to read
-     * and complete, and a minimum past this asks for one nobody would. */
-    private static final int MOST_ELEMENTS = 64;
+    /** What this stops at, named where every budget of this compiler's is named. The figures are
+     *  {@link CompositionBudget}'s so that a reader of a stopped search reaches the one it ran out
+     *  of. */
+    private static final int MOST_ELEMENTS =
+            CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS.maximum();
 
-    /** How many characters a proposed string is worth building. Its own number, because a string of
-     * sixty-five is one literal where a collection of sixty-five is sixty-five values each built in
-     * turn — holding the two to one figure bounds a string by something about collections. */
-    private static final int MOST_CHARACTERS = 4096;
+    private static final int MOST_CHARACTERS =
+            CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS.maximum();
 
-    /** How many pairings of what a map's key and value propose are built at once. Every pair is built
-     * before any of them is tried, so this bounds what is allocated rather than what is walked. */
-    private static final int MOST_PAIRINGS = 64;
+    private static final int MOST_PAIRINGS =
+            CompositionBudget.PAIRINGS_BUILT_AT_ONCE.maximum();
 
     /**
      * Values of a count, and whether they are all the values of it there were.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -68,14 +68,15 @@ final class Witnesses {
      * some were never built, which is a different thing to tell an author and a different thing for a
      * measure to record.
      */
-    record Sized(List<FixtureTemplate> values, Generator.UnresolvedCombination.Reason heldBack) {
+    record Sized(List<FixtureTemplate> values, Set<CompositionBudget> heldBack) {
 
         Sized {
             values = List.copyOf(values);
+            heldBack = Set.copyOf(heldBack);
         }
 
         static Sized all(List<FixtureTemplate> values) {
-            return new Sized(values, null);
+            return new Sized(values, Set.of());
         }
     }
 
@@ -116,6 +117,10 @@ final class Witnesses {
      * built and why are one answer given twice rather than two answers that may disagree. Whenever
      * that one offers nothing this names a reason: a caller left to supply its own default for the
      * silence would be deciding again what this is here to answer.
+     *
+     * <p>The word and not which budget it was. A budget that stopped this is the build's own answer
+     * ({@link Sized#heldBack()}) and travels as itself; what is here is the word a search comes back
+     * with, for readers that have only ever wanted that.
      */
     static Generator.UnresolvedCombination.Reason reasonForSize(Type carrier, int size,
                                                                 ReadingPolicy policy,
@@ -124,8 +129,9 @@ final class Witnesses {
         if (!made.values().isEmpty()) {
             return null;
         }
-        return made.heldBack() == null
-                ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : made.heldBack();
+        return made.heldBack().isEmpty()
+                ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE
+                : Generator.UnresolvedCombination.Reason.wordFor(made.heldBack());
     }
 
     /**
@@ -155,7 +161,8 @@ final class Witnesses {
     }
 
     /**
-     * Why a value of {@code carrier} holding {@code least} was not built in full, or null where it was.
+     * Which budgets of this compiler's stopped a value of {@code carrier} holding {@code least} from
+     * being built in full, and empty where none did.
      *
      * <p>The same decision {@link #holding} reads, asked for its other half. Written once because the
      * two have to agree: a reader was told a search stopped short of pairings nothing had asked to
@@ -165,10 +172,10 @@ final class Witnesses {
      * floor nothing was built for is a position offering what it ordinarily offers, and naming a
      * reason there would put "nothing composes one" under every position that has no floor at all.
      */
-    static Generator.UnresolvedCombination.Reason heldBackFor(Type carrier, int least,
-                                                              Symbols symbols,
-                                                              ReadingPolicy policy) {
-        return least <= 0 ? null : sized(carrier, least, symbols, policy, Set.of()).heldBack();
+    static Set<CompositionBudget> heldBackFor(Type carrier, int least, Symbols symbols,
+                                              ReadingPolicy policy) {
+        return least <= 0 ? Set.of()
+                : sized(carrier, least, symbols, policy, Set.of()).heldBack();
     }
 
     /**
@@ -181,15 +188,18 @@ final class Witnesses {
      */
     private record Made(FixtureTemplate value, int count) {}
 
-    /** What a value of {@code carrier} counting {@code size} comes to: what was built, and what was
-     * not. */
-    private record Built(List<Made> proposals,
-                         Generator.UnresolvedCombination.Reason heldBack) {
+    /** What a value of {@code carrier} counting {@code size} comes to: what was built, and which
+     * budgets of this compiler's stopped the rest of it being built. */
+    private record Built(List<Made> proposals, Set<CompositionBudget> heldBack) {
 
-        static final Built NONE = new Built(List.of(), null);
+        static final Built NONE = new Built(List.of(), Set.of());
 
         static Built of(List<Made> proposals) {
-            return new Built(List.copyOf(proposals), null);
+            return new Built(List.copyOf(proposals), Set.of());
+        }
+
+        static Built stoppedBy(CompositionBudget budget) {
+            return new Built(List.of(), Set.of(budget));
         }
 
         /** Those holding exactly {@code size}, which is what a line drawn at a count is met by. */
@@ -215,7 +225,7 @@ final class Witnesses {
         // put beside this one by the caller.
         if (carrier == Type.STRING) {
             return least > MOST_CHARACTERS
-                    ? new Built(List.of(), Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                    ? Built.stoppedBy(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS)
                     : Built.of(List.of(new Made(FixtureTemplate.string("x".repeat(least)), least)));
         }
         if (!(carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
@@ -223,8 +233,7 @@ final class Witnesses {
             return Built.NONE;
         }
         if (least > MOST_ELEMENTS) {
-            return new Built(List.of(),
-                    Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+            return Built.stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS);
         }
         // A list may hold the same element as many times as it needs to.
         if (carrier instanceof Type.ListOf list) {
@@ -261,10 +270,19 @@ final class Witnesses {
         // a value's first — and taking them in step would offer only the pairs whose two proposals
         // happen to have been read in the same order. Nearest first is what makes the bound below cost
         // the least: what it drops is the pairs furthest from what either side proposed first.
-        for (int apart = 0;
-                apart <= keys.size() + values.size() - 2 && out.size() < MOST_PAIRINGS; apart++) {
+        // Recorded where the budget is reached and not worked out afterwards from how many were
+        // built. How many pairs there are and how many were made differ whenever this stops, and
+        // they are the same two numbers whether or not it was this that stopped it — so a reader
+        // asking which budget ran out would be reading it off a subtraction that does not know.
+        boolean stopped = false;
+        pairing:
+        for (int apart = 0; apart <= keys.size() + values.size() - 2; apart++) {
             for (int i = Math.max(0, apart - values.size() + 1);
-                    i <= Math.min(apart, keys.size() - 1) && out.size() < MOST_PAIRINGS; i++) {
+                    i <= Math.min(apart, keys.size() - 1); i++) {
+                if (out.size() == MOST_PAIRINGS) {
+                    stopped = true;
+                    break pairing;
+                }
                 FixtureTemplate value = values.get(apart - i);
                 List<FixtureTemplate> entries = new ArrayList<>();
                 for (FixtureTemplate key
@@ -274,8 +292,8 @@ final class Witnesses {
                 out.add(new Made(FixtureTemplate.collection(entries), entries.size()));
             }
         }
-        return new Built(out, keys.size() * values.size() > out.size()
-                ? Generator.UnresolvedCombination.Reason.SEARCH_LIMIT : null);
+        return new Built(out,
+                stopped ? Set.of(CompositionBudget.PAIRINGS_BUILT_AT_ONCE) : Set.of());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3113,6 +3113,11 @@ public final class Adequacy {
                 ItemAssessment.Owed each = point.item();
                 switch (each.attempt()) {
                     case ItemAssessment.Attempt.Built built -> rows.add(built.row());
+                    // A search a budget of this compiler's ended came to nothing like any other,
+                    // and what a block short of rows records is that nothing came of it. Which
+                    // figure ended it is the point's own to say and is said where a reader asks
+                    // about the point, not in a list of what this run did not offer.
+                    case ItemAssessment.Attempt.Stopped why -> unresolved.add(why.why());
                     case ItemAssessment.Attempt.Unresolved why -> {
                         unresolved.add(why.why());
                         // And where the decoders were out of reach, the block is short of rows it

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1786,7 +1786,7 @@ public final class Adequacy {
             throw new IllegalStateException("a reading owing nothing at a point its line owes one"
                     + " at: " + debt.point() + " at " + reading);
         }
-        if (here.attempt() == null) {
+        if (!here.searches().ran()) {
             // The search answered about this behavior and looked for nothing here, at a point the
             // line says is worth searching. That is the search and the debt disagreeing about one
             // point rather than evidence of anything, and a state read as either would report our
@@ -1794,7 +1794,7 @@ public final class Adequacy {
             throw new IllegalStateException("nothing was searched for at " + debt.point()
                     + ", which the line says is worth searching, at " + reading);
         }
-        return new PointResolver.ReadingEvidence.Searched(here.attempt());
+        return new PointResolver.ReadingEvidence.Searched(here.searches());
     }
 
     /** The same, with a value composed at every point worth one — which is a request, and costs what
@@ -3111,7 +3111,12 @@ public final class Adequacy {
             for (OwedBoundaryPoint point
                     : OwedBoundaryPoint.oneForEachPoint(OwedBoundaryPoint.across(boundaries)).at()) {
                 ItemAssessment.Owed each = point.item();
-                switch (each.attempt()) {
+                // Every search of the point, because a block short of rows is short of what each of
+                // them did not offer. One of them stands for none of the others: a reading searched
+                // twice can have composed a row under one caller's conditions and been stopped
+                // under the other's, and both are things this run has to account for.
+                for (ItemAssessment.Attempt made : each.searches().each()) {
+                switch (made) {
                     case ItemAssessment.Attempt.Built built -> rows.add(built.row());
                     // A search a budget of this compiler's ended came to nothing like any other,
                     // and what a block short of rows records is that nothing came of it. Which
@@ -3144,15 +3149,14 @@ public final class Adequacy {
                     // per point would put the compiler's own bookkeeping in a list of an author's
                     // work.
                     //
-                    // A point the measurement does say is worth searching is a different thing, and
-                    // it is the same thing `atEdge` refuses: this walks what a search answered, so a
-                    // hole in it is the search having skipped a point it was asked about.
-                    case null -> {
-                        if (each.worthSearching()) {
-                            throw new IllegalStateException("nothing was searched for at "
-                                    + point + ", which is worth searching");
-                        }
-                    }
+                }
+                }
+                // A point the measurement does say is worth searching is a different thing, and it
+                // is the same thing `atEdge` refuses: this walks what a search answered, so a hole
+                // in it is the search having skipped a point it was asked about.
+                if (!each.searches().ran() && each.worthSearching()) {
+                    throw new IllegalStateException("nothing was searched for at "
+                            + point + ", which is worth searching");
                 }
             }
             return new Generator.GenerationResult(rows, unresolved,

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -379,7 +379,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
         // of this compiler's, one finding nothing — and every one of those is a fact about this
         // point. Kept as the strongest, whatever the others found out was dropped, and the answer a
         // reader got depended on the order the readings were walked in.
-        List<ItemAssessment.Attempt> attempts = new ArrayList<>();
+        SearchOutcomes searched = SearchOutcomes.none();
         // Whether a value at the point exists is a fact about the point and not about the reading
         // that reached it: one reading proving it proves it. The other two states are what a reading
         // says about itself, so the weaker of them stands only where nothing proved anything.
@@ -392,7 +392,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                         "a reading owing nothing at a point it owes one at: " + role);
             }
             coverage.add(owed.coverage());
-            attempts.addAll(owed.searches().each());
+            searched = searched.plus(owed.searches());
             if (owed.projection().proves()) {
                 projection = ItemAssessment.WritabilityProjection.PROVEN;
             } else if (projection != ItemAssessment.WritabilityProjection.PROVEN
@@ -401,7 +401,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
             }
         }
         return new ObligationAssessment(asked.criterion(),
-                ObligationCoverage.acrossTheReadings(coverage), projection, attempts);
+                ObligationCoverage.acrossTheReadings(coverage), projection, searched);
     }
 
     /** The measured half, which a point owed a row always has. */

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -374,7 +374,12 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                     "a point nobody is owed a row at, assessed as one that is: " + not.reason());
         }
         List<Measurement<ItemAssessment.Coverage>> coverage = new ArrayList<>();
-        ItemAssessment.Attempt built = null;
+        // What each reading's search came to, all of them. A search is made per reading and the
+        // readings can have come to different things — one composing a row, one stopped at a figure
+        // of this compiler's, one finding nothing — and every one of those is a fact about this
+        // point. Kept as the strongest, whatever the others found out was dropped, and the answer a
+        // reader got depended on the order the readings were walked in.
+        List<ItemAssessment.Attempt> attempts = new ArrayList<>();
         // Whether a value at the point exists is a fact about the point and not about the reading
         // that reached it: one reading proving it proves it. The other two states are what a reading
         // says about itself, so the weaker of them stands only where nothing proved anything.
@@ -387,12 +392,8 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                         "a reading owing nothing at a point it owes one at: " + role);
             }
             coverage.add(owed.coverage());
-            // The strongest of them and not the first. A row read back where it was built for is
-            // grounds that a row can be written at the point; one nothing could place is not, and
-            // taking whichever reading came first would let the second stand in for the first and
-            // decide what the account says by the order the readings were walked in.
-            if (outranks(owed.attempt(), built)) {
-                built = owed.attempt();
+            if (owed.attempt() != null) {
+                attempts.add(owed.attempt());
             }
             if (owed.projection().proves()) {
                 projection = ItemAssessment.WritabilityProjection.PROVEN;
@@ -402,27 +403,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
             }
         }
         return new ObligationAssessment(asked.criterion(),
-                ObligationCoverage.acrossTheReadings(coverage), projection, built);
-    }
-
-    /**
-     * Whether {@code made} says more about a row at the point than {@code held} does.
-     *
-     * <p>Existential over the readings, the way a row that was found is: what one reading of a line
-     * established, another reading of the same line does not take back. Which leaves an order among
-     * what a search may come back with — a row that was placed, a row nothing could place, and
-     * nothing — and it is the same order everywhere the readings of one line are folded.
-     */
-    private static boolean outranks(ItemAssessment.Attempt made, ItemAssessment.Attempt held) {
-        return says(made) > says(held);
-    }
-
-    private static int says(ItemAssessment.Attempt attempt) {
-        return switch (attempt) {
-            case ItemAssessment.Attempt.Certified _ -> 2;
-            case ItemAssessment.Attempt.Unverified _ -> 1;
-            case null, default -> 0;
-        };
+                ObligationCoverage.acrossTheReadings(coverage), projection, attempts);
     }
 
     /** The measured half, which a point owed a row always has. */

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationPointAssessment.java
@@ -392,9 +392,7 @@ public record BorderObligationPointAssessment(BorderObligationPoint point,
                         "a reading owing nothing at a point it owes one at: " + role);
             }
             coverage.add(owed.coverage());
-            if (owed.attempt() != null) {
-                attempts.add(owed.attempt());
-            }
+            attempts.addAll(owed.searches().each());
             if (owed.projection().proves()) {
                 projection = ItemAssessment.WritabilityProjection.PROVEN;
             } else if (projection != ItemAssessment.WritabilityProjection.PROVEN

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -848,14 +848,18 @@ final class Coverages {
                                     java.util.List.of(label),
                                     souther.compiler.partition.Generator.UnresolvedCombination
                                             .Reason.THE_RULES_LEAVE_NOTHING_THERE), within);
-                    case Realization.Unknown unknown -> switch (unknown.why()) {
-                        case NOTHING_COMPOSED_ONE -> nothingComposedOne(label, within);
-                        case THE_SEARCH_RAN_OUT -> new ItemAssessment.Attempt.Unresolved(
-                                new souther.compiler.partition.Generator.UnresolvedCombination(
-                                        java.util.List.of(label),
-                                        souther.compiler.partition.Generator.UnresolvedCombination
-                                                .Reason.SEARCH_LIMIT), within);
-                    };
+                    // A walk that reached no placement. Where a budget of this compiler's is why it
+                    // reached none, that travels: the point is one this declined to look further
+                    // for, which is not the point being one nothing promises.
+                    case Realization.Unknown unknown -> unknown.stoppedBy().isEmpty()
+                            ? new ItemAssessment.Attempt.Unresolved(
+                                    new souther.compiler.partition.Generator.UnresolvedCombination(
+                                            java.util.List.of(label), wordOf(unknown)), within)
+                            : new ItemAssessment.Attempt.Stopped(
+                                    new souther.compiler.partition.Generator.UnresolvedCombination(
+                                            java.util.List.of(label), wordOf(unknown)),
+                                    within, java.util.List.of(),
+                                    new EstablishmentGap.Composition(unknown.stoppedBy()));
                 };
             }
         };
@@ -1004,7 +1008,7 @@ final class Coverages {
      * not a thing an observation did, so it travels as far as the account's own reasons go and no
      * further.
      */
-    private static EstablishmentGap stopped(StandingAtAPoint.Met.CouldNotTell why) {
+    private static EstablishmentGap.Observation stopped(StandingAtAPoint.Met.CouldNotTell why) {
         Set<Incompleteness.Code> codes = new LinkedHashSet<>();
         for (souther.compiler.partition.ReadingGap each : why.why()) {
             if (each instanceof souther.compiler.partition.ReadingGap.Observation it) {
@@ -1012,6 +1016,23 @@ final class Coverages {
             }
         }
         return new EstablishmentGap.Observation(codes);
+    }
+
+    /**
+     * The word a walk that reached no placement comes back with.
+     *
+     * <p>The realizer's own, kept as it is. What it says is which of the two things a walk that
+     * found nothing did, and it says it whether or not a figure of this compiler's was reached —
+     * which is why the figure travels beside it rather than being read out of it.
+     */
+    private static souther.compiler.partition.Generator.UnresolvedCombination.Reason wordOf(
+            Realization.Unknown unknown) {
+        return switch (unknown.why()) {
+            case NOTHING_COMPOSED_ONE -> souther.compiler.partition.Generator
+                    .UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
+            case THE_SEARCH_RAN_OUT -> souther.compiler.partition.Generator
+                    .UnresolvedCombination.Reason.SEARCH_LIMIT;
+        };
     }
 
     /** A search that came to nothing at {@code subject}, which is what a point is written as. */
@@ -1038,7 +1059,7 @@ final class Coverages {
      * outcome of a search that dropped its region, and the reader that wanted it back built the
      * same value by hand a moment later.
      */
-    private static ItemAssessment.Attempt.Searched whatCameOfIt(
+    private static ItemAssessment.Attempt whatCameOfIt(
             souther.compiler.partition.Generator.BoundaryAttempt made, String subject,
             souther.compiler.partition.WayToTheBorder within,
             Supplier<StandingAtAPoint.Met> standing) {
@@ -1096,6 +1117,12 @@ final class Coverages {
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
                     new ItemAssessment.Attempt.Unresolved(left.why(), within,
                             left.unrepresented());
+            // And a search a budget of this compiler's ended, which is the one outcome here that
+            // names something anybody could raise. Said as the one above, an obligation this
+            // declined to work on left the count as one the model admits no row at.
+            case souther.compiler.partition.Generator.BoundaryAttempt.Stopped left ->
+                    new ItemAssessment.Attempt.Stopped(left.why(), within, left.unrepresented(),
+                            new EstablishmentGap.Composition(left.by()));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -721,12 +721,12 @@ final class Coverages {
                     Measurement<ItemAssessment.Coverage> coverage = absent != null ? absent
                             : verdictOf(shape.met(owed.criterion(), rows), guard,
                                     border, observed);
-                    // No attempt. Nothing was searched for here, and that is said by there being no
-                    // attempt rather than by an attempt saying nobody asked: whether a value was
+                    // No search. Nothing was searched for here, and that is said by there being no
+                    // search rather than by a search saying nobody asked: whether a value was
                     // composed is a fact about who asked for one, and a measurement that carried it
                     // was answering a question it had not been put.
                     yield new ItemAssessment.Owed(owed.criterion(), coverage,
-                            shape.projection(), null);
+                            shape.projection(), SearchOutcomes.none());
                 }
             });
         }
@@ -884,66 +884,42 @@ final class Coverages {
         }
         java.util.Map<DomainPoint, ItemAssessment> kept = new java.util.LinkedHashMap<>();
         for (DomainPoint point : a.items().keySet()) {
-            kept.put(point, keeps(a.at(point), b.at(point)) ? a.at(point) : b.at(point));
+            kept.put(point, together(a.at(point), b.at(point)));
         }
         return new BorderAssessment(a.border(), kept);
     }
 
     /**
-     * Whether what the first reading saw at a point stands, rather than what the second saw.
+     * What two searches of one point of one reading come to, dimension by dimension.
      *
-     * <p>What was measured first, and what was composed only where the two measured alike. A row
-     * that was found is the whole of what a point asks for; where neither reading found one, the
-     * reading that composed a row to offer has something to say that a reading which composed
-     * nothing does not, and the point is owed the same row either way.
+     * <p><b>Not one of them.</b> They are searches of the same point under one reading, and the
+     * point is owed once — so what a reader is owed is what both of them found out. Taking whichever
+     * saw more, every fact the other one established was gone before anything downstream could ask:
+     * a search a budget of this compiler's stopped, dropped for one that came back with nothing, is
+     * how a point this declined to work on left the count as one the model admits no row at.
      *
-     * <p>Here because the search is made per reading. One search against one region has one outcome
-     * and nothing to choose between; two readings carry two, and keeping the first would drop a row
-     * an author could have been offered.
+     * <p>Each dimension by whatever owns it. What the rows came to is coverage's own question
+     * ({@link ObligationCoverage#acrossOneReadingsSearches}); what the rules prove is a reading of
+     * the declarations and the two searches read the same ones, so a difference there is not
+     * something to fold but something that has gone wrong.
      */
-    private static boolean keeps(ItemAssessment a, ItemAssessment b) {
-        if (rank(a) != rank(b)) {
-            return rank(a) > rank(b);
+    private static ItemAssessment together(ItemAssessment a, ItemAssessment b) {
+        if (!(a instanceof ItemAssessment.Owed one) || !(b instanceof ItemAssessment.Owed two)) {
+            // Two readings of one line owe the same points, so a point no row is owed at is that
+            // under both — and there is nothing about it to put together.
+            return a;
         }
-        return composed(a) >= composed(b);
-    }
-
-    /**
-     * How much the search of this reading's own region came back with.
-     *
-     * <p>A row read back where it was built for outranks one nothing could place, which outranks a
-     * search a budget of this compiler's stopped, which outranks none at all. The first is grounds
-     * that a row can be written at the point; the third is not grounds and is still the point's
-     * question left open for a reason somebody could act on, and a reading holding it cannot be
-     * dropped for one that holds nothing.
-     */
-    private static int composed(ItemAssessment item) {
-        if (!(item instanceof ItemAssessment.Owed owed) || owed.attempt() == null) {
-            return 0;
+        if (!one.criterion().equals(two.criterion())) {
+            throw new IllegalStateException("two searches of one point asking for different"
+                    + " values: " + one.criterion() + " and " + two.criterion());
         }
-        return switch (owed.attempt()) {
-            case ItemAssessment.Attempt.Certified _ -> 3;
-            case ItemAssessment.Attempt.Unverified _ -> 2;
-            case ItemAssessment.Attempt.Stopped _ -> 1;
-            case ItemAssessment.Attempt.Unresolved _, ItemAssessment.Attempt.Unavailable _ -> 0;
-        };
-    }
-
-    private static int rank(ItemAssessment item) {
-        if (!(item instanceof ItemAssessment.Owed owed)) {
-            // Two readings of one line owe the same points, so this is one of them against itself.
-            return 0;
+        if (one.projection() != two.projection()) {
+            throw new IllegalStateException("two searches of one point disagreeing about what the"
+                    + " rules prove there: " + one.projection() + " and " + two.projection());
         }
-        return switch (owed.coverage()) {
-            case Measurement.Complete<ItemAssessment.Coverage> whole ->
-                    whole.value() instanceof ItemAssessment.Coverage.Hit ? 3 : 1;
-            // A reading made in part saw less than a settled one and more than none: found is
-            // found either way, and what it did not find is undecided rather than absent.
-            case Measurement.Partial<ItemAssessment.Coverage> part ->
-                    part.value() instanceof ItemAssessment.Coverage.Hit ? 3 : 2;
-            case Measurement.NotMeasured<ItemAssessment.Coverage> _,
-                 Measurement.FailedToMeasure<ItemAssessment.Coverage> _ -> 0;
-        };
+        return new ItemAssessment.Owed(one.criterion(),
+                ObligationCoverage.acrossOneReadingsSearches(one.coverage(), two.coverage()),
+                one.projection(), one.searches().plus(two.searches()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -597,29 +597,6 @@ final class Coverages {
     }
 
     /**
-     * The readings of one behavior's lines, one entry per line.
-     *
-     * <p>What each reading saw, kept whole: a point one reading found a row at is found, and no
-     * other reading of the line takes that back.
-     *
-     * <p><b>After everything that is a reading's own.</b> Which conditions a row has to satisfy to
-     * reach the comparison is one of those, so a search is made per reading and merged here rather
-     * than made once against whichever reading this kept. Merged first, the region a row is composed
-     * in is one reading's, chosen by the order a walk took.
-     *
-     * <p><b>And never across two debts.</b> A line holds the authored line and where it was read;
-     * a debt holds the authored line and the value it is at — so two readings under one line are one
-     * debt by construction, and a pair that is not says the two identities have come apart.
-     */
-    static List<BorderAssessment> merged(LineReadings readings) {
-        java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
-        for (BorderAssessment each : readings.each()) {
-            out.merge(BoundaryLine.of(each.border()), each, Coverages::whicheverSawMore);
-        }
-        return List.copyOf(out.values());
-    }
-
-    /**
      * The same lines, with what building a value at each point that is worth one came to.
      *
      * <p>Takes what was measured rather than measuring again. A search is evidence added to an
@@ -785,6 +762,29 @@ final class Coverages {
     }
 
     /**
+     * The readings of one behavior's lines, one entry per line.
+     *
+     * <p>What each reading saw, kept whole: a point one reading found a row at is found, and no
+     * other reading of the line takes that back.
+     *
+     * <p><b>After everything that is a reading's own.</b> Which conditions a row has to satisfy to
+     * reach the comparison is one of those, so a search is made per reading and merged here rather
+     * than made once against whichever reading this kept. Merged first, the region a row is composed
+     * in is one reading's, chosen by the order a walk took.
+     *
+     * <p><b>And never across two debts.</b> A line holds the authored line and where it was read;
+     * a debt holds the authored line and the value it is at — so two readings under one line are one
+     * debt by construction, and a pair that is not says the two identities have come apart.
+     */
+    static List<BorderAssessment> merged(LineReadings readings) {
+        java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
+        for (BorderAssessment each : readings.each()) {
+            out.merge(BoundaryLine.of(each.border()), each, Coverages::whicheverSawMore);
+        }
+        return List.copyOf(out.values());
+    }
+
+    /**
      * How a row is looked for at one border, on whatever it was drawn on.
      *
      * <p>Beside {@link #reading} rather than inside it. Both are about one border and neither is the
@@ -911,21 +911,21 @@ final class Coverages {
     /**
      * How much the search of this reading's own region came back with.
      *
-     * <p>A row read back where it was built for outranks one nothing could place, which outranks
-     * none at all. The first is grounds that a row can be written at the point and the second is
-     * not, so a reading holding the second cannot be the one that is kept where another holds the
-     * first — the grounds are read off whichever reading this keeps, and taking them from the
-     * reading that happened to come first would lose them to the order two call sites of one helper
-     * were walked in.
+     * <p>A row read back where it was built for outranks one nothing could place, which outranks a
+     * search a budget of this compiler's stopped, which outranks none at all. The first is grounds
+     * that a row can be written at the point; the third is not grounds and is still the point's
+     * question left open for a reason somebody could act on, and a reading holding it cannot be
+     * dropped for one that holds nothing.
      */
     private static int composed(ItemAssessment item) {
-        if (!(item instanceof ItemAssessment.Owed owed)) {
+        if (!(item instanceof ItemAssessment.Owed owed) || owed.attempt() == null) {
             return 0;
         }
         return switch (owed.attempt()) {
-            case ItemAssessment.Attempt.Certified _ -> 2;
-            case ItemAssessment.Attempt.Unverified _ -> 1;
-            case null, default -> 0;
+            case ItemAssessment.Attempt.Certified _ -> 3;
+            case ItemAssessment.Attempt.Unverified _ -> 2;
+            case ItemAssessment.Attempt.Stopped _ -> 1;
+            case ItemAssessment.Attempt.Unresolved _, ItemAssessment.Attempt.Unavailable _ -> 0;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -768,9 +768,10 @@ final class Coverages {
      * other reading of the line takes that back.
      *
      * <p><b>After everything that is a reading's own.</b> Which conditions a row has to satisfy to
-     * reach the comparison is one of those, so a search is made per reading and merged here rather
-     * than made once against whichever reading this kept. Merged first, the region a row is composed
-     * in is one reading's, chosen by the order a walk took.
+     * reach the comparison is one of those, so a search is made per reading and the searches are
+     * put together here rather than one being made against whichever reading came first. Put
+     * together first, the region a row is composed in is one reading's, chosen by the order a walk
+     * took.
      *
      * <p><b>And never across two debts.</b> A line holds the authored line and where it was read;
      * a debt holds the authored line and the value it is at — so two readings under one line are one
@@ -779,7 +780,7 @@ final class Coverages {
     static List<BorderAssessment> merged(LineReadings readings) {
         java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
         for (BorderAssessment each : readings.each()) {
-            out.merge(BoundaryLine.of(each.border()), each, Coverages::whicheverSawMore);
+            out.merge(BoundaryLine.of(each.border()), each, Coverages::asOneLine);
         }
         return List.copyOf(out.values());
     }
@@ -866,18 +867,19 @@ final class Coverages {
     }
 
     /**
-     * Which of two readings of one line the report keeps.
+     * Two readings of one line, as the one line they are readings of.
      *
-     * <p>Existential and per point, the same way an arm is: a row met a point if it met it through
-     * any reading of the line. So a reading that found a row outranks one that could not tell, which
-     * outranks one that looked and found none, which outranks one that was never made. Anything else
-     * would let a second call site of a helper take back what a row at the first one established.
+     * <p><b>Nothing is chosen between.</b> A helper called from two places is one line read once
+     * and searched twice — the authored line and the target are the same, and what differs is the
+     * region a row for it was composed in — so the two are put together and neither stands for the
+     * other. Kept as whichever saw more, whatever the other established was gone before anything
+     * downstream could ask, and a point whose only search a budget stopped came out holding nothing.
      *
-     * <p>Point by point rather than border by border. Two readings of one line are the same border
-     * and can have seen different things at different points, and keeping whichever border saw more
-     * on the whole would throw away a point the other one had.
+     * <p>Point by point rather than border by border. Two readings of one line can have seen
+     * different things at different points, and one answer for the whole border would settle a
+     * point from what happened at another.
      */
-    private static BorderAssessment whicheverSawMore(BorderAssessment a, BorderAssessment b) {
+    private static BorderAssessment asOneLine(BorderAssessment a, BorderAssessment b) {
         if (!a.border().obligation().equals(b.border().obligation())) {
             throw new IllegalStateException("two readings of one line owing different rows: "
                     + a.border().obligation() + " and " + b.border().obligation());

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -21,11 +21,10 @@ import java.util.Set;
  * by files that stop for nothing like each other. So a producer that stops hands this over, and one
  * that has nothing to hand over says so by there being no gap rather than by a gap nobody made.
  *
- * <p>One case today. A candidate this compiler declined to compose leaves the same question open
- * for the same kind of reason, and it is not here: what stops that composing is a different budget
- * in a different stage, and the value that would have been read back was never built. A case for it
- * arrives beside this one, and every reader that has to tell them apart is a reader an exhaustive
- * switch already stops.
+ * <p>Two cases, and what tells them apart is how far this compiler had got when it stopped. An
+ * observation is of a value that exists and did not come back whole; a composing is of a value that
+ * was never built. They leave the same question open and they are different work to close: one
+ * takes keeping more of what is built, the other takes building more of what the rules leave.
  */
 public sealed interface EstablishmentGap {
 
@@ -44,6 +43,35 @@ public sealed interface EstablishmentGap {
                         "an observation that stopped something says what stopped it");
             }
             causes = Collections.unmodifiableSet(EnumSet.copyOf(causes));
+        }
+    }
+
+    /**
+     * A budget of this compiler's ran out before any value was composed for the point.
+     *
+     * <p>Made where the composing stopped and carried out, never worked out afterwards. What a
+     * search comes back with is a word, and two of this compiler's budgets come back with the same
+     * word while one of them is written wherever a walk stops for any reason at all — so a reader
+     * recovering a budget from that word would be recovering one that may never have been reached.
+     *
+     * <p><b>Only where nothing was composed.</b> A budget that cut an offering short after a value
+     * was built took nothing away from the point: the value is there, and what was lost is the rest
+     * of an offer. Such a budget travels on what was built and not here, because a gap here is read
+     * as the showing having been stopped.
+     *
+     * <p>A set, because a search meets as many figures as it meets and no two of them are the same
+     * piece of work. Ranked, the one a reader was told about would be whichever the walk hit first.
+     */
+    record Composition(Set<souther.compiler.partition.CompositionBudget> budgets)
+            implements EstablishmentGap {
+
+        public Composition {
+            if (budgets == null || budgets.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a composing this compiler stopped says which budget stopped it");
+            }
+            budgets = Collections.unmodifiableSet(
+                    EnumSet.copyOf(budgets));
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -38,14 +38,19 @@ public sealed interface ItemAssessment {
      *                   about a value being there. What the rules say on their own, so it is settled
      *                   without building anything and stays true whatever a search afterwards makes
      *                   of the point
-     * @param attempt    what building a value here came to, or null where nobody asked for one to be
-     *                   built. Null is the absence of the evidence and never a state of the point:
-     *                   whether a value was composed is a fact about who asked, and it used to be
-     *                   carried here as an attempt saying nobody had — a measurement answering a
-     *                   question it was not put (issue #1001)
+     * @param searches   what building a value here came to, over every search that was made for it,
+     *                   and empty where nobody asked for one to be built. Empty is the absence of
+     *                   the evidence and never a state of the point: whether a value was composed is
+     *                   a fact about who asked, and it used to be carried here as an attempt saying
+     *                   nobody had — a measurement answering a question it was not put.
+     *
+     *                   <p>Several, because one reading of a line can be searched more than once: a
+     *                   helper called from two arms is the same line at the same target, and a row
+     *                   for it is composed under each caller's own conditions
      */
     record Owed(Criterion criterion, Measurement<Coverage> coverage,
-                WritabilityProjection projection, Attempt attempt) implements ItemAssessment {
+                WritabilityProjection projection, SearchOutcomes searches)
+            implements ItemAssessment {
 
         /**
          * Whether building a value here would tell anybody anything.
@@ -107,13 +112,10 @@ public sealed interface ItemAssessment {
             };
         }
 
-        /** The same point, with what a search of it came to. */
+        /** The same point, with what one more search of it came to. */
         public Owed settledBy(Attempt searched) {
-            if (attempt != null) {
-                throw new IllegalStateException(
-                        "a point searched twice: " + criterion + " already has " + attempt);
-            }
-            return new Owed(criterion, coverage, projection, searched);
+            return new Owed(criterion, coverage, projection,
+                    searches.plus(SearchOutcomes.of(searched)));
         }
 
         /**
@@ -124,11 +126,12 @@ public sealed interface ItemAssessment {
          * a value with a row at it and no {@code A_ROW_IS_AT_IT} would be a state somebody could
          * build. Read through, that state cannot be spelled.
          *
-         * <p>Which is also what makes composing a search safe. A search changes the {@link #attempt}
-         * and nothing else, and every ground is monotone in what it reads, so the set this answers
-         * can only grow. It used to be a verdict picked from the evidence by a fixed order, where
-         * building a value at a point the rules already proved replaced the proof with the witness —
-         * true of whether anything was known, and false of what was doing the knowing.
+         * <p>Which is also what makes composing a search safe. A search adds to the
+         * {@link #searches} and changes nothing else, and every ground is monotone in what it reads,
+         * so the set this answers can only grow. It used to be a verdict picked from the evidence by
+         * a fixed order, where building a value at a point the rules already proved replaced the
+         * proof with the witness — true of whether anything was known, and false of what was doing
+         * the knowing.
          */
         public WritabilityEvidence writabilityEvidence() {
             // The certified arm and not `Built`. What grounds this is a value shown to be at the
@@ -136,8 +139,7 @@ public sealed interface ItemAssessment {
             // counted here, an observation this compiler cut short would be reported as the model
             // admitting a row, which is the same trade as the one it is here to stop, made the
             // other way round. What that row does license is said by `WritabilityKnowledge`.
-            return WritabilityEvidence.of(projection, hasRowWitness(),
-                    attempt instanceof Attempt.Certified);
+            return WritabilityEvidence.of(projection, hasRowWitness(), searches.certified());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -357,8 +357,18 @@ public sealed interface ItemAssessment {
      *
      * <p>Made once. The row a person is offered and the value that witnessed the point are the same
      * value, built one time and read twice.
+     *
+     * <p><b>Five outcomes, and three things that may be true of one.</b> The outcomes are what
+     * happened and are exclusive, so a reader asking which of them this is asks an exhaustive
+     * switch. What may be true of one — that a row came of it, that a search ran, that a budget of
+     * this compiler's stopped it — cuts across them: a row that was built and not read back is both
+     * a row somebody may have and a showing this compiler stopped, and neither of those is the
+     * other's special case. Written as one hierarchy, one of the three had to be the spine and the
+     * others became fields or were read off the spelling of whichever arm a reader had in hand.
      */
-    sealed interface Attempt {
+    sealed interface Attempt
+            permits Attempt.Certified, Attempt.Unverified, Attempt.Stopped, Attempt.Unresolved,
+                    Attempt.Unavailable {
 
         /**
          * What a search of the region came to, whichever way it came out.
@@ -369,8 +379,13 @@ public sealed interface ItemAssessment {
          * reached — is an outcome of a search that ran and carries what it ran over. What was
          * written instead was a comment saying so, and the one outcome that arrived by a different
          * route was filed as a search nobody made and dropped its region on the way.
+         *
+         * <p>Beside {@link Attempt} rather than under it. Every outcome but one is a search that
+         * ran, and making this the spine of the outcomes would put the one that is not — a search
+         * nobody could run — outside a hierarchy it belongs in.
          */
-        sealed interface Searched extends Attempt {
+        sealed interface Searched
+                permits Certified, Unverified, Stopped, Unresolved {
 
             /** What the way to the point took in and what it could not, which is what says how much
              *  the outcome beside it is worth. */
@@ -412,23 +427,42 @@ public sealed interface ItemAssessment {
          * {@link Certified}, and gets a compile error rather than a silent yes if a third way of
          * being built arrives.
          */
-        sealed interface Built extends Searched {
+        sealed interface Built permits Certified, Unverified {
 
             /** The value this search composed, whichever of the two this is. */
             Generator.GeneratedRow row();
 
             /** A row composed where the whole way was stated and used. */
-            static Built certified(Generator.GeneratedRow row,
-                                   souther.compiler.partition.WayToTheBorder way) {
+            static Certified certified(Generator.GeneratedRow row,
+                                       souther.compiler.partition.WayToTheBorder way) {
                 return new Certified(row, way, List.of());
             }
+        }
+
+        /**
+         * An attempt a budget of this compiler's stopped, and which budget it was.
+         *
+         * <p>Across the outcomes rather than one of them, because what a budget stops depends on
+         * how far the attempt had got. Stopped before anything was composed, there is no row and
+         * the point is left with nothing; stopped after, there is a row and what is missing is the
+         * reading that would have placed it. Both are this compiler having been stopped and neither
+         * is a thing the model said, which is the one question an account puts to them.
+         *
+         * <p><b>Nothing here says a row cannot be written.</b> What each of these licenses is that
+         * the question is open — and open because of a figure somebody could raise, which is what
+         * tells it from a point nothing ever promised.
+         */
+        sealed interface Prevented permits Unverified, Stopped {
+
+            /** Which budget of this compiler's stopped it, in the words the account reads. */
+            EstablishmentGap by();
         }
 
         /** Built, and read back standing where it was built for. */
         record Certified(Generator.GeneratedRow row,
                          souther.compiler.partition.WayToTheBorder way,
                          List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed)
-                implements Built {
+                implements Attempt, Searched, Built {
 
             public Certified {
                 uncomposed = List.copyOf(uncomposed);
@@ -441,16 +475,63 @@ public sealed interface ItemAssessment {
          * <p>Nothing here is about the model. The row is as much a row as {@link Certified}'s and is
          * offered as one; what is missing is this compiler's own confirmation, and {@code why} is
          * what stopped it.
+         *
+         * <p>An observation and never anything else. What was stopped here is a reading of a value
+         * that exists, so the only budget that can be named is one an observation ran out of — a
+         * budget that stopped the composing stopped it before there was anything to read, which is
+         * {@link Stopped}. Written as any gap at all, the two states a search comes back in could be
+         * built holding each other's reasons.
          */
         record Unverified(Generator.GeneratedRow row,
                           souther.compiler.partition.WayToTheBorder way,
                           List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
-                          EstablishmentGap why)
-                implements Built {
+                          EstablishmentGap.Observation why)
+                implements Attempt, Searched, Built, Prevented {
 
             public Unverified {
                 uncomposed = List.copyOf(uncomposed);
                 Objects.requireNonNull(why, "a row nothing certified says what stopped it");
+            }
+
+            @Override
+            public EstablishmentGap by() {
+                return why;
+            }
+        }
+
+        /**
+         * A budget of this compiler's stopped the search before any value was composed.
+         *
+         * <p>Told apart from {@link Unresolved} by what it licenses and not by how it feels. A
+         * search that ran through what it had and came back with nothing leaves a point nothing has
+         * promised anything about; a search this compiler ended leaves a point whose question is
+         * open, and open for a reason with a figure attached to it. Held as one, the second was read
+         * as the first, and an obligation this compiler declined to work on left the count as one
+         * the model admits no row at.
+         *
+         * <p>Carries the way and what the composer could not act on, like every other outcome of a
+         * search: the walk happened, and where it happened is what says how much the rest is worth.
+         *
+         * <p>{@code why} says what such a search comes back with, which is the word it has always
+         * come back with; {@code by} is which budget it was. The first cannot be read back from the
+         * second's absence and the second is not recoverable from the first, so both are carried.
+         */
+        record Stopped(Generator.UnresolvedCombination why,
+                       souther.compiler.partition.WayToTheBorder way,
+                       List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
+                       EstablishmentGap.Composition stoppedBy)
+                implements Attempt, Searched, Prevented {
+
+            public Stopped {
+                uncomposed = List.copyOf(uncomposed);
+                Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
+                Objects.requireNonNull(stoppedBy, "a search this compiler stopped says which"
+                        + " budget stopped it");
+            }
+
+            @Override
+            public EstablishmentGap by() {
+                return stoppedBy;
             }
         }
 
@@ -469,7 +550,7 @@ public sealed interface ItemAssessment {
         record Unresolved(Generator.UnresolvedCombination why,
                           souther.compiler.partition.WayToTheBorder way,
                           List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed)
-                implements Searched {
+                implements Attempt, Searched {
 
             public Unresolved {
                 uncomposed = List.copyOf(uncomposed);
@@ -525,7 +606,14 @@ public sealed interface ItemAssessment {
          * point answered rather than a search to account for, and for a search nobody made.
          */
         default List<souther.compiler.partition.ReachabilityGap> unaccountedFor() {
-            if (!(this instanceof Unresolved left) || left.why().reason().provesInfeasible()) {
+            Searched left = switch (this) {
+                case Unresolved it -> it.why().reason().provesInfeasible() ? null : it;
+                // A search a budget ended walked as far as it walked, and what it could not compose
+                // against on the way is the first thing that would explain what it came back with.
+                case Stopped it -> it;
+                case Certified _, Unverified _, Unavailable _ -> null;
+            };
+            if (left == null) {
                 return List.of();
             }
             List<souther.compiler.partition.ReachabilityGap> out = new java.util.ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -529,6 +529,14 @@ public sealed interface ItemAssessment {
                 Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
                 Objects.requireNonNull(stoppedBy, "a search this compiler stopped says which"
                         + " budget stopped it");
+                // Carried across the boundary and checked again here, because a copy that travels
+                // is a copy that can be made to travel wrong. What the word is remains the budgets'
+                // to say at both ends, so neither end holds a pair that disagrees.
+                if (why.reason() != Generator.UnresolvedCombination.Reason
+                        .wordFor(stoppedBy.budgets())) {
+                    throw new IllegalArgumentException("a search stopped by "
+                            + stoppedBy.budgets() + " does not come back with " + why.reason());
+                }
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
@@ -17,7 +17,7 @@ import souther.compiler.partition.Criterion;
  *
  * @param projection what reading the rules reaching the value this point sits in established about a
  *                   value being there
- * @param attempts   what building a value here came to under each reading of the line, and empty
+ * @param searches   what building a value here came to under each reading of the line, and empty
  *                   where nobody asked for one. Every one of them and not the strongest: what a
  *                   search of one reading came to is a fact about this point, two readings can have
  *                   come to two different things, and neither takes the other back. Kept as one, the
@@ -25,15 +25,15 @@ import souther.compiler.partition.Criterion;
  */
 public record ObligationAssessment(Criterion criterion, ObligationCoverage coverage,
                                    ItemAssessment.WritabilityProjection projection,
-                                   java.util.List<ItemAssessment.Attempt> attempts) {
+                                   SearchOutcomes searches) {
 
     public ObligationAssessment {
-        if (criterion == null || coverage == null || projection == null) {
+        if (criterion == null || coverage == null || projection == null || searches == null) {
             throw new IllegalArgumentException(
-                    "an obligation is a criterion, what the readings came to, and what the rules"
-                            + " prove: " + criterion + " " + coverage + " " + projection);
+                    "an obligation is a criterion, what the readings came to, what the rules prove"
+                            + " and what was searched for: " + criterion + " " + coverage + " "
+                            + projection + " " + searches);
         }
-        attempts = java.util.List.copyOf(attempts);
     }
 
     /** Whether a row this compilation observed stands at the point. */
@@ -59,9 +59,8 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
 
     /** The same point, with what one more search of it came to. */
     public ObligationAssessment settledBy(ItemAssessment.Attempt searched) {
-        java.util.List<ItemAssessment.Attempt> out = new java.util.ArrayList<>(attempts);
-        out.add(searched);
-        return new ObligationAssessment(criterion, coverage, projection, out);
+        return new ObligationAssessment(criterion, coverage, projection,
+                searches.plus(SearchOutcomes.of(searched)));
     }
 
     /**
@@ -75,7 +74,7 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
         // written at the point whichever reading of the line composed it — the readings owe the one
         // row between them, so what one of them showed the point, they all showed it.
         return ItemAssessment.WritabilityEvidence.of(projection, hasRowWitness(),
-                attempts.stream().anyMatch(each -> each instanceof ItemAssessment.Attempt.Certified));
+                searches.certified());
     }
 
     /**
@@ -90,7 +89,7 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
      * told about whichever the readings happened to be walked in front of.
      */
     public WritabilityKnowledge writabilityKnowledge() {
-        return WritabilityKnowledge.of(writabilityEvidence(), attempts);
+        return WritabilityKnowledge.of(writabilityEvidence(), searches);
     }
 
     /** What the readings behind this went without. */

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
@@ -17,11 +17,15 @@ import souther.compiler.partition.Criterion;
  *
  * @param projection what reading the rules reaching the value this point sits in established about a
  *                   value being there
- * @param attempt    what building a value here came to, or null where nobody asked for one
+ * @param attempts   what building a value here came to under each reading of the line, and empty
+ *                   where nobody asked for one. Every one of them and not the strongest: what a
+ *                   search of one reading came to is a fact about this point, two readings can have
+ *                   come to two different things, and neither takes the other back. Kept as one, the
+ *                   fact a reader was given was whichever the readings were walked in front of
  */
 public record ObligationAssessment(Criterion criterion, ObligationCoverage coverage,
                                    ItemAssessment.WritabilityProjection projection,
-                                   ItemAssessment.Attempt attempt) {
+                                   java.util.List<ItemAssessment.Attempt> attempts) {
 
     public ObligationAssessment {
         if (criterion == null || coverage == null || projection == null) {
@@ -29,6 +33,7 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
                     "an obligation is a criterion, what the readings came to, and what the rules"
                             + " prove: " + criterion + " " + coverage + " " + projection);
         }
+        attempts = java.util.List.copyOf(attempts);
     }
 
     /** Whether a row this compilation observed stands at the point. */
@@ -52,13 +57,11 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
         };
     }
 
-    /** The same point, with what a search of it came to. */
+    /** The same point, with what one more search of it came to. */
     public ObligationAssessment settledBy(ItemAssessment.Attempt searched) {
-        if (attempt != null) {
-            throw new IllegalStateException(
-                    "a point searched twice: " + criterion + " already has " + attempt);
-        }
-        return new ObligationAssessment(criterion, coverage, projection, searched);
+        java.util.List<ItemAssessment.Attempt> out = new java.util.ArrayList<>(attempts);
+        out.add(searched);
+        return new ObligationAssessment(criterion, coverage, projection, out);
     }
 
     /**
@@ -68,8 +71,11 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
      * record already carries, and a set kept beside them would be the same facts written twice.
      */
     public ItemAssessment.WritabilityEvidence writabilityEvidence() {
+        // Any one of them. A value read back where it was built for is grounds that a row can be
+        // written at the point whichever reading of the line composed it — the readings owe the one
+        // row between them, so what one of them showed the point, they all showed it.
         return ItemAssessment.WritabilityEvidence.of(projection, hasRowWitness(),
-                attempt instanceof ItemAssessment.Attempt.Certified);
+                attempts.stream().anyMatch(each -> each instanceof ItemAssessment.Attempt.Certified));
     }
 
     /**
@@ -78,9 +84,13 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
      * <p>What an account reads. The grounds alone answer one question and leave two situations
      * looking alike — nothing has shown a row can be written, and the showing of it was stopped —
      * and an account acts on those differently.
+     *
+     * <p>Over every search of the point, so that what stopped any of them is said. Two readings
+     * stopped by two figures are two pieces of work, and a reader told about one of them would be
+     * told about whichever the readings happened to be walked in front of.
      */
     public WritabilityKnowledge writabilityKnowledge() {
-        return WritabilityKnowledge.of(writabilityEvidence(), attempt);
+        return WritabilityKnowledge.of(writabilityEvidence(), attempts);
     }
 
     /** What the readings behind this went without. */

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
@@ -157,4 +157,33 @@ public sealed interface ObligationCoverage {
         return missed ? new Missed()
                 : new NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS);
     }
+
+    /**
+     * What two searches of one reading of one line saw, as one reading's measurement.
+     *
+     * <p>For the one place two of those meet: a line read once and searched twice, which is a
+     * helper called from two arms. They are not two readings — the authored line and the target are
+     * the same, and what differs is the region a row for it was composed in — so what a debt is
+     * gathered from has to be one measurement, and this is how the two become it.
+     *
+     * <p><b>Written in terms of {@link #acrossTheReadings} and not beside it.</b> What a set of
+     * measurements comes to is that one's answer, and a second reading of the same question here
+     * would be a second coverage semantics free to part from it. So the pair is put through it and
+     * the answer is written back as the measurement that says the same thing, which makes
+     * {@code acrossTheReadings(a, b)} and {@code acrossTheReadings(across(a, b))} the same answer by
+     * construction rather than by two pieces of code being kept in step.
+     */
+    static Measurement<ItemAssessment.Coverage> acrossOneReadingsSearches(
+            Measurement<ItemAssessment.Coverage> a, Measurement<ItemAssessment.Coverage> b) {
+        return switch (acrossTheReadings(List.of(a, b))) {
+            // A row was seen. Kept as the measurement that saw it, so that what that reading went
+            // without is still said: a row found by a reading which could not read everything is
+            // found, and what it could not read is a fact of its own.
+            case Witnessed _ -> a.made().map(ItemAssessment.Coverage::hit).orElse(false) ? a : b;
+            case Undecided it -> new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(),
+                    it.weakening());
+            case Missed _ -> new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit());
+            case NotMeasured it -> new Measurement.NotMeasured<>(it.why());
+        };
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
@@ -176,14 +176,30 @@ public sealed interface ObligationCoverage {
     static Measurement<ItemAssessment.Coverage> acrossOneReadingsSearches(
             Measurement<ItemAssessment.Coverage> a, Measurement<ItemAssessment.Coverage> b) {
         return switch (acrossTheReadings(List.of(a, b))) {
-            // A row was seen. Kept as the measurement that saw it, so that what that reading went
-            // without is still said: a row found by a reading which could not read everything is
-            // found, and what it could not read is a fact of its own.
-            case Witnessed _ -> a.made().map(ItemAssessment.Coverage::hit).orElse(false) ? a : b;
+            // A row was seen, and what the searches behind it went without is what both of them
+            // went without. Kept as whichever of the two saw it, the answer turned on which was
+            // walked first — the one that saw a row and read everything, and the one that saw a row
+            // and could not, are one reading here, and what it could not read is a fact of its own.
+            case Witnessed _ -> {
+                WeakeningSet went = wentWithout(a).union(wentWithout(b));
+                yield went.isEmpty()
+                        ? new Measurement.Complete<>(new ItemAssessment.Coverage.Hit())
+                        : new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), went);
+            }
             case Undecided it -> new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(),
                     it.weakening());
             case Missed _ -> new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit());
             case NotMeasured it -> new Measurement.NotMeasured<>(it.why());
+        };
+    }
+
+    /** What one search of a reading could not read, and none where it read everything. */
+    private static WeakeningSet wentWithout(Measurement<ItemAssessment.Coverage> made) {
+        return switch (made) {
+            case Measurement.Partial<ItemAssessment.Coverage> it -> it.by();
+            case Measurement.FailedToMeasure<ItemAssessment.Coverage> it -> it.by();
+            case Measurement.Complete<ItemAssessment.Coverage> _,
+                 Measurement.NotMeasured<ItemAssessment.Coverage> _ -> WeakeningSet.none();
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -124,6 +124,13 @@ public final class PointResolver {
                         case ItemAssessment.Attempt.Unresolved(var why, var _, var _) ->
                                 walked.put(reading,
                                         new SearchCoverage.ReadingSearch.Attempted(why));
+                        // A search a budget of this compiler's ended, which came to nothing like
+                        // the one above. What offering a row is short of is the same either way,
+                        // and which figure ended it is the point's own to say rather than this
+                        // walk's: what is recorded here is that a search ran and produced no row.
+                        case ItemAssessment.Attempt.Stopped(var why, var _, var _, var _) ->
+                                walked.put(reading,
+                                        new SearchCoverage.ReadingSearch.Attempted(why));
                         // A search that ran with nothing to run against. Said in the words the
                         // generator says it in, as the reading's own outcome: it is a fact about
                         // this run, and one of the reasons a reader may not act on — so a line

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -49,10 +49,10 @@ public final class PointResolver {
          * owed a row at is the search and the debt disagreeing about the same point, which the walk
          * refuses rather than records.
          */
-        record Searched(ItemAssessment.Attempt attempt) implements ReadingEvidence {
+        record Searched(SearchOutcomes outcomes) implements ReadingEvidence {
 
             public Searched {
-                if (attempt == null) {
+                if (outcomes == null || !outcomes.ran()) {
                     throw new IllegalArgumentException(
                             "a reading that was searched came to something");
                 }
@@ -104,7 +104,12 @@ public final class PointResolver {
                         walked.put(reading, new SearchCoverage.ReadingSearch.OutOfScope());
                 case ReadingEvidence.NoAnswer _ ->
                         walked.put(reading, new SearchCoverage.ReadingSearch.Unavailable());
-                case ReadingEvidence.Searched(ItemAssessment.Attempt attempt) -> {
+                // Every search of this reading, in the order they were made. One reading can be
+                // searched more than once — a helper called twice is one line at one target — and
+                // a row composed under one caller's conditions is a row, whatever the other came
+                // to. Read as one, the row an author is offered turned on which of them was kept.
+                case ReadingEvidence.Searched(SearchOutcomes outcomes) -> {
+                    for (ItemAssessment.Attempt attempt : outcomes.each()) {
                     switch (attempt) {
                         // A row read back where it was built for. Which reading composed it is
                         // where the row goes, and what a reader asking about one coordinate
@@ -151,6 +156,7 @@ public final class PointResolver {
                                                 List.of(reading.target().label()),
                                                 Generator.UnresolvedCombination.Reason
                                                         .NOTHING_TO_BUILD_AGAINST)));
+                    }
                     }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
@@ -1,0 +1,133 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.ReachabilityGap;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * What looking for a row at one point came to, over every search that was made for it.
+ *
+ * <p><b>Several, because one reading of a line can be searched more than once.</b> A helper called
+ * from two arms is one line read once — the same authored line at the same target — and a row for it
+ * is composed under each caller's own conditions, so one reading has two searches and they can have
+ * come to different things. Held as one outcome, the point carried whichever of them a fold put
+ * first, and what the other found out was gone before anything could read it.
+ *
+ * <p><b>Nothing here ranks them.</b> A row that was composed, a search a budget of this compiler's
+ * ended, and a search that ran through what it had are three facts about one point; there is no
+ * order in which one of them stands for another, and every question a reader puts is answered by
+ * looking at all of them. What is chosen is a row to offer somebody ({@link #rowToOffer}), which is
+ * a choice about what to show and not about what happened.
+ */
+public record SearchOutcomes(List<ItemAssessment.Attempt> each) {
+
+    public SearchOutcomes {
+        each = List.copyOf(each);
+    }
+
+    /** Nobody asked for a value to be built here. */
+    public static SearchOutcomes none() {
+        return new SearchOutcomes(List.of());
+    }
+
+    /** One search, or none where {@code attempt} is null. */
+    public static SearchOutcomes of(ItemAssessment.Attempt attempt) {
+        return attempt == null ? none() : new SearchOutcomes(List.of(attempt));
+    }
+
+    /** These and those, in the order they were made. */
+    public SearchOutcomes plus(SearchOutcomes other) {
+        if (other.each.isEmpty()) {
+            return this;
+        }
+        if (each.isEmpty()) {
+            return other;
+        }
+        List<ItemAssessment.Attempt> out = new ArrayList<>(each);
+        out.addAll(other.each);
+        return new SearchOutcomes(out);
+    }
+
+    /** Whether anybody searched here at all. */
+    public boolean ran() {
+        return !each.isEmpty();
+    }
+
+    /**
+     * The one search there was.
+     *
+     * <p>For a caller that already knows the point was searched once — a line one behavior read
+     * once is searched once, and most of them are. Checked rather than assumed: a caller that asks
+     * this of a point searched twice is a caller reading one of the two as the whole answer, which
+     * is the thing this type exists to stop, and it gets told rather than given the first.
+     */
+    public ItemAssessment.Attempt only() {
+        if (each.size() != 1) {
+            throw new IllegalStateException(
+                    "one search was asked for at a point that had " + each.size() + ": " + each);
+        }
+        return each.get(0);
+    }
+
+    /**
+     * Whether a row was composed and read back standing where it was composed for.
+     *
+     * <p>Any one of them. The searches are of one point and the point is one point, so what one of
+     * them showed about it, they all showed.
+     */
+    public boolean certified() {
+        return each.stream().anyMatch(it -> it instanceof ItemAssessment.Attempt.Certified);
+    }
+
+    /**
+     * Which budgets of this compiler's stopped a showing here, and empty where none did.
+     *
+     * <p>All of them. Two searches stopped by two figures are two pieces of work, and a reader
+     * asking what would have to give is owed both.
+     */
+    public Set<EstablishmentGap> prevented() {
+        Set<EstablishmentGap> out = new LinkedHashSet<>();
+        for (ItemAssessment.Attempt attempt : each) {
+            if (attempt instanceof ItemAssessment.Attempt.Prevented it) {
+                out.add(it.by());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * A row to put in front of somebody, where any of these composed one.
+     *
+     * <p>A choice, and the one choice here that is allowed to be one. What a person is offered is
+     * one row — two rows for one point is two answers they have to separate — so a row read back
+     * where it was built for is offered before one nothing could place. That decides what to show
+     * and takes nothing away: what each search came to is still here for whoever asks.
+     */
+    public Optional<ItemAssessment.Attempt.Built> rowToOffer() {
+        Optional<ItemAssessment.Attempt.Built> placed = each.stream()
+                .filter(it -> it instanceof ItemAssessment.Attempt.Certified)
+                .map(ItemAssessment.Attempt.Built.class::cast)
+                .findFirst();
+        return placed.isPresent() ? placed : each.stream()
+                .filter(it -> it instanceof ItemAssessment.Attempt.Built)
+                .map(ItemAssessment.Attempt.Built.class::cast)
+                .findFirst();
+    }
+
+    /** Every condition on the way that none of these composed against. */
+    public List<ReachabilityGap> unaccountedFor() {
+        List<ReachabilityGap> out = new ArrayList<>();
+        for (ItemAssessment.Attempt attempt : each) {
+            for (ReachabilityGap gap : attempt.unaccountedFor()) {
+                if (!out.contains(gap)) {
+                    out.add(gap);
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
@@ -118,6 +118,33 @@ public record SearchOutcomes(List<ItemAssessment.Attempt> each) {
                 .findFirst();
     }
 
+    /**
+     * The searches a reader is owed a sentence about, one per thing that happened.
+     *
+     * <p><b>Told apart by what they are and never by how they read.</b> Two searches of one reading
+     * that came to the same thing are one piece of news; two that came to different things are two,
+     * however alike a renderer's words for them. Left to whoever writes the sentences, the same two
+     * facts collapse or do not depending on the wording, which puts a decision about what happened
+     * in the one place that has stopped looking at it.
+     *
+     * <p>A search that composed a row is not among them. What such a search came to is the row,
+     * which a reader gets by being offered it; what this answers is what a point with nothing at it
+     * has to say for itself.
+     */
+    public List<ItemAssessment.Attempt> worthSaying() {
+        List<ItemAssessment.Attempt> out = new ArrayList<>();
+        for (ItemAssessment.Attempt attempt : each) {
+            if (attempt instanceof ItemAssessment.Attempt.Built
+                    || attempt instanceof ItemAssessment.Attempt.Unavailable) {
+                continue;
+            }
+            if (!out.contains(attempt)) {
+                out.add(attempt);
+            }
+        }
+        return List.copyOf(out);
+    }
+
     /** Every condition on the way that none of these composed against. */
     public List<ReachabilityGap> unaccountedFor() {
         List<ReachabilityGap> out = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -116,7 +116,7 @@ public sealed interface WritabilityKnowledge {
      * and the order says so rather than leaving it to whichever the caller looked at.
      */
     static WritabilityKnowledge of(ItemAssessment.WritabilityEvidence evidence,
-                                   java.util.List<ItemAssessment.Attempt> attempts) {
+                                   SearchOutcomes searches) {
         if (evidence.known()) {
             return new Established(evidence);
         }
@@ -133,17 +133,7 @@ public sealed interface WritabilityKnowledge {
         // of its line, two readings can have been stopped by two different figures, and what a
         // reader is owed is everything that would have to give — so the gaps are collected and
         // never ranked.
-        Set<EstablishmentGap> stopped = new LinkedHashSet<>();
-        for (ItemAssessment.Attempt each : attempts) {
-            if (each == null) {
-                continue;   // nobody asked for a value to be built under that reading
-            }
-            switch (each) {
-                case ItemAssessment.Attempt.Prevented it -> stopped.add(it.by());
-                case ItemAssessment.Attempt.Certified _, ItemAssessment.Attempt.Unresolved _,
-                     ItemAssessment.Attempt.Unavailable _ -> { }
-            }
-        }
+        Set<EstablishmentGap> stopped = searches.prevented();
         return stopped.isEmpty() ? new NoEvidence() : new Prevented(stopped);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -1,6 +1,13 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.partition.CompositionBudget;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * What this compilation knows about a row being writable at one point, and where the knowing
@@ -44,11 +51,53 @@ public sealed interface WritabilityKnowledge {
         }
     }
 
-    /** A budget of this compiler's stopped the establishing, and this is which. */
-    record Prevented(EstablishmentGap by) implements WritabilityKnowledge {
+    /**
+     * Budgets of this compiler's stopped the establishing, and these are which.
+     *
+     * <p>A set, and one that holds at most one of each kind. Two readings of one point may have
+     * been stopped by two different figures, and neither of them outranks the other — what a reader
+     * wants is everything that would have to be raised, and a choice between them would tell them
+     * about whichever reading a walk happened to reach first.
+     *
+     * <p>Normalised here rather than by whoever collects them. Two observations that each name a
+     * cause are one observation naming both, and two composings are one composing naming every
+     * budget: held unnormalised, the same two facts arriving in two orders would be two different
+     * values, and a law about the order readings are folded in could not be stated as an equality.
+     */
+    record Prevented(Set<EstablishmentGap> by) implements WritabilityKnowledge {
 
         public Prevented {
             Objects.requireNonNull(by, "a showing that was stopped says what stopped it");
+            by = normalised(by);
+            if (by.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a showing that was stopped says what stopped it");
+            }
+        }
+
+        /** One gap of each kind, holding between them everything the kinds were given. */
+        private static Set<EstablishmentGap> normalised(Set<EstablishmentGap> gaps) {
+            Set<Incompleteness.Code> observed = EnumSet.noneOf(Incompleteness.Code.class);
+            Set<CompositionBudget> budgets = EnumSet.noneOf(CompositionBudget.class);
+            for (EstablishmentGap each : gaps) {
+                switch (each) {
+                    case EstablishmentGap.Observation it -> observed.addAll(it.causes());
+                    case EstablishmentGap.Composition it -> budgets.addAll(it.budgets());
+                }
+            }
+            Set<EstablishmentGap> out = new LinkedHashSet<>();
+            if (!observed.isEmpty()) {
+                out.add(new EstablishmentGap.Observation(observed));
+            }
+            if (!budgets.isEmpty()) {
+                out.add(new EstablishmentGap.Composition(budgets));
+            }
+            return Collections.unmodifiableSet(out);
+        }
+
+        /** One gap that was made, for a caller that has exactly one. */
+        public static Prevented by(EstablishmentGap gap) {
+            return new Prevented(Set.of(gap));
         }
     }
 
@@ -67,17 +116,34 @@ public sealed interface WritabilityKnowledge {
      * and the order says so rather than leaving it to whichever the caller looked at.
      */
     static WritabilityKnowledge of(ItemAssessment.WritabilityEvidence evidence,
-                                   ItemAssessment.Attempt attempt) {
+                                   java.util.List<ItemAssessment.Attempt> attempts) {
         if (evidence.known()) {
             return new Established(evidence);
         }
-        // The one thing that was stopped rather than absent. Read off the attempt's own case and
-        // never off the reason inside an unresolved one: a search that came back with nothing has
-        // already lost which budget it was, so a reader rebuilding that from the word left over is
-        // rebuilding what the word does not hold.
-        if (attempt instanceof ItemAssessment.Attempt.Unverified it) {
-            return new Prevented(it.why());
+        // Asked of the outcome's own case and never of the reason inside it: a search that came
+        // back with nothing has already lost which budget it was, so a reader rebuilding that from
+        // the word left over is rebuilding what the word does not hold.
+        //
+        // Exhaustive, so that an outcome added is classified here rather than falling to the last
+        // arm. Which of the five this is decides nothing on its own — what decides is whether it is
+        // one a budget of this compiler's stopped, and that is a question the outcomes answer by
+        // implementing {@link ItemAssessment.Attempt.Prevented} or not.
+        //
+        // Over every search of the point and not one of them. A point is searched once per reading
+        // of its line, two readings can have been stopped by two different figures, and what a
+        // reader is owed is everything that would have to give — so the gaps are collected and
+        // never ranked.
+        Set<EstablishmentGap> stopped = new LinkedHashSet<>();
+        for (ItemAssessment.Attempt each : attempts) {
+            if (each == null) {
+                continue;   // nobody asked for a value to be built under that reading
+            }
+            switch (each) {
+                case ItemAssessment.Attempt.Prevented it -> stopped.add(it.by());
+                case ItemAssessment.Attempt.Certified _, ItemAssessment.Attempt.Unresolved _,
+                     ItemAssessment.Attempt.Unavailable _ -> { }
+            }
         }
-        return new NoEvidence();
+        return stopped.isEmpty() ? new NoEvidence() : new Prevented(stopped);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1876,17 +1876,26 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     /** What the search for a value at an edge came to, where it ran and found none. */
     private static String whatWasTried(ItemAssessment.Attempt attempt, SourceNameResolver names,
                                        SourceId declaredIn) {
-        if (!(attempt instanceof ItemAssessment.Attempt.Unresolved left)) {
+        // One opening per outcome, and not one for everything that came back without a row. A
+        // search this compiler stopped and a search that had everything and reached nothing are
+        // different news, and a proof is not a failure at all — read under one opening, an author
+        // is sent looking for a row nothing can write, or told nothing was composed for a point
+        // where the composing never started.
+        if (attempt == null) {
             return "";   // nothing ran, and what a run would have said is not this line's to guess
         }
-        // A proof is not a failure, and the sentence in front of the reason may not say it is.
-        // Every other word here is this compiler saying what it did not manage; one of them is the
-        // model settling the point, and reading them under one opening sends an author looking for
-        // a row nothing can write. Asked of the reason, which is where that decision is written.
-        String opening = left.why().reason().provesInfeasible()
-                ? " — " : " — nothing composed one: ";
-        return opening + left.why().said().orElseGet(() -> whyUnresolved(left.why()))
-                + whatTheRegionLeftOut(left.unaccountedFor(), names, declaredIn);
+        return switch (attempt) {
+            case ItemAssessment.Attempt.Certified _, ItemAssessment.Attempt.Unverified _,
+                 ItemAssessment.Attempt.Unavailable _ -> "";
+            case ItemAssessment.Attempt.Stopped it ->
+                    " — this compiler stopped at " + said(it.stoppedBy().budgets()) + ": "
+                            + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
+                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+            case ItemAssessment.Attempt.Unresolved it ->
+                    (it.why().reason().provesInfeasible() ? " — " : " — nothing composed one: ")
+                            + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
+                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -20,6 +20,7 @@ import souther.compiler.observe.MeasureReason;
 import souther.compiler.query.InputCaseEvidence;
 import souther.compiler.query.Measure;
 import souther.compiler.query.Measurement;
+import souther.compiler.query.SearchOutcomes;
 import souther.compiler.query.Weakening;
 import souther.compiler.query.WeakeningSet;
 import souther.compiler.observe.MeasurementStatus;
@@ -526,7 +527,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             out.append(String.format("      · not known to be writable: the %s point %s (%s)%n",
                     each.debt().role(), each.said(), each.debt().describe(names, null)));
             readings(out, each.debt(), _ -> true, at -> whatWasTried(
-                    at.owedAt(each.debt().at()).attempt(), names, null));
+                    at.owedAt(each.debt().at()).searches(), names, null));
         }
         Map<String, List<Adequacy.Finding>> byDeclaration = new java.util.LinkedHashMap<>();
         for (Adequacy.Finding each : module.declarations()) {
@@ -1312,7 +1313,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // reader looking at two models that differ here is looking at what the compiler could
             // establish — and without this the difference reads as the tool being arbitrary.
             readings(out, p, _ -> true, at -> whatWasTried(
-                    at.owedAt(p.at()).attempt(), names, declaredIn));
+                    at.owedAt(p.at()).searches(), names, declaredIn));
         }
         // And what the model itself answered, which is not a row anybody is behind on. Named by the
         // reason rather than left blank: a point the rules refuse and a point this language cannot
@@ -1874,6 +1875,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /** What the search for a value at an edge came to, where it ran and found none. */
+    private static String whatWasTried(SearchOutcomes outcomes, SourceNameResolver names,
+                                       SourceId declaredIn) {
+        List<String> said = new ArrayList<>();
+        for (ItemAssessment.Attempt each : outcomes.each()) {
+            String here = whatWasTried(each, names, declaredIn);
+            if (!here.isEmpty() && !said.contains(here)) {
+                said.add(here);
+            }
+        }
+        return String.join("", said);
+    }
+
+    /** The same, of one search of the point. */
     private static String whatWasTried(ItemAssessment.Attempt attempt, SourceNameResolver names,
                                        SourceId declaredIn) {
         // One opening per outcome, and not one for everything that came back without a row. A

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1923,8 +1923,49 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                 .TwoNumbersAtOneLocation _ ->
                                 "a condition on another number taken where this row is already"
                                         + " being written for one";
+                        // What stopped the looking, and not that nothing was found. An author does
+                        // nothing about the first and may do something about the second.
+                        case souther.compiler.partition.ReachabilityGap.Why
+                                .TheWalkForItsPositionsWasStopped(var by) ->
+                                "a condition on positions this compiler stopped looking at ("
+                                        + said(by) + ")";
                     };
         };
+    }
+
+    /**
+     * What a budget of this compiler's is called where a reader meets one.
+     *
+     * <p>Its own words and not the constant's name. What the compiler calls a figure is a name for
+     * the code that reads it; what a reader wants is what this compiler declined to do, in a phrase
+     * they can act on — and a budget added arrives here as a compile error rather than as a name
+     * nobody wrote a sentence for.
+     */
+    private static String said(java.util.Set<souther.compiler.partition.CompositionBudget> budgets) {
+        List<String> out = new ArrayList<>();
+        for (souther.compiler.partition.CompositionBudget each : budgets) {
+            out.add(switch (each) {
+                case ELEMENTS_A_PROPOSAL_HOLDS -> "how many elements a proposed collection holds";
+                case CHARACTERS_A_PROPOSAL_HOLDS -> "how many characters a proposed string holds";
+                case PAIRINGS_BUILT_AT_ONCE -> "how many of a map's pairings are built at once";
+                case ELEMENTS_A_TOTAL_IS_SPREAD_OVER ->
+                        "how many elements a total is spread over";
+                case SHAPES_OF_A_TOTAL_OFFERED -> "how many containers are offered for one total";
+                case DECOMPOSITIONS_OF_A_TOTAL_OFFERED ->
+                        "how many ways a total is decomposed";
+                case PLACES_A_PAIR_IS_TRIED_AT -> "how many places a pair is tried at";
+                case STEPS_A_SEARCH_MAY_TAKE -> "how many steps a search takes";
+                case ASSIGNMENTS_A_SEARCH_COMPOSES -> "how many assignments a search composes";
+                case VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED ->
+                        "how many values of an unbounded progression are tried";
+                case LEVELS_A_SIDE_IS_ASKED_AT -> "how many levels a side is asked at";
+                case TIMES_THE_RULES_ARE_ASKED_AGAIN -> "how often the rules are read again";
+                case VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT ->
+                        "how many values a position on the way is tried at";
+                case DEPTH_A_CONSTRUCTION_PLAN_DESCENDS -> "how deep a value is built";
+            });
+        }
+        return String.join(", ", out);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1726,11 +1726,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // the carrying dropping it.
                 case COVERAGE -> "undecided whether a row is at the " + point
                         + whatTheRowsWentWithout(owed);
-                // Named for what happened and not for the limit's number. Which budget it was is
-                // the observation's own word, and what an author is told is that the row this
-                // compiler composed is not evidence of anything until it can be read back.
-                case WRITABILITY -> "a row was built for the " + point
-                        + ", and " + why(owed.writabilityKnowledge());
+                // Named for what happened, which is not one thing. A reading that did not come
+                // back is of a row this compiler composed; a composing that stopped never had one
+                // — and an opening written for the first says a row was built at a point where
+                // none was. So the sentence is the gap's, and the gaps say which they are.
+                case WRITABILITY ->
+                        "nothing could show a row can be written at the " + point
+                                + " — " + why(owed.writabilityKnowledge());
             });
         }
         return said;
@@ -1763,19 +1765,35 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         };
     }
 
-    /** Why nothing could confirm the row a search composed, in the observation's own words. */
+    /**
+     * Why nothing could show a row can be written at a point, in the words of what was stopped.
+     *
+     * <p>Every one of them and not the first. A point may have been stopped in more than one way —
+     * a reading of one value that did not come back, a composing for another that never started —
+     * and what a reader wants is everything that would have to give for the point to be settled.
+     */
     private static String why(WritabilityKnowledge knowledge) {
-        if (!(knowledge instanceof WritabilityKnowledge.Prevented(EstablishmentGap by))) {
+        if (!(knowledge instanceof WritabilityKnowledge.Prevented(Set<EstablishmentGap> by))) {
             // Only a point whose showing was stopped is written this way, and what stopped it is
             // what this exists to say.
             throw new IllegalStateException("a point undecided about being writable was not "
                     + "stopped from being shown so: " + knowledge);
         }
-        return switch (by) {
-            case EstablishmentGap.Observation(Set<Incompleteness.Code> causes) -> causes.stream()
-                    .map(AdequacyReport::whatStopped)
-                    .collect(Collectors.joining(", and "));
-        };
+        List<String> out = new ArrayList<>();
+        for (EstablishmentGap each : by) {
+            out.add(switch (each) {
+                case EstablishmentGap.Observation(Set<Incompleteness.Code> causes) ->
+                        "a row was built for it, and " + causes.stream()
+                                .map(AdequacyReport::whatStopped)
+                                .collect(Collectors.joining(", and "));
+                // What this compiler declined to build, and which figure decided it. An author does
+                // nothing about this; what it says is that the point is open because of a policy
+                // here, which is what keeps it out of the work they are told they owe.
+                case EstablishmentGap.Composition(var budgets) ->
+                        "nothing was composed for it: this compiler stopped at " + said(budgets);
+            });
+        }
+        return String.join(", and ", out);
     }
 
     /** What one observation gap cost, said as what it stopped rather than as its code. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1877,14 +1877,16 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     /** What the search for a value at an edge came to, where it ran and found none. */
     private static String whatWasTried(SearchOutcomes outcomes, SourceNameResolver names,
                                        SourceId declaredIn) {
+        // Which searches are worth a sentence is the outcomes' answer, not this one's. Told apart
+        // here, two of them would be one piece of news whenever the words for them happened to
+        // match — a report deciding what happened from what it was about to write.
         List<String> said = new ArrayList<>();
-        for (ItemAssessment.Attempt each : outcomes.each()) {
-            String here = whatWasTried(each, names, declaredIn);
-            if (!here.isEmpty() && !said.contains(here)) {
-                said.add(here);
-            }
+        for (ItemAssessment.Attempt each : outcomes.worthSaying()) {
+            said.add(whatWasTried(each, names, declaredIn));
         }
-        return String.join("", said);
+        // One sentence per search, with the readings' own separator between them. Run together,
+        // two searches of one reading read as one clause that says two things.
+        return String.join(";", said);
     }
 
     /** The same, of one search of the point. */

--- a/souther-compiler/src/test/java/souther/compiler/APointThisCompilerDeclinedToComposeForStillOwesARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APointThisCompilerDeclinedToComposeForStillOwesARowTest.java
@@ -1,0 +1,151 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A point this compiler declined to compose a value for is a point the model still owes a row at.
+ *
+ * <p>What the account is for is telling an author what the model owes. A budget of this compiler's
+ * is not the model saying anything: the row it declined to build may be the easiest one in the file
+ * to write by hand, and an obligation that leaves the count over it is this compiler's own policy
+ * printed as a fact about what somebody wrote.
+ *
+ * <p><b>The same rule reached by two different figures.</b> One model asks for a collection of a
+ * given length and one asks for a total spread over elements that hold at most one, and they stop at
+ * two different budgets in two different stages. Held against one of them, closing the other would
+ * be a separate piece of work nobody could see was missing.
+ *
+ * <p>And read as a count that does not move. What a strict build refuses over changes with the
+ * number in the model, which is the model's own business; how many rows it owes does not.
+ */
+class APointThisCompilerDeclinedToComposeForStillOwesARowTest {
+
+    /** A rule on how many elements a list holds, with one short row written. */
+    private static String aLengthOf(int many) {
+        return """
+                module example.count
+
+                data Many
+                data Few
+
+                behavior decide : (items: List<Int>) -> Many | Few
+
+                let decide (items) =
+                    if List.length(items) >= %d
+                    then Many else Few
+
+                example decide
+                    | "three is few" : ([ 1, 2, 3 ]) -> Few
+                """.formatted(many);
+    }
+
+    /** The same rule on a total, over elements the rules leave at most one. */
+    private static String aTotalOf(int total) {
+        return """
+                module example.total
+
+                data Many
+                data Few
+
+                data Small = Int
+                    invariant range = value >= 0 && value <= 1
+
+                data Line = { amount: Small }
+
+                behavior decide : (lines: List<Line>) -> Many | Few
+
+                let decide (lines) =
+                    if List.sum(List.map(one -> one.amount.value, lines)) >= %d
+                    then Many else Few
+
+                example decide
+                    | "one line" : ([ Line { amount = Small(1) } ]) -> Few
+                """.formatted(total);
+    }
+
+    /**
+     * The line owes its four points at every number, on both sides of every figure.
+     *
+     * <p>Ten is under every budget there is, and two hundred is over the ones these models reach.
+     * Sixty-four and sixty-five are either side of how many elements a proposal holds, which is
+     * where the count used to start moving.
+     */
+    @Test
+    void theCountDoesNotMoveWithTheFigureThisCompilerStopsAt() {
+        List<String> counted = new ArrayList<>();
+        for (int many : new int[] {10, 64, 65, 200}) {
+            counted.add(many + ": " + obligationsIn(report(aLengthOf(many))));
+        }
+        for (int total : new int[] {10, 200}) {
+            counted.add(total + ": " + obligationsIn(report(aTotalOf(total))));
+        }
+
+        assertEquals(List.of("10: 1/4", "64: 1/4", "65: 1/4", "200: 1/4", "10: 1/4", "200: 1/4"),
+                counted,
+                "one row is written and four points are owed, whatever this compiler could build");
+    }
+
+    /**
+     * And the point says which figure this compiler stopped at, rather than that nothing promises a
+     * row there.
+     *
+     * <p>The two sentences send an author to different places. One says the model admits no row and
+     * the work is to write a different rule; the other says a policy here ran out, and names the
+     * figure that would have to give.
+     */
+    @Test
+    void thePointNamesTheFigureRatherThanTheModel() {
+        String length = report(aLengthOf(200));
+        String total = report(aTotalOf(200));
+
+        assertFalse(length.contains("not known to be writable"),
+                () -> "nothing here says the model promises no row: " + length);
+        assertTrue(length.contains(
+                "this compiler stopped at how many elements a proposed collection holds"),
+                () -> "and the figure it stopped at is named: " + length);
+        assertTrue(total.contains("this compiler stopped at how many elements a total is spread"),
+                () -> "the total reaches its own figure and names that one: " + total);
+    }
+
+    /**
+     * A search a budget ended is not reported as one that composed nothing.
+     *
+     * <p>The two are one sentence away from each other and mean opposite things: a search that had
+     * everything and reached nothing says what this compiler can do, and one that stopped says how
+     * far it was willing to go.
+     */
+    @Test
+    void aSearchABudgetEndedIsNotSaidToHaveComposedNothing() {
+        String length = report(aLengthOf(200));
+
+        assertFalse(length.contains("nothing composed one: this compiler stopped"),
+                () -> "a stopped search wears its own opening: " + length);
+    }
+
+    /** What the border section of a report says a behavior's obligations came to. */
+    private static String obligationsIn(String report) {
+        return report.lines()
+                .filter(each -> each.contains("border") && each.contains("obligations"))
+                .map(each -> each.substring(each.indexOf("obligations") + "obligations ".length()))
+                .findFirst().orElseThrow(() -> new AssertionError(report));
+    }
+
+    private static String report(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -84,7 +83,7 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
 
         assertTrue(at.writabilityEvidence().has(ItemAssessment.WritabilityEvidence.Ground.A_VALUE_WAS_BUILT),
                 "a value at 10 went through the decoder");
-        assertInstanceOf(ItemAssessment.Attempt.Built.class, at.attempt(),
+        assertInstanceOf(ItemAssessment.Attempt.Built.class, at.searches().only(),
                 "and the value it built is kept, because it is also the row an author is offered");
     }
 
@@ -130,7 +129,7 @@ at.coverage().made().orElseThrow());
                 at.writabilityEvidence().grounds(),
                 "every rule of `Amount` was read, so 0 is a value it holds, and that is the whole"
                         + " of what showed it");
-        assertInstanceOf(ItemAssessment.Attempt.Unresolved.class, at.attempt(),
+        assertInstanceOf(ItemAssessment.Attempt.Unresolved.class, at.searches().only(),
                 "and the search still came back with nothing, which takes nothing away from that");
     }
 
@@ -219,8 +218,8 @@ at.coverage().made().orElseThrow());
                 "the row is the witness");
         assertFalse(at.worthSearching(),
                 "and a value that is already there is not worth building one for");
-        assertNull(at.attempt(),
-                "so nothing was searched for, which is said by there being no attempt");
+        assertFalse(at.searches().ran(),
+                "so nothing was searched for, which is said by there being no search");
     }
 
     /**
@@ -260,7 +259,7 @@ at.coverage().made().orElseThrow());
                 "nobody wrote a row, which says nothing about whether one could be written");
         assertFalse(at.writabilityEvidence().has(ItemAssessment.WritabilityEvidence.Ground.A_ROW_IS_AT_IT),
                 "and a measurement nobody made puts no row at the point");
-        assertInstanceOf(ItemAssessment.Attempt.Built.class, at.attempt(),
+        assertInstanceOf(ItemAssessment.Attempt.Built.class, at.searches().only(),
                 "a value was built here, and what it settles is the writability and not the rows");
     }
 
@@ -306,7 +305,7 @@ at.coverage().made().orElseThrow());
                     assertInstanceOf(Measurement.NotMeasured.class,
                             at.owed().coverage()).why(), at.label());
             assertFalse(at.owed().worthSearching(), at.label());
-            assertNull(at.owed().attempt(), at.label());
+            assertFalse(at.owed().searches().ran(), at.label());
         }
     }
 
@@ -368,8 +367,8 @@ at.coverage().made().orElseThrow());
                         + " left when nothing was");
         assertTrue(unbuilt.worthSearching(),
                 "a value here would have settled something, so the point is worth searching");
-        assertNull(unbuilt.attempt(),
-                "and nobody asked for one: said by there being no attempt, not by an attempt that"
+        assertFalse(unbuilt.searches().ran(),
+                "and nobody asked for one: said by there being no search, not by a search that"
                         + " reports not having been asked for");
         assertInstanceOf(Measurement.Complete.class, unbuilt.coverage(),
                 "the rows were read all the same: what is missing is the value, not the reading");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhyItOwesNoRowAtAPointTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhyItOwesNoRowAtAPointTest.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -525,7 +524,7 @@ class ABorderSaysWhyItOwesNoRowAtAPointTest {
         assertTrue(line.owedAt(PointRole.OUT).hasRowWitness(), "and one is well over it");
         for (PointRole role : List.of(PointRole.IN, PointRole.OUT)) {
             assertFalse(line.owedAt(role).worthSearching(), role.toString());
-            assertNull(line.owedAt(role).attempt(), role.toString());
+            assertFalse(line.owedAt(role).searches().ran(), role.toString());
         }
 
         // And the block an author reads says nothing about them, because nothing is owed there.

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A composer that stops at a figure of this compiler's says which figure, at the figure and not one
+ * short of it.
+ *
+ * <p>Put to the producer directly and one either side of the line. What a search comes back with is
+ * the same word whether it walked everything it had or stopped at a number — so a test that only
+ * asked what it came back with would pass while the number and the name had come apart, which is
+ * the whole of what a budget travelling as itself is for.
+ *
+ * <p>The figures are read from {@link CompositionBudget} rather than written here. A budget raised
+ * moves this test with it, and a test holding its own copy of the number would go on asking about a
+ * line the compiler no longer has.
+ *
+ * <p><b>Only the figures a producer can be put either side of on its own.</b> How many elements a
+ * total is spread over is reached by what the elements may hold rather than by the total, so one
+ * side of it takes a model whose elements are bounded — that one is held against a model, and what
+ * is here is the half that a call can ask for.
+ */
+class ABudgetIsNamedByThePlaceItStopsTest {
+
+    private static final Symbols SYMBOLS = Symbols.none(DefaultStdlib.get());
+    private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
+
+    /**
+     * A collection at the figure is built, and one past it is a composing this stopped.
+     *
+     * <p>Both halves. That the far side names the budget says the name travels; that the near side
+     * names none says the name is the figure being reached and not the shape of the ask.
+     */
+    @Test
+    void aProposalHoldsAsManyElementsAsTheFigureAndNoMore() {
+        int most = CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS.maximum();
+
+        assertEquals(Set.of(),
+                Witnesses.heldBackFor(Type.list(Type.INT), most, SYMBOLS, POLICY),
+                "a collection of exactly as many as a row carries is one this builds");
+        assertEquals(Set.of(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS),
+                Witnesses.heldBackFor(Type.list(Type.INT), most + 1, SYMBOLS, POLICY),
+                "and one past it is this compiler declining, said as the figure it declined at");
+    }
+
+    /** The same of a string, which has a figure of its own and says that one. */
+    @Test
+    void aProposalHoldsAsManyCharactersAsItsOwnFigure() {
+        int most = CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS.maximum();
+
+        assertEquals(Set.of(), Witnesses.heldBackFor(Type.STRING, most, SYMBOLS, POLICY),
+                "a string of exactly as many characters as one is worth building");
+        assertEquals(Set.of(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS),
+                Witnesses.heldBackFor(Type.STRING, most + 1, SYMBOLS, POLICY),
+                "and one past it names the string's figure and not the collection's");
+    }
+
+    /**
+     * A total the figure does reach is composed, and what it did not offer is held back rather than
+     * reported as a composing that was stopped.
+     *
+     * <p>The distinction the account turns on. A budget that cut an offering short after a value
+     * was built took nothing away from the point, so it may not arrive as a point nothing was
+     * composed for.
+     */
+    @Test
+    void aTotalTheFigureReachesIsBuiltAndSaysWhatItHeldBack() {
+        TermRealizations.Realization made = totalOf(4);
+
+        TermRealizations.Realization.Built built = assertInstanceOf(
+                TermRealizations.Realization.Built.class, made,
+                () -> "a container of ones reaches a small total: " + made);
+        assertFalse(built.values().isEmpty(), "and a row can be written from it");
+        assertFalse(built.heldBack().isEmpty(),
+                "the walk offered some of the decompositions and says which figures stopped the"
+                        + " rest, which is not the same news as nothing having been composed");
+    }
+
+    /** Containers of whole numbers adding up to {@code total}. */
+    private static TermRealizations.Realization totalOf(int total) {
+        Type ofWholeNumbers = new Type.ListOf(Type.INT);
+        NumericTerm.TakenOf sum = NumericTerm.TakenOf.of(
+                ValueName.Stdlib.operation("List", "sum"), TermPath.of("ns"), ofWholeNumbers,
+                SYMBOLS);
+        assertNotNull(sum, "a walk that adds up a list of whole numbers is a number of it");
+        TermOrders orders = souther.compiler.inputs.TermOrdersFixtures
+                .at(sum, ofWholeNumbers, SYMBOLS);
+        return TermRealizations.at(ofWholeNumbers, orders, Count.of(total),
+                NothingTheRulesSay.REGION, SYMBOLS, POLICY);
+    }
+
+    /** Every budget the enum names has a figure, and a figure nobody could reach is not one. */
+    @Test
+    void everyBudgetNamesAFigureAWalkCouldReach() {
+        List<String> wrong = new ArrayList<>();
+        for (CompositionBudget each : CompositionBudget.values()) {
+            if (each.maximum() <= 0) {
+                wrong.add(each + " stops at " + each.maximum());
+            }
+        }
+
+        assertEquals(List.of(), wrong, "a budget is how much of a search this compiler will do");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest.java
@@ -1,0 +1,101 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A condition on the way that nothing placed says whether a figure of this compiler's stopped the
+ * placing.
+ *
+ * <p>A row is composed either way, and what the condition costs is that the row was not composed
+ * against it — so this is not a point nothing could be established at, and it is not nothing either.
+ * A reader told only that no value was composed for the condition's positions cannot tell a walk
+ * that tried what it had from one that stopped at a number, and only the second names something
+ * anybody could raise.
+ *
+ * <p>Held here rather than against a model. The walk stops at eight values of a position, and a
+ * model that reaches that has to leave a condition over two positions where the first has more than
+ * eight values the second refuses — which is a model about the arithmetic rather than about this.
+ * At this end the walk is put one either side of its own figure.
+ */
+class AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest {
+
+    /** A position of whole numbers, which is a run wider than the walk looks at. */
+    private static final NumericTerm.FromOnePosition WIDE =
+            new NumericTerm.ValueOf(TermPath.of("p.x"));
+
+    /** A second position the walk has no order for, so nothing it tries at the first leads
+     *  anywhere. */
+    private static final NumericTerm.FromOnePosition NOWHERE =
+            new NumericTerm.ValueOf(TermPath.of("p.y"));
+
+    /**
+     * A walk that ran out of the values it looks at says which figure it stopped at.
+     *
+     * <p>The far side of the line. Every value of the first position leads nowhere, so the walk
+     * tries as many as it looks at and comes back with nothing — and what it comes back with is
+     * that a figure of this compiler's is why, rather than that the positions have no values.
+     */
+    @Test
+    void aWalkThatRanOutOfWhatItLooksAtNamesTheFigure() {
+        NumericWitness.Standing standing = NumericWitness.of(NothingTheRulesSay.REGION,
+                List.of(WIDE, NOWHERE), term -> term == NOWHERE ? null : Carrier.WHOLE);
+
+        assertNull(standing.at(), "the second position has no order, so no pair stands anywhere");
+        assertEquals(Set.of(CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT),
+                standing.stoppedBy(),
+                "and the walk stopped at how many values a position on the way is tried at");
+    }
+
+    /**
+     * A walk that had nothing to try names no figure.
+     *
+     * <p>The near side. A position with no order was never walked, so nothing was cut short — and
+     * saying a figure stopped it would name a budget nobody reached.
+     */
+    @Test
+    void aWalkWithNothingToTryNamesNoFigure() {
+        NumericWitness.Standing standing = NumericWitness.of(NothingTheRulesSay.REGION,
+                List.of(NOWHERE), _ -> null);
+
+        assertNull(standing.at(), "there is nothing for the position to stand on");
+        assertEquals(Set.of(), standing.stoppedBy(),
+                "and nothing was stopped, which is not the same as having been stopped by nothing");
+    }
+
+    /** And a walk that found somewhere for every position says neither. */
+    @Test
+    void aWalkThatFoundSomewhereNamesNoFigure() {
+        NumericWitness.Standing standing = NumericWitness.of(NothingTheRulesSay.REGION,
+                List.of(WIDE), _ -> Carrier.WHOLE);
+
+        assertNotNull(standing.at(), "a whole number stands somewhere in a region nothing narrows");
+        assertTrue(standing.stoppedBy().isEmpty(), "so no figure was reached on the way");
+    }
+
+    /**
+     * What such a walk hands the row's account, which is a condition it was not composed against and
+     * not a point nothing could be established at.
+     */
+    @Test
+    void whatItHandsOverIsAConditionAndNeverAPointNothingWasComposedFor() {
+        ReachabilityGap.Why why = new ReachabilityGap.Why.TheWalkForItsPositionsWasStopped(
+                Set.of(CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT));
+
+        assertEquals(Set.of(CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT),
+                ((ReachabilityGap.Why.TheWalkForItsPositionsWasStopped) why).by(),
+                "the figure travels as itself, so a reader can be told which one to raise");
+    }
+
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest.java
@@ -59,6 +59,37 @@ class AConditionOnTheWayNobodyPlacedSaysWhetherAFigureStoppedItTest {
     }
 
     /**
+     * A run holding exactly as many values as the walk takes names no figure.
+     *
+     * <p>The case the count cannot see. A run of that many and a run this stopped walking come back
+     * the same length, so a walk that recorded the figure on reaching it would report a budget
+     * nobody could raise — this compiler saying it declined to look where there was nothing left to
+     * look at, which is the trade the whole of this is here to stop, made the other way round.
+     *
+     * <p>One either side of it as well, because a rule about one number is met by a constant.
+     */
+    @Test
+    void aRunWalkedToItsEndNamesNoFigureHoweverManyItHeld() {
+        int most = CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT.maximum();
+
+        assertEquals(Set.of(), stoppedByOverARunOf(most - 1),
+                "a run of one fewer than the walk takes is walked to its end");
+        assertEquals(Set.of(), stoppedByOverARunOf(most),
+                "and so is a run of exactly as many, which is what a count cannot tell from a"
+                        + " walk that stopped");
+        assertEquals(Set.of(CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT),
+                stoppedByOverARunOf(most + 1),
+                "one more than it takes is a value the run holds and this did not take");
+    }
+
+    /** What the walk over a run of {@code many} whole numbers stopped at, where every value of it
+     *  leads nowhere. */
+    private static Set<CompositionBudget> stoppedByOverARunOf(int many) {
+        return NumericWitness.of(new ARunOfThisMany(many), List.of(WIDE, NOWHERE),
+                term -> term == NOWHERE ? null : Carrier.WHOLE).stoppedBy();
+    }
+
+    /**
      * A walk that had nothing to try names no figure.
      *
      * <p>The near side. A position with no order was never walked, so nothing was cut short — and

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
@@ -70,7 +70,7 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
         for (BorderAssessment border : measured()) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
-                        && owed.attempt() instanceof ItemAssessment.Attempt.Unresolved unresolved) {
+                        && owed.searches().only() instanceof ItemAssessment.Attempt.Unresolved unresolved) {
                     reasons.add(unresolved.why().reason().toString());
                 }
             });
@@ -88,7 +88,7 @@ class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
         for (BorderAssessment border : measured()) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
-                        && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                        && owed.searches().only() instanceof ItemAssessment.Attempt.Built built) {
                     rows.add(built.row().inputs().stream().map(FixtureTemplate::text).toList()
                             .toString());
                 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
@@ -117,7 +117,7 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
             for (BorderAssessment border : lines(model)) {
                 border.items().forEach((role, item) -> {
                     if (item instanceof ItemAssessment.Owed owed
-                            && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                            && owed.searches().only() instanceof ItemAssessment.Attempt.Built built) {
                         held.check(model, border.label() + " " + border.border().named(role),
                                 written(built.row()));
                     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -225,11 +225,11 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
                 """;
 
         for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
-            assertEquals(owed(pointAt(ON_GUARDS, level)).attempt().getClass(),
-                    owed(pointAt(chained, level)).attempt().getClass(),
+            assertEquals(owed(pointAt(ON_GUARDS, level)).searches().only().getClass(),
+                    owed(pointAt(chained, level)).searches().only().getClass(),
                     "one chain and four guards say the same thing, at " + level);
             assertInstanceOf(ItemAssessment.Attempt.Built.class,
-                    owed(pointAt(chained, level)).attempt(),
+                    owed(pointAt(chained, level)).searches().only(),
                     "and both of them find a row at " + level);
         }
     }
@@ -361,7 +361,7 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     /** The row one point was answered with, where one was built at all. */
     private static ItemAssessment.Attempt.Built built(String source, String level) {
         return assertInstanceOf(ItemAssessment.Attempt.Built.class,
-                owed(pointAt(source, level)).attempt(), "a row was composed at " + level);
+                owed(pointAt(source, level)).searches().only(), "a row was composed at " + level);
     }
 
     /**
@@ -375,7 +375,7 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     void aLevelTheRegionHasAnAnswerAtIsComposed() {
         ItemAssessment.Owed off = owed(pointAt(ON_GUARDS, "x + 2 * y = 17"));
 
-        assertInstanceOf(ItemAssessment.Attempt.Built.class, off.attempt(),
+        assertInstanceOf(ItemAssessment.Attempt.Built.class, off.searches().only(),
                 "a row at the level exists in the region that reaches the guard");
     }
 
@@ -388,8 +388,8 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     @Test
     void whereTheBoundsAreWrittenDoesNotMoveTheAnswer() {
         for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
-            assertEquals(owed(pointAt(ON_TYPES, level)).attempt().getClass(),
-                    owed(pointAt(ON_GUARDS, level)).attempt().getClass(),
+            assertEquals(owed(pointAt(ON_TYPES, level)).searches().only().getClass(),
+                    owed(pointAt(ON_GUARDS, level)).searches().only().getClass(),
                     "the same line over the same region, at " + level);
         }
     }
@@ -404,7 +404,7 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     @Test
     void aRowOfferedForALevelReachesTheGuardThatOwesIt() {
         for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
-            ItemAssessment.Attempt attempt = owed(pointAt(A_GUARD_ABOVE, level)).attempt();
+            ItemAssessment.Attempt attempt = owed(pointAt(A_GUARD_ABOVE, level)).searches().only();
             ItemAssessment.Attempt.Built built = assertInstanceOf(
                     ItemAssessment.Attempt.Built.class, attempt, "a row was composed at " + level);
             assertTrue(largeIn(built.row()) <= 6,
@@ -422,7 +422,7 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
     @Test
     void aRowForALineInsideTheOtherArmStandsWhereThatConditionFails() {
         ItemAssessment.Attempt.Built built = assertInstanceOf(ItemAssessment.Attempt.Built.class,
-                owed(pointAt(INSIDE_THE_OTHER_ARM, "x + 2 * y = 16")).attempt(),
+                owed(pointAt(INSIDE_THE_OTHER_ARM, "x + 2 * y = 16")).searches().only(),
                 "a row at the level exists in the arm the condition fails on");
 
         assertTrue(largeIn(built.row()) <= 6,

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -292,20 +293,25 @@ class ARowIsComposedForAPointOnATotalTest {
     @Test
     void whereNoShapeOfferedIsARowTheSearchSaysItStopped() {
         List<String> said = new ArrayList<>();
+        List<Object> budgets = new ArrayList<>();
         for (BorderAssessment border : lines(MODEL, "noShapeOfferedReachesIt")) {
             if (!border.label().contains("List.sum")) {
                 continue;
             }
             ItemAssessment at = border.at(PointRole.ON);
             if (at instanceof ItemAssessment.Owed owed
-                    && owed.attempt() instanceof ItemAssessment.Attempt.Unresolved why) {
+                    && owed.attempt() instanceof ItemAssessment.Attempt.Stopped why) {
                 said.add(why.why().reason().toString());
+                budgets.add(why.stoppedBy().budgets());
             }
         }
 
         assertEquals(List.of("SEARCH_LIMIT"), said,
                 "two of the decompositions were made and the rest were not, so what a reader is"
                         + " told is that this stopped");
+        assertEquals(List.of(Set.of(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED)), budgets,
+                "and which figure of this compiler's decided it, which is the half of the answer"
+                        + " that says what would have to give for the point to be settled");
         assertEquals(List.of(), otherThanTheAnswer(MODEL + "\nexample noShapeOfferedReachesIt\n"
                         + "    | (Two { xs = [Awkward(2), Awkward(5)] }) -> " + WHATEVER + "\n"),
                 "and the row an author writes for it is one the model holds, which is why the other"

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
@@ -142,7 +142,7 @@ class ARowIsComposedForAPointOnATotalTest {
                 // the one a line is drawn at owes no point off it, which is the order's answer and
                 // was the order's answer before any of this.
                 if (item instanceof ItemAssessment.Owed one
-                        && !(one.attempt() instanceof ItemAssessment.Attempt.Built)) {
+                        && one.searches().rowToOffer().isEmpty()) {
                     owed.add(point);
                 }
             });
@@ -300,7 +300,7 @@ class ARowIsComposedForAPointOnATotalTest {
             }
             ItemAssessment at = border.at(PointRole.ON);
             if (at instanceof ItemAssessment.Owed owed
-                    && owed.attempt() instanceof ItemAssessment.Attempt.Stopped why) {
+                    && owed.searches().only() instanceof ItemAssessment.Attempt.Stopped why) {
                 said.add(why.why().reason().toString());
                 budgets.add(why.stoppedBy().budgets());
             }
@@ -338,7 +338,7 @@ class ARowIsComposedForAPointOnATotalTest {
         for (String behavior : ON_A_TOTAL) {
             forEachPoint(behavior, (point, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
-                        && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                        && owed.searches().only() instanceof ItemAssessment.Attempt.Built built) {
                     held.check(behavior, point, written(built.row()));
                 }
             });

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -244,7 +244,7 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
         for (BorderAssessment border : lines) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
-                        && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                        && owed.searches().only() instanceof ItemAssessment.Attempt.Built built) {
                     rows.put(border.label() + " " + border.border().named(role),
                             as.apply(built.row()));
                 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
@@ -207,7 +207,7 @@ class ARunBoundedAtBothEndsIsLookedInsideTest {
             String model, String border, PointRole role) {
         BorderAssessment at = bordersOf(model).get(border);
         assertNotNull(at, bordersOf(model).keySet().toString());
-        return at.owedAt(role).attempt();
+        return at.owedAt(role).searches().only();
     }
 
     /** The row offered at one point, as a reader would paste it, or null where none was. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunOfThisMany.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunOfThisMany.java
@@ -1,0 +1,52 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.EmptyInput;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.SearchRegion;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A region that leaves every position a run of a given number of whole numbers.
+ *
+ * <p>For putting a walk either side of how many values it takes. What a walk that stopped and a
+ * walk that reached the end of a run come back with is the same list, so the two are told apart by
+ * a run whose width is known and set one either side of the figure.
+ *
+ * @param many how many whole numbers every position of this region runs over
+ */
+record ARunOfThisMany(int many) implements SearchRegion {
+
+    @Override
+    public SearchRegion assuming(NumericDomain.LinearForm<NumericTerm> form,
+                                 NumericDomain.Rel rel) {
+        return this;
+    }
+
+    @Override
+    public SearchRegion given(Map<NumericTerm, Count> fixed) {
+        return this;
+    }
+
+    /**
+     * From nought upward, so that the walk starts inside the run rather than at an end of it.
+     *
+     * <p>Outward from what it starts at is how the walk goes, so a run from nought to {@code many}
+     * gives it {@code many} values above where it starts and none below. Centred instead, the two
+     * directions would each hold half and the figure would be reached at twice the width.
+     */
+    @Override
+    public NumericDomain.Bounds runsBetween(NumericDomain.LinearForm<NumericTerm> form) {
+        return new NumericDomain.Bounds(new Endpoint(Count.of(0), true),
+                new Endpoint(Count.of(many - 1), true));
+    }
+
+    @Override
+    public Optional<EmptyInput> emptiness() {
+        return Optional.empty();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -12,6 +12,8 @@ import souther.compiler.numeric.Count;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -66,9 +68,15 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
         TermRealizations.Realization.Built built =
                 assertInstanceOf(TermRealizations.Realization.Built.class, offering());
 
-        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT, built.heldBack(),
+        assertEquals(Set.of(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
+                        CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
+                        CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED),
+                built.heldBack(),
                 "the walk stopped at the figure with counts left to try, and a reader told every"
                         + " container had been refused would act on a walk that never made them");
+        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+                Generator.UnresolvedCombination.Reason.wordFor(built.heldBack()),
+                "and the word such a walk has always come back with is the one it comes back with");
     }
 
     /** Distinct containers, so the figure is a figure of what a caller has to try. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -192,7 +192,7 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
     }
 
     private static WritabilityKnowledge prevented() {
-        return new WritabilityKnowledge.Prevented(new EstablishmentGap.Observation(
+        return WritabilityKnowledge.Prevented.by(new EstablishmentGap.Observation(
                 EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest.java
@@ -124,7 +124,7 @@ class ARowBuiltAtAPointIsNotUnbuiltByWhatTheObservationKeptTest {
     }
 
     private static ItemAssessment.Attempt attemptAt(int length, PointRole role) {
-        return line(length).owedAt(role).attempt();
+        return line(length).owedAt(role).searches().only();
     }
 
     private static BorderAssessment line(int length) {

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
@@ -77,8 +77,8 @@ class ARowIsLookedForWhereEachReadingOfTheLineIsTest {
         ItemAssessment.Owed on = assertInstanceOf(ItemAssessment.Owed.class,
                 at(searched, "a = 100").get(0).at(PointRole.ON));
         ItemAssessment.Attempt.Built built = assertInstanceOf(
-                ItemAssessment.Attempt.Built.class, on.attempt(),
-                () -> "a row stands at the line under one of the two calls: " + on.attempt());
+                ItemAssessment.Attempt.Built.class, on.searches().rowToOffer().orElseThrow(),
+                () -> "a row stands at the line under one of the two calls: " + on.searches().rowToOffer().orElseThrow());
         List<String> row = built.row().inputs().stream()
                 .map(each -> each.text()).toList();
 

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowIsNotOfferedForAPointItIsNotSeenToStandAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowIsNotOfferedForAPointItIsNotSeenToStandAtTest.java
@@ -78,7 +78,7 @@ class ARowIsNotOfferedForAPointItIsNotSeenToStandAtTest {
         for (ItemAssessment item : owed) {
             ItemAssessment.Attempt.Unresolved no = assertInstanceOf(
                     ItemAssessment.Attempt.Unresolved.class,
-                    ((ItemAssessment.Owed) item).attempt(),
+                    ((ItemAssessment.Owed) item).searches().only(),
                     "nothing composed a row that reaches this point, so none is offered");
             assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                     no.why().reason(),
@@ -93,7 +93,7 @@ class ARowIsNotOfferedForAPointItIsNotSeenToStandAtTest {
         for (ItemAssessment item : pointsOfTheInnerLine()) {
             ItemAssessment.Attempt.Unresolved no = assertInstanceOf(
                     ItemAssessment.Attempt.Unresolved.class,
-                    ((ItemAssessment.Owed) item).attempt());
+                    ((ItemAssessment.Owed) item).searches().only());
             assertFalse(no.way().declined().isEmpty(),
                     "a disjunction states one of two things and this reading says so: "
                             + no.way().onTheWay());

--- a/souther-compiler/src/test/java/souther/compiler/query/ASearchIsAskedForAndAMeasurementIsNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASearchIsAskedForAndAMeasurementIsNotTest.java
@@ -12,7 +12,6 @@ import java.util.TreeSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -121,12 +120,13 @@ class ASearchIsAskedForAndAMeasurementIsNotTest {
                 assertEquals(owed.coverage(), now.coverage(), "what the rows came to");
                 assertEquals(owed.projection(), now.projection(),
                         "what reading the rules established on its own");
-                assertNull(owed.attempt(), "nothing was searched for while measuring");
+                assertFalse(owed.searches().ran(), "nothing was searched for while measuring");
                 if (owed.worthSearching()) {
-                    assertNotNull(now.attempt(), "and a point worth searching was searched");
+                    assertTrue(now.searches().ran(), "and a point worth searching was searched");
                     anySearched = true;
                 } else {
-                    assertNull(now.attempt(), "a point not worth searching was left alone");
+                    assertFalse(now.searches().ran(),
+                            "a point not worth searching was left alone");
                 }
                 // Nothing a search does is evidence against a point, so the grounds can only be
                 // added to. A superset and not a rank: the grounds are not alternatives, so there is

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
@@ -1,0 +1,235 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.Generator;
+import souther.compiler.partition.OnTheWay;
+import souther.compiler.partition.WayToTheBorder;
+import souther.compiler.source.SourceId;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every outcome a search can come to says which of three things it is to an account, and it says it
+ * where the account asks.
+ *
+ * <p>What an account puts to a search is one question: did anything show a row can be written here,
+ * was a showing stopped by a budget of this compiler's, or is there neither. The outcomes are five
+ * and the question has three answers, so the map between them is where a mistake lives — and the
+ * mistake it has made before is an outcome falling to whichever arm a reader wrote last, which
+ * turns this compiler's own limit into the model refusing a row.
+ *
+ * <p><b>The outcomes are enumerated from the type and not from a list here.</b> An outcome added is
+ * one this has no representative for, and what fails is the count rather than a case quietly
+ * getting the answer its neighbour has.
+ */
+class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
+
+    private static final WayToTheBorder WAY = new WayToTheBorder(List.of(
+            new OnTheWay.Declined(Citation.of(new SourcePos(4, 3, new SourceId("m.sou"))),
+                    new OnTheWay.Why.NoWordsForTheShape())));
+
+    /** One of each outcome, by the leaf that names it. */
+    private static Map<Class<?>, ItemAssessment.Attempt> oneOfEach() {
+        Map<Class<?>, ItemAssessment.Attempt> out = new LinkedHashMap<>();
+        for (ItemAssessment.Attempt each : List.of(certified(), unverified(), stopped(),
+                unresolved(), unavailable())) {
+            out.put(each.getClass(), each);
+        }
+        return out;
+    }
+
+    /**
+     * Every outcome the type declares has one here, so what follows is about all of them.
+     *
+     * <p>The first thing this checks and the reason the rest is worth reading. A representative
+     * missing is an outcome nothing below says anything about, and the tests would go on passing
+     * while the account had a case nobody had classified.
+     */
+    @Test
+    void everyOutcomeTheTypeDeclaresHasOneHere() {
+        List<String> declared = new ArrayList<>();
+        for (Class<?> each : ItemAssessment.Attempt.class.getPermittedSubclasses()) {
+            declared.add(each.getSimpleName());
+        }
+        List<String> held = new ArrayList<>();
+        oneOfEach().keySet().forEach(each -> held.add(each.getSimpleName()));
+
+        assertEquals(declared.stream().sorted().toList(), held.stream().sorted().toList(),
+                "an outcome a search can come to and nothing here is a representative of");
+    }
+
+    /**
+     * What each outcome tells an account about a row being writable at the point.
+     *
+     * <p>Read through the capability rather than by naming the leaves: an outcome says whether a
+     * budget of this compiler's stopped it by implementing {@code Prevented}, and this is what that
+     * comes to where the answer is read.
+     */
+    @Test
+    void anOutcomeSaysAShowingWasStoppedExactlyWhereABudgetStoppedIt() {
+        oneOfEach().forEach((leaf, attempt) -> {
+            WritabilityKnowledge knowledge = WritabilityKnowledge.of(nothingShown(),
+                    SearchOutcomes.of(attempt));
+            if (attempt instanceof ItemAssessment.Attempt.Prevented it) {
+                assertEquals(WritabilityKnowledge.Prevented.by(it.by()), knowledge,
+                        () -> leaf.getSimpleName() + " is a showing a budget stopped, and what"
+                                + " stopped it is what it hands over");
+            } else {
+                assertInstanceOf(WritabilityKnowledge.NoEvidence.class, knowledge,
+                        () -> leaf.getSimpleName() + " met no budget on the way to an answer, so"
+                                + " calling it prevented would say this compiler was stopped where"
+                                + " it was not");
+            }
+        });
+    }
+
+    /**
+     * And where that leaves the obligation, which is the whole of what the account is for.
+     *
+     * <p>A point every row was read against and none is at. A budget of this compiler's leaves it
+     * counted and undecided; anything else leaves it out of the count, because nothing has shown
+     * the row an author would be told to write is one that exists.
+     */
+    @Test
+    void aBudgetLeavesTheObligationCountedAndNothingElseDoes() {
+        oneOfEach().forEach((leaf, attempt) -> {
+            ObligationDisposition disposition = ObligationDisposition.of(
+                    new ObligationCoverage.Missed(),
+                    WritabilityKnowledge.of(nothingShown(), SearchOutcomes.of(attempt)));
+            if (attempt instanceof ItemAssessment.Attempt.Prevented) {
+                assertEquals(new ObligationDisposition.Undecided(
+                                EnumSet.of(ObligationDisposition.Uncertainty.WRITABILITY)),
+                        disposition,
+                        () -> leaf.getSimpleName() + " is this compiler being stopped, which is not"
+                                + " the model refusing a row and may not take one out of the count");
+            } else {
+                assertEquals(new ObligationDisposition.NotCounted(
+                                Set.of(ObligationDisposition.Reason.NOT_KNOWN_TO_BE_WRITABLE)),
+                        disposition,
+                        () -> leaf.getSimpleName() + " has shown nothing and was stopped by"
+                                + " nothing, so a row at the point is not work anybody is behind on");
+            }
+        });
+    }
+
+    /**
+     * The order the searches are folded in does not change what the account reads.
+     *
+     * <p>The law a rank cannot satisfy. Two searches of one point stopped by two figures are two
+     * pieces of work and neither stands for the other, so what comes out has to hold both — and
+     * holding both is what makes the answer the same whichever was walked first.
+     */
+    @Test
+    void theOrderTheSearchesAreFoldedInDoesNotChangeTheAnswer() {
+        List<ItemAssessment.Attempt> made =
+                List.of(unresolved(), stopped(), stoppedBy(CompositionBudget.STEPS_A_SEARCH_MAY_TAKE),
+                        unverified());
+
+        WritabilityKnowledge forward = WritabilityKnowledge.of(nothingShown(),
+                new SearchOutcomes(made));
+        WritabilityKnowledge backward = WritabilityKnowledge.of(nothingShown(),
+                new SearchOutcomes(made.reversed()));
+
+        assertEquals(forward, backward, "the searches of one point are a set of facts about it");
+        WritabilityKnowledge.Prevented held = assertInstanceOf(
+                WritabilityKnowledge.Prevented.class, forward);
+        assertEquals(Set.of(new EstablishmentGap.Observation(
+                        EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+                        new EstablishmentGap.Composition(EnumSet.of(
+                                CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS,
+                                CompositionBudget.STEPS_A_SEARCH_MAY_TAKE))),
+                held.by(),
+                "and every figure that would have to give is there, none of them ranked away");
+    }
+
+    /**
+     * Gaps of one kind arriving apart are the same as one gap holding both.
+     *
+     * <p>Which is what makes the law above an equality rather than a set of values that agree. Two
+     * searches each naming one code are the same thing as one naming both, so a reader comparing
+     * two accounts is comparing what was established and not how it arrived.
+     */
+    @Test
+    void howTheGapsWereSplitOnTheWayIsNotSomethingAnAccountHolds() {
+        WritabilityKnowledge apart = new WritabilityKnowledge.Prevented(Set.of(
+                new EstablishmentGap.Observation(EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)),
+                new EstablishmentGap.Observation(EnumSet.of(Incompleteness.Code.VALUE_UNREADABLE))));
+        WritabilityKnowledge together = WritabilityKnowledge.Prevented.by(
+                new EstablishmentGap.Observation(EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED,
+                        Incompleteness.Code.VALUE_UNREADABLE)));
+
+        assertEquals(together, apart,
+                "two observations naming one cause each are one observation naming both");
+    }
+
+    /** A row read back is grounds, and grounds outrank nothing — they answer a different question. */
+    @Test
+    void aRowReadBackIsGroundsWhateverElseWasStopped() {
+        ItemAssessment.Owed owed = new ItemAssessment.Owed(
+                new souther.compiler.partition.Criterion.AtTheLevel(
+                        souther.compiler.partition.Level.ACount.of(1)),
+                new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit()),
+                ItemAssessment.WritabilityProjection.UNPROVEN,
+                new SearchOutcomes(List.of(stopped(), certified())));
+
+        assertTrue(owed.writabilityEvidence().has(
+                        ItemAssessment.WritabilityEvidence.Ground.A_VALUE_WAS_BUILT),
+                "one search read a row back, and no other search takes that back");
+        assertInstanceOf(WritabilityKnowledge.Established.class,
+                WritabilityKnowledge.of(owed.writabilityEvidence(), owed.searches()),
+                "so the point is established, and what stopped the other search is not the answer");
+    }
+
+    private static ItemAssessment.WritabilityEvidence nothingShown() {
+        return new ItemAssessment.WritabilityEvidence(Set.of());
+    }
+
+    private static ItemAssessment.Attempt certified() {
+        return ItemAssessment.Attempt.Built.certified(
+                new Generator.GeneratedRow(new Generator.Purpose.ForAPoint("p.x = 11"), List.of()),
+                WAY);
+    }
+
+    private static ItemAssessment.Attempt unverified() {
+        return new ItemAssessment.Attempt.Unverified(
+                new Generator.GeneratedRow(new Generator.Purpose.ForAPoint("p.x = 11"), List.of()),
+                WAY, List.of(),
+                new EstablishmentGap.Observation(EnumSet.of(Incompleteness.Code.VALUE_TRUNCATED)));
+    }
+
+    private static ItemAssessment.Attempt stopped() {
+        return stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS);
+    }
+
+    private static ItemAssessment.Attempt stoppedBy(CompositionBudget budget) {
+        return new ItemAssessment.Attempt.Stopped(
+                new Generator.UnresolvedCombination(List.of("p.x = 11"),
+                        Generator.UnresolvedCombination.Reason.wordFor(Set.of(budget))),
+                WAY, List.of(), new EstablishmentGap.Composition(EnumSet.of(budget)));
+    }
+
+    private static ItemAssessment.Attempt unresolved() {
+        return new ItemAssessment.Attempt.Unresolved(
+                new Generator.UnresolvedCombination(List.of("p.x = 11"),
+                        Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED), WAY);
+    }
+
+    private static ItemAssessment.Attempt unavailable() {
+        return new ItemAssessment.Attempt.Unavailable(
+                ItemAssessment.Attempt.Reason.NO_CLASSES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
@@ -1,0 +1,143 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.partition.ReadingGap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Putting two searches of one reading together does not change what the debt above them says.
+ *
+ * <p>A line read once and searched twice has to arrive at the gathering as one reading, so the two
+ * measurements are made one. That is a second place where what the rows came to is decided, and the
+ * thing to be afraid of is its parting from the first — a coverage semantics written twice is two
+ * answers about one question, and which of them a reader gets would depend on how many times a
+ * helper happened to be called.
+ *
+ * <p>So what is checked is not a table of cases but the relation between the two: whatever the pair
+ * comes to when the debt reads them apart is what it comes to when the debt reads them folded. Held
+ * as a table, every case anybody thought of would pass and the one nobody thought of is the one the
+ * fold gets wrong.
+ */
+class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
+
+    /** Every measurement a reading of a point can be in, one of each. */
+    private static List<Measurement<ItemAssessment.Coverage>> everyShape() {
+        return List.of(
+                new Measurement.Complete<>(new ItemAssessment.Coverage.Hit()),
+                new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit()),
+                new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), truncated()),
+                new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), truncated()),
+                new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), unreadable()),
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS),
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED),
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED),
+                new Measurement.FailedToMeasure<>(ItemAssessment.Coverage.CouldNotAsk.ARMS_UNREADABLE,
+                        unreadable()));
+    }
+
+    /**
+     * The fold and the debt agree, at every pair there is.
+     *
+     * <p>Every pair and not a chosen few, because the shapes are few enough to walk. What this
+     * refuses is the fold deciding anything: it may only say the debt's answer back.
+     */
+    @Test
+    void whatTheDebtSaysIsTheSameWhicheverWayThePairReachesIt() {
+        List<String> apart = new ArrayList<>();
+        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
+            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
+                ObligationCoverage read = ObligationCoverage.acrossTheReadings(List.of(a, b));
+                ObligationCoverage folded = ObligationCoverage.acrossTheReadings(
+                        List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                if (!read.equals(folded)) {
+                    apart.add(a + " with " + b + ": read " + read + ", folded " + folded);
+                }
+            }
+        }
+
+        assertEquals(List.of(), apart,
+                "a fold of two searches of one reading says what the debt says of the two");
+    }
+
+    /**
+     * And it is the same either way round, so nothing turns on which search was walked first.
+     *
+     * <p>Over the pairs a run can produce. Two readings saying the build asked for nothing and that
+     * it asked for no arms is not one of them — the first is said by every line of a run that
+     * measured nothing, so a reading beside it saying anything else is two runs — and the debt's own
+     * fold keeps whichever of those it saw last. That the fold here says the same is this test's
+     * subject; that the debt does it at all is not, and it is written down where it belongs.
+     */
+    @Test
+    void thePairIsTheSameWhicheverOfThemCameFirst() {
+        List<String> apart = new ArrayList<>();
+        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
+            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
+                if (bothSayNobodyAsked(a, b)) {
+                    continue;
+                }
+                ObligationCoverage one = ObligationCoverage.acrossTheReadings(
+                        List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                ObligationCoverage other = ObligationCoverage.acrossTheReadings(
+                        List.of(ObligationCoverage.acrossOneReadingsSearches(b, a)));
+                if (!one.equals(other)) {
+                    apart.add(a + " with " + b + ": " + one + " one way, " + other + " the other");
+                }
+            }
+        }
+
+        assertEquals(List.of(), apart, "the searches of one reading are a set of facts about it");
+    }
+
+    /**
+     * A row one of them saw is still seen, and what that reading went without is still said.
+     *
+     * <p>The one case where the fold keeps a measurement rather than writing one: a row found by a
+     * reading that could not read everything is found, and what it could not read is a fact of its
+     * own that a canonical answer would drop.
+     */
+    @Test
+    void aRowSeenByAReadingThatWentWithoutSomethingKeepsWhatItWentWithout() {
+        Measurement<ItemAssessment.Coverage> seen =
+                new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), truncated());
+        Measurement<ItemAssessment.Coverage> missed =
+                new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit());
+
+        Measurement<ItemAssessment.Coverage> folded =
+                ObligationCoverage.acrossOneReadingsSearches(seen, missed);
+
+        assertEquals(seen, folded, "the row stands, and so does what the reading that saw it"
+                + " could not read");
+        assertTrue(ObligationCoverage.acrossTheReadings(List.of(folded))
+                        instanceof ObligationCoverage.Witnessed,
+                "and the debt reads it as a row at the point, which is what it is");
+    }
+
+    /** Two readings each saying a question was not put, for two different reasons — which no run
+     *  produces, and which the debt's own fold answers by the one it saw last. */
+    private static boolean bothSayNobodyAsked(Measurement<ItemAssessment.Coverage> a,
+                                              Measurement<ItemAssessment.Coverage> b) {
+        return a instanceof Measurement.NotMeasured<ItemAssessment.Coverage> one
+                && b instanceof Measurement.NotMeasured<ItemAssessment.Coverage> two
+                && one.why() != two.why()
+                && ((ItemAssessment.Coverage.NotAsked) one.why()).mayHideARow()
+                && ((ItemAssessment.Coverage.NotAsked) two.why()).mayHideARow();
+    }
+
+    private static WeakeningSet truncated() {
+        return WeakeningSet.of(new Weakening.BorderValueUnreadable(null,
+                ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)));
+    }
+
+    private static WeakeningSet unreadable() {
+        return WeakeningSet.of(new Weakening.BorderValueUnreadable(null,
+                ReadingGap.of(Incompleteness.Code.VALUE_UNREADABLE)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
@@ -97,24 +97,58 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     }
 
     /**
-     * A row one of them saw is still seen, and what that reading went without is still said.
+     * The folded value is the same value either way round, and not only the same answer.
      *
-     * <p>The one case where the fold keeps a measurement rather than writing one: a row found by a
-     * reading that could not read everything is found, and what it could not read is a fact of its
-     * own that a canonical answer would drop.
+     * <p>The law the projection above does not reach. What the debt says of the pair can be the
+     * same while the measurement the fold writes differs, and the difference is read: a reading's
+     * measurement says what the searches behind it went without, which a report prints. So a fold
+     * that agreed with the debt and kept whichever it saw first would move that sentence with the
+     * order the readings were walked in.
      */
     @Test
-    void aRowSeenByAReadingThatWentWithoutSomethingKeepsWhatItWentWithout() {
+    void thePairIsTheSameValueWhicheverOfThemCameFirst() {
+        List<String> apart = new ArrayList<>();
+        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
+            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
+                if (bothSayNobodyAsked(a, b)) {
+                    continue;
+                }
+                Measurement<ItemAssessment.Coverage> one =
+                        ObligationCoverage.acrossOneReadingsSearches(a, b);
+                Measurement<ItemAssessment.Coverage> other =
+                        ObligationCoverage.acrossOneReadingsSearches(b, a);
+                if (!one.equals(other)) {
+                    apart.add(a + " with " + b + ": " + one + " one way, " + other + " the other");
+                }
+            }
+        }
+
+        assertEquals(List.of(), apart, "the searches of one reading are a set of facts about it");
+    }
+
+    /**
+     * A row one of them saw is still seen, and what both of them went without is said.
+     *
+     * <p>Both, because the measurement is of the reading and the reading is both searches. Kept as
+     * whichever saw the row, what the other could not read would be there or not depending on which
+     * of them saw it — and a reader would be told a reading went without nothing on the strength of
+     * the search that happened to come first.
+     */
+    @Test
+    void aRowSeenByOneSearchKeepsWhatEitherOfThemWentWithout() {
         Measurement<ItemAssessment.Coverage> seen =
                 new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), truncated());
-        Measurement<ItemAssessment.Coverage> missed =
-                new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit());
+        Measurement<ItemAssessment.Coverage> elsewhere =
+                new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), unreadable());
 
         Measurement<ItemAssessment.Coverage> folded =
-                ObligationCoverage.acrossOneReadingsSearches(seen, missed);
+                ObligationCoverage.acrossOneReadingsSearches(seen, elsewhere);
 
-        assertEquals(seen, folded, "the row stands, and so does what the reading that saw it"
-                + " could not read");
+        assertEquals(new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(),
+                        truncated().union(unreadable())),
+                folded,
+                "the row stands, and what either search could not read is what the reading"
+                        + " went without");
         assertTrue(ObligationCoverage.acrossTheReadings(List.of(folded))
                         instanceof ObligationCoverage.Witnessed,
                 "and the debt reads it as a row at the point, which is what it is");

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatShowsARowCanBeWrittenIsASetAndNotAChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatShowsARowCanBeWrittenIsASetAndNotAChoiceTest.java
@@ -98,9 +98,11 @@ class WhatShowsARowCanBeWrittenIsASetAndNotAChoiceTest {
                             + " came to nothing and the reading nobody made leave it out");
             assertEquals(owed.hasRowWitness(), evidence.has(Ground.A_ROW_IS_AT_IT),
                     "the row ground is a row this compilation read standing at the point");
-            assertEquals(owed.attempt() instanceof ItemAssessment.Attempt.Built,
+            assertEquals(owed.searches().each().stream()
+                            .anyMatch(each -> each instanceof ItemAssessment.Attempt.Certified),
                     evidence.has(Ground.A_VALUE_WAS_BUILT),
-                    "and the construction ground is the attempt having built one");
+                    "and the construction ground is a search having built one and read it back"
+                            + " — any of them, since the searches are of the one point");
             assertEquals(!evidence.grounds().isEmpty(), evidence.known(),
                     "known is having a ground, and empty is the whole of what unknown was");
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -321,7 +321,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     }
 
     private static PointResolver.ReadingEvidence searched(ItemAssessment.Attempt attempt) {
-        return new PointResolver.ReadingEvidence.Searched(attempt);
+        return new PointResolver.ReadingEvidence.Searched(SearchOutcomes.of(attempt));
     }
 
     private static ItemAssessment.Attempt built(String carrier) {

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -278,7 +278,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
         PointResolution resolved = PointResolver.resolveAt(
                 new ObligationAssessment(new Criterion.AtTheLevel(Level.ACount.of(1)),
                         new ObligationCoverage.Witnessed(),
-                        ItemAssessment.WritabilityProjection.PROVEN, null),
+                        ItemAssessment.WritabilityProjection.PROVEN, List.of()),
                 List.of(at("anywhere")), _ -> {
                     throw new AssertionError("nothing is searched at a point a row stands at");
                 });
@@ -317,7 +317,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     private static ObligationAssessment owed() {
         return new ObligationAssessment(new Criterion.AtTheLevel(Level.ACount.of(1)),
                 new ObligationCoverage.Missed(),
-                ItemAssessment.WritabilityProjection.PROVEN, null);
+                ItemAssessment.WritabilityProjection.PROVEN, List.of());
     }
 
     private static PointResolver.ReadingEvidence searched(ItemAssessment.Attempt attempt) {

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichReadingComposesTheRowALineIsOwedTest.java
@@ -278,7 +278,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
         PointResolution resolved = PointResolver.resolveAt(
                 new ObligationAssessment(new Criterion.AtTheLevel(Level.ACount.of(1)),
                         new ObligationCoverage.Witnessed(),
-                        ItemAssessment.WritabilityProjection.PROVEN, List.of()),
+                        ItemAssessment.WritabilityProjection.PROVEN, SearchOutcomes.none()),
                 List.of(at("anywhere")), _ -> {
                     throw new AssertionError("nothing is searched at a point a row stands at");
                 });
@@ -317,7 +317,7 @@ class WhichReadingComposesTheRowALineIsOwedTest {
     private static ObligationAssessment owed() {
         return new ObligationAssessment(new Criterion.AtTheLevel(Level.ACount.of(1)),
                 new ObligationCoverage.Missed(),
-                ItemAssessment.WritabilityProjection.PROVEN, List.of());
+                ItemAssessment.WritabilityProjection.PROVEN, SearchOutcomes.none());
     }
 
     private static PointResolver.ReadingEvidence searched(ItemAssessment.Attempt attempt) {


### PR DESCRIPTION
Closes #1232.

A point this compiler declined to compose a value for was reported as a point nothing can write a
row at, and left the count. #1212 wrote the rule this breaks — a budget of this compiler's leaves an
obligation counted and makes no finding — and built the mechanism for one budget, the one an
observation of a composed value runs out of. Every other budget was invisible to it.

## What was wrong

An attempt said whether a row had been built. Every way of coming back without one was a single case
carrying a word, and the word is one of two: one of them is written wherever a walk stops for any
reason at all, and the other says of itself that it bundles "a collection of more elements than a
row is worth carrying" with "a position nothing built a value at". So nothing downstream could tell
a policy of this compiler's from a fact about the model, and the account turned the first into the
second.

The `List.length` model in the issue was one way in. The `List.sum` model below is another, through
a different figure in a different stage, and closing only the first would have left it.

## What is here

**Every figure this compiler stops a search at is named in one place**, with the figure. Fourteen of
them. One is how many ways a total is decomposed, which is read off the walk that has them rather
than written down again.

**Each place that stops records which figure stopped it, where it stops.** Three of them worked it
out afterwards from what was left behind — how many pairings were built against how many there are,
a flag shared by three causes, a queue that is empty for one reason and short for another — and each
now says so at the line that decides not to go on. The word each search comes back with is read off
the budget, so the two cannot part, and never the other way round.

**An attempt is five outcomes with three things that may be true of one.** Whether a row came of it,
whether a search ran, and whether a budget stopped it cut across the outcomes; a value built and not
read back answers two at once. An account asks for the capability and gets a compile error rather
than a silent no when an outcome is added.

**The readings of one point are collected rather than ranked.** A search is made per reading, and
one reading can be searched more than once — a helper called from two arms is one line at one target
composed under two callers' conditions. The rank kept whichever said more about a row, so a search a
budget ended, met beside one that came back empty-handed, was dropped for it. `SearchOutcomes` holds
them all and each reader asks the question it has.

**The report says which figure**, in words a reader can act on, rather than saying a row was built at
a point where none was.

## What it moves

64 obligations across the suite move from `not counted: not known to be writable` to counted and
undecided:

| figure | obligations |
| --- | --- |
| how many elements a proposal holds | 37 |
| how many elements a total is spread over | 27 |
| how many ways a total is decomposed | 27 |

The last two travel together, which is why the rows add to more than 64.

Held back after a value was composed is not the same news and does not touch the account: that
happens about 15,000 times in the suite against 66 stops, which is the difference the split is for.

`ASSIGNMENTS_A_SEARCH_COMPOSES` — the figure in the main search loop — fires ten times and moves
nothing. It is in because the definition of the population is what a budget does and not how often.

## What is measured and what is not

Fired in the suite: the three above, the assignments, the pairings, and how many levels a side is
asked at. Not fired: the characters a proposal holds (measured directly at its figure instead), the
places a pair is tried at, the steps, the progression, the re-reads, the values a position on the
way is tried at (measured directly), and the depth.

No illegal transition was seen: nothing met by a row carries a composition gap, no stop names no
figure, nothing established was weakened.

## Laws

- Every outcome of a search is enumerated from the type, and an outcome with no representative fails
  before the rest is read.
- A budget leaves an obligation counted, and nothing else does.
- Folding the searches of one point in any order is the same answer, and gaps of one kind arriving
  apart are the same as one gap holding both.
- Folding two searches of one reading says what the debt says of the two, at every pair of
  measurements there is.
- A producer put either side of a figure names it on the far side and nothing on the near one.
- The places a figure is reached are counted from the classes and each says what it does with it.
  Written by hand first; the count corrected four entries.

## Left open, with issues

- #1244 — the depth a construction plan descends is a budget nothing carries. It does not stop a
  composing; it returns a plan that is short, and a failure afterwards is reported like any other.
  Its name is in the inventory and its javadoc says nothing carries it.
- #1245 — which reason a debt was not measured for is whichever reading was walked last. Found by
  the fold law here, unreachable in one run, same shape as what this took out.

The reachability channel — a condition on the way a figure stopped the placing of — is wired and
measured at its own figure, and the corpus reaches it nowhere.
