### PR TITLE
Read a string predicate once, and hand the reading on

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -1,7 +1,8 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
-import souther.compiler.regex.PatternSyntax;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
 import souther.compiler.types.Type;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
@@ -164,26 +165,54 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
         if (position == null) {
             return null;
         }
-        PatternSyntax syntax = stated.accepts();
-        if (syntax == null) {
-            // A pattern written more deeply than this reads is a limit of the reading and not a
-            // shape it has no word for, so it is said as itself. Left to fall through, it would go
-            // out as a form nothing here takes apart — and an author would go looking for the
-            // construct that was the trouble, when every construct in it is one this reads.
-            return StringPredicates.readTooLittleOf(e, symbols)
-                    ? PlannedValues.unreadable(Set.of(position),
-                            UnreadReason.PATTERN_TOO_DEEPLY_NESTED)
-                    : null;
-        }
-        // Named and not built. What the position finally admits is met out of every rule that
-        // reached it, and a pattern met with three written strings is a question about three
-        // strings — built here, it would be a machine nobody needed and the position would have
-        // that much less for the meet it does need. So what is said is which machine would answer
-        // this rule, and whether one is ever made of it is settled where the position's plan is
-        // worked out under its allowance.
-        return PlannedValues.at(position, new AdmittedPlan.Pattern(
-                states ? souther.compiler.regex.PatternPlan.of(syntax)
-                        : souther.compiler.regex.PatternPlan.notMatching(syntax)));
+        return switch (stated.reading()) {
+            // Named and not built. What the position finally admits is met out of every rule that
+            // reached it, and a pattern met with three written strings is a question about three
+            // strings — built here, it would be a machine nobody needed and the position would have
+            // that much less for the meet it does need. So what is said is which machine would
+            // answer this rule, and whether one is ever made of it is settled where the position's
+            // plan is worked out under its allowance.
+            case StringPredicates.Reading.Accepting it -> PlannedValues.at(position,
+                    new AdmittedPlan.Pattern(states ? PatternPlan.of(it.accepts())
+                            : PatternPlan.notMatching(it.accepts())));
+            case StringPredicates.Reading.PatternNotRead it -> stoppedBy(it.why(), position);
+            // A rule whose text this could not work out is a rule this did not read, and what that
+            // costs is the leaf's to say — over every position the clause names, which is more than
+            // this one wherever the text is written out of another.
+            case StringPredicates.Reading.WrittenArgumentNotKnown _ -> null;
+        };
+    }
+
+    /**
+     * What a pattern this reading stopped short of costs, or nothing where the leaf says it.
+     *
+     * <p>Only the one this reading is itself the limit of. A pattern written more deeply than this
+     * reads is a limit of the reading and not a shape it has no word for, so it is said as itself —
+     * left to fall through, it would go out as a form nothing here takes apart, and an author would
+     * go looking for the construct that was the trouble when every construct in it is one this
+     * reads. Every other construct is one the subset does not hold, which is a rule this could not
+     * read like any other, and what that costs is worked out once at the leaf over every position
+     * the clause names.
+     *
+     * <p>No {@code default}: a construct the subset learns to stop at is one somebody decides about
+     * here, rather than one that quietly joins the eleven.
+     */
+    private PlannedValues<FactSubject> stoppedBy(PatternRead.Unsupported why, FactSubject position) {
+        return switch (why) {
+            case NESTED_TOO_DEEPLY -> PlannedValues.unreadable(Set.of(position),
+                    UnreadReason.PATTERN_TOO_DEEPLY_NESTED);
+            case A_GROUP_ABOUT_THE_MATCH,
+                 A_BACK_REFERENCE,
+                 A_CHARACTER_PROPERTY,
+                 A_BOUNDARY,
+                 A_QUOTATION,
+                 A_CLASS_OF_CLASSES,
+                 A_COUNT_THIS_CANNOT_READ,
+                 SOMETHING_UNCLOSED,
+                 AN_ESCAPE_THIS_DOES_NOT_READ,
+                 AN_ANCHOR_THIS_CANNOT_PLACE,
+                 A_POSSESSIVE_REPETITION -> null;
+        };
     }
 
     /** What one comparison of a position with a value says, or nothing where it is not one. */

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -155,9 +155,11 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * is reaching the position and the written text and turning the answer into a plan — so a
      * predicate this reading learns is a row in that table and not an arm added here.
      *
