### PR TITLE
Say where a behavior's input is read, rather than reading nothing

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * What the model's own rules say arrives at each place in a behavior's body.
@@ -170,9 +171,14 @@ public final class PathReachability {
      * position and stopping at the business parameters — which is the rule the check that types the
      * body reads them by, asked here rather than worked out a second way. A trailing parameter
      * stands for a behavior this one depends on and guarantees nothing about a value.
+     *
+     * <p><b>The reading is required.</b> What a caller has where a module's could not be made is no
+     * reading, and a walk of a body against one made up says about this compilation having stopped
+     * what it would say about the model. A caller without one measures nothing here.
      */
     public static Answers of(Core body, ReadingPolicy policy, Hir.SpecBehavior spec, Hir.FnDef fn,
                              CoverageSites.Plan plan, InputDomain read, Symbols symbols) {
+        Objects.requireNonNull(read, "a reachability reading is made against an input that was read");
         if (fn == null || spec == null) {
             return Answers.NONE;
         }
@@ -193,6 +199,7 @@ public final class PathReachability {
      */
     public static Answers of(Core body, Scope params, CoverageSites.Plan plan, InputDomain read,
                              Symbols symbols, ReadingPolicy policy) {
+        Objects.requireNonNull(read, "a reachability reading is made against an input that was read");
         if (body == null) {
             return Answers.NONE;
         }
@@ -208,16 +215,12 @@ public final class PathReachability {
                 in = engine.enter(new Core.Read(p.getValue().name(), p.getKey(),
                         p.getValue().type(), body.pos()), in.known(), in.at());
             }
-            // A behavior with no reading reads as one whose declarations leave nothing said, which
-            // is what every question below is answered against. Settled once here, since the walk
-            // and the environment it walks with are both about the same reading.
-            InputDomain of = read == null ? InputDomain.NONE : read;
             PathReachability reading =
-                    new PathReachability(engine, plan, of, symbols, out, arriving);
+                    new PathReachability(engine, plan, read, symbols, out, arriving);
             reading.entry = in.known();
             reading.entered = in.at();
             reading.walk(body, in.known(), in.at(),
-                            InputReads.ofParameters(of.parameterReads(), ElementBindings.NONE),
+                            InputReads.ofParameters(read.parameterReads(), ElementBindings.NONE),
                             List.of(), true);
             walked = true;
         } catch (RuntimeException why) {
@@ -314,7 +317,9 @@ public final class PathReachability {
                                      souther.compiler.reach.ComparisonArrival> arriving) {
         this.engine = engine;
         this.plan = plan;
-        this.read = read;
+        // Here as well as at the ways in, so that nothing inside this class is written against a
+        // reading that might not be one.
+        this.read = Objects.requireNonNull(read);
         this.symbols = symbols;
         this.out = out;
         this.arriving = arriving;

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * What can arrive at each position of one behavior's input, read once.
@@ -111,25 +112,6 @@ public final class InputDomain {
      */
     public record RuleRoot(TermPath at, Type type, RootOpening opening) {}
 
-    /**
-     * A reading with no positions in it.
-     *
-     * <p><b>More than one absence is written down as this, and they are not the same absence.</b> A
-     * {@code >->} composition has no input of its own — what it takes is its first stage's and is
-     * read there — and that is a fact about the behavior. A caller that could not get a reading at
-     * all also substitutes this, and that is a fact about the compile: what such a caller goes on
-     * to measure is an input with no positions, which is what a behavior the model divides nowhere
-     * comes back with.
-     *
-     * <p>The boundary measures no longer do the second ({@code Adequacy.Divided} asks for the
-     * reading and is absent without one). {@code PathReached} still does, through
-     * {@code Adequacy.domainOf}. Until that is closed this constant means the first by intent and
-     * the second by accident, and a reader must not take it for either on its own.
-     */
-    public static final InputDomain NONE =
-            new InputDomain(List.of(), Map.of(), List.of(), List.of(), null, NameReach.NONE,
-                    List.of(), List.of(), List.of());
-
     private final List<Position> positions;
     private final Map<TermPath, Position> byPath;
     private final Map<BindingId, String> read;
@@ -184,8 +166,12 @@ public final class InputDomain {
         this.read = Map.copyOf(read);
         this.parameters = List.copyOf(parameters);
         this.roots = List.copyOf(roots);
-        this.policy = policy;
-        this.reach = reach;
+        // Every one of these is what a walk that ran came back with. A reading is made by walking
+        // an input and no other way, so there is no state of this in which one of them is missing —
+        // and a reader asking how the names in it are read gets the policy it was read under
+        // whatever the walk found.
+        this.policy = Objects.requireNonNull(policy, "a reading is made under a policy");
+        this.reach = Objects.requireNonNull(reach, "a reading says what its names reach");
         Map<TermPath, Position> at = new LinkedHashMap<>();
         // The first reading of a path stands. A path is where a rule and a row meet, so two
         // readings under one path would be the position answering differently depending on which
@@ -300,9 +286,13 @@ public final class InputDomain {
         List<Position> settled = found.stream()
                 .map(each -> shortOfHandedOnRules(each, handoffs.unresolvedAt(each.path())))
                 .toList();
-        return settled.isEmpty() ? NONE
-                : new InputDomain(settled, read, parameters, roots, policy, observed.reach(),
-                        account.placed(), account.clauses(), observed.cases());
+        // Whatever the walk found, including nothing. A behavior declaring no parameters has an
+        // input with no positions in it, and that is a reading that was made rather than one that
+        // was not: it holds the parameters it was given, the policy it was read under and the names
+        // it reached. Answered with a value standing for no reading at all, an input nobody could
+        // read would be the same value as an input there was nothing to read.
+        return new InputDomain(settled, read, parameters, roots, policy, observed.reach(),
+                account.placed(), account.clauses(), observed.cases());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -787,11 +787,6 @@ public final class Adequacy {
                         souther.compiler.check.PathReachability.Answers.NONE);
     }
 
-    private static InputDomain domainOf(Map<String, InputDomain> read, Hir.SpecBehavior spec) {
-        return read == null ? InputDomain.NONE
-                : read.getOrDefault(spec.name(), InputDomain.NONE);
-    }
-
     /**
      * What a row would be written for: the input as it was read, and where the model divides it.
      *
@@ -816,10 +811,18 @@ public final class Adequacy {
         souther.compiler.partition.Partitions.Partitioning divided =
                 db.ask(new Divided(module, spec.name())).value();
         Answer<Symbols> scope = Names.derivedSymbols(db, module);
-        if (divided == null || !scope.present()) {
+        Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(module));
+        if (divided == null || !scope.present() || !sigs.present()) {
             return null;
         }
-        InputDomain domain = domainOf(db.ask(new Inputs(module)).value(), spec);
+        // The reading is the one the classification holds, not one looked up beside it. Both this
+        // and what divides it are about the same behavior of the same module, so there is no pair
+        // to get wrong.
+        if (!(BoundaryForMeasurement.of(sigs.value(), db.ask(new Inputs(module)).value(), spec)
+                instanceof BoundaryForMeasurement.Derived(
+                        Sig _, InputForMeasurement.Local(Hir.SpecBehavior _, InputDomain domain)))) {
+            return null;
+        }
         return souther.compiler.partition.MeasuredInput.of(spec.name(),
                 domain.reading(scope.value()), divided);
     }
@@ -881,11 +884,29 @@ public final class Adequacy {
                                     ? souther.compiler.coverage.DecisionSources.NONE
                                     : checked.decisions(),
                             checked == null ? souther.compiler.coverage.SuppliedRules.NONE : checked.supplied());
+            // Asked here and not above, because this is where one is needed: what a behavior's
+            // boundary came to is asked of the signatures and the readings together, and the
+            // answer above is about there being no places to ask it of. Asked at the way in, a
+            // module whose signatures could not be worked out would stop saying the one thing this
+            // already knows about it.
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!sigs.present()) {
+                return Answer.absent();
+            }
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             Map<String, souther.compiler.check.PathReachability.Answers> out = new LinkedHashMap<>();
             for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
-                if (!(behavior instanceof Hir.SpecBehavior spec)) {
-                    continue;   // a composition has no body of its own, so no places of its own
+                // A composition has no body of its own and so no places of its own, and a behavior
+                // whose input this compilation could not read is one nothing here is measured
+                // against. Both are read off the one classification rather than worked out again:
+                // the other reader of this same walk skipped what it could not read while this one
+                // measured it against an input with no positions, which is the two answering one
+                // question in two places.
+                if (!(BoundaryForMeasurement.of(sigs.value(), readInputs, behavior)
+                        instanceof BoundaryForMeasurement.Derived(
+                                Sig _, InputForMeasurement.Local(Hir.SpecBehavior spec,
+                                        InputDomain read)))) {
+                    continue;
                 }
                 souther.compiler.core.Core body = bodies.get(spec.name());
                 Hir.FnDef fn = db.ask(new Bodies.SettledFn(name, spec.name())).value();
@@ -893,7 +914,7 @@ public final class Adequacy {
                     continue;
                 }
                 out.put(spec.name(), souther.compiler.check.PathReachability.of(
-                        body, db.ask(new Front.Reading()).value(), spec, fn, plan, domainOf(readInputs, spec),
+                        body, db.ask(new Front.Reading()).value(), spec, fn, plan, read,
                         scope.value()));
             }
             return Answer.of(Ordered.map(out));
@@ -1015,7 +1036,7 @@ public final class Adequacy {
 
             @Override
             public souther.compiler.diag.Diagnostic.Builder outsideInputDomain(
-                    souther.compiler.inputs.TermPath position,
+                    TermPath position,
                     souther.compiler.numeric.NumericDomain.Bounds admits,
                     souther.compiler.reach.PathDecision departure) {
                 return said.hint(new DeadBranchMessage.ThePositionStopsShortOfIt(
@@ -1218,13 +1239,10 @@ public final class Adequacy {
                     switch (BoundaryForMeasurement.of(sigs.value(), readInputs, behavior)) {
                         case BoundaryForMeasurement.NotDerived why ->
                                 SignatureEvidence.notMeasurable(behavior, why);
-                        case BoundaryForMeasurement.Derived(Sig sig, InputDomain read) ->
+                        case BoundaryForMeasurement.Derived(Sig sig, InputForMeasurement input) ->
                                 evidenceOf(behavior.name(), sig, scope.value(), asked,
                                         RowReadings.readingFor(byTarget, behavior.name()),
-                                        behavior instanceof Hir.SpecBehavior spec
-                                                ? spec.params().stream().map(Hir.Param::name).toList()
-                                                : List.of(),
-                                        read,
+                                        InputCaseExclusions.of(input),
                                         producing.get(behavior.name()), producingPlan,
                                         reachableArms == null ? NOTHING_PROVEN
                                                 : reachableArms.getOrDefault(behavior.name(),
@@ -1283,16 +1301,18 @@ public final class Adequacy {
             Map<String, souther.compiler.check.StatedContract> declared =
                     db.ask(new Bodies.StatedContracts(name)).value();
 
-            // Whether there is a subject first, and what could be read of it second. The two
-            // questions are asked in that order because a measure that does not apply is owed no
-            // input: a composition is measured at its stages whether or not its own signature
-            // worked out, and answering "the boundary was not derived" for one would be this
-            // measure reporting a prerequisite it never had.
             Map<String, Measure<List<BorderAssessment>>> lines =
                     db.ask(new BoundaryReadings(name)).value();
             if (lines == null) {
                 return Answer.absent();
             }
+            // Whether there is a subject first, and what could be read of it second. The two
+            // questions are asked in that order because a measure that does not apply is owed no
+            // input: a composition is measured at its stages whether or not its own signature
+            // worked out, and answering "the boundary was not derived" for one would be this
+            // measure reporting a prerequisite it never had. Which is a question about the model —
+            // the declaration says what it is — and not about what this compilation produced,
+            // which is the only thing asked below.
             return answerEveryBehavior(prepared.value(), behavior -> {
                 if (!(behavior instanceof Hir.SpecBehavior spec)) {
                     return PartitionEvidence.NONE;   // measured at its stages, not here
@@ -1300,7 +1320,7 @@ public final class Adequacy {
                 return switch (BoundaryForMeasurement.of(sigs.value(), readInputs, spec)) {
                     case BoundaryForMeasurement.NotDerived why ->
                             PartitionEvidence.notMeasurable(why, spec.name());
-                    case BoundaryForMeasurement.Derived(Sig sig, InputDomain _) ->
+                    case BoundaryForMeasurement.Derived(Sig sig, InputForMeasurement _) ->
                             measured(db, name, spec, sig, level, scope.value(),
                                     byTarget, lines.get(spec.name()));
                 };
@@ -1381,21 +1401,24 @@ public final class Adequacy {
                 return Answer.absent();
             }
             Hir.SpecBehavior spec = specOf(prepared.value(), behavior);
-            Sig sig = sigs.value().get(behavior);
-            if (spec == null || sig == null) {
-                // No such behavior here, or one this compilation could not give a signature. Either
-                // way there is nothing to divide, which is not the same as a behavior the model
-                // divides nowhere.
-                return Answer.absent();
+            if (spec == null) {
+                return Answer.absent();   // no such behavior here, or one measured at its stages
             }
             // The reading the measurement is made against, which is what makes it a measurement of
             // this behavior's input rather than of nothing. A module holding a type nobody could
             // name has none, and a measurement made without one divides an input with no positions:
             // what comes back is a partitioning that divides nothing, which is what a behavior
             // whose rules part nothing comes back with. Absent here, so the two are not one answer.
-            Map<String, InputDomain> read = db.ask(new Inputs(name)).value();
-            InputDomain domain = read == null ? null : read.get(spec.name());
-            if (domain == null) {
+            //
+            // Read off the one classification, so that what a missing signature and a missing
+            // reading come to is not worked out again here. Both come back absent, which is this
+            // query's answer surface and not one reason: what has no partitioning has none however
+            // it came to have none, and which prerequisite went missing is said by the measures
+            // that report it.
+            if (!(BoundaryForMeasurement.of(sigs.value(), db.ask(new Inputs(name)).value(), spec)
+                    instanceof BoundaryForMeasurement.Derived(
+                            Sig _, InputForMeasurement.Local(Hir.SpecBehavior _,
+                                    InputDomain domain)))) {
                 return Answer.absent();
             }
             souther.compiler.query.Bodies.Elaborated checked =
@@ -2710,10 +2733,19 @@ public final class Adequacy {
             Map<String, PartitionEvidence> partitions = coverage.value();
 
             Hir.SpecBehavior spec = specOf(prepared.value(), behavior);
-            Sig sig = sigs.value().get(behavior);
             souther.compiler.partition.Partitions.Partitioning divided =
                     db.ask(new Divided(name, behavior)).value();
-            if (spec == null || sig == null || divided == null) {
+            if (spec == null || divided == null) {
+                return Answer.absent();
+            }
+            // What this generation composes against, taken from the one classification of what a
+            // measure of this behavior works from rather than looked up here. A generation that
+            // read the signatures and the readings itself would be deciding a second time what a
+            // missing entry means.
+            if (!(BoundaryForMeasurement.of(sigs.value(), readInputs, spec)
+                    instanceof BoundaryForMeasurement.Derived(
+                            Sig sig, InputForMeasurement.Local(Hir.SpecBehavior _,
+                                    InputDomain read)))) {
                 return Answer.absent();
             }
             // Asked whatever the level is. Somebody asking for the rows is what a generation is,
@@ -2756,7 +2788,7 @@ public final class Adequacy {
                         divided, bodies.get(behavior), plan,
                         RowReadings.readingFor(byTarget, behavior),
                         constructing(db, name),
-                        domainOf(readInputs, spec),
+                        read,
                         runningRowsOf(trialling(db, name),
                                 behavior, sig),
                         levelOf(db).runsInstrumentedRows(),
@@ -4753,31 +4785,6 @@ public final class Adequacy {
     }
 
     /**
-     * The cases of an input the rules refuse, which are the ones no row can be written at.
-     *
-     * <p>Asked of the reading, case by case and by the declaration each case is. Only a refusal
-     * takes a case out: a case the reading could not settle stays counted, because what would take
-     * it out is a proof and not the absence of one — and a case counted where the reading was set
-     * aside is exactly the case nobody could have proven anything about.
-     *
-     * <p>Nothing a body says reaches this. An {@code unreachable} arm is a claim about the same
-     * position, checked against this reading rather than read into it.
-     */
-    private static Set<TypeSymbol> refusedAt(InputDomain read, String parameter,
-                                             Set<TypeSymbol> declared) {
-        if (parameter == null || declared.isEmpty()) {
-            return Set.of();
-        }
-        souther.compiler.inputs.Position at = read.at(TermPath.of(parameter));
-        if (at == null) {
-            return Set.of();   // nothing was read about the position, so nothing is proven about it
-        }
-        return declared.stream()
-                .filter(each -> at.admissionOf(each) instanceof souther.compiler.inputs.Admits.Refused)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
      * The cases the output has to be covered at, which is not quite what a row's expected arm is held
      * against ({@link TypeOps#outputCases}).
      *
@@ -4803,15 +4810,15 @@ public final class Adequacy {
     }
 
     /**
-     * @param parameters the behavior's parameter names, which is how a position this counts is found
-     *                   in the reading of the behavior's input
-     * @param read       what can arrive at each position of the input, which is what decides the
-     *                   denominator here. Not the type's cases alone: a case the rules refuse is one
-     *                   no row can be built at, and counting it holds the model short for ever
+     * @param excluded which of the cases declared at each position the rules refuse, which is what
+     *                 decides the denominator here. Not the type's cases alone: a case the rules
+     *                 refuse is one no row can be built at, and counting it holds the model short
+     *                 for ever. Handed the answer and not the reading it was read off, so that a
+     *                 behavior with no reading of its own has nothing to be handed in its place
      */
     static SignatureEvidence evidenceOf(String name, Sig sig, Symbols symbols, boolean asked,
                                         RowReading seen,
-                                        List<String> parameters, InputDomain read,
+                                        InputCaseExclusions excluded,
                                         souther.compiler.core.Core body,
                                         souther.compiler.coverage.CoverageSites.Plan plan,
                                         souther.compiler.check.PathReachability.Answers.AsRun reachable) {
@@ -4839,8 +4846,7 @@ public final class Adequacy {
             inSpecified.add(new LinkedHashSet<>());
             inExecuted.add(new LinkedHashSet<>());
             inVerified.add(new LinkedHashSet<>());
-            inExcluded.add(refusedAt(read, i < parameters.size() ? parameters.get(i) : null,
-                    declared));
+            inExcluded.add(excluded.at(i, declared));
         }
 
         // What the model declares is settled above and holds whether or not anybody measured; what

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -20,6 +20,7 @@ import souther.compiler.check.HelperGraph;
 import souther.compiler.check.HelperNames;
 import souther.compiler.check.HelperTable;
 import souther.compiler.check.InjectionSigs;
+import souther.compiler.inputs.InputDomain;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
 import souther.compiler.check.Lower;
@@ -1998,9 +1999,10 @@ public final class Bodies {
             souther.compiler.coverage.DecisionSources decisions, souther.compiler.coverage.SuppliedRules supplied) {
         ReadingPolicy policy = db.ask(new Front.Reading()).value();
         Answer<Symbols> scope = Names.derivedSymbols(db, module);
-        Answer<Map<String, souther.compiler.inputs.InputDomain>> inputs =
+        Answer<Map<String, InputDomain>> inputs =
                 db.ask(new souther.compiler.query.Adequacy.Inputs(module));
-        if (!scope.present() || !inputs.present()) {
+        Answer<Map<String, Sig>> sigs = db.ask(new Signatures(module));
+        if (!scope.present() || !inputs.present() || !sigs.present()) {
             return Map.of();
         }
         // The same numbering every measure is taken over, so a claim and the reading that judges it
@@ -2013,17 +2015,24 @@ public final class Bodies {
                 souther.compiler.coverage.CoverageSites.of(bodies, decisions, supplied);
         Map<String, souther.compiler.claims.Claims> out = new LinkedHashMap<>();
         for (Hir.BehaviorDef behavior : settled.behaviors()) {
-            souther.compiler.inputs.InputDomain read = inputs.value().get(behavior.name());
             Core body = bodies.get(behavior.name());
-            if (!(behavior instanceof Hir.SpecBehavior) || read == null || body == null) {
+            // What this compilation worked out about the behavior's boundary, read off the one
+            // classification. A composition has no body of its own and a behavior whose input was
+            // not read has nothing for a claim to be judged against; both come back as no local
+            // reading, and neither is decided here — the other reader of this same walk decides it
+            // from the same value.
+            if (body == null
+                    || !(BoundaryForMeasurement.of(sigs.value(), inputs.value(), behavior)
+                    instanceof BoundaryForMeasurement.Derived(
+                            Sig _, InputForMeasurement.Local(
+                                    Hir.SpecBehavior spec, InputDomain read)))) {
                 continue;
             }
-            Hir.FnDef fn = db.ask(new SettledFn(module, behavior.name())).value();
-            out.put(behavior.name(), souther.compiler.claims.Claims.of(
+            Hir.FnDef fn = db.ask(new SettledFn(module, spec.name())).value();
+            out.put(spec.name(), souther.compiler.claims.Claims.of(
                     souther.compiler.claims.UnreachableClaims.of(body, read, scope.value(), plan),
                     souther.compiler.check.PathReachability.of(
-                            body, policy, (Hir.SpecBehavior) behavior, fn, plan, read,
-                            scope.value())));
+                            body, policy, spec, fn, plan, read, scope.value())));
         }
         // In the order the module declares them, which is the order a reader meets the diagnostics
         // these carry. `Map.copyOf` keeps the entries and not the order (see `Ordered`), so a
@@ -2035,7 +2044,7 @@ public final class Bodies {
      *  than judged again: what refuses a build and what a report prints are one answer. */
     private static List<Report> contradicted(Db db, String module,
                                              Map<String, souther.compiler.claims.Claims> claims) {
-        Answer<Map<String, souther.compiler.inputs.InputDomain>> inputs =
+        Answer<Map<String, InputDomain>> inputs =
                 db.ask(new souther.compiler.query.Adequacy.Inputs(module));
         if (!inputs.present()) {
             return List.of();

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
@@ -1,19 +1,25 @@
 package souther.compiler.query;
 
+import souther.compiler.ast.Hir;
 import souther.compiler.check.Sig;
 import souther.compiler.inputs.InputDomain;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * What a measure of one behavior has to work from at its boundary, or which part of it is missing.
  *
- * <p>Two things and not one. A signature says what the behavior takes and answers with, and a
- * reading of the input says where its positions are and what the rules leave the numbers at them.
- * A measure that reads the boundary needs both, and they go missing for different reasons: a
- * declaration resting on a name nothing resolved has no signature, and a module holding a type
- * nobody could name has no reading of what any of its behaviors take. A behavior can have the
- * first and not the second.
+ * <p>A signature, and where what the behavior takes is read. The signature says what it takes and
+ * answers with; where its input is read is {@link InputForMeasurement} — here, as a reading whose
+ * positions and numbers a measure goes on to ask about, or at its stages for a {@code >->}
+ * composition. So a boundary that was worked out always has a signature, and holds a reading only
+ * where the behavior has an input of its own.
+ *
+ * <p>They go missing for different reasons, which is why {@link NotDerived} has two: a declaration
+ * resting on a name nothing resolved has no signature, and a module holding a type nobody could
+ * name has no reading of what any of its behaviors take. A behavior can have the first and not the
+ * second.
  *
  * <p>What is not an analysis's to say is what a report should do about either. Read straight, the
  * absence is a key a measure can skip — which is what both measures of a behavior's boundary did,
@@ -28,28 +34,33 @@ import java.util.Map;
 public sealed interface BoundaryForMeasurement {
 
     /**
-     * The boundary a measure works from: what the behavior declares, and the input as it was read.
+     * The boundary a measure works from: what the behavior declares, and where what it takes is
+     * read.
      *
-     * <p>Both, because a measure that reads one reads the other. Handed the signature alone, a
-     * reader that needed the reading took it from a map that may not hold one and read the absence
-     * as an input with no positions — which measures as an input the model divides nowhere.
+     * <p>The second because of what happened without it. Handed the signature alone, a reader that
+     * needed the reading took it from a map that may not hold one and read the absence as an input
+     * with no positions — which measures as an input the model divides nowhere. Here a measure is
+     * told where what the behavior takes is read, and a behavior whose reading could not be made is
+     * not one of these at all.
      *
-     * @param inputs {@link InputDomain#NONE} for a behavior with no input of its own, which is a
-     *               {@code >->} composition: what it takes is its first stage's and is read there
+     * @param input where what this behavior takes is read ({@link InputForMeasurement}), which is
+     *              here for a declared behavior and at its stages for a composition. A boundary
+     *              this compilation could not work out is not one of these
      */
-    record Derived(Sig sig, InputDomain inputs) implements BoundaryForMeasurement {
+    record Derived(Sig sig, InputForMeasurement input) implements BoundaryForMeasurement {
 
         public Derived {
-            java.util.Objects.requireNonNull(sig, "a derived boundary is a signature");
-            java.util.Objects.requireNonNull(inputs, "a derived boundary is an input that was read");
+            Objects.requireNonNull(sig, "a derived boundary is a signature");
+            Objects.requireNonNull(input, "a derived boundary says where its input is read");
         }
     }
 
     /**
-     * One of the two is missing, so nothing that reads the boundary could be measured.
+     * The signature, or a reading this behavior was owed, is missing — so nothing that reads the
+     * boundary could be measured.
      *
      * <p>A {@link FailureReason} as well as an arm, because it is both: the fact a measure holds
-     * about its input, and the word every measure short of that input has no number for.
+     * about its boundary, and the word every measure short of it has no number for.
      */
     enum NotDerived implements BoundaryForMeasurement, FailureReason {
 
@@ -98,22 +109,40 @@ public sealed interface BoundaryForMeasurement {
      *
      * <p>Asked of the declaration rather than of the name, because only a declaration says whether
      * this behavior has an input of its own to read. A {@code >->} composition takes what its first
-     * stage takes and is read there, so having no reading here is what it is rather than a reading
-     * that was refused — and told apart by the name alone, every composition in the module reads as
-     * a behavior whose input nobody could read.
+     * stage takes and is read there, which is what {@link InputForMeasurement.AtStages} says — told
+     * apart by the name alone, every composition in the module reads as a behavior whose input
+     * nobody could read.
+     *
+     * <p><b>The one place a behavior is put in one of these states.</b> A measure that worked it out
+     * again from the signatures, the kind of the declaration and a lookup that may miss would be
+     * deciding a second time what a missing entry means, and the two decisions moved apart: of the
+     * two readers of one reachability walk, one skipped a behavior whose input was not read and the
+     * other measured it against an input with no positions.
+     *
+     * <p><b>Three steps, in this order.</b> A signature is asked for first, and without one there is
+     * no boundary whatever the behavior is. With one in hand the declaration says whether a reading
+     * of an input of its own is owed at all — a composition's is its first stage's — and only where
+     * one is owed is its presence asked about. Taken in the other order, a module whose reading
+     * could not be made would report every composition in it as a behavior whose input nobody could
+     * read.
+     *
+     * <p>Which is not the question of whether a measure applies to this behavior. That one is the
+     * declaration's, asked by each measure that has a subject to choose; what is answered here is
+     * what this compilation worked out.
      */
     static BoundaryForMeasurement of(Map<String, Sig> signatures,
                                      Map<String, InputDomain> read,
-                                     souther.compiler.ast.Hir.BehaviorDef behavior) {
+                                     Hir.BehaviorDef behavior) {
         Sig sig = signatures.get(behavior.name());
         if (sig == null) {
             return NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED;
         }
-        if (!(behavior instanceof souther.compiler.ast.Hir.SpecBehavior)) {
-            return new Derived(sig, InputDomain.NONE);   // its input is its first stage's
+        if (!(behavior instanceof Hir.SpecBehavior spec)) {
+            return new Derived(sig, InputForMeasurement.AtStages.INSTANCE);
         }
-        InputDomain inputs = read == null ? null : read.get(behavior.name());
-        return inputs == null ? NotDerived.BEHAVIOR_INPUT_NOT_READ : new Derived(sig, inputs);
+        InputDomain inputs = read == null ? null : read.get(spec.name());
+        return inputs == null ? NotDerived.BEHAVIOR_INPUT_NOT_READ
+                : new Derived(sig, new InputForMeasurement.Local(spec, inputs));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/InputCaseExclusions.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/InputCaseExclusions.java
@@ -1,0 +1,82 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.inputs.Admits;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.inputs.Position;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Which of the cases declared at an input position no row can be written at.
+ *
+ * <p>The one thing a count of what the rows cover takes from a reading of the input, asked here so
+ * that the count itself never holds one. A measure handed the reading would need one for a
+ * behavior that has no reading to be handed — and what it would be given is an input with no
+ * positions, which answers "nothing is refused" while saying it read something.
+ *
+ * <p>Only a refusal takes a case out. A case the reading could not settle stays counted, because
+ * what takes it out is a proof and not the absence of one.
+ */
+public sealed interface InputCaseExclusions {
+
+    /**
+     * The cases at {@code position} the rules refuse, out of the ones {@code declared} there.
+     *
+     * @param position which input position, counted as the signature declares them
+     * @param declared the cases that position's type has, which is what these are taken out of
+     */
+    Set<TypeSymbol> at(int position, Set<TypeSymbol> declared);
+
+    /** What the rules of one behavior's own input refuse, read off the reading of it. */
+    static InputCaseExclusions of(InputForMeasurement input) {
+        return switch (input) {
+            case InputForMeasurement.Local(Hir.SpecBehavior spec, InputDomain read) ->
+                    new AsTheRulesRefuse(spec, read);
+            // A composition has no positions of its own to refuse anything at: what it takes is its
+            // first stage's, and a case refused there is refused where that stage is measured.
+            case InputForMeasurement.AtStages _ -> NothingIsRefusedHere.INSTANCE;
+        };
+    }
+
+    /**
+     * Read off the reading, case by case and by the declaration each case is.
+     *
+     * <p>Which position a case is asked about is the parameter's name, which is how the reading
+     * files what it read. The two come from one declaration, so there is no pairing to get wrong.
+     */
+    record AsTheRulesRefuse(Hir.SpecBehavior spec, InputDomain read) implements InputCaseExclusions {
+
+        @Override
+        public Set<TypeSymbol> at(int position, Set<TypeSymbol> declared) {
+            // Counted as the signature lists them, and named as the declaration writes them, which
+            // are two lists that need not be the same length. A position past the names has none
+            // to ask the reading about, and nothing is proven about a position nobody asked about.
+            if (declared.isEmpty() || position >= spec.params().size()) {
+                return Set.of();
+            }
+            Position stands = read.at(TermPath.of(spec.params().get(position).name()));
+            if (stands == null) {
+                return Set.of();   // nothing was read about the position, so nothing is proven of it
+            }
+            return declared.stream()
+                    .filter(each -> stands.admissionOf(each) instanceof Admits.Refused)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+    }
+
+    /** No case is refused, because there are no rules here to refuse one. */
+    enum NothingIsRefusedHere implements InputCaseExclusions {
+
+        INSTANCE;
+
+        @Override
+        public Set<TypeSymbol> at(int position, Set<TypeSymbol> declared) {
+            return Set.of();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/InputForMeasurement.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/InputForMeasurement.java
@@ -1,0 +1,54 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.inputs.InputDomain;
+
+import java.util.Objects;
+
+/**
+ * Where a measure of one behavior reads what that behavior takes.
+ *
+ * <p>Two places and not two outcomes. A declared behavior takes an input of its own and it is read
+ * here; a {@code >->} composition takes what its first stage takes and is measured there. Both are
+ * facts about the behavior, settled by its declaration, and neither is a measurement that could not
+ * be made — what this compilation failed to work out is {@link BoundaryForMeasurement.NotDerived}
+ * and lives on the other side of the boundary.
+ *
+ * <p>Which is why this is inside {@link BoundaryForMeasurement.Derived} rather than beside it. Held
+ * as a third state of the boundary, a reader asking whether the boundary was worked out would write
+ * {@code instanceof Derived} and leave a composition out of an answer it belongs in — the two are
+ * different questions, and only one of them is about this compilation.
+ */
+public sealed interface InputForMeasurement {
+
+    /**
+     * The behavior's own input, as it was read.
+     *
+     * <p>The declaration and the reading together, because the reading is of that declaration and
+     * of no other. Handed the reading alone, a reader that needed to know whose positions these are
+     * would go back to the behavior it started from and pair the two a second time — and two
+     * behaviors with a parameter spelled the same way is all it takes for the second pairing to
+     * differ from the first.
+     *
+     * @param spec the declaration these positions were read from, which is what says the behavior
+     *             has an input of its own at all
+     */
+    record Local(Hir.SpecBehavior spec, InputDomain domain) implements InputForMeasurement {
+
+        public Local {
+            Objects.requireNonNull(spec, "a local input is read from a declaration");
+            Objects.requireNonNull(domain, "a local input is an input that was read");
+        }
+    }
+
+    /**
+     * The behavior takes what its first stage takes, so what it takes is measured there.
+     *
+     * <p>No reading here and none owed: a composition names its stages and each of them is a
+     * behavior of its own with its own positions. Said as what it is rather than as an input with
+     * no positions, which is what a behavior the model divides nowhere comes back with.
+     */
+    enum AtStages implements InputForMeasurement {
+        INSTANCE
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AReadingWithNoPositionsIsStillAReadingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AReadingWithNoPositionsIsStillAReadingTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * A walk that found no positions comes back with a reading, and not with the absence of one.
+ *
+ * <p>Which is what tells the two apart everywhere else. A reading is made by walking what a
+ * behavior takes, so what it found is what the input has; a caller that could not get one has
+ * nothing, and there is no value of this type for it to answer with. Written down as one value
+ * they were the same answer, and a behavior nobody could read the input of measured as an input
+ * the model divides nowhere.
+ *
+ * <p>So this holds the empty one to being a reading: it says how its names are read and what it
+ * was made of, the way one that found ten positions does.
+ */
+class AReadingWithNoPositionsIsStillAReadingTest {
+
+    private static final String MODEL = """
+            module example.nothing
+
+            data Size = Int
+
+            behavior size : (n: Size) -> Size
+            let size (n) = n
+            """;
+
+    private static Symbols symbols() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    /** Nothing to walk is not nothing walked. */
+    @Test
+    void aWalkOverNoParametersIsAReadingOfAnInputWithNoPositions() {
+        ReadingPolicy policy = ReadAs.THE_COMPILATION_DOES;
+        InputDomain read = InputDomain.of(List.of(), symbols(), policy);
+
+        assertNotNull(read, "a walk answers with a reading");
+        assertEquals(List.of(), read.positions(), "and it found no positions");
+        assertEquals(List.of(), read.parameters(), "because it was given no parameters");
+        assertNull(read.at(TermPath.of("n")),
+                "so it has no position anywhere, which is its own answer and not a missing one");
+    }
+
+    /**
+     * And it answers what it was read under.
+     *
+     * <p>The half a shared empty value could not hold. Standing for every absence at once it
+     * belonged to no compile, so it had no policy to give, and a reader asking how the names in it
+     * are read got nothing back.
+     */
+    @Test
+    void andItSaysHowItsNamesAreRead() {
+        ReadingPolicy policy = ReadAs.THE_COMPILATION_DOES;
+
+        assertSame(policy, InputDomain.of(List.of(), symbols(), policy).policy());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NothingThatWalksATreeNamesTheReadingOfTheInputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NothingThatWalksATreeNamesTheReadingOfTheInputTest.java
@@ -415,7 +415,11 @@ class NothingThatWalksATreeNamesTheReadingOfTheInputTest {
 
     private static final class InAMemberType {
         static Object taken() {
-            return InputDomain.NONE.positions();
+            // The call is what puts a member of the reading in this class file, which is what is
+            // being witnessed. A reading is made by walking an input and there is none to walk
+            // here, so the call is written and not made.
+            InputDomain read = null;
+            return read == null ? List.of() : read.positions();
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/WhereAMeasureReadsWhatABehaviorTakesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhereAMeasureReadsWhatABehaviorTakesTest.java
@@ -1,0 +1,136 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.inputs.InputDomain;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Where what a behavior takes is read is the boundary's answer, and a composition's is at its
+ * stages.
+ *
+ * <p>Two behaviors of one module, and the difference between them is not that one of them could
+ * not be read. {@code issue} takes an input of its own and it is read here; {@code whole} takes
+ * what its first stage takes and is measured there. Both have a signature and both are measured,
+ * so neither is short of anything.
+ *
+ * <p>Which is the thing an input with no positions could not say. Handed one for the composition,
+ * every measure that reads the boundary was told the model divides it nowhere — the same answer a
+ * behavior whose rules part nothing gets, and the same answer a behavior nobody could read the
+ * input of got.
+ */
+class WhereAMeasureReadsWhatABehaviorTakesTest {
+
+    private static final String MODULE = "example.stages";
+
+    private static final String MODEL = """
+            module example.stages
+
+            data Amount = Int
+                invariant value >= 0
+            data Invoice = { amount: Amount }
+            data Receipt = { n: Int }
+
+            behavior issue : (a: Amount) -> Invoice
+                constructs Invoice
+            let issue (a) = Invoice { amount = a }
+
+            behavior receipt : (i: Invoice) -> Receipt
+                constructs Receipt
+            let receipt (i) = Receipt { n = 1 }
+
+            behavior whole = issue >-> receipt
+            """;
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static Hir.BehaviorDef declared(Compilation compilation, String name) {
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(MODULE)).value();
+        assertNotNull(prepared, "the model under test compiles");
+        return prepared.behaviors().stream().filter(each -> each.name().equals(name))
+                .findFirst().orElseThrow();
+    }
+
+    private static BoundaryForMeasurement boundaryOf(Compilation compilation, String name) {
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(MODULE)).value();
+        Map<String, InputDomain> read = compilation.db().ask(new Adequacy.Inputs(MODULE)).value();
+        assertNotNull(sigs, "the signatures answered");
+        assertNotNull(read, "and so did the reading of what the behaviors take");
+        return BoundaryForMeasurement.of(sigs, read, declared(compilation, name));
+    }
+
+    /** A declared behavior's input is read here, and the reading is the one the module made. */
+    @Test
+    void aDeclaredBehaviorsInputIsReadWhereItIsDeclared() {
+        Compilation compilation = measured();
+        InputDomain read =
+                compilation.db().ask(new Adequacy.Inputs(MODULE)).value().get("issue");
+
+        BoundaryForMeasurement.Derived derived = assertInstanceOf(
+                BoundaryForMeasurement.Derived.class, boundaryOf(compilation, "issue"));
+        InputForMeasurement.Local local =
+                assertInstanceOf(InputForMeasurement.Local.class, derived.input());
+
+        assertEquals("issue", local.spec().name(),
+                "the reading is paired with the declaration it was read from");
+        assertSame(read, local.domain(), "and it is the module's reading, not one made beside it");
+    }
+
+    /**
+     * A composition has no reading of its own, and that is what it says.
+     *
+     * <p>Not an input with no positions. The reading of the module holds no entry for it — there
+     * was nothing to walk — and what a measure is told is where the input is, so nothing here is
+     * an answer about what the model does or does not divide.
+     */
+    @Test
+    void aCompositionIsMeasuredAtItsStages() {
+        Compilation compilation = measured();
+
+        assertNull(compilation.db().ask(new Adequacy.Inputs(MODULE)).value().get("whole"),
+                "nothing walked an input of the composition's own");
+
+        BoundaryForMeasurement.Derived derived = assertInstanceOf(
+                BoundaryForMeasurement.Derived.class, boundaryOf(compilation, "whole"),
+                "its signature was worked out, so its boundary was");
+        assertSame(InputForMeasurement.AtStages.INSTANCE, derived.input());
+    }
+
+    /**
+     * And what the signature measure takes from a reading, it does not take from the composition.
+     *
+     * <p>The one thing that count reads off an input is which declared cases the rules refuse. A
+     * composition has no positions of its own to refuse anything at, which is an answer this makes
+     * without a reading — asked for one it would have to be handed an empty one, and the count
+     * would be reading "nothing is refused" off a reading that read nothing.
+     */
+    @Test
+    void andACompositionIsCountedWithoutOne() {
+        Compilation compilation = measured();
+
+        assertSame(InputCaseExclusions.NothingIsRefusedHere.INSTANCE,
+                InputCaseExclusions.of(InputForMeasurement.AtStages.INSTANCE));
+
+        Adequacy.SignatureEvidence signature = compilation.db()
+                .ask(new Adequacy.Witnesses(MODULE)).value().get("whole");
+        assertNotNull(signature, "the signature measure answered for the composition");
+        assertFalse(signature.notMeasurable(),
+                "and it is a measure that was made, not one short of its boundary");
+    }
+}


### PR DESCRIPTION
Closes #1257.

`InputDomain.NONE` stood for three unlike things: a `>->` composition that
has no input of its own, a caller that could not get a reading at all, and a
walk that was handed no parameters. The second was the one #1257 names, and
`Adequacy.domainOf` made it — so `PathReached` read a module whose reading
could not be made as an input the model divides nowhere, while `Bodies`, the
other caller of that same reachability walk, skipped such a behavior. One
question, two places, two answers.

## What this does

**A reading is made by walking an input and no other way.** The constant is
gone. `InputDomain.of` answers with what the walk found whatever that is, so a
behavior declaring no parameters gets a reading with no positions in it, which
holds its parameters, the policy it was read under and the names it reached.
`policy()` is no longer nullable.

**Where an input is read is the boundary's answer.**
`BoundaryForMeasurement.Derived` carries an `InputForMeasurement`: `Local`,
which pairs the declaration with the reading made from it, or `AtStages` for a
composition. What this compile could not work out stays outside that, as the
two `NotDerived` reasons — so it is not possible to ask whether the boundary
was derived and leave a composition out of the answer, and `behavior_input_not_read`
goes on being published as it was.

**One classification, read by everyone who faces a missing reading.** The
reachability walk's two callers, `Divided`, the subject a row is written for
and the generation all read `BoundaryForMeasurement.of` rather than working out
again what a missing entry means. `PathReachability` requires a reading and
substitutes none, at both ways in and at the constructor.

**The count of what the rows cover no longer holds a reading.** The one thing
it took from one is which declared cases the rules refuse, which is now handed
to it as `InputCaseExclusions`. A composition refuses none of its own, said
without a reading to say it with — which is what would otherwise have wanted an
empty one built by hand.

## What this leaves alone

Which measure a behavior is the subject of is each measure's own question,
asked of the declaration. A composition is measured at its stages whether or
not its own signature worked out, so the partition and boundary measures go on
answering `no subject` for one and the signature measure goes on reporting
`behavior_boundary_not_derived`. Those three deliberately disagree, and
`ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest` holds them apart.

## What was measured

No input reaches the state #1257 describes. A module holding a name nothing
resolved has no elaborated bodies, so `PathReached` already returned before
reaching the substitution. This is a change to what can be represented, not to
what any compile reports; the suite is green throughout.

Two tests are added: that a walk over no parameters comes back with a reading
that says how its names are read, and that a declared behavior's input is read
where it is declared while a composition's is at its stages and is counted
without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
