### PR TITLE
Take a module's numbering from the check that made it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -7,6 +7,7 @@ import souther.compiler.observe.ArmObservation;
 import souther.compiler.inputs.TermPath;
 
 
+import souther.compiler.coverage.CoverageSites;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.DeadBranchMessage;
 import souther.compiler.diag.msg.ExampleMessage;
@@ -2288,12 +2289,14 @@ public final class Adequacy {
             // waits on a run, so taking `Plan.NONE` where the build did not ask for the instrumented
             // classes bought nothing and left a body that owes no arm looking like a body nobody
             // measured (issue #955).
-            souther.compiler.coverage.CoverageSites.Plan plan = Output.Evaluated.planOf(db, name);
+            Bodies.Elaborated checked = db.ask(new Bodies.Checked(name)).value();
+            CoverageSites.Plan plan =
+                    checked == null ? CoverageSites.Plan.NONE : checked.plan();
             // Whether the bodies came back at all. Which behaviors have one is the model's answer
             // and is asked of the declarations below; this is the other question — whether what a
             // body holds could be read — and answering both from this map is what made a module the
             // compile stopped in report every behavior as one with no body (issue #996).
-            boolean bodiesRead = db.ask(new Bodies.Checked(name)).value() != null;
+            boolean bodiesRead = checked != null;
             Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Set<Integer> lit = new LinkedHashSet<>();
             for (RowReading observed : byTarget.values()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -2262,6 +2262,14 @@ public final class Bodies {
          * says which module. Built from the bodies and the module handed over separately, the two
          * are only as true as the caller made them — and there are a dozen callers, each holding
          * one of these and taking the parts off it.
+         *
+         * <p><b>Each call walks the bodies again.</b> What comes back is a plan of its own, and two
+         * of them number one arm alike because the walk is a function of the bodies rather than
+         * because anything here hands the same one out twice. So a caller holding two — the
+         * emitter's and a measure's, say — holds two answers that agree, which is not the same as
+         * holding one answer, and nothing yet says what it would take for two numberings of one
+         * module to mean the same thing. Said here because it is asked here: a caller that had to
+         * work it out would work it out once per call site.
          */
         public souther.compiler.coverage.CoverageSites.Plan plan() {
             return souther.compiler.coverage.CoverageSites.of(of, decisions, supplied);

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -388,7 +388,6 @@ public final class Output {
                 return Answer.absent();   // the plan is not about these bodies
             }
         }
-
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -26,7 +26,6 @@ import souther.compiler.core.EnsuresEnforcement;
 import souther.compiler.codegen.Backend;
 import souther.compiler.codegen.Emissions;
 import souther.compiler.codegen.Instrumentation;
-import souther.compiler.coverage.CoverageSites;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.DataMessage;
@@ -390,12 +389,6 @@ public final class Output {
             }
         }
 
-        /** The plan of the same module, for a caller that needs to read what a hit set means. Made
-         * from the same answer the classes were generated from, so the numbers agree. */
-        public static CoverageSites.Plan planOf(Db db, String module) {
-            Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();
-            return checked == null ? CoverageSites.Plan.NONE : checked.plan();
-        }
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
@@ -65,7 +65,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void oneRunPassesTheComparisonInsideAFunctionValueOncePerElement() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan = planOf(compilation);
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
         ComparisonEmissionSite perElement = comparisonAt(plan, "fee", 9);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -88,7 +88,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void aComparisonGivenANameIsRecordedWhereItIsWritten() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan = planOf(compilation);
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
         ComparisonEmissionSite named = comparisonAt(plan, "fee", 7);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -102,7 +102,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void aComparisonABehaviorAnswersWithIsRecordedToo() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan = planOf(compilation);
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
         ComparisonEmissionSite answered = comparisonAt(plan, "positive", 12);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -143,8 +143,10 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, taken from the check that made it. */
-    private static CoverageSites.Plan planOf(Compilation compilation) {
+    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
+     *  Named apart from the plans this package's other tests build straight from bodies: those are
+     *  a walk of their own, and this is the one the compile settled on. */
+    private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
@@ -143,9 +143,9 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
-     *  Named apart from the plans this package's other tests build straight from bodies: those are
-     *  a walk of their own, and this is the one the compile settled on. */
+    /** The numbering of the bodies the classes below were generated from, asked of the check the
+     *  emitter reads too. Named apart from the plans this package's other tests build straight from
+     *  bodies, which have no compile behind them at all. */
     private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
@@ -5,6 +5,7 @@ import souther.compiler.Emitted;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
@@ -64,8 +65,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void oneRunPassesTheComparisonInsideAFunctionValueOncePerElement() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan =
-                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        CoverageSites.Plan plan = planOf(compilation);
         ComparisonEmissionSite perElement = comparisonAt(plan, "fee", 9);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -88,8 +88,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void aComparisonGivenANameIsRecordedWhereItIsWritten() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan =
-                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        CoverageSites.Plan plan = planOf(compilation);
         ComparisonEmissionSite named = comparisonAt(plan, "fee", 7);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -103,8 +102,7 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     @Test
     void aComparisonABehaviorAnswersWithIsRecordedToo() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan =
-                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        CoverageSites.Plan plan = planOf(compilation);
         ComparisonEmissionSite answered = comparisonAt(plan, "positive", 12);
         Map<String, ClassFileImage> classes = probed(compilation);
 
@@ -143,6 +141,14 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.answerEverything();
         return compilation;
+    }
+
+    /** The numbering the classes below were lit against, taken from the check that made it. */
+    private static CoverageSites.Plan planOf(Compilation compilation) {
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles");
+        return checked.plan();
     }
 
     private static Map<String, ClassFileImage> probed(Compilation compilation) {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -5,6 +5,7 @@ import souther.compiler.Emitted;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
@@ -60,8 +61,7 @@ class AComparisonSaysWhichWayItCameOutTest {
     @Test
     void twoWaysOfFailingOneConditionAreNotOneObservation() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan =
-                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        CoverageSites.Plan plan = planOf(compilation);
         Behavior submit = new Behavior(probed(compilation));
 
         Observation early = submit.observing(-1L);
@@ -159,6 +159,14 @@ class AComparisonSaysWhichWayItCameOutTest {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.answerEverything();
         return compilation;
+    }
+
+    /** The numbering the classes below were lit against, taken from the check that made it. */
+    private static CoverageSites.Plan planOf(Compilation compilation) {
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles");
+        return checked.plan();
     }
 
     private static Map<String, ClassFileImage> probed(Compilation compilation) {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -61,7 +61,7 @@ class AComparisonSaysWhichWayItCameOutTest {
     @Test
     void twoWaysOfFailingOneConditionAreNotOneObservation() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan = planOf(compilation);
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
         Behavior submit = new Behavior(probed(compilation));
 
         Observation early = submit.observing(-1L);
@@ -161,8 +161,10 @@ class AComparisonSaysWhichWayItCameOutTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, taken from the check that made it. */
-    private static CoverageSites.Plan planOf(Compilation compilation) {
+    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
+     *  Named apart from the plans this package's other tests build straight from bodies: those are
+     *  a walk of their own, and this is the one the compile settled on. */
+    private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -161,9 +161,9 @@ class AComparisonSaysWhichWayItCameOutTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
-     *  Named apart from the plans this package's other tests build straight from bodies: those are
-     *  a walk of their own, and this is the one the compile settled on. */
+    /** The numbering of the bodies the classes below were generated from, asked of the check the
+     *  emitter reads too. Named apart from the plans this package's other tests build straight from
+     *  bodies, which have no compile behind them at all. */
     private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -5,6 +5,7 @@ import souther.compiler.Emitted;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.jvm.ClassFileImage;
 import souther.compiler.query.Output;
@@ -60,6 +61,14 @@ class ProbedBytecodeTest {
         return compilation;
     }
 
+    /** The numbering the classes below were lit against, taken from the check that made it. */
+    private static CoverageSites.Plan planOf(Compilation compilation) {
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles");
+        return checked.plan();
+    }
+
     private static Map<String, ClassFileImage> probed(Compilation compilation) {
         souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
                 .ask(new Output.Evaluated(compilation.modules().get(0),
@@ -94,8 +103,7 @@ class ProbedBytecodeTest {
     @Test
     void aRunRecordsTheArmsItTook() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan =
-                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        CoverageSites.Plan plan = planOf(compilation);
         Behavior submit = new Behavior(probed(compilation));
 
         Set<Integer> negative = submit.armsFor(-1L);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -61,9 +61,9 @@ class ProbedBytecodeTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
-     *  Named apart from the plans this package's other tests build straight from bodies: those are
-     *  a walk of their own, and this is the one the compile settled on. */
+    /** The numbering of the bodies the classes below were generated from, asked of the check the
+     *  emitter reads too. Named apart from the plans this package's other tests build straight from
+     *  bodies, which have no compile behind them at all. */
     private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -61,8 +61,10 @@ class ProbedBytecodeTest {
         return compilation;
     }
 
-    /** The numbering the classes below were lit against, taken from the check that made it. */
-    private static CoverageSites.Plan planOf(Compilation compilation) {
+    /** The numbering the classes below were lit against, asked of the check the emitter reads too.
+     *  Named apart from the plans this package's other tests build straight from bodies: those are
+     *  a walk of their own, and this is the one the compile settled on. */
+    private static CoverageSites.Plan checkedPlanOf(Compilation compilation) {
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
         assertNotNull(checked, "the model under test compiles");
@@ -103,7 +105,7 @@ class ProbedBytecodeTest {
     @Test
     void aRunRecordsTheArmsItTook() {
         Compilation compilation = compiled();
-        CoverageSites.Plan plan = planOf(compilation);
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
         Behavior submit = new Behavior(probed(compilation));
 
         Set<Integer> negative = submit.armsFor(-1L);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatDerivesANumberingIsWhatHoldsTheBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatDerivesANumberingIsWhatHoldsTheBodiesTest.java
@@ -1,0 +1,120 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A module's numbering is derived where its bodies are held, and nowhere else in the compiler.
+ *
+ * <p>{@link CoverageSites#of} is a function of the bodies, so two calls of it over one module come
+ * to one numbering. That is what a reader takes on trust when it derives its own: the emitter wrote
+ * numbers into probe calls under one plan, and a measure looks a hit up under another, and the two
+ * are about one place only while the walk keeps agreeing with itself. Which is a property to hold
+ * rather than a thing to rely on quietly — and the fewer places derive one, the less of the
+ * compiler that property has to hold across.
+ *
+ * <p>So what is fixed here is not that the numbering is right; it is who may ask for one. A reader
+ * that wants to know what a hit set means asks the check that holds the bodies, and there is one
+ * such check per module. A second derivation somewhere else is a second answer that no later check
+ * could tell from the first, since both are true of the same bodies until one of them stops being.
+ *
+ * <p><b>Who derives one, not who has one.</b> A method that asks the check for the module's
+ * numbering is not counted here and is not meant to be: it takes the answer the bodies' own holder
+ * gives, which is the whole of what this fixes. So a second way of <em>reaching</em> that answer —
+ * a helper elsewhere that asks the check and hands the plan on — stays green under this. What is
+ * wrong with such a helper is that a reader then has two routes to one answer, not that the two
+ * could disagree.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it — a call written inside a lambda belongs to the lambda, and
+ * this says so.
+ *
+ * <p><b>What it does not see, said rather than left to be found.</b> The tests are not in
+ * {@code target/classes}: a test deriving a plan straight from bodies is a fixture standing in for
+ * a compile, and there is no reader downstream of it to disagree with. And what is read is this
+ * module's classes — a caller written in the CLI or the language server would not be counted here.
+ * Widening it is not free: those modules are built after this one, so a walk over their output
+ * would read whatever the last build left and would say nothing at all on a clean one.
+ */
+class WhatDerivesANumberingIsWhatHoldsTheBodiesTest {
+
+    private static final String SITES = "souther/compiler/coverage/CoverageSites";
+
+    /** A method that may derive one, how many times it does, and why it is one of the ones that
+     *  does. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_DERIVE = List.of(
+            new Licence("souther.compiler.query.Bodies.judged", 1,
+                    "what a body claims cannot arrive is judged against the arms of the same"
+                            + " bodies, and the claim and the reading that judges it have to name"
+                            + " one arm"),
+            new Licence("souther.compiler.query.Bodies.Elaborated.plan", 1,
+                    "what every reader outside the check asks: the bodies are held here, so this is"
+                            + " where a numbering of them is a numbering of anything at all"));
+
+    @Test
+    void onlyTheCheckThatHoldsThemDerivesAModulesNumbering() throws IOException {
+        assertEquals(declared(), derivations(),
+                "a numbering derived anywhere else is a second answer about one module's arms, and"
+                        + " a reader holding it is reading a run against numbers nothing wrote."
+                        + " What may derive one, and why: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_DERIVE.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_DERIVE.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler derives a numbering. */
+    private static Map<String, Integer> derivations() throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(SITES)
+                            && call.name().stringValue().equals("of")) {
+                        calls.merge(from + "." + method.methodName().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -44,6 +44,14 @@ class ProbeMappingTest {
         return compilation;
     }
 
+    /** One compile's numbering of {@code module}, which is the check's own and not a second walk. */
+    private static CoverageSites.Plan planOf(Compilation compilation, String module) {
+        Bodies.Elaborated checked =
+                compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        return checked.plan();
+    }
+
     /**
      * A plan made from one compile, used to emit another's bodies.
      *
@@ -57,7 +65,7 @@ class ProbeMappingTest {
         Compilation elsewhere = compiled();
         String module = emitting.modules().get(0);
         Output.Classes.Inputs in = Output.Classes.inputs(emitting.db(), module);
-        CoverageSites.Plan somewhereElse = Output.Evaluated.planOf(elsewhere.db(), module);
+        CoverageSites.Plan somewhereElse = planOf(elsewhere, module);
         assertNotNull(in);
         assertTrue(somewhereElse.sites().size() > 0, "the other compile has arms of its own");
 
@@ -86,7 +94,7 @@ class ProbeMappingTest {
         String module = emitting.modules().get(0);
         Output.Classes.Inputs in = Output.Classes.inputs(emitting.db(), module);
         assertNotNull(in);
-        CoverageSites.Plan real = Output.Evaluated.planOf(emitting.db(), module);
+        CoverageSites.Plan real = planOf(emitting, module);
         assertTrue(real.sites().size() > 0);
 
         // The same plan with one more arm in it than any body will emit.

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -44,9 +44,9 @@ class ProbeMappingTest {
         return compilation;
     }
 
-    /** The numbering {@code compilation} settled on for {@code module}, asked of the check that
-     *  holds its bodies. Every call walks them again and comes to the same numbers, the walk being
-     *  a function of the bodies; what matters here is which compile's bodies were walked. */
+    /** The numbering of {@code module}'s bodies as {@code compilation} checked them. Which compile
+     *  they were checked by is what the tests below turn on: two compiles of one source number one
+     *  arm alike, and a plan of one compile's bodies is about that compile's trees. */
     private static CoverageSites.Plan checkedPlanOf(Compilation compilation, String module) {
         Bodies.Elaborated checked =
                 compilation.db().ask(new Bodies.Checked(module)).value();

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -44,8 +44,10 @@ class ProbeMappingTest {
         return compilation;
     }
 
-    /** One compile's numbering of {@code module}, which is the check's own and not a second walk. */
-    private static CoverageSites.Plan planOf(Compilation compilation, String module) {
+    /** The numbering {@code compilation} settled on for {@code module}, asked of the check that
+     *  holds its bodies. Every call walks them again and comes to the same numbers, the walk being
+     *  a function of the bodies; what matters here is which compile's bodies were walked. */
+    private static CoverageSites.Plan checkedPlanOf(Compilation compilation, String module) {
         Bodies.Elaborated checked =
                 compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");
@@ -65,7 +67,7 @@ class ProbeMappingTest {
         Compilation elsewhere = compiled();
         String module = emitting.modules().get(0);
         Output.Classes.Inputs in = Output.Classes.inputs(emitting.db(), module);
-        CoverageSites.Plan somewhereElse = planOf(elsewhere, module);
+        CoverageSites.Plan somewhereElse = checkedPlanOf(elsewhere, module);
         assertNotNull(in);
         assertTrue(somewhereElse.sites().size() > 0, "the other compile has arms of its own");
 
@@ -94,7 +96,7 @@ class ProbeMappingTest {
         String module = emitting.modules().get(0);
         Output.Classes.Inputs in = Output.Classes.inputs(emitting.db(), module);
         assertNotNull(in);
-        CoverageSites.Plan real = planOf(emitting, module);
+        CoverageSites.Plan real = checkedPlanOf(emitting, module);
         assertTrue(real.sites().size() > 0);
 
         // The same plan with one more arm in it than any body will emit.

--- a/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -148,9 +148,10 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
             assertNotNull(checked, "the model under test compiles");
             Core body = checked.behaviorBodies().get(name);
             assertNotNull(body, "the behavior under test has a body");
-            // The emitter's plan, which is the numbering the classes below were lit against. A plan
-            // built here again would be the same numbering and would be a second thing to be right.
-            CoverageSites.Plan plan = Output.Evaluated.planOf(compilation.db(), module);
+            // The emitter's plan, which is the numbering the classes below were lit against. Taken
+            // from the check that made it, so there is nothing here for a second walk to disagree
+            // with.
+            CoverageSites.Plan plan = checked.plan();
             Symbols symbols = Scopes.derived(compilation.db(), module).value();
             InputDomain inputs =
                     compilation.db().ask(new Adequacy.Inputs(module)).value().get(name);

--- a/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -148,9 +148,10 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
             assertNotNull(checked, "the model under test compiles");
             Core body = checked.behaviorBodies().get(name);
             assertNotNull(body, "the behavior under test has a body");
-            // The emitter's plan, which is the numbering the classes below were lit against. Taken
-            // from the check that made it, so there is nothing here for a second walk to disagree
-            // with.
+            // The emitter's plan, which is the numbering the classes below were lit against. Asked
+            // of the check the emitter reads too: this walks the bodies again and would be a second
+            // thing to be right, and it comes to the same numbers because the walk is a function of
+            // the bodies both took.
             CoverageSites.Plan plan = checked.plan();
             Symbols symbols = Scopes.derived(compilation.db(), module).value();
             InputDomain inputs =

--- a/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -148,10 +148,8 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
             assertNotNull(checked, "the model under test compiles");
             Core body = checked.behaviorBodies().get(name);
             assertNotNull(body, "the behavior under test has a body");
-            // The emitter's plan, which is the numbering the classes below were lit against. Asked
-            // of the check the emitter reads too: this walks the bodies again and would be a second
-            // thing to be right, and it comes to the same numbers because the walk is a function of
-            // the bodies both took.
+            // Of the check the emitter reads too, so the numbering below is of the bodies the
+            // classes were generated from.
             CoverageSites.Plan plan = checked.plan();
             Symbols symbols = Scopes.derived(compilation.db(), module).value();
             InputDomain inputs =


### PR DESCRIPTION
Toward #1282. The first step, and on its own: it moves nothing about how a
run is recorded or read back.

## What this is

A reader wanting to know what a hit set means had two ways to the same
answer. `Output.Evaluated.planOf` asked `Bodies.Checked` and read the plan
off it, so a question about the numbering of a module's bodies could be put
to the emitter's side of the compiler by a route of its own. Nothing was
derived twice by it, but which route a reader took was a choice rather than
the only way there was.

`Adequacy` is where that showed. It went through `planOf` for the plan and
asked `Bodies.Checked` again on the next line for whether the bodies came
back at all — one query, twice, for two halves of one answer.

So the plan is taken where the check already is. `Adequacy` asks once and
reads both from that answer, and a module the check has no answer for gets
no plan rather than one assembled from parts. `planOf` is gone. What derives
a numbering is the module that holds the bodies.

The tests that used `planOf` ask `Bodies.Checked` themselves now. javac
enumerated them; nothing was searched for by name.

## What this deliberately does not do

The plan is still derived per call of `Elaborated.plan()` rather than held
on the answer. Holding it was tried and refused, by
`EverythingAnAnswerHoldsMeansSomethingTest`: a `Plan` is keyed by node
identity inside, and an answer holding one is an answer holding something
that means nothing by `equals`. The register would have had to grow to say
so at every place under it.

The refusal is right and the register should not have grown. A `Plan` is a
working index the emitter reaches into for *this* Core instance rather than
an equal one — that is what the identity keying is for, and it is not
something to be turned into a value. What a run's numbering *is*, as
something two builds can be held against each other by, is a separate value
and is the next step rather than this one.

Both of the checks that measure the harm the register guards against stayed
green throughout, so nothing here rests on the exception either way.