-     * <p>Null and not {@link AdmissibleValues#unreadable} for the leaves that are not this, so that
-     * the one place a reading gives up stays where it is: what a rule this could not read costs is
-     * worked out there, and a second answer to it here would be a second account of the same thing.
+     * <p>Null and not {@link AdmissibleValues#unreadable} wherever the leaf's own account is the
+     * right one, so that the one place a reading gives up stays where it is: what a rule this could
+     * not read costs is worked out there, and a second answer to it here would be a second account
+     * of the same thing. That is every leaf that is not one of these, and every one of these whose
+     * reading stopped at something other than this reading's own limit.
      */
     private PlannedValues<FactSubject> pattern(Core e, boolean states) {
         StringPredicates.Stated stated = StringPredicates.statedByChecked(e, symbols);
@@ -195,7 +197,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * the clause names.
      *
      * <p>No {@code default}: a construct the subset learns to stop at is one somebody decides about
-     * here, rather than one that quietly joins the eleven.
+     * here, rather than one that quietly takes the answer its neighbours were given.
      */
     private PlannedValues<FactSubject> stoppedBy(PatternRead.Unsupported why, FactSubject position) {
         return switch (why) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1783,7 +1783,7 @@ public final class InvariantChecker {
      *
      * <p>Which calls those are is {@link StringPredicates}' and is asked rather than spelled: the
      * same table says what such a call means about the strings at a position, and a second list of
-     * spellings here would be a second answer to which rules this compiler reads (issue #1249).
+     * spellings here would be a second answer to which rules this compiler reads.
      *
      * <p>Only where the position is one this reading names. A predicate about something deeper than
      * the coordinates in hand states nothing this walk can file, and filing it against the position
@@ -1810,19 +1810,31 @@ public final class InvariantChecker {
         if (stated == null) {
             return null;
         }
-        return switch (StringPredicates.divides(atom, symbols)) {
-            case StringPredicates.Divides.IntoTwo _ -> byName.get(nameOf(stated.subject(), at));
+        return switch (stated.reading()) {
+            case StringPredicates.Reading.Accepting accepting ->
+                    dividedBy(accepting, stated.subject(), at, byName);
+            // A rule this did not read says nothing here: the reading that stopped is the one that
+            // reports being stopped, and a second account of it from this side would be a limit
+            // filed as a fact about the model.
+            case StringPredicates.Reading.PatternNotRead _ -> null;
+            case StringPredicates.Reading.WrittenArgumentNotKnown _ -> null;
+        };
+    }
+
+    /** The same, off the strings the rule was read as. */
+    private Coordinate dividedBy(StringPredicates.Reading.Accepting accepting, Core subject,
+                                 Denotations at, Map<FactSubject, Coordinate> byName) {
+        return switch (StringPredicates.divides(accepting)) {
+            case StringPredicates.Divides.IntoTwo _ -> byName.get(nameOf(subject, at));
             // Every string, so the rule tells no value here from another and the position is one
             // the model divides no way — which is what it comes back as when nothing is filed.
             case StringPredicates.Divides.NothingIsRuledOut _ -> null;
             // No string, so the rules leave no value here. That is a fact about the values and is
             // said where emptiness is, not as a division with no line through it.
             case StringPredicates.Divides.NothingIsLeft _ -> null;
-            // And where this compiler could not tell, it says nothing here: the reading that spent
-            // the allowance is the one that reports being stopped, and a second account of it from
-            // this side would be a limit filed as a fact about the model.
-            case StringPredicates.Divides.CouldNotTell _ -> null;
-            case null -> null;
+            // And where a limit stopped the machine, the same as above: what it cost is reported by
+            // whoever spent it.
+            case StringPredicates.Divides.StoppedByLimit _ -> null;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
@@ -3,7 +3,12 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.core.Kernel;
+import souther.compiler.regex.Language;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
 import souther.compiler.regex.PatternSyntax;
+import souther.compiler.types.ValueName;
 
 import java.util.List;
 
@@ -16,13 +21,20 @@ import java.util.List;
  * language over code points is what {@link souther.compiler.regex} is. Read one spelling at a time
  * instead, {@code matches} was a set of strings and the four beside it were forms nothing took
  * apart, so a position an author had written a rule for admitted every string there is — and a
- * value nobody could compose there took its siblings' obligations down with it (issue #1249).
+ * value nobody could compose there took its siblings' obligations down with it.
  *
  * <p><b>Keyed by what the operation means and not by how a rule is written.</b> Each entry says
  * which argument carries the position, which carries the text, and what the strings around that
  * text may be. A predicate added to the library is a row here or is named as one this does not
  * answer for ({@code EveryPredicateOverAStringIsReadAsASetOfStringsTest}), so a new one does not become
  * a rule that quietly says nothing.
+ *
+ * <p><b>One clause, one reading, handed on.</b> What a clause states is worked out once, by the
+ * entry point its tree has, and comes back as a {@link Reading} that holds what became of it — the
+ * strings, or what stopped the reading short of them. Everything asked afterwards takes that value
+ * ({@link #divides}), so no caller goes back to the clause to establish a second time what it
+ * already has. Answering "was it read" from a re-read would be one question with two derivations,
+ * and the day either the fold or the parser learns a form is the day they part.
  *
  * <p>{@code String.isEmpty} is not here, and is not missing. It is written in the library as
  * {@code String.length(s) == 0} and arrives as that comparison, which is a question about a number
@@ -34,8 +46,9 @@ public enum StringPredicates {
      * The strings a written pattern accepts.
      *
      * <p>The one entry whose text is not text: it is a pattern, and what it accepts is what reading
-     * it comes to rather than anything composed here. So it has no shape below and the caller reads
-     * it, which is also where a pattern this compiler cannot take apart is said to be one.
+     * it comes to rather than anything composed here. So it has no shape below, and it is the only
+     * entry a reading can stop short of, which is where a pattern this compiler cannot take apart is
+     * said to be one.
      */
     MATCHES(Kernel.STRING_MATCHES, null),
 
@@ -120,90 +133,160 @@ public enum StringPredicates {
     }
 
     /**
-     * The strings one written clause admits at the value it is about, or null where it is no
-     * predicate of this kind or what it names could not be read.
+     * What became of reading one predicate as the strings it admits.
+     *
+     * <p>Kept whole because the reading has readers that want different parts of it. What a rule
+     * admits is one answer; that the reading stopped, and at what, is another; and a reader handed
+     * only the first would ask for the second by reading the clause again. Which of these
+     * distinctions reaches an author is the reader's to settle — what is settled here is that
+     * nothing was thrown away before it could.
+     */
+    public sealed interface Reading {
+
+        /** The strings the predicate admits at the position it is about. */
+        record Accepting(PatternSyntax accepts) implements Reading {
+
+            public Accepting {
+                if (accepts == null) {
+                    throw new IllegalArgumentException(
+                            "a reading that finished says which strings it accepts");
+                }
+            }
+        }
+
+        /**
+         * A pattern it states that this reads no further into, and what stopped the reading.
+         *
+         * <p>Only {@link StringPredicates#MATCHES} arrives here. The others compose what they
+         * accept out of text, and there is nothing in that to be stopped by.
+         */
+        record PatternNotRead(PatternRead.Unsupported why) implements Reading {
+
+            public PatternNotRead {
+                if (why == null) {
+                    throw new IllegalArgumentException(
+                            "a pattern nothing read was stopped by something");
+                }
+            }
+        }
+
+        /**
+         * The predicate is one of these, and what the author wrote in it is not a string this
+         * compiler works out.
+         *
+         * <p>A rule read as far as the call and no further, which is not the same as a clause that
+         * is no predicate of this kind — there a reader has nothing to say, and here it has a
+         * position with a rule on it that nothing here turned into strings.
+         */
+        record WrittenArgumentNotKnown() implements Reading {}
+    }
+
+    /**
+     * A checked clause's predicate: the argument the rule is about, and what reading it came to.
+     *
+     * @param subject the argument the rule is about, for a caller that resolves it to a position
+     * @param reading what this compiler made of the strings the predicate states there
+     */
+    public record Stated(Core subject, Reading reading) {
+
+        public Stated {
+            if (subject == null || reading == null) {
+                throw new IllegalArgumentException(
+                        "a predicate that was stated is about something and was read");
+            }
+        }
+    }
+
+    /**
+     * What this predicate says, given the text written in it.
+     *
+     * <p>The whole of the reading, and the one copy of it. What each tree does for itself is reach
+     * the call and work out the text — {@code ConstEval} on one side, {@link Terms#folded} on the
+     * other — and from that text onwards there is a single answer, so a construct the subset learns
+     * is learned by both at once.
+     */
+    private Reading readingOf(String written) {
+        if (!takesAPattern()) {
+            return new Reading.Accepting(accepting(written));
+        }
+        return switch (PatternParser.read(written)) {
+            case PatternRead.Read read -> new Reading.Accepting(read.syntax());
+            case PatternRead.NotRead not -> new Reading.PatternNotRead(not.why());
+        };
+    }
+
+    /**
+     * What one written clause says about the value it is about, or null where it is no predicate of
+     * this kind.
      *
      * <p>Off the written tree, for the readers that hold one — what a declaration's rules propose a
-     * value from is walked before a body is checked, and there is no {@link souther.compiler.core.Core}
-     * there to ask. What it is <em>not</em> is a second table: which operations are predicates over
-     * strings and what each says is above, and both readers take that from there.
+     * value from is walked before a body is checked, and there is no {@link Core} there to ask. What
+     * it is <em>not</em> is a second table: which operations are predicates over strings and what
+     * each says is above, and both readers take that from there.
      *
      * <p>About the value the newtype carries and not about any position: a caller here is looking at
      * the clauses of one declaration, where {@code value} is what the rule is about, so which
      * argument carries the subject is checked and nothing is resolved through it.
+     *
+     * <p>A call of another number of arguments is no statement of this kind, the same as a call of
+     * another operation. This reads the tree a body is checked from, where an application is typed
+     * against what it names but a malformed one has not yet been refused.
      */
-    public static souther.compiler.regex.PatternSyntax statedByWritten(Hir.Expr clause,
-                                                                     Symbols symbols) {
+    public static Reading statedByWritten(Hir.Expr clause, Symbols symbols) {
         if (!(clause instanceof Hir.Apply call) || call.answered() == null) {
             return null;
         }
         StringPredicates predicate = call.answered().denotes()
-                instanceof souther.compiler.types.ValueName.Stdlib.Operation operation
+                instanceof ValueName.Stdlib.Operation operation
                 ? of(symbols.kernelOf(operation)) : null;
         if (predicate == null || call.args().size() != predicate.arity()) {
             return null;
         }
         String written = ConstEval.against(symbols)
                 .evalString(call.args().get(predicate.written())).orElse(null);
-        if (written == null) {
-            return null;
-        }
-        if (!predicate.takesAPattern()) {
-            return predicate.accepting(written);
-        }
-        return souther.compiler.regex.PatternParser.read(written)
-                instanceof souther.compiler.regex.PatternRead.Read read ? read.syntax() : null;
+        return written == null
+                ? new Reading.WrittenArgumentNotKnown() : predicate.readingOf(written);
     }
-
-    /**
-     * What one checked clause says, and about which of its arguments.
-     *
-     * @param subject the argument the rule is about, for a caller that resolves it to a position
-     * @param accepts the strings the predicate admits there, or null where the pattern it states is
-     *                one this compiler reads no further into
-     */
-    public record Stated(Core subject, souther.compiler.regex.PatternSyntax accepts) {}
 
     /**
      * The same off a checked clause, or null where it is no predicate of this kind.
      *
-     * <p>Beside {@link #statedByWritten} and in the same file on purpose. One question —
-     * which operations say which strings stand at a position — and two trees to ask it of: a
-     * declaration's rules are walked before a body is checked and hold no {@link Core}, and the
-     * reading of what a position admits holds nothing else. Two entry points and one table, so a
-     * predicate learned is learned by both.
+     * <p>Beside {@link #statedByWritten} and in the same file on purpose. One question — which
+     * operations say which strings stand at a position — and two trees to ask it of: a declaration's
+     * rules are walked before a body is checked and hold no {@link Core}, and the reading of what a
+     * position admits holds nothing else. Two entry points and one table, so a predicate learned is
+     * learned by both.
      *
-     * <p><b>Two folds, and that is the part to watch.</b> What the author wrote is read through the
-     * folder each tree has, and they are not the same code — so a written argument one of them folds
-     * and the other does not is a rule one reader takes in and the other passes over, which is the
-     * shape this whole arrangement exists to stop. They are adjacent here so that the next person to
-     * change one sees the other.
+     * <p><b>Two folds, and that is the whole of the difference.</b> What the author wrote is reached
+     * through the folder each tree has, and they are not the same code — so a written argument one of
+     * them folds and the other does not is a rule one reader takes in and the other passes over,
+     * which is the shape this arrangement exists to stop. They are adjacent here so that the next
+     * person to change one sees the other. Everything past the text they hand over is
+     * {@link #readingOf} and is one.
+     *
+     * <p>A call of another number of arguments is refused rather than read as no predicate. Its
+     * arity is settled against the declared signature before a {@link Core.PreservedCall} is built,
+     * so one arriving here says the table above and the library have come to disagree — read as no
+     * predicate, that disagreement would go on quietly costing every rule written with this
+     * operation.
      */
     public static Stated statedByChecked(Core clause, Symbols symbols) {
         if (!(clause instanceof Core.PreservedCall call)
-                || !(call.operation() instanceof souther.compiler.types.ValueName.Stdlib.Operation
-                        operation)) {
+                || !(call.operation() instanceof ValueName.Stdlib.Operation operation)) {
             return null;
         }
         StringPredicates predicate = of(symbols.kernelOf(operation));
-        if (predicate == null || call.args().size() != predicate.arity()) {
+        if (predicate == null) {
             return null;
         }
-        if (!(Terms.folded(call.args().get(predicate.written()), symbols) instanceof String written)) {
-            return null;
+        if (call.args().size() != predicate.arity()) {
+            throw new IllegalStateException(predicate + " is read as a call of " + predicate.arity()
+                    + " arguments and the library declares one of " + call.args().size());
         }
         Core subject = call.args().get(predicate.subject());
-        if (!predicate.takesAPattern()) {
-            return new Stated(subject, predicate.accepting(written));
-        }
-        // A pattern written more deeply than this reads is a limit of the reading and not a shape it
-        // has no word for, so the caller is handed the subject with nothing accepted and says that
-        // as itself. Left to look like no predicate at all, an author would go looking for the
-        // construct that was the trouble, when every construct in it is one this reads.
-        souther.compiler.regex.PatternRead said =
-                souther.compiler.regex.PatternParser.read(written);
-        return new Stated(subject, said instanceof souther.compiler.regex.PatternRead.Read read
-                ? read.syntax() : null);
+        return Terms.folded(call.args().get(predicate.written()), symbols) instanceof String written
+                ? new Stated(subject, predicate.readingOf(written))
+                : new Stated(subject, new Reading.WrittenArgumentNotKnown());
     }
 
     /**
@@ -218,7 +301,7 @@ public enum StringPredicates {
      * <p>Off the set and never off what was written. Whether the strings are all of them is a fact
      * about the language, and a caller looking at the text for an empty one would be back to
      * deciding meaning from a spelling — the thing that made {@code contains} unreadable in the
-     * first place (issue #1249).
+     * first place.
      */
     public sealed interface Divides {
 
@@ -232,60 +315,41 @@ public enum StringPredicates {
         record NothingIsLeft() implements Divides {}
 
         /**
-         * This compiler could not build the machine, so it could not tell which of the three.
+         * A limit of this compiler stopped the machine being built, so which of the three it is was
+         * never worked out.
          *
          * <p>Its own answer and never one of the others. A limit read as "no division" would be a
          * claim about the model made out of an allowance running down, which is the shape this
          * whole reading exists to stop.
+         *
+         * <p>Which limit stopped it is not carried up. A machine larger than one is allowed to be
+         * and an answer that has spent all it may are two things to whoever counts them, and one
+         * thing here: neither is a division this can speak about.
          */
-        record CouldNotTell() implements Divides {}
+        record StoppedByLimit() implements Divides {}
     }
 
     /**
-     * What {@code clause} divides the position it is about into, or null where it is no predicate
-     * of this kind or where the reading of it did not finish.
+     * What the strings a predicate admits divide the position it is about into.
+     *
+     * <p>Asked of a reading and never of a clause. What divides a position is what the rule admits
+     * there, so a caller that has read the clause hands the reading on — reading it again to answer
+     * this would be one clause with two derivations of one answer.
      *
      * <p>The machine is built here because the question is about the strings and there is no other
      * way to ask it. What it costs is one language per clause of this kind, under the allowance one
      * value is written from — the shapes composed above are a few states, and a pattern larger than
-     * that allowance is the one case that comes back unable to tell.
+     * that allowance is the one case that comes back stopped.
      */
-    public static Divides divides(Core clause, Symbols symbols) {
-        Stated stated = statedByChecked(clause, symbols);
-        if (stated == null || stated.accepts() == null) {
-            return null;
-        }
-        souther.compiler.regex.Language strings = souther.compiler.regex.PatternPlan
-                .of(stated.accepts())
-                .compile(souther.compiler.regex.PatternPlan.Budget.OF_A_WITNESS);
+    public static Divides divides(Reading.Accepting reading) {
+        Language strings = PatternPlan.of(reading.accepts())
+                .compile(PatternPlan.Budget.OF_A_WITNESS);
         if (strings == null) {
-            return new Divides.CouldNotTell();
+            return new Divides.StoppedByLimit();
         }
         if (strings.isEmpty()) {
             return new Divides.NothingIsLeft();
         }
         return strings.isEverything() ? new Divides.NothingIsRuledOut() : new Divides.IntoTwo();
-    }
-
-    /**
-     * Whether a pattern this could not take apart is one it read too little of rather than one it
-     * has no word for.
-     *
-     * <p>Asked of the same reading the caller's {@link Stated} came from, so that the two answers
-     * are one reading of one pattern.
-     */
-    public static boolean readTooLittleOf(Core clause, Symbols symbols) {
-        if (!(clause instanceof Core.PreservedCall call)
-                || !(call.operation() instanceof souther.compiler.types.ValueName.Stdlib.Operation
-                        operation)) {
-            return false;
-        }
-        StringPredicates predicate = of(symbols.kernelOf(operation));
-        return predicate != null && predicate.takesAPattern()
-                && call.args().size() == predicate.arity()
-                && Terms.folded(call.args().get(predicate.written()), symbols) instanceof String it
-                && souther.compiler.regex.PatternParser.read(it)
-                        instanceof souther.compiler.regex.PatternRead.NotRead why
-                && why.why() == souther.compiler.regex.PatternRead.Unsupported.NESTED_TOO_DEEPLY;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
@@ -19,8 +19,8 @@ import java.util.List;
  * says about the position it names is which strings stand there — the same kind of answer
  * {@code String.matches} gives and the same kind this compiler already knows how to hold, since a
  * language over code points is what {@link souther.compiler.regex} is. Read one spelling at a time
- * instead, {@code matches} was a set of strings and the four beside it were forms nothing took
- * apart, so a position an author had written a rule for admitted every string there is — and a
+ * instead, {@code matches} was a set of strings and the predicates beside it were forms nothing
+ * took apart, so a position an author had written a rule for admitted every string there is — and a
  * value nobody could compose there took its siblings' obligations down with it.
  *
  * <p><b>Keyed by what the operation means and not by how a rule is written.</b> Each entry says
@@ -157,8 +157,8 @@ public enum StringPredicates {
         /**
          * A pattern it states that this reads no further into, and what stopped the reading.
          *
-         * <p>Only {@link StringPredicates#MATCHES} arrives here. The others compose what they
-         * accept out of text, and there is nothing in that to be stopped by.
+         * <p>Only an entry whose text is a pattern arrives here. One that composes what it accepts
+         * out of text has nothing in that to be stopped by.
          */
         record PatternNotRead(PatternRead.Unsupported why) implements Reading {
 
@@ -264,11 +264,11 @@ public enum StringPredicates {
      * person to change one sees the other. Everything past the text they hand over is
      * {@link #readingOf} and is one.
      *
-     * <p>A call of another number of arguments is refused rather than read as no predicate. Its
-     * arity is settled against the declared signature before a {@link Core.PreservedCall} is built,
-     * so one arriving here says the table above and the library have come to disagree — read as no
-     * predicate, that disagreement would go on quietly costing every rule written with this
-     * operation.
+     * <p>A call of another number of arguments is refused rather than read as no predicate. A call
+     * standing for one of these operations is an application that was typed against the signature
+     * it names, where its arity was settled, so one arriving here with another number of arguments
+     * says the table above and the library have come to disagree — read as no predicate, that
+     * disagreement would go on quietly costing every rule written with this operation.
      */
     public static Stated statedByChecked(Core clause, Symbols symbols) {
         if (!(clause instanceof Core.PreservedCall call)

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.ClauseHelpers;
+import souther.compiler.check.StringPredicates;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.FieldDomains;
@@ -1680,10 +1681,15 @@ public final class Partitions {
                     // to the runtime, which is a format and nothing else, and this is which strings
                     // the rule admits — asked through the constraint, every predicate the decoder
                     // has no word for proposed no value, and a position an author had written a
-                    // rule for was offered `"x"` and refused (issue #1249).
-                    souther.compiler.regex.PatternSyntax admits =
-                            souther.compiler.check.StringPredicates.statedByWritten(each, symbols);
-                    String written = admits == null ? null : writtenFor(admits);
+                    // rule for was offered `"x"` and refused.
+                    //
+                    // Told which strings only where the reading came to them. Why it did not is
+                    // the reading's to keep and nothing here has a use for it: a rule this could
+                    // not read proposes no value, the same as one whose strings nobody can paste.
+                    StringPredicates.Reading admits =
+                            StringPredicates.statedByWritten(each, symbols);
+                    String written = admits instanceof StringPredicates.Reading.Accepting it
+                            ? writtenFor(it.accepts()) : null;
                     if (written != null) {
                         candidates.add(FixtureTemplate.string(written));
                     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1714,10 +1714,11 @@ public final class Partitions {
     /**
      * A value a source can carry that {@code regex} accepts, or null where there is none to offer.
      *
-     * <p>Null three ways, and they are one answer here: a pattern outside the subset this compiler
-     * reads, one whose machine costs more than writing a value is allowed, and one every string of
-     * which is something nobody can paste. What a caller does with each of them is offer no
-     * candidate, so they are not told apart — a row is offered or it is not.
+     * <p>Null two ways, and they are one answer here: a pattern whose machine costs more than
+     * writing a value is allowed, and one every string of which is something nobody can paste. What
+     * a caller does with each of them is offer no candidate, so they are not told apart — a row is
+     * offered or it is not. A pattern outside the subset this compiler reads never reaches here:
+     * the reading says so, and the caller offers no candidate for the same reason.
      *
      * <p>Read by the one thing here that reads patterns. What this used to have was a reader of its
      * own, which meant two answers to "what does this pattern accept" and one model where they

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -271,6 +271,41 @@ class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
     }
 
     /**
+     * A pattern this reads no deeper into, which is a limit of the reading and says so.
+     *
+     * <p>Every construct in it is one this reads. What stopped the reading is how deeply they are
+     * written, which is this compiler's measure and not the author's spelling — told that the form
+     * is one nothing reads, they would go looking for the construct that was the trouble.
+     */
+    @Test
+    void aPatternThisReadsNoDeeperIntoIsSaidAsThat() {
+        String deep = "(".repeat(201) + "a" + ")".repeat(201);
+        Measured measured = of("    invariant String.matches(\"" + deep + "\", name)");
+
+        assertTrue(measured.says("written more deeply nested than this compiler reads"),
+                measured.human());
+        assertFalse(measured.says("written in a form this compiler does not read"),
+                measured.human());
+    }
+
+    /**
+     * And a pattern stopped by a construct the subset has no word for, which is not that.
+     *
+     * <p>{@code \\p{Alpha}} names a property of a character, and the subset here names symbols by
+     * their numbers. So the rule is one written in a form nothing read, like any other — the pair
+     * with the one above is what says the two are told apart by what stopped the reading rather
+     * than by the reading having stopped.
+     */
+    @Test
+    void aPatternStoppedByAConstructThisHasNoWordForIsAFormNothingRead() {
+        Measured measured = of("    invariant String.matches(\"\\\\p{Alpha}+\", name)");
+
+        assertTrue(measured.says("written in a form this compiler does not read"), measured.human());
+        assertFalse(measured.says("written more deeply nested than this compiler reads"),
+                measured.human());
+    }
+
+    /**
      * And a clause nothing here takes apart, which is what a limit of this compiler looks like.
      *
      * <p>Here the question standing is the truth: what the clause says about the values was never


### PR DESCRIPTION
Closes #1267.

## What was wrong

`StringPredicates.Stated` held the strings a predicate admits and nothing about a reading
that came to none of them — `accepts == null` was an absence with no word for what it was.
A reader wanting the reason had to go back to the clause: `readTooLittleOf` folded the
written argument and parsed the pattern a second time to answer what the caller's `Stated`
had already established, and `divides(Core, Symbols)` re-established the whole reading for a
caller that was holding it. One question, two derivations, agreeing because the reading is a
function rather than because there is one reading.

The same shape a third time in the producer: `statedByWritten` returned a `PatternSyntax` and
collapsed an unread pattern to null, so the next reader wanting a reason on that side would
have grown a second `readTooLittleOf` of its own.

## What it is now

`recognition → reading → derived question`, one way, with no way back to the clause in
between.

```java
public sealed interface Reading {
    record Accepting(PatternSyntax accepts) implements Reading {}
    record PatternNotRead(PatternRead.Unsupported why) implements Reading {}
    record WrittenArgumentNotKnown() implements Reading {}
}

public record Stated(Core subject, Reading reading) {}
```

- `divides` takes a `Reading.Accepting` and returns a `Divides` — no `Core`, no `Symbols`, no
  null. The `case null` arm in `InvariantChecker` is gone with it.
- `Divides.CouldNotTell` is `Divides.StoppedByLimit`. `PatternPlan.compile` returns null only
  where the meter refused a build, so the arm's name now says its generating condition.
- `readTooLittleOf` is deleted.
- The parse lives at one private method both trees hand their text to. What is
  representation-specific stops at the fold (`ConstEval` on one side, `Terms.folded` on the
  other); everything past the text is one answer.
- A `PreservedCall` is built after its arity has been settled against the declared signature,
  so one arriving with another number of arguments says the table and the library have come
  to disagree. Refused rather than read as no predicate — read as none, the drift would go on
  quietly costing every rule written with the operation. The written tree keeps null there:
  it reads applications that have not yet been refused.

`null` now means one thing at each entry point: this clause is no predicate of this kind.

## The eleven and the one

`AdmissibleReading` told `NESTED_TOO_DEEPLY` apart from the other eleven `Unsupported`
constructs with an `if`, so a construct added to the subset's stop list would have become
`FORM_NOT_READ` without anybody deciding. It is a switch with no `default` now.

Only a pattern nested deeper than this reads is said by that reading as itself — every
construct in it is one this reads, and an author told the form is unreadable would go looking
for the construct that was the trouble. The eleven are rules nothing read like any other, and
what those cost is worked out at the leaf over every position the clause names, which is more
than the subject wherever the text is written out of another position.

## Tests

Two cases in `ARuleReadToTheEndIsNotOneThisCouldNotReadTest`, which is where the pair belongs:
a pattern nested past the limit is reported as nested too deeply, and one stopped by
`\p{Alpha}` is reported as a form nothing reads. Neither sentence was reached by any test
before — returning null from the `NESTED_TOO_DEEPLY` arm leaves the whole suite green without
the first of them.

11,570 tests, all modules, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
