### PR TITLE
Fold a comparison from what its operator placed

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ComparisonClaim.java
@@ -15,12 +15,18 @@ import java.util.Objects;
  * places a line under one of them and nothing under the other while both go on being called what a
  * rule placed.
  *
- * <p><b>Two ways in and no more.</b> A comparison the source wrote is answered where it is
- * recognised ({@link Comparison}), from the operator it was written with. A comparison this compiler
- * composed out of what the rules proved never had an operator, and is answered from the relation the
- * reasoning arrived at ({@link #stating}). Whichever door it came through, no reader below holds an
- * operator or goes back to one — that is what the two doors are for, and it is why there is no third
- * that reads a claim off something else again.
+ * <p><b>Two ways in, and a list of the bridges.</b> A comparison the source wrote is answered from
+ * the operator it was written with, where it is recognised. A comparison this compiler composed out
+ * of what the rules proved never had an operator, and is answered from the relation the reasoning
+ * arrived at ({@link #stating}). Those two are the whole of where a claim comes from, and there is
+ * no third that reads one off something else again.
+ *
+ * <p>How many recognitions the first is written as is a different question, and not one this can
+ * answer with a number: a tree a check produces ({@link Comparison}) and a tree a fold walks are
+ * different trees, and each is recognised where it is read. Which sites those are is enumerated off
+ * the compiled classes, together with what each is licensed for
+ * ({@code AnOperatorIsAskedWhatItPlacesInOnePlaceTest}). What every one of them is for is the same:
+ * below it, no reader holds an operator or goes back to one.
  *
  * <p><b>Two cases, because an operator that placed nothing is no comparison.</b> That an operator
  * compares is settled where a comparison is recognised ({@link Comparison}), and this is what such

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -102,14 +102,17 @@ public final class ConstEval {
         }
         Object a = l.get();
         Object b = r.get();
+        // A comparison folds through what its operator placed, and this is where the operator's
+        // words are left behind: what such an expression comes to is the relation it states of its
+        // two sides, which is the one answer a reading that never had an operator asks for as well.
+        if (ComparisonPlacement.of(bin.op()) instanceof ComparisonClaim placed) {
+            return Optional.ofNullable(stands(placed.statedRelation(), a, b));
+        }
         return switch (bin.op()) {
             case AND -> a instanceof Boolean x && b instanceof Boolean y
                     ? Optional.of(x && y) : Optional.empty();
             case OR -> a instanceof Boolean x && b instanceof Boolean y
                     ? Optional.of(x || y) : Optional.empty();
-            case EQ -> Optional.of(equal(a, b));
-            case NE -> Optional.of(!equal(a, b));
-            case LT, LE, GT, GE -> compare(bin.op(), a, b);
             case ADD, SUB, MUL -> arith(bin.op(), a, b);
             // `++` appends two strings or two lists (spec §an-operator-takes-the-types-it-is-defined-for);
             // the string case folds, and a list is not a constant here to begin with.
@@ -117,6 +120,12 @@ public final class ConstEval {
                     ? Optional.of(x + y) : Optional.empty();
             // `/` is left to the run-time check (it aborts on a zero divisor, and Decimal `/` rounds).
             case DIV -> Optional.empty();
+            // Answered above as what it placed. Written out rather than left to a default, because
+            // what would arrive here is the partition above having admitted a comparison into the
+            // arms that compute a value, and an arm inventing an answer for that is how a fold
+            // comes to disagree with every other reader of the same comparison.
+            case EQ, NE, LT, LE, GT, GE -> throw new IllegalStateException(
+                    "a comparison is folded from what it placed, not from " + bin.op());
         };
     }
 
@@ -124,54 +133,37 @@ public final class ConstEval {
      * Whether {@code rel} holds between two folded constants, or {@code null} where these two
      * cannot answer it.
      *
-     * <p>What a comparison of written values comes to, asked by a relation rather than by the
-     * operator one was written with. A reading that composed a comparison out of what the rules
-     * proved has no operator and no node — it has what the comparison places and its two sides — and
-     * this is where such a statement is folded, over the same order and the same equality the
-     * operators fold through.
+     * <p>The whole of what a comparison of written values comes to, whichever words the caller has
+     * it in. A reading that composed a comparison out of what the rules proved has no operator and
+     * no node — it has what the comparison places and its two sides — and an expression written with
+     * an operator arrives with the relation that operator placed
+     * ({@link ComparisonClaim#statedRelation}). One fold under the crossing, rather than one on
+     * either side of it agreeing about every pair of constants there is until somebody edits one.
      *
      * <p>An ordering answers where the two are of one ordered kind, and an equality answers of any
      * two constants at all: {@code true == true} is decided where {@code true < true} is not
      * something to decide.
+     *
+     * <p><b>Which way the two stand is worked out here and goes nowhere.</b> A sign handed back to a
+     * caller is what a second table of six is written over — {@code c < 0} and the three beside it
+     * are the same table as {@link Rel#holds} in another hand — so the order of two constants is
+     * taken and answered in the one place, and there is nothing to call for the sign alone.
      */
     static Boolean stands(Rel rel, Object a, Object b) {
-        Integer c = order(a, b);
-        if (c != null) {
-            return rel.holds(c);
+        if (a instanceof Long x && b instanceof Long y) {
+            return rel.holds(Long.compare(x, y));
+        }
+        if (a instanceof BigDecimal x && b instanceof BigDecimal y) {
+            return rel.holds(x.compareTo(y));
+        }
+        if (a instanceof String x && b instanceof String y) {
+            return rel.holds(x.compareTo(y));
         }
         return switch (rel) {
             case EQ -> equal(a, b);
             case NE -> !equal(a, b);
             case GE, GT, LE, LT -> null;
         };
-    }
-
-    private static Optional<Object> compare(BinOp op, Object a, Object b) {
-        Integer c = order(a, b);
-        if (c == null) {
-            return Optional.empty();
-        }
-        return Optional.of(switch (op) {
-            case LT -> c < 0;
-            case LE -> c <= 0;
-            case GT -> c > 0;
-            case GE -> c >= 0;
-            default -> throw new IllegalStateException();
-        });
-    }
-
-    /** Total order over two constants of the same ordered kind, or null if they are not comparable. */
-    private static Integer order(Object a, Object b) {
-        if (a instanceof Long x && b instanceof Long y) {
-            return Long.compare(x, y);
-        }
-        if (a instanceof BigDecimal x && b instanceof BigDecimal y) {
-            return x.compareTo(y);
-        }
-        if (a instanceof String x && b instanceof String y) {
-            return x.compareTo(y);
-        }
-        return null;
     }
 
     private static Optional<Object> arith(BinOp op, Object a, Object b) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -806,10 +806,10 @@ final class Predicates {
      *
      * <p>Folded from the two sides and what the comparison places, because a statement has no node
      * to fold. Which is the whole of what folding a comparison is either way — an expression folds a
-     * side at a time and puts the two together under its operator ({@link ConstEval}) — and it is
-     * what lets a composed comparison be decided at all: {@code Int.compare(1, 2) >= 0} folds
-     * through nothing the library declares, and the order it states of {@code 1} and {@code 2} is
-     * settled here.
+     * side at a time and puts the two together under the relation its operator placed
+     * ({@link ConstEval#stands}) — and it is what lets a composed comparison be decided at all:
+     * {@code Int.compare(1, 2) >= 0} folds through nothing the library declares, and the order it
+     * states of {@code 1} and {@code 2} is settled here.
      */
     private Boolean decidedAt(StatedComparison stated) {
         Object left = Terms.folded(stated.left(), terms.symbols());

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonFoldsToWhatItsOperatorPlacedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonFoldsToWhatItsOperatorPlacedTest.java
@@ -1,0 +1,93 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.CoverageOrigin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * An expression written with a comparing operator folds to what the relation that operator placed
+ * comes to of its two sides.
+ *
+ * <p>The way from the operator to the answer, taken whole: what the operator placed
+ * ({@link ComparisonPlacement}), the relation that placement states, and the fold of that relation
+ * over two constants. Each of the six is put through it, because what is being fixed is the way and
+ * not any one relation — a claim read off the wrong operator answers every question a reader can
+ * ask of it, and answers them about a comparison nobody wrote.
+ *
+ * <p>What the relations themselves come to is fixed against how two values stand, and not here.
+ */
+class AComparisonFoldsToWhatItsOperatorPlacedTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    /** The six as the language writes them. */
+    private static final List<BinOp> COMPARING =
+            List.of(BinOp.LT, BinOp.LE, BinOp.GT, BinOp.GE, BinOp.EQ, BinOp.NE);
+
+    @Test
+    void everyComparingOperatorFoldsToWhatItPlacedOverTwoConstants() {
+        assertEquals(List.of(
+                "1 LT 2 = true", "1 LE 2 = true", "1 GT 2 = false", "1 GE 2 = false",
+                "1 EQ 2 = false", "1 NE 2 = true",
+                "2 LT 2 = false", "2 LE 2 = true", "2 GT 2 = false", "2 GE 2 = true",
+                "2 EQ 2 = true", "2 NE 2 = false",
+                "2 LT 1 = false", "2 LE 1 = false", "2 GT 1 = true", "2 GE 1 = true",
+                "2 EQ 1 = false", "2 NE 1 = true",
+                // No order to answer an ordering by, and an equality all the same.
+                "true LT true = not a constant", "true LE true = not a constant",
+                "true GT true = not a constant", "true GE true = not a constant",
+                "true EQ true = true", "true NE true = false",
+                "true LT false = not a constant", "true LE false = not a constant",
+                "true GT false = not a constant", "true GE false = not a constant",
+                "true EQ false = false", "true NE false = true"),
+                folded(List.of(
+                        new Pair(new Hir.IntLit(1, POS, null), new Hir.IntLit(2, POS, null)),
+                        new Pair(new Hir.IntLit(2, POS, null), new Hir.IntLit(2, POS, null)),
+                        new Pair(new Hir.IntLit(2, POS, null), new Hir.IntLit(1, POS, null)),
+                        new Pair(new Hir.BoolLit(true, POS, null), new Hir.BoolLit(true, POS, null)),
+                        new Pair(new Hir.BoolLit(true, POS, null),
+                                new Hir.BoolLit(false, POS, null)))));
+    }
+
+    /** Two written values a comparison is folded of. */
+    private record Pair(Hir.Expr left, Hir.Expr right) { }
+
+    /** Every comparing operator over every pair, as one row each. */
+    private static List<String> folded(List<Pair> pairs) {
+        List<String> rows = new ArrayList<>();
+        for (Pair pair : pairs) {
+            for (BinOp op : COMPARING) {
+                rows.add(written(pair.left()) + " " + op + " " + written(pair.right())
+                        + " = " + fold(op, pair.left(), pair.right()));
+            }
+        }
+        return rows;
+    }
+
+    /** What {@code left op right} folds to, or that it folds to no constant. Folded against the
+     *  real library, which is what a fold is asked of, though a comparison of two literals names
+     *  none of it. */
+    private static String fold(BinOp op, Hir.Expr left, Hir.Expr right) {
+        return ConstEval.against(Symbols.none(DefaultStdlib.get()))
+                .eval(new Hir.Binary(op, left, right, CoverageOrigin.unwritten(), POS, null))
+                .map(String::valueOf)
+                .orElse("not a constant");
+    }
+
+    private static String written(Hir.Expr value) {
+        return switch (value) {
+            case Hir.IntLit i -> String.valueOf(i.value());
+            case Hir.BoolLit b -> String.valueOf(b.value());
+            default -> throw new IllegalArgumentException("not a value written here: " + value);
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonFoldsToWhatItsOperatorPlacedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonFoldsToWhatItsOperatorPlacedTest.java
@@ -9,7 +9,11 @@ import souther.compiler.types.CoverageOrigin;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -19,9 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * <p>The way from the operator to the answer, taken whole: what the operator placed
  * ({@link ComparisonPlacement}), the relation that placement states, and the fold of that relation
- * over two constants. Each of the six is put through it, because what is being fixed is the way and
- * not any one relation — a claim read off the wrong operator answers every question a reader can
- * ask of it, and answers them about a comparison nobody wrote.
+ * over two constants. Every operator that compares is put through it, because what is being fixed
+ * is the way and not any one relation — a claim read off the wrong operator answers every question
+ * a reader can ask of it, and answers them about a comparison nobody wrote.
+ *
+ * <p><b>Which operators those are is asked of the operator.</b> Written out here, this would be a
+ * second membership beside {@link BinOp#compares} — the one it is asked of everywhere else — and
+ * the two can be given different answers about an operator added later. Written out, the operator
+ * added later is folded by nothing here and this stays green while saying "every".
  *
  * <p>What the relations themselves come to is fixed against how two values stand, and not here.
  */
@@ -29,65 +38,85 @@ class AComparisonFoldsToWhatItsOperatorPlacedTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
 
-    /** The six as the language writes them. */
+    /** Every operator that compares, asked of the operator. */
     private static final List<BinOp> COMPARING =
-            List.of(BinOp.LT, BinOp.LE, BinOp.GT, BinOp.GE, BinOp.EQ, BinOp.NE);
+            Stream.of(BinOp.values()).filter(BinOp::compares).toList();
+
+    /** What a fold that answers no constant is said as, which is what the callers read empty as. */
+    private static final String NOT_A_CONSTANT = "not a constant";
+
+    /** Two written values, and what folding each comparison of them comes to. */
+    private record Written(String left, String right, Hir.Expr leftValue, Hir.Expr rightValue,
+                           Map<BinOp, String> folds) { }
+
+    private static final List<Written> PAIRS = List.of(
+            new Written("1", "2", intLit(1), intLit(2), Map.of(
+                    BinOp.LT, "true", BinOp.LE, "true", BinOp.GT, "false", BinOp.GE, "false",
+                    BinOp.EQ, "false", BinOp.NE, "true")),
+            new Written("2", "2", intLit(2), intLit(2), Map.of(
+                    BinOp.LT, "false", BinOp.LE, "true", BinOp.GT, "false", BinOp.GE, "true",
+                    BinOp.EQ, "true", BinOp.NE, "false")),
+            new Written("2", "1", intLit(2), intLit(1), Map.of(
+                    BinOp.LT, "false", BinOp.LE, "false", BinOp.GT, "true", BinOp.GE, "true",
+                    BinOp.EQ, "false", BinOp.NE, "true")),
+            // No order to answer an ordering by, and an equality all the same.
+            new Written("true", "true", boolLit(true), boolLit(true), Map.of(
+                    BinOp.LT, NOT_A_CONSTANT, BinOp.LE, NOT_A_CONSTANT,
+                    BinOp.GT, NOT_A_CONSTANT, BinOp.GE, NOT_A_CONSTANT,
+                    BinOp.EQ, "true", BinOp.NE, "false")),
+            new Written("true", "false", boolLit(true), boolLit(false), Map.of(
+                    BinOp.LT, NOT_A_CONSTANT, BinOp.LE, NOT_A_CONSTANT,
+                    BinOp.GT, NOT_A_CONSTANT, BinOp.GE, NOT_A_CONSTANT,
+                    BinOp.EQ, "false", BinOp.NE, "true")));
 
     @Test
     void everyComparingOperatorFoldsToWhatItPlacedOverTwoConstants() {
-        assertEquals(List.of(
-                "1 LT 2 = true", "1 LE 2 = true", "1 GT 2 = false", "1 GE 2 = false",
-                "1 EQ 2 = false", "1 NE 2 = true",
-                "2 LT 2 = false", "2 LE 2 = true", "2 GT 2 = false", "2 GE 2 = true",
-                "2 EQ 2 = true", "2 NE 2 = false",
-                "2 LT 1 = false", "2 LE 1 = false", "2 GT 1 = true", "2 GE 1 = true",
-                "2 EQ 1 = false", "2 NE 1 = true",
-                // No order to answer an ordering by, and an equality all the same.
-                "true LT true = not a constant", "true LE true = not a constant",
-                "true GT true = not a constant", "true GE true = not a constant",
-                "true EQ true = true", "true NE true = false",
-                "true LT false = not a constant", "true LE false = not a constant",
-                "true GT false = not a constant", "true GE false = not a constant",
-                "true EQ false = false", "true NE false = true"),
-                folded(List.of(
-                        new Pair(new Hir.IntLit(1, POS, null), new Hir.IntLit(2, POS, null)),
-                        new Pair(new Hir.IntLit(2, POS, null), new Hir.IntLit(2, POS, null)),
-                        new Pair(new Hir.IntLit(2, POS, null), new Hir.IntLit(1, POS, null)),
-                        new Pair(new Hir.BoolLit(true, POS, null), new Hir.BoolLit(true, POS, null)),
-                        new Pair(new Hir.BoolLit(true, POS, null),
-                                new Hir.BoolLit(false, POS, null)))));
-    }
-
-    /** Two written values a comparison is folded of. */
-    private record Pair(Hir.Expr left, Hir.Expr right) { }
-
-    /** Every comparing operator over every pair, as one row each. */
-    private static List<String> folded(List<Pair> pairs) {
-        List<String> rows = new ArrayList<>();
-        for (Pair pair : pairs) {
+        Map<String, String> written = new LinkedHashMap<>();
+        Map<String, String> folded = new LinkedHashMap<>();
+        for (Written pair : PAIRS) {
             for (BinOp op : COMPARING) {
-                rows.add(written(pair.left()) + " " + op + " " + written(pair.right())
-                        + " = " + fold(op, pair.left(), pair.right()));
+                String row = pair.left() + " " + op + " " + pair.right();
+                written.put(row, pair.folds().get(op));
+                folded.put(row, fold(op, pair.leftValue(), pair.rightValue()));
             }
         }
-        return rows;
+        assertEquals(written, folded);
     }
 
-    /** What {@code left op right} folds to, or that it folds to no constant. Folded against the
-     *  real library, which is what a fold is asked of, though a comparison of two literals names
-     *  none of it. */
+    /**
+     * What is written below is an answer for each operator that compares, and for no other.
+     *
+     * <p>The two sets are made differently on purpose — one is asked of the operator, the other is
+     * what somebody wrote out — so holding them against each other is what says an operator added
+     * to the language is folded here rather than passed over in silence. It is also what says the
+     * fold above ran at all: two empty sets agree, and these do not.
+     */
+    @Test
+    void whatIsWrittenOutCoversEveryOperatorThatCompares() {
+        List<Set<BinOp>> asked = new ArrayList<>();
+        List<Set<BinOp>> answered = new ArrayList<>();
+        for (Written pair : PAIRS) {
+            asked.add(Set.copyOf(COMPARING));
+            answered.add(pair.folds().keySet());
+        }
+        assertEquals(asked, answered,
+                "an operator that compares and is not written out here is folded by nothing");
+    }
+
+    /** What {@code left op right} folds to. Folded against the real library, which is what a fold
+     *  is asked of, though a comparison of two literals names none of it. */
     private static String fold(BinOp op, Hir.Expr left, Hir.Expr right) {
         return ConstEval.against(Symbols.none(DefaultStdlib.get()))
                 .eval(new Hir.Binary(op, left, right, CoverageOrigin.unwritten(), POS, null))
                 .map(String::valueOf)
-                .orElse("not a constant");
+                .orElse(NOT_A_CONSTANT);
     }
 
-    private static String written(Hir.Expr value) {
-        return switch (value) {
-            case Hir.IntLit i -> String.valueOf(i.value());
-            case Hir.BoolLit b -> String.valueOf(b.value());
-            default -> throw new IllegalArgumentException("not a value written here: " + value);
-        };
+    private static Hir.Expr intLit(long value) {
+        return new Hir.IntLit(value, POS, null);
+    }
+
+    private static Hir.Expr boolLit(boolean value) {
+        return new Hir.BoolLit(value, POS, null);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -60,7 +60,11 @@ class AnOperatorIsAskedWhatItPlacesInOnePlaceTest {
                             + " the claim to the readings of what it bounds"),
             new Licence("souther.compiler.inputs.ComparedNumber.of", 1,
                     "reads any binary a walk met, so an operator that places nothing arrives here"
-                            + " and is answered rather than excluded"));
+                            + " and is answered rather than excluded"),
+            new Licence("souther.compiler.check.ConstEval.binary", 1,
+                    "folds any binary an expression is written with, so an operator that places"
+                            + " nothing arrives here too; what it placed is spent on the relation"
+                            + " the fold answers and is handed to nobody"));
 
     @Test
     void onlyARecognitionReadsAnOperatorForWhatItPlaces() throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorIsAskedWhatItPlacesInOnePlaceTest.java
@@ -34,11 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * is part of what is declared, and a call added anywhere lands as a number that does not match.
  *
  * <p>What a count cannot say is who came through a door: a licence given to a method covers every
- * caller of it. So the doors are held apart by the language instead.
- * {@link souther.compiler.inputs.ComparedNumber#of} is the wide one and is package-private, which
- * makes {@code ComparedNumbers} the one way to it from outside and a body's binaries the one thing
- * that arrives; a reader holding a comparison takes {@code lineOf} and hands over the claim it
- * already has.
+ * caller of it. So the doors are held apart by the language instead. The wide ones are the readers
+ * that meet a binary nothing has recognised yet, and each is shut to a caller holding a comparison.
+ * {@link souther.compiler.inputs.ComparedNumber#of} is package-private, which makes
+ * {@code ComparedNumbers} the one way to it from outside and a body's binaries the one thing that
+ * arrives; a reader holding a comparison takes {@code lineOf} and hands over the claim it already
+ * has. {@code ConstEval.binary} is private, and the fold is the one thing that reaches it.
  *
  * <p>Read off the compiled classes, because what a method calls is what the class file says. A
  * reading of the sources would answer the same question a second way, and would not see a call

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARelationComesToBetweenTwoFoldedConstantsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARelationComesToBetweenTwoFoldedConstantsTest.java
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * What each of the six relations comes to between two folded constants.
+ * What each relation comes to between two folded constants.
  *
  * <p>Two questions, held apart. What a relation answers is decided by how the two values stand —
  * below one another, at one another, above, or of no ordered kind at all — and by nothing else, so
@@ -21,29 +24,39 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * <p>Read one table at a time, so a kind whose ordering moved is told apart from a relation whose
  * meaning did.
+ *
+ * <p><b>Which relations there are is asked of {@link Rel}.</b> Written out here, a relation added
+ * to it would be answered about by nothing while these tables went on saying "each".
  */
 class WhatARelationComesToBetweenTwoFoldedConstantsTest {
 
-    /** The six in one order, so a row is read the same way wherever it appears. */
-    private static final List<Rel> RELATIONS =
-            List.of(Rel.EQ, Rel.NE, Rel.LT, Rel.LE, Rel.GT, Rel.GE);
+    /** Every relation, asked of the type that has them. */
+    private static final List<Rel> RELATIONS = List.of(Rel.values());
 
-    /** A way two values can stand, and what each of the six answers of two values standing so. */
-    private record Standing(String name, List<String> answers) { }
+    /** What a relation two constants cannot answer is said as. */
+    private static final String UNDECIDED = "undecided";
+
+    /** A way two values can stand, and what each relation answers of two values standing so. */
+    private record Standing(String name, Map<Rel, String> answers) { }
 
     private static final List<Standing> STANDINGS = List.of(
-            new Standing("below",
-                    List.of("false", "true", "true", "true", "false", "false")),
-            new Standing("at",
-                    List.of("true", "false", "false", "true", "false", "true")),
-            new Standing("above",
-                    List.of("false", "true", "false", "false", "true", "true")),
+            new Standing("below", Map.of(
+                    Rel.EQ, "false", Rel.NE, "true", Rel.LT, "true", Rel.LE, "true",
+                    Rel.GT, "false", Rel.GE, "false")),
+            new Standing("at", Map.of(
+                    Rel.EQ, "true", Rel.NE, "false", Rel.LT, "false", Rel.LE, "true",
+                    Rel.GT, "false", Rel.GE, "true")),
+            new Standing("above", Map.of(
+                    Rel.EQ, "false", Rel.NE, "true", Rel.LT, "false", Rel.LE, "false",
+                    Rel.GT, "true", Rel.GE, "true")),
             // An equality answers of any two constants at all, and an ordering is not something to
             // decide where there is no order to decide it by.
-            new Standing("of no ordered kind, one value",
-                    List.of("true", "false", "undecided", "undecided", "undecided", "undecided")),
-            new Standing("of no ordered kind, two values",
-                    List.of("false", "true", "undecided", "undecided", "undecided", "undecided")));
+            new Standing("of no ordered kind, one value", Map.of(
+                    Rel.EQ, "true", Rel.NE, "false", Rel.LT, UNDECIDED, Rel.LE, UNDECIDED,
+                    Rel.GT, UNDECIDED, Rel.GE, UNDECIDED)),
+            new Standing("of no ordered kind, two values", Map.of(
+                    Rel.EQ, "false", Rel.NE, "true", Rel.LT, UNDECIDED, Rel.LE, UNDECIDED,
+                    Rel.GT, UNDECIDED, Rel.GE, UNDECIDED)));
 
     /** Two folded values, how they stand, and how they are named in a row. */
     private record Pair(String name, Object left, Object right, String stands) { }
@@ -66,35 +79,40 @@ class WhatARelationComesToBetweenTwoFoldedConstantsTest {
             new Pair("\"a\" and \"a\"", "a", "a", "at"),
             new Pair("\"b\" and \"a\"", "b", "a", "above"));
 
-    /** Values of no one ordered kind, which is where an equality answers alone. */
+    /** Pairs of no one ordered kind, which is where an equality answers alone. */
     private static final List<Pair> OF_NO_ORDERED_KIND = List.of(
             new Pair("false and false", false, false, "of no ordered kind, one value"),
             new Pair("false and true", false, true, "of no ordered kind, two values"),
             new Pair("1 and 1.0m", 1L, decimal("1.0"), "of no ordered kind, two values"));
 
     @Test
-    void howTheTwoStandDecidesWhatEachOfTheSixAnswers() {
-        assertEquals(expected(EACH_WAY_OF_STANDING), answered(EACH_WAY_OF_STANDING),
+    void howTheTwoStandDecidesWhatEachRelationAnswers() {
+        assertEquals(written(EACH_WAY_OF_STANDING), answered(EACH_WAY_OF_STANDING),
                 "what a relation answers is read off how the two values stand and nothing else");
     }
 
     @Test
-    void everyKindStandsTheWayItsOwnComparisonSays() {
-        List<Pair> pairs = new ArrayList<>(EACH_ORDERED_KIND);
-        pairs.addAll(OF_NO_ORDERED_KIND);
-        assertEquals(expected(pairs), answered(pairs),
+    void everyOrderedKindStandsTheWayItsOwnComparisonSays() {
+        assertEquals(written(EACH_ORDERED_KIND), answered(EACH_ORDERED_KIND),
                 "a kind whose values are put in the wrong order answers every relation about them"
                         + " consistently and about the wrong pair");
+    }
+
+    @Test
+    void twoValuesOfNoOneOrderedKindAnswerTheEqualityAlone() {
+        assertEquals(written(OF_NO_ORDERED_KIND), answered(OF_NO_ORDERED_KIND),
+                "an ordering of values there is no order over is undecided, and an equality of them"
+                        + " is not");
     }
 
     /**
      * Of two values of one ordered kind, the equality answers what being one value answers.
      *
      * <p>The two are asked in different words — where the values stand, and whether they are the
-     * one value ({@link ConstEval#equal}) — and an equality of such a pair is answered in the first,
-     * so what makes that the whole answer is that the two agree. A decimal is where they could come
-     * apart, since {@code 1.0m} and {@code 1.00m} are two ways of writing one amount, and both
-     * answers are the amount's.
+     * one value ({@link ConstEval#equal}) — and an equality of such a pair is answered in the
+     * first, so what makes that the whole answer is that the two agree. A decimal is where they
+     * could come apart, since {@code 1.0m} and {@code 1.00m} are two ways of writing one amount,
+     * and both answers are the amount's.
      */
     @Test
     void ofOneOrderedKindTheEqualityAnswersWhatBeingOneValueAnswers() {
@@ -111,6 +129,26 @@ class WhatARelationComesToBetweenTwoFoldedConstantsTest {
                 bothWays());
     }
 
+    /**
+     * What is written above is an answer for each relation there is, and for no other.
+     *
+     * <p>The two sets are made differently on purpose — one is asked of {@link Rel}, the other is
+     * what somebody wrote out — so holding them against each other is what says a relation added
+     * later is answered about here rather than passed over. It is also what says the tables above
+     * were read at all: two empty sets agree, and these do not.
+     */
+    @Test
+    void whatIsWrittenOutCoversEveryRelationThereIs() {
+        List<Set<Rel>> asked = new ArrayList<>();
+        List<Set<Rel>> answered = new ArrayList<>();
+        for (Standing each : STANDINGS) {
+            asked.add(Set.copyOf(RELATIONS));
+            answered.add(each.answers().keySet());
+        }
+        assertEquals(asked, answered,
+                "a relation no way of standing writes an answer for is fixed by nothing");
+    }
+
     private static List<String> bothWays() {
         List<Pair> pairs = new ArrayList<>(EACH_WAY_OF_STANDING.subList(0, 3));
         pairs.addAll(EACH_ORDERED_KIND);
@@ -120,32 +158,32 @@ class WhatARelationComesToBetweenTwoFoldedConstantsTest {
                 + ", one value = " + ConstEval.equal(each.left(), each.right())).toList();
     }
 
-    /** What the six answer of each pair, taken from the way it stands. */
-    private static List<String> expected(List<Pair> pairs) {
-        List<String> rows = new ArrayList<>();
+    /** What each relation answers of each pair, taken from the way it stands. */
+    private static Map<String, String> written(List<Pair> pairs) {
+        Map<String, String> rows = new LinkedHashMap<>();
         for (Pair pair : pairs) {
-            List<String> answers = standing(pair.stands()).answers();
-            for (int at = 0; at < RELATIONS.size(); at++) {
-                rows.add(row(pair, RELATIONS.get(at), answers.get(at)));
+            Map<Rel, String> answers = standing(pair.stands()).answers();
+            for (Rel rel : RELATIONS) {
+                rows.put(row(pair, rel), answers.get(rel));
             }
         }
         return rows;
     }
 
-    /** What the six answer of each pair, taken from the fold. */
-    private static List<String> answered(List<Pair> pairs) {
-        List<String> rows = new ArrayList<>();
+    /** What each relation answers of each pair, taken from the fold. */
+    private static Map<String, String> answered(List<Pair> pairs) {
+        Map<String, String> rows = new LinkedHashMap<>();
         for (Pair pair : pairs) {
             for (Rel rel : RELATIONS) {
                 Boolean stands = ConstEval.stands(rel, pair.left(), pair.right());
-                rows.add(row(pair, rel, stands == null ? "undecided" : String.valueOf(stands)));
+                rows.put(row(pair, rel), stands == null ? UNDECIDED : String.valueOf(stands));
             }
         }
         return rows;
     }
 
-    private static String row(Pair pair, Rel rel, String answer) {
-        return pair.name() + " (" + pair.stands() + ") " + rel + " = " + answer;
+    private static String row(Pair pair, Rel rel) {
+        return pair.name() + " (" + pair.stands() + ") " + rel;
     }
 
     private static Standing standing(String name) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARelationComesToBetweenTwoFoldedConstantsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARelationComesToBetweenTwoFoldedConstantsTest.java
@@ -1,0 +1,159 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What each of the six relations comes to between two folded constants.
+ *
+ * <p>Two questions, held apart. What a relation answers is decided by how the two values stand —
+ * below one another, at one another, above, or of no ordered kind at all — and by nothing else, so
+ * the meaning is fixed against those five ways of standing. Which values stand which way is the
+ * other question: each ordered kind is read by its own comparison, and a kind put through one
+ * ordering says nothing about the other two.
+ *
+ * <p>Read one table at a time, so a kind whose ordering moved is told apart from a relation whose
+ * meaning did.
+ */
+class WhatARelationComesToBetweenTwoFoldedConstantsTest {
+
+    /** The six in one order, so a row is read the same way wherever it appears. */
+    private static final List<Rel> RELATIONS =
+            List.of(Rel.EQ, Rel.NE, Rel.LT, Rel.LE, Rel.GT, Rel.GE);
+
+    /** A way two values can stand, and what each of the six answers of two values standing so. */
+    private record Standing(String name, List<String> answers) { }
+
+    private static final List<Standing> STANDINGS = List.of(
+            new Standing("below",
+                    List.of("false", "true", "true", "true", "false", "false")),
+            new Standing("at",
+                    List.of("true", "false", "false", "true", "false", "true")),
+            new Standing("above",
+                    List.of("false", "true", "false", "false", "true", "true")),
+            // An equality answers of any two constants at all, and an ordering is not something to
+            // decide where there is no order to decide it by.
+            new Standing("of no ordered kind, one value",
+                    List.of("true", "false", "undecided", "undecided", "undecided", "undecided")),
+            new Standing("of no ordered kind, two values",
+                    List.of("false", "true", "undecided", "undecided", "undecided", "undecided")));
+
+    /** Two folded values, how they stand, and how they are named in a row. */
+    private record Pair(String name, Object left, Object right, String stands) { }
+
+    /** One pair for each way of standing, over the kind an ordering is written of most. */
+    private static final List<Pair> EACH_WAY_OF_STANDING = List.of(
+            new Pair("1 and 2", 1L, 2L, "below"),
+            new Pair("2 and 2", 2L, 2L, "at"),
+            new Pair("2 and 1", 2L, 1L, "above"),
+            new Pair("true and true", true, true, "of no ordered kind, one value"),
+            new Pair("true and false", true, false, "of no ordered kind, two values"));
+
+    /** The kinds that carry an ordering of their own, each put through all three of them. */
+    private static final List<Pair> EACH_ORDERED_KIND = List.of(
+            new Pair("1.0m and 2.0m", decimal("1.0"), decimal("2.0"), "below"),
+            // Written differently and the one amount, which is what a decimal is compared by.
+            new Pair("1.0m and 1.00m", decimal("1.0"), decimal("1.00"), "at"),
+            new Pair("2.0m and 1.0m", decimal("2.0"), decimal("1.0"), "above"),
+            new Pair("\"a\" and \"b\"", "a", "b", "below"),
+            new Pair("\"a\" and \"a\"", "a", "a", "at"),
+            new Pair("\"b\" and \"a\"", "b", "a", "above"));
+
+    /** Values of no one ordered kind, which is where an equality answers alone. */
+    private static final List<Pair> OF_NO_ORDERED_KIND = List.of(
+            new Pair("false and false", false, false, "of no ordered kind, one value"),
+            new Pair("false and true", false, true, "of no ordered kind, two values"),
+            new Pair("1 and 1.0m", 1L, decimal("1.0"), "of no ordered kind, two values"));
+
+    @Test
+    void howTheTwoStandDecidesWhatEachOfTheSixAnswers() {
+        assertEquals(expected(EACH_WAY_OF_STANDING), answered(EACH_WAY_OF_STANDING),
+                "what a relation answers is read off how the two values stand and nothing else");
+    }
+
+    @Test
+    void everyKindStandsTheWayItsOwnComparisonSays() {
+        List<Pair> pairs = new ArrayList<>(EACH_ORDERED_KIND);
+        pairs.addAll(OF_NO_ORDERED_KIND);
+        assertEquals(expected(pairs), answered(pairs),
+                "a kind whose values are put in the wrong order answers every relation about them"
+                        + " consistently and about the wrong pair");
+    }
+
+    /**
+     * Of two values of one ordered kind, the equality answers what being one value answers.
+     *
+     * <p>The two are asked in different words — where the values stand, and whether they are the
+     * one value ({@link ConstEval#equal}) — and an equality of such a pair is answered in the first,
+     * so what makes that the whole answer is that the two agree. A decimal is where they could come
+     * apart, since {@code 1.0m} and {@code 1.00m} are two ways of writing one amount, and both
+     * answers are the amount's.
+     */
+    @Test
+    void ofOneOrderedKindTheEqualityAnswersWhatBeingOneValueAnswers() {
+        assertEquals(List.of(
+                "1 and 2: EQ = false, NE = true, one value = false",
+                "2 and 2: EQ = true, NE = false, one value = true",
+                "2 and 1: EQ = false, NE = true, one value = false",
+                "1.0m and 2.0m: EQ = false, NE = true, one value = false",
+                "1.0m and 1.00m: EQ = true, NE = false, one value = true",
+                "2.0m and 1.0m: EQ = false, NE = true, one value = false",
+                "\"a\" and \"b\": EQ = false, NE = true, one value = false",
+                "\"a\" and \"a\": EQ = true, NE = false, one value = true",
+                "\"b\" and \"a\": EQ = false, NE = true, one value = false"),
+                bothWays());
+    }
+
+    private static List<String> bothWays() {
+        List<Pair> pairs = new ArrayList<>(EACH_WAY_OF_STANDING.subList(0, 3));
+        pairs.addAll(EACH_ORDERED_KIND);
+        return pairs.stream().map(each -> each.name()
+                + ": EQ = " + ConstEval.stands(Rel.EQ, each.left(), each.right())
+                + ", NE = " + ConstEval.stands(Rel.NE, each.left(), each.right())
+                + ", one value = " + ConstEval.equal(each.left(), each.right())).toList();
+    }
+
+    /** What the six answer of each pair, taken from the way it stands. */
+    private static List<String> expected(List<Pair> pairs) {
+        List<String> rows = new ArrayList<>();
+        for (Pair pair : pairs) {
+            List<String> answers = standing(pair.stands()).answers();
+            for (int at = 0; at < RELATIONS.size(); at++) {
+                rows.add(row(pair, RELATIONS.get(at), answers.get(at)));
+            }
+        }
+        return rows;
+    }
+
+    /** What the six answer of each pair, taken from the fold. */
+    private static List<String> answered(List<Pair> pairs) {
+        List<String> rows = new ArrayList<>();
+        for (Pair pair : pairs) {
+            for (Rel rel : RELATIONS) {
+                Boolean stands = ConstEval.stands(rel, pair.left(), pair.right());
+                rows.add(row(pair, rel, stands == null ? "undecided" : String.valueOf(stands)));
+            }
+        }
+        return rows;
+    }
+
+    private static String row(Pair pair, Rel rel, String answer) {
+        return pair.name() + " (" + pair.stands() + ") " + rel + " = " + answer;
+    }
+
+    private static Standing standing(String name) {
+        return STANDINGS.stream().filter(each -> each.name().equals(name)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("no way of standing named " + name));
+    }
+
+    private static BigDecimal decimal(String written) {
+        return new BigDecimal(written);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -116,7 +116,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "types an operand under the operator it stands beside"),
             new Held("souther.compiler.check.ConstEval.arith",
                     "what the operator computes of two constants"),
-            new Held("souther.compiler.check.ConstEval.compare", "the same for a comparison"),
             new Held("souther.compiler.reading.Meetings.run",
                     "walks the operands under the operator they are written with"),
 
@@ -278,8 +277,9 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "asks whether the operator joins two conditions, which is the one thing an"
                             + " operand can be held to before the one beside it has been read"),
             new Held("souther.compiler.check.ConstEval.binary",
-                    "what the operator computes of two constants, and which operand it needs to"
-                            + " compute it"),
+                    "what the operator computes of two constants, which operand it needs to compute"
+                            + " it, and — for the six that compare — what it placed, which is what"
+                            + " the fold is asked for instead of the operator"),
             new Held("souther.compiler.check.DischargeRules.noSmallerThan",
                     "which operands a string joined by another is no shorter than"),
             new Held("souther.compiler.core.GrowingFold.appended",


### PR DESCRIPTION
Closes #1253.

## What was wrong

Whether a comparison of two written constants holds was answered twice over in `ConstEval`, once for each vocabulary a caller can hold it in.

| the caller has | the way in | how it decides |
| --- | --- | --- |
| the operator an author wrote | `binary` | `EQ`/`NE` from `equal`, the four orderings through `compare` |
| the relation a reading arrived at | `stands` | `Rel.holds` |

Both sat on the same order and the same equality, so they agreed about every pair of constants there is. Nothing said they had to. `Rel.holds` is written as the one place a relation is worked out at a sign, and `compare` was that same table in the operator's words.

The crossing between the two vocabularies had a fold on each side of it rather than under it. `ConstEval` was also the last reader in the compiler deciding what a comparison means from the operator directly — `ComparisonClaim` holds that derivation everywhere else, and `ComparisonPlacement.of` is licensed to the readers that recognise a comparison.

## The design

```
BinOp
  → ComparisonPlacement.of      what the operator placed, asked once
  → ComparisonClaim
  → statedRelation              the one crossing between the vocabularies
  → stands                      the one fold
  → Rel.holds                   the one truth table at a sign
```

`binary` splits on the placement once and joins the route a reading already takes. `compare` has no caller and is gone, and `binary`'s `EQ` and `NE` arms go with it.

`order` is gone too, and this is the half that keeps the duplication from being rebuilt. Left as a helper handing back a sign, a second table of six could be written over it without going anywhere near `ComparisonPlacement`:

```java
Integer c = order(a, b);
return c != null && c < 0;
```

The sign is now taken inside `stands` and answered there, so there is nothing to call for it alone.

The six comparing operators stay written out in the switch that computes a value. What would reach them is the partition above having admitted a comparison, and an arm inventing an answer for that is how a fold comes to disagree with every other reader of the same comparison.

## What the censuses say now

`ConstEval.binary` is a fourth site reading an operator for what it places. The reason is the one `ComparedNumber.of` carries: it folds any binary an expression is written with, so an operator that places nothing arrives here too and is answered rather than excluded. What it placed is spent on the relation and handed to nobody, and `binary` is private, so nothing outside the fold can reach it.

`WhereAnOperatorMayStillBeHeldIsWrittenDownTest` has one line fewer — `ConstEval.compare` — and `binary` stays, since a binary still names its operator to ask what it placed.

`ComparisonClaim` said there were two ways in and named a recognition as one of them. There are still two ways a claim comes to be; how many recognitions the operator side is written as is a different question, because a tree a check produces and a tree a fold walks are different trees. The doc says that, and the census answers the number off the compiled classes.

## Tests

Two questions, so two tests.

`WhatARelationComesToBetweenTwoFoldedConstantsTest` fixes the relation semantics against how the two values stand — below, at, above, of no ordered kind and one value, of no ordered kind and two — and then holds each ordered kind to those states through all three orderings. Of two values of one ordered kind, `EQ` answers what being one value answers (`equal`), which is the premise that lets one fold answer both; `1.0m` and `1.00m` are where the two could come apart.

`AComparisonFoldsToWhatItsOperatorPlacedTest` puts all six operators through `eval`, which is the way from the operator to the answer end to end.

Each was checked by breaking what it claims to see:

| mutation | what went red |
| --- | --- |
| `statedRelation()` → `denied().statedRelation()` | the operator route only |
| decimal ordering negated | the representation table only |
| `equal` losing its decimal arm | one row of the equality law: `1.0m and 1.00m: one value = false` |

Full reactor run: 11,549 tests, BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
