### PR TITLE
Say what each number a numbering hands out is an address of

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/coverage/BinderAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/BinderAddress.java
@@ -1,0 +1,59 @@
+package souther.compiler.coverage;
+
+/**
+ * Which binding a name in a body reads from, said as where the binder stands rather than as the
+ * number the compiler minted for it.
+ *
+ * <p>A {@code BindingId} is a binder and its reads holding one value, which is what a pass needs and
+ * is right for it. What it is made of is an owner and a count over that owner's bindings, and both
+ * move: an expansion owns the copy it made and numbers copies as it makes them, so the same helper
+ * spliced into the same body twice gives its bindings different owners, and a body edited above a
+ * binder renumbers it. Neither changes what the body does.
+ *
+ * <p>So a reading that has to survive being taken twice reads a binding as a place. A binder that
+ * stands inside the body is at a slot of a node, and the node is at an address; a name the body did
+ * not bind is the behavior's own parameter, which the signature wrote and numbered.
+ *
+ * <p>There is no third arm on purpose. A read whose binding is neither is a body holding a name
+ * nothing in sight binds, which is not something to give an address to.
+ */
+sealed interface BinderAddress {
+
+    /**
+     * One of the behavior's parameters, which the signature binds and the body does not.
+     *
+     * @param index which parameter, in the order the signature writes them
+     */
+    record Parameter(String behavior, int index) implements BinderAddress {
+
+        public Parameter {
+            if (behavior == null) {
+                throw new IllegalArgumentException("a parameter is somebody's parameter");
+            }
+            if (index < 0) {
+                throw new IllegalArgumentException(
+                        "a parameter stands somewhere among the signature's: " + index);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return behavior + "(" + index + ")";
+        }
+    }
+
+    /** A binder standing at a slot of a node of the body. */
+    record Local(NodeAddress owner, BinderSlot slot) implements BinderAddress {
+
+        public Local {
+            if (owner == null || slot == null) {
+                throw new IllegalArgumentException("a binder stands at a slot of somewhere");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return owner + "." + slot;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/BinderAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/BinderAddress.java
@@ -17,7 +17,7 @@ package souther.compiler.coverage;
  * <p>There is no third arm on purpose. A read whose binding is neither is a body holding a name
  * nothing in sight binds, which is not something to give an address to.
  */
-sealed interface BinderAddress {
+public sealed interface BinderAddress {
 
     /**
      * One of the behavior's parameters, which the signature binds and the body does not.

--- a/souther-compiler/src/main/java/souther/compiler/coverage/BinderSlot.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/BinderSlot.java
@@ -1,0 +1,63 @@
+package souther.compiler.coverage;
+
+/**
+ * Which of a node's binders one is.
+ *
+ * <p>Beside {@link CoreStructure.Edge} rather than among it. An edge leads to a child, and every
+ * child is an expression the walk goes on into; a binder is neither — it is a name the node opens
+ * for what stands under it, and there is nothing below it to walk. Held as one vocabulary they
+ * would be a step down that goes nowhere, which a path is not.
+ *
+ * <p>One arm per node kind that opens a name, and no more: a node kind that starts binding arrives
+ * here as a case the walk cannot answer rather than as a binder nothing can address.
+ */
+sealed interface BinderSlot {
+
+    /** The name a {@code let} opens for its body. */
+    record LetBinder() implements BinderSlot {
+
+        @Override
+        public String toString() {
+            return "let";
+        }
+    }
+
+    /** One of the names a function value takes. */
+    record BlockParam(int index) implements BinderSlot {
+
+        public BlockParam {
+            if (index < 0) {
+                throw new IllegalArgumentException("a parameter stands somewhere: " + index);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "param(" + index + ")";
+        }
+    }
+
+    /** The name a {@code match} case opens for what it matched. */
+    record CaseBinder(int index) implements BinderSlot {
+
+        public CaseBinder {
+            if (index < 0) {
+                throw new IllegalArgumentException("a case stands somewhere: " + index);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "case(" + index + ")";
+        }
+    }
+
+    /** The name an attempted construction opens for what it built. */
+    record ConstructedBinder() implements BinderSlot {
+
+        @Override
+        public String toString() {
+            return "built";
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/BinderSlot.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/BinderSlot.java
@@ -11,7 +11,7 @@ package souther.compiler.coverage;
  * <p>One arm per node kind that opens a name, and no more: a node kind that starts binding arrives
  * here as a case the walk cannot answer rather than as a binder nothing can address.
  */
-sealed interface BinderSlot {
+public sealed interface BinderSlot {
 
     /** The name a {@code let} opens for its body. */
     record LetBinder() implements BinderSlot {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
@@ -1,70 +1,32 @@
 package souther.compiler.coverage;
 
-import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * What each name of one body reads from, as a place rather than as a minted number.
  *
- * <p>Built with the addresses of the body's own places, because that is what a binder standing in it
- * is named by. Asked once per body and read by whatever is writing the body down in a form two
- * compiles can be held against each other by.
+ * <p>Read off the one descent that worked out where the body's places are ({@link NodeAddresses}),
+ * because a binder is at a slot of a node and the node is at an address. A walk of its own here
+ * would be a second answer to what the body holds, with its own idea of what to make of a node
+ * several ways lead to.
  */
 final class Binders {
 
     private final String behavior;
 
-    private final Map<BindingId, BinderAddress> byId = new LinkedHashMap<>();
+    private final Map<BindingId, BinderAddress> byId;
 
-    private Binders(String behavior) {
+    private Binders(String behavior, Map<BindingId, BinderAddress> byId) {
         this.behavior = behavior;
+        this.byId = byId;
     }
 
-    /** Where every binder of {@code body} stands, {@code body} being {@code behavior}'s. */
-    static Binders of(String behavior, Core body, NodeAddresses places) {
-        Binders out = new Binders(behavior);
-        out.walk(body, places);
-        return out;
-    }
-
-    private void walk(Core at, NodeAddresses places) {
-        switch (at) {
-            case Core.LetIn li ->
-                    put(li.binder(), places.of(li), new BinderSlot.LetBinder());
-            case Core.Block b -> {
-                for (int i = 0; i < b.params().size(); i++) {
-                    put(b.params().get(i), places.of(b), new BinderSlot.BlockParam(i));
-                }
-            }
-            case Core.Match m -> {
-                for (int i = 0; i < m.cases().size(); i++) {
-                    put(m.cases().get(i).binder(), places.of(m), new BinderSlot.CaseBinder(i));
-                }
-            }
-            case Core.IfConstructed ic ->
-                    put(ic.binder(), places.of(ic), new BinderSlot.ConstructedBinder());
-            default -> { }
-        }
-        for (CoreStructure.Child child : CoreStructure.childrenOf(at)) {
-            walk(child.node(), places);
-        }
-    }
-
-    private void put(Core.Binder binder, NodeAddress owner, BinderSlot slot) {
-        if (binder == null || binder.binding() == null) {
-            return;   // a slot the node has and this body left empty
-        }
-        // One binder per place, so a second answer for one id is a body binding one name twice —
-        // which the reads under it could not tell apart either.
-        BinderAddress already = byId.put(binder.binding(), new BinderAddress.Local(owner, slot));
-        if (already != null) {
-            throw new IllegalStateException("`" + behavior + "` binds " + binder.binding()
-                    + " at " + already + " and again at " + byId.get(binder.binding()));
-        }
+    /** Where every binder of the body {@code places} was taken over stands. */
+    static Binders of(NodeAddresses places) {
+        return new Binders(places.behavior(), places.bound());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
@@ -1,0 +1,96 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What each name of one body reads from, as a place rather than as a minted number.
+ *
+ * <p>Built with the addresses of the body's own places, because that is what a binder standing in it
+ * is named by. Asked once per body and read by whatever is writing the body down in a form two
+ * compiles can be held against each other by.
+ */
+final class Binders {
+
+    private final String behavior;
+
+    private final Map<BindingId, BinderAddress> byId = new LinkedHashMap<>();
+
+    private Binders(String behavior) {
+        this.behavior = behavior;
+    }
+
+    /** Where every binder of {@code body} stands, {@code body} being {@code behavior}'s. */
+    static Binders of(String behavior, Core body, NodeAddresses places) {
+        Binders out = new Binders(behavior);
+        out.walk(body, places);
+        return out;
+    }
+
+    private void walk(Core at, NodeAddresses places) {
+        switch (at) {
+            case Core.LetIn li ->
+                    put(li.binder(), places.of(li), new BinderSlot.LetBinder());
+            case Core.Block b -> {
+                for (int i = 0; i < b.params().size(); i++) {
+                    put(b.params().get(i), places.of(b), new BinderSlot.BlockParam(i));
+                }
+            }
+            case Core.Match m -> {
+                for (int i = 0; i < m.cases().size(); i++) {
+                    put(m.cases().get(i).binder(), places.of(m), new BinderSlot.CaseBinder(i));
+                }
+            }
+            case Core.IfConstructed ic ->
+                    put(ic.binder(), places.of(ic), new BinderSlot.ConstructedBinder());
+            default -> { }
+        }
+        for (CoreStructure.Child child : CoreStructure.childrenOf(at)) {
+            walk(child.node(), places);
+        }
+    }
+
+    private void put(Core.Binder binder, NodeAddress owner, BinderSlot slot) {
+        if (binder == null || binder.binding() == null) {
+            return;   // a slot the node has and this body left empty
+        }
+        // One binder per place, so a second answer for one id is a body binding one name twice —
+        // which the reads under it could not tell apart either.
+        BinderAddress already = byId.put(binder.binding(), new BinderAddress.Local(owner, slot));
+        if (already != null) {
+            throw new IllegalStateException("`" + behavior + "` binds " + binder.binding()
+                    + " at " + already + " and again at " + byId.get(binder.binding()));
+        }
+    }
+
+    /**
+     * Where {@code read} reads from.
+     *
+     * <p>Three answers and only two of them are places. A name the body binds is at the binder's
+     * slot; a name it does not is the behavior's own parameter, which the signature bound and
+     * numbered in the order it wrote them. Anything else is a read of a binding nothing in sight
+     * opens, and there is no address to give it: the body would be saying it reads something no
+     * reader of this could find, and answering with a made-up place would put that in a value.
+     */
+    BinderAddress at(BindingId read) {
+        BinderAddress local = byId.get(read);
+        if (local != null) {
+            return local;
+        }
+        // The declaration this body is of, which is what binds a parameter and numbered the
+        // parameters in the order it wrote them. Told by the name it declares and not by the module
+        // beside it: which module a plan is labelled with is the caller's word for a collection of
+        // bodies, and a body is this behavior's because it is the body this walk was handed under
+        // that name.
+        if (read.owner() instanceof BindingOwner.OfValue declared
+                && declared.name().equals(behavior)) {
+            return new BinderAddress.Parameter(behavior, read.ordinal());
+        }
+        throw new IllegalStateException("`" + behavior + "` reads " + read
+                + ", which nothing in its body binds and its signature does not name");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Binders.java
@@ -17,16 +17,24 @@ final class Binders {
 
     private final String behavior;
 
+    /** The declaration this body is of, which is what binds its parameters. Module and name
+     *  together, because that is what tells one owner from another: two modules declaring
+     *  {@code f} own different bindings, so a read of the other module's would be taken for this
+     *  behavior's parameter if only the name were compared. */
+    private final BindingOwner.OfValue signature;
+
     private final Map<BindingId, BinderAddress> byId;
 
-    private Binders(String behavior, Map<BindingId, BinderAddress> byId) {
+    private Binders(String module, String behavior, Map<BindingId, BinderAddress> byId) {
         this.behavior = behavior;
+        this.signature = new BindingOwner.OfValue(module, behavior);
         this.byId = byId;
     }
 
-    /** Where every binder of the body {@code places} was taken over stands. */
-    static Binders of(NodeAddresses places) {
-        return new Binders(places.behavior(), places.bound());
+    /** Where every binder of the body {@code places} was taken over stands, that body being the one
+     *  {@code module} declares under the name the addresses are of. */
+    static Binders of(String module, NodeAddresses places) {
+        return new Binders(module, places.behavior(), places.bound());
     }
 
     /**
@@ -43,13 +51,9 @@ final class Binders {
         if (local != null) {
             return local;
         }
-        // The declaration this body is of, which is what binds a parameter and numbered the
-        // parameters in the order it wrote them. Told by the name it declares and not by the module
-        // beside it: which module a plan is labelled with is the caller's word for a collection of
-        // bodies, and a body is this behavior's because it is the body this walk was handed under
-        // that name.
-        if (read.owner() instanceof BindingOwner.OfValue declared
-                && declared.name().equals(behavior)) {
+        // The declaration this body is of, which binds its parameters and numbered them in the
+        // order it wrote them.
+        if (signature.equals(read.owner())) {
             return new BinderAddress.Parameter(behavior, read.ordinal());
         }
         throw new IllegalStateException("`" + behavior + "` reads " + read

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
@@ -1,0 +1,55 @@
+package souther.compiler.coverage;
+
+import java.util.List;
+
+/**
+ * The way down from a behavior's body to one place in it, as the slots it goes through.
+ *
+ * <p>What a place is, said in something two walks of one body can both arrive at. The object
+ * standing at a place tells it from every other place while a walk holds the tree, and tells a
+ * second walk nothing: the trees are equal and the objects are not the same, so an address made of
+ * objects crosses nothing. This is made of what the source wrote — the right of a {@code &&}, the
+ * second case of a {@code match} — so two walks of one body write the same one.
+ *
+ * <p>Of a body and not of a module. Which body it is of is said beside it ({@link NodeAddress}),
+ * because a path is the same list of slots in every body shaped alike and means a different place
+ * in each.
+ *
+ * <p>The empty path is the body itself.
+ *
+ * @param edges the slots gone through, outermost first
+ */
+record CorePath(List<CoreStructure.Edge> edges) {
+
+    static final CorePath ROOT = new CorePath(List.of());
+
+    CorePath {
+        if (edges == null) {
+            throw new IllegalArgumentException("a way down is a way down through something");
+        }
+        edges = List.copyOf(edges);
+    }
+
+    /** This, then one more step. */
+    CorePath then(CoreStructure.Edge edge) {
+        List<CoreStructure.Edge> longer = new java.util.ArrayList<>(edges);
+        longer.add(edge);
+        return new CorePath(longer);
+    }
+
+    @Override
+    public String toString() {
+        if (edges.isEmpty()) {
+            return "<body>";
+        }
+        StringBuilder out = new StringBuilder();
+        for (CoreStructure.Edge edge : edges) {
+            // A slot with nothing to say beyond which one it is says only that. The rest carry an
+            // index, and it is the half of the answer.
+            String said = edge.toString();
+            out.append('/').append(said.endsWith("[]")
+                    ? said.substring(0, said.length() - 2) : said);
+        }
+        return out.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -19,11 +20,11 @@ import java.util.List;
  *
  * @param edges the slots gone through, outermost first
  */
-record CorePath(List<CoreStructure.Edge> edges) {
+public record CorePath(List<CoreStructure.Edge> edges) {
 
     static final CorePath ROOT = new CorePath(List.of());
 
-    CorePath {
+    public CorePath {
         if (edges == null) {
             throw new IllegalArgumentException("a way down is a way down through something");
         }
@@ -32,7 +33,7 @@ record CorePath(List<CoreStructure.Edge> edges) {
 
     /** This, then one more step. */
     CorePath then(CoreStructure.Edge edge) {
-        List<CoreStructure.Edge> longer = new java.util.ArrayList<>(edges);
+        List<CoreStructure.Edge> longer = new ArrayList<>(edges);
         longer.add(edge);
         return new CorePath(longer);
     }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoreStructure.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoreStructure.java
@@ -4,6 +4,7 @@ import souther.compiler.core.Core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.IntFunction;
 
 /**
  * Which slot of a node each of its children stands in, named.
@@ -27,10 +28,10 @@ import java.util.List;
  * lets an edge and a node stand for a step down. The switch is over a sealed type, so a node kind
  * added to the IR arrives here as a compile error rather than as a place nothing can address.
  */
-final class CoreStructure {
+public final class CoreStructure {
 
     /** Which slot of its parent a child stands in. */
-    sealed interface Edge {
+    public sealed interface Edge {
 
         record NegOperand() implements Edge {}
 
@@ -237,7 +238,7 @@ final class CoreStructure {
     }
 
     private static void indexed(List<Child> out, List<Core> children,
-                                java.util.function.IntFunction<Edge> slot) {
+                                IntFunction<Edge> slot) {
         for (int i = 0; i < children.size(); i++) {
             out.add(new Child(slot.apply(i), children.get(i)));
         }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoreStructure.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoreStructure.java
@@ -1,0 +1,247 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Which slot of a node each of its children stands in, named.
+ *
+ * <p>What a place in a body is addressed by. A node is where it is because of the way down to it —
+ * the right of a {@code ++} rather than the left, the second case of a {@code match} rather than the
+ * first — and until something says which way each step went, the only thing that tells two places
+ * apart is the object standing at them. That is enough for a walk holding the tree and no use at all
+ * to anything comparing two walks, which is what a numbering has to be compared by.
+ *
+ * <p>{@link Core#forEachChild} hands children over without saying where they came from: the three
+ * operators under it separate an expression slot from a name slot and a construction slot, and
+ * nothing separates {@code then} from {@code else}. So this is beside it rather than built on it.
+ *
+ * <p>Not a general facility for the compiler. What is named here is what an address of one place in
+ * one body needs, and the vocabulary is this package's because that is the question it answers. A
+ * pass wanting to rewrite children has {@code Core.mapChildren}, which is about slots and not about
+ * where they are.
+ *
+ * <p><b>One edge apiece.</b> No node hands over two children under one {@link Edge}, which is what
+ * lets an edge and a node stand for a step down. The switch is over a sealed type, so a node kind
+ * added to the IR arrives here as a compile error rather than as a place nothing can address.
+ */
+final class CoreStructure {
+
+    /** Which slot of its parent a child stands in. */
+    sealed interface Edge {
+
+        record NegOperand() implements Edge {}
+
+        record FieldTarget() implements Edge {}
+
+        record BinaryLeft() implements Edge {}
+
+        record BinaryRight() implements Edge {}
+
+        record CallArgument(int index) implements Edge {}
+
+        record PreservedArgument(int index) implements Edge {}
+
+        /** The binding an {@code Apply} loads what it applies from, which is a name and not an
+         *  expression. */
+        record AppliedFunction() implements Edge {}
+
+        record ApplyArgument(int index) implements Edge {}
+
+        record IfCondition() implements Edge {}
+
+        record IfThen() implements Edge {}
+
+        record IfElse() implements Edge {}
+
+        /** The construction an attempt tests, which is where its condition is. */
+        record ConstructedAttempt() implements Edge {}
+
+        record ConstructedThen() implements Edge {}
+
+        record ConstructedElse(int index) implements Edge {}
+
+        record LetValue() implements Edge {}
+
+        record LetBody() implements Edge {}
+
+        record BlockBody() implements Edge {}
+
+        record ListElement(int index) implements Edge {}
+
+        record SomeValue() implements Edge {}
+
+        record TupleElement(int index) implements Edge {}
+
+        /** The tuple a {@code TupleGet} reads from. */
+        record TupleSource() implements Edge {}
+
+        record FieldValue(int index) implements Edge {}
+
+        record MatchScrutinee() implements Edge {}
+
+        record MatchCase(int index) implements Edge {}
+    }
+
+    /** One step down: the slot, and what stands in it. */
+    record Child(Edge edge, Core node) {
+
+        Child {
+            if (edge == null || node == null) {
+                throw new IllegalArgumentException("a step down is a slot and what is in it");
+            }
+        }
+    }
+
+    /**
+     * The children of {@code e}, each with the slot it stands in, in the order the node holds them.
+     *
+     * <p>Exhaustive, and the leaves answer with nothing rather than being left out of the switch: a
+     * node kind that answers no children is a decision about that kind, and one that fell through a
+     * default would be a place a walk stopped without anyone saying so.
+     */
+    static List<Child> childrenOf(Core e) {
+        List<Child> out = new ArrayList<>();
+        switch (e) {
+            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _,
+                 Core.Read _, Core.UnitValue _, Core.OptionNone _, Core.Unreachable _ -> { }
+            case Core.Neg n -> out.add(new Child(new Edge.NegOperand(), n.operand()));
+            case Core.FieldAccess fa -> out.add(new Child(new Edge.FieldTarget(), fa.target()));
+            case Core.Binary b -> {
+                out.add(new Child(new Edge.BinaryLeft(), b.left()));
+                out.add(new Child(new Edge.BinaryRight(), b.right()));
+            }
+            case Core.Call c -> indexed(out, c.args(), Edge.CallArgument::new);
+            case Core.PreservedCall p -> indexed(out, p.args(), Edge.PreservedArgument::new);
+            case Core.Apply a -> {
+                out.add(new Child(new Edge.AppliedFunction(), a.fn()));
+                indexed(out, a.args(), Edge.ApplyArgument::new);
+            }
+            case Core.If iff -> {
+                out.add(new Child(new Edge.IfCondition(), iff.cond()));
+                out.add(new Child(new Edge.IfThen(), iff.then()));
+                out.add(new Child(new Edge.IfElse(), iff.els()));
+            }
+            case Core.IfConstructed ic -> {
+                out.add(new Child(new Edge.ConstructedAttempt(), ic.construct()));
+                out.add(new Child(new Edge.ConstructedThen(), ic.then()));
+                for (int i = 0; i < ic.els().size(); i++) {
+                    out.add(new Child(new Edge.ConstructedElse(i), ic.els().get(i).body()));
+                }
+            }
+            case Core.LetIn li -> {
+                out.add(new Child(new Edge.LetValue(), li.value()));
+                out.add(new Child(new Edge.LetBody(), li.body()));
+            }
+            case Core.Block b -> out.add(new Child(new Edge.BlockBody(), b.body()));
+            case Core.ListLit lit -> indexed(out, lit.elements(), Edge.ListElement::new);
+            case Core.OptionSome s -> out.add(new Child(new Edge.SomeValue(), s.value()));
+            case Core.Tuple t -> indexed(out, t.elements(), Edge.TupleElement::new);
+            case Core.TupleGet tg -> out.add(new Child(new Edge.TupleSource(), tg.tuple()));
+            case Core.Construct nd -> {
+                for (int i = 0; i < nd.values().size(); i++) {
+                    out.add(new Child(new Edge.FieldValue(i), nd.values().get(i).value()));
+                }
+            }
+            case Core.Match m -> {
+                out.add(new Child(new Edge.MatchScrutinee(), m.scrutinee()));
+                for (int i = 0; i < m.cases().size(); i++) {
+                    out.add(new Child(new Edge.MatchCase(i), m.cases().get(i).body()));
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The children of one node, handed over a slot at a time to a walk that names each as it goes.
+     *
+     * <p>For a walk that has to descend the slots itself — because it is deciding something at each
+     * of them and not only visiting them — and must still be held to the children the node has. It
+     * says which slot it is taking and which node it believes is in it, and this is what says both
+     * are right; {@link #requireExhausted()} at the end is what says none was left.
+     *
+     * <p>So the walk keeps its own reason for going where it goes, and stops being the second place
+     * that says which slots a node has.
+     */
+    static final class Children {
+
+        private final Core of;
+
+        private final List<Child> children;
+
+        private final List<Edge> taken = new ArrayList<>();
+
+        private Children(Core of, List<Child> children) {
+            this.of = of;
+            this.children = children;
+        }
+
+        /** The children of {@code e}, to be taken a slot at a time. */
+        static Children of(Core e) {
+            return new Children(e, childrenOf(e));
+        }
+
+        /**
+         * The node in {@code edge}, which the caller says is {@code expected}.
+         *
+         * <p>Three ways to be wrong and all of them loud: a slot this node has none of, a slot
+         * already taken, and a slot holding something other than what the caller reached for. The
+         * last is what a walk descending by hand gets wrong — the left of a comparison walked as
+         * the right — and it is the one nothing else here would notice.
+         */
+        Core take(Edge edge, Core expected) {
+            for (Child child : children) {
+                if (!child.edge().equals(edge)) {
+                    continue;
+                }
+                if (taken.contains(edge)) {
+                    throw new IllegalStateException("the " + edge + " of a "
+                            + of.getClass().getSimpleName() + " at " + of.pos()
+                            + " was taken twice");
+                }
+                if (child.node() != expected) {
+                    throw new IllegalStateException("the " + edge + " of a "
+                            + of.getClass().getSimpleName() + " at " + of.pos()
+                            + " holds something other than what the walk reached for");
+                }
+                taken.add(edge);
+                return child.node();
+            }
+            throw new IllegalStateException("a " + of.getClass().getSimpleName() + " at " + of.pos()
+                    + " has no " + edge + "; its slots are "
+                    + children.stream().map(Child::edge).toList());
+        }
+
+        /**
+         * That every slot was taken.
+         *
+         * <p>What stops a walk from quietly going nowhere. A node kind that grows a child is a
+         * compile error in the switch above and nothing in the walk; without this the walk would go
+         * on visiting what it always did and the new child would be somewhere nothing looks.
+         */
+        void requireExhausted() {
+            if (taken.size() != children.size()) {
+                List<Edge> missed = new ArrayList<>();
+                children.forEach(child -> {
+                    if (!taken.contains(child.edge())) {
+                        missed.add(child.edge());
+                    }
+                });
+                throw new IllegalStateException("a walk of a " + of.getClass().getSimpleName()
+                        + " at " + of.pos() + " went nowhere near " + missed);
+            }
+        }
+    }
+
+    private static void indexed(List<Child> out, List<Core> children,
+                                java.util.function.IntFunction<Edge> slot) {
+        for (int i = 0; i < children.size(); i++) {
+            out.add(new Child(slot.apply(i), children.get(i)));
+        }
+    }
+
+    private CoreStructure() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -245,6 +245,15 @@ public final class CoverageSites {
             for (ComparisonOccurrence numbered : controlByComparison.keySet()) {
                 requireHeld(numbered, comparisons, "given a control point");
             }
+            // And the numbering says what each number it handed out addresses, so there is one
+            // address per site and it is at the site's own number. A plan is put together field by
+            // field, so the two can be handed over out of step — and a reader asking what a hit
+            // means would be told about a place the number was never issued to, or about none.
+            if (identity.byNumber().size() != sites.size()) {
+                throw new IllegalArgumentException("this plan numbered " + sites.size()
+                        + " places and says what " + identity.byNumber().size() + " of them are;"
+                        + " the sites and the addresses are one answer or they are two");
+            }
         }
 
         private static void requireHeld(ComparisonOccurrence which, ComparisonCatalog comparisons,
@@ -414,9 +423,11 @@ public final class CoverageSites {
             // What the body does, beside where its places are. A numbering is two numberings when
             // the numbers address different places, and it is two when the code at those places
             // does different things; neither half says the other.
-            executable.put(body.getKey(), ExecutableIdentity.of(body.getValue(),
-                    Binders.of(body.getKey(), body.getValue(),
-                            NodeAddresses.of(body.getKey(), body.getValue()))));
+            //
+            // Off the addresses the walk just took, rather than taking them again: where a body's
+            // places are is one answer, and a second descent for it would be a second.
+            executable.put(body.getKey(),
+                    ExecutableIdentity.of(body.getValue(), Binders.of(walk.places)));
         }
         return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
                 walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat,
@@ -744,7 +755,16 @@ public final class CoverageSites {
                     // into a field at a time: what is numbered is inside the fields, and the
                     // construction itself is where the attempt's own arms are made below.
                     structural.take(new CoreStructure.Edge.ConstructedAttempt(), ic.construct());
-                    ic.construct().values().forEach(given -> walk(given.value(), inside));
+                    // And the construction's own slots, taken from the same place: this is where
+                    // the walk goes two levels at once, so it is where the slots of the level it
+                    // passes through would go unvisited with nothing to say so.
+                    CoreStructure.Children built =
+                            CoreStructure.Children.of(ic.construct());
+                    for (int i = 0; i < ic.construct().values().size(); i++) {
+                        walk(built.take(new CoreStructure.Edge.FieldValue(i),
+                                ic.construct().values().get(i).value()), inside);
+                    }
+                    built.requireExhausted();
                     // And what an attempted construction decides by is the value it is given.
                     DecidedBy decided =
                             decidedAt(ic.origin(), ic.expansion(), decisions, supplied);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -224,7 +224,8 @@ public final class CoverageSites {
                        Map<ComparisonOccurrence, Integer> controlByComparison,
                        java.util.Set<Core> mayRepeat,
                        IdentityHashMap<Core, ForkOccurrence> forkByNode,
-                       ComparisonCatalog comparisons) {
+                       ComparisonCatalog comparisons,
+                       NumberingIdentity identity) {
 
         public Plan {
             // Half of what a numbering could get wrong is the key's own answer now: an occurrence
@@ -258,7 +259,8 @@ public final class CoverageSites {
         public static final Plan NONE = new Plan(List.of(), List.of(), new IdentityHashMap<>(),
                 new LinkedHashMap<>(), new IdentityHashMap<>(), new LinkedHashMap<>(),
                 java.util.Set.of(), new IdentityHashMap<>(),
-                ComparisonCatalog.of(ModuleBodies.none()));
+                ComparisonCatalog.of(ModuleBodies.none()),
+                NumberingIdentity.of(ModuleBodies.none().module()));
 
         /**
          * Whether one run of the behavior can pass {@code node} more than once.
@@ -406,17 +408,30 @@ public final class CoverageSites {
         // rather than two descents that happen to agree.
         ComparisonCatalog comparisons = ComparisonCatalog.of(of);
         Walk walk = new Walk(comparisons, decisions, supplied);
+        Map<String, ExecutableIdentity> executable = new LinkedHashMap<>();
         for (Map.Entry<String, Core> body : of.bodies().entrySet()) {
             walk.behavior(body.getKey(), body.getValue());
+            // What the body does, beside where its places are. A numbering is two numberings when
+            // the numbers address different places, and it is two when the code at those places
+            // does different things; neither half says the other.
+            executable.put(body.getKey(), ExecutableIdentity.of(body.getValue(),
+                    Binders.of(body.getKey(), body.getValue(),
+                            NodeAddresses.of(body.getKey(), body.getValue()))));
         }
         return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
                 walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat,
-                walk.forkByNode, comparisons);
+                walk.forkByNode, comparisons,
+                new NumberingIdentity(of.module(), executable, walk.byNumber));
     }
 
     private static final class Walk {
 
         private final List<Site> sites = new ArrayList<>();
+        /** What each number handed out is an address of, at the number's own position. */
+        private final List<SiteAddress> byNumber = new ArrayList<>();
+        /** Where the places of the body being walked are. Made per body, since a path is a way down
+         *  from one body's root and means a different place in every other. */
+        private NodeAddresses places;
         private final List<GuardRef> guards = new ArrayList<>();
         private final IdentityHashMap<Core, int[]> byNode = new IdentityHashMap<>();
         private final Map<ComparisonOccurrence, Integer> byComparison = new LinkedHashMap<>();
@@ -465,6 +480,10 @@ public final class CoverageSites {
             this.behavior = name;
             this.ordinal = 0;
             this.answering = NormalReturn.ofBody(body);
+            // Where each place of this body is, worked out before anything is numbered: a number is
+            // handed out for a place, and this is what says which place that is in something a
+            // second walk of the same body also arrives at.
+            this.places = NodeAddresses.of(name, body);
             walk(body, true);
         }
 
@@ -487,7 +506,9 @@ public final class CoverageSites {
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
             int probe = reachable && answers(arm) && answering.mayEnter(owner, part)
-                    ? site(outcome, owner, origin, part, decided) : NO_SITE;
+                    ? site(outcome, owner, origin, part, decided,
+                            new SiteAddress.Arm(places.of(owner), part))
+                    : NO_SITE;
             return new ControlPointId.ArmOccurrence(controls++,
                     probe == NO_SITE ? OptionalInt.empty() : OptionalInt.of(probe),
                     // The fork's own coordinate, as a site takes it: an arm's body is what lowering
@@ -542,9 +563,13 @@ public final class CoverageSites {
          *
          * @param owner the {@code if}, {@code match} or attempted construction the arm is one of
          * @param arm   the arm's body, which says what the arm is made of and not where it is
+         * @param where what the number about to be handed out is an address of. Passed in rather
+         *              than worked out from the rest: which family a number was issued to is what
+         *              a reader of the recording has no other way of telling, and reading it back
+         *              off the outcome here would be the numbering deciding it twice
          */
         private int site(SourceOutcome outcome, Core owner, CoverageOrigin origin, int part,
-                         DecidedBy decided) {
+                         DecidedBy decided, SiteAddress where) {
             // Said here because this is where anything is numbered, and the rule is about numbering
             // rather than about comparisons: an arm of a fork nothing wrote is as much a row nobody
             // can be owed as a comparison of one. Stated for the comparisons alone, it left the arms
@@ -562,6 +587,9 @@ public final class CoverageSites {
             // answers about one place. The walk holds none for that reason.
             sites.add(new Site(behavior, outcome, Citation.of(owner.pos()),
                     index, ordinal++, new Obligation(behavior, origin, part, decided)));
+            // Filed in the order the numbers are handed out, so the number is the position: what a
+            // number is an address of is what this list says at it.
+            byNumber.add(where);
             return index;
         }
 
@@ -588,28 +616,49 @@ public final class CoverageSites {
             if (repeating) {
                 mayRepeat.add(e);
             }
+            // The slots this node has, taken one at a time below. The walk decides something at
+            // each of them and so descends them itself; what it may not also do is be a second
+            // answer to which slots there are.
+            CoreStructure.Children structural = CoreStructure.Children.of(e);
             switch (e) {
                 case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _,
                      Core.Read _, Core.UnitValue _, Core.OptionNone _ -> { }
                 // A leaf, and one holding no fork. Whether the arm it stands in is an arm to cover is
                 // decided where that arm is made, not here.
                 case Core.Unreachable _ -> { }
-                case Core.Neg n -> walk(n.operand(), inside);
-                case Core.FieldAccess fa -> walk(fa.target(), inside);
+                case Core.Neg n ->
+                        walk(structural.take(new CoreStructure.Edge.NegOperand(), n.operand()),
+                                inside);
+                case Core.FieldAccess fa ->
+                        walk(structural.take(new CoreStructure.Edge.FieldTarget(), fa.target()),
+                                inside);
                 case Core.Binary b -> {
                     number(b, inside);
-                    walk(b.left(), inside);
-                    walk(b.right(), inside);
+                    walk(structural.take(new CoreStructure.Edge.BinaryLeft(), b.left()), inside);
+                    walk(structural.take(new CoreStructure.Edge.BinaryRight(), b.right()), inside);
                 }
-                case Core.Call c -> c.args().forEach(arg -> walk(arg, inside));
+                case Core.Call c -> {
+                    for (int i = 0; i < c.args().size(); i++) {
+                        walk(structural.take(new CoreStructure.Edge.CallArgument(i),
+                                c.args().get(i)), inside);
+                    }
+                }
                 // What a representation kept standing for an analysis to read. Coverage is measured
                 // over the tree that runs, which keeps none of these, so reaching one would mean this
                 // count was taken over a tree nothing executes.
                 case Core.PreservedCall p -> throw p.unexpectedIn("coverage numbering");
-                case Core.Apply a -> a.args().forEach(arg -> walk(arg, inside));
+                case Core.Apply a -> {
+                    // The binding what is applied is loaded from. Taken and not gone into: it is a
+                    // name, so it numbers nothing and has nothing under it to number.
+                    structural.take(new CoreStructure.Edge.AppliedFunction(), a.fn());
+                    for (int i = 0; i < a.args().size(); i++) {
+                        walk(structural.take(new CoreStructure.Edge.ApplyArgument(i),
+                                a.args().get(i)), inside);
+                    }
+                }
                 case Core.LetIn li -> {
-                    walk(li.value(), inside);
-                    walk(li.body(), inside);
+                    walk(structural.take(new CoreStructure.Edge.LetValue(), li.value()), inside);
+                    walk(structural.take(new CoreStructure.Edge.LetBody(), li.body()), inside);
                 }
                 // A function value, and its arms are arms: what is written here runs when whatever
                 // this is handed to applies it, and the rows that make that happen go through them.
@@ -621,16 +670,36 @@ public final class CoverageSites {
                 case Core.Block b -> {
                     boolean outside = repeating;
                     repeating = true;
-                    walk(b.body(), inside);
+                    walk(structural.take(new CoreStructure.Edge.BlockBody(), b.body()), inside);
                     repeating = outside;
                 }
-                case Core.ListLit lit -> lit.elements().forEach(el -> walk(el, inside));
-                case Core.OptionSome s -> walk(s.value(), inside);
-                case Core.Tuple t -> t.elements().forEach(el -> walk(el, inside));
-                case Core.TupleGet tg -> walk(tg.tuple(), inside);
-                case Core.Construct nd -> nd.values().forEach(given -> walk(given.value(), inside));
+                case Core.ListLit lit -> {
+                    for (int i = 0; i < lit.elements().size(); i++) {
+                        walk(structural.take(new CoreStructure.Edge.ListElement(i),
+                                lit.elements().get(i)), inside);
+                    }
+                }
+                case Core.OptionSome s ->
+                        walk(structural.take(new CoreStructure.Edge.SomeValue(), s.value()),
+                                inside);
+                case Core.Tuple t -> {
+                    for (int i = 0; i < t.elements().size(); i++) {
+                        walk(structural.take(new CoreStructure.Edge.TupleElement(i),
+                                t.elements().get(i)), inside);
+                    }
+                }
+                case Core.TupleGet tg ->
+                        walk(structural.take(new CoreStructure.Edge.TupleSource(), tg.tuple()),
+                                inside);
+                case Core.Construct nd -> {
+                    for (int i = 0; i < nd.values().size(); i++) {
+                        walk(structural.take(new CoreStructure.Edge.FieldValue(i),
+                                nd.values().get(i).value()), inside);
+                    }
+                }
                 case Core.If iff -> {
-                    walk(iff.cond(), inside);
+                    walk(structural.take(new CoreStructure.Edge.IfCondition(), iff.cond()),
+                            inside);
                     // Which rule this fork decides by, taken before its arms are numbered: two
                     // calls of one library combinator are one fork inlined twice and are not one
                     // thing to cover, and what tells them apart is the rule each was handed.
@@ -638,10 +707,10 @@ public final class CoverageSites {
                             decidedAt(iff.origin(), iff.expansion(), decisions, supplied);
                     ControlPointId.ArmOccurrence then =
                             armOf(HELD, iff, iff.origin(), 0, iff.then(), inside, decided);
-                    walk(iff.then(), inside);
+                    walk(structural.take(new CoreStructure.Edge.IfThen(), iff.then()), inside);
                     ControlPointId.ArmOccurrence els =
                             armOf(FAILED, iff, iff.origin(), 1, iff.els(), inside, decided);
-                    walk(iff.els(), inside);
+                    walk(structural.take(new CoreStructure.Edge.IfElse(), iff.els()), inside);
                     byNode.put(iff, probesOf(then, els));
                     arms(iff, new ControlPointId.ArmOccurrence[] {then, els});
                     if (then.isMeasured() || els.isMeasured()) {
@@ -651,7 +720,8 @@ public final class CoverageSites {
                     }
                 }
                 case Core.Match m -> {
-                    walk(m.scrutinee(), inside);
+                    walk(structural.take(new CoreStructure.Edge.MatchScrutinee(), m.scrutinee()),
+                            inside);
                     // What a `match` decides by is its subject, as an `if` decides by its condition.
                     // A subject the caller's rule answered is a decision the caller made, and its
                     // arms are one obligation per rule handed in.
@@ -663,12 +733,17 @@ public final class CoverageSites {
                         Core.Case arm = m.cases().get(i);
                         arms[i] = armOf(matched(arm), m, m.origin(), i, arm.body(), inside,
                                 decided);
-                        walk(arm.body(), inside);
+                        walk(structural.take(new CoreStructure.Edge.MatchCase(i), arm.body()),
+                                inside);
                     }
                     byNode.put(m, probesOf(arms));
                     arms(m, arms);
                 }
                 case Core.IfConstructed ic -> {
+                    // The construction the attempt tests. Taken as the one slot it is, and gone
+                    // into a field at a time: what is numbered is inside the fields, and the
+                    // construction itself is where the attempt's own arms are made below.
+                    structural.take(new CoreStructure.Edge.ConstructedAttempt(), ic.construct());
                     ic.construct().values().forEach(given -> walk(given.value(), inside));
                     // And what an attempted construction decides by is the value it is given.
                     DecidedBy decided =
@@ -676,17 +751,23 @@ public final class CoverageSites {
                     ControlPointId.ArmOccurrence[] arms =
                             new ControlPointId.ArmOccurrence[1 + ic.els().size()];
                     arms[0] = armOf(BUILT, ic, ic.origin(), 0, ic.then(), inside, decided);
-                    walk(ic.then(), inside);
+                    walk(structural.take(new CoreStructure.Edge.ConstructedThen(), ic.then()),
+                            inside);
                     for (int i = 0; i < ic.els().size(); i++) {
                         Core.ElseArm arm = ic.els().get(i);
                         arms[i + 1] = armOf(refused(arm), ic, ic.origin(), i + 1,
                                 arm.body(), inside, decided);
-                        walk(arm.body(), inside);
+                        walk(structural.take(new CoreStructure.Edge.ConstructedElse(i),
+                                arm.body()), inside);
                     }
                     byNode.put(ic, probesOf(arms));
                     arms(ic, arms);
                 }
             }
+            // That the walk went to every slot the node has. A node kind that grows a child stops
+            // the switch above from compiling; a case here that forgot to descend one stops nothing,
+            // and what it leaves is a place the numbering never reaches and nothing to say so.
+            structural.requireExhausted();
         }
 
         /**
@@ -724,7 +805,8 @@ public final class CoverageSites {
             // one, neither of which a fork can say.
             byComparison.put(which,
                     site(new SourceOutcome.Compared(comparison.op()), comparison,
-                            comparison.origin(), 0, DecidedBy.THE_DECLARATION));
+                            comparison.origin(), 0, DecidedBy.THE_DECLARATION,
+                            new SiteAddress.Comparison(places.of(comparison))));
             controlByComparison.put(which, controls++);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -10,9 +10,11 @@ import souther.compiler.types.CoverageOrigin;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The arms of a behavior's body that an {@code example} row can be in or not in.
@@ -426,8 +428,8 @@ public final class CoverageSites {
             //
             // Off the addresses the walk just took, rather than taking them again: where a body's
             // places are is one answer, and a second descent for it would be a second.
-            executable.put(body.getKey(),
-                    ExecutableIdentity.of(body.getValue(), Binders.of(walk.places)));
+            executable.put(body.getKey(), ExecutableIdentity.of(body.getValue(),
+                    Binders.of(of.module(), walk.places)));
         }
         return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
                 walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat,
@@ -440,6 +442,8 @@ public final class CoverageSites {
         private final List<Site> sites = new ArrayList<>();
         /** What each number handed out is an address of, at the number's own position. */
         private final List<SiteAddress> byNumber = new ArrayList<>();
+        /** The places numbered so far, so that none is numbered twice. */
+        private final Set<SiteAddress> issued = new LinkedHashSet<>();
         /** Where the places of the body being walked are. Made per body, since a path is a way down
          *  from one body's root and means a different place in every other. */
         private NodeAddresses places;
@@ -590,6 +594,15 @@ public final class CoverageSites {
                 throw new IllegalStateException("a construct with no source wrote it is being "
                         + "numbered at " + owner.pos()
                         + "; a tree rebuilt for an analysis is not the tree that runs");
+            }
+            // One number per place. A node several ways lead to is arrived at once per way, and a
+            // place numbered twice is a second site the emitter lights on no run — the shape of a
+            // real omission, and reported as one. Held on the address rather than on whatever each
+            // family has to hand: what a number is issued for is the place, so the place is what
+            // may be issued for once.
+            if (!issued.add(where)) {
+                throw new IllegalStateException("`" + behavior + "` numbers " + where
+                        + " twice; a place a run is recorded at is recorded at one number");
             }
             int index = sites.size();
             // Of the node's own coordinate. This walk is over one module and an arm of a

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
@@ -66,9 +66,11 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
      *
      * <p>A node several ways lead to says the same thing however it was arrived at, so it is written
      * once and the one value stands wherever it is reached. Written out per arrival instead, a body
-     * whose shared subtrees nest would be a value larger than the body — and every comparison of two
-     * of them would walk all of it, where sharing lets the halves be found the same by being the
-     * same.
+     * whose shared subtrees nest would come to a value larger than the body it is of.
+     *
+     * <p>What that buys is the size of the value and not the cost of comparing two. Two of these
+     * built by two compiles share nothing with each other, so a shared subtree is walked once per
+     * place it stands in when they are held against each other, however few times it was written.
      */
     private static ExecutableIdentity of(Core body, Binders binders,
                                          Map<Core, ExecutableIdentity> said) {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
@@ -1,0 +1,196 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What a body does, written so that two compiles of one source write the same thing.
+ *
+ * <p>Beside the numbering rather than under it. A run is recorded in numbers, and a number means a
+ * place only under the numbering that handed it out; holding one numbering against another needs
+ * both what each number is an address of and what the code at those addresses does. This is the
+ * second half: two numberings that address the same places in bodies that do different things are
+ * not two views of one measurement.
+ *
+ * <p><b>What is taken out, and why each.</b> A position is where the source put a term and not what
+ * the term says. A {@link souther.compiler.types.CoverageOrigin} counts the constructs of a source
+ * from one end, so a clause gaining a line moves every ordinal below it. Which copy of a body a fork
+ * stands in is where the fork is. And a binding is an owner and a count over that owner, both minted
+ * as an expansion makes copies — so a name is written here as the place it is bound at
+ * ({@link BinderAddress}), which is a fact about the body rather than about the run that built it.
+ *
+ * <p><b>What is kept.</b> Everything a run turns on: which node kind, the operator, the literal, the
+ * type, the field, the case a pattern selects, what a call reaches, and the children in the order
+ * the node holds them. A function value keeps how many names it takes, which is not a binder but is
+ * part of what applying it does.
+ *
+ * <p><b>Open types are refused rather than normalised.</b> A metavariable belongs to the elaboration
+ * that raised it and no body a run goes through holds one, so meeting one here means this was taken
+ * over a tree that is not the tree that runs — and a reading that quietly stood in for it would say
+ * two bodies are one on the strength of a name the compiler invented.
+ */
+record ExecutableIdentity(Kind kind, List<Object> settled, List<ExecutableIdentity> children) {
+
+    /** Which node this is. Named rather than held as the class, so that what two of these compare
+     *  is what they say and not which classes a loader happened to make. */
+    enum Kind {
+        INT, DECIMAL, STR, BOOL, TEMPORAL, READ, UNIT_VALUE, OPTION_NONE, UNREACHABLE, NEG,
+        FIELD_ACCESS, BINARY, CALL, APPLY, IF, IF_CONSTRUCTED, LET_IN, BLOCK, LIST_LIT,
+        OPTION_SOME, TUPLE, TUPLE_GET, CONSTRUCT, MATCH
+    }
+
+    ExecutableIdentity {
+        settled = List.copyOf(settled);
+        children = List.copyOf(children);
+    }
+
+    /**
+     * What {@code body} does, {@code binders} saying where each name it reads is bound.
+     *
+     * <p>The children are walked in the order {@link CoreStructure} names the slots, which is the
+     * order the node holds them. So the shape of this value is the shape of the body, and two
+     * bodies that differ in which slot a term stands in differ here.
+     */
+    static ExecutableIdentity of(Core body, Binders binders) {
+        List<Object> settled = new ArrayList<>();
+        settled.add(open(body.type()));
+        Kind kind = say(body, settled, binders);
+        List<ExecutableIdentity> children = new ArrayList<>();
+        for (CoreStructure.Child child : CoreStructure.childrenOf(body)) {
+            children.add(of(child.node(), binders));
+        }
+        return new ExecutableIdentity(kind, settled, children);
+    }
+
+    /** Everything but the children and the type: what the node says on its own. */
+    private static Kind say(Core e, List<Object> settled, Binders binders) {
+        return switch (e) {
+            case Core.Int it -> {
+                settled.add(it.value());
+                yield Kind.INT;
+            }
+            case Core.Decimal it -> {
+                settled.add(it.value());
+                yield Kind.DECIMAL;
+            }
+            case Core.Str it -> {
+                settled.add(it.value());
+                yield Kind.STR;
+            }
+            case Core.Bool it -> {
+                settled.add(it.value());
+                yield Kind.BOOL;
+            }
+            case Core.Temporal it -> {
+                settled.add(it.kind());
+                settled.add(it.text());
+                yield Kind.TEMPORAL;
+            }
+            // The place the name is bound, never the name: two bodies alike but for what a `let`
+            // spells do the same thing, and the id the compiler minted for it moves with the copy.
+            case Core.Read it -> {
+                settled.add(it.binding() == null ? null : binders.at(it.binding()));
+                yield Kind.READ;
+            }
+            case Core.UnitValue it -> {
+                settled.add(it.data());
+                yield Kind.UNIT_VALUE;
+            }
+            case Core.OptionNone _ -> Kind.OPTION_NONE;
+            case Core.Unreachable it -> {
+                settled.add(it.reason());
+                yield Kind.UNREACHABLE;
+            }
+            case Core.Neg _ -> Kind.NEG;
+            case Core.FieldAccess it -> {
+                settled.add(it.field());
+                yield Kind.FIELD_ACCESS;
+            }
+            case Core.Binary it -> {
+                settled.add(it.op());
+                yield Kind.BINARY;
+            }
+            case Core.Call it -> {
+                settled.add(it.fn());
+                yield Kind.CALL;
+            }
+            // What an analysis kept standing, which the tree that runs holds none of. Reaching one
+            // means this was taken over a tree nothing executes.
+            case Core.PreservedCall it -> throw it.unexpectedIn("what a body does");
+            case Core.Apply _ -> Kind.APPLY;
+            case Core.If _ -> Kind.IF;
+            // The words the author put the departures under. They are written in the source and a
+            // report quotes them, so two bodies that name their ways out differently say different
+            // things.
+            case Core.IfConstructed it -> {
+                it.els().forEach(arm -> settled.add(arm.clause()));
+                yield Kind.IF_CONSTRUCTED;
+            }
+            case Core.LetIn _ -> Kind.LET_IN;
+            // How many names it takes. Not a binder — those are where they are and are read as
+            // places — but applying a function of two names to one is not what this does.
+            case Core.Block it -> {
+                settled.add(it.params().size());
+                yield Kind.BLOCK;
+            }
+            case Core.ListLit _ -> Kind.LIST_LIT;
+            case Core.OptionSome _ -> Kind.OPTION_SOME;
+            case Core.Tuple _ -> Kind.TUPLE;
+            case Core.TupleGet it -> {
+                settled.add(it.index());
+                settled.add(it.arity());
+                yield Kind.TUPLE_GET;
+            }
+            case Core.Construct it -> {
+                settled.add(it.typeName());
+                it.values().forEach(value -> settled.add(value.field()));
+                yield Kind.CONSTRUCT;
+            }
+            case Core.Match it -> {
+                it.cases().forEach(one -> settled.add(one.pattern()));
+                yield Kind.MATCH;
+            }
+        };
+    }
+
+    /**
+     * {@code type}, where it is one a run can have.
+     *
+     * <p>Refused rather than stood in for. What is left open belongs to the elaboration that raised
+     * it: a metavariable is named after the application that made it, and an inferred variable after
+     * whatever the checker called it. Either is a name this compile invented, so two bodies holding
+     * one would be compared on it.
+     */
+    private static Type open(Type type) {
+        switch (type) {
+            case null -> { }
+            case Type.MetaVar it -> throw new IllegalStateException(
+                    "a body that runs holds no metavariable: " + it);
+            case Type.Var it -> {
+                if (it.inferred()) {
+                    throw new IllegalStateException(
+                            "a body that runs holds no inferred type variable: " + it);
+                }
+            }
+            // Inside as well as at the top: what is left open is left open wherever it stands, and
+            // a list of them is as much a type no run has as one of them is.
+            case Type.ListOf it -> open(it.element());
+            case Type.SetOf it -> open(it.element());
+            case Type.OptionOf it -> open(it.element());
+            case Type.MapOf it -> {
+                open(it.key());
+                open(it.value());
+            }
+            case Type.TupleOf it -> it.elements().forEach(ExecutableIdentity::open);
+            case Type.FnOf it -> {
+                it.params().forEach(ExecutableIdentity::open);
+                open(it.result());
+            }
+            default -> { }
+        }
+        return type;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
@@ -4,7 +4,9 @@ import souther.compiler.core.Core;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * What a body does, written so that two compiles of one source write the same thing.
@@ -32,17 +34,18 @@ import java.util.List;
  * over a tree that is not the tree that runs — and a reading that quietly stood in for it would say
  * two bodies are one on the strength of a name the compiler invented.
  */
-record ExecutableIdentity(Kind kind, List<Object> settled, List<ExecutableIdentity> children) {
+public record ExecutableIdentity(Kind kind, List<Object> settled,
+                                 List<ExecutableIdentity> children) {
 
     /** Which node this is. Named rather than held as the class, so that what two of these compare
      *  is what they say and not which classes a loader happened to make. */
-    enum Kind {
+    public enum Kind {
         INT, DECIMAL, STR, BOOL, TEMPORAL, READ, UNIT_VALUE, OPTION_NONE, UNREACHABLE, NEG,
         FIELD_ACCESS, BINARY, CALL, APPLY, IF, IF_CONSTRUCTED, LET_IN, BLOCK, LIST_LIT,
         OPTION_SOME, TUPLE, TUPLE_GET, CONSTRUCT, MATCH
     }
 
-    ExecutableIdentity {
+    public ExecutableIdentity {
         settled = List.copyOf(settled);
         children = List.copyOf(children);
     }
@@ -55,14 +58,34 @@ record ExecutableIdentity(Kind kind, List<Object> settled, List<ExecutableIdenti
      * bodies that differ in which slot a term stands in differ here.
      */
     static ExecutableIdentity of(Core body, Binders binders) {
+        return of(body, binders, new IdentityHashMap<>());
+    }
+
+    /**
+     * The same, with what each node came to kept.
+     *
+     * <p>A node several ways lead to says the same thing however it was arrived at, so it is written
+     * once and the one value stands wherever it is reached. Written out per arrival instead, a body
+     * whose shared subtrees nest would be a value larger than the body — and every comparison of two
+     * of them would walk all of it, where sharing lets the halves be found the same by being the
+     * same.
+     */
+    private static ExecutableIdentity of(Core body, Binders binders,
+                                         Map<Core, ExecutableIdentity> said) {
+        ExecutableIdentity already = said.get(body);
+        if (already != null) {
+            return already;
+        }
         List<Object> settled = new ArrayList<>();
-        settled.add(open(body.type()));
+        settled.add(typeOf(body));
         Kind kind = say(body, settled, binders);
         List<ExecutableIdentity> children = new ArrayList<>();
         for (CoreStructure.Child child : CoreStructure.childrenOf(body)) {
-            children.add(of(child.node(), binders));
+            children.add(of(child.node(), binders, said));
         }
-        return new ExecutableIdentity(kind, settled, children);
+        ExecutableIdentity made = new ExecutableIdentity(kind, settled, children);
+        said.put(body, made);
+        return made;
     }
 
     /** Everything but the children and the type: what the node says on its own. */
@@ -92,7 +115,11 @@ record ExecutableIdentity(Kind kind, List<Object> settled, List<ExecutableIdenti
             // The place the name is bound, never the name: two bodies alike but for what a `let`
             // spells do the same thing, and the id the compiler minted for it moves with the copy.
             case Core.Read it -> {
-                settled.add(it.binding() == null ? null : binders.at(it.binding()));
+                if (it.binding() == null) {
+                    throw new IllegalStateException("a body that runs reads no name nothing bound: `"
+                            + it.name() + "` at " + it.pos());
+                }
+                settled.add(binders.at(it.binding()));
                 yield Kind.READ;
             }
             case Core.UnitValue it -> {
@@ -164,6 +191,14 @@ record ExecutableIdentity(Kind kind, List<Object> settled, List<ExecutableIdenti
      * whatever the checker called it. Either is a name this compile invented, so two bodies holding
      * one would be compared on it.
      */
+    private static Type typeOf(Core e) {
+        if (e.type() == null) {
+            throw new IllegalStateException("a body that runs holds no term of no type: a "
+                    + e.getClass().getSimpleName() + " at " + e.pos());
+        }
+        return open(e.type());
+    }
+
     private static Type open(Type type) {
         switch (type) {
             case null -> { }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
@@ -200,8 +200,10 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
     }
 
     private static Type open(Type type) {
+        if (type == null) {
+            return null;   // a slot of a type a constructor left empty, which says nothing here
+        }
         switch (type) {
-            case null -> { }
             case Type.MetaVar it -> throw new IllegalStateException(
                     "a body that runs holds no metavariable: " + it);
             case Type.Var it -> {
@@ -210,22 +212,13 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
                             "a body that runs holds no inferred type variable: " + it);
                 }
             }
-            // Inside as well as at the top: what is left open is left open wherever it stands, and
-            // a list of them is as much a type no run has as one of them is.
-            case Type.ListOf it -> open(it.element());
-            case Type.SetOf it -> open(it.element());
-            case Type.OptionOf it -> open(it.element());
-            case Type.MapOf it -> {
-                open(it.key());
-                open(it.value());
-            }
-            case Type.TupleOf it -> it.elements().forEach(ExecutableIdentity::open);
-            case Type.FnOf it -> {
-                it.params().forEach(ExecutableIdentity::open);
-                open(it.result());
-            }
             default -> { }
         }
+        // Inside as well as at the top: what is left open is left open wherever it stands, and a
+        // list of them is as much a type no run has as one of them is. Which types a type is made
+        // of is asked of the one place that says so, rather than listed again here — a constructor
+        // added to the language would otherwise be one this walked past.
+        Type.forEachChild(type, ExecutableIdentity::open);
         return type;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddress.java
@@ -19,9 +19,9 @@ import java.util.Set;
  *                 alike, so the path alone is not a place
  * @param occurrences every way down from that body to it
  */
-record NodeAddress(String behavior, Set<CorePath> occurrences) {
+public record NodeAddress(String behavior, Set<CorePath> occurrences) {
 
-    NodeAddress {
+    public NodeAddress {
         if (behavior == null) {
             throw new IllegalArgumentException("a place is a place in somebody's body");
         }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddress.java
@@ -1,0 +1,41 @@
+package souther.compiler.coverage;
+
+import java.util.Set;
+
+/**
+ * Where one place of one body is, said so that two walks of that body come to the same answer.
+ *
+ * <p><b>Every way to it, not one of them.</b> A body is a tree to read and a graph to walk: a pass
+ * that rewrote two equal subtrees into one left a node two ways lead to, and the numbering treats it
+ * as one place — it is one comparison, numbered once. So what the place is includes both ways, and
+ * an address holding only the first would say the same thing about a body where the second way went
+ * somewhere else. Ordinarily there is one way and this holds one path.
+ *
+ * <p>A set and not a list, because the ways to a place do not come in an order that means anything:
+ * which one a walk finds first is the walk's business, and two walks that found them in different
+ * orders found the same place.
+ *
+ * @param behavior whose body the place is in. A path is the same list of slots in every body shaped
+ *                 alike, so the path alone is not a place
+ * @param occurrences every way down from that body to it
+ */
+record NodeAddress(String behavior, Set<CorePath> occurrences) {
+
+    NodeAddress {
+        if (behavior == null) {
+            throw new IllegalArgumentException("a place is a place in somebody's body");
+        }
+        if (occurrences == null || occurrences.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "a place with no way to it is one nothing reaches: " + behavior);
+        }
+        occurrences = Set.copyOf(occurrences);
+    }
+
+    @Override
+    public String toString() {
+        return occurrences.size() == 1
+                ? behavior + occurrences.iterator().next()
+                : behavior + occurrences;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddresses.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddresses.java
@@ -1,0 +1,78 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where every place of one body is, worked out once.
+ *
+ * <p>Keyed by identity, because this is the one crossing from a walk that holds the tree to an
+ * address that does not need it. A caller has a node — it is walking the body the numbering was
+ * taken over — and wants what that node's place is called; two nodes that look alike are two places
+ * and a value-keyed map would give the first one's answer for the second.
+ *
+ * <p><b>Every way to a place, gathered on the way down.</b> The walk descends each slot once, so a
+ * node several slots lead to is arrived at several times and its address collects each arrival.
+ * There is no cap: a place with more ways to it than a reader expected is a fact about the body, and
+ * a limit here would be this reading refusing bodies rather than describing them.
+ */
+final class NodeAddresses {
+
+    private final String behavior;
+
+    private final Map<Core, Set<CorePath>> waysTo = new IdentityHashMap<>();
+
+    private NodeAddresses(String behavior) {
+        this.behavior = behavior;
+    }
+
+    /** The addresses of every place in {@code body}, which is {@code behavior}'s. */
+    static NodeAddresses of(String behavior, Core body) {
+        NodeAddresses out = new NodeAddresses(behavior);
+        out.walk(body, CorePath.ROOT);
+        return out;
+    }
+
+    private void walk(Core at, CorePath here) {
+        Set<CorePath> ways = waysTo.computeIfAbsent(at, _ -> new LinkedHashSet<>());
+        if (!ways.add(here)) {
+            return;   // this same way down, met again: nothing below it is new either
+        }
+        for (CoreStructure.Child child : CoreStructure.childrenOf(at)) {
+            walk(child.node(), here.then(child.edge()));
+        }
+    }
+
+    /**
+     * What {@code node}'s place is called, for a node of the body this was taken over.
+     *
+     * <p>Throws for a node from anywhere else. A walk asking this is walking the body these
+     * addresses are of, so a node they do not hold is a walk over other trees than these — and an
+     * address invented for it would name a place in a body nobody is talking about.
+     */
+    NodeAddress of(Core node) {
+        Set<CorePath> ways = waysTo.get(node);
+        if (ways == null) {
+            throw new IllegalStateException("no place in `" + behavior + "` is a "
+                    + node.getClass().getSimpleName() + " at " + node.pos()
+                    + "; these addresses were taken over other trees than the one asking");
+        }
+        return new NodeAddress(behavior, ways);
+    }
+
+    /** How many places the body has, which is what a reader of this counts over. */
+    int size() {
+        return waysTo.size();
+    }
+
+    /** Every place, for a reader that wants the whole of one body's addresses. */
+    Map<Core, NodeAddress> all() {
+        Map<Core, NodeAddress> out = new IdentityHashMap<>();
+        waysTo.forEach((node, ways) -> out.put(node, new NodeAddress(behavior, ways)));
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddresses.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NodeAddresses.java
@@ -2,29 +2,45 @@ package souther.compiler.coverage;
 
 import souther.compiler.core.Core;
 
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Where every place of one body is, worked out once.
+ * Where every place of one body is, and where every name it binds stands, worked out in one descent.
+ *
+ * <p>One descent and not two. Where a place is and where a binder stands are the same question asked
+ * of the same walk — a binder is at a slot of a node, and the node is at an address — and two walks
+ * answering them would be two answers to what a body holds, each with its own idea of what to do
+ * with a node that several ways lead to.
  *
  * <p>Keyed by identity, because this is the one crossing from a walk that holds the tree to an
  * address that does not need it. A caller has a node — it is walking the body the numbering was
  * taken over — and wants what that node's place is called; two nodes that look alike are two places
  * and a value-keyed map would give the first one's answer for the second.
  *
- * <p><b>Every way to a place, gathered on the way down.</b> The walk descends each slot once, so a
- * node several slots lead to is arrived at several times and its address collects each arrival.
- * There is no cap: a place with more ways to it than a reader expected is a fact about the body, and
- * a limit here would be this reading refusing bodies rather than describing them.
+ * <p><b>Every way to a place.</b> The descent goes down each slot once from each way it arrived, so
+ * a node several slots lead to collects each arrival. That is the size of the answer rather than a
+ * cost on the way to it: a place several ways lead to <em>is</em> several ways, and there is no cap
+ * — a limit here would be this refusing bodies rather than describing them.
  */
 final class NodeAddresses {
 
     private final String behavior;
 
     private final Map<Core, Set<CorePath>> waysTo = new IdentityHashMap<>();
+
+    /** Where each name the body binds is bound, kept as the node and slot until the descent is done
+     *  — a binder's address is its owner's, and the owner's is not settled until every way to it has
+     *  been arrived at. */
+    private final List<StandingAt> binders = new ArrayList<>();
+
+    private record StandingAt(souther.compiler.types.BindingId binding, Core owner,
+                              BinderSlot slot) {}
 
     private NodeAddresses(String behavior) {
         this.behavior = behavior;
@@ -42,8 +58,38 @@ final class NodeAddresses {
         if (!ways.add(here)) {
             return;   // this same way down, met again: nothing below it is new either
         }
+        if (ways.size() == 1) {
+            // The names this node opens, taken once however many ways lead to it: a node met again
+            // is the same node and binds the same names at the same slots.
+            binderSlots(at);
+        }
         for (CoreStructure.Child child : CoreStructure.childrenOf(at)) {
             walk(child.node(), here.then(child.edge()));
+        }
+    }
+
+    private void binderSlots(Core at) {
+        switch (at) {
+            case Core.LetIn it -> keep(it.binder(), it, new BinderSlot.LetBinder());
+            case Core.Block it -> {
+                for (int i = 0; i < it.params().size(); i++) {
+                    keep(it.params().get(i), it, new BinderSlot.BlockParam(i));
+                }
+            }
+            case Core.Match it -> {
+                for (int i = 0; i < it.cases().size(); i++) {
+                    keep(it.cases().get(i).binder(), it, new BinderSlot.CaseBinder(i));
+                }
+            }
+            case Core.IfConstructed it ->
+                    keep(it.binder(), it, new BinderSlot.ConstructedBinder());
+            default -> { }
+        }
+    }
+
+    private void keep(Core.Binder binder, Core owner, BinderSlot slot) {
+        if (binder != null && binder.binding() != null) {
+            binders.add(new StandingAt(binder.binding(), owner, slot));
         }
     }
 
@@ -64,6 +110,11 @@ final class NodeAddresses {
         return new NodeAddress(behavior, ways);
     }
 
+    /** Whose body these are of. */
+    String behavior() {
+        return behavior;
+    }
+
     /** How many places the body has, which is what a reader of this counts over. */
     int size() {
         return waysTo.size();
@@ -73,6 +124,24 @@ final class NodeAddresses {
     Map<Core, NodeAddress> all() {
         Map<Core, NodeAddress> out = new IdentityHashMap<>();
         waysTo.forEach((node, ways) -> out.put(node, new NodeAddress(behavior, ways)));
+        return out;
+    }
+
+    /** Where each name the body binds stands, now that every way to every owner is known. */
+    Map<souther.compiler.types.BindingId, BinderAddress> bound() {
+        Map<souther.compiler.types.BindingId, BinderAddress> out = new LinkedHashMap<>();
+        for (StandingAt each : binders) {
+            BinderAddress where = new BinderAddress.Local(of(each.owner()), each.slot());
+            BinderAddress already = out.put(each.binding(), where);
+            // Two binders under one name is a body whose reads cannot say which they mean. Told by
+            // the places being different rather than by there being a second answer: a node several
+            // ways lead to is arrived at once here, and asking twice about one binder is not a
+            // second binder.
+            if (already != null && !already.equals(where)) {
+                throw new IllegalStateException("`" + behavior + "` binds " + each.binding()
+                        + " at " + already + " and again at " + where);
+            }
+        }
         return out;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
@@ -1,0 +1,64 @@
+package souther.compiler.coverage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What a numbering is, said so that two of them can be held against each other.
+ *
+ * <p>A run is recorded in bare numbers, and a number means a place only under the numbering that
+ * handed it out. So a measure reading a recording made under another numbering is answering about
+ * places it was not asked about, and the answer is an ordinary yes or no. What stops that is being
+ * able to say two numberings are the same one — and that is neither "the same construction" nor
+ * "the same inputs".
+ *
+ * <p><b>Not the same construction.</b> A numbering is derived on demand and the store recomputes,
+ * so a token minted per construction would call one numbering two, and a claim answered against a
+ * recording made a moment earlier would be refused for having been made a moment earlier.
+ *
+ * <p><b>Not the same inputs.</b> That the walk is a function of the bodies is exactly the property
+ * a reader takes on trust today; identity by input digest moves the trust one step and leaves it
+ * standing. A walk whose order came to depend on something else would hand out different numbers
+ * under one digest, and nothing would say so.
+ *
+ * <p><b>The same address space.</b> Two numberings are one when each number means the same place in
+ * the same executable. Both halves: {@link #byNumber} says what number addresses what place, and
+ * {@link #executable} says what the code at those places does, because two bodies that do different
+ * things are not two views of one measurement however their places line up.
+ *
+ * @param module   whose bodies these are numbered from
+ * @param executable what each behavior of the module does, by name. A map and not a list: what
+ *                   order a module declares its behaviors in is not part of what a number means,
+ *                   and where it moves the numbers with it {@code byNumber} moves too
+ * @param byNumber what each number is an address of, the number being the position in the list
+ */
+record NumberingIdentity(String module, Map<String, ExecutableIdentity> executable,
+                         List<SiteAddress> byNumber) {
+
+    NumberingIdentity {
+        if (module == null) {
+            throw new IllegalArgumentException("a numbering is of somebody's module");
+        }
+        executable = Map.copyOf(executable);
+        byNumber = List.copyOf(byNumber);
+    }
+
+    /** The numbering of nothing, which is what a module with no bodies to walk has. */
+    static NumberingIdentity of(String module) {
+        return new NumberingIdentity(module, Map.of(), List.of());
+    }
+
+    /** What number {@code n} is an address of. */
+    SiteAddress at(int n) {
+        if (n < 0 || n >= byNumber.size()) {
+            throw new IllegalArgumentException(
+                    "this numbering handed out no " + n + "; it handed out " + byNumber.size());
+        }
+        return byNumber.get(n);
+    }
+
+    @Override
+    public String toString() {
+        return "numbering of " + module + " over " + byNumber.size() + " places";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
@@ -32,10 +32,10 @@ import java.util.Map;
  *                   and where it moves the numbers with it {@code byNumber} moves too
  * @param byNumber what each number is an address of, the number being the position in the list
  */
-record NumberingIdentity(String module, Map<String, ExecutableIdentity> executable,
-                         List<SiteAddress> byNumber) {
+public record NumberingIdentity(String module, Map<String, ExecutableIdentity> executable,
+                                List<SiteAddress> byNumber) {
 
-    NumberingIdentity {
+    public NumberingIdentity {
         if (module == null) {
             throw new IllegalArgumentException("a numbering is of somebody's module");
         }
@@ -49,7 +49,7 @@ record NumberingIdentity(String module, Map<String, ExecutableIdentity> executab
     }
 
     /** What number {@code n} is an address of. */
-    SiteAddress at(int n) {
+    public SiteAddress at(int n) {
         if (n < 0 || n >= byNumber.size()) {
             throw new IllegalArgumentException(
                     "this numbering handed out no " + n + "; it handed out " + byNumber.size());

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SiteAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SiteAddress.java
@@ -12,7 +12,7 @@ package souther.compiler.coverage;
  * means a place in a body, and a place is where it is rather than which object stood there
  * ({@link NodeAddress}).
  */
-sealed interface SiteAddress {
+public sealed interface SiteAddress {
 
     /** Where a run through one arm of one fork is recorded.
      *

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SiteAddress.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SiteAddress.java
@@ -1,0 +1,53 @@
+package souther.compiler.coverage;
+
+/**
+ * What one number the instrumentation hands out is an address of.
+ *
+ * <p>Two families under one numbering. An arm and a comparison are both places a run is recorded at
+ * and both take a number from the one counter, because what records a run is one set of numbers; a
+ * number written for an arm and a number written for a comparison are told apart by nothing in the
+ * number itself. So the numbering says which each was issued to, and says it here.
+ *
+ * <p>The whole of what a number means, so that a numbering can be held against another one. A number
+ * means a place in a body, and a place is where it is rather than which object stood there
+ * ({@link NodeAddress}).
+ */
+sealed interface SiteAddress {
+
+    /** Where a run through one arm of one fork is recorded.
+     *
+     * @param part which arm of the fork, in the order the fork holds them */
+    record Arm(NodeAddress fork, int part) implements SiteAddress {
+
+        public Arm {
+            if (fork == null) {
+                throw new IllegalArgumentException("an arm is an arm of a fork somewhere");
+            }
+            if (part < 0) {
+                throw new IllegalArgumentException(
+                        "an arm stands somewhere among the fork's: " + part);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "arm " + part + " of " + fork;
+        }
+    }
+
+    /** Where a run through one comparison is recorded. A comparison is one construct, so there is
+     *  no part: what a fork holds several of is arms. */
+    record Comparison(NodeAddress comparison) implements SiteAddress {
+
+        public Comparison {
+            if (comparison == null) {
+                throw new IllegalArgumentException("a comparison is one written somewhere");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "comparison at " + comparison;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -217,6 +217,11 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "asks which operator a library operation is defined as"),
             new Held("souther.compiler.coverage.CoverageSites.Walk.number",
                     "records the operator an outcome was written with, which is what a report shows"),
+            new Held("souther.compiler.coverage.ExecutableIdentity.say",
+                    "what a comparison does, written into what says whether two bodies do the same"
+                            + " thing: two bodies alike but for which way they compare are two"
+                            + " bodies, and a run recorded against one says nothing about the"
+                            + " other"),
             new Held("souther.compiler.report.ArmVocabulary.label",
                     "writes the operator into the words a report shows for an arm"),
             new Held("souther.compiler.reading.Meetings.run",

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
@@ -28,13 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AComparisonIsHeldWhereverItIsWrittenTest {
 
-    private static Map<String, Core> bodiesOf(String source) {
+    /** The bodies a source compiles to, under the name the source declares them in. The name comes
+     *  with them: a body's own parameters belong to the behavior the module declares, so a plan
+     *  built under some other module's name is a plan of bodies whose names it cannot place. */
+    private record Checked(String module, Map<String, Core> bodies) {}
+
+    private static Checked bodiesOf(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
+        String module = compilation.modules().get(0);
         Bodies.Elaborated checked = compilation.db()
-                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+                .ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");
-        return checked.behaviorBodies();
+        return new Checked(module, checked.behaviorBodies());
     }
 
     private static List<String> operatorsIn(String source) {
@@ -48,23 +54,22 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      * catalog exists for. A list the catalog handed over would be a second answer to keep in step
      * with {@link ComparisonCatalog#at}, and nothing in the compiler wants one.
      */
-    private static List<Core.Binary> comparisonsIn(Map<String, Core> bodies) {
-        ComparisonCatalog catalog = catalogOf(bodies);
+    private static List<Core.Binary> comparisonsIn(Checked checked) {
+        ComparisonCatalog catalog = catalogOf(checked);
         List<Core.Binary> out = new ArrayList<>();
-        bodies.values().forEach(body -> collect(body, catalog, out));
+        checked.bodies().values().forEach(body -> collect(body, catalog, out));
         return out;
     }
 
-    /** The catalog of {@code bodies}, under a module name this fixture supplies. Which name it is
-     *  does not matter here: every question below is of one catalog, and a name only has to tell
-     *  one module's comparisons from another's. */
-    private static ComparisonCatalog catalogOf(Map<String, Core> bodies) {
-        return ComparisonCatalog.of(new ModuleBodies("example", new LinkedHashMap<>(bodies)));
+    private static ComparisonCatalog catalogOf(Checked checked) {
+        return ComparisonCatalog.of(new ModuleBodies(checked.module(),
+                new LinkedHashMap<>(checked.bodies())));
     }
 
-    /** The plan of the same, under the same name. */
-    private static CoverageSites.Plan planOf(Map<String, Core> bodies) {
-        return CoverageSites.of(new ModuleBodies("example", new LinkedHashMap<>(bodies)),
+    /** The plan of the same bodies, under the same name. */
+    private static CoverageSites.Plan planOf(Checked checked) {
+        return CoverageSites.of(new ModuleBodies(checked.module(),
+                        new LinkedHashMap<>(checked.bodies())),
                 DecisionSources.NONE, SuppliedRules.NONE);
     }
 
@@ -170,9 +175,9 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void aComparisonCanBeCataloguedWithNoSiteToRecordARunAt() {
-        Map<String, Core> bodies = bodiesOf(BEHIND_AN_ABORT);
-        ComparisonCatalog catalog = catalogOf(bodies);
-        CoverageSites.Plan plan = planOf(bodies);
+        Checked checked = bodiesOf(BEHIND_AN_ABORT);
+        ComparisonCatalog catalog = catalogOf(checked);
+        CoverageSites.Plan plan = planOf(checked);
 
         List<ComparisonOccurrence> held = catalog.all().stream()
                 .map(ComparisonCatalog.Catalogued::which).toList();
@@ -192,15 +197,15 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void aComparisonInsideAFunctionValueMayBePassedMoreThanOnce() {
-        Map<String, Core> bodies = bodiesOf("""
+        Checked checked = bodiesOf("""
                 module example.inside
 
                 behavior positives : (xs: List<Int>) -> List<Int>
 
                 let positives (xs) = List.filter(x -> x > 0, xs)
                 """);
-        CoverageSites.Plan plan = planOf(bodies);
-        Core.Binary comparison = comparisonsIn(bodies).get(0);
+        CoverageSites.Plan plan = planOf(checked);
+        Core.Binary comparison = comparisonsIn(checked).get(0);
 
         assertTrue(plan.comparisons().occurrenceAt(comparison).filter(plan::instruments)
                         .isPresent(), "it is numbered");
@@ -219,9 +224,9 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
     @Test
     void everyComparisonOfABodyIsOneTheCatalogNames() {
         for (String source : List.of(NAMED_BEFORE_THE_FORK, INSIDE_A_FUNCTION_VALUE, BEHIND_AN_ABORT)) {
-            Map<String, Core> bodies = bodiesOf(source);
-            ComparisonCatalog catalog = catalogOf(bodies);
-            bodies.values().forEach(body -> recognised(body, each ->
+            Checked checked = bodiesOf(source);
+            ComparisonCatalog catalog = catalogOf(checked);
+            checked.bodies().values().forEach(body -> recognised(body, each ->
                     assertTrue(catalog.occurrenceAt(each).isPresent(),
                             () -> "the catalog names " + each.op() + " at " + each.pos())));
         }
@@ -238,7 +243,7 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void twoComparisonsSpelledAlikeAreTwoOccurrences() {
-        Map<String, Core> bodies = bodiesOf("""
+        Checked checked = bodiesOf("""
                 module example.twice
 
                 behavior band : (a: Int) -> Int
@@ -247,7 +252,7 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
 
                 let band (a) = if over(a) then (if over(a) then 1 else 2) else 3
                 """);
-        ComparisonCatalog catalog = catalogOf(bodies);
+        ComparisonCatalog catalog = catalogOf(checked);
 
         List<ComparisonCatalog.Catalogued> held = catalog.all();
         assertEquals(2, held.size(), "the helper is spliced into the body at both calls");
@@ -275,9 +280,9 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
                 let check (a) = if a > 10 then 1 else 2
                 """;
         ComparisonCatalog here = ComparisonCatalog.of(
-                new ModuleBodies("one", new LinkedHashMap<>(bodiesOf(body.formatted("one")))));
+                new ModuleBodies("one", new LinkedHashMap<>(bodiesOf(body.formatted("one")).bodies())));
         ComparisonCatalog there = ComparisonCatalog.of(
-                new ModuleBodies("two", new LinkedHashMap<>(bodiesOf(body.formatted("two")))));
+                new ModuleBodies("two", new LinkedHashMap<>(bodiesOf(body.formatted("two")).bodies())));
 
         assertEquals(1, here.all().size(), "each module writes one comparison");
         assertEquals(1, there.all().size(), "each module writes one comparison");
@@ -303,10 +308,10 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
                 let check (a) = if a > 10 then 1 else 2
                 """;
         CoverageSites.Plan here = CoverageSites.of(
-                new ModuleBodies("one", new LinkedHashMap<>(bodiesOf(body.formatted("one")))),
+                new ModuleBodies("one", new LinkedHashMap<>(bodiesOf(body.formatted("one")).bodies())),
                 DecisionSources.NONE, SuppliedRules.NONE);
         ComparisonOccurrence there = ComparisonCatalog.of(new ModuleBodies(
-                "two", new LinkedHashMap<>(bodiesOf(body.formatted("two"))))).all().get(0).which();
+                "two", new LinkedHashMap<>(bodiesOf(body.formatted("two")).bodies()))).all().get(0).which();
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> here.instruments(there));
@@ -325,7 +330,7 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void aPlanCannotNumberAComparisonItsCatalogNeverHeld() {
-        Map<String, Core> bodies = bodiesOf(NAMED_BEFORE_THE_FORK);
+        Checked checked = bodiesOf(NAMED_BEFORE_THE_FORK);
         ComparisonOccurrence elsewhere = new ComparisonOccurrence("nowhere", "fee", 0);
         Map<ComparisonOccurrence, Integer> numbered = new LinkedHashMap<>();
         numbered.put(elsewhere, 0);
@@ -333,7 +338,7 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new CoverageSites.Plan(List.of(), List.of(), new IdentityHashMap<>(),
                         numbered, new IdentityHashMap<>(), new LinkedHashMap<>(),
-                        java.util.Set.of(), new IdentityHashMap<>(), catalogOf(bodies),
+                        java.util.Set.of(), new IdentityHashMap<>(), catalogOf(checked),
                         NumberingIdentity.of("example")));
         assertTrue(refused.getMessage().contains("one answer or they are two"),
                 refused.getMessage());
@@ -351,16 +356,17 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void bodiesInAnotherOrderAreAnotherModuleBodies() {
-        Map<String, Core> bodies = bodiesOf(TWO_BEHAVIORS);
-        assertEquals(2, bodies.size(), "the model under test declares two behaviors");
+        Checked checked = bodiesOf(TWO_BEHAVIORS);
+        assertEquals(2, checked.bodies().size(), "the model under test declares two behaviors");
         LinkedHashMap<String, Core> reversed = new LinkedHashMap<>();
-        List<String> names = new ArrayList<>(bodies.keySet());
+        List<String> names = new ArrayList<>(checked.bodies().keySet());
         for (int at = names.size() - 1; at >= 0; at--) {
-            reversed.put(names.get(at), bodies.get(names.get(at)));
+            reversed.put(names.get(at), checked.bodies().get(names.get(at)));
         }
 
-        assertNotEquals(new ModuleBodies("example", new LinkedHashMap<>(bodies)),
-                new ModuleBodies("example", reversed),
+        assertNotEquals(
+                new ModuleBodies(checked.module(), new LinkedHashMap<>(checked.bodies())),
+                new ModuleBodies(checked.module(), reversed),
                 "one order is what the numbering is of, so the other is another value");
     }
 
@@ -374,8 +380,8 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
      */
     @Test
     void oneComparisonStandingInTwoBodiesIsRefused() {
-        Map<String, Core> bodies = bodiesOf(TWO_BEHAVIORS);
-        Core shared = bodies.values().iterator().next();
+        Checked checked = bodiesOf(TWO_BEHAVIORS);
+        Core shared = checked.bodies().values().iterator().next();
         LinkedHashMap<String, Core> both = new LinkedHashMap<>();
         both.put("one", shared);
         both.put("two", shared);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
@@ -333,7 +333,8 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new CoverageSites.Plan(List.of(), List.of(), new IdentityHashMap<>(),
                         numbered, new IdentityHashMap<>(), new LinkedHashMap<>(),
-                        java.util.Set.of(), new IdentityHashMap<>(), catalogOf(bodies)));
+                        java.util.Set.of(), new IdentityHashMap<>(), catalogOf(bodies),
+                        NumberingIdentity.of("example")));
         assertTrue(refused.getMessage().contains("one answer or they are two"),
                 refused.getMessage());
     }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/APlaceSeveralWaysLeadToIsStillOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/APlaceSeveralWaysLeadToIsStillOnePlaceTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.CoverageConstruct;
+import souther.compiler.types.CoverageOrigin;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A node several ways lead to is one place, bound once, and numbered once.
+ *
+ * <p>A body is a tree to read and a graph to walk. Nothing a source writes makes one node stand in
+ * two slots, but a pass that rewrote two equal subtrees into one leaves exactly that, and the
+ * corpora hold such a place. What that place must not become is two: two names for one binder, or
+ * two numbers for one arm — the second of which the emitter lights on no run and every count reads
+ * as a place nothing reaches.
+ *
+ * <p>The trees here are built rather than compiled, because no source this compiler accepts makes
+ * one. They are what a pass would leave, and they are handed to the numbering as bodies.
+ */
+class APlaceSeveralWaysLeadToIsStillOnePlaceTest {
+
+    private static final SourcePos AT = new SourcePos(1, 1);
+
+    private static final CoverageOrigin FORK =
+            CoverageOrigin.written("demo", 0, CoverageConstruct.IF);
+
+    /** One fork standing in both sides of a comparison, which is two ways to one place. */
+    private static Core sharedFork() {
+        Core fork = new Core.If(new Core.Bool(true, Type.BOOL, AT),
+                new Core.Int(1, Type.INT, AT), new Core.Int(2, Type.INT, AT),
+                FORK, Type.INT, AT, List.of());
+        return new Core.Binary(BinOp.ADD, fork, fork, null, Type.INT, AT);
+    }
+
+    /** One {@code let} standing in both sides, which is two ways to one binder. */
+    private static Core sharedBinder() {
+        BindingId bound = new BindingId(new BindingOwner.OfValue("demo", "b"), 0);
+        Core let = new Core.LetIn(new Core.Binder("x", bound),
+                new Core.Int(1, Type.INT, AT),
+                new Core.Read("x", bound, Type.INT, AT), Type.INT, AT);
+        return new Core.Binary(BinOp.ADD, let, let, null, Type.INT, AT);
+    }
+
+    @Test
+    void bothWaysToAPlaceAreItsAddress() {
+        NodeAddresses places = NodeAddresses.of("b", sharedFork());
+        Core fork = ((Core.Binary) sharedForkOf(places)).left();
+
+        assertEquals(2, places.of(fork).occurrences().size(),
+                () -> "the fork stands under both sides: " + places.of(fork));
+        assertEquals(Set.of(
+                        CorePath.ROOT.then(new CoreStructure.Edge.BinaryLeft()),
+                        CorePath.ROOT.then(new CoreStructure.Edge.BinaryRight())),
+                places.of(fork).occurrences(),
+                "and the address says which sides");
+    }
+
+    /** A binder several ways lead to is one binder, at one place. */
+    @Test
+    void aBinderSeveralWaysLeadToIsBoundOnce() {
+        Core body = sharedBinder();
+        NodeAddresses places = NodeAddresses.of("b", body);
+        Binders binders = Binders.of("demo", places);
+
+        BindingId bound = ((Core.LetIn) ((Core.Binary) body).left()).binder().binding();
+        Core let = ((Core.Binary) body).left();
+
+        assertEquals(new BinderAddress.Local(places.of(let), new BinderSlot.LetBinder()),
+                binders.at(bound),
+                "one binder, at the one place both ways lead to");
+        assertEquals(2, places.of(let).occurrences().size(),
+                () -> "and that place is both ways: " + places.of(let));
+    }
+
+    /**
+     * And numbering it twice is refused.
+     *
+     * <p>The arms of a fork are made once per arrival, so a fork two ways lead to would take two
+     * numbers for one place. The second is a site the emitter lights on no run, which every count
+     * reads as an arm nothing reaches — the shape of a real omission, reported as one.
+     */
+    @Test
+    void aPlaceIsNumberedOnceOrRefused() {
+        Map<String, Core> bodies = new LinkedHashMap<>();
+        bodies.put("b", sharedFork());
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> CoverageSites.of(new ModuleBodies("demo", new LinkedHashMap<>(bodies)),
+                        DecisionSources.NONE, SuppliedRules.NONE));
+
+        assertTrue(refused.getMessage().contains("twice"),
+                () -> "the numbering says the place was numbered twice: " + refused.getMessage());
+    }
+
+    /** The body this test's addresses were taken over, so the fork asked about is the one in it. */
+    private static Core sharedForkOf(NodeAddresses places) {
+        return places.all().keySet().stream()
+                .filter(Core.Binary.class::isInstance)
+                .findFirst().orElseThrow();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -45,25 +45,29 @@ class CoverageSitesTest {
                         unreachable "a member over thirty is handled elsewhere"
             """;
 
-    private static Map<String, Core> bodiesOf(String source) {
+    /** The bodies a source compiles to, under the name the source declares them in. The name comes
+     *  with them: a body's own parameters belong to the behavior the module declares, so a plan
+     *  built under some other module's name is a plan of bodies whose names it cannot place. */
+    private record Checked(String module, Map<String, Core> bodies) {}
+
+    private static Checked bodiesOf(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
+        String module = compilation.modules().get(0);
         Bodies.Elaborated checked = compilation.db()
-                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+                .ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");
-        return checked.behaviorBodies();
+        return new Checked(module, checked.behaviorBodies());
     }
 
     private static CoverageSites.Plan planOf(String source) {
         return planOf(bodiesOf(source));
     }
 
-    /** A plan of {@code bodies}, under a module name this fixture supplies. What the name is does
-     *  not matter to anything here — every question asked below is of one plan, and a name only
-     *  has to tell one module's comparisons from another's. */
-    private static CoverageSites.Plan planOf(Map<String, Core> bodies) {
+    private static CoverageSites.Plan planOf(Checked checked) {
         return CoverageSites.of(
-                new ModuleBodies("example", new java.util.LinkedHashMap<>(bodies)),
+                new ModuleBodies(checked.module(),
+                        new java.util.LinkedHashMap<>(checked.bodies())),
                 souther.compiler.coverage.DecisionSources.NONE,
                 souther.compiler.coverage.SuppliedRules.NONE);
     }
@@ -174,7 +178,7 @@ class CoverageSitesTest {
      */
     @Test
     void aForkNothingReachesIsPlannedWithNoArms() {
-        Map<String, Core> bodies = bodiesOf("""
+        Checked checked = bodiesOf("""
                 module example.dead
 
                 data Yes
@@ -196,9 +200,9 @@ class CoverageSitesTest {
                                 | No  -> Score(3)
                         }
                 """);
-        CoverageSites.Plan plan = planOf(bodies);
+        CoverageSites.Plan plan = planOf(checked);
 
-        Core.Match outer = (Core.Match) unwrap(bodies.get("scoreFor"));
+        Core.Match outer = (Core.Match) unwrap(checked.bodies().get("scoreFor"));
         Core.Match inner = innerMatch(outer.cases().get(1).body());
         assertArrayEquals(new int[] {CoverageSites.NO_SITE, CoverageSites.NO_SITE},
                 plan.probesOf(inner), "the emitter still finds it, and finds nothing to light");
@@ -308,7 +312,7 @@ class CoverageSitesTest {
      */
     @Test
     void anArmWithoutAProbeKeepsItsPlaceInTheArray() {
-        Map<String, Core> bodies = bodiesOf("""
+        Checked checked = bodiesOf("""
                 module example.order
 
                 data Yes
@@ -325,9 +329,9 @@ class CoverageSitesTest {
                         | Yes -> unreachable "the caller has already refused a yes"
                         | No  -> Score(0)
                 """);
-        CoverageSites.Plan plan = planOf(bodies);
+        CoverageSites.Plan plan = planOf(checked);
 
-        Core.Match match = (Core.Match) unwrap(bodies.get("scoreFor"));
+        Core.Match match = (Core.Match) unwrap(checked.bodies().get("scoreFor"));
         assertArrayEquals(new int[] {CoverageSites.NO_SITE, 0}, plan.probesOf(match),
                 "the surviving arm is second, and it is the second entry that holds its probe");
     }
@@ -392,10 +396,10 @@ class CoverageSitesTest {
 
     @Test
     void aSiteIsFoundByTheNodeInstanceTheEmitterHolds() {
-        Map<String, Core> bodies = bodiesOf(MODEL);
-        CoverageSites.Plan plan = planOf(bodies);
+        Checked checked = bodiesOf(MODEL);
+        CoverageSites.Plan plan = planOf(checked);
 
-        Core body = bodies.get("daysFor");
+        Core body = checked.bodies().get("daysFor");
         Core.Match match = (Core.Match) unwrap(body);
         int[] arms = plan.probesOf(match);
         assertNotNull(arms, "the plan is keyed by the instances it was built from");
@@ -476,6 +480,6 @@ class CoverageSitesTest {
 
     @Test
     void aModuleWithNoBodiesPlansNothing() {
-        assertSame(true, planOf(Map.<String, Core>of()).hasNoProbes());
+        assertSame(true, planOf(new Checked("example.empty", Map.of())).hasNoProbes());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -112,12 +113,12 @@ class EveryChildANodeHandsOverStandsInANamedSlotTest {
 
     /** Applies {@code at} to every node of {@code body}, once per node however many ways there are
      *  to it, and answers how many there were. */
-    private static int walk(Core body, java.util.function.Consumer<Core> at) {
+    private static int walk(Core body, Consumer<Core> at) {
         Map<Core, Boolean> seen = new IdentityHashMap<>();
         return walk(body, at, seen);
     }
 
-    private static int walk(Core e, java.util.function.Consumer<Core> at, Map<Core, Boolean> seen) {
+    private static int walk(Core e, Consumer<Core> at, Map<Core, Boolean> seen) {
         if (seen.put(e, Boolean.TRUE) != null) {
             return 0;
         }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
@@ -1,0 +1,193 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.core.Core;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The slots {@link CoreStructure} names are the children a node has, and no two of them are one
+ * slot.
+ *
+ * <p>Two walks of the IR, and the whole of what makes the second one worth having is that it meets
+ * the same children. {@link Core#forEachChild} is derived from the one switch that says which slots
+ * a node has, so a node kind either walk forgot is a compile error in that switch; what neither the
+ * language nor the compiler notices is this one handing over a different set, or the same set in a
+ * different order, or two children under one name. Each of those makes an address of a place either
+ * wrong or not an address at all — the third silently, since a path is a list of slots and a slot
+ * that stood for two children stands for neither.
+ *
+ * <p>Asked of the bodies the conformance corpora compile to, which is what the compiler is held to
+ * elsewhere, rather than of a model written to have one of everything. A model like that says what
+ * its author remembered to put in it.
+ */
+class EveryChildANodeHandsOverStandsInANamedSlotTest {
+
+    @Test
+    void theNamedSlotsAreTheChildrenTheNodeHandsOver() {
+        int nodes = 0;
+        for (Core body : bodies()) {
+            nodes += walk(body, node -> {
+                List<Core> named = CoreStructure.childrenOf(node).stream()
+                        .map(CoreStructure.Child::node).toList();
+                List<Core> handed = new ArrayList<>();
+                Core.forEachChild(node, handed::add);
+
+                assertEquals(handed.size(), named.size(),
+                        () -> node.getClass().getSimpleName() + " at " + node.pos()
+                                + " hands over " + handed.size() + " children and has "
+                                + named.size() + " named slots");
+                for (int i = 0; i < handed.size(); i++) {
+                    assertSame(handed.get(i), named.get(i),
+                            "the child in slot " + i + " of a "
+                                    + node.getClass().getSimpleName() + " at " + node.pos());
+                }
+            });
+        }
+        assertTrue(nodes > 0, "no body was walked at all, so this says nothing");
+    }
+
+    @Test
+    void noNodeHandsOverTwoChildrenUnderOneSlot() {
+        for (Core body : bodies()) {
+            walk(body, node -> {
+                List<CoreStructure.Child> children = CoreStructure.childrenOf(node);
+                Set<CoreStructure.Edge> slots = new LinkedHashSet<>();
+                children.forEach(child -> slots.add(child.edge()));
+                assertEquals(children.size(), slots.size(),
+                        () -> "a " + node.getClass().getSimpleName() + " at " + node.pos()
+                                + " puts two children in one slot: " + children.stream()
+                                        .map(CoreStructure.Child::edge).toList());
+            });
+        }
+    }
+
+    /**
+     * How much of the vocabulary the two above are about.
+     *
+     * <p>Both of them hold of whatever they meet, so what they are worth is which slots that is.
+     * Written down rather than counted, and written as what is met rather than as what ought to be:
+     * a slot nothing here reaches is not a fault, and a slot that stops being reached is something
+     * to look at. Either way the list moves and somebody reads it.
+     *
+     * <p>Five are not reached. {@code PreservedArgument} stands in no body that runs — a preserved
+     * call is what an analysis keeps and coverage numbering refuses one outright — so nothing that
+     * compiles will ever put one here. {@code TupleElement} and {@code TupleSource} are of a shape
+     * the models below do not write. {@code AppliedFunction} and {@code ApplyArgument} are for a
+     * function value that is applied through a binding rather than spliced, which is what the
+     * expansion these bodies go through leaves none of.
+     */
+    @Test
+    void theseAreTheSlotsTheModelsReach() {
+        Set<String> met = new TreeSet<>();
+        for (Core body : bodies()) {
+            walk(body, node -> CoreStructure.childrenOf(node)
+                    .forEach(child -> met.add(child.edge().getClass().getSimpleName())));
+        }
+
+        assertEquals(List.of("BinaryLeft", "BinaryRight", "BlockBody", "CallArgument",
+                        "ConstructedAttempt", "ConstructedElse", "ConstructedThen", "FieldTarget",
+                        "FieldValue", "IfCondition", "IfElse", "IfThen", "LetBody", "LetValue",
+                        "ListElement", "MatchCase", "MatchScrutinee", "NegOperand", "SomeValue"),
+                List.copyOf(met),
+                "which slots the models put something in, and so which slots the checks above are"
+                        + " about");
+    }
+
+    /** Applies {@code at} to every node of {@code body}, once per node however many ways there are
+     *  to it, and answers how many there were. */
+    private static int walk(Core body, java.util.function.Consumer<Core> at) {
+        Map<Core, Boolean> seen = new IdentityHashMap<>();
+        return walk(body, at, seen);
+    }
+
+    private static int walk(Core e, java.util.function.Consumer<Core> at, Map<Core, Boolean> seen) {
+        if (seen.put(e, Boolean.TRUE) != null) {
+            return 0;
+        }
+        at.accept(e);
+        int count = 1;
+        for (CoreStructure.Child child : CoreStructure.childrenOf(e)) {
+            count += walk(child.node(), at, seen);
+        }
+        return count;
+    }
+
+    private static final String BESIDE_THE_CORPORA = """
+            module demo
+
+            data Warm = Int invariant hot = value >= 240
+            data Low
+            data Box = { held: Int }
+
+            let picked (n: Int): List<Int> = [ n | n >= 240, n <= 300 ]
+
+            behavior attempt : (t: Int) -> Warm | Low
+                constructs Warm
+            let attempt (t) = if Warm(t) as w then w else Low
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a) ++ picked(b)
+
+            behavior negated : (n: Int) -> Int
+            let negated (n) = -n + 1
+
+            behavior boxed : (n: Int) -> Box
+                constructs Box
+            let boxed (n) = Box { held = n }
+
+            behavior listed : (n: Int) -> List<Int>
+            let listed (n) = [ n, n + 1 ]
+
+            behavior kept : (xs: List<Int>) -> List<Int>
+            let kept (xs) = List.filter(x -> x >= 240, xs)
+
+            data Held = { at: Int? }
+
+            behavior optional : (n: Int) -> Held
+                constructs Held
+            let optional (n) = Held { at = n }
+            """;
+
+    /** Every behavior body the conformance corpora compile to, and one model beside them. */
+    private static List<Core> bodies() {
+        List<Core> out = new ArrayList<>();
+        List<List<String>> sources = new ArrayList<>();
+        ConformanceCorpus.all().forEach(corpus -> sources.add(corpus.sources()));
+        sources.add(List.of(BESIDE_THE_CORPORA));
+        for (List<String> each : sources) {
+            Compilation compilation = Compilation.ofSources(each, ModulePath.EMPTY);
+            compilation.answerEverything();
+            int before = out.size();
+            for (String module : compilation.modules()) {
+                Bodies.Elaborated checked =
+                        compilation.db().ask(new Bodies.Checked(module)).value();
+                if (checked != null) {
+                    out.addAll(checked.behaviorBodies().values());
+                }
+            }
+            // A source set that did not check contributes nothing, and would leave everything below
+            // saying less than it says it does while staying green. Refused rather than skipped.
+            assertTrue(out.size() > before,
+                    () -> "a source set compiled to no body at all: " + compilation.errors());
+        }
+        assertFalse(out.isEmpty(), "no corpus compiled, so nothing below says anything");
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
@@ -1,0 +1,195 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.core.Core;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every name a body reads is bound at a place this can point at, and the same place in two compiles
+ * of one source.
+ *
+ * <p>What {@link BinderAddress} is for. A {@code BindingId} says a binder and its reads are one
+ * thing, which is what the passes need; what it is made of is an owner and a count, and an expansion
+ * owns the copies it makes and numbers them as it makes them. So a reading of a body that carried
+ * the id would move when nothing about the body did, and a reading that dropped it could not say
+ * which of two names a read meant.
+ *
+ * <p><b>The refusal is the point of the third arm not existing.</b> A read this cannot place is a
+ * body reading a name nothing in sight binds. If that happens, what a reader of these addresses
+ * wants is to be told, not to be handed a place that was invented for the occasion — so it throws,
+ * and this is where the corpus says whether it ever has to.
+ */
+class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
+
+    private static final String SPLICED = """
+            module demo
+
+            let picked (n: Int, cap: Int): List<Int> = {
+                let ceiling = cap + 1
+                [ n | n >= 240, n <= ceiling ]
+            }
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a, b) ++ picked(b, a)
+            """;
+
+    private static final String BINDING_SHAPES = """
+            module demo
+
+            data Warm = Int invariant hot = value >= 240
+            data Low
+            data UnderThirty
+            data ThirtyOrOver
+            data Band = UnderThirty | ThirtyOrOver
+
+            behavior attempt : (t: Int) -> Warm | Low
+                constructs Warm
+            let attempt (t) = if Warm(t) as w then w else Low
+
+            behavior matched : (band: Band) -> Int
+            let matched (band) =
+                match band with
+                    | UnderThirty -> 1
+                    | ThirtyOrOver -> 2
+
+            behavior kept : (xs: List<Int>) -> List<Int>
+            let kept (xs) = List.filter(x -> x >= 240, xs)
+            """;
+
+    @Test
+    void everyReadIsPlaced() {
+        Set<String> arms = new LinkedHashSet<>();
+        int reads = 0;
+        for (Body body : everyBody()) {
+            NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
+            Binders binders = Binders.of(body.behavior(), body.body(), places);
+            for (Core.Read read : readsIn(body.body())) {
+                if (read.binding() == null) {
+                    continue;
+                }
+                reads++;
+                arms.add(binders.at(read.binding()).getClass().getSimpleName());
+            }
+        }
+
+        assertTrue(reads > 0, "no name was read at all, so this says nothing");
+        assertEquals(Set.of("Local", "Parameter"), arms,
+                "both ways of being bound are met, so neither arm is here on a guess");
+    }
+
+    /** And a binder that moved only because a copy was numbered differently is at the same
+     *  place. */
+    @Test
+    void twoCompilationsPlaceTheSameNamesAtTheSamePlaces() {
+        for (String source : List.of(SPLICED, BINDING_SHAPES)) {
+            assertEquals(placementsIn(source), placementsIn(source),
+                    "where a body's names are bound does not move between two compiles of it");
+        }
+    }
+
+    /**
+     * The two splices of one helper bind their names at two places.
+     *
+     * <p>Which is the whole of what the id could not say: the copies are equal trees, so their
+     * binders are alike in everything but where they stand, and the compiler tells them apart by
+     * having numbered them as it made them.
+     *
+     * <p>Three names apiece and not one, the arguments being bound where the call was spliced: the
+     * helper's two parameters and the {@code let} it writes. They stand one inside the next, so
+     * what tells the three of one copy apart is how far down each is, and what tells a copy from
+     * its twin is which side of the {@code ++} it was spliced into.
+     */
+    @Test
+    void aSplicedHelpersNamesAreBoundOncePerSplice() {
+        List<String> lets = placementsIn(SPLICED).stream()
+                .filter(each -> each.endsWith(".let"))
+                .sorted().toList();
+
+        assertEquals(List.of(
+                        "over/BinaryLeft.let",
+                        "over/BinaryLeft/LetBody.let",
+                        "over/BinaryLeft/LetBody/LetBody.let",
+                        "over/BinaryRight.let",
+                        "over/BinaryRight/LetBody.let",
+                        "over/BinaryRight/LetBody/LetBody.let"),
+                lets,
+                "the helper's names, bound once per splice");
+    }
+
+    private static Set<String> placementsIn(String source) {
+        Set<String> out = new LinkedHashSet<>();
+        for (Body body : bodiesOf(List.of(List.of(source)))) {
+            NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
+            Binders binders = Binders.of(body.behavior(), body.body(), places);
+            for (Core.Read read : readsIn(body.body())) {
+                if (read.binding() != null) {
+                    out.add(binders.at(read.binding()).toString());
+                }
+            }
+        }
+        return out;
+    }
+
+    private static List<Core.Read> readsIn(Core body) {
+        List<Core.Read> out = new ArrayList<>();
+        walk(body, new IdentityHashMap<>(), node -> {
+            if (node instanceof Core.Read read) {
+                out.add(read);
+            }
+        });
+        return out;
+    }
+
+    private static void walk(Core e, Map<Core, Boolean> seen,
+                             java.util.function.Consumer<Core> at) {
+        if (seen.put(e, Boolean.TRUE) != null) {
+            return;
+        }
+        at.accept(e);
+        CoreStructure.childrenOf(e).forEach(child -> walk(child.node(), seen, at));
+    }
+
+    private record Body(String module, String behavior, Core body) {}
+
+    private static List<Body> everyBody() {
+        List<List<String>> sources = new ArrayList<>();
+        ConformanceCorpus.all().forEach(corpus -> sources.add(corpus.sources()));
+        sources.add(List.of(SPLICED));
+        sources.add(List.of(BINDING_SHAPES));
+        return bodiesOf(sources);
+    }
+
+    private static List<Body> bodiesOf(List<List<String>> sources) {
+        List<Body> out = new ArrayList<>();
+        for (List<String> each : sources) {
+            Compilation compilation = Compilation.ofSources(each, ModulePath.EMPTY);
+            compilation.answerEverything();
+            int before = out.size();
+            for (String module : compilation.modules()) {
+                Bodies.Elaborated checked =
+                        compilation.db().ask(new Bodies.Checked(module)).value();
+                if (checked != null) {
+                    checked.behaviorBodies().forEach((behavior, body) ->
+                            out.add(new Body(module, behavior, body)));
+                }
+            }
+            assertTrue(out.size() > before,
+                    () -> "a source set compiled to no body at all: " + compilation.errors());
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -76,7 +77,7 @@ class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
         int reads = 0;
         for (Body body : everyBody()) {
             NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
-            Binders binders = Binders.of(body.behavior(), body.body(), places);
+            Binders binders = Binders.of(places);
             for (Core.Read read : readsIn(body.body())) {
                 if (read.binding() == null) {
                     continue;
@@ -134,7 +135,7 @@ class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
         Set<String> out = new LinkedHashSet<>();
         for (Body body : bodiesOf(List.of(List.of(source)))) {
             NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
-            Binders binders = Binders.of(body.behavior(), body.body(), places);
+            Binders binders = Binders.of(places);
             for (Core.Read read : readsIn(body.body())) {
                 if (read.binding() != null) {
                     out.add(binders.at(read.binding()).toString());
@@ -155,7 +156,7 @@ class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
     }
 
     private static void walk(Core e, Map<Core, Boolean> seen,
-                             java.util.function.Consumer<Core> at) {
+                             Consumer<Core> at) {
         if (seen.put(e, Boolean.TRUE) != null) {
             return;
         }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -77,11 +78,14 @@ class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
         int reads = 0;
         for (Body body : everyBody()) {
             NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
-            Binders binders = Binders.of(places);
+            Binders binders = Binders.of(body.module(), places);
             for (Core.Read read : readsIn(body.body())) {
-                if (read.binding() == null) {
-                    continue;
-                }
+                // Refused rather than passed over. A name with nothing bound to it is a body that
+                // does not run, and what this is about is that every name has a place — so a read
+                // without one is this saying less than it says it does, not a shape to skip.
+                assertNotNull(read.binding(),
+                        () -> "`" + body.behavior() + "` reads `" + read.name() + "` at "
+                                + read.pos() + ", which nothing bound");
                 reads++;
                 arms.add(binders.at(read.binding()).getClass().getSimpleName());
             }
@@ -135,11 +139,9 @@ class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
         Set<String> out = new LinkedHashSet<>();
         for (Body body : bodiesOf(List.of(List.of(source)))) {
             NodeAddresses places = NodeAddresses.of(body.behavior(), body.body());
-            Binders binders = Binders.of(places);
+            Binders binders = Binders.of(body.module(), places);
             for (Core.Read read : readsIn(body.body())) {
-                if (read.binding() != null) {
-                    out.add(binders.at(read.binding()).toString());
-                }
+                out.add(binders.at(read.binding()).toString());
             }
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/coverage/TwoNumberingsOfOneModuleAreOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/TwoNumberingsOfOneModuleAreOneTest.java
@@ -1,0 +1,166 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * When two numberings of one module are one, and when they are two.
+ *
+ * <p>What everything else here is for. A run is recorded in bare numbers; a number means a place
+ * only under the numbering that handed it out; so a measure reading a recording is answering about
+ * the places that recording is of, or about other places and saying nothing either way. The parts
+ * are held on their own — where a place is, what a body does, where a name is bound — and this is
+ * the whole of them: the answer a reader would act on.
+ *
+ * <p>Written as the two directions together, because either alone is easy and wrong. Called equal
+ * whenever the source is the same, a numbering says nothing and refuses nothing; called equal only
+ * for the very same construction, it refuses every recomputation and the store recomputes.
+ */
+class TwoNumberingsOfOneModuleAreOneTest {
+
+    private static final String MODEL = """
+            module demo
+
+            let picked (n: Int, cap: Int): List<Int> = [ n | n >= 240, n <= cap ]
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a, b) ++ picked(b, a)
+
+            behavior graded : (n: Int) -> Int
+            let graded (n) = if n >= 1 then 1 else 2
+            """;
+
+    /** The same model with a blank line above it and a comment in it: the same bodies, written
+     *  further down the file. */
+    private static final String MOVED = "\n// a note the author left\n" + MODEL;
+
+    /** The same bodies with a declaration above them, so the module counts its constructs from
+     *  somewhere else. */
+    private static final String AFTER_ANOTHER = MODEL.replace(
+            "behavior over :",
+            """
+            behavior first : (n: Int) -> Int
+            let first (n) = if n >= 9 then 1 else 2
+
+            behavior over :""");
+
+    /** The same two behaviors, declared the other way round: the same bodies, numbered from the
+     *  other end. */
+    private static final String DECLARED_THE_OTHER_WAY = """
+            module demo
+
+            let picked (n: Int, cap: Int): List<Int> = [ n | n >= 240, n <= cap ]
+
+            behavior graded : (n: Int) -> Int
+            let graded (n) = if n >= 1 then 1 else 2
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a, b) ++ picked(b, a)
+            """;
+
+    /** Two comparisons, the other way round. The same places and the same shapes: what differs is
+     *  which comparison stands at which of them. */
+    private static final String A_THEN_B = """
+            module demo
+
+            behavior f : (a: Int, b: Int) -> Int
+            let f (a, b) = if a >= 1 && b >= 2 then 1 else 2
+            """;
+
+    private static final String B_THEN_A = A_THEN_B.replace(
+            "if a >= 1 && b >= 2", "if b >= 2 && a >= 1");
+
+    // --- one numbering ------------------------------------------------------------------------
+
+    @Test
+    void aNumberingIsTheOneAnotherWalkOfTheSameBodiesComesTo() {
+        assertEquals(numberingOf(MODEL), numberingOf(MODEL),
+                "two compiles of one source number its bodies alike");
+    }
+
+    @Test
+    void andItDoesNotMoveWhenTheSourceMovesUnderIt() {
+        assertEquals(numberingOf(MODEL), numberingOf(MOVED),
+                "a blank line and a comment above the bodies leave what they do and where their"
+                        + " places are alone");
+    }
+
+    @Test
+    void norWhenTheModuleCountsItsConstructsFromSomewhereElse() {
+        NumberingIdentity plain = numberingOf(MODEL);
+        NumberingIdentity behind = numberingOf(AFTER_ANOTHER);
+
+        assertEquals(plain.executable().get("over"), behind.executable().get("over"),
+                "a declaration above them does not change what the bodies below it do");
+        assertEquals(plain.executable().get("graded"), behind.executable().get("graded"),
+                "and the same of the other one");
+    }
+
+    // --- two numberings -----------------------------------------------------------------------
+
+    @Test
+    void twoBodiesThatCompareTheOtherWayAreTwoNumberings() {
+        assertNotEquals(numberingOf(A_THEN_B), numberingOf(B_THEN_A),
+                "the same places, with the other comparison standing at each of them");
+    }
+
+    /**
+     * And declaring the behaviors the other way round is two numberings.
+     *
+     * <p>What the two halves are for, one each. The bodies do the same things, so the executable
+     * half is equal and says nothing; what moved is which number went to which place, and the
+     * addresses say so. A numbering that held only what the bodies do would call these one and let
+     * a recording of the first be read under the second.
+     */
+    @Test
+    void andSoIsNumberingThemFromTheOtherEnd() {
+        NumberingIdentity one = numberingOf(MODEL);
+        NumberingIdentity other = numberingOf(DECLARED_THE_OTHER_WAY);
+
+        assertEquals(one.executable(), other.executable(),
+                "the bodies do the same things whichever order they are declared in");
+        assertNotEquals(one.byNumber(), other.byNumber(),
+                "and the numbers went to other places");
+        assertNotEquals(one, other, "so it is another numbering");
+    }
+
+    /** And a number is an address of an arm or of a comparison, never of both. */
+    @Test
+    void eachNumberIsAnAddressOfOneOrTheOther() {
+        NumberingIdentity numbering = numberingOf(MODEL);
+        Map<String, Integer> byFamily = new LinkedHashMap<>();
+        for (int n = 0; n < numbering.byNumber().size(); n++) {
+            byFamily.merge(numbering.at(n).getClass().getSimpleName(), 1, Integer::sum);
+        }
+
+        assertTrue(byFamily.containsKey("Arm") && byFamily.containsKey("Comparison"),
+                () -> "both families are handed numbers out of the one counter: " + byFamily);
+    }
+
+    private static NumberingIdentity numberingOf(String source) {
+        Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked =
+                compilation.db().ask(new Bodies.Checked(module)).value();
+        assertTrue(checked != null,
+                () -> "the model under test compiled to nothing: " + compilation.errors());
+        SequencedMap<String, Core> bodies = new LinkedHashMap<>(checked.behaviorBodies());
+        return CoverageSites.of(new ModuleBodies(module, bodies),
+                        checked.decisions(), checked.supplied())
+                .identity();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/TwoWalksOfOneBodyNameItsPlacesAlikeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/TwoWalksOfOneBodyNameItsPlacesAlikeTest.java
@@ -1,0 +1,172 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.core.Core;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A place in a body is named by the way down to it, so two walks of that body name it alike and no
+ * two places take one name.
+ *
+ * <p>The two halves an address has to have. If two places could take one name, a number filed under
+ * that name is about neither of them; if one place took two names in two walks, nothing said of it
+ * by one walk reaches the other. Node identity has the first and not the second — it is what a
+ * numbering used, and it is why two numberings of one module could never be held against each
+ * other.
+ *
+ * <p>Asked of trees this compiler produced rather than of trees written here. What an address has to
+ * survive is expansion and lowering: a helper spliced into two calls is two places that look alike
+ * and stand in different slots, and that is the case the whole thing is for.
+ */
+class TwoWalksOfOneBodyNameItsPlacesAlikeTest {
+
+    /** A helper spliced twice, so two places are equal trees standing in different slots. */
+    private static final String SPLICED = """
+            module demo
+
+            let picked (n: Int): List<Int> = [ n | n >= 240, n <= 300 ]
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a) ++ picked(b)
+            """;
+
+    private static final String NESTED = """
+            module demo
+
+            let inner (n: Int): List<Int> = [ n | n >= 240 ]
+
+            let outer (n: Int): List<Int> = inner(n) ++ inner(n)
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = outer(a) ++ outer(b)
+            """;
+
+    @Test
+    void noTwoPlacesOfOneBodyTakeOneName() {
+        int places = 0;
+        for (Map.Entry<String, Core> body : everyBody()) {
+            NodeAddresses addresses = NodeAddresses.of(body.getKey(), body.getValue());
+            Map<NodeAddress, Core> byName = new LinkedHashMap<>();
+            for (Map.Entry<Core, NodeAddress> each : addresses.all().entrySet()) {
+                Core already = byName.put(each.getValue(), each.getKey());
+                assertEquals(null, already,
+                        () -> "two places of `" + body.getKey() + "` are called "
+                                + each.getValue());
+            }
+            places += addresses.size();
+        }
+        assertTrue(places > 0, "no body was walked at all, so this says nothing");
+    }
+
+    @Test
+    void twoCompilationsOfOneSourceNameItsPlacesAlike() {
+        for (String source : List.of(SPLICED, NESTED)) {
+            assertEquals(namesIn(source), namesIn(source),
+                    "the places of a body do not move between two compiles of its source");
+        }
+    }
+
+    /**
+     * A helper spliced twice is two places, and the addresses say which slot each stands in.
+     *
+     * <p>The case node identity had and a citation did not: the copies are equal trees written at
+     * one line, so what tells them apart is the way down to each. Here that is the left and the
+     * right of the {@code ++} they were spliced into.
+     */
+    @Test
+    void aSplicedHelperIsAsManyPlacesAsItWasSplicedInto() {
+        List<String> conditions = namesIn(SPLICED).stream()
+                .filter(each -> each.endsWith("/IfCondition"))
+                .sorted().toList();
+
+        assertEquals(List.of(
+                        "over/BinaryLeft/LetBody/IfCondition",
+                        "over/BinaryLeft/LetBody/IfThen/IfCondition",
+                        "over/BinaryRight/LetBody/IfCondition",
+                        "over/BinaryRight/LetBody/IfThen/IfCondition"),
+                conditions,
+                "two guards of one comprehension, spliced into each side of the `++`");
+    }
+
+    /**
+     * How many ways lead to a place, over everything walked here.
+     *
+     * <p>What says whether the set an address holds is a set for a reason. A tree gives one way to
+     * each place; a pass that shared a subtree gives several, and the count is what the sharing
+     * actually is rather than what a reader guesses it might be. Written down because an address
+     * holding every way is only worth the trouble while there are places with more than one.
+     */
+    @Test
+    void theseAreTheWaysThatLeadToAPlace() {
+        Map<Integer, Integer> byWays = new TreeMap<>();
+        for (Map.Entry<String, Core> body : everyBody()) {
+            NodeAddresses addresses = NodeAddresses.of(body.getKey(), body.getValue());
+            addresses.all().values()
+                    .forEach(at -> byWays.merge(at.occurrences().size(), 1, Integer::sum));
+        }
+
+        // The claim is that sharing happens at all, not how much of it there is: the count moves
+        // with whatever the corpora are and with what the passes above leave shared, and pinning it
+        // would make this a test of the corpora. What it must not become is a body where every
+        // place has one way, because then a set is holding one thing everywhere and nothing here
+        // says whether it needed to.
+        assertTrue(byWays.keySet().stream().anyMatch(ways -> ways > 1),
+                () -> "no place has more than one way to it, so nothing here shows why an address"
+                        + " holds a set of them: " + byWays);
+        assertEquals(1, byWays.keySet().stream().mapToInt(Integer::intValue).min().orElse(0),
+                () -> "and most places have exactly one: " + byWays);
+    }
+
+    /** The addresses of every place of every body of {@code source}, as text, from a fresh
+     *  compile. */
+    private static Set<String> namesIn(String source) {
+        Set<String> out = new LinkedHashSet<>();
+        for (Map.Entry<String, Core> body : bodiesOf(List.of(List.of(source)))) {
+            NodeAddresses.of(body.getKey(), body.getValue()).all().values()
+                    .forEach(at -> out.add(at.toString()));
+        }
+        return out;
+    }
+
+    private static List<Map.Entry<String, Core>> everyBody() {
+        List<List<String>> sources = new ArrayList<>();
+        ConformanceCorpus.all().forEach(corpus -> sources.add(corpus.sources()));
+        sources.add(List.of(SPLICED));
+        sources.add(List.of(NESTED));
+        return bodiesOf(sources);
+    }
+
+    private static List<Map.Entry<String, Core>> bodiesOf(List<List<String>> sources) {
+        List<Map.Entry<String, Core>> out = new ArrayList<>();
+        for (List<String> each : sources) {
+            Compilation compilation = Compilation.ofSources(each, ModulePath.EMPTY);
+            compilation.answerEverything();
+            int before = out.size();
+            for (String module : compilation.modules()) {
+                Bodies.Elaborated checked =
+                        compilation.db().ask(new Bodies.Checked(module)).value();
+                if (checked != null) {
+                    out.addAll(checked.behaviorBodies().entrySet());
+                }
+            }
+            assertTrue(out.size() > before,
+                    () -> "a source set compiled to no body at all: " + compilation.errors());
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
@@ -132,7 +132,8 @@ class WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest {
     // --- the fixture ------------------------------------------------------------------------
 
     private static ExecutableIdentity identityOf(String module, String behavior, Core body) {
-        return ExecutableIdentity.of(body, Binders.of(NodeAddresses.of(behavior, body)));
+        return ExecutableIdentity.of(body,
+                Binders.of(module, NodeAddresses.of(behavior, body)));
     }
 
     private static List<ExecutableIdentity> identitiesOf(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -131,8 +132,7 @@ class WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest {
     // --- the fixture ------------------------------------------------------------------------
 
     private static ExecutableIdentity identityOf(String module, String behavior, Core body) {
-        return ExecutableIdentity.of(body,
-                Binders.of(behavior, body, NodeAddresses.of(behavior, body)));
+        return ExecutableIdentity.of(body, Binders.of(NodeAddresses.of(behavior, body)));
     }
 
     private static List<ExecutableIdentity> identitiesOf(String source) {
@@ -166,7 +166,7 @@ class WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest {
         };
     }
 
-    private static void binders(Core e, java.util.function.Consumer<Core.Binder> at) {
+    private static void binders(Core e, Consumer<Core.Binder> at) {
         switch (e) {
             case Core.LetIn it -> at.accept(it.binder());
             case Core.Block it -> it.params().forEach(at);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest.java
@@ -1,0 +1,238 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Re-issuing the numbers the compiler minted for a body's names leaves what the body does alone.
+ *
+ * <p>The one thing {@link ExecutableIdentity} exists to be. A {@code BindingId} is an owner and a
+ * count over that owner's bindings, and both are minted while the body is being built: an expansion
+ * owns each copy it makes and numbers copies in the order it makes them. So a reading that carried
+ * them would say two builds of one source built different things as soon as the inliner allocated
+ * differently — which is the dependency the whole of this is moving off, not a dependency to move
+ * one level down.
+ *
+ * <p>So the numbers are re-issued here and the answer must not move. Done to the bindings a body
+ * binds, which are the ones minted: a parameter is bound by the signature, in the order it was
+ * written, and moving one of those is a different body — which the last test below is.
+ *
+ * <p>The rewrite is a fixture and not a pass. What it does to the tree is what a differently
+ * allocating inliner would have left, and nothing downstream sees it.
+ */
+class WhatABodyDoesDoesNotMoveWithTheNumbersMintedForItsNamesTest {
+
+    private static final String SPLICED = """
+            module demo
+
+            let picked (n: Int, cap: Int): List<Int> = {
+                let ceiling = cap + 1
+                [ n | n >= 240, n <= ceiling ]
+            }
+
+            behavior over : (a: Int, b: Int) -> List<Int>
+            let over (a, b) = picked(a, b) ++ picked(b, a)
+            """;
+
+    private static final String SHAPES = """
+            module demo
+
+            data Warm = Int invariant hot = value >= 240
+            data Low
+            data UnderThirty
+            data ThirtyOrOver
+            data Band = UnderThirty | ThirtyOrOver
+
+            behavior attempt : (t: Int) -> Warm | Low
+                constructs Warm
+            let attempt (t) = if Warm(t) as w then w else Low
+
+            behavior matched : (band: Band, n: Int) -> Int
+            let matched (band, n) =
+                match band with
+                    | UnderThirty -> n + 1
+                    | ThirtyOrOver -> n + 2
+
+            behavior kept : (xs: List<Int>) -> List<Int>
+            let kept (xs) = List.filter(x -> x >= 240, xs)
+            """;
+
+    @Test
+    void reIssuingTheNumbersMintedForABodysNamesLeavesWhatItDoesAlone() {
+        int reIssued = 0;
+        for (String source : List.of(SPLICED, SHAPES)) {
+            for (Body body : bodiesOf(source)) {
+                // A body that binds nothing has nothing to re-issue and is still a body this holds
+                // of. What would make the whole of it say nothing is no body binding anything,
+                // which is counted below rather than demanded of each.
+                Map<BindingId, BindingId> again = reIssued(body.body());
+                Core moved = renamed(body.body(), again);
+
+                assertEquals(identityOf(body.module(), body.behavior(), body.body()),
+                        identityOf(body.module(), body.behavior(), moved),
+                        () -> "what `" + body.behavior() + "` does, after its names were minted"
+                                + " again");
+                reIssued += again.size();
+            }
+        }
+        assertTrue(reIssued > 0, "no name was re-issued at all, so this says nothing");
+    }
+
+    /** And two compiles of one source, which is the same claim about the ordinary route. */
+    @Test
+    void twoCompilesOfOneSourceDoTheSameThing() {
+        for (String source : List.of(SPLICED, SHAPES)) {
+            assertEquals(identitiesOf(source), identitiesOf(source),
+                    "what a source's bodies do does not move between two compiles of it");
+        }
+    }
+
+    /**
+     * And it is not equality on everything: a body reading another parameter does another thing.
+     *
+     * <p>The control the test above needs. Re-issuing a name leaves the answer alone because a name
+     * is written as where it is bound; a parameter is bound by the signature at the place the
+     * signature put it, so reading the second where the first was read is a different body — and an
+     * identity that shrugged at that would shrug at the rest.
+     */
+    @Test
+    void aBodyThatReadsAnotherParameterDoesAnotherThing() {
+        Body matched = bodiesOf(SHAPES).stream()
+                .filter(each -> each.behavior().equals("matched")).findFirst().orElse(null);
+        assertNotNull(matched, "the model under test has the behavior this is about");
+
+        BindingOwner.OfValue signature = new BindingOwner.OfValue(matched.module(), "matched");
+        Map<BindingId, BindingId> swapped = new LinkedHashMap<>();
+        swapped.put(new BindingId(signature, 0), new BindingId(signature, 1));
+        swapped.put(new BindingId(signature, 1), new BindingId(signature, 0));
+
+        assertNotEquals(identityOf(matched.module(), matched.behavior(), matched.body()),
+                identityOf(matched.module(), matched.behavior(),
+                        renamed(matched.body(), swapped)),
+                "a body reading its other parameter is not the body that reads this one");
+    }
+
+    // --- the fixture ------------------------------------------------------------------------
+
+    private static ExecutableIdentity identityOf(String module, String behavior, Core body) {
+        return ExecutableIdentity.of(body,
+                Binders.of(behavior, body, NodeAddresses.of(behavior, body)));
+    }
+
+    private static List<ExecutableIdentity> identitiesOf(String source) {
+        List<ExecutableIdentity> out = new ArrayList<>();
+        bodiesOf(source).forEach(body ->
+                out.add(identityOf(body.module(), body.behavior(), body.body())));
+        return out;
+    }
+
+    /** A new number for every name {@code body} binds, of a new copy as well as a new count — which
+     *  is what an inliner that had allocated differently would have left. */
+    private static Map<BindingId, BindingId> reIssued(Core body) {
+        Map<BindingId, BindingId> out = new LinkedHashMap<>();
+        binders(body, binder -> {
+            if (binder != null && binder.binding() != null) {
+                out.computeIfAbsent(binder.binding(),
+                        id -> new BindingId(elsewhere(id.owner()), id.ordinal() + 500));
+            }
+        });
+        return out;
+    }
+
+    /** The same owner, minted at another point in a run that made the copies in another order. */
+    private static BindingOwner elsewhere(BindingOwner owner) {
+        return switch (owner) {
+            case BindingOwner.Expansion it ->
+                    new BindingOwner.Expansion(it.within(), it.expanded(), it.ordinal() + 500);
+            case BindingOwner.Synthesized it ->
+                    new BindingOwner.Synthesized(it.within(), it.pass(), it.ordinal() + 500);
+            default -> owner;
+        };
+    }
+
+    private static void binders(Core e, java.util.function.Consumer<Core.Binder> at) {
+        switch (e) {
+            case Core.LetIn it -> at.accept(it.binder());
+            case Core.Block it -> it.params().forEach(at);
+            case Core.Match it -> it.cases().forEach(one -> at.accept(one.binder()));
+            case Core.IfConstructed it -> at.accept(it.binder());
+            default -> { }
+        }
+        CoreStructure.childrenOf(e).forEach(child -> binders(child.node(), at));
+    }
+
+    /** {@code e} with every binding {@code subst} names replaced, binders and reads alike. */
+    private static Core renamed(Core e, Map<BindingId, BindingId> subst) {
+        Core rebuilt = Core.mapAll(e,
+                child -> renamed(child, subst),
+                read -> (Core.Read) renamedHere(read, subst));
+        return renamedHere(rebuilt, subst);
+    }
+
+    /** The node's own bindings, the children having been done already. */
+    private static Core renamedHere(Core e, Map<BindingId, BindingId> subst) {
+        return switch (e) {
+            case Core.Read it -> new Core.Read(it.name(), moved(it.binding(), subst), it.type(),
+                    it.pos());
+            case Core.LetIn it -> new Core.LetIn(moved(it.binder(), subst), it.value(), it.body(),
+                    it.type(), it.pos());
+            case Core.Block it -> new Core.Block(
+                    it.params().stream().map(each -> moved(each, subst)).toList(),
+                    it.body(), it.type(), it.pos());
+            case Core.IfConstructed it -> new Core.IfConstructed(it.construct(),
+                    moved(it.binder(), subst), it.then(), it.els(), it.origin(), it.type(),
+                    it.pos(), it.expansion());
+            case Core.Match it -> new Core.Match(it.scrutinee(),
+                    it.cases().stream()
+                            .map(one -> new Core.Case(one.pattern(), moved(one.binder(), subst),
+                                    one.body(), one.pos()))
+                            .toList(),
+                    it.origin(), it.type(), it.pos(), it.expansion());
+            default -> e;
+        };
+    }
+
+    private static Core.Binder moved(Core.Binder binder, Map<BindingId, BindingId> subst) {
+        return binder == null ? null
+                : new Core.Binder(binder.name(), moved(binder.binding(), subst));
+    }
+
+    private static BindingId moved(BindingId id, Map<BindingId, BindingId> subst) {
+        return id == null ? null : subst.getOrDefault(id, id);
+    }
+
+    private record Body(String module, String behavior, Core body) {}
+
+    private static List<Body> bodiesOf(String source) {
+        Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        List<Body> out = new ArrayList<>();
+        for (String module : compilation.modules()) {
+            Bodies.Elaborated checked =
+                    compilation.db().ask(new Bodies.Checked(module)).value();
+            if (checked != null) {
+                checked.behaviorBodies().forEach((behavior, body) ->
+                        out.add(new Body(module, behavior, body)));
+            }
+        }
+        assertTrue(!out.isEmpty(),
+                () -> "the model under test compiled to nothing: " + compilation.errors());
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.codegen.Backend;
 import souther.compiler.codegen.Instrumentation;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.NumberingIdentity;
+import souther.compiler.coverage.SiteAddress;
 
 import java.util.List;
 
@@ -99,15 +101,21 @@ class ProbeMappingTest {
         CoverageSites.Plan real = checkedPlanOf(emitting, module);
         assertTrue(real.sites().size() > 0);
 
-        // The same plan with one more arm in it than any body will emit.
+        // The same plan with one more arm in it than any body will emit. The numbering says what
+        // each number it handed out addresses, so the extra number is given an address too: a plan
+        // whose sites and addresses disagree is refused where it is built, and what is under test
+        // here is what the emitter does with an arm no body has.
         CoverageSites.Site extra = real.sites().get(0);
         List<CoverageSites.Site> longer = new java.util.ArrayList<>(real.sites());
         longer.add(new CoverageSites.Site(extra.behavior(), extra.outcome(), extra.at(),
                 real.sites().size(), real.sites().size(), extra.obligation()));
+        List<SiteAddress> addressed = new java.util.ArrayList<>(real.identity().byNumber());
+        addressed.add(real.identity().at(0));
         CoverageSites.Plan overcounted =
                 new CoverageSites.Plan(longer, real.guards(), real.byNode(), real.byComparison(),
                         real.armsByNode(), real.controlByComparison(), real.mayRepeat(),
-                        real.forkByNode(), real.comparisons(), real.identity());
+                        real.forkByNode(), real.comparisons(),
+                        new NumberingIdentity(module, real.identity().executable(), addressed));
 
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(),

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -107,7 +107,7 @@ class ProbeMappingTest {
         CoverageSites.Plan overcounted =
                 new CoverageSites.Plan(longer, real.guards(), real.byNode(), real.byComparison(),
                         real.armsByNode(), real.controlByComparison(), real.mayRepeat(),
-                        real.forkByNode(), real.comparisons());
+                        real.forkByNode(), real.comparisons(), real.identity());
 
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(),

--- a/souther-compiler/src/test/java/souther/compiler/reading/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
@@ -170,7 +170,7 @@ class AGroupIsOnlyOfferedWhereARunPassesItOnceTest {
             };
             return new CoverageSites.Plan(plan.sites(), plan.guards(), plan.byNode(),
                     plan.byComparison(), plan.armsByNode(), plan.controlByComparison(),
-                    everywhere, plan.forkByNode(), plan.comparisons());
+                    everywhere, plan.forkByNode(), plan.comparisons(), plan.identity());
         }
     }
 }


### PR DESCRIPTION
Toward #1282, after #1293. Nothing reads what this adds; the readers are the
steps after it.

## What a numbering has to be, to be held against another one

A run is recorded in bare numbers, and a number means a place only under the
numbering that handed it out. The javadoc on `CoverageSites` asks the walk to
be a function of the bodies for exactly this reason — the emitter builds one
plan, a measurement builds another, and a probe means nothing otherwise — and
that is a property the plan is asked to have, with nothing anywhere that
compares two.

Neither of the obvious identities is the one wanted. A token minted per
construction calls one numbering two, and the store recomputes. A digest of
the inputs moves the trust one step and leaves it standing: that the walk is
a function of the bodies is the very thing being taken on trust.

So a numbering says what each number is an address of, and what the code at
those addresses does.

## A place is the way down to it

What addressed a place was the object standing at it. That tells a place from
every other place while a walk holds the tree, and tells a second walk
nothing — which is why two numberings could never be compared.

A place is now the slots gone through from the body's root. A helper spliced
into two calls stands under two different slots and is two places by this; it
was two objects and, measured, one citation. `CoreStructure` is where the
slots are named, and it is the only place that says which slots a node has:
the numbering walk now takes them from it a slot at a time, saying which it
is taking and what it believes is in it, and is held to having taken all of
them. Swapping the sides of a comparison and forgetting an arm were both put
in, and both refused.

## And what the code at those places does

Two numberings addressing the same places in bodies that do different things
are not two views of one measurement. `ExecutableIdentity` is that half,
written with what the compiler minted while building the body taken out:
positions, the ordinal a module counts its constructs by, which copy of a
body a fork stands in, and the numbers minted for names. A name is written as
the place it is bound at, so re-issuing every one of those — a fresh copy and
a fresh count, which is what a differently allocating inliner leaves — does
not move the answer. Reading another parameter does, which is the control
beside it.

A type left open is refused rather than normalised. Measured first: no body
the corpora compile to holds a metavariable or an inferred variable anywhere
a walk reaches, so there is nothing to stand in for and standing in would
compare two bodies on a name this compile invented.

## What this deliberately leaves alone

`Plan` carries the answer and goes on keying its own lookups by node
identity. That is what the emitter wants — it reaches into the tree it is
walking for *this* node, not an equal one — and it is not what crosses
between two builds. The two are different questions and stay two values.

`NumberingIdentity` is read by nothing yet.
