### PR TITLE
A narrowing is made from what settles it, never from the case's name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -21,12 +21,15 @@ import java.util.Set;
  * that is an answer rather than a failure — what a reader does about a subject it cannot open is the
  * reader's ({@code E1202} for a {@code match}).
  *
- * <p>Everything a later stage needs to know about a case is on the {@link CaseSelector}: what to
- * test, and what the value is once the test answers. So a reader never asks the subject a second
- * time. That is the rule this type exists to keep — the backend used to re-derive optional-ness,
- * arity and or-pattern-ness while emitting, which is what {@code Core}'s own contract says it must
- * not do.
- *
+ * <p>What a case comes to is settled here and never asked of the subject again. Two halves of it,
+ * and they go to different readers. What to test and what the value is once the test answers is the
+ * {@link CaseSelector}, which says that much wherever it is written and is what a backend emits.
+ * What selecting the case <em>covers</em> is a fact about the declarations this compile read, and
+ * it is the half a later stage cannot work out for itself — so {@link ResolvedCase} is the pair,
+ * and it is the pair that crosses into {@code Core}. That is the rule this type exists to keep: the
+ * backend used to re-derive optional-ness, arity and or-pattern-ness while emitting, and the
+ * readings of an input used to re-derive which distinction an arm picked from its name, which one
+ * name over several leaves cannot say (#1252).
  */
 sealed interface CaseSpace {
 
@@ -242,10 +245,10 @@ sealed interface CaseSpace {
      * compile read — so it is answered here, where they are, and the value carries no way of asking
      * again.
      *
-     * <p>Also where a selector that came back from {@code Core} is made whole again. A pass reading
-     * an elaborated arm has the selector and not what it covers — {@code Core} carries nothing about
-     * the program around it — and asking here is that pass crossing back into this one rather than
-     * a second reading.
+     * <p>Also where a caller holding a selector alone gets the pair. An elaborated arm carries the
+     * resolution already, so a reader of {@code Core} asks the arm and not this; what comes here is
+     * a selector built somewhere with no arm around it, and asking is that caller crossing into
+     * this pass rather than reading the declarations a second time.
      */
     static ResolvedCase resolve(CaseSelector selector, Symbols symbols) {
         return ResolvedCase.of(selector, covers(selector, symbols));

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -106,7 +106,6 @@ public final class MatchElaborator {
         Type branchType = null;
         for (int armIndex = 0; armIndex < m.cases().size(); armIndex++) {
             Hir.Case c = m.cases().get(armIndex);
-            List<CaseSelector> selected = new ArrayList<>();
             List<TypeSymbol> answersFor = new ArrayList<>();
             List<ResolvedCase> alternatives = new ArrayList<>();
             for (Hir.Name written : c.caseTypes()) {
@@ -117,10 +116,6 @@ public final class MatchElaborator {
                 }
                 alternatives.add(resolved);
                 answersFor.addAll(resolved.atoms());
-                // What goes into the arm is the selector. An arm is emitted from what it tests
-                // and reads, which is all of a case that survives into `Core`; what it covers is
-                // this pass's to hold and is not carried past it.
-                selected.add(resolved.selector());
             }
             // What the arm's own alternatives say about each other, before what they say about the
             // arms before them. An alternative that adds nothing is a mistake inside this arm, and
@@ -148,9 +143,13 @@ public final class MatchElaborator {
                         .say(new MatchMessage.MatchedByMoreThanOneCase(overlap.value().name()))
                         .build());
             }
-            Core.ResolvedPattern pattern = selected.size() == 1
-                    ? new Core.ResolvedPattern.Single(selected.get(0))
-                    : new Core.ResolvedPattern.AnyOf(selected, scrutinee);
+            // Carried on as resolved. What a case covers is read off the declarations, which no
+            // reader below this holds, so a pass that handed on the selector alone would leave
+            // every question about which case of the subject an arm picked to be answered from its
+            // name — and a case that is itself a sum reaches several leaves under one name.
+            Core.ResolvedPattern pattern = alternatives.size() == 1
+                    ? new Core.ResolvedPattern.Single(alternatives.get(0))
+                    : new Core.ResolvedPattern.AnyOf(alternatives, scrutinee);
             Type bindType = pattern.bindType();
             if (c.unwrapAsserts() != null) {
                 if (!(pattern instanceof Core.ResolvedPattern.Single)) {
@@ -213,7 +212,8 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(new Core.ResolvedPattern.Single(selector), CoreBinders.of(c.binding()), body, c.pos()));
+            arms.add(new Core.Case(new Core.ResolvedPattern.Single(resolved),
+                    CoreBinders.of(c.binding()), body, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -353,11 +353,10 @@ final class PathEngine {
      * holds of every one of them. Nothing special is done about that: the union is what the arm
      * covers.
      *
-     * <p>{@code Core} carries the selector and not what it covers, so the arm's side is resolved
-     * back here. That is this pass crossing into the one that resolves a case, and not a second
-     * reading of what a case means: {@link CaseSpace#resolve} is where that is worked out, and
-     * the selector is what it is asked about — a carrier of an optional is not the case a name of
-     * the same spelling would be.
+     * <p>What the arm covers is taken off the arm. {@code Core} carries each case as this compile
+     * resolved it, so the atoms are already there; resolved again here they would be the same
+     * answer worked out twice, and the day the two differed one side of an inclusion would be
+     * reading a case the other side never saw.
      *
      * <p>A rule under no case applies to every answer, so any arm reaching it is an arm it holds of.
      *
@@ -374,8 +373,8 @@ final class PathEngine {
             return false;
         }
         Set<TypeSymbol> ruleCovers = new LinkedHashSet<>(selected.atoms());
-        for (CaseSelector armCase : pattern.selectors()) {
-            if (!ruleCovers.containsAll(CaseSpace.resolve(armCase, symbols).atoms())) {
+        for (ResolvedCase armCase : pattern.cases()) {
+            if (!ruleCovers.containsAll(armCase.atoms())) {
                 return false;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -687,20 +687,34 @@ public final class PathReachability {
         }
     }
 
-    /** What the rules leave one arm, or null where the arm names no case — a binding of the whole
-     *  value, which the rules of the position say nothing about. */
+    /**
+     * What the rules leave one arm, or null where the arm names no case — a binding of the whole
+     * value, which the rules of the position say nothing about.
+     *
+     * <p><b>Asked of the distinctions the arm reaches and not of the names it is written by.</b> A
+     * name is not a distinction of a position: an optional's carriers name none of them, and a case
+     * that is itself a sum names the leaves under it rather than any one of them. Asked by name,
+     * every such arm came back as a position that had settled nothing — this compiler reporting a
+     * limit as an answer about the model, and `unreachable` written on an arm the rules admit
+     * going unreported (#1252). What the arm reaches is the checker's resolution of it, read as
+     * distinctions where the two vocabularies agree.
+     */
     private Reachability saidOf(Position at, TermPath path, Core.Case arm, boolean nothingAbove) {
         List<TypeSymbol> named = arm.caseTypes();
         if (named.isEmpty()) {
             return null;
         }
-        if (named.stream().allMatch(each -> at.admissionOf(each) instanceof Admits.Refused)) {
+        List<souther.compiler.inputs.Refinement> reaches = new java.util.ArrayList<>();
+        for (souther.compiler.types.ResolvedCase each : arm.pattern().cases()) {
+            reaches.addAll(souther.compiler.inputs.Refinement.allOf(each));
+        }
+        if (reaches.stream().allMatch(each -> at.admissionOf(each) instanceof Admits.Refused)) {
             // Every case it is written for is one the rules refuse, so an arm a row could still
             // take is not among these: an arm goes only where all of them go.
             return new Reachability.Unreachable(
                     Proof.everyCaseRefused(path.toString(), named));
         }
-        for (TypeSymbol each : named) {
+        for (souther.compiler.inputs.Refinement each : reaches) {
             if (at.admissionOf(each) instanceof Admits.Unsettled unsettled) {
                 return new Reachability.Unsettled(
                         WhyUnsettled.thePositionDidNotSettleIt(unsettled.why()));

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -548,13 +548,10 @@ public sealed interface Core {
          *  written. */
         List<ResolvedCase> cases();
 
-        /** The same, as what tests and reads a value — which is what a backend emits. */
+        /** The same, as what tests and reads a value — which is what a backend emits. A projection
+         *  of {@link #cases()} and answered as one: what an arm selects is that value's to say. */
         default List<CaseSelector> selectors() {
-            List<CaseSelector> out = new java.util.ArrayList<>();
-            for (ResolvedCase each : cases()) {
-                out.add(each.selector());
-            }
-            return out;
+            return cases().stream().map(ResolvedCase::selector).toList();
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -6,6 +6,7 @@ import souther.compiler.types.CaseSelector;
 import souther.compiler.types.CoverageOrigin;
 import souther.compiler.types.Refinement;
 import souther.compiler.types.ReachName;
+import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -522,35 +523,55 @@ public sealed interface Core {
     /**
      * What an arm selects and what it binds, both decided by the checker.
      *
-     * <p>{@code selectors} are the cases the arm answers for, in the order they are written; more
-     * than one is an or-pattern. {@code binding} is what the value is read as once the arm is taken,
-     * and it is the arm's own rather than any one selector's: an or-pattern binds the subject,
-     * because no single case type fits all of its alternatives.
+     * <p>{@code cases} are the cases the arm answers for, in the order they are written; more than
+     * one is an or-pattern. {@code binding} is what the value is read as once the arm is taken, and
+     * it is the arm's own rather than any one case's: an or-pattern binds the subject, because no
+     * single case type fits all of its alternatives.
      *
-     * <p>Nothing here is worked out again downstream. A reader emitting this tests each selector's
+     * <p><b>As the checker resolved them, and not as they were written.</b> A case is carried here
+     * as a {@link ResolvedCase} — what the value is tested and read as, together with the atoms
+     * selecting it covers. The second half is a fact about the declarations this compile read: a
+     * case that is itself a sum stands for the leaves under it (spec §sum-data), so {@code OnceKind}
+     * selects two of them where {@code Station} selects one. Kept as a selector alone it was
+     * unrecoverable below this point — nothing downstream holds declarations to ask — and every
+     * reader that needed which case of a subject an arm picked answered from the name, which says
+     * neither how many leaves it reaches nor whether it is an optional's carrier.
+     *
+     * <p>Nothing here is worked out again downstream. A reader emitting this tests each case's
      * {@link Refinement} and reads the binding through {@code binding}, and never asks whether the
      * subject was an optional, whether the arm named one case or several, or whether a case is a
      * primitive. Those are the questions {@code Core} exists to have answered already.
      */
     sealed interface ResolvedPattern {
 
-        /** The cases the arm answers for, in the order they are written. */
-        List<CaseSelector> selectors();
+        /** The cases the arm answers for, as this compile resolved them, in the order they are
+         *  written. */
+        List<ResolvedCase> cases();
+
+        /** The same, as what tests and reads a value — which is what a backend emits. */
+        default List<CaseSelector> selectors() {
+            List<CaseSelector> out = new java.util.ArrayList<>();
+            for (ResolvedCase each : cases()) {
+                out.add(each.selector());
+            }
+            return out;
+        }
 
         /**
          * The one case this arm selects, or empty where it selects no one case.
          *
-         * <p>Asked here rather than worked out from the shape of the pattern. What a narrowing of
-         * the subject is follows from the selector — its name and what the value turns out to be
-         * are made together and cannot disagree ({@link CaseSelector}) — so a reader that decided
-         * from the pattern's shape that one selector must be there, and then took its name, would
-         * be rebuilding a decision this already holds out of less than it was made from. That is
-         * how an optional's {@code Some} came to be read as a sum's case named {@code Some}.
+         * <p>Asked here rather than worked out from the shape of the pattern. A reader that decided
+         * from the pattern's shape that one case must be there, and then took its name, would be
+         * rebuilding a decision this already holds out of less than it was made from. That is how
+         * an optional's {@code Some} came to be read as a sum's case named {@code Some}.
          *
-         * <p>Empty is an answer and not an absence of one: an or-pattern narrows the subject to no
-         * one case, so there is no narrowing for a reader to have.
+         * <p>Empty is an answer and not an absence of one: an or-pattern selects several cases and
+         * therefore no one of them, which is a fact about what was written and not a count standing
+         * in for one. What that selection then comes to at a position — one of the distinctions the
+         * declarations state there, or none — is the other question, and it is answered from the
+         * atoms this carries rather than from anything about the pattern.
          */
-        Optional<CaseSelector> selectedCase();
+        Optional<ResolvedCase> selectedCase();
 
         /**
          * What the value is read as once the arm is taken.
@@ -578,27 +599,27 @@ public sealed interface Core {
         }
 
         /** An arm answering for one case, which binds what that case's carrier holds. */
-        record Single(CaseSelector selector) implements ResolvedPattern {
+        record Single(ResolvedCase selected) implements ResolvedPattern {
 
             public Single {
-                if (selector == null) {
+                if (selected == null) {
                     throw new IllegalArgumentException("an arm selects a case");
                 }
             }
 
             @Override
-            public List<CaseSelector> selectors() {
-                return List.of(selector);
+            public List<ResolvedCase> cases() {
+                return List.of(selected);
             }
 
             @Override
-            public Optional<CaseSelector> selectedCase() {
-                return Optional.of(selector);
+            public Optional<ResolvedCase> selectedCase() {
+                return Optional.of(selected);
             }
 
             @Override
             public Refinement binding() {
-                return selector.refinement();
+                return selected.refinement();
             }
         }
 
@@ -606,20 +627,20 @@ public sealed interface Core {
          * An arm answering for several, which binds the subject: no one case type fits all of its
          * alternatives, and every alternative is already the subject.
          */
-        record AnyOf(List<CaseSelector> selectors, Type subject) implements ResolvedPattern {
+        record AnyOf(List<ResolvedCase> cases, Type subject) implements ResolvedPattern {
 
             public AnyOf {
-                if (selectors == null || selectors.size() < 2) {
+                if (cases == null || cases.size() < 2) {
                     throw new IllegalArgumentException("an arm answering for several names several");
                 }
                 if (subject == null) {
                     throw new IllegalArgumentException("what such an arm binds is the subject");
                 }
-                selectors = List.copyOf(selectors);
+                cases = List.copyOf(cases);
             }
 
             @Override
-            public Optional<CaseSelector> selectedCase() {
+            public Optional<ResolvedCase> selectedCase() {
                 return Optional.empty();
             }
 
@@ -643,8 +664,9 @@ public sealed interface Core {
             return pattern.caseTypes();
         }
 
-        /** The one case this arm selects, or empty where it selects no one case. */
-        public Optional<CaseSelector> selectedCase() {
+        /** The one case this arm selects, as this compile resolved it, or empty where it selects no
+         *  one case. */
+        public Optional<ResolvedCase> selectedCase() {
             return pattern.selectedCase();
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -538,6 +538,21 @@ public sealed interface Core {
         List<CaseSelector> selectors();
 
         /**
+         * The one case this arm selects, or empty where it selects no one case.
+         *
+         * <p>Asked here rather than worked out from the shape of the pattern. What a narrowing of
+         * the subject is follows from the selector — its name and what the value turns out to be
+         * are made together and cannot disagree ({@link CaseSelector}) — so a reader that decided
+         * from the pattern's shape that one selector must be there, and then took its name, would
+         * be rebuilding a decision this already holds out of less than it was made from. That is
+         * how an optional's {@code Some} came to be read as a sum's case named {@code Some}.
+         *
+         * <p>Empty is an answer and not an absence of one: an or-pattern narrows the subject to no
+         * one case, so there is no narrowing for a reader to have.
+         */
+        Optional<CaseSelector> selectedCase();
+
+        /**
          * What the value is read as once the arm is taken.
          *
          * <p>Derived rather than carried. What an arm binds follows from what it selects — one case
@@ -577,6 +592,11 @@ public sealed interface Core {
             }
 
             @Override
+            public Optional<CaseSelector> selectedCase() {
+                return Optional.of(selector);
+            }
+
+            @Override
             public Refinement binding() {
                 return selector.refinement();
             }
@@ -599,6 +619,11 @@ public sealed interface Core {
             }
 
             @Override
+            public Optional<CaseSelector> selectedCase() {
+                return Optional.empty();
+            }
+
+            @Override
             public Refinement binding() {
                 return new Refinement.Direct(subject);
             }
@@ -616,6 +641,11 @@ public sealed interface Core {
         /** The cases this arm answers for. */
         public List<TypeSymbol> caseTypes() {
             return pattern.caseTypes();
+        }
+
+        /** The one case this arm selects, or empty where it selects no one case. */
+        public Optional<CaseSelector> selectedCase() {
+            return pattern.selectedCase();
         }
 
         /** The type the binding takes inside this arm. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -3,6 +3,7 @@ package souther.compiler.inputs;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -135,9 +136,16 @@ public final class InputReads {
      * it names is as many spellings of one position as there are walks, of which the axes carry
      * one.
      *
-     * <p>Only where the arm selects one case. An arm answering for several narrows to none of them
-     * in particular, and a name that stands for no position is what a reader is given for it —
-     * which is what it was given before there was anything to say.
+     * <p>Only where the arm selects one case, which the arm says ({@link Core.Case#selectedCase}).
+     * An arm answering for several narrows to none of them in particular, and a name that stands
+     * for no position is what a reader is given for it — which is what it was given before there
+     * was anything to say.
+     *
+     * <p><b>And the narrowing is the selector's, not one worked out from it here.</b> Which case an
+     * arm took was decided by the checker, together with what the value turns out to be once it is
+     * taken; a reader that took the case's name instead would have an optional's present carrier
+     * and a sum's case declared under the same word arriving as one thing. So what crosses into
+     * this vocabulary is the selector, and nothing here asks what the scrutinee's type was.
      *
      * <p><b>And where the scrutinee stands for one of several written values, the arm narrows that
      * set.</b> Which is a different answer from the one above and not a weaker copy of it: a
@@ -151,7 +159,8 @@ public final class InputReads {
         if (arm.binder() == null || arm.binder().binding() == null) {
             return this;
         }
-        if (arm.caseTypes().size() != 1) {
+        CaseSelector selected = arm.selectedCase().orElse(null);
+        if (selected == null) {
             return admitting(match, arm, symbols);
         }
         // What the arm narrows is a position of the input, and a scrutinee that stands at none
@@ -163,7 +172,7 @@ public final class InputReads {
         if (scrutinee == null) {
             return admitting(match, arm, symbols);
         }
-        TermPath narrowed = scrutinee.refine(Refinement.sumCase(arm.caseTypes().get(0)));
+        TermPath narrowed = scrutinee.refine(Refinement.of(selected));
         // And nothing is asked of the reading. What this answers is which location the arm's name
         // stands for, which the arm and the scrutinee's path settle between them: the value that was
         // matched, read as the case the arm selects. Whether a row is ever written there — whether
@@ -206,7 +215,7 @@ public final class InputReads {
         if (one == null) {
             return this;
         }
-        for (souther.compiler.types.CaseSelector selector : arm.pattern().selectors()) {
+        for (CaseSelector selector : arm.pattern().selectors()) {
             if (!(selector.refinement() instanceof souther.compiler.types.Refinement.Direct)) {
                 return this;
             }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -136,16 +136,18 @@ public final class InputReads {
      * it names is as many spellings of one position as there are walks, of which the axes carry
      * one.
      *
-     * <p>Only where the arm selects one case, which the arm says ({@link Core.Case#selectedCase}).
-     * An arm answering for several narrows to none of them in particular, and a name that stands
-     * for no position is what a reader is given for it — which is what it was given before there
-     * was anything to say.
+     * <p>Only where the arm narrows the scrutinee to one distinction of it. An arm answering for
+     * several cases narrows to none of them in particular, and so does one naming a case that is
+     * itself a sum, which stands for the leaves under it while the position divides into those
+     * leaves. A name that stands for no position is what a reader is given for either — which is
+     * what it was given before there was anything to say.
      *
-     * <p><b>And the narrowing is the selector's, not one worked out from it here.</b> Which case an
-     * arm took was decided by the checker, together with what the value turns out to be once it is
-     * taken; a reader that took the case's name instead would have an optional's present carrier
-     * and a sum's case declared under the same word arriving as one thing. So what crosses into
-     * this vocabulary is the selector, and nothing here asks what the scrutinee's type was.
+     * <p><b>And the narrowing is the checker's resolution, not one worked out from it here.</b>
+     * Which case an arm took was decided there, together with what the value turns out to be once
+     * it is taken and which leaves selecting it covers; a reader that took the case's name instead
+     * would have an optional's present carrier and a sum's case declared under the same word
+     * arriving as one thing, and a case above two leaves arriving as a place. So what crosses into
+     * this vocabulary is the resolved case, and nothing here asks what the scrutinee's type was.
      *
      * <p><b>And where the scrutinee stands for one of several written values, the arm narrows that
      * set.</b> Which is a different answer from the one above and not a weaker copy of it: a
@@ -159,8 +161,11 @@ public final class InputReads {
         if (arm.binder() == null || arm.binder().binding() == null) {
             return this;
         }
-        CaseSelector selected = arm.selectedCase().orElse(null);
-        if (selected == null) {
+        // The narrowing the arm puts on the scrutinee, and nothing where the arm puts none: an arm
+        // selecting several cases selects no one of them, and one selecting a case that is itself a
+        // sum narrows to several of the position's distinctions and so to no one of them.
+        Refinement narrowing = arm.selectedCase().map(Refinement::of).orElse(null);
+        if (narrowing == null) {
             return admitting(match, arm, symbols);
         }
         // What the arm narrows is a position of the input, and a scrutinee that stands at none
@@ -172,7 +177,7 @@ public final class InputReads {
         if (scrutinee == null) {
             return admitting(match, arm, symbols);
         }
-        TermPath narrowed = scrutinee.refine(Refinement.of(selected));
+        TermPath narrowed = scrutinee.refine(narrowing);
         // And nothing is asked of the reading. What this answers is which location the arm's name
         // stands for, which the arm and the scrutinee's path settle between them: the value that was
         // matched, read as the case the arm selects. Whether a row is ever written there — whether

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -126,6 +126,22 @@ public sealed interface Position permits ReadPosition {
     Admits admissionOf(TypeSymbol leaf);
 
     /**
+     * The same, of the distinction a narrowing names.
+     *
+     * <p>What a reader holding a {@code match} arm has. An arm is written by a name, and a name is
+     * not a distinction of a position: an optional's carriers name none of them, and a case that is
+     * itself a sum names the leaves under it rather than any one of them. Asked by name, such an
+     * arm is answered {@link Unsettlement.NoSuchDistinction} — which is true, and is a fact about
+     * the key rather than about the model, so a caller reading it as the position falling short
+     * reports a limit of this compiler as an answer about what the rules leave (#1252).
+     *
+     * <p>So the key is the narrowing, which is what both vocabularies agree on
+     * ({@link Refinement}), and what an arm covers is asked of every distinction it reaches
+     * ({@link Refinement#allOf}).
+     */
+    Admits admissionOf(Refinement narrowing);
+
+    /**
      * How much of what the rules say about this position's values one reading took in.
      *
      * <p>That reading's account of itself, and nothing else. Nothing downstream decides anything

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -66,16 +66,40 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm.FromOnePosition te
      */
     @Override
     public Admits admissionOf(TypeSymbol leaf) {
+        return admissionOf(distinction(
+                each -> each instanceof Case.SumCase sum && sum.leaf().equals(leaf)));
+    }
+
+    @Override
+    public Admits admissionOf(Refinement narrowing) {
+        return admissionOf(distinction(each -> narrowing.equals(Refinement.of(each))));
+    }
+
+    /**
+     * Which distinction of this position a key names, or null where it names none.
+     *
+     * <p>One lookup and two keys. A leaf and a narrowing pick out the same distinction where they
+     * pick out one at all, and worked out twice the two would answer differently on the day the
+     * distinctions changed — a caller asking by leaf being told a case stands while one asking by
+     * narrowing was told nothing was read about it.
+     */
+    private Case distinction(java.util.function.Predicate<Case> named) {
         for (Case each : declared) {
-            if (each instanceof Case.SumCase sum && sum.leaf().equals(leaf)) {
-                return admissionOf(each);
+            if (named.test(each)) {
+                return each;
             }
         }
-        return new Admits.Unsettled(new Unsettlement.NoSuchDistinction());
+        return null;
     }
 
     @Override
     public Admits admissionOf(Case one) {
+        if (one == null) {
+            // A key that names no distinction of this position. Said as the reading stating no such
+            // distinction, which is what it is: a fact about the two vocabularies not being about
+            // the same values, and not about how far the rules were read.
+            return new Admits.Unsettled(new Unsettlement.NoSuchDistinction());
+        }
         if (obligations instanceof ObligationDomain.Conservative) {
             return new Admits.Unsettled(new Unsettlement.RulesLeaveNothing());
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -522,9 +522,10 @@ final class ReadQuantities implements Quantities {
         return switch (asking(terms)) {
             case StructuralContext.Merge.Together it -> it.context();
             case StructuralContext.Merge.Disagreeing it -> throw new IllegalArgumentException(
-                    "`" + it.why().at() + "` is asked to be " + it.why().one().spelled()
-                            + " and " + it.why().other().spelled() + ", which no value of this"
-                            + " input is, so there is nothing here to answer about " + terms);
+                    "`" + it.why().at().discriminated() + "` is asked to be "
+                            + it.why().one().discriminated() + " and "
+                            + it.why().other().discriminated() + ", which no value of this input"
+                            + " is, so there is nothing here to answer about " + terms);
         };
     }
 
@@ -573,8 +574,8 @@ final class ReadQuantities implements Quantities {
     private static Emptiness.AtAField.Where placeOf(InputAtom atom, TermPath root, String path) {
         if (!(atom instanceof InputAtom.Named named)) {
             throw new IllegalStateException(
-                    "`" + root + "` names a subject at `" + path + "` that arrived here with no"
-                            + " place, so nothing can say where a proof about it is");
+                    "`" + root.discriminated() + "` names a subject at `" + path + "` that arrived"
+                            + " here with no place, so nothing can say where a proof about it is");
         }
         return new Emptiness.AtAField.Where.In(named.place());
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -188,8 +188,8 @@ final class ReadQuantities implements Quantities {
         // something about a place it has never been.
         if (position == null) {
             throw new IllegalArgumentException(
-                    "`" + at + "` is no position of this input, so there is nothing here to say"
-                            + " how many it holds");
+                    "`" + at.at().discriminated() + "` is no position of this input, so there is"
+                            + " nothing here to say how many it holds");
         }
         NumericTerm counted = howManyItHolds(at.at());
         if (counted == null) {
@@ -1047,9 +1047,9 @@ final class ReadQuantities implements Quantities {
     private NumericTerm held(NumericTerm term) {
         if (rootOf(term.subjectPath()) == null) {
             throw new IllegalArgumentException(
-                    "`" + term.subjectPath() + "` is under no value whose rules this reading holds"
-                            + " and can name it by, so there is nothing here to answer about "
-                            + term);
+                    "`" + term.subjectPath().discriminated() + "` is under no value whose rules this"
+                            + " reading holds and can name it by, so there is nothing here to answer"
+                            + " about " + term);
         }
         return term;
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.TypeSymbol;
 
 /**
@@ -14,6 +15,14 @@ import souther.compiler.types.TypeSymbol;
  * anything, and {@link Case} already reads both as distinctions of one kind; a refinement written
  * for cases alone would be a second reading of that, and the optional would arrive later as a
  * shape of its own with nothing to be an instance of.
+ *
+ * <p><b>Made only from a value that already settles which narrowing it is.</b> Two vocabularies
+ * decide that — what a position's type divides into ({@link Case}) and what a written pattern
+ * selects ({@link CaseSelector}) — and each has a way in here. What has no way in is a name: an
+ * optional's present carrier and a sum's case are both called {@code Some} where one is written,
+ * so a narrowing built from the name alone is one of the two chosen by whoever built it. Every
+ * reader below compares narrowings by equality, so the two spellings of one place never meet, and
+ * what a body wrote through such a path is about a position nothing else in this compiler names.
  */
 public sealed interface Refinement {
 
@@ -21,12 +30,26 @@ public sealed interface Refinement {
     String spelled();
 
     /**
+     * The same, with which kind of narrowing it is said as well.
+     *
+     * <p>For a message about this compiler and never for a report about a model. Two narrowings of
+     * unlike kinds can be written the same way — {@code @Some} is an optional's present carrier
+     * where an optional stands and a sum's case where one is declared with that name — so a
+     * diagnostic that spelled only the path would say two unequal positions are one, which is what
+     * an author is told when the compiler is the one that is confused.
+     */
+    String discriminated();
+
+    /**
      * The narrowing {@code one} is, or null where sitting in that distinction narrows no position.
      *
-     * <p>The one place the two vocabularies are related. What a position divides into and what a
-     * position under it stands beneath are the same statement read twice — a row whose value is an
-     * {@code Approved} is a row at every position {@code Approved} declares — and a second relating
-     * of them would be the classes and the branches disagreeing about which is which.
+     * <p>The one way in for a reader that has what a position's type divides into. What a position
+     * divides into and what a position under it stands beneath are the same statement read twice —
+     * a row whose value is an {@code Approved} is a row at every position {@code Approved} declares
+     * — and a second relating of them would be the classes and the branches disagreeing about which
+     * is which. {@link #of(CaseSelector)} is beside this and is not that second relating: it takes
+     * what a checked pattern selected, which is the other value that settles a narrowing, and the
+     * two are held to one answer where a type states a division a pattern can select.
      *
      * <p>Exhaustive over {@link Case}, with no {@code default}: a distinction the reading learns to
      * make later stops this compiling rather than arriving as a branch that is quietly never walked.
@@ -37,26 +60,36 @@ public sealed interface Refinement {
      */
     static Refinement of(Case one) {
         return switch (one) {
-            case Case.SumCase sum -> sumCase(sum.leaf());
+            case Case.SumCase sum -> new SumCase(sum.leaf());
             case Case.Presence presence -> new Presence(presence.present());
             case Case.Truth _, Case.Named _ -> null;
         };
     }
 
     /**
-     * The narrowing to {@code leaf}, for a caller that already has the case and not the distinction.
+     * The narrowing {@code selected} is, for a reader holding what a written pattern selects.
      *
-     * <p>Not a second correspondence. {@link #of} relates two vocabularies — what a position divides
-     * into, and what a position under it stands beneath — and a caller holding a {@code match} arm's
-     * case has not asked that question: which case the arm selected was settled where the arm was
-     * read. Sent back through {@link Distinctions} to be turned into a {@link Case} first, it would
-     * be a reader re-deriving what it was already told, which is the arrangement this vocabulary
-     * exists to stop.
+     * <p>The same relating of vocabularies as {@link #of(Case)} and from the other end. A position's
+     * type says what it divides into; a checked pattern says which of those divisions the arm took.
+     * Both settle a narrowing on their own, and a reader that has one of them has no second question
+     * to ask.
      *
-     * <p>Here rather than at a constructor, so that what a narrowing is stays this type's to say.
+     * <p><b>Read off what the selector refines the value to, and never off its name.</b> The two are
+     * made together and cannot disagree ({@link CaseSelector}), and only the first tells an
+     * optional's present carrier from a sum's case declared under the same word. A reader taking the
+     * name would build the sum's narrowing for both, so an optional's arm would write a path the
+     * reading of the position never spells.
+     *
+     * <p>Exhaustive over {@link souther.compiler.types.Refinement}, with no {@code default}: a way
+     * of selecting a case added later stops this compiling rather than arriving as whichever arm is
+     * nearest.
      */
-    static Refinement sumCase(TypeSymbol leaf) {
-        return new SumCase(leaf);
+    static Refinement of(CaseSelector selected) {
+        return switch (selected.refinement()) {
+            case souther.compiler.types.Refinement.Direct _ -> new SumCase(selected.name());
+            case souther.compiler.types.Refinement.OptionPresent _ -> new Presence(true);
+            case souther.compiler.types.Refinement.OptionAbsent _ -> new Presence(false);
+        };
     }
 
     /**
@@ -88,6 +121,11 @@ public sealed interface Refinement {
         @Override
         public String spelled() {
             return leaf.name();
+        }
+
+        @Override
+        public String discriminated() {
+            return spelled() + "[sum-case]";
         }
 
         @Override
@@ -132,6 +170,11 @@ public sealed interface Refinement {
         @Override
         public String spelled() {
             return present ? "Some" : "None";
+        }
+
+        @Override
+        public String discriminated() {
+            return spelled() + "[presence]";
         }
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
@@ -3,6 +3,8 @@ package souther.compiler.inputs;
 import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.TypeSymbol;
 
+import java.util.List;
+
 /**
  * A narrowing of which values may stand at a position, which does not move to another position.
  *
@@ -49,9 +51,11 @@ public sealed interface Refinement {
      * divides into and what a position under it stands beneath are the same statement read twice —
      * a row whose value is an {@code Approved} is a row at every position {@code Approved} declares
      * — and a second relating of them would be the classes and the branches disagreeing about which
-     * is which. {@link #of(CaseSelector)} is beside this and is not that second relating: it takes
-     * what a checked pattern selected, which is the other value that settles a narrowing, and the
-     * two are held to one answer where a type states a division a pattern can select.
+     * is which. {@link #of(ResolvedCase)} is beside this and is not that second relating: it takes
+     * what a checked pattern was resolved to select, which is the other value that settles a
+     * narrowing, and the two are held to one answer where a type states a division a pattern can
+     * select. Resolved and not merely selected: a selector says what a value is tested and read as,
+     * which one name over several leaves says as fully as one over a single leaf.
      *
      * <p>Exhaustive over {@link Case}, with no {@code default}: a distinction the reading learns to
      * make later stops this compiling rather than arriving as a branch that is quietly never walked.
@@ -100,13 +104,36 @@ public sealed interface Refinement {
      * nearest.
      */
     static Refinement of(ResolvedCase selected) {
+        List<Refinement> covered = allOf(selected);
+        return covered.size() == 1 ? covered.get(0) : null;
+    }
+
+    /**
+     * Every distinction of a position that selecting {@code selected} covers, in the order the
+     * selection reaches them.
+     *
+     * <p>The general reading, and {@link #of(ResolvedCase)} is the same answer asked for the one
+     * case where there is exactly one. Two readers want the two: one puts a narrowing on a path,
+     * which takes a single distinction or none, and one asks what the rules leave an arm, which is
+     * asked of every distinction the arm can arrive at. Worked out twice, an arm over two leaves
+     * would be a place to nobody and two places to somebody else.
+     *
+     * <p>Exhaustive over {@link souther.compiler.types.Refinement}, with no {@code default}: a way
+     * of selecting a case added later stops this compiling rather than arriving as whichever arm is
+     * nearest.
+     */
+    static List<Refinement> allOf(ResolvedCase selected) {
         return switch (selected.refinement()) {
-            case souther.compiler.types.Refinement.Direct _ -> selected.atoms().size() == 1
-                    ? new SumCase(selected.atoms().get(0)) : null;
+            // A case that is itself a sum stands for the leaves under it (spec §sum-data), and a
+            // position divides into those leaves, so what it covers is one distinction per atom.
+            case souther.compiler.types.Refinement.Direct _ ->
+                    selected.atoms().stream().map(each -> (Refinement) new SumCase(each)).toList();
             // An optional's carriers cover themselves and are not leaves of anything, so what they
-            // narrow to follows from the carrier alone ({@code CaseSpace}).
-            case souther.compiler.types.Refinement.OptionPresent _ -> new Presence(true);
-            case souther.compiler.types.Refinement.OptionAbsent _ -> new Presence(false);
+            // narrow to follows from the carrier alone ({@code check.CaseSpace}).
+            case souther.compiler.types.Refinement.OptionPresent _ ->
+                    List.of(new Presence(true));
+            case souther.compiler.types.Refinement.OptionAbsent _ ->
+                    List.of(new Presence(false));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
@@ -1,6 +1,6 @@
 package souther.compiler.inputs;
 
-import souther.compiler.types.CaseSelector;
+import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.TypeSymbol;
 
 /**
@@ -17,12 +17,14 @@ import souther.compiler.types.TypeSymbol;
  * shape of its own with nothing to be an instance of.
  *
  * <p><b>Made only from a value that already settles which narrowing it is.</b> Two vocabularies
- * decide that — what a position's type divides into ({@link Case}) and what a written pattern
- * selects ({@link CaseSelector}) — and each has a way in here. What has no way in is a name: an
- * optional's present carrier and a sum's case are both called {@code Some} where one is written,
- * so a narrowing built from the name alone is one of the two chosen by whoever built it. Every
- * reader below compares narrowings by equality, so the two spellings of one place never meet, and
- * what a body wrote through such a path is about a position nothing else in this compiler names.
+ * decide that — what a position's type divides into ({@link Case}) and what a written pattern was
+ * resolved to select ({@link ResolvedCase}) — and each has a way in here. What has no way in is a
+ * name, and a name falls short twice over. An optional's present carrier and a sum's case are both
+ * called {@code Some} where one is written, so a narrowing built from the name is one of the two
+ * chosen by whoever built it. And a case that is itself a sum is one name over several leaves,
+ * while a position divides into the leaves, so a narrowing built from that name is a place the
+ * reading has none of. Every reader below compares narrowings by equality, so a path spelled either
+ * way never meets the position it was meant to be about.
  */
 public sealed interface Refinement {
 
@@ -67,26 +69,42 @@ public sealed interface Refinement {
     }
 
     /**
-     * The narrowing {@code selected} is, for a reader holding what a written pattern selects.
+     * The narrowing {@code selected} is, or null where selecting it narrows a position to no one
+     * distinction.
      *
      * <p>The same relating of vocabularies as {@link #of(Case)} and from the other end. A position's
      * type says what it divides into; a checked pattern says which of those divisions the arm took.
      * Both settle a narrowing on their own, and a reader that has one of them has no second question
      * to ask.
      *
-     * <p><b>Read off what the selector refines the value to, and never off its name.</b> The two are
-     * made together and cannot disagree ({@link CaseSelector}), and only the first tells an
-     * optional's present carrier from a sum's case declared under the same word. A reader taking the
-     * name would build the sum's narrowing for both, so an optional's arm would write a path the
-     * reading of the position never spells.
+     * <p><b>Read off what the selection was resolved to, and never off the name it was written
+     * by.</b> Two facts settle it and neither is the name. What the value turns out to be tells an
+     * optional's present carrier from a sum's case declared under the same word — a reader taking
+     * the name would build the sum's narrowing for both. And which leaves the selection covers tells
+     * a case that divides the position from one that is itself divided: a case that is a sum stands
+     * for the leaves under it (spec §sum-data), and the reading of a position divides it into those
+     * leaves ({@link Distinctions}), so an arm naming the case above them narrows to several of them
+     * and to no one of them. Read from the name, {@code @OnceKind} would be written where the
+     * reading holds {@code @Station} and {@code @Hospital}.
+     *
+     * <p>So a narrowing is the leaf itself and not the name it was reached by. A case declared over
+     * one leaf is written as that leaf here, which is how the position spells it.
+     *
+     * <p>Null and not a refusal. An arm can select a case that divides nothing at a position, the
+     * way a {@code Bool}'s two values divide none, and what a reader is owed for one is that there
+     * is no narrowing here — the same answer {@link #of(Case)} gives for the distinctions that put
+     * nothing under them.
      *
      * <p>Exhaustive over {@link souther.compiler.types.Refinement}, with no {@code default}: a way
      * of selecting a case added later stops this compiling rather than arriving as whichever arm is
      * nearest.
      */
-    static Refinement of(CaseSelector selected) {
+    static Refinement of(ResolvedCase selected) {
         return switch (selected.refinement()) {
-            case souther.compiler.types.Refinement.Direct _ -> new SumCase(selected.name());
+            case souther.compiler.types.Refinement.Direct _ -> selected.atoms().size() == 1
+                    ? new SumCase(selected.atoms().get(0)) : null;
+            // An optional's carriers cover themselves and are not leaves of anything, so what they
+            // narrow to follows from the carrier alone ({@code CaseSpace}).
             case souther.compiler.types.Refinement.OptionPresent _ -> new Presence(true);
             case souther.compiler.types.Refinement.OptionAbsent _ -> new Presence(false);
         };

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermPath.java
@@ -50,6 +50,18 @@ public record TermPath(String head, List<Step> steps) {
     /** One step of a path: two that go somewhere, and one that stays and narrows. */
     public sealed interface Step {
 
+        /**
+         * How this is written where a narrowing says which kind it is as well.
+         *
+         * <p>The same text for every step that carries no narrowing, which is why this is here
+         * rather than at the one that does: a caller spelling a path asks each step how it is
+         * written, and a caller that reached inside a step to add the kind would be deciding a
+         * step's separator somewhere other than the step.
+         */
+        default String discriminated() {
+            return toString();
+        }
+
         /** The field of a record. */
         record Field(String name) implements Step {
 
@@ -89,6 +101,11 @@ public record TermPath(String head, List<Step> steps) {
             @Override
             public String toString() {
                 return "@" + refinement.spelled();
+            }
+
+            @Override
+            public String discriminated() {
+                return "@" + refinement.discriminated();
             }
         }
     }
@@ -336,11 +353,10 @@ public record TermPath(String head, List<Step> steps) {
                 }
                 out.append(field);
             }
-            case Step.Refine refine -> out.append('@').append(discriminating
-                    ? refine.refinement().discriminated() : refine.refinement().spelled());
-            // No separator: what a list holds follows the list, and a dot before it would read as a
-            // field of it. The same is true of a narrowing, which wears its own `@` above.
-            case Step.Element _ -> out.append(step);
+            // Neither wears a separator: what a list holds follows the list, and a narrowing of a
+            // position follows the position, and a dot before either would read as a field of it.
+            case Step.Element _, Step.Refine _ ->
+                    out.append(discriminating ? step.discriminated() : step.toString());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermPath.java
@@ -299,7 +299,24 @@ public record TermPath(String head, List<Step> steps) {
     private static String spelled(List<Step> steps) {
         StringBuilder out = new StringBuilder();
         for (Step step : steps) {
-            spell(out, step);
+            spell(out, step, false);
+        }
+        return out.toString();
+    }
+
+    /**
+     * The same path, with each narrowing saying which kind it is.
+     *
+     * <p>For a message about this compiler and never for one about a model. Two paths spelled alike
+     * can hold narrowings that are not equal — an optional's present carrier and a sum's case
+     * declared as {@code Some} are both written {@code @Some} — and a message that spelled only the
+     * path would say two positions this compiler holds apart are one place, which leaves an author
+     * reading a sentence that is true of the words and false of the model.
+     */
+    public String discriminated() {
+        StringBuilder out = new StringBuilder(head);
+        for (Step step : steps) {
+            spell(out, step, true);
         }
         return out.toString();
     }
@@ -311,7 +328,7 @@ public record TermPath(String head, List<Step> steps) {
      * separator is decided. A step added later stops this compiling rather than arriving in a
      * report under a dot that says it is a field.
      */
-    private static void spell(StringBuilder out, Step step) {
+    private static void spell(StringBuilder out, Step step, boolean discriminating) {
         switch (step) {
             case Step.Field field -> {
                 if (!out.isEmpty()) {
@@ -319,9 +336,11 @@ public record TermPath(String head, List<Step> steps) {
                 }
                 out.append(field);
             }
-            // Neither wears a separator: what a list holds follows the list, and a narrowing of a
-            // position follows the position, and a dot before either would read as a field of it.
-            case Step.Element _, Step.Refine _ -> out.append(step);
+            case Step.Refine refine -> out.append('@').append(discriminating
+                    ? refine.refinement().discriminated() : refine.refinement().spelled());
+            // No separator: what a list holds follows the list, and a dot before it would read as a
+            // field of it. The same is true of a narrowing, which wears its own `@` above.
+            case Step.Element _ -> out.append(step);
         }
     }
 
@@ -329,7 +348,7 @@ public record TermPath(String head, List<Step> steps) {
     public String toString() {
         StringBuilder out = new StringBuilder(head);
         for (Step step : steps) {
-            spell(out, step);
+            spell(out, step, false);
         }
         return out.toString();
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -14,6 +14,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.semantics.ConditionJoin;
+import souther.compiler.types.CaseSelector;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -134,6 +135,11 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
      * arrive at one — a scrutinee no position holds, an arm answering for several cases, a case the
      * declarations leave no position at — nothing is invented and the arm is declined.
      *
+     * <p>And the narrowing is the one the arm's selector settles, taken as it is rather than built
+     * again from the case's name: the name alone does not say whether an optional's present carrier
+     * or a sum's case was selected, and a narrowing spelled the wrong way is a position the reading
+     * of the input never holds.
+     *
      * <p>Never empty, for the reason {@link #stating} is never empty: an arm that established
      * nothing and an arm nothing could be read of are the two answers a walk has to tell apart, and
      * a silence is both of them.
@@ -141,7 +147,8 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
     static OnTheWay entering(Core.Match match, Core.Case arm, InputDomain inputs, InputReads reads,
                              Symbols symbols) {
         Citation at = Citation.of(arm.pos());
-        if (arm.caseTypes().size() != 1) {
+        CaseSelector selected = arm.selectedCase().orElse(null);
+        if (selected == null) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
         // The arm is declined for either answer: a search composes against a position read as one
@@ -161,8 +168,7 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
         if (scrutinee == null || inputs.at(scrutinee) == null) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
-        return new OnTheWay.Narrowed(at,
-                scrutinee.refine(Refinement.sumCase(arm.caseTypes().get(0))));
+        return new OnTheWay.Narrowed(at, scrutinee.refine(Refinement.of(selected)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -14,7 +14,6 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.semantics.ConditionJoin;
-import souther.compiler.types.CaseSelector;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -132,13 +131,14 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
      * <p><b>The narrowing and never the arm.</b> What a search can compose against is a position
      * read as one of its cases; "the second arm was taken" is a fact about the text. So what is
      * carried is the scrutinee's position with the arm's case on it, and where this reading cannot
-     * arrive at one — a scrutinee no position holds, an arm answering for several cases, a case the
-     * declarations leave no position at — nothing is invented and the arm is declined.
+     * arrive at one — a scrutinee no position holds, an arm answering for several cases, an arm
+     * naming a case that is itself a sum, a case the declarations leave no position at — nothing is
+     * invented and the arm is declined.
      *
-     * <p>And the narrowing is the one the arm's selector settles, taken as it is rather than built
-     * again from the case's name: the name alone does not say whether an optional's present carrier
-     * or a sum's case was selected, and a narrowing spelled the wrong way is a position the reading
-     * of the input never holds.
+     * <p>And the narrowing is the one the checker's resolution of the arm settles, taken as it is
+     * rather than built again from the case's name: the name says neither whether an optional's
+     * present carrier or a sum's case was selected nor how many leaves selecting it covers, and a
+     * narrowing spelled the wrong way is a position the reading of the input never holds.
      *
      * <p>Never empty, for the reason {@link #stating} is never empty: an arm that established
      * nothing and an arm nothing could be read of are the two answers a walk has to tell apart, and
@@ -147,8 +147,8 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
     static OnTheWay entering(Core.Match match, Core.Case arm, InputDomain inputs, InputReads reads,
                              Symbols symbols) {
         Citation at = Citation.of(arm.pos());
-        CaseSelector selected = arm.selectedCase().orElse(null);
-        if (selected == null) {
+        Refinement narrowing = arm.selectedCase().map(Refinement::of).orElse(null);
+        if (narrowing == null) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
         // The arm is declined for either answer: a search composes against a position read as one
@@ -168,7 +168,7 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
         if (scrutinee == null || inputs.at(scrutinee) == null) {
             return new OnTheWay.Declined(at, new OnTheWay.Why.ForkArmNotReadAsANarrowing());
         }
-        return new OnTheWay.Narrowed(at, scrutinee.refine(Refinement.of(selected)));
+        return new OnTheWay.Narrowed(at, scrutinee.refine(narrowing));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
@@ -57,7 +57,8 @@ public final class ResolvedCase {
         return new ResolvedCase(selector, atoms);
     }
 
-    /** What tests and reads the value — what {@code Core} carries and the backend emits. */
+    /** What tests and reads the value — the projection a backend emits. {@code Core} carries this
+     *  whole value, because what it covers is the half a reader below the checker cannot rebuild. */
     public CaseSelector selector() {
         return selector;
     }

--- a/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ResolvedCase.java
@@ -29,8 +29,12 @@ import java.util.List;
  * resolved one; what stops it is that the one caller is the descent itself, and a second maker
  * would be a second answer to what a case covers ({@code check.CaseSpace#resolve}).
  *
- * <p>What is emitted downstream is the selector — {@link #selector()} — which is all {@code Core}
- * and the backend have ever needed.
+ * <p>What a backend emits is the selector — {@link #selector()} — and what {@code Core} carries is
+ * this. The two are not the same need. A backend tests and reads a value, which the selector says
+ * on its own; a reader asking which case of a subject an arm picked is asking about the leaves, and
+ * below the checker there are no declarations left to work them out from. Carried as a selector
+ * alone, that reader answered from the name, and one name over two leaves became a place nothing
+ * else in the compiler holds.
  */
 public final class ResolvedCase {
 

--- a/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
@@ -265,6 +265,52 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
         assertEquals(List.of("E1326"), errorsIn(throughHelper));
     }
 
+    /**
+     * An arm is held to the rules whichever name it is written by.
+     *
+     * <p>What a position divides into is the leaves its subject reaches, so an arm naming a case
+     * that is itself a sum names none of them and an arm over an optional names neither of its
+     * presences. Asked of the position by name, both came back as a position that had settled
+     * nothing — and a claim nothing settles is judged unproven, so {@code unreachable} written on
+     * an arm the model admits went unreported. The leaf spelling of the same claim was reported all
+     * along, which is what made the hole quiet: one of the two spellings of one model was checked.
+     */
+    @Test
+    void anArmNamingACaseAboveLeavesIsHeldToTheRulesToo() {
+        String bySpelling = """
+                module m
+
+                data Station
+                data Hospital
+                data Renkei
+                data OnceKind  = Station | Hospital
+                data VisitKind = OnceKind | Renkei
+
+                data Box = { k: VisitKind }
+                    invariant k == Station
+
+                data Ack = { at: String }
+
+                behavior byLeaf : (b: Box) -> Ack
+                    constructs Ack
+                let byLeaf (b) =
+                    match b.k with
+                        | Station -> unreachable "but the invariant leaves exactly this one"
+                        | Hospital -> Ack { at = "h" }
+                        | Renkei -> Ack { at = "r" }
+
+                behavior byInnerSum : (b: Box) -> Ack
+                    constructs Ack
+                let byInnerSum (b) =
+                    match b.k with
+                        | OnceKind -> unreachable "but the invariant leaves Station, under this"
+                        | Renkei -> Ack { at = "r" }
+                """;
+
+        assertEquals(List.of("E1326", "E1326"), errorsIn(bySpelling),
+                "the arm over the inner sum reaches Station as surely as the arm naming it");
+    }
+
     /** The codes of whatever this model is refused for, in the order they are reported. */
     private static List<String> errorsIn(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -9,6 +9,7 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.CaseSelector;
 import souther.compiler.types.ReachName;
+import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -63,7 +64,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         PathEngine.Entered in = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), x),
+                arm(new Core.ResolvedPattern.Single(aLeaf(FOUND)), x),
                 answer, Known.top(), Denotations.none());
 
         FactSubject opened = in.at().subject(x.binding());
@@ -79,7 +80,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
 
         PathEngine.Entered in = engine.enteringArm(
                 arm(new Core.ResolvedPattern.AnyOf(
-                        List.of(CaseSelector.direct(FOUND), CaseSelector.direct(MISSING)),
+                        List.of(aLeaf(FOUND), aLeaf(MISSING)),
                         Type.ref(FOUND)), x),
                 answer, Known.top(), Denotations.none());
 
@@ -96,10 +97,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder second = CoreBinders.of(binders.binder("b", POS));
 
         FactSubject one = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), first),
+                arm(new Core.ResolvedPattern.Single(aLeaf(FOUND)), first),
                 answer, Known.top(), Denotations.none()).at().subject(first.binding());
         FactSubject other = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), second),
+                arm(new Core.ResolvedPattern.Single(aLeaf(FOUND)), second),
                 answer, Known.top(), Denotations.none()).at().subject(second.binding());
 
         assertEquals(one, other);
@@ -113,7 +114,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         PathEngine.Entered in = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.optionPresent(Type.INT)), x),
+                arm(new Core.ResolvedPattern.Single(aCarrier(CaseSelector.optionPresent(Type.INT), TypeSymbol.SOME)), x),
                 answer, Known.top(), Denotations.none());
 
         FactSubject optional = engine.terms().subjectOf(answer, Denotations.none());
@@ -132,10 +133,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder second = CoreBinders.of(binders.binder("b", POS));
 
         FactSubject one = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.optionPresent(Type.INT)), first),
+                arm(new Core.ResolvedPattern.Single(aCarrier(CaseSelector.optionPresent(Type.INT), TypeSymbol.SOME)), first),
                 answer, Known.top(), Denotations.none()).at().subject(first.binding());
         FactSubject other = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.optionPresent(Type.INT)), second),
+                arm(new Core.ResolvedPattern.Single(aCarrier(CaseSelector.optionPresent(Type.INT), TypeSymbol.SOME)), second),
                 answer, Known.top(), Denotations.none()).at().subject(second.binding());
 
         assertEquals(one, other);
@@ -150,7 +151,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         PathEngine.Entered in = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.optionPresent(Type.INT)), x),
+                arm(new Core.ResolvedPattern.Single(aCarrier(CaseSelector.optionPresent(Type.INT), TypeSymbol.SOME)), x),
                 written, Known.top(), Denotations.none());
 
         assertEquals(engine.terms().subjectOf(three, Denotations.none()),
@@ -165,7 +166,7 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         PathEngine.Entered in = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), x),
+                arm(new Core.ResolvedPattern.Single(aLeaf(FOUND)), x),
                 answer, Known.top(), Denotations.none());
 
         assertEquals(answer, in.at().valueOf(x.binding()),
@@ -190,10 +191,10 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
 
         Denotations outer = reading.enteringArm(
                 arm(new Core.ResolvedPattern.AnyOf(
-                        List.of(CaseSelector.direct(AN_INT), CaseSelector.direct(MISSING)),
+                        List.of(aLeaf(AN_INT), aLeaf(MISSING)),
                         answer.type()), x),
                 answer, Known.top(), Denotations.none()).at();
-        Core.Case inner = arm(new Core.ResolvedPattern.Single(CaseSelector.direct(AN_INT)), y);
+        Core.Case inner = arm(new Core.ResolvedPattern.Single(aLeaf(AN_INT)), y);
         PathEngine.Entered in = reading.enteringArm(inner,
                 new Core.Read("x", x.binding(), answer.type(), POS), Known.top(), outer);
 
@@ -297,8 +298,11 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
         TypeSymbol station = named(symbols, "Station");
         TypeSymbol hospital = named(symbols, "Hospital");
         Type visitKind = Type.ref(named(symbols, "VisitKind"));
+        // Resolved the way the checker resolves an arm, so what the alternatives cover is this
+        // compile's answer rather than one written here.
         Core.ResolvedPattern both = new Core.ResolvedPattern.AnyOf(
-                List.of(CaseSelector.direct(station), CaseSelector.direct(hospital)), visitKind);
+                List.of(CaseSpace.resolve(CaseSelector.direct(station), symbols),
+                        CaseSpace.resolve(CaseSelector.direct(hospital), symbols)), visitKind);
 
         assertTrue(reading.impliedBy(
                         new Guard.Case(CaseSpace.resolve(CaseSelector.direct(once), symbols)), both),
@@ -309,7 +313,17 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     }
 
     private static Core.ResolvedPattern single(TypeSymbol name) {
-        return new Core.ResolvedPattern.Single(CaseSelector.direct(name));
+        return new Core.ResolvedPattern.Single(aLeaf(name));
+    }
+
+    /** A leaf as this compile would resolve it: a case that covers itself. */
+    private static ResolvedCase aLeaf(TypeSymbol leaf) {
+        return ResolvedCase.of(CaseSelector.direct(leaf), List.of(leaf));
+    }
+
+    /** One of an optional's carriers, which covers itself and no leaf of anything. */
+    private static ResolvedCase aCarrier(CaseSelector carrier, TypeSymbol covers) {
+        return ResolvedCase.of(carrier, List.of(covers));
     }
 
     private static TypeSymbol named(Symbols symbols, String type) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
@@ -24,9 +24,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * primitive, each time it wrote an arm, and a third reader in the checker asked the same questions
  * its own way. Three readings of one thing agree until the day one of them is extended.
  *
- * <p>So {@code CaseSpace} answers it once, a {@code CaseSelector} carries the answer, and everything
- * downstream reads the selector. This is asked of the sources: a tripwire and not a proof — a helper
- * in between defeats it — but the line that would have to be added first is the one it fails on.
+ * <p>So {@code CaseSpace} answers it once and a {@code ResolvedCase} carries the answer: the
+ * selector for a reader that tests and reads a value, and the atoms beside it for one that asks
+ * which case of a subject an arm picked. Everything downstream reads that value rather than the
+ * subject. This is asked of the sources: a tripwire and not a proof — a helper in between defeats
+ * it — but the line that would have to be added first is the one it fails on.
  */
 class WhatACaseMeansIsDecidedInOnePlaceTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.DefaultStdlib;
 import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.types.Refinement;
@@ -20,7 +22,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * What selecting a case covers, and where that is worked out.
@@ -114,21 +116,87 @@ class WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest {
     }
 
     /**
-     * What is handed downstream is the selector.
+     * What a selector is, and what it therefore cannot answer on its own.
      *
-     * <p>{@code Core} carries what tests and reads a value and nothing about the program around it.
-     * That is what keeps the atoms in this package: a reader of {@code Core} that wanted them would
-     * have to go back to the declarations, which is the second reading being removed.
+     * <p>A name and a refinement, and nothing about the program the case was written in. That is
+     * what makes it sayable wherever it is written — and it is also the whole of why the atoms are
+     * a second value rather than a third component: an invariant that needs {@link Symbols} to
+     * state was never an invariant of a selector.
      */
     @Test
-    void whatGoesDownstreamIsTheSelectorAlone() {
+    void aSelectorIsANameAndARefinementAndSaysNothingAboutTheProgram() {
         ResolvedCase once = resolvedCase("VisitKind", "OnceKind");
         assertEquals(once.name(), once.selector().name());
         assertEquals(once.refinement(), once.selector().refinement());
-        assertTrue(java.util.Arrays.stream(once.selector().getClass().getRecordComponents())
-                        .map(java.lang.reflect.RecordComponent::getName).toList()
-                        .equals(List.of("name", "refinement")),
+        assertEquals(List.of("name", "refinement"),
+                java.util.Arrays.stream(once.selector().getClass().getRecordComponents())
+                        .map(java.lang.reflect.RecordComponent::getName).toList(),
                 "a selector is a name and a refinement; what it covers is not one of its parts");
+    }
+
+    /**
+     * And what goes downstream is the resolution, not the selector alone.
+     *
+     * <p><b>The boundary the other way round from where it began.</b> {@code Core} used to carry the
+     * selector, on the ground that a backend tests and reads a value and wants nothing about the
+     * program around it. That is true of a backend and false of every other reader: which case of a
+     * subject an arm picked is a question about the leaves, and below the checker there are no
+     * declarations left to work them out from. Handed the selector alone, such a reader answered
+     * from the name — and {@code OnceKind} is one name over two leaves, so the answer was a place
+     * the reading of a position never holds (#1252).
+     *
+     * <p>Asked of a compiled body rather than of the shape of the types, because the claim is that
+     * the atoms actually survive the checker. Nothing here holds {@link Symbols}: if what an arm
+     * covers could only be had by asking the declarations again, this could not be written.
+     */
+    @Test
+    void whatGoesDownstreamIsTheResolutionAndNotTheSelectorAlone() {
+        Core.Case arm = armSelecting(inner());
+
+        assertEquals(List.of("Station", "Hospital"),
+                arm.selectedCase().orElseThrow().atoms().stream().map(TypeSymbol::name).toList(),
+                "a reader of Core says what the arm covers without a declaration in hand");
+        assertEquals(named("OnceKind"), arm.selectedCase().orElseThrow().selector().name(),
+                "and the selector a backend emits is still there, as a projection of it");
+    }
+
+    /** The model an arm over the inner sum is written in. */
+    private static String inner() {
+        return MODULE + """
+
+                data Ack = { at: String }
+
+                behavior visit : (k: VisitKind) -> Ack
+                let visit (k) =
+                    match k with
+                        | OnceKind as x -> Ack { at = "once" }
+                        | Renkei as r -> Ack { at = "renkei" }
+                """;
+    }
+
+    /** The first arm of the first {@code match} of {@code visit}, as the checker built it. */
+    private static Core.Case armSelecting(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Core body = compilation.db().ask(new Bodies.Checked(module)).value()
+                .behaviorBodies().get("visit");
+        assertNotNull(body, "the model under test compiles");
+        return firstMatch(body).cases().get(0);
+    }
+
+    private static Core.Match firstMatch(Core at) {
+        if (at instanceof Core.Match match) {
+            return match;
+        }
+        Core.Match[] found = new Core.Match[1];
+        Core.forEachChild(at, each -> {
+            if (found[0] == null) {
+                found[0] = firstMatch(each);
+            }
+        });
+        return found[0];
     }
 
     /** Kept in what a declaration comes to, so it compares as a value and not as an object. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
@@ -6,6 +6,7 @@ import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.CaseSelector;
+import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -90,7 +91,8 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         Denotations at = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), x),
+                arm(new Core.ResolvedPattern.Single(
+                        ResolvedCase.of(CaseSelector.direct(FOUND), List.of(FOUND))), x),
                 written, Known.top(), Denotations.none()).at();
 
         assertSame(written, engine.terms().writtenValue(read(x, Type.ref(FOUND)), at));
@@ -105,7 +107,8 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 
         Denotations at = engine.enteringArm(
-                arm(new Core.ResolvedPattern.Single(CaseSelector.direct(FOUND)), x),
+                arm(new Core.ResolvedPattern.Single(
+                        ResolvedCase.of(CaseSelector.direct(FOUND), List.of(FOUND))), x),
                 answer, Known.top(), Denotations.none()).at();
 
         assertNull(engine.terms().writtenValue(read(x, Type.ref(FOUND)), at));

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AClauseAboveASumIsReadAtTheFieldItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AClauseAboveASumIsReadAtTheFieldItIsAboutTest.java
@@ -446,7 +446,7 @@ class AClauseAboveASumIsReadAtTheFieldItIsAboutTest {
     private static Refinement caseNamedAt(InputDomain read, TermPath sum, String name) {
         for (Case each : read.at(sum).obligationCases()) {
             if (each instanceof Case.SumCase one && one.leaf().name().equals(name)) {
-                return Refinement.sumCase(one.leaf());
+                return Refinement.of(one);
             }
         }
         throw new IllegalStateException("no case named " + name);
@@ -463,7 +463,7 @@ class AClauseAboveASumIsReadAtTheFieldItIsAboutTest {
     private static Refinement caseNamed(InputDomain read, String name) {
         for (Case each : read.at(TermPath.of("h").then("q")).obligationCases()) {
             if (each instanceof Case.SumCase one && one.leaf().name().equals(name)) {
-                return Refinement.sumCase(one.leaf());
+                return Refinement.of(one);
             }
         }
         throw new IllegalStateException("no case named " + name);

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
@@ -63,9 +63,14 @@ class ALeafIsNotAnAbsenceTest {
     }
 
     private StructuralInspection.Branch unitCase(String name) {
-        return new StructuralInspection.Branch(
-                Refinement.of(souther.compiler.types.CaseSelector.direct(
-                        ((Type.Ref) named(name)).name())), null);
+        return new StructuralInspection.Branch(toLeaf(((Type.Ref) named(name)).name()), null);
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(souther.compiler.types.TypeSymbol leaf) {
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                souther.compiler.types.CaseSelector.direct(leaf), java.util.List.of(leaf)));
     }
 
     private Type named(String name) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
@@ -64,7 +64,8 @@ class ALeafIsNotAnAbsenceTest {
 
     private StructuralInspection.Branch unitCase(String name) {
         return new StructuralInspection.Branch(
-                Refinement.sumCase(((Type.Ref) named(name)).name()), null);
+                Refinement.of(souther.compiler.types.CaseSelector.direct(
+                        ((Type.Ref) named(name)).name())), null);
     }
 
     private Type named(String name) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANameIsReadOnceHoweverTheRuleSpelledItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANameIsReadOnceHoweverTheRuleSpelledItTest.java
@@ -117,7 +117,7 @@ class ANameIsReadOnceHoweverTheRuleSpelledItTest {
     void oneKeyUnderTwoValuesIsTwoAddresses() {
         InputDomain read = reading(SHARED, "read");
         TermPath sum = TermPath.of("q");
-        TermPath aCase = sum.refine(Refinement.sumCase(caseNamed(read, sum, "A")));
+        TermPath aCase = sum.refine(narrowingTo(read, sum, "A"));
 
         assertNotEquals(new RuleAddress(sum, RuleKey.of("limit")),
                 new RuleAddress(aCase, RuleKey.of("limit")));
@@ -135,8 +135,8 @@ class ANameIsReadOnceHoweverTheRuleSpelledItTest {
     void aPathUnderAnotherValuePlacesNothing() {
         InputDomain read = reading(SHARED, "read");
         TermPath sum = TermPath.of("q");
-        TermPath a = sum.refine(Refinement.sumCase(caseNamed(read, sum, "A")));
-        TermPath b = sum.refine(Refinement.sumCase(caseNamed(read, sum, "B")));
+        TermPath a = sum.refine(narrowingTo(read, sum, "A"));
+        TermPath b = sum.refine(narrowingTo(read, sum, "B"));
 
         assertNull(RuleAddress.of(a, b.then("limit")),
                 "no rule of `A` names a position in `B`");
@@ -162,9 +162,19 @@ class ANameIsReadOnceHoweverTheRuleSpelledItTest {
 
     /** The case's own name, taken off the reading that holds it. */
     private static TypeSymbol caseNamed(InputDomain read, TermPath sum, String name) {
+        return distinctionAt(read, sum, name).leaf();
+    }
+
+    /** The narrowing to that case, spelled by the distinction the reading holds rather than by the
+     *  case's name — which is how every reader of this path spells it. */
+    private static Refinement narrowingTo(InputDomain read, TermPath sum, String name) {
+        return Refinement.of(distinctionAt(read, sum, name));
+    }
+
+    private static Case.SumCase distinctionAt(InputDomain read, TermPath sum, String name) {
         for (Case each : read.at(sum).obligationCases()) {
             if (each instanceof Case.SumCase one && one.leaf().name().equals(name)) {
-                return one.leaf();
+                return one;
             }
         }
         throw new IllegalStateException("no case named " + name);

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -19,7 +19,6 @@ import souther.compiler.types.TypeSymbol;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -120,9 +119,11 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
                 behavior open : (b: Box) -> Ack
                 """);
 
-        assertEquals(List.of("Empty", "Held"), spelledCases(read, "slot"),
+        // That the model under test states what this is about, and no more than that: which order a
+        // type's divisions come back in is settled elsewhere and is nothing this claim rests on.
+        assertEquals(java.util.Set.of("Empty", "Held"), spelledCases(read, "slot"),
                 "the sum states its cases");
-        assertEquals(List.of("None", "Some"), spelledCases(read, "tag"),
+        assertEquals(java.util.Set.of("None", "Some"), spelledCases(read, "tag"),
                 "and the optional states whether it holds anything");
 
         for (Case each : distinctionsAt(read, "slot")) {
@@ -194,8 +195,8 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
                 read.symbols);
     }
 
-    private static List<String> spelledCases(Read read, String field) {
-        List<String> out = new ArrayList<>();
+    private static java.util.Set<String> spelledCases(Read read, String field) {
+        java.util.Set<String> out = new java.util.LinkedHashSet<>();
         for (Case each : distinctionsAt(read, field)) {
             out.add(Refinement.of(each).spelled());
         }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -56,6 +56,37 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ANarrowingIsSpelledByTheOneThatOwnsItTest {
 
+    /** A leaf, a case that is itself a sum, an or-pattern, and both of an optional's carriers. */
+    private static final String A_MODEL_OF_EVERY_SHAPE = """
+            module m
+
+            data Station  = { at: String }
+            data Hospital = { at: String }
+            data Renkei   = { at: String }
+            data OnceKind  = Station | Hospital
+            data VisitKind = OnceKind | Renkei
+
+            data Tagged = { tag: Int? }
+            data Ack = { at: String }
+
+            behavior visit : (k: VisitKind, t: Tagged) -> Ack
+            let visit (k, t) = {
+                let named = match k with
+                    | OnceKind as once ->
+                        match once with
+                            | Station as s -> s.at
+                            | Hospital as h -> h.at
+                    | Renkei as r -> r.at
+                let both = match k with
+                    | Station | Hospital -> "once"
+                    | Renkei as r -> r.at
+                let held = match t.tag with
+                    | Some v -> v
+                    | None -> 0
+                Ack { at = named }
+            }
+            """;
+
     @Test
     void aNarrowingHasNoConstructorAReaderCanReach() {
         for (Class<?> variant : new Class<?>[] {Refinement.SumCase.class, Refinement.Presence.class}) {
@@ -78,6 +109,13 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
      * takes: a way in whose parameter is a name, a string, a list of case types or a selector that
      * has not been resolved against the declarations is one that cannot answer for a case standing
      * over several leaves, whatever it is called.
+     *
+     * <p>{@code allOf} is the third name and not a third answer. It takes the same
+     * {@link ResolvedCase} and says every distinction that selection covers; {@code of} is that
+     * asked for the one case where there is exactly one, and is written in terms of it. Two readers
+     * want the two — a path takes a single narrowing or none, and what the rules leave an arm is
+     * asked of every distinction it can arrive at — and the check below is that the second is the
+     * first read again rather than a second decision about what a selection covers.
      */
     @Test
     void everyWayInTakesAValueThatSettlesTheNarrowing() {
@@ -86,15 +124,31 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
                         .filter(each -> Modifier.isStatic(each.getModifiers())
                                 && !Modifier.isPrivate(each.getModifiers()))
                         .toList();
-        assertEquals(java.util.Set.of("of"),
+        assertEquals(java.util.Set.of("of", "allOf"),
                 ways.stream().map(java.lang.reflect.Method::getName)
                         .collect(java.util.stream.Collectors.toSet()),
-                "a way to spell a narrowing that is not `of` is a decision, not an accident");
+                "a way to spell a narrowing that is not one of these is a decision, not an accident");
         assertEquals(java.util.Set.of(Case.class, ResolvedCase.class),
                 ways.stream().map(each -> each.getParameterTypes()[0])
                         .collect(java.util.stream.Collectors.toSet()),
                 "a narrowing is made from what a position divides into or from what an arm was"
                         + " resolved to select, and from nothing that settles less than either");
+    }
+
+    /** And the singular reading is the plural one, asked for the case where there is exactly one. */
+    @Test
+    void theOneNarrowingIsTheOnlyOneCovered() {
+        Read read = read(A_MODEL_OF_EVERY_SHAPE);
+
+        for (Core.Case arm : armsOf(read.body)) {
+            if (arm.selectedCase().isEmpty()) {
+                continue;
+            }
+            ResolvedCase selected = arm.selectedCase().orElseThrow();
+            List<Refinement> covered = Refinement.allOf(selected);
+            assertEquals(covered.size() == 1 ? covered.get(0) : null, Refinement.of(selected),
+                    () -> "the one narrowing of `" + selected + "` is whatever it alone covers");
+        }
     }
 
     /**
@@ -118,35 +172,7 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
      */
     @Test
     void everySelectionTheCheckerMakesAnswersOneNarrowingOrNone() {
-        Read read = read("""
-                module m
-
-                data Station  = { at: String }
-                data Hospital = { at: String }
-                data Renkei   = { at: String }
-                data OnceKind  = Station | Hospital
-                data VisitKind = OnceKind | Renkei
-
-                data Tagged = { tag: Int? }
-                data Ack = { at: String }
-
-                behavior visit : (k: VisitKind, t: Tagged) -> Ack
-                let visit (k, t) = {
-                    let named = match k with
-                        | OnceKind as once ->
-                            match once with
-                                | Station as s -> s.at
-                                | Hospital as h -> h.at
-                        | Renkei as r -> r.at
-                    let both = match k with
-                        | Station | Hospital -> "once"
-                        | Renkei as r -> r.at
-                    let held = match t.tag with
-                        | Some v -> v
-                        | None -> 0
-                    Ack { at = named }
-                }
-                """);
+        Read read = read(A_MODEL_OF_EVERY_SHAPE);
 
         Map<String, Refinement> answered = new LinkedHashMap<>();
         int orPatterns = 0;

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -4,27 +4,29 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
-import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
+import souther.compiler.core.Core;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
-import souther.compiler.types.CaseSelector;
-import souther.compiler.types.Type;
+import souther.compiler.types.ResolvedCase;
 import souther.compiler.types.TypeSymbol;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -32,23 +34,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Two vocabularies say which narrowing a place carries. What a position's type divides into is
  * {@link Case}, read by {@link Distinctions}; which of those divisions a written arm selected is
- * {@link CaseSelector}, decided by the checker. Both settle a narrowing on their own, so both have
- * a way in here — and what may not have one is a value that settles less than a narrowing. A name
- * is such a value: an optional's present carrier and a case of a sum declared as {@code Some} are
- * written the same word, so a narrowing built from the name is one of the two chosen by whoever
- * built it.
+ * {@link ResolvedCase}, decided by the checker. Both settle a narrowing on their own, so both have
+ * a way in here — and what may not have one is a value that settles less than a narrowing.
  *
- * <p>That is not a hypothetical. {@code Refinement.sumCase(TypeSymbol)} was the second way in, and
- * the reading of a {@code match} arm used it: every path a body wrote through {@code Some v} came
- * out carrying a sum's case where the reading of the position carried a presence. The two spell
- * {@code x@Some} alike and are not equal, so those paths were positions nothing else in this
- * compiler names — silence wherever a reader shrugs at a path it cannot find, and an internal error
- * in the one place that refuses (#1252).
+ * <p>A name is such a value, and it falls short twice over. An optional's present carrier and a
+ * case of a sum declared as {@code Some} are written the same word. And a case that is itself a sum
+ * is one name over several leaves (spec §sum-data) while a position divides into the leaves, so
+ * {@code OnceKind} names no one of them. Both were live: {@code Refinement.sumCase(TypeSymbol)} was
+ * a second way in, and the reading of a {@code match} arm used it, so a body inside {@code | Some v}
+ * wrote at {@code x@Some} carrying a sum's case where the reading carried a presence, and a body
+ * inside {@code | OnceKind as x} wrote at {@code k@OnceKind}, which the reading has no position for
+ * at all (#1252).
+ *
+ * <p>Nothing compared them: a reader that looks such a path up finds nothing and says nothing.
  *
  * <p>What holds the rule is that the variants have no constructor a caller can reach and that the
  * two ways in take the two values that determine a narrowing. What holds the correspondence is
- * {@link #twoVocabulariesAnswerOneNarrowing}, below: exhaustiveness stops a variant being added
- * without an answer, and only a comparison stops an existing one being answered wrongly.
+ * {@link #everySelectionTheCheckerMakesAnswersOneNarrowingOrNone}, below: exhaustiveness stops a
+ * variant being added without an answer, and only a comparison stops an existing one being answered
+ * wrongly.
  */
 class ANarrowingIsSpelledByTheOneThatOwnsItTest {
 
@@ -71,8 +75,9 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
      * <p>Named rather than counted. A count is tripped by a private helper, which is nobody's way
      * in, and the reading of it that fits is to raise the number — which lets a way in be added
      * later with nothing having said so. What is checked beside the names is what each of them
-     * takes: a way in whose parameter is a name, a string or a list of case types is one that
-     * cannot tell the two narrowings apart, whatever it is called.
+     * takes: a way in whose parameter is a name, a string, a list of case types or a selector that
+     * has not been resolved against the declarations is one that cannot answer for a case standing
+     * over several leaves, whatever it is called.
      */
     @Test
     void everyWayInTakesAValueThatSettlesTheNarrowing() {
@@ -85,73 +90,127 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
                 ways.stream().map(java.lang.reflect.Method::getName)
                         .collect(java.util.stream.Collectors.toSet()),
                 "a way to spell a narrowing that is not `of` is a decision, not an accident");
-        assertEquals(java.util.Set.of(Case.class, CaseSelector.class),
+        assertEquals(java.util.Set.of(Case.class, ResolvedCase.class),
                 ways.stream().map(each -> each.getParameterTypes()[0])
                         .collect(java.util.stream.Collectors.toSet()),
-                "a narrowing is made from what a position divides into or from what an arm"
-                        + " selected, and from nothing that settles less than either");
+                "a narrowing is made from what a position divides into or from what an arm was"
+                        + " resolved to select, and from nothing that settles less than either");
     }
 
     /**
-     * The two vocabularies answer one narrowing, shape by shape.
+     * Every selection the checker makes answers one of the position's distinctions, or none.
      *
      * <p>The correspondence itself, and the reason the exhaustive {@code switch}es are not the whole
      * of the rule. Nothing stops {@code OptionPresent} being answered with {@code Presence(false)}:
      * every arm would be covered, every reading would compile, and an optional's arms would swap
-     * which position they wrote at. So each division a type states is matched here against the
-     * selector a pattern selecting it carries.
+     * which position they wrote at.
      *
-     * <p>Read off a compiled model rather than written out, so that what the checker actually builds
-     * for {@code Some} is what is compared — a selector written here by hand would agree with
-     * whatever this test thought the checker does.
+     * <p><b>Read forward, off what the checker put on the arms.</b> A test that built a selector for
+     * each distinction and compared the two would only ever meet the selections it thought of, and
+     * the one that mattered is the one it would not have thought of: {@code OnceKind} has no
+     * distinction to be paired with, so it never appears among the pairs and its narrowing goes
+     * unasked about. So the arms of the model are walked, every selection the checker resolved is
+     * taken as it stands, and each is required to answer either one distinction the position states
+     * or none at all.
+     *
+     * <p>The model states each shape once: a case that is a leaf, a case that is itself a sum, an
+     * or-pattern, and both of an optional's carriers.
      */
     @Test
-    void twoVocabulariesAnswerOneNarrowing() {
+    void everySelectionTheCheckerMakesAnswersOneNarrowingOrNone() {
         Read read = read("""
                 module m
 
-                data Empty
-                data Held = { least: Int }
-                data Slot = Empty | Held
-                data Box = { slot: Slot, tag: Int? }
+                data Station  = { at: String }
+                data Hospital = { at: String }
+                data Renkei   = { at: String }
+                data OnceKind  = Station | Hospital
+                data VisitKind = OnceKind | Renkei
+
+                data Tagged = { tag: Int? }
                 data Ack = { at: String }
 
-                behavior open : (b: Box) -> Ack
+                behavior visit : (k: VisitKind, t: Tagged) -> Ack
+                let visit (k, t) = {
+                    let named = match k with
+                        | OnceKind as once ->
+                            match once with
+                                | Station as s -> s.at
+                                | Hospital as h -> h.at
+                        | Renkei as r -> r.at
+                    let both = match k with
+                        | Station | Hospital -> "once"
+                        | Renkei as r -> r.at
+                    let held = match t.tag with
+                        | Some v -> v
+                        | None -> 0
+                    Ack { at = named }
+                }
                 """);
 
-        // That the model under test states what this is about, and no more than that: which order a
-        // type's divisions come back in is settled elsewhere and is nothing this claim rests on.
-        assertEquals(java.util.Set.of("Empty", "Held"), spelledCases(read, "slot"),
-                "the sum states its cases");
-        assertEquals(java.util.Set.of("None", "Some"), spelledCases(read, "tag"),
-                "and the optional states whether it holds anything");
-
-        for (Case each : distinctionsAt(read, "slot")) {
-            Case.SumCase one = (Case.SumCase) each;
-            assertEquals(Refinement.of(each), Refinement.of(CaseSelector.direct(one.leaf())),
-                    () -> "a case of a sum is one narrowing, read either way: " + one.leaf());
+        Map<String, Refinement> answered = new LinkedHashMap<>();
+        int orPatterns = 0;
+        for (Core.Case arm : armsOf(read.body)) {
+            if (arm.selectedCase().isEmpty()) {
+                orPatterns++;
+                continue;
+            }
+            ResolvedCase selected = arm.selectedCase().orElseThrow();
+            answered.put(selected.toString(), Refinement.of(selected));
         }
-        Type held = elementOf(read, "tag");
-        assertEquals(Refinement.of(new Case.Presence(true)),
-                Refinement.of(CaseSelector.optionPresent(held)),
-                "an optional holding something is one narrowing, read either way");
-        assertEquals(Refinement.of(new Case.Presence(false)),
-                Refinement.of(CaseSelector.optionAbsent()),
-                "and so is an optional holding nothing");
+
+        assertEquals(List.of(
+                        "m.OnceKind covering [m.Station, m.Hospital]",
+                        "m.Renkei covering [m.Renkei]",
+                        "m.Station covering [m.Station]",
+                        "m.Hospital covering [m.Hospital]",
+                        "Some covering [Some]",
+                        "None covering [None]"),
+                List.copyOf(answered.keySet()),
+                "the model states each shape of selection once");
+        assertEquals(1, orPatterns,
+                "and one arm selects several cases, which is the shape that selects no one of them");
+
+        // A case standing over several leaves answers no one distinction. Read from its name it
+        // would answer `@OnceKind`, which is a place the reading of the position never holds.
+        assertNull(answered.get("m.OnceKind covering [m.Station, m.Hospital]"),
+                "a case that is itself a sum narrows to several of the position's distinctions,"
+                        + " and so to no one of them");
+
+        // And every other selection answers exactly one of them, matched against what the position
+        // itself states rather than against a narrowing written here.
+        Map<Refinement, String> stated = new LinkedHashMap<>();
+        for (Case each : distinctionsAt(read, TermPath.of("k"))) {
+            stated.put(Refinement.of(each), "k");
+        }
+        for (Case each : distinctionsAt(read, TermPath.of("t").then("tag"))) {
+            stated.put(Refinement.of(each), "t.tag");
+        }
+        for (Map.Entry<String, Refinement> each : answered.entrySet()) {
+            if (each.getValue() == null) {
+                continue;
+            }
+            assertTrue(stated.containsKey(each.getValue()),
+                    () -> "the checker resolved `" + each.getKey() + "` to "
+                            + each.getValue().discriminated()
+                            + ", which no position of this input divides into: " + stated.keySet()
+                                    .stream().map(Refinement::discriminated).toList());
+        }
+        assertEquals(stated.size(), answered.values().stream().filter(java.util.Objects::nonNull)
+                        .distinct().count(),
+                "and between them the arms reach every distinction the two positions state");
     }
 
     /**
-     * And the two are told apart, which is what makes the correspondence load-bearing.
+     * And a presence is not a case of a sum, which is what makes the correspondence load-bearing.
      *
      * <p>A presence and a case of a sum are unequal however they are spelled, so a reader that
      * built one where the other belongs writes at a position nothing else reaches. Were they equal
-     * instead, the mistake would be invisible and this correspondence would say nothing.
+     * instead, the mistake would be invisible and the correspondence above would say nothing.
      */
     @Test
     void aPresenceIsNotACaseOfASumHoweverItIsWritten() {
-        Refinement declaredSome = Refinement.of(CaseSelector.direct(
-                souther.compiler.types.TypeSymbols.declared(
-                        new souther.compiler.types.TypeKey("m", "Some"))));
+        Refinement declaredSome = aLeafNamed("m", "Some");
 
         assertEquals("Some", declaredSome.spelled());
         assertEquals("Some", Refinement.of(new Case.Presence(true)).spelled());
@@ -174,7 +233,7 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
     void twoNarrowingsToTheSameThingAreOne() {
         assertEquals(anInt(), anInt());
         assertEquals(anInt().hashCode(), anInt().hashCode());
-        assertNotEquals(anInt(), Refinement.of(CaseSelector.direct(TypeSymbol.primitive("Bool"))));
+        assertNotEquals(anInt(), aLeaf(TypeSymbol.primitive("Bool")));
 
         assertEquals(Refinement.of(new Case.Presence(true)), Refinement.of(new Case.Presence(true)));
         assertNotEquals(Refinement.of(new Case.Presence(true)),
@@ -184,33 +243,42 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
     }
 
     private static Refinement anInt() {
-        return Refinement.of(CaseSelector.direct(TypeSymbol.primitive("Int")));
+        return aLeaf(TypeSymbol.primitive("Int"));
     }
 
-    /** What the type at {@code field} of the parameter divides into. */
-    private static List<Case> distinctionsAt(Read read, String field) {
-        return Distinctions.ofType(
-                TypeView.of(read.inputs.at(TermPath.of("b").then(field)).view().declared(),
-                        read.symbols),
-                read.symbols);
+    private static Refinement aLeafNamed(String module, String name) {
+        return aLeaf(souther.compiler.types.TypeSymbols.declared(
+                new souther.compiler.types.TypeKey(module, name)));
     }
 
-    private static java.util.Set<String> spelledCases(Read read, String field) {
-        java.util.Set<String> out = new java.util.LinkedHashSet<>();
-        for (Case each : distinctionsAt(read, field)) {
-            out.add(Refinement.of(each).spelled());
-        }
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement aLeaf(TypeSymbol leaf) {
+        return Refinement.of(ResolvedCase.of(
+                souther.compiler.types.CaseSelector.direct(leaf), List.of(leaf)));
+    }
+
+    /** Every arm of every {@code match} the body holds, outermost first. */
+    private static List<Core.Case> armsOf(Core body) {
+        List<Core.Case> out = new ArrayList<>();
+        collect(body, out);
         return out;
     }
 
-    /** What the optional at {@code field} holds, which is what its present carrier is written for. */
-    private static Type elementOf(Read read, String field) {
-        TypeView view = TypeView.of(
-                read.inputs.at(TermPath.of("b").then(field)).view().declared(), read.symbols);
-        return ((Shape.Optional) view.shape()).element();
+    private static void collect(Core at, List<Core.Case> out) {
+        if (at instanceof Core.Match match) {
+            out.addAll(match.cases());
+        }
+        Core.forEachChild(at, each -> collect(each, out));
     }
 
-    private record Read(InputDomain inputs, Symbols symbols) {}
+    /** What the type at one position divides into. */
+    private static List<Case> distinctionsAt(Read read, TermPath at) {
+        return Distinctions.ofType(
+                TypeView.of(read.inputs.at(at).view().declared(), read.symbols), read.symbols);
+    }
+
+    private record Read(InputDomain inputs, Core body, Symbols symbols) {}
 
     private static Read read(String source) {
         Compilation compilation =
@@ -220,10 +288,11 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
-                .filter(b -> b.name().equals("open")).findFirst().orElseThrow();
+                .filter(b -> b.name().equals("visit")).findFirst().orElseThrow();
         return new Read(
-                InputDomain.of(spec, sigs.get("open"), symbols, ReadAs.THE_COMPILATION_DOES),
-                symbols);
+                InputDomain.of(spec, sigs.get("visit"), symbols, ReadAs.THE_COMPILATION_DOES),
+                checked.behaviorBodies().get("visit"), symbols);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -2,10 +2,26 @@ package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Shape;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,17 +31,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A narrowing is spelled where narrowings are owned, and nowhere else.
  *
- * <p>Measured against the shape of the API rather than against an answer. {@link Refinement#of} says
- * it is "the one place the two vocabularies are related", and {@code TermPath.requirements} says a
- * requirement is read from the path "here and nowhere else" — both sentences, and both were kept by
- * whoever happened to read them. The classes of a position spelled a sum's narrowing a second time
- * and never spelled an optional's, so an optional's classes narrowed nothing and two of them could
- * sit in one row; and the boundary search planned a value against no requirement at all, so a row
- * offered for a line under a case carried another case. A sentence is kept by whoever reads it; a
- * signature is kept by everyone (ADR-0114).
+ * <p>Two vocabularies say which narrowing a place carries. What a position's type divides into is
+ * {@link Case}, read by {@link Distinctions}; which of those divisions a written arm selected is
+ * {@link CaseSelector}, decided by the checker. Both settle a narrowing on their own, so both have
+ * a way in here — and what may not have one is a value that settles less than a narrowing. A name
+ * is such a value: an optional's present carrier and a case of a sum declared as {@code Some} are
+ * written the same word, so a narrowing built from the name is one of the two chosen by whoever
+ * built it.
  *
- * <p>The scan below is a tripwire under that, not the other way round — what holds it is that the
- * variants have no constructor a caller can reach.
+ * <p>That is not a hypothetical. {@code Refinement.sumCase(TypeSymbol)} was the second way in, and
+ * the reading of a {@code match} arm used it: every path a body wrote through {@code Some v} came
+ * out carrying a sum's case where the reading of the position carried a presence. The two spell
+ * {@code x@Some} alike and are not equal, so those paths were positions nothing else in this
+ * compiler names — silence wherever a reader shrugs at a path it cannot find, and an internal error
+ * in the one place that refuses (#1252).
+ *
+ * <p>What holds the rule is that the variants have no constructor a caller can reach and that the
+ * two ways in take the two values that determine a narrowing. What holds the correspondence is
+ * {@link #twoVocabulariesAnswerOneNarrowing}, below: exhaustiveness stops a variant being added
+ * without an answer, and only a comparison stops an existing one being answered wrongly.
  */
 class ANarrowingIsSpelledByTheOneThatOwnsItTest {
 
@@ -43,27 +67,98 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
     }
 
     /**
-     * And the two ways in take what they are named for.
+     * And every way in takes a value that already settles which narrowing it is.
      *
-     * <p>Written out rather than counted. {@link Refinement#of} answers which narrowing a
-     * distinction is, and {@link Refinement#sumCase} builds one for a caller that already has the
-     * case — two questions, and a third entry arriving is a decision somebody made here.
+     * <p>Named rather than counted. A count is tripped by a private helper, which is nobody's way
+     * in, and the reading of it that fits is to raise the number — which lets a way in be added
+     * later with nothing having said so. What is checked beside the names is what each of them
+     * takes: a way in whose parameter is a name, a string or a list of case types is one that
+     * cannot tell the two narrowings apart, whatever it is called.
      */
     @Test
-    void everyWayInTakesWhatTheNarrowingIsReadFrom() {
-        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
-                Refinement.of(new Case.SumCase(TypeSymbol.primitive("Int"), false)),
-                "one case read two ways is one narrowing");
-        // Named rather than counted. A count is tripped by a private helper, which is nobody's way
-        // in, and the reading of it that fits is to raise the number — which lets a way in be added
-        // later with nothing having said so.
-        assertEquals(java.util.Set.of("of", "sumCase"),
+    void everyWayInTakesAValueThatSettlesTheNarrowing() {
+        List<java.lang.reflect.Method> ways =
                 java.util.Arrays.stream(Refinement.class.getDeclaredMethods())
                         .filter(each -> Modifier.isStatic(each.getModifiers())
                                 && !Modifier.isPrivate(each.getModifiers()))
-                        .map(java.lang.reflect.Method::getName)
+                        .toList();
+        assertEquals(java.util.Set.of("of"),
+                ways.stream().map(java.lang.reflect.Method::getName)
                         .collect(java.util.stream.Collectors.toSet()),
-                "a third way to spell a narrowing is a decision, not an accident");
+                "a way to spell a narrowing that is not `of` is a decision, not an accident");
+        assertEquals(java.util.Set.of(Case.class, CaseSelector.class),
+                ways.stream().map(each -> each.getParameterTypes()[0])
+                        .collect(java.util.stream.Collectors.toSet()),
+                "a narrowing is made from what a position divides into or from what an arm"
+                        + " selected, and from nothing that settles less than either");
+    }
+
+    /**
+     * The two vocabularies answer one narrowing, shape by shape.
+     *
+     * <p>The correspondence itself, and the reason the exhaustive {@code switch}es are not the whole
+     * of the rule. Nothing stops {@code OptionPresent} being answered with {@code Presence(false)}:
+     * every arm would be covered, every reading would compile, and an optional's arms would swap
+     * which position they wrote at. So each division a type states is matched here against the
+     * selector a pattern selecting it carries.
+     *
+     * <p>Read off a compiled model rather than written out, so that what the checker actually builds
+     * for {@code Some} is what is compared — a selector written here by hand would agree with
+     * whatever this test thought the checker does.
+     */
+    @Test
+    void twoVocabulariesAnswerOneNarrowing() {
+        Read read = read("""
+                module m
+
+                data Empty
+                data Held = { least: Int }
+                data Slot = Empty | Held
+                data Box = { slot: Slot, tag: Int? }
+                data Ack = { at: String }
+
+                behavior open : (b: Box) -> Ack
+                """);
+
+        assertEquals(List.of("Empty", "Held"), spelledCases(read, "slot"),
+                "the sum states its cases");
+        assertEquals(List.of("None", "Some"), spelledCases(read, "tag"),
+                "and the optional states whether it holds anything");
+
+        for (Case each : distinctionsAt(read, "slot")) {
+            Case.SumCase one = (Case.SumCase) each;
+            assertEquals(Refinement.of(each), Refinement.of(CaseSelector.direct(one.leaf())),
+                    () -> "a case of a sum is one narrowing, read either way: " + one.leaf());
+        }
+        Type held = elementOf(read, "tag");
+        assertEquals(Refinement.of(new Case.Presence(true)),
+                Refinement.of(CaseSelector.optionPresent(held)),
+                "an optional holding something is one narrowing, read either way");
+        assertEquals(Refinement.of(new Case.Presence(false)),
+                Refinement.of(CaseSelector.optionAbsent()),
+                "and so is an optional holding nothing");
+    }
+
+    /**
+     * And the two are told apart, which is what makes the correspondence load-bearing.
+     *
+     * <p>A presence and a case of a sum are unequal however they are spelled, so a reader that
+     * built one where the other belongs writes at a position nothing else reaches. Were they equal
+     * instead, the mistake would be invisible and this correspondence would say nothing.
+     */
+    @Test
+    void aPresenceIsNotACaseOfASumHoweverItIsWritten() {
+        Refinement declaredSome = Refinement.of(CaseSelector.direct(
+                souther.compiler.types.TypeSymbols.declared(
+                        new souther.compiler.types.TypeKey("m", "Some"))));
+
+        assertEquals("Some", declaredSome.spelled());
+        assertEquals("Some", Refinement.of(new Case.Presence(true)).spelled());
+        assertNotEquals(Refinement.of(new Case.Presence(true)), declaredSome,
+                "two places written `@Some` are two places where one is an optional's carrier");
+        assertNotEquals(declaredSome.discriminated(),
+                Refinement.of(new Case.Presence(true)).discriminated(),
+                "and a message about this compiler says which of them it holds");
     }
 
     /**
@@ -76,18 +171,58 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
      */
     @Test
     void twoNarrowingsToTheSameThingAreOne() {
-        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
-                Refinement.sumCase(TypeSymbol.primitive("Int")));
-        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")).hashCode(),
-                Refinement.sumCase(TypeSymbol.primitive("Int")).hashCode());
-        assertNotEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
-                Refinement.sumCase(TypeSymbol.primitive("Bool")));
+        assertEquals(anInt(), anInt());
+        assertEquals(anInt().hashCode(), anInt().hashCode());
+        assertNotEquals(anInt(), Refinement.of(CaseSelector.direct(TypeSymbol.primitive("Bool"))));
 
         assertEquals(Refinement.of(new Case.Presence(true)), Refinement.of(new Case.Presence(true)));
         assertNotEquals(Refinement.of(new Case.Presence(true)),
                 Refinement.of(new Case.Presence(false)));
-        assertFalse(Refinement.of(new Case.Presence(true))
-                        .equals(Refinement.sumCase(TypeSymbol.primitive("Int"))),
+        assertFalse(Refinement.of(new Case.Presence(true)).equals(anInt()),
                 "and a presence is not a case of a sum");
+    }
+
+    private static Refinement anInt() {
+        return Refinement.of(CaseSelector.direct(TypeSymbol.primitive("Int")));
+    }
+
+    /** What the type at {@code field} of the parameter divides into. */
+    private static List<Case> distinctionsAt(Read read, String field) {
+        return Distinctions.ofType(
+                TypeView.of(read.inputs.at(TermPath.of("b").then(field)).view().declared(),
+                        read.symbols),
+                read.symbols);
+    }
+
+    private static List<String> spelledCases(Read read, String field) {
+        List<String> out = new ArrayList<>();
+        for (Case each : distinctionsAt(read, field)) {
+            out.add(Refinement.of(each).spelled());
+        }
+        return out;
+    }
+
+    /** What the optional at {@code field} holds, which is what its present carrier is written for. */
+    private static Type elementOf(Read read, String field) {
+        TypeView view = TypeView.of(
+                read.inputs.at(TermPath.of("b").then(field)).view().declared(), read.symbols);
+        return ((Shape.Optional) view.shape()).element();
+    }
+
+    private record Read(InputDomain inputs, Symbols symbols) {}
+
+    private static Read read(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("open")).findFirst().orElseThrow();
+        return new Read(
+                InputDomain.of(spec, sigs.get("open"), symbols, ReadAs.THE_COMPILATION_DOES),
+                symbols);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
@@ -179,12 +179,18 @@ class APositionUnderACaseIsAPositionTest {
 
                 behavior open : (b: Box) -> Ack
                 """, "open");
-        Position least = read.at(TermPath.of("b").refine(
-                Refinement.of(souther.compiler.types.CaseSelector.direct(
-                        caseNamed(read, "Held")))).then("least"));
+        Position least = read.at(TermPath.of("b")
+                .refine(toLeaf(caseNamed(read, "Held"))).then("least"));
         assertNotNull(least, "a field of the case is a position");
         assertTrue(least.rulesLeftUnread().isEmpty(),
                 "and the clause relating it to the field beside it was reached");
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(souther.compiler.types.TypeSymbol leaf) {
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                souther.compiler.types.CaseSelector.direct(leaf), java.util.List.of(leaf)));
     }
 
     /** The case's own name, taken off the reading that holds it. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
@@ -180,7 +180,8 @@ class APositionUnderACaseIsAPositionTest {
                 behavior open : (b: Box) -> Ack
                 """, "open");
         Position least = read.at(TermPath.of("b").refine(
-                Refinement.sumCase(caseNamed(read, "Held"))).then("least"));
+                Refinement.of(souther.compiler.types.CaseSelector.direct(
+                        caseNamed(read, "Held")))).then("least"));
         assertNotNull(least, "a field of the case is a position");
         assertTrue(least.rulesLeftUnread().isEmpty(),
                 "and the clause relating it to the field beside it was reached");

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
@@ -127,8 +127,9 @@ class OneReadingTakesBothRoadsToAPositionTest {
     }
 
     private static Refinement caseOf(InputDomain read, String name) {
-        return Refinement.sumCase(souther.compiler.types.TypeSymbols.declared(
-                new souther.compiler.types.TypeKey("g", name)));
+        return Refinement.of(souther.compiler.types.CaseSelector.direct(
+                souther.compiler.types.TypeSymbols.declared(
+                        new souther.compiler.types.TypeKey("g", name))));
     }
 
     private static InputDomain reading(TermPath demanded) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneReadingTakesBothRoadsToAPositionTest.java
@@ -126,10 +126,13 @@ class OneReadingTakesBothRoadsToAPositionTest {
         assertEquals(spelled(reading(List.of(head, tail))), spelled(reading(List.of(tail, head))));
     }
 
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
     private static Refinement caseOf(InputDomain read, String name) {
-        return Refinement.of(souther.compiler.types.CaseSelector.direct(
-                souther.compiler.types.TypeSymbols.declared(
-                        new souther.compiler.types.TypeKey("g", name))));
+        souther.compiler.types.TypeSymbol leaf = souther.compiler.types.TypeSymbols.declared(
+                new souther.compiler.types.TypeKey("g", name));
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                souther.compiler.types.CaseSelector.direct(leaf), List.of(leaf)));
     }
 
     private static InputDomain reading(TermPath demanded) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheWalkStopsWhereTheInputReturnsToADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheWalkStopsWhereTheInputReturnsToADeclarationTest.java
@@ -134,7 +134,7 @@ class TheWalkStopsWhereTheInputReturnsToADeclarationTest {
     @Test
     void anExpressionStopsAtTheOperandsOfItsOperator() {
         InputDomain read = reading(THROUGH_A_CASE, "read");
-        TermPath left = TermPath.of("x").refine(Refinement.of(CaseSelector.direct(named(read, "Add")))).then("l");
+        TermPath left = TermPath.of("x").refine(toLeaf(named(read, "Add"))).then("l");
 
         assertNotNull(read.at(left), () -> spelled(read));
         assertEquals("x", returnedAt(read, left).openedAt().toString(),
@@ -169,7 +169,7 @@ class TheWalkStopsWhereTheInputReturnsToADeclarationTest {
     void theReturningOccurrenceIsStillRead() {
         InputDomain read = reading(THROUGH_A_CASE, "read");
         Position left = read.at(
-                TermPath.of("x").refine(Refinement.of(CaseSelector.direct(named(read, "Add")))).then("l"));
+                TermPath.of("x").refine(toLeaf(named(read, "Add"))).then("l"));
 
         assertEquals(2, left.obligationCases().size(),
                 "the sum there divides into its cases whichever time round it is");
@@ -180,6 +180,13 @@ class TheWalkStopsWhereTheInputReturnsToADeclarationTest {
         BlockedDescent stopped = BlockedDescent.of(read.at(path).structure());
         assertNotNull(stopped, () -> path + " is where the path returns, and it says so");
         return assertInstanceOf(BlockReason.RecursiveExpansion.class, stopped.why());
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(souther.compiler.types.TypeSymbol leaf) {
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                CaseSelector.direct(leaf), List.of(leaf)));
     }
 
     /** The declaration {@code name} stands for in the model under test. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheWalkStopsWhereTheInputReturnsToADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheWalkStopsWhereTheInputReturnsToADeclarationTest.java
@@ -11,6 +11,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
 
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ class TheWalkStopsWhereTheInputReturnsToADeclarationTest {
     @Test
     void anExpressionStopsAtTheOperandsOfItsOperator() {
         InputDomain read = reading(THROUGH_A_CASE, "read");
-        TermPath left = TermPath.of("x").refine(Refinement.sumCase(named(read, "Add"))).then("l");
+        TermPath left = TermPath.of("x").refine(Refinement.of(CaseSelector.direct(named(read, "Add")))).then("l");
 
         assertNotNull(read.at(left), () -> spelled(read));
         assertEquals("x", returnedAt(read, left).openedAt().toString(),
@@ -168,7 +169,7 @@ class TheWalkStopsWhereTheInputReturnsToADeclarationTest {
     void theReturningOccurrenceIsStillRead() {
         InputDomain read = reading(THROUGH_A_CASE, "read");
         Position left = read.at(
-                TermPath.of("x").refine(Refinement.sumCase(named(read, "Add"))).then("l"));
+                TermPath.of("x").refine(Refinement.of(CaseSelector.direct(named(read, "Add")))).then("l"));
 
         assertEquals(2, left.obligationCases().size(),
                 "the sum there divides into its cases whichever time round it is");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
@@ -15,6 +15,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
@@ -75,8 +76,8 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
     }
 
     private static TermPath under(String leaf) {
-        return TermPath.of("query").refine(Refinement.sumCase(
-                TypeSymbols.declared(new TypeKey("example.q", leaf))));
+        return TermPath.of("query").refine(Refinement.of(CaseSelector.direct(
+                TypeSymbols.declared(new TypeKey("example.q", leaf)))));
     }
 
     /** Every class of every position, including the ones only one case has. */
@@ -129,8 +130,8 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
         assertFalse(tag.requirements().compatibleWith(sum.requiring(classOf(sum, "FeedQuery"))),
                 "and a row that is a FeedQuery is at none of them");
         assertEquals(Requirements.NONE.and(TermPath.of("query"),
-                        Refinement.sumCase(
-                                TypeSymbols.declared(new TypeKey("example.q", "GlobalQuery")))),
+                        Refinement.of(CaseSelector.direct(
+                                TypeSymbols.declared(new TypeKey("example.q", "GlobalQuery"))))),
                 tag.requirements(),
                 "which the path says on its own, with nothing kept beside it");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
@@ -76,8 +76,16 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
     }
 
     private static TermPath under(String leaf) {
-        return TermPath.of("query").refine(Refinement.of(CaseSelector.direct(
-                TypeSymbols.declared(new TypeKey("example.q", leaf)))));
+        return TermPath.of("query").refine(toLeaf(leaf));
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(String leaf) {
+        souther.compiler.types.TypeSymbol named =
+                TypeSymbols.declared(new TypeKey("example.q", leaf));
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                CaseSelector.direct(named), java.util.List.of(named)));
     }
 
     /** Every class of every position, including the ones only one case has. */
@@ -129,9 +137,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
                 "a row that is a GlobalQuery is at the positions the case declares");
         assertFalse(tag.requirements().compatibleWith(sum.requiring(classOf(sum, "FeedQuery"))),
                 "and a row that is a FeedQuery is at none of them");
-        assertEquals(Requirements.NONE.and(TermPath.of("query"),
-                        Refinement.of(CaseSelector.direct(
-                                TypeSymbols.declared(new TypeKey("example.q", "GlobalQuery"))))),
+        assertEquals(Requirements.NONE.and(TermPath.of("query"), toLeaf("GlobalQuery")),
                 tag.requirements(),
                 "which the path says on its own, with nothing kept beside it");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -18,6 +18,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -238,7 +239,7 @@ class AConstructionPositionIsNotAnInputPositionTest {
     /** The requirement a class of {@code d} states by being the {@code Approved} case of it. */
     private static Requirements throughApproved(Read read) {
         return Requirements.NONE.and(TermPath.of(read.spec().params().get(0).name()),
-                Refinement.sumCase(caseNamed(SUM, "probe")));
+                Refinement.of(CaseSelector.direct(caseNamed(SUM, "probe"))));
     }
 
     /** The name of the case to build through, taken off a behavior that is declared to take one. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -239,7 +239,14 @@ class AConstructionPositionIsNotAnInputPositionTest {
     /** The requirement a class of {@code d} states by being the {@code Approved} case of it. */
     private static Requirements throughApproved(Read read) {
         return Requirements.NONE.and(TermPath.of(read.spec().params().get(0).name()),
-                Refinement.of(CaseSelector.direct(caseNamed(SUM, "probe"))));
+                toLeaf(caseNamed(SUM, "probe")));
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(TypeSymbol leaf) {
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                CaseSelector.direct(leaf), java.util.List.of(leaf)));
     }
 
     /** The name of the case to build through, taken off a behavior that is declared to take one. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -14,6 +14,7 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeKey;
 
@@ -217,7 +218,7 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
     }
 
     private static Refinement caseOf(String leaf) {
-        return Refinement.sumCase(TypeSymbols.declared(new TypeKey("g", leaf)));
+        return Refinement.of(CaseSelector.direct(TypeSymbols.declared(new TypeKey("g", leaf))));
     }
 
     /** The behavior's one parameter type, and the names it is read against. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -217,8 +217,12 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
                 "nothing here asks one position to be two things").plan();
     }
 
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
     private static Refinement caseOf(String leaf) {
-        return Refinement.of(CaseSelector.direct(TypeSymbols.declared(new TypeKey("g", leaf))));
+        souther.compiler.types.TypeSymbol named = TypeSymbols.declared(new TypeKey("g", leaf));
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                CaseSelector.direct(named), java.util.List.of(named)));
     }
 
     /** The behavior's one parameter type, and the names it is read against. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
@@ -99,10 +99,16 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
         return read.subject().axes().where(each -> each.id().equals(axis.id()));
     }
 
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement toLeaf(souther.compiler.types.TypeSymbol leaf) {
+        return Refinement.of(souther.compiler.types.ResolvedCase.of(
+                CaseSelector.direct(leaf), java.util.List.of(leaf)));
+    }
+
     private static TermPath under(String module, String leaf, String field) {
         return TermPath.of("query")
-                .refine(Refinement.of(CaseSelector.direct(
-                        TypeSymbols.declared(new TypeKey(module, leaf)))))
+                .refine(toLeaf(TypeSymbols.declared(new TypeKey(module, leaf))))
                 .then(field);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
@@ -17,6 +17,7 @@ import souther.compiler.query.Output;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
@@ -100,7 +101,8 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
 
     private static TermPath under(String module, String leaf, String field) {
         return TermPath.of("query")
-                .refine(Refinement.sumCase(TypeSymbols.declared(new TypeKey(module, leaf))))
+                .refine(Refinement.of(CaseSelector.direct(
+                        TypeSymbols.declared(new TypeKey(module, leaf)))))
                 .then(field);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
@@ -153,10 +153,13 @@ class AComparisonOnANumberTakenOfALocationSteersARowTest {
                         | Empty -> No
                 """;
         Read read = read(inArm);
-        TermPath underNamed = TermPath.of("slot").refine(souther.compiler.inputs.Refinement.of(
-                souther.compiler.types.CaseSelector.direct(
-                        souther.compiler.types.TypeSymbols.declared(
-                                new souther.compiler.types.TypeKey("example.arm", "Named")))))
+        souther.compiler.types.TypeSymbol named = souther.compiler.types.TypeSymbols.declared(
+                new souther.compiler.types.TypeKey("example.arm", "Named"));
+        // A leaf is a case that covers itself, which is what the checker's resolution of the arm
+        // says, so selecting it narrows the position to that one distinction.
+        TermPath underNamed = TermPath.of("slot").refine(
+                souther.compiler.inputs.Refinement.of(souther.compiler.types.ResolvedCase.of(
+                        souther.compiler.types.CaseSelector.direct(named), List.of(named))))
                 .then("c");
 
         assertEquals(List.of(read.lengthAt(underNamed)),

--- a/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
@@ -153,9 +153,11 @@ class AComparisonOnANumberTakenOfALocationSteersARowTest {
                         | Empty -> No
                 """;
         Read read = read(inArm);
-        TermPath underNamed = TermPath.of("slot").refine(souther.compiler.inputs.Refinement.sumCase(
-                souther.compiler.types.TypeSymbols.declared(
-                        new souther.compiler.types.TypeKey("example.arm", "Named")))).then("c");
+        TermPath underNamed = TermPath.of("slot").refine(souther.compiler.inputs.Refinement.of(
+                souther.compiler.types.CaseSelector.direct(
+                        souther.compiler.types.TypeSymbols.declared(
+                                new souther.compiler.types.TypeKey("example.arm", "Named")))))
+                .then("c");
 
         assertEquals(List.of(read.lengthAt(underNamed)),
                 read.sides().stream().map(Condition.Side::at).distinct().toList(),

--- a/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
@@ -3,9 +3,7 @@ package souther.compiler.reading;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.NumericMeasures;
-import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeView;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
@@ -16,7 +14,6 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 
 import java.util.List;
@@ -66,16 +63,17 @@ class AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest {
                     | None -> No
             """;
 
-    /** The position the arm's name stands at, spelled by the narrowing the optional's own carrier
-     *  is. */
-    private static TermPath underSome(Read read) {
-        TermPath optional = TermPath.of("b").then("held");
-        // What the optional holds, which is what its present carrier is written for. Taken off the
-        // type rather than passed the optional itself: the two spell one narrowing today, and a
-        // carrier written for the wrong type is a selector no checker would build.
-        Shape.Optional shape = (Shape.Optional) TypeView.of(
-                read.inputs.at(optional).view().declared(), read.symbols).shape();
-        return optional.refine(Refinement.of(CaseSelector.optionPresent(shape.element())))
+    /**
+     * The position the arm's name stands at.
+     *
+     * <p>Spelled in the reading's own vocabulary — the distinction an optional's type states — and
+     * not in the arm's. What is being claimed is that the two meet, so naming the place from the
+     * side the body is compared against leaves the body's side with nothing written here to agree
+     * with.
+     */
+    private static TermPath underSome() {
+        return TermPath.of("b").then("held")
+                .refine(Refinement.of(new souther.compiler.inputs.Case.Presence(true)))
                 .then("c");
     }
 
@@ -90,7 +88,7 @@ class AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest {
     void theComparisonInsideTheArmIsAboutThePositionUnderThePresence() {
         Read read = read(THROUGH_AN_OPTIONAL);
 
-        assertEquals(List.of(read.lengthAt(underSome(read))),
+        assertEquals(List.of(read.lengthAt(underSome())),
                 read.sides().stream().map(Condition.Side::at).distinct().toList(),
                 "the number is the length of the field under the optional's present carrier");
     }
@@ -104,7 +102,7 @@ class AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest {
         // Said with each narrowing's kind on it, because that is the whole of what goes wrong here:
         // a position spelled `b.held@Some` is in the list either way, and only the kind tells the
         // one the reading holds from the one a body would have written at.
-        assertNotNull(read.inputs.at(underSome(read)),
+        assertNotNull(read.inputs.at(underSome()),
                 () -> "the body writes at a position the reading does not hold: "
                         + read.inputs.positions().stream()
                                 .map(each -> each.path().discriminated()).toList());

--- a/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
@@ -1,0 +1,146 @@
+package souther.compiler.reading;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.NumericMeasures;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a body writes inside {@code | Some v} is written at the position the reading of the input
+ * holds for that narrowing.
+ *
+ * <p>The integration invariant, and it is a different claim from the one the two vocabularies
+ * answer alike. That one is about a narrowing: given an optional, the division its type states and
+ * the selector a pattern selecting it carries come to the same {@link Refinement}. This one is
+ * about a path: the reading of a body, walking through the arm, arrives at a location the reading
+ * of the input can be asked about. Both were true of a sum's arm and only the first is enough to
+ * make the second so — a producer can hold the right narrowing and still put it after the wrong
+ * steps.
+ *
+ * <p>What made this worth a test of its own is that the two came apart silently. The reading of an
+ * arm built its narrowing from the case's name, which spells an optional's present carrier and a
+ * sum's case alike, so a body inside {@code | Some v} wrote at {@code x@Some} carrying a sum's case
+ * while the input's reading held {@code x@Some} carrying a presence. Nothing compared the two: most
+ * readers look a path up, find nothing and say nothing, and the one that refuses raised in the
+ * middle of a report and took the whole model's with it (#1252).
+ *
+ * <p>Read as the location a comparison is about rather than as a line of a report. What a report
+ * prints about such a position is a further question and moves with how it is worded; what may not
+ * move is that the two readings meet at one place.
+ */
+class AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest {
+
+    private static final String THROUGH_AN_OPTIONAL = """
+            module example.optional
+
+            data Yes
+            data No
+            data Answer = Yes | No
+
+            data Slot = { c: String }
+            data Box = { held: Slot? }
+
+            behavior gate : (b: Box) -> Answer
+            let gate (b) =
+                match b.held with
+                    | Some s -> if String.length(s.c) <= 3 then Yes else No
+                    | None -> No
+            """;
+
+    /** The position the arm's name stands at, spelled by the narrowing the optional's own carrier
+     *  is. */
+    private static TermPath underSome(Read read) {
+        Type held = read.inputs.at(TermPath.of("b").then("held")).view().declared();
+        return TermPath.of("b").then("held")
+                .refine(Refinement.of(CaseSelector.optionPresent(held)))
+                .then("c");
+    }
+
+    /**
+     * The comparison inside the arm is about that position.
+     *
+     * <p>Which is what the arm's name means: {@code s} is {@code b.held} read as the case it turned
+     * out to be, and {@code s.c} is the field of it. A narrowing spelled any other way puts the
+     * comparison at a location spelled the same and equal to nothing.
+     */
+    @Test
+    void theComparisonInsideTheArmIsAboutThePositionUnderThePresence() {
+        Read read = read(THROUGH_AN_OPTIONAL);
+
+        assertEquals(List.of(read.lengthAt(underSome(read))),
+                read.sides().stream().map(Condition.Side::at).distinct().toList(),
+                "the number is the length of the field under the optional's present carrier");
+    }
+
+    /** And that position is one the reading of the input holds, which is what makes it a place
+     *  anything else can be asked about. */
+    @Test
+    void thatPositionIsOneTheReadingOfTheInputHolds() {
+        Read read = read(THROUGH_AN_OPTIONAL);
+
+        // Said with each narrowing's kind on it, because that is the whole of what goes wrong here:
+        // a position spelled `b.held@Some` is in the list either way, and only the kind tells the
+        // one the reading holds from the one a body would have written at.
+        assertNotNull(read.inputs.at(underSome(read)),
+                () -> "the body writes at a position the reading does not hold: "
+                        + read.inputs.positions().stream()
+                                .map(each -> each.path().discriminated()).toList());
+    }
+
+    /** One model read, with the symbols a term named here is built against. */
+    private record Read(CoverageRead.Read read, InputDomain inputs, Symbols symbols) {
+
+        /** Every comparison the reading named, over every way in to every arm. */
+        List<Condition.Side> sides() {
+            return read.arms().values().stream()
+                    .filter(PathAccess.Ways.class::isInstance)
+                    .flatMap(access -> ((PathAccess.Ways) access).ways().stream())
+                    .flatMap(way -> way.decisions().stream())
+                    .map(Decision::constrains)
+                    .filter(Condition.Side.class::isInstance)
+                    .map(Condition.Side.class::cast)
+                    .distinct().toList();
+        }
+
+        /** The number a string's length is, built here rather than matched by how it is written. */
+        NumericTerm lengthAt(TermPath at) {
+            NumericTerm.TakenOf taken = NumericTerm.TakenOf.of(
+                    NumericMeasures.takenOf(Type.STRING, symbols), at, Type.STRING, symbols);
+            assertNotNull(taken, "the length of a string is a number this compiler names");
+            return taken;
+        }
+    }
+
+    private static Read read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Core body = checked.behaviorBodies().get("gate");
+        assertNotNull(body, "the behavior under test has a body");
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        InputDomain inputs = compilation.db().ask(new Adequacy.Inputs(module)).value().get("gate");
+        assertNotNull(inputs, "the behavior's input is read");
+        return new Read(CoverageRead.of("gate", body,
+                CoverageSites.of(checked.behaviorBodies(), checked.decisions(), checked.supplied()),
+                inputs, symbols), inputs, symbols);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest.java
@@ -3,7 +3,9 @@ package souther.compiler.reading;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.NumericMeasures;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
@@ -67,9 +69,13 @@ class AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest {
     /** The position the arm's name stands at, spelled by the narrowing the optional's own carrier
      *  is. */
     private static TermPath underSome(Read read) {
-        Type held = read.inputs.at(TermPath.of("b").then("held")).view().declared();
-        return TermPath.of("b").then("held")
-                .refine(Refinement.of(CaseSelector.optionPresent(held)))
+        TermPath optional = TermPath.of("b").then("held");
+        // What the optional holds, which is what its present carrier is written for. Taken off the
+        // type rather than passed the optional itself: the two spell one narrowing today, and a
+        // carrier written for the wrong type is a selector no checker would build.
+        Shape.Optional shape = (Shape.Optional) TypeView.of(
+                read.inputs.at(optional).view().declared(), read.symbols).shape();
+        return optional.refine(Refinement.of(CaseSelector.optionPresent(shape.element())))
                 .then("c");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
@@ -71,10 +71,12 @@ class ACaseIsNotHalfDecidedTest {
     @Test
     void anArmsBindingIsReadOffWhatItSelects() {
         CaseSelector present = CaseSelector.optionPresent(ELEMENT);
-        assertEquals(present.refinement(), new Core.ResolvedPattern.Single(present).binding(),
+        assertEquals(present.refinement(), new Core.ResolvedPattern.Single(covering(present,
+                        TypeSymbol.SOME)).binding(),
                 "one case binds what that case's carrier holds, and there is nowhere to say"
                         + " otherwise");
-        assertNull(new Core.ResolvedPattern.Single(CaseSelector.optionAbsent()).bindType(),
+        assertNull(new Core.ResolvedPattern.Single(
+                        covering(CaseSelector.optionAbsent(), TypeSymbol.NONE)).bindType(),
                 "a carrier holding nothing says so as fully as any other");
     }
 
@@ -84,7 +86,7 @@ class ACaseIsNotHalfDecidedTest {
         TypeSymbol aBool = TypeSymbol.primitive(Type.Prim.BOOL);
         Type subject = Type.union(java.util.Set.of(anInt, aBool));
         Core.ResolvedPattern.AnyOf several = new Core.ResolvedPattern.AnyOf(
-                List.of(CaseSelector.direct(anInt), CaseSelector.direct(aBool)), subject);
+                List.of(aLeaf(anInt), aLeaf(aBool)), subject);
         assertEquals(new Refinement.Direct(subject), several.binding(),
                 "no one case type fits all of the alternatives, and each is already the subject");
     }
@@ -94,10 +96,19 @@ class ACaseIsNotHalfDecidedTest {
         TypeSymbol anInt = TypeSymbol.primitive(Type.Prim.INT);
         Type subject = Type.union(java.util.Set.of(anInt));
         assertThrows(IllegalArgumentException.class,
-                () -> new Core.ResolvedPattern.AnyOf(List.of(CaseSelector.direct(anInt)), subject),
+                () -> new Core.ResolvedPattern.AnyOf(List.of(aLeaf(anInt)), subject),
                 "one case is a Single, which reads its binding off the case");
         assertThrows(IllegalArgumentException.class,
                 () -> new Core.ResolvedPattern.AnyOf(List.of(), subject));
+    }
+
+    /** A leaf as this compile would resolve it: a case that covers itself. */
+    private static ResolvedCase aLeaf(TypeSymbol leaf) {
+        return covering(CaseSelector.direct(leaf), leaf);
+    }
+
+    private static ResolvedCase covering(CaseSelector selector, TypeSymbol... atoms) {
+        return ResolvedCase.of(selector, List.of(atoms));
     }
 
     @Test


### PR DESCRIPTION
Closes #1252.

## What was wrong

A narrowing of an input position is one of the distinctions the declarations state there. Two vocabularies decide which one: what a position's type divides into (`Case`, read by `Distinctions`) and what a written arm was resolved to select (`ResolvedCase`, decided by the checker). Neither is a name, and the compiler was using names.

`Refinement` had a third way in, `sumCase(TypeSymbol)`, and the reading of a `match` arm used it with `caseTypes().get(0)`. A name falls short twice over:

| written | the reading holds | the arm produced |
| --- | --- | --- |
| `\| Some v ->` over `Slot?` | `x@Some` carrying `Presence(true)` | `x@Some` carrying `SumCase(Some)` |
| `\| OnceKind as x ->` over `VisitKind = OnceKind \| Renkei` | `k@Station`, `k@Hospital` | `k@OnceKind` |

Both spell a path that nothing else in the compiler names. Most readers look such a path up, find nothing and say nothing — indistinguishable from a model that states nothing there. The one reader that refuses instead (`ReadQuantities.ordersOf`) raised in the middle of an adequacy report and took the whole model's with it, so the `crm` example produced no report at all.

The issue read that raise as the walk having failed to reach the position. It had not: the reading holds `accounts[*].domain@Some`. The message was true of the term as spelled and false about the model, which is also why the issue's second question — whether the walk should be able to name an optional under a list — does not arise.

## The design

```
CaseSelector    settles what a value is tested and read as at run time.
ResolvedCase    settles that selection against this compilation's declarations.
                Only the second can settle an input-path narrowing.
```

`sumCase(TypeSymbol)` is gone. The two entries left are `of(Case)` and `of(ResolvedCase)`, and neither accepts a value that settles less than a narrowing.

`Core.ResolvedPattern` carries `ResolvedCase`. The checker resolved each written case against the declarations and then dropped the resolution, on the ground that a backend needs only the selector — true of a backend and false of every reader that asks which case of a subject an arm picked, because below the checker there are no declarations left to work the leaves out from. `selectors()` is now a projection, so a backend reads what it always read.

`Refinement.allOf(ResolvedCase)` is the general reading: every distinction a selection covers, one per leaf for a case that is itself a sum. `of(ResolvedCase)` is that asked for the case where there is exactly one, written in terms of it. A path takes a single narrowing or none; what the rules leave an arm is asked of every distinction it can arrive at.

`Position` answers by narrowing as well as by leaf, and which distinction a key names is decided in one place for both.

The readers that narrow a path — `InputReads.insideArm` and `ReachingCuts.entering` — take the checker's resolution as it stands. Neither asks whether the pattern named one case or what the scrutinee's type was.

## What it was costing

`crm` produced no adequacy report at all.

And `PathReachability` asked a position about an arm by name, so a name that is not a distinction came back as "the position settled nothing" and the claim was judged unproven. Measured on one model with both spellings of one claim:

```
| Station  -> unreachable "..."   E1326 — refused
| OnceKind -> unreachable "..."   silent, and OnceKind covers Station
```

`unreachable` written on an arm the model admits went unreported whenever the arm named a case above leaves or a carrier of an optional.

## Tests

`ANarrowingIsSpelledByTheOneThatOwnsItTest` held the wrong invariant twice over. It listed the ways in by name, which made `sumCase` a spelled-out feature; and its correspondence built a selector for each distinction and compared the pairs, which meets only the selections it thought of — `OnceKind` has no distinction to be paired with, so it never appeared among the pairs. It now walks the arms of a model holding each shape once, takes every selection the checker resolved as it stands, and requires each to answer one distinction the position states or none.

`WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest` still stated the old boundary — what goes downstream is the selector alone — and its body only checked that a selector has two record components, so it never held the boundary its name claimed. It now asserts what a reader of `Core` can say with no declaration in hand.

`AnArmOfAnOptionalWritesAtThePositionTheReadingHoldsTest` is the integration invariant, kept separate from the correspondence: the comparison inside `| Some s -> String.length(s.c) <= 3` is about the position under the presence, and that position is one the reading holds. It observes path identity, not any line of a report.

Positive controls, each measured:

| mutation | what goes red |
| --- | --- |
| `OptionPresent -> SumCase(name)` | correspondence 1, integration 2 |
| `OptionAbsent -> Presence(true)` | correspondence 1 |
| `Direct -> SumCase(name)` (ignore the atoms) | correspondence 1, on `OnceKind` |
| drop the atoms from `Core` | the Core-boundary test |
| ask reachability with the single narrowing only | the E1326 test, on `OnceKind` |

## Measured

`mvn -o test` green. Checkstyle's `UnusedImports` clean.

All 14 example models compiled before and after: 13 produce byte-identical reports, `crm` goes from an internal compiler error to a full one. `| Some ` arms appear at 10 sites across 6 of those models, so the malformed path was written in all of them — everywhere but `crm` the readers that met it shrugged.

## Not in this PR

`held` is untouched beyond the wording of its message. It answers "is this term this input's?" with `rootOf(path) != null`, which is the other question — a path with a parameter head can still have no root above it where the walk opened no reading. Whether that is reachable now is a measurement to take before deciding between an answer and a raise on the true condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)