### PR TITLE
A place is a value of the numbering that issued it

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -4,6 +4,12 @@ import souther.compiler.query.WeakeningSet;
 import souther.compiler.query.Weakening;
 import souther.compiler.query.Measurement;
 import souther.compiler.check.Carrier;
+import souther.compiler.coverage.ComparisonEmissionSite;
+import souther.compiler.coverage.CorePath;
+import souther.compiler.coverage.NodeAddress;
+import souther.compiler.coverage.NumberingIdentity;
+import souther.compiler.coverage.SiteAddress;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.check.Clause;
 import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleRef;
@@ -33,6 +39,7 @@ import souther.compiler.types.TypeSymbols;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -56,14 +63,10 @@ final class AReportOfOneBorder {
      * numbering and of nothing else, so what is written here is the numbering — one comparison, in
      * the body this fixture stands for — and the place is read out of it.
      */
-    private static final souther.compiler.coverage.ComparisonEmissionSite WHERE =
-            souther.compiler.coverage.SiteNumbering.of(
-                            new souther.compiler.coverage.NumberingIdentity("example.rate",
-                                    Map.of(),
-                                    List.of(new souther.compiler.coverage.SiteAddress.Comparison(
-                                            new souther.compiler.coverage.NodeAddress("example.rate",
-                                                    java.util.Set.of(
-                                                            souther.compiler.coverage.CorePath.ROOT))))))
+    private static final ComparisonEmissionSite WHERE =
+            SiteNumbering.of(new NumberingIdentity("example.rate", Map.of(),
+                            List.of(new SiteAddress.Comparison(
+                                    new NodeAddress("example.rate", Set.of(CorePath.ROOT))))))
                     .comparison(0);
 
     /** The number the lines below are on, which their orders are the orders of. */

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -49,6 +49,23 @@ import java.util.function.Function;
  */
 final class AReportOfOneBorder {
 
+    /**
+     * Where the comparison the lines below come off is recorded.
+     *
+     * <p>Stated rather than compiled, like the rest of this fixture. A place is a place of a
+     * numbering and of nothing else, so what is written here is the numbering — one comparison, in
+     * the body this fixture stands for — and the place is read out of it.
+     */
+    private static final souther.compiler.coverage.ComparisonEmissionSite WHERE =
+            souther.compiler.coverage.SiteNumbering.of(
+                            new souther.compiler.coverage.NumberingIdentity("example.rate",
+                                    Map.of(),
+                                    List.of(new souther.compiler.coverage.SiteAddress.Comparison(
+                                            new souther.compiler.coverage.NodeAddress("example.rate",
+                                                    java.util.Set.of(
+                                                            souther.compiler.coverage.CorePath.ROOT))))))
+                    .comparison(0);
+
     /** The number the lines below are on, which their orders are the orders of. */
     private static final NumericTerm.ValueOf AT_W_A =
             new NumericTerm.ValueOf(TermPath.of("w").then("a"));
@@ -99,7 +116,7 @@ final class AReportOfOneBorder {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5))),
-                        new souther.compiler.coverage.ComparisonEmissionSite(0)),
+                        WHERE),
                 new souther.compiler.partition.LineFacts(
                         new ComparisonClaim.Cut(souther.compiler.numeric.Towards.BELOW, true)));
         return Border.at(

--- a/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
@@ -6,6 +6,7 @@ import souther.cli.Main;
 import org.junit.jupiter.api.Test;
 import souther.compiler.types.CoverageOrigin;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.check.PathReachability;
@@ -316,28 +317,28 @@ class AnArmNothingReachesIsNotOwedARowTest {
      * is what the emitter and a measurement agree on and it moves whenever the numbering does, so a
      * test that names one is naming the walk's order and not the arm.
      */
-    private static List<Integer> armProbes() {
+    private static List<ArmProbe> armProbes() {
         Compilation compilation = Compilation.ofSource(CAPPED, "Main");
         compilation.answerEverything();
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
         return checked.plan().arms("classify").stream()
-                .map(CoverageSites.Site::index).toList();
+                .map(CoverageSites.ArmSite::index).toList();
     }
 
     /** The arm nothing reaches — the {@code then} of a guard at 50 no pair can be above. */
-    private static final int UNREACHED = armProbes().get(0);
+    private static final ArmProbe UNREACHED = armProbes().get(0);
 
     /** The arm every run takes. */
-    private static final int TAKEN = armProbes().get(1);
+    private static final ArmProbe TAKEN = armProbes().get(1);
 
-    private static CoverageSites.Site arm(int index) {
-        return new CoverageSites.Site("classify",
+    private static CoverageSites.ArmSite arm(ArmProbe probe) {
+        return new CoverageSites.ArmSite("classify",
                 new souther.compiler.coverage.SourceOutcome.Held(
                         new souther.compiler.coverage.SourceOutcome.HeldBy.Condition()),
-                null, index, index,
+                null, probe, probe.raw(),
                 new CoverageSites.Obligation("classify",
-                        CoverageOrigin.written("t", index,
+                        CoverageOrigin.written("t", probe.raw(),
                                 souther.compiler.types.CoverageConstruct.IF), 0,
                         souther.compiler.coverage.DecidedBy.THE_DECLARATION));
     }
@@ -372,10 +373,10 @@ class AnArmNothingReachesIsNotOwedARowTest {
     }
 
     /** The probes of the arms this account holds, in the order the body holds them. */
-    private static List<Integer> probesOf(Adequacy.BranchEvidence measured) {
+    private static List<ArmProbe> probesOf(Adequacy.BranchEvidence measured) {
         return measured.arms().all().stream()
                 .flatMap(arm -> arm.occurrences().stream())
-                .map(CoverageSites.Site::index).toList();
+                .map(CoverageSites.ArmSite::index).toList();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
@@ -113,19 +114,20 @@ public final class PathReachability {
          *
          * @param lit the probes a row was recorded at
          */
-        public AsRun asRunWith(java.util.Set<Integer> lit) {
+        public AsRun asRunWith(java.util.Set<ArmProbe> lit) {
             Map<ControlPointId, Reachability> out = new LinkedHashMap<>(found);
-            java.util.Set<Integer> provedWrong = new java.util.LinkedHashSet<>();
+            java.util.Set<ArmProbe> provedWrong =
+                    new java.util.LinkedHashSet<>();
             found.forEach((where, said) -> {
                 if (!(where instanceof ControlPointId.ArmOccurrence arm)
-                        || arm.probe().isEmpty() || !lit.contains(arm.probe().getAsInt())) {
+                        || arm.probe().isEmpty() || !lit.contains(arm.probe().get())) {
                     return;
                 }
                 if (said instanceof Reachability.Unreachable) {
-                    provedWrong.add(arm.probe().getAsInt());
+                    provedWrong.add(arm.probe().get());
                 }
                 out.put(where, new Reachability.Reachable(
-                        Witness.aRunWentThrough(arm.probe().getAsInt())));
+                        Witness.aRunWentThrough(arm.probe().get())));
             });
             // The arrivals as they were: a run corrects what an arm's denominator counts, and the
             // geometry the arrivals decide was settled from the model before any row ran.
@@ -139,7 +141,8 @@ public final class PathReachability {
          *                    the model is wrong then — this reading is — and a measure says so
          *                    rather than quietly counting the arm again
          */
-        public record AsRun(Answers answers, java.util.Set<Integer> provedWrong) {
+        public record AsRun(Answers answers,
+                            java.util.Set<ArmProbe> provedWrong) {
 
             public AsRun {
                 provedWrong = java.util.Set.copyOf(provedWrong);
@@ -154,10 +157,10 @@ public final class PathReachability {
 
         /** Whether nothing arrives at the arm recorded at {@code probe}. What every denominator
          *  takes an arm out by, and the one arm of the answer that takes anything out. */
-        public boolean nothingArrivesAt(int probe) {
+        public boolean nothingArrivesAt(ArmProbe probe) {
             for (Map.Entry<ControlPointId, Reachability> each : found.entrySet()) {
                 if (each.getKey() instanceof ControlPointId.ArmOccurrence arm
-                        && arm.probe().isPresent() && arm.probe().getAsInt() == probe) {
+                        && arm.probe().isPresent() && arm.probe().get().equals(probe)) {
                     return each.getValue() instanceof Reachability.Unreachable;
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -606,9 +606,9 @@ final class BodyGen {
                 return;
             }
             ctx.comparisonSiteOf(bin).ifPresent(site -> {
-                ctx.emitted(site.value());
+                ctx.emitted(site.raw());
                 code.dup();
-                code.loadConstant(site.value());
+                code.loadConstant(site.raw());
                 code.invokestatic(CD_Probe, "compared", MTD_Probe_compared);
             });
         }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -266,8 +266,11 @@ final class CodegenContext {
     List<Integer> plannedButNotEmitted() {
         List<Integer> missing = new java.util.ArrayList<>();
         for (souther.compiler.coverage.CoverageSites.Site site : coverage.sites()) {
-            if (!emittedSites.contains(site.index())) {
-                missing.add(site.index());
+            // By the number, because what was emitted is what was written into the code: this is
+            // the side of the boundary where a place is a constant in a call, and both families
+            // are written the same way there.
+            if (!emittedSites.contains(site.index().raw())) {
+                missing.add(site.index().raw());
             }
         }
         return missing;

--- a/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
@@ -18,8 +18,8 @@ import java.util.Set;
  * numbers out in another order does not align, and is refused where it arrives rather than
  * answered.
  *
- * <p>The addresses are of the numbering that did the aligning, so asking one of them anything is a
- * reference comparison rather than a walk over what the numbering is.
+ * <p>The addresses are of the numbering that did the aligning, and a reader asking about a place of
+ * that same numbering is asking about the same value.
  */
 public record AlignedObservation(Set<ArmProbe> arms, Set<SeenComparison> comparisons) {
 

--- a/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
@@ -18,21 +18,55 @@ import java.util.Set;
  * numbers out in another order does not align, and is refused where it arrives rather than
  * answered.
  *
- * <p>The addresses are of the numbering that did the aligning, and a reader asking about a place of
- * that same numbering is asking about the same value.
+ * <p><b>And which numbering that was is carried, not left at the door.</b> An address is a place of
+ * some numbering, and a reader can hold two: what a value made of one numbering's places says about
+ * another's is nothing, and saying it as an ordinary "no" is the very answer this exists to stop —
+ * a row reported as not having reached a place it was never asked about. Checked at the moment the
+ * value was made, that is a property of one call; carried, it is a property of the value, and every
+ * question put to it is answered or refused.
+ *
+ * <p><b>Made where the alignment is made.</b> There is no way here to put places beside a numbering
+ * that did not issue them.
  */
-public record AlignedObservation(Set<ArmProbe> arms, Set<SeenComparison> comparisons) {
+public final class AlignedObservation {
 
-    /** A run that passed nowhere, aligned with nothing to align. */
-    public static final AlignedObservation NONE = new AlignedObservation(Set.of(), Set.of());
+    private final NumberingIdentity numbering;
 
-    public AlignedObservation {
-        arms = arms == null ? Set.of() : Set.copyOf(arms);
-        comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
+    private final Set<ArmProbe> arms;
+
+    private final Set<SeenComparison> comparisons;
+
+    AlignedObservation(NumberingIdentity numbering, Set<ArmProbe> arms,
+                       Set<SeenComparison> comparisons) {
+        if (numbering == null) {
+            throw new IllegalArgumentException(
+                    "a run read as places is read as places of some numbering");
+        }
+        this.numbering = numbering;
+        this.arms = Set.copyOf(arms);
+        this.comparisons = Set.copyOf(comparisons);
+        this.arms.forEach(each -> requireOurs(each.numbering(), each));
+        this.comparisons.forEach(each -> requireOurs(each.at().numbering(), each));
+    }
+
+    /** What this run is read under, which is what a place put to it has to be a place of. */
+    public NumberingIdentity numbering() {
+        return numbering;
+    }
+
+    /** The arms the run was recorded at, as places of this numbering. */
+    public Set<ArmProbe> arms() {
+        return arms;
+    }
+
+    /** The ways its comparisons came out, as places of this numbering. */
+    public Set<SeenComparison> comparisons() {
+        return comparisons;
     }
 
     /** Whether the run was recorded at {@code probe}. */
     public boolean lit(ArmProbe probe) {
+        requireOurs(probe.numbering(), probe);
         return arms.contains(probe);
     }
 
@@ -40,11 +74,40 @@ public record AlignedObservation(Set<ArmProbe> arms, Set<SeenComparison> compari
      *  comparison having been reached: one that came out the other way was reached and is not
      *  this. */
     public boolean saw(ComparisonEmissionSite at, boolean held) {
+        requireOurs(at.numbering(), at);
         return comparisons.contains(new SeenComparison(at, held));
     }
 
     /** Whether the run reached {@code at} at all, whichever way the comparison there came out. */
     public boolean reached(ComparisonEmissionSite at) {
         return saw(at, true) || saw(at, false);
+    }
+
+    private void requireOurs(NumberingIdentity of, Object place) {
+        if (!numbering.equals(of)) {
+            throw new IllegalArgumentException(place + " is a place of " + of
+                    + ", and this run was read under " + numbering
+                    + "; what one numbering's run did at another's places is nothing, and"
+                    + " answering it would say a row missed a place it was never asked about");
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof AlignedObservation that
+                        && numbering.equals(that.numbering)
+                        && arms.equals(that.arms)
+                        && comparisons.equals(that.comparisons);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(numbering, arms, comparisons);
+    }
+
+    @Override
+    public String toString() {
+        return "a run of " + numbering + " at " + arms + " and " + comparisons;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/AlignedObservation.java
@@ -1,0 +1,50 @@
+package souther.compiler.coverage;
+
+import java.util.Set;
+
+/**
+ * A run, read as places of the numbering it was recorded under.
+ *
+ * <p>What every reader of a run holds, and the only thing that answers about places. A recording is
+ * numbers and a numbering says what each number addresses; the two are held against each other once
+ * ({@link SiteNumbering#align}), and what comes out of that is this. So a reader asking whether a
+ * run went through an arm is asking about an arm of the numbering it is reading under, and there is
+ * no way to ask it about a number.
+ *
+ * <p><b>What the alignment established.</b> That the run was recorded under a numbering equal to
+ * this one — the same places addressed by the same numbers in bodies doing the same things — and
+ * that every number it holds is one that numbering handed out, for the family it is read as. A
+ * recording of another module, of another build of other bodies, or of a numbering that hands its
+ * numbers out in another order does not align, and is refused where it arrives rather than
+ * answered.
+ *
+ * <p>The addresses are of the numbering that did the aligning, so asking one of them anything is a
+ * reference comparison rather than a walk over what the numbering is.
+ */
+public record AlignedObservation(Set<ArmProbe> arms, Set<SeenComparison> comparisons) {
+
+    /** A run that passed nowhere, aligned with nothing to align. */
+    public static final AlignedObservation NONE = new AlignedObservation(Set.of(), Set.of());
+
+    public AlignedObservation {
+        arms = arms == null ? Set.of() : Set.copyOf(arms);
+        comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
+    }
+
+    /** Whether the run was recorded at {@code probe}. */
+    public boolean lit(ArmProbe probe) {
+        return arms.contains(probe);
+    }
+
+    /** Whether the run had the comparison at {@code at} come out {@code held}. Not the same as the
+     *  comparison having been reached: one that came out the other way was reached and is not
+     *  this. */
+    public boolean saw(ComparisonEmissionSite at, boolean held) {
+        return comparisons.contains(new SeenComparison(at, held));
+    }
+
+    /** Whether the run reached {@code at} at all, whichever way the comparison there came out. */
+    public boolean reached(ComparisonEmissionSite at) {
+        return saw(at, true) || saw(at, false);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ArmProbe.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ArmProbe.java
@@ -1,0 +1,74 @@
+package souther.compiler.coverage;
+
+/**
+ * Where a run through one arm is recorded: a number, and the numbering that handed it out.
+ *
+ * <p>An address and not an identity. What a probed class calls is {@code Probe.hit} with an
+ * {@code int}, and what comes back from a recording is that {@code int} — so the number is the
+ * vocabulary a run through an arm is written and read in, and it reaches no further. Which arm a
+ * reading is talking about is a place in a body ({@link SiteAddress.Arm}), and the two are held
+ * apart because they are answered by different things: the numbering hands out an address for the
+ * arms it instruments, and a body has arms whether anything instruments them or not.
+ *
+ * <p><b>Beside {@link ComparisonEmissionSite} and not the same as one.</b> Both are numbers out of
+ * one counter, because what records a run is one set of numbers. A number written for an arm and a
+ * number written for a comparison are told apart by nothing in the number, so they are told apart
+ * by being different types — and which one a number was issued for is the numbering's answer,
+ * given once where the number was handed out.
+ *
+ * <p><b>What it carries is the numbering, and the numbering is a value.</b> Two derivations of one
+ * module come to the same numbering, so two addresses of it are the same address. A token minted
+ * per construction would have made them two — and one of these is held under answers a store keeps,
+ * where an answer that never equals its own recomputation is every reader of it running again on
+ * every revision.
+ *
+ * <p><b>Made by the numbering and by nothing else.</b> There is no way here to pair a number with a
+ * numbering that did not hand it out: {@link SiteNumbering#arm} is the only maker, and it refuses a
+ * number that numbering never issued and one it issued to a comparison.
+ */
+public final class ArmProbe implements RunSite {
+
+    private final NumberingIdentity numbering;
+
+    private final int raw;
+
+    ArmProbe(NumberingIdentity numbering, int raw) {
+        if (numbering == null) {
+            throw new IllegalArgumentException("a place a run is recorded at is one some numbering"
+                    + " handed out: " + raw);
+        }
+        if (raw < 0) {
+            throw new IllegalArgumentException(
+                    "a place a run is recorded at is a place the emitter numbered: " + raw);
+        }
+        this.numbering = numbering;
+        this.raw = raw;
+    }
+
+    @Override
+    public NumberingIdentity numbering() {
+        return numbering;
+    }
+
+    @Override
+    public int raw() {
+        return raw;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof ArmProbe that
+                        && raw == that.raw && numbering.equals(that.numbering);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * numbering.hashCode() + raw;
+    }
+
+    @Override
+    public String toString() {
+        return "arm@" + raw;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonEmissionSite.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonEmissionSite.java
@@ -1,33 +1,71 @@
 package souther.compiler.coverage;
 
 /**
- * Where a run through one comparison is recorded, which is a number the instrumentation hands out.
+ * Where a run through one comparison is recorded: a number, and the numbering that handed it out.
  *
  * <p>An address and not an identity. What a probed class calls is {@code Probe.compared} with an
- * {@code int}, and what comes back from a recording is that {@code int} — so this is the vocabulary
- * a run is written and read in, and it reaches no further. Which comparison a reading is talking
- * about is {@link ComparisonOccurrence}, and the two are held apart because they are answered by
- * different things: the plan hands out an address for the comparisons it instruments, and the
- * catalog names every comparison the bodies hold whether anything instruments it or not.
+ * {@code int}, and what comes back from a recording is that {@code int} — so the number is the
+ * vocabulary a run is written and read in, and it reaches no further. Which comparison a reading is
+ * talking about is {@link ComparisonOccurrence}, and the two are held apart because they are
+ * answered by different things: the plan hands out an address for the comparisons it instruments,
+ * and the catalog names every comparison the bodies hold whether anything instruments it or not.
  *
  * <p>Kept as one value rather than as the {@code int} it wraps, so that an address cannot be handed
  * where an identity is wanted. Under one type the two were the same number, and a reading that
  * asked which comparison it was looking at got an answer that was true only while every comparison
  * the catalog held was one the emitter had numbered.
  *
- * @param value the number the emitter writes into the call and a recording reads back
+ * <p><b>What it carries is the numbering, and the numbering is a value.</b> Two derivations of one
+ * module come to the same numbering, so two addresses of it are the same address — which is what
+ * lets one of these be held under an answer a store keeps and compared with what a recomputation
+ * makes of it.
+ *
+ * <p><b>Made by the numbering and by nothing else.</b> {@link SiteNumbering#comparison} is the only
+ * maker, and it refuses a number that numbering never issued and one it issued to an arm.
  */
-public record ComparisonEmissionSite(int value) {
+public final class ComparisonEmissionSite implements RunSite {
 
-    public ComparisonEmissionSite {
-        if (value < 0) {
-            throw new IllegalArgumentException(
-                    "a place a run is recorded at is a place the emitter numbered: " + value);
+    private final NumberingIdentity numbering;
+
+    private final int raw;
+
+    ComparisonEmissionSite(NumberingIdentity numbering, int raw) {
+        if (numbering == null) {
+            throw new IllegalArgumentException("a place a run is recorded at is one some numbering"
+                    + " handed out: " + raw);
         }
+        if (raw < 0) {
+            throw new IllegalArgumentException(
+                    "a place a run is recorded at is a place the emitter numbered: " + raw);
+        }
+        this.numbering = numbering;
+        this.raw = raw;
+    }
+
+    @Override
+    public NumberingIdentity numbering() {
+        return numbering;
+    }
+
+    @Override
+    public int raw() {
+        return raw;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other
+                || other instanceof ComparisonEmissionSite that
+                        && raw == that.raw && numbering.equals(that.numbering);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * numbering.hashCode() + raw;
     }
 
     @Override
     public String toString() {
-        return "site@" + value;
+        return "site@" + raw;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOutcome.java
@@ -19,19 +19,26 @@ package souther.compiler.coverage;
  * has a catalog to say which comparison that is. Which comparison a reading is talking about is
  * {@link ComparisonOccurrence}, and the plan is what turns one into the other.
  *
- * @param at   where the run was recorded
+ * <p><b>The number and not an address.</b> A probed class is handed the number the emitter wrote
+ * into the call and has no numbering to ask what it addresses; a recording is what that class left
+ * behind, so it is written in numbers. Joining one back to the place it was issued for is the other
+ * side of that boundary and belongs there — a recording that carried an address would be carrying
+ * an answer nothing running could have given.
+ *
+ * @param at   the number the run was recorded at
  * @param held the way it came out
  */
-public record ComparisonOutcome(ComparisonEmissionSite at, boolean held) {
+public record ComparisonOutcome(int at, boolean held) {
 
     public ComparisonOutcome {
-        if (at == null) {
-            throw new IllegalArgumentException("a way a comparison came out is a way of one");
+        if (at < 0) {
+            throw new IllegalArgumentException(
+                    "a run is recorded at a number the emitter wrote: " + at);
         }
     }
 
     @Override
     public String toString() {
-        return at + (held ? " held" : " failed");
+        return "site@" + at + (held ? " held" : " failed");
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
@@ -49,11 +49,11 @@ public record ControlClaim(ControlPointId at) {
      * it. What this does not say is how many times, which is why a claim is only ever made where a
      * run passes the place once ({@link CoverageSites.Plan#mayRepeat}).
      */
-    public boolean satisfiedBy(Observation seen) {
+    public boolean satisfiedBy(AlignedObservation seen) {
         return switch (at) {
             case ControlPointId.ArmOccurrence arm ->
-                    arm.probe().isPresent() && seen.lit(arm.probe().getAsInt());
-            case ControlPointId.ComparisonPoint point -> seen.saw(point.way());
+                    arm.probe().isPresent() && seen.lit(arm.probe().get());
+            case ControlPointId.ComparisonPoint point -> seen.saw(point.at(), point.held());
         };
     }
 
@@ -61,7 +61,8 @@ public record ControlClaim(ControlPointId at) {
     public String toString() {
         return switch (at) {
             case ControlPointId.ArmOccurrence arm -> "arm " + arm.controlId();
-            case ControlPointId.ComparisonPoint point -> point.way().toString();
+            case ControlPointId.ComparisonPoint point ->
+                    point.at() + (point.held() ? " held" : " failed");
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlPointId.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlPointId.java
@@ -3,7 +3,7 @@ package souther.compiler.coverage;
 import souther.compiler.diag.Citation;
 import souther.compiler.types.CoverageOrigin;
 
-import java.util.OptionalInt;
+import java.util.Optional;
 
 /**
  * A place in a body that something can or cannot arrive at, named once.
@@ -47,8 +47,8 @@ public sealed interface ControlPointId {
      *               side of it can never take makes that side dead <em>here</em> while it is alive
      *               wherever else the library is used
      */
-    record ArmOccurrence(int controlId, OptionalInt probe, Citation at, CoverageOrigin origin)
-            implements ControlPointId {
+    record ArmOccurrence(int controlId, Optional<ArmProbe> probe, Citation at,
+                         CoverageOrigin origin) implements ControlPointId {
 
         /**
          * Whether {@code module}'s own source wrote the fork this is an arm of.
@@ -85,30 +85,26 @@ public sealed interface ControlPointId {
      * reached both by a value that made {@code B} false and by one that never reached {@code B} —
      * the arm cannot say which comparison came out which way, and a line is drawn on the comparison.
      *
-     * <p>The place and what a run records at it are the same value here ({@link #way}), rather than
-     * this holding a copy of its parts. A reading that carried the comparison and the way separately
-     * would be two halves a caller could pair with another place's, which is what asking a run
-     * whether it did this then takes on trust.
+     * <p>What a plan may claim, written in the plan's own vocabulary: the address this numbering
+     * issued for the comparison, and the way it came out. A running class records the number
+     * instead, having no numbering to ask what it addresses, and putting the two together is the
+     * boundary between a recording and a numbering rather than anything this holds.
      *
-     * @param way which comparison, coming out which way — as a run would record it
+     * <p>One place and one way, so there is nothing here for a caller to pair wrongly. Two halves
+     * carrying a place each — an address beside a recorded number — would be a control point saying
+     * where it is twice.
+     *
+     * @param at   where this numbering records a run through the comparison
+     * @param held the way it came out
      */
-    record ComparisonPoint(int controlId, ComparisonOutcome way) implements ControlPointId {
+    record ComparisonPoint(int controlId, ComparisonEmissionSite at, boolean held)
+            implements ControlPointId {
 
         public ComparisonPoint {
-            if (way == null) {
+            if (at == null) {
                 throw new IllegalArgumentException(
-                        "a place a comparison comes out one way is a place of one way");
+                        "a place a comparison comes out one way is a place");
             }
-        }
-
-        /** Where a run through this is recorded, which is what a claim about it is answered from. */
-        public ComparisonEmissionSite at() {
-            return way.at();
-        }
-
-        /** The way it came out. */
-        public boolean held() {
-            return way.held();
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CorePath.java
@@ -22,7 +22,9 @@ import java.util.List;
  */
 public record CorePath(List<CoreStructure.Edge> edges) {
 
-    static final CorePath ROOT = new CorePath(List.of());
+    /** The body itself, which is where every way down starts. Public because the constructor
+     *  beside it is: this is that same value under the name for it. */
+    public static final CorePath ROOT = new CorePath(List.of());
 
     public CorePath {
         if (edges == null) {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -443,10 +443,6 @@ public final class CoverageSites {
                     .filter(ArmSite.class::isInstance).map(ArmSite.class::cast)
                     .toList();
         }
-
-        public Site site(int index) {
-            return sites.get(index);
-        }
     }
 
     /** The sites of every behavior body in one module, numbered in the order the bodies are declared
@@ -682,8 +678,10 @@ public final class CoverageSites {
          */
         private int armSite(SourceOutcome.Arm outcome, Core owner, CoverageOrigin origin,
                             int part, DecidedBy decided) {
-            int raw = numbering.number(new SiteAddress.Arm(places.of(owner), part));
+            // Asked before the place is numbered, so that a tree nothing wrote is refused for
+            // being that rather than for whatever the numbering noticed about it first.
             written(origin, owner);
+            int raw = numbering.number(new SiteAddress.Arm(places.of(owner), part));
             sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw, ordinal++,
                     new Obligation(behavior, origin, part, decided)));
             return raw;
@@ -691,8 +689,8 @@ public final class CoverageSites {
 
         private int comparisonSite(SourceOutcome.Compared outcome, Core owner,
                                    CoverageOrigin origin, DecidedBy decided) {
-            int raw = numbering.number(new SiteAddress.Comparison(places.of(owner)));
             written(origin, owner);
+            int raw = numbering.number(new SiteAddress.Comparison(places.of(owner)));
             sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw,
                     ordinal++, new Obligation(behavior, origin, 0, decided)));
             return raw;

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -10,11 +10,9 @@ import souther.compiler.types.CoverageOrigin;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.Optional;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The arms of a behavior's body that an {@code example} row can be in or not in.
@@ -156,31 +154,65 @@ public final class CoverageSites {
      * @param ordinal     where it comes in its behavior, for display
      * @param obligation  what a row would be owed for, which several occurrences share
      */
-    public record Site(String behavior, SourceOutcome outcome, Citation at,
-                       int index, int ordinal, Obligation obligation) {
+    public sealed interface Site permits ArmSite, ComparisonSite {
 
-        public Site {
+        String behavior();
+
+        SourceOutcome outcome();
+
+        Citation at();
+
+        /** Where a run through this is recorded, of whichever family it was issued to. */
+        RunSite index();
+
+        int ordinal();
+
+        Obligation obligation();
+
+        /** What the author wrote this an outcome of. */
+        default CoverageConstruct construct() {
+            return obligation().origin().kind();
+        }
+
+        /** What a reader is told this is, which the two halves settle together. */
+        default OutcomeName name() {
+            return OutcomeName.of(construct(), outcome());
+        }
+    }
+
+    /**
+     * One arm of one fork, as it stands in the tree that runs.
+     *
+     * <p>The way through a fork a branch measure counts, and what it is is said by its type rather
+     * than asked of it. A reader that only ever has arms — a denominator, a row owed at one, the
+     * words a report writes for one — takes one of these, and a comparison cannot be handed where
+     * one is wanted.
+     */
+    public record ArmSite(String behavior, SourceOutcome.Arm outcome, Citation at,
+                          ArmProbe index, int ordinal, Obligation obligation) implements Site {
+
+        public ArmSite {
             // The pair is what carries the meaning, so the pair is what is checked. Not every
             // combination is a construct of the language — a comprehension attempts no construction,
             // a `match` settles no condition — and a walk that put an outcome on the wrong construct
             // is the defect this whole value exists to make impossible.
             OutcomeName.of(obligation.origin().kind(), outcome);
         }
+    }
 
-        /** What the author wrote this an outcome of. */
-        public CoverageConstruct construct() {
-            return obligation.origin().kind();
-        }
+    /**
+     * One comparison, as a place a run through it is recorded.
+     *
+     * <p>Not an arm and counted as one nowhere. A condition stops as soon as it is settled, so which
+     * arm a row landed in does not say which comparison ran — and a measure over arms that took one
+     * of these would be counting a place its denominator was never about.
+     */
+    public record ComparisonSite(String behavior, SourceOutcome.Compared outcome, Citation at,
+                                 ComparisonEmissionSite index, int ordinal, Obligation obligation)
+            implements Site {
 
-
-        /** What a reader is told this is, which the two halves settle together. */
-        public OutcomeName name() {
-            return OutcomeName.of(construct(), outcome);
-        }
-
-        /** Whether this is one of the arms a branch measure counts. */
-        public boolean isArm() {
-            return outcome.isArm();
+        public ComparisonSite {
+            OutcomeName.of(obligation.origin().kind(), outcome);
         }
     }
 
@@ -204,7 +236,8 @@ public final class CoverageSites {
      *           can pick the wrong half of.
      */
     public record GuardRef(String behavior, CoverageOrigin origin, DecidedBy decided,
-                           int siteIndexThen, int siteIndexElse, SourcePos at) {
+                           java.util.Optional<ArmProbe> whereThen,
+                           java.util.Optional<ArmProbe> whereElse, SourcePos at) {
 
         /** The fork this is one occurrence of. Two calls of one helper give two of these, and a line
          * drawn on the condition is one line however many of them there are. */
@@ -221,13 +254,13 @@ public final class CoverageSites {
      * here must be the ones the emitter is walking — the same answer, not an equal one.
      */
     public record Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
-                       Map<ComparisonOccurrence, Integer> byComparison,
+                       Map<ComparisonOccurrence, ComparisonEmissionSite> byComparison,
                        IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode,
                        Map<ComparisonOccurrence, Integer> controlByComparison,
                        java.util.Set<Core> mayRepeat,
                        IdentityHashMap<Core, ForkOccurrence> forkByNode,
                        ComparisonCatalog comparisons,
-                       NumberingIdentity identity) {
+                       SiteNumbering numbering) {
 
         public Plan {
             // Half of what a numbering could get wrong is the key's own answer now: an occurrence
@@ -251,11 +284,17 @@ public final class CoverageSites {
             // address per site and it is at the site's own number. A plan is put together field by
             // field, so the two can be handed over out of step — and a reader asking what a hit
             // means would be told about a place the number was never issued to, or about none.
-            if (identity.byNumber().size() != sites.size()) {
+            if (numbering.identity().byNumber().size() != sites.size()) {
                 throw new IllegalArgumentException("this plan numbered " + sites.size()
-                        + " places and says what " + identity.byNumber().size() + " of them are;"
-                        + " the sites and the addresses are one answer or they are two");
+                        + " places and says what " + numbering.identity().byNumber().size()
+                        + " of them are; the sites and the addresses are one answer or they are"
+                        + " two");
             }
+        }
+
+        /** What this plan is a numbering of, as two builds can be held against each other by. */
+        public NumberingIdentity identity() {
+            return numbering.identity();
         }
 
         private static void requireHeld(ComparisonOccurrence which, ComparisonCatalog comparisons,
@@ -271,7 +310,7 @@ public final class CoverageSites {
                 new LinkedHashMap<>(), new IdentityHashMap<>(), new LinkedHashMap<>(),
                 java.util.Set.of(), new IdentityHashMap<>(),
                 ComparisonCatalog.of(ModuleBodies.none()),
-                NumberingIdentity.of(ModuleBodies.none().module()));
+                SiteNumbering.of(NumberingIdentity.of(ModuleBodies.none().module())));
 
         /**
          * Whether one run of the behavior can pass {@code node} more than once.
@@ -312,8 +351,8 @@ public final class CoverageSites {
                 ComparisonOccurrence which, boolean result) {
             Integer control = controlByComparison.get(ofThisPlan(which));
             return control == null ? java.util.Optional.empty()
-                    : emissionSiteOf(which).map(site -> new ControlPointId.ComparisonPoint(
-                            control, new ComparisonOutcome(site, result)));
+                    : emissionSiteOf(which).map(site ->
+                            new ControlPointId.ComparisonPoint(control, site, result));
         }
 
         /**
@@ -348,9 +387,7 @@ public final class CoverageSites {
          */
         public java.util.Optional<ComparisonEmissionSite> emissionSiteOf(
                 ComparisonOccurrence which) {
-            Integer site = byComparison.get(ofThisPlan(which));
-            return site == null ? java.util.Optional.empty()
-                    : java.util.Optional.of(new ComparisonEmissionSite(site));
+            return java.util.Optional.ofNullable(byComparison.get(ofThisPlan(which)));
         }
 
         /**
@@ -400,9 +437,10 @@ public final class CoverageSites {
         }
 
         /** The arms of one behavior, which is what a branch measure counts. */
-        public List<Site> arms(String behavior) {
+        public List<ArmSite> arms(String behavior) {
             return sites.stream()
-                    .filter(site -> site.behavior().equals(behavior) && site.isArm())
+                    .filter(site -> site.behavior().equals(behavior))
+                    .filter(ArmSite.class::isInstance).map(ArmSite.class::cast)
                     .toList();
         }
 
@@ -431,27 +469,87 @@ public final class CoverageSites {
             executable.put(body.getKey(), ExecutableIdentity.of(body.getValue(),
                     Binders.of(of.module(), walk.places)));
         }
-        return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
-                walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat,
-                walk.forkByNode, comparisons,
-                new NumberingIdentity(of.module(), executable, walk.byNumber));
+        // The numbering, now that every place is in it and what the bodies do is known — and then
+        // the walk's numbers read back as places of it. One direction and one moment: nothing above
+        // could have made an address, and nothing below sees a number.
+        SiteNumbering numbering = walk.numbering.finish(of.module(), executable);
+        List<Site> sites = new ArrayList<>();
+        for (DraftSite draft : walk.sites) {
+            sites.add(switch (draft.outcome()) {
+                case SourceOutcome.Arm arm -> new ArmSite(draft.behavior(), arm, draft.at(),
+                        numbering.arm(draft.raw()), draft.ordinal(), draft.obligation());
+                case SourceOutcome.Compared compared -> new ComparisonSite(draft.behavior(),
+                        compared, draft.at(), numbering.comparison(draft.raw()), draft.ordinal(),
+                        draft.obligation());
+            });
+        }
+        List<GuardRef> guards = new ArrayList<>();
+        for (DraftGuard draft : walk.guards) {
+            guards.add(new GuardRef(draft.behavior(), draft.origin(), draft.decided(),
+                    armAt(numbering, draft.whereThen()), armAt(numbering, draft.whereElse()),
+                    draft.at()));
+        }
+        Map<ComparisonOccurrence, ComparisonEmissionSite> byComparison = new LinkedHashMap<>();
+        walk.byComparison.forEach((which, raw) ->
+                byComparison.put(which, numbering.comparison(raw)));
+        IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode = new IdentityHashMap<>();
+        walk.armsByNode.forEach((node, arms) -> {
+            ControlPointId.ArmOccurrence[] issued =
+                    new ControlPointId.ArmOccurrence[arms.length];
+            for (int i = 0; i < arms.length; i++) {
+                issued[i] = new ControlPointId.ArmOccurrence(arms[i].controlId(),
+                        armAt(numbering, arms[i].raw()), arms[i].at(), arms[i].origin());
+            }
+            armsByNode.put(node, issued);
+        });
+        return new Plan(List.copyOf(sites), List.copyOf(guards), walk.byNode,
+                byComparison, armsByNode, walk.controlByComparison, walk.mayRepeat,
+                walk.forkByNode, comparisons, numbering);
     }
+
+    /** The arm {@code raw} addresses, where an arm was numbered at all. */
+    private static Optional<ArmProbe> armAt(SiteNumbering numbering, java.util.OptionalInt raw) {
+        return raw.isPresent() ? Optional.of(numbering.arm(raw.getAsInt())) : Optional.empty();
+    }
+
+    /**
+     * One site as the walk has it, before there is a numbering for its number to be a place of.
+     *
+     * <p>The walk carries numbers because it is what makes the numbering: what a number means is
+     * fixed by every place still to be reached and by what the bodies do, so no address of it can
+     * exist until the walk is over. The numbers become places once, at {@link #issued}, and the
+     * places are what everything downstream is handed.
+     */
+    private record DraftSite(String behavior, SourceOutcome outcome, Citation at, int raw,
+                             int ordinal, Obligation obligation) {}
+
+    /** One arm as the walk has it: the control point it is, and the number its place was given
+     *  where the emitter records one. */
+    private record DraftArm(int controlId, java.util.OptionalInt raw, Citation at,
+                            CoverageOrigin origin) {
+
+        boolean isMeasured() {
+            return raw.isPresent();
+        }
+    }
+
+    /** The two arms of one {@code if} as the walk has them. */
+    private record DraftGuard(String behavior, CoverageOrigin origin, DecidedBy decided,
+                              java.util.OptionalInt whereThen, java.util.OptionalInt whereElse,
+                              SourcePos at) {}
 
     private static final class Walk {
 
-        private final List<Site> sites = new ArrayList<>();
-        /** What each number handed out is an address of, at the number's own position. */
-        private final List<SiteAddress> byNumber = new ArrayList<>();
-        /** The places numbered so far, so that none is numbered twice. */
-        private final Set<SiteAddress> issued = new LinkedHashSet<>();
+        private final List<DraftSite> sites = new ArrayList<>();
+        /** What hands the numbers out, and says what each addresses in the same act. */
+        private final SiteNumbering.Building numbering = SiteNumbering.begin();
         /** Where the places of the body being walked are. Made per body, since a path is a way down
          *  from one body's root and means a different place in every other. */
         private NodeAddresses places;
-        private final List<GuardRef> guards = new ArrayList<>();
+        private final List<DraftGuard> guards = new ArrayList<>();
         private final IdentityHashMap<Core, int[]> byNode = new IdentityHashMap<>();
         private final Map<ComparisonOccurrence, Integer> byComparison = new LinkedHashMap<>();
-        private final IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode =
-                new IdentityHashMap<>();
+        private final IdentityHashMap<Core, DraftArm[]> armsByNode = new IdentityHashMap<>();
         private final IdentityHashMap<Core, ForkOccurrence> forkByNode = new IdentityHashMap<>();
         private final Map<ComparisonOccurrence, Integer> controlByComparison =
                 new LinkedHashMap<>();
@@ -468,11 +566,11 @@ public final class CoverageSites {
         private boolean repeating;
         /** The outcomes that carry nothing of their own. What each of them means is settled with
          *  the construct beside it, so one instance stands for every occurrence. */
-        private static final SourceOutcome HELD =
+        private static final SourceOutcome.Arm HELD =
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition());
-        private static final SourceOutcome FAILED =
+        private static final SourceOutcome.Arm FAILED =
                 new SourceOutcome.Failed(new SourceOutcome.FailedBy.Condition());
-        private static final SourceOutcome BUILT =
+        private static final SourceOutcome.Arm BUILT =
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Construction());
         /** Which nodes are comparisons, which this walk asks rather than reads off their shape. */
         private final ComparisonCatalog comparisons;
@@ -513,19 +611,18 @@ public final class CoverageSites {
          * gets as far as an {@code unreachable} is E1911 and states nothing, so an arm only such a
          * row could go through is an arm no row will ever be recorded in.
          */
-        private ControlPointId.ArmOccurrence armOf(SourceOutcome outcome, Core owner,
-                                                   CoverageOrigin origin, int part, Core arm,
-                                                   boolean reachable,
-                                                   DecidedBy decided) {
+        private DraftArm armOf(SourceOutcome.Arm outcome, Core owner,
+                               CoverageOrigin origin, int part, Core arm,
+                               boolean reachable,
+                               DecidedBy decided) {
             // The arm is made either way. Whether a run through it can be recorded is the second
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
-            int probe = reachable && answers(arm) && answering.mayEnter(owner, part)
-                    ? site(outcome, owner, origin, part, decided,
-                            new SiteAddress.Arm(places.of(owner), part))
-                    : NO_SITE;
-            return new ControlPointId.ArmOccurrence(controls++,
-                    probe == NO_SITE ? OptionalInt.empty() : OptionalInt.of(probe),
+            java.util.OptionalInt raw = reachable && answers(arm)
+                    && answering.mayEnter(owner, part)
+                    ? java.util.OptionalInt.of(armSite(outcome, owner, origin, part, decided))
+                    : java.util.OptionalInt.empty();
+            return new DraftArm(controls++, raw,
                     // The fork's own coordinate, as a site takes it: an arm's body is what lowering
                     // rewrites and carries whatever position it was built from, so quoting it sends
                     // an author somewhere else in the file.
@@ -539,7 +636,7 @@ public final class CoverageSites {
          * a name rather than a lookup for exactly that reason: made apart, the fork's identity would
          * be something each reader worked out again from whatever component it had to hand.
          */
-        private void arms(Core fork, ControlPointId.ArmOccurrence[] arms) {
+        private void arms(Core fork, DraftArm[] arms) {
             armsByNode.put(fork, arms);
             if (arms.length > 0) {
                 forkByNode.put(fork, new ForkOccurrence(arms[0].controlId()));
@@ -548,10 +645,10 @@ public final class CoverageSites {
 
         /** The probe numbers of {@code arms}, in their order, {@link #NO_SITE} where an arm has
          *  none. What the emitter indexes and what the branch measure counts. */
-        private static int[] probesOf(ControlPointId.ArmOccurrence... arms) {
+        private static int[] probesOf(DraftArm... arms) {
             int[] out = new int[arms.length];
             for (int i = 0; i < arms.length; i++) {
-                out[i] = arms[i].probe().orElse(NO_SITE);
+                out[i] = arms[i].raw().orElse(NO_SITE);
             }
             return out;
         }
@@ -583,8 +680,25 @@ public final class CoverageSites {
          *              a reader of the recording has no other way of telling, and reading it back
          *              off the outcome here would be the numbering deciding it twice
          */
-        private int site(SourceOutcome outcome, Core owner, CoverageOrigin origin, int part,
-                         DecidedBy decided, SiteAddress where) {
+        private int armSite(SourceOutcome.Arm outcome, Core owner, CoverageOrigin origin,
+                            int part, DecidedBy decided) {
+            int raw = numbering.number(new SiteAddress.Arm(places.of(owner), part));
+            written(origin, owner);
+            sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw, ordinal++,
+                    new Obligation(behavior, origin, part, decided)));
+            return raw;
+        }
+
+        private int comparisonSite(SourceOutcome.Compared outcome, Core owner,
+                                   CoverageOrigin origin, DecidedBy decided) {
+            int raw = numbering.number(new SiteAddress.Comparison(places.of(owner)));
+            written(origin, owner);
+            sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw,
+                    ordinal++, new Obligation(behavior, origin, 0, decided)));
+            return raw;
+        }
+
+        private void written(CoverageOrigin origin, Core owner) {
             // Said here because this is where anything is numbered, and the rule is about numbering
             // rather than about comparisons: an arm of a fork nothing wrote is as much a row nobody
             // can be owed as a comparison of one. Stated for the comparisons alone, it left the arms
@@ -595,26 +709,6 @@ public final class CoverageSites {
                         + "numbered at " + owner.pos()
                         + "; a tree rebuilt for an analysis is not the tree that runs");
             }
-            // One number per place. A node several ways lead to is arrived at once per way, and a
-            // place numbered twice is a second site the emitter lights on no run — the shape of a
-            // real omission, and reported as one. Held on the address rather than on whatever each
-            // family has to hand: what a number is issued for is the place, so the place is what
-            // may be issued for once.
-            if (!issued.add(where)) {
-                throw new IllegalStateException("`" + behavior + "` numbers " + where
-                        + " twice; a place a run is recorded at is recorded at one number");
-            }
-            int index = sites.size();
-            // Of the node's own coordinate. This walk is over one module and an arm of a
-            // helper another module of this compile wrote is in that module's file, so a
-            // source carried here beside the position would be the wrong half of two
-            // answers about one place. The walk holds none for that reason.
-            sites.add(new Site(behavior, outcome, Citation.of(owner.pos()),
-                    index, ordinal++, new Obligation(behavior, origin, part, decided)));
-            // Filed in the order the numbers are handed out, so the number is the position: what a
-            // number is an address of is what this list says at it.
-            byNumber.add(where);
-            return index;
         }
 
         /**
@@ -729,18 +823,17 @@ public final class CoverageSites {
                     // thing to cover, and what tells them apart is the rule each was handed.
                     DecidedBy decided =
                             decidedAt(iff.origin(), iff.expansion(), decisions, supplied);
-                    ControlPointId.ArmOccurrence then =
+                    DraftArm then =
                             armOf(HELD, iff, iff.origin(), 0, iff.then(), inside, decided);
                     walk(structural.take(new CoreStructure.Edge.IfThen(), iff.then()), inside);
-                    ControlPointId.ArmOccurrence els =
+                    DraftArm els =
                             armOf(FAILED, iff, iff.origin(), 1, iff.els(), inside, decided);
                     walk(structural.take(new CoreStructure.Edge.IfElse(), iff.els()), inside);
                     byNode.put(iff, probesOf(then, els));
-                    arms(iff, new ControlPointId.ArmOccurrence[] {then, els});
+                    arms(iff, new DraftArm[] {then, els});
                     if (then.isMeasured() || els.isMeasured()) {
-                        guards.add(new GuardRef(behavior, iff.origin(), decided,
-                                then.probe().orElse(NO_SITE), els.probe().orElse(NO_SITE),
-                                iff.pos()));
+                        guards.add(new DraftGuard(behavior, iff.origin(), decided,
+                                then.raw(), els.raw(), iff.pos()));
                     }
                 }
                 case Core.Match m -> {
@@ -751,8 +844,7 @@ public final class CoverageSites {
                     // arms are one obligation per rule handed in.
                     DecidedBy decided =
                             decidedAt(m.origin(), m.expansion(), decisions, supplied);
-                    ControlPointId.ArmOccurrence[] arms =
-                            new ControlPointId.ArmOccurrence[m.cases().size()];
+                    DraftArm[] arms = new DraftArm[m.cases().size()];
                     for (int i = 0; i < m.cases().size(); i++) {
                         Core.Case arm = m.cases().get(i);
                         arms[i] = armOf(matched(arm), m, m.origin(), i, arm.body(), inside,
@@ -781,8 +873,7 @@ public final class CoverageSites {
                     // And what an attempted construction decides by is the value it is given.
                     DecidedBy decided =
                             decidedAt(ic.origin(), ic.expansion(), decisions, supplied);
-                    ControlPointId.ArmOccurrence[] arms =
-                            new ControlPointId.ArmOccurrence[1 + ic.els().size()];
+                    DraftArm[] arms = new DraftArm[1 + ic.els().size()];
                     arms[0] = armOf(BUILT, ic, ic.origin(), 0, ic.then(), inside, decided);
                     walk(structural.take(new CoreStructure.Edge.ConstructedThen(), ic.then()),
                             inside);
@@ -837,17 +928,16 @@ public final class CoverageSites {
             // predicates written separately are two lines, and one predicate handed to two calls is
             // one, neither of which a fork can say.
             byComparison.put(which,
-                    site(new SourceOutcome.Compared(comparison.op()), comparison,
-                            comparison.origin(), 0, DecidedBy.THE_DECLARATION,
-                            new SiteAddress.Comparison(places.of(comparison))));
+                    comparisonSite(new SourceOutcome.Compared(comparison.op()), comparison,
+                            comparison.origin(), DecidedBy.THE_DECLARATION));
             controlByComparison.put(which, controls++);
         }
 
-        private static SourceOutcome matched(Core.Case arm) {
+        private static SourceOutcome.Arm matched(Core.Case arm) {
             return new SourceOutcome.Matched(arm.caseTypes());
         }
 
-        private static SourceOutcome refused(Core.ElseArm arm) {
+        private static SourceOutcome.Arm refused(Core.ElseArm arm) {
             return new SourceOutcome.Failed(
                     new SourceOutcome.FailedBy.Construction(arm.clause()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ExecutableIdentity.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * over a tree that is not the tree that runs — and a reading that quietly stood in for it would say
  * two bodies are one on the strength of a name the compiler invented.
  */
-public record ExecutableIdentity(Kind kind, List<Object> settled,
+public record ExecutableIdentity(Kind kind, List<Settled> settled,
                                  List<ExecutableIdentity> children) {
 
     /** Which node this is. Named rather than held as the class, so that what two of these compare
@@ -78,8 +78,8 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
         if (already != null) {
             return already;
         }
-        List<Object> settled = new ArrayList<>();
-        settled.add(typeOf(body));
+        List<Settled> settled = new ArrayList<>();
+        settled.add(new Settled.OfType(typeOf(body)));
         Kind kind = say(body, settled, binders);
         List<ExecutableIdentity> children = new ArrayList<>();
         for (CoreStructure.Child child : CoreStructure.childrenOf(body)) {
@@ -91,27 +91,27 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
     }
 
     /** Everything but the children and the type: what the node says on its own. */
-    private static Kind say(Core e, List<Object> settled, Binders binders) {
+    private static Kind say(Core e, List<Settled> settled, Binders binders) {
         return switch (e) {
             case Core.Int it -> {
-                settled.add(it.value());
+                settled.add(new Settled.Whole(it.value()));
                 yield Kind.INT;
             }
             case Core.Decimal it -> {
-                settled.add(it.value());
+                settled.add(new Settled.Fraction(it.value()));
                 yield Kind.DECIMAL;
             }
             case Core.Str it -> {
-                settled.add(it.value());
+                settled.add(new Settled.Word(it.value()));
                 yield Kind.STR;
             }
             case Core.Bool it -> {
-                settled.add(it.value());
+                settled.add(new Settled.Truth(it.value()));
                 yield Kind.BOOL;
             }
             case Core.Temporal it -> {
-                settled.add(it.kind());
-                settled.add(it.text());
+                settled.add(new Settled.TemporalKind(it.kind()));
+                settled.add(new Settled.Word(it.text()));
                 yield Kind.TEMPORAL;
             }
             // The place the name is bound, never the name: two bodies alike but for what a `let`
@@ -121,29 +121,29 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
                     throw new IllegalStateException("a body that runs reads no name nothing bound: `"
                             + it.name() + "` at " + it.pos());
                 }
-                settled.add(binders.at(it.binding()));
+                settled.add(new Settled.Bound(binders.at(it.binding())));
                 yield Kind.READ;
             }
             case Core.UnitValue it -> {
-                settled.add(it.data());
+                settled.add(new Settled.Names(it.data()));
                 yield Kind.UNIT_VALUE;
             }
             case Core.OptionNone _ -> Kind.OPTION_NONE;
             case Core.Unreachable it -> {
-                settled.add(it.reason());
+                settled.add(new Settled.Word(it.reason()));
                 yield Kind.UNREACHABLE;
             }
             case Core.Neg _ -> Kind.NEG;
             case Core.FieldAccess it -> {
-                settled.add(it.field());
+                settled.add(new Settled.Word(it.field()));
                 yield Kind.FIELD_ACCESS;
             }
             case Core.Binary it -> {
-                settled.add(it.op());
+                settled.add(new Settled.Operator(it.op()));
                 yield Kind.BINARY;
             }
             case Core.Call it -> {
-                settled.add(it.fn());
+                settled.add(new Settled.Applies(it.fn()));
                 yield Kind.CALL;
             }
             // What an analysis kept standing, which the tree that runs holds none of. Reaching one
@@ -155,31 +155,31 @@ public record ExecutableIdentity(Kind kind, List<Object> settled,
             // report quotes them, so two bodies that name their ways out differently say different
             // things.
             case Core.IfConstructed it -> {
-                it.els().forEach(arm -> settled.add(arm.clause()));
+                it.els().forEach(arm -> settled.add(new Settled.MaybeWord(arm.clause())));
                 yield Kind.IF_CONSTRUCTED;
             }
             case Core.LetIn _ -> Kind.LET_IN;
             // How many names it takes. Not a binder — those are where they are and are read as
             // places — but applying a function of two names to one is not what this does.
             case Core.Block it -> {
-                settled.add(it.params().size());
+                settled.add(new Settled.Count(it.params().size()));
                 yield Kind.BLOCK;
             }
             case Core.ListLit _ -> Kind.LIST_LIT;
             case Core.OptionSome _ -> Kind.OPTION_SOME;
             case Core.Tuple _ -> Kind.TUPLE;
             case Core.TupleGet it -> {
-                settled.add(it.index());
-                settled.add(it.arity());
+                settled.add(new Settled.Count(it.index()));
+                settled.add(new Settled.Count(it.arity()));
                 yield Kind.TUPLE_GET;
             }
             case Core.Construct it -> {
-                settled.add(it.typeName());
-                it.values().forEach(value -> settled.add(value.field()));
+                settled.add(new Settled.Names(it.typeName()));
+                it.values().forEach(value -> settled.add(new Settled.Word(value.field())));
                 yield Kind.CONSTRUCT;
             }
             case Core.Match it -> {
-                it.cases().forEach(one -> settled.add(one.pattern()));
+                it.cases().forEach(one -> settled.add(new Settled.Matching(one.pattern())));
                 yield Kind.MATCH;
             }
         };

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NumberingIdentity.java
@@ -2,6 +2,7 @@ package souther.compiler.coverage;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * What a numbering is, said so that two of them can be held against each other.
@@ -26,26 +27,57 @@ import java.util.Map;
  * {@link #executable} says what the code at those places does, because two bodies that do different
  * things are not two views of one measurement however their places line up.
  *
- * @param module   whose bodies these are numbered from
- * @param executable what each behavior of the module does, by name. A map and not a list: what
- *                   order a module declares its behaviors in is not part of what a number means,
- *                   and where it moves the numbers with it {@code byNumber} moves too
- * @param byNumber what each number is an address of, the number being the position in the list
+ * <p><b>The hash is kept, and it decides nothing.</b> Comparing two of these walks every place and
+ * every body, and an address carries one — so a set of addresses would hash the whole numbering per
+ * member. What the number saves is the walking, and where two hashes agree the fields are compared
+ * all the same: a hash is what makes an answer quick to reach and never what the answer is.
  */
-public record NumberingIdentity(String module, Map<String, ExecutableIdentity> executable,
-                                List<SiteAddress> byNumber) {
+public final class NumberingIdentity {
 
-    public NumberingIdentity {
+    private final String module;
+
+    private final Map<String, ExecutableIdentity> executable;
+
+    private final List<SiteAddress> byNumber;
+
+    private final int hash;
+
+    /**
+     * @param module     whose bodies these are numbered from
+     * @param executable what each behavior of the module does, by name. A map and not a list: what
+     *                   order a module declares its behaviors in is not part of what a number
+     *                   means, and where it moves the numbers with it {@code byNumber} moves too
+     * @param byNumber   what each number is an address of, the number being the position in the list
+     */
+    public NumberingIdentity(String module, Map<String, ExecutableIdentity> executable,
+                             List<SiteAddress> byNumber) {
         if (module == null) {
             throw new IllegalArgumentException("a numbering is of somebody's module");
         }
-        executable = Map.copyOf(executable);
-        byNumber = List.copyOf(byNumber);
+        this.module = module;
+        this.executable = Map.copyOf(executable);
+        this.byNumber = List.copyOf(byNumber);
+        this.hash = Objects.hash(this.module, this.executable, this.byNumber);
     }
 
     /** The numbering of nothing, which is what a module with no bodies to walk has. */
     static NumberingIdentity of(String module) {
         return new NumberingIdentity(module, Map.of(), List.of());
+    }
+
+    /** Whose bodies these are numbered from. */
+    public String module() {
+        return module;
+    }
+
+    /** What each behavior of the module does, by name. */
+    public Map<String, ExecutableIdentity> executable() {
+        return executable;
+    }
+
+    /** What each number is an address of, the number being the position in the list. */
+    public List<SiteAddress> byNumber() {
+        return byNumber;
     }
 
     /** What number {@code n} is an address of. */
@@ -55,6 +87,28 @@ public record NumberingIdentity(String module, Map<String, ExecutableIdentity> e
                     "this numbering handed out no " + n + "; it handed out " + byNumber.size());
         }
         return byNumber.get(n);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof NumberingIdentity that)) {
+            return false;
+        }
+        // The number first and the fields all the same. Two numberings that hash alike and differ
+        // are two numberings, and a reader told otherwise would be reading a run against places it
+        // was never near — which is the one thing this value exists to stop.
+        return hash == that.hash
+                && module.equals(that.module)
+                && executable.equals(that.executable)
+                && byNumber.equals(that.byNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -11,10 +11,12 @@ import java.util.Set;
  * things a reader could get from different runs, and a reader that asked for one of them would be
  * reasoning about a run it had only half of.
  *
- * <p>{@link #comparisons} implies {@link #taken}: a way a comparison came out is recorded by the
- * same call that records the comparison having been reached, so a run holding the first without the
- * second is one nothing produces. That holds by how the recording is written rather than by a rule
- * the emitter is asked to keep, which is the difference between an invariant and a convention.
+ * <p>{@link #comparisons} and {@link #taken} agree about the comparisons, in both directions: one
+ * call records a comparison as reached and records which way it came out, so a run holding either
+ * without the other is one nothing produces. Held both ways because either half alone is a value a
+ * reader is answered wrongly from — a way out of a place the run says it never reached, or a place
+ * the run reached that no way out of it is recorded for, which reads as a comparison nothing
+ * evaluated.
  *
  * <p><b>Numbers, and what numbering they are of.</b> A probed class is handed the number the
  * emitter wrote into the call and has no numbering to ask what it addresses, so what a run leaves
@@ -51,6 +53,23 @@ public record Observation(NumberingIdentity numbering, Set<Integer> taken,
             if (!taken.contains(way.at())) {
                 throw new IllegalArgumentException(
                         "a run that saw " + way + " is one that reached " + way.at());
+            }
+        }
+        // And the other way round, which is the same call seen from the other side. What a
+        // comparison's number is written by is one call that records both, so a run holding the
+        // number of a comparison and no way out of it is one nothing produces — and read, it says
+        // the comparison was never reached, because a comparison is answered by the ways out and
+        // the numbers a branch measure counts are the arms.
+        //
+        // Which family a number was issued to is the numbering's answer, and this run says which
+        // numbering it is of, so it can be asked here.
+        Set<Integer> answered = new java.util.LinkedHashSet<>();
+        comparisons.forEach(way -> answered.add(way.at()));
+        for (int raw : taken) {
+            if (numbering.at(raw) instanceof SiteAddress.Comparison && !answered.contains(raw)) {
+                throw new IllegalArgumentException("a run that reached " + numbering.at(raw)
+                        + " is one that had it come out some way; " + raw
+                        + " is recorded as reached and no way out of it is");
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -5,18 +5,23 @@ import java.util.Set;
 /**
  * What one run of one row was seen to do, as a value nothing goes on changing.
  *
- * <p>One snapshot and not two channels. What is recorded has two shapes — the places a run passed
+ * <p>One snapshot and not two channels. What is recorded has two shapes — the arms a run passed
  * through, and the ways the comparisons it evaluated came out — and they are taken together, of one
  * thread, between one {@code begin} and one {@code end}. Handed over as two values they would be two
  * things a reader could get from different runs, and a reader that asked for one of them would be
  * reasoning about a run it had only half of.
  *
- * <p>{@link #comparisons} and {@link #taken} agree about the comparisons, in both directions: one
- * call records a comparison as reached and records which way it came out, so a run holding either
- * without the other is one nothing produces. Held both ways because either half alone is a value a
- * reader is answered wrongly from — a way out of a place the run says it never reached, or a place
- * the run reached that no way out of it is recorded for, which reads as a comparison nothing
- * evaluated.
+ * <p><b>A family apiece, though the numbers come out of one counter.</b> One counter hands the
+ * numbers out because the call a probed class makes carries one number and nothing else; that is a
+ * fact about the instruction, and it is not a reason to write the two families into one set. Held
+ * together, what a run did at an arm and what it did at a comparison are told apart by asking the
+ * numbering which each number was issued to — which is the family being worked out again from a
+ * number, by a reader, after the numbering already said it. Here the recording says it, because the
+ * call that wrote each entry knew.
+ *
+ * <p>So a comparison is recorded by the way it came out and by nothing else: that a way out of it
+ * exists <em>is</em> its having been reached, and there is no second bit to keep in step with. An
+ * arm has no way out to record and is the number itself.
  *
  * <p><b>Numbers, and what numbering they are of.</b> A probed class is handed the number the
  * emitter wrote into the call and has no numbering to ask what it addresses, so what a run leaves
@@ -27,11 +32,11 @@ import java.util.Set;
  * answered.
  *
  * @param numbering   what the classes this run went through were numbered by
- * @param taken       the numbers the run was recorded at, which is what a branch measure counts and
- *                    what a boundary drawn on a guard is met by
+ * @param arms        the numbers of the arms the run was recorded at, which is what a branch
+ *                    measure counts
  * @param comparisons the ways the comparisons it evaluated came out
  */
-public record Observation(NumberingIdentity numbering, Set<Integer> taken,
+public record Observation(NumberingIdentity numbering, Set<Integer> arms,
                           Set<ComparisonOutcome> comparisons) {
 
     public Observation {
@@ -39,38 +44,29 @@ public record Observation(NumberingIdentity numbering, Set<Integer> taken,
             throw new IllegalArgumentException(
                     "a run was recorded under some numbering or its numbers mean nothing");
         }
-        taken = taken == null ? Set.of() : Set.copyOf(taken);
+        arms = arms == null ? Set.of() : Set.copyOf(arms);
         comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
-        // Held here and not left to whoever records one. What a recording is written like is a
-        // producer's business and can change; that a way out of a comparison means the comparison
-        // was reached is what every reader of this is entitled to, and a value that broke it would
-        // certify a claim about a place the same value says was never got to.
+        // And each number under the family the call that wrote it was for. Said here, where the
+        // recording is made, rather than left to whoever reads it: a number written into the wrong
+        // family is the emitter having lit a place it was not at, and a reader meeting it later has
+        // a run that says something no run could say.
         //
         // Both ways out of one comparison together are not a breach and must not be refused: a
         // place a run comes back to is evaluated more than once, and a recording that held only
         // which way it went the first time would be saying less than it saw.
-        for (ComparisonOutcome way : comparisons) {
-            if (!taken.contains(way.at())) {
-                throw new IllegalArgumentException(
-                        "a run that saw " + way + " is one that reached " + way.at());
-            }
+        for (int raw : arms) {
+            requireIssuedTo(numbering, raw, SiteAddress.Arm.class, "an arm");
         }
-        // And the other way round, which is the same call seen from the other side. What a
-        // comparison's number is written by is one call that records both, so a run holding the
-        // number of a comparison and no way out of it is one nothing produces — and read, it says
-        // the comparison was never reached, because a comparison is answered by the ways out and
-        // the numbers a branch measure counts are the arms.
-        //
-        // Which family a number was issued to is the numbering's answer, and this run says which
-        // numbering it is of, so it can be asked here.
-        Set<Integer> answered = new java.util.LinkedHashSet<>();
-        comparisons.forEach(way -> answered.add(way.at()));
-        for (int raw : taken) {
-            if (numbering.at(raw) instanceof SiteAddress.Comparison && !answered.contains(raw)) {
-                throw new IllegalArgumentException("a run that reached " + numbering.at(raw)
-                        + " is one that had it come out some way; " + raw
-                        + " is recorded as reached and no way out of it is");
-            }
+        for (ComparisonOutcome way : comparisons) {
+            requireIssuedTo(numbering, way.at(), SiteAddress.Comparison.class, "a comparison");
+        }
+    }
+
+    private static void requireIssuedTo(NumberingIdentity numbering, int raw,
+                                        Class<? extends SiteAddress> family, String what) {
+        if (!family.isInstance(numbering.at(raw))) {
+            throw new IllegalArgumentException(raw + " is recorded as " + what
+                    + ", and the numbering handed it out for " + numbering.at(raw));
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -16,18 +16,27 @@ import java.util.Set;
  * second is one nothing produces. That holds by how the recording is written rather than by a rule
  * the emitter is asked to keep, which is the difference between an invariant and a convention.
  *
- * @param taken       the sites the run was recorded at, which is what a branch measure counts and
+ * <p><b>Numbers, and what numbering they are of.</b> A probed class is handed the number the
+ * emitter wrote into the call and has no numbering to ask what it addresses, so what a run leaves
+ * behind is numbers. What says which numbering they are of is the classes the run went through, and
+ * this carries what those classes were emitted under. So the two halves of "where was this run
+ * recorded" are here and nowhere else: a reader turns them into places by holding this against a
+ * numbering ({@link SiteNumbering#align}), and one that does not match is refused rather than
+ * answered.
+ *
+ * @param numbering   what the classes this run went through were numbered by
+ * @param taken       the numbers the run was recorded at, which is what a branch measure counts and
  *                    what a boundary drawn on a guard is met by
  * @param comparisons the ways the comparisons it evaluated came out
  */
-public record Observation(Set<Integer> taken, Set<ComparisonOutcome> comparisons) {
-
-    /** An empty snapshot: a run recorded as having passed nowhere. Not the same as having no
-     *  account of a run at all, which is not something this can say and is said where a run is
-     *  handed over. */
-    public static final Observation NONE = new Observation(Set.of(), Set.of());
+public record Observation(NumberingIdentity numbering, Set<Integer> taken,
+                          Set<ComparisonOutcome> comparisons) {
 
     public Observation {
+        if (numbering == null) {
+            throw new IllegalArgumentException(
+                    "a run was recorded under some numbering or its numbers mean nothing");
+        }
         taken = taken == null ? Set.of() : Set.copyOf(taken);
         comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
         // Held here and not left to whoever records one. What a recording is written like is a
@@ -39,26 +48,10 @@ public record Observation(Set<Integer> taken, Set<ComparisonOutcome> comparisons
         // place a run comes back to is evaluated more than once, and a recording that held only
         // which way it went the first time would be saying less than it saw.
         for (ComparisonOutcome way : comparisons) {
-            if (!taken.contains(way.at().value())) {
+            if (!taken.contains(way.at())) {
                 throw new IllegalArgumentException(
                         "a run that saw " + way + " is one that reached " + way.at());
             }
         }
-    }
-
-    /** Whether the run was recorded at {@code site}. */
-    public boolean lit(int site) {
-        return taken.contains(site);
-    }
-
-    /** Whether the run had {@code way} happen. Not the same as its comparison having been reached:
-     *  a comparison that came out the other way was reached and is not this. */
-    public boolean saw(ComparisonOutcome way) {
-        return comparisons.contains(way);
-    }
-
-    /** Whether the run reached {@code site} at all, whichever way the comparison there came out. */
-    public boolean reached(ComparisonEmissionSite site) {
-        return lit(site.value());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
@@ -17,11 +17,15 @@ import java.util.Set;
  * <p>The recording is per thread because a row is per thread. Rows are evaluated on their own workers,
  * and a thread-shared recording would attribute every row's arms to every row.
  *
- * <p>One recording and not one per shape of thing recorded. What a run leaves behind is the places it
+ * <p>One recording and not one per shape of thing recorded. What a run leaves behind is the arms it
  * passed through and the ways its comparisons came out, and the two are one run's — begun together,
  * read together and let go together. Kept as two thread locals they would be two lifecycles that
  * happen to be driven from the same three calls, and a shape added later would be a third: nothing
  * would stop one of them being begun and another read.
+ *
+ * <p>Which is not the same as writing them into one set. The two families take their numbers from
+ * one counter because the call carries one number; what each call records is what that call was
+ * for, and the recording says which rather than leaving a reader to ask the numbering afterwards.
  */
 public final class Probe {
 
@@ -38,7 +42,11 @@ public final class Probe {
          * one has a numbering to say what its numbers address. */
         private final NumberingIdentity numbering;
 
-        private final BitSet taken = new BitSet();
+        /** The arms, as bits, because an arm is a number and a run passes many. */
+        private final BitSet arms = new BitSet();
+
+        /** The comparisons, as the ways they came out. A comparison is recorded by how it answered
+         *  and by nothing else: that a way out of it exists is its having been reached. */
         private final Set<ComparisonOutcome> comparisons = new LinkedHashSet<>();
 
         private Recording(NumberingIdentity numbering) {
@@ -51,7 +59,7 @@ public final class Probe {
     public static void hit(int site) {
         Recording recording = RECORDING.get();
         if (recording != null) {
-            recording.taken.set(site);
+            recording.arms.set(site);
         }
     }
 
@@ -59,10 +67,11 @@ public final class Probe {
      * Called by probed code where a comparison this plan numbers answered, with the value it
      * answered.
      *
-     * <p>Records both facts, because they are one event. That the comparison was reached and the way
-     * it came out are read by different measures, and emitting a call each would make "a way recorded
-     * implies its comparison reached" a rule the emitter has to keep rather than something no run can
-     * be found breaking.
+     * <p>One entry and not two. That the comparison was reached and the way it came out are one
+     * fact recorded once: a way out of it exists, and a reader asking whether it was reached is
+     * asking whether any does. Written as a way out and a bit beside it, the two would be a rule
+     * something has to keep in step, and a run holding one without the other would be a value every
+     * reader had to be told what to make of.
      *
      * <p>Takes the value rather than a second site chosen from it, so that the numbering the emitter
      * was given is the numbering it uses and a way out is never a number a reading picked.
@@ -70,7 +79,6 @@ public final class Probe {
     public static void compared(boolean held, int site) {
         Recording recording = RECORDING.get();
         if (recording != null) {
-            recording.taken.set(site);
             recording.comparisons.add(new ComparisonOutcome(site, held));
         }
     }
@@ -100,12 +108,12 @@ public final class Probe {
             throw new IllegalStateException("nothing is recording on this thread, so there is no"
                     + " run to take a snapshot of; a row nobody watched has no account");
         }
-        Set<Integer> sites = new LinkedHashSet<>();
-        for (int at = recording.taken.nextSetBit(0); at >= 0;
-                at = recording.taken.nextSetBit(at + 1)) {
-            sites.add(at);
+        Set<Integer> arms = new LinkedHashSet<>();
+        for (int at = recording.arms.nextSetBit(0); at >= 0;
+                at = recording.arms.nextSetBit(at + 1)) {
+            arms.add(at);
         }
-        return new Observation(recording.numbering, sites, recording.comparisons);
+        return new Observation(recording.numbering, arms, recording.comparisons);
     }
 
     /** Stops collecting, and lets go of the recording. A worker thread outlives the row it ran, so a

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
@@ -33,8 +33,17 @@ public final class Probe {
      * what a caller gets is {@link Observation}, which is a value. */
     private static final class Recording {
 
+        /** What the classes this run is going through were numbered by. Taken where the collecting
+         * starts, because that is where the classes about to be run are in hand — nothing inside
+         * one has a numbering to say what its numbers address. */
+        private final NumberingIdentity numbering;
+
         private final BitSet taken = new BitSet();
         private final Set<ComparisonOutcome> comparisons = new LinkedHashSet<>();
+
+        private Recording(NumberingIdentity numbering) {
+            this.numbering = numbering;
+        }
     }
 
     /** Called by probed code where an arm ran. Public and static because that is what an
@@ -62,28 +71,41 @@ public final class Probe {
         Recording recording = RECORDING.get();
         if (recording != null) {
             recording.taken.set(site);
-            recording.comparisons.add(
-                    new ComparisonOutcome(new ComparisonEmissionSite(site), held));
+            recording.comparisons.add(new ComparisonOutcome(site, held));
         }
     }
 
-    /** Starts collecting on this thread. */
-    public static void begin() {
-        RECORDING.set(new Recording());
+    /**
+     * Starts collecting on this thread, of classes numbered by {@code numbering}.
+     *
+     * <p>Said here because here is where it can be. The numbers a probed class writes are the
+     * numbering's, and the class has nothing to say about which numbering that was; what does is
+     * whoever loaded the classes and is about to run a row through them.
+     */
+    public static void begin(NumberingIdentity numbering) {
+        RECORDING.set(new Recording(numbering));
     }
 
-    /** What this thread has been through so far, as one value nothing can go on changing. */
+    /**
+     * What this thread has been through so far, as one value nothing can go on changing.
+     *
+     * <p>Refused where nothing is collecting. A snapshot has to say which numbering its numbers are
+     * of, and there is none to say when no recording was begun — so what a caller has then is no
+     * account of a run rather than a run that passed nowhere, and it is the caller that knows which:
+     * it is the one that decided whether to begin.
+     */
     public static Observation snapshot() {
         Recording recording = RECORDING.get();
         if (recording == null) {
-            return Observation.NONE;
+            throw new IllegalStateException("nothing is recording on this thread, so there is no"
+                    + " run to take a snapshot of; a row nobody watched has no account");
         }
         Set<Integer> sites = new LinkedHashSet<>();
         for (int at = recording.taken.nextSetBit(0); at >= 0;
                 at = recording.taken.nextSetBit(at + 1)) {
             sites.add(at);
         }
-        return new Observation(sites, recording.comparisons);
+        return new Observation(recording.numbering, sites, recording.comparisons);
     }
 
     /** Stops collecting, and lets go of the recording. A worker thread outlives the row it ran, so a

--- a/souther-compiler/src/main/java/souther/compiler/coverage/RunRecord.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/RunRecord.java
@@ -1,0 +1,32 @@
+package souther.compiler.coverage;
+
+/**
+ * What this compile's own recording has of one run.
+ *
+ * <p>Two answers and not an account that may be empty. A run recorded under a numbering and a run
+ * nothing was recording are different facts about a row: the first says where it went, and the
+ * second says nobody was watching. Written as one empty account, the second reads as a row that
+ * passed nowhere — which is what a row shown to miss every arm looks like, and is the opposite of
+ * what happened.
+ *
+ * <p>Said here rather than left to a reader. A number a run leaves behind means a place under the
+ * numbering that handed it out ({@link SiteNumbering#align}), so an account has to say which
+ * numbering it is of; a compile that recorded nothing has no numbering to name, and an account
+ * naming one it was never under is the mistake that alignment exists to refuse.
+ */
+public sealed interface RunRecord {
+
+    /** The run was recorded, and this is what it left behind. */
+    record Recorded(Observation seen) implements RunRecord {
+
+        public Recorded {
+            if (seen == null) {
+                throw new IllegalArgumentException("a recorded run is a run that was recorded");
+            }
+        }
+    }
+
+    /** Nothing was recording. The classes the row ran through were generated without the calls that
+     *  would have written anything down, so there is nothing here and nothing went nowhere. */
+    record NotRecording() implements RunRecord {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/RunRecord.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/RunRecord.java
@@ -3,11 +3,10 @@ package souther.compiler.coverage;
 /**
  * What this compile's own recording has of one run.
  *
- * <p>Two answers and not an account that may be empty. A run recorded under a numbering and a run
- * nothing was recording are different facts about a row: the first says where it went, and the
- * second says nobody was watching. Written as one empty account, the second reads as a row that
- * passed nowhere — which is what a row shown to miss every arm looks like, and is the opposite of
- * what happened.
+ * <p>Two answers and not an account that may be empty. A run that was recorded and a row there is
+ * no account of are different facts: the first says where it went, and the second says nothing was
+ * written down. Written as one empty account, the second reads as a row that passed nowhere — which
+ * is what a row shown to miss every arm looks like, and is the opposite of what happened.
  *
  * <p>Said here rather than left to a reader. A number a run leaves behind means a place under the
  * numbering that handed it out ({@link SiteNumbering#align}), so an account has to say which
@@ -26,7 +25,15 @@ public sealed interface RunRecord {
         }
     }
 
-    /** Nothing was recording. The classes the row ran through were generated without the calls that
-     *  would have written anything down, so there is nothing here and nothing went nowhere. */
-    record NotRecording() implements RunRecord {}
+    /**
+     * No account of the run was taken.
+     *
+     * <p>Said as the absence rather than as its reason. There are two of those and a reader here
+     * acts on neither: the classes the row ran through may have been generated without the calls
+     * that write a run down, or the row may have stopped somewhere the snapshot is not reached —
+     * and a name asserting the first would be asserting it of the second. What every reader of this
+     * needs is that there is no account, which is not the same as an account of a run that went
+     * nowhere.
+     */
+    record NoAccount() implements RunRecord {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/RunSite.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/RunSite.java
@@ -1,0 +1,33 @@
+package souther.compiler.coverage;
+
+/**
+ * A number a run is recorded at, of whichever family it was issued to.
+ *
+ * <p>What a recording is written in. One counter hands the numbers out because one set of numbers
+ * is what a run leaves behind, so a recording holds arms and comparisons together and something has
+ * to be able to say "a place, of either kind" without saying which.
+ *
+ * <p><b>Which is not the same as a reader being able to take either.</b> The two arms are the two
+ * types they are, and a reader that wants an arm says {@link ArmProbe}: what it is asking is
+ * answered by an arm and by nothing else, and a comparison handed to it would be a claim about a
+ * place the reader was not asking about. This exists for the few that hold both — what records a
+ * run, and what a run is read back as — and a reader that named it to avoid choosing has chosen
+ * wrong.
+ *
+ * <p>Sealed, so the two are the whole of it and a third family added later arrives at every place
+ * that takes one.
+ */
+public sealed interface RunSite permits ArmProbe, ComparisonEmissionSite {
+
+    /** The numbering that handed this out, which is what says what the number means. */
+    NumberingIdentity numbering();
+
+    /**
+     * The number itself, which is what a probed class is given and what a recording reads back.
+     *
+     * <p>The one way out of the typed vocabulary, and it goes to the code being emitted. Anything
+     * else asking for it is turning an address back into something a caller can pair with a place
+     * it was not issued for.
+     */
+    int raw();
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/RunSite.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/RunSite.java
@@ -27,7 +27,8 @@ public sealed interface RunSite permits ArmProbe, ComparisonEmissionSite {
      *
      * <p>The one way out of the typed vocabulary, and it goes to the code being emitted. Anything
      * else asking for it is turning an address back into something a caller can pair with a place
-     * it was not issued for.
+     * it was not issued for — which is what the numbering exists to stop, so who may ask is fixed
+     * by a walk over the compiled classes rather than by this sentence.
      */
     int raw();
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SeenComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SeenComparison.java
@@ -1,0 +1,22 @@
+package souther.compiler.coverage;
+
+/**
+ * One comparison of a numbering, and the way a run had it come out.
+ *
+ * <p>What {@link ComparisonOutcome} is once the number has been read as a place. The two say the
+ * same thing about one event and are not interchangeable: the first is what a running class writes
+ * down, where a number is all there is to write, and this is what a reader asks about, where a
+ * number addresses nothing on its own.
+ *
+ * <p>Which way it came out and not merely that it was reached, because those are different
+ * questions and a reader that had only the second could not tell a row that took the other way from
+ * one that never got there.
+ */
+public record SeenComparison(ComparisonEmissionSite at, boolean held) {
+
+    public SeenComparison {
+        if (at == null) {
+            throw new IllegalArgumentException("a way a comparison came out is a way one came out");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Settled.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Settled.java
@@ -1,0 +1,73 @@
+package souther.compiler.coverage;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * One thing a node of a body settles on its own, as what it is.
+ *
+ * <p>Held as a sum rather than as whatever the node happened to have. What a node says varies by
+ * node — a literal is a number here and an operator there — and a list of them under no type is a
+ * value nothing downstream can be asked anything about: what reaches it is told it holds objects,
+ * and a reader that wanted to know what a body does would have to know which node put what where.
+ *
+ * <p>Which is not only a matter of reading. {@link ExecutableIdentity} is part of what says a
+ * recording is of these bodies, so it crosses everywhere a recording does — including the seam an
+ * execution that is not this one's would be written against. Untyped, that seam asks such an
+ * execution to know the compiler's own trees.
+ */
+public sealed interface Settled {
+
+    /** The type the node was decided to have, which every one of them says. */
+    record OfType(Type type) implements Settled {}
+
+    /** A whole number written in the body. */
+    record Whole(long value) implements Settled {}
+
+    /** A decimal written in the body. */
+    record Fraction(BigDecimal value) implements Settled {}
+
+    /** A truth written in the body. */
+    record Truth(boolean value) implements Settled {}
+
+    /**
+     * A word the body holds: text written in it, a field it reads or fills, the reason under an
+     * {@code unreachable}, or the name an author put a departure under.
+     *
+     * <p>One arm for the several of them because they are one thing here — a word the source wrote,
+     * compared as it was written. Which word it is, is said by where it stands: a node's words are
+     * added in a fixed order under a {@link ExecutableIdentity.Kind} that says which node it is.
+     */
+    record Word(String text) implements Settled {}
+
+    /** A word a node may or may not have, kept as the difference between having none and having
+     *  one: an {@code else} the author named and one they left unnamed are not the same body. */
+    record MaybeWord(Optional<String> text) implements Settled {}
+
+    /** Which kind of temporal a literal is, beside the text of it. */
+    record TemporalKind(Type.Prim kind) implements Settled {}
+
+    /** Where a name this node reads is bound, as a place rather than as what it is spelled. */
+    record Bound(BinderAddress at) implements Settled {}
+
+    /** A type the node names: what a unit value is, or what a construction constructs. */
+    record Names(TypeSymbol data) implements Settled {}
+
+    /** What a comparison compares by. */
+    record Operator(BinOp op) implements Settled {}
+
+    /** What a call applies. */
+    record Applies(Core.CallTarget fn) implements Settled {}
+
+    /** A number that is part of what the node does rather than a value it holds: how many names a
+     *  block takes, which member of a tuple is read and out of how many. */
+    record Count(int of) implements Settled {}
+
+    /** Which case a match arm matches. */
+    record Matching(Core.ResolvedPattern pattern) implements Settled {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
@@ -92,18 +92,14 @@ public final class SiteNumbering {
                     + " is being read under " + identity
                     + "; a number means a place under the numbering that handed it out");
         }
+        // A family apiece, each read back as what the recording says it is. Nothing here picks the
+        // arms out of a set holding both: which family a number was issued to is this numbering's
+        // answer, and a number recorded as one family and issued to the other is refused by the
+        // reading itself rather than passed over.
         Set<ArmProbe> arms = new LinkedHashSet<>();
-        for (int raw : seen.taken()) {
-            // Which family the number was issued to is the numbering's answer, and a comparison's
-            // number is not an arm. Both are here, and what tells them apart is what was said when
-            // each was handed out.
-            if (at(raw) instanceof SiteAddress.Arm) {
-                arms.add(arm(raw));
-            }
+        for (int raw : seen.arms()) {
+            arms.add(arm(raw));
         }
-        // And the ways out, read the same way. Both halves or neither: a comparison passed through
-        // as the number it was recorded as would leave a reader asking about places by a number
-        // again, one family below the crossing this is.
         Set<SeenComparison> ways = new LinkedHashSet<>();
         for (ComparisonOutcome way : seen.comparisons()) {
             ways.add(new SeenComparison(comparison(way.at()), way.held()));

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
@@ -1,0 +1,182 @@
+package souther.compiler.coverage;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The numbering of one module's bodies: what handed the numbers out, and what they mean.
+ *
+ * <p>What a numbering is, is {@link NumberingIdentity}, and it is a value: two builds come to the
+ * same one over the same executable with the same numbers addressing the same places, which is what
+ * lets a recording made under one be read under the other. So an address of a numbering is that
+ * value and a number, and two derivations of one module hand out addresses that are each other.
+ *
+ * <p><b>Nothing here is a token minted per construction.</b> One would answer "is this address
+ * mine" with a reference comparison, and it would answer wrongly: the store recomputes, and an
+ * address held under an answer would stop equalling the one a recomputation makes — so every reader
+ * of that answer would run again on every revision, and a claim answered against a recording made a
+ * moment earlier would be refused for having been made a moment earlier.
+ *
+ * <p>What this class is, then, is the one place an address is made. A number crosses back into a
+ * place here and nowhere else, and it is refused where this numbering never handed it out or handed
+ * it out to the other family.
+ */
+public final class SiteNumbering {
+
+    private final NumberingIdentity identity;
+
+    private SiteNumbering(NumberingIdentity identity) {
+        this.identity = identity;
+    }
+
+    /**
+     * The numbering {@code identity} names, as something places can be read out of.
+     *
+     * <p>What a numbering is, is the identity; this adds the reading and nothing else. So it opens
+     * no way to an address that was not issued: every place handed out here is one the identity
+     * says a number of its own addresses, of the family it says, and a caller stating an identity
+     * has stated the places along with it.
+     *
+     * <p>What it is for is a reader that has an identity and no walk — one that took a recording
+     * off an artifact, or a fixture saying which places it means.
+     */
+    public static SiteNumbering of(NumberingIdentity identity) {
+        return new SiteNumbering(identity);
+    }
+
+    /** What this numbering is, as two builds can be held against each other by. */
+    public NumberingIdentity identity() {
+        return identity;
+    }
+
+    /**
+     * The place {@code raw} was issued for, as an arm.
+     *
+     * <p>Refused where this numbering handed out no such number, and refused where it handed it out
+     * for a comparison. Both are the same mistake seen from two sides — a number read as addressing
+     * a place it was not issued for — and neither can be told from a right answer afterwards.
+     */
+    public ArmProbe arm(int raw) {
+        if (!(at(raw) instanceof SiteAddress.Arm)) {
+            throw new IllegalArgumentException(
+                    raw + " was issued for " + at(raw) + ", which is not an arm");
+        }
+        return new ArmProbe(identity, raw);
+    }
+
+    /** The same, for a comparison. */
+    public ComparisonEmissionSite comparison(int raw) {
+        if (!(at(raw) instanceof SiteAddress.Comparison)) {
+            throw new IllegalArgumentException(
+                    raw + " was issued for " + at(raw) + ", which is not a comparison");
+        }
+        return new ComparisonEmissionSite(identity, raw);
+    }
+
+    /**
+     * {@code seen}, read as places of this numbering.
+     *
+     * <p>The one crossing from what a run left behind to what a reader asks about, and the only
+     * place a number becomes a place. What it establishes is that the run was recorded under a
+     * numbering equal to this one, and that every number it holds is one this numbering handed out.
+     * Both are refused rather than answered: a recording of another numbering read under this one
+     * says a row went through places it was never near, and that reads as an ordinary yes or no
+     * everywhere downstream.
+     */
+    public AlignedObservation align(Observation seen) {
+        if (!identity.equals(seen.numbering())) {
+            throw new IllegalArgumentException("a run recorded under " + seen.numbering()
+                    + " is being read under " + identity
+                    + "; a number means a place under the numbering that handed it out");
+        }
+        Set<ArmProbe> arms = new LinkedHashSet<>();
+        for (int raw : seen.taken()) {
+            // Which family the number was issued to is the numbering's answer, and a comparison's
+            // number is not an arm. Both are here, and what tells them apart is what was said when
+            // each was handed out.
+            if (at(raw) instanceof SiteAddress.Arm) {
+                arms.add(arm(raw));
+            }
+        }
+        // And the ways out, read the same way. Both halves or neither: a comparison passed through
+        // as the number it was recorded as would leave a reader asking about places by a number
+        // again, one family below the crossing this is.
+        Set<SeenComparison> ways = new LinkedHashSet<>();
+        for (ComparisonOutcome way : seen.comparisons()) {
+            ways.add(new SeenComparison(comparison(way.at()), way.held()));
+        }
+        return new AlignedObservation(arms, ways);
+    }
+
+    private SiteAddress at(int raw) {
+        return identity.at(raw);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof SiteNumbering that && identity.equals(that.identity);
+    }
+
+    @Override
+    public int hashCode() {
+        return identity.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return identity.toString();
+    }
+
+    /** A numbering being handed out, before what it numbers is known. */
+    static Building begin() {
+        return new Building();
+    }
+
+    /**
+     * The numbering while it is being handed out.
+     *
+     * <p>A number and what it addresses are one act: the walk asks for a place to be numbered and
+     * the place is written down in the same call, so there is no moment at which a number exists
+     * and what it is an address of has still to be worked out. Which is the shape the whole of this
+     * rests on — a number paired with a place anywhere else would be that correspondence rebuilt
+     * from whatever the rebuilder had to hand.
+     *
+     * <p>What it hands back is the number and not an address, because there is no numbering yet: a
+     * numbering is every place and what the bodies do, and both are still being found out. The walk
+     * carries numbers until {@link #finish}, and then reads them back as places of what it made.
+     */
+    static final class Building {
+
+        private final List<SiteAddress> byNumber = new ArrayList<>();
+
+        private final Set<SiteAddress> issued = new LinkedHashSet<>();
+
+        /**
+         * A number for {@code where}.
+         *
+         * <p>A number and not an address, because there is no numbering yet for an address to be
+         * of: what a number means is fixed by every place this walk has still to reach, and by what
+         * the bodies do. So the walk carries numbers and the addresses are made at
+         * {@link #finish}, which is the moment a number first means anything.
+         */
+        int number(SiteAddress where) {
+            // One number per place. A node several ways lead to is arrived at once per way, and a
+            // place numbered twice is a second site the emitter lights on no run — the shape of a
+            // real omission, and read as one by every count.
+            if (!issued.add(where)) {
+                throw new IllegalStateException(where + " is numbered twice; a place a run is"
+                        + " recorded at is recorded at one number");
+            }
+            byNumber.add(where);
+            return byNumber.size() - 1;
+        }
+
+        /** The numbering, now that what its bodies do is known too. */
+        SiteNumbering finish(String module, Map<String, ExecutableIdentity> executable) {
+            return new SiteNumbering(new NumberingIdentity(module, executable, byNumber));
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SiteNumbering.java
@@ -108,7 +108,7 @@ public final class SiteNumbering {
         for (ComparisonOutcome way : seen.comparisons()) {
             ways.add(new SeenComparison(comparison(way.at()), way.held()));
         }
-        return new AlignedObservation(arms, ways);
+        return new AlignedObservation(identity, arms, ways);
     }
 
     private SiteAddress at(int raw) {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SourceOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SourceOutcome.java
@@ -23,16 +23,26 @@ import java.util.Optional;
 public sealed interface SourceOutcome {
 
     /**
+     * One of the ways through a fork that a branch measure counts.
+     *
+     * <p>Which of them is not a question anything asks of a value: a fork has arms and a comparison
+     * is not one of them, so which a way through is belongs to what it is rather than to a predicate
+     * over it. A reader that only ever has arms says so and takes one of these; the few that hold
+     * both take what they both are.
+     */
+    sealed interface Arm extends SourceOutcome permits Held, Failed, Matched {}
+
+    /**
      * The way taken because the decision held.
      *
      * <p>Not always an arm the author wrote. A {@code guard}'s is the rest of the block and a
      * comprehension's is the element it yields, and what says which of those this is, is the
      * construct beside it.
      */
-    record Held(HeldBy by) implements SourceOutcome {}
+    record Held(HeldBy by) implements Arm {}
 
     /** The way taken because the decision did not hold. */
-    record Failed(FailedBy by) implements SourceOutcome {}
+    record Failed(FailedBy by) implements Arm {}
 
     /**
      * What held.
@@ -77,7 +87,7 @@ public sealed interface SourceOutcome {
      * @param cases the cases written on the arm. Several where the source wrote them together, which
      *              is one run of code and so one arm
      */
-    record Matched(List<TypeSymbol> cases) implements SourceOutcome {
+    record Matched(List<TypeSymbol> cases) implements Arm {
 
         public Matched {
             cases = List.copyOf(cases);
@@ -92,11 +102,4 @@ public sealed interface SourceOutcome {
      */
     record Compared(BinOp op) implements SourceOutcome {}
 
-    /** Whether this is one of the arms a branch measure counts. */
-    default boolean isArm() {
-        return switch (this) {
-            case Compared _ -> false;
-            case Held _, Failed _, Matched _ -> true;
-        };
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -18,7 +18,9 @@ import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
+import souther.compiler.coverage.RunRecord;
 import souther.compiler.coverage.Probe;
+import souther.compiler.generated.ProbeImage;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.SoutherJvmAbi;
@@ -221,7 +223,7 @@ public final class ExampleVerifier {
         MemoryClassLoader loader = new MemoryClassLoader(artifact.classes(), parent);
         return new ExampleVerifier(module, symbols, fields, sigs, requirements, loader, values,
                 deadline, policy, answering.over(artifact.implementations(), loader), declared,
-                contracts);
+                contracts, artifact.probes());
     }
 
     /**
@@ -703,6 +705,9 @@ public final class ExampleVerifier {
     /** What each behavior of this module takes injected, in the order its constructor takes it. */
     private final Map<String, List<BehaviorRequirement>> requirements;
     private final MemoryClassLoader loader;
+    /** Whether the classes a row is run against record where it goes, and in whose numbers. What a
+     * run leaves behind is those numbers, so this is what says what they address. */
+    private final ProbeImage probes;
     /** The values a row may name: this module's own, and the ones its imports bring in. */
     private final Map<String, Hir.FnDef> values;
     /** What one row gets to be evaluated within ({@link #checkRow}). Carried rather than looked up,
@@ -758,7 +763,9 @@ public final class ExampleVerifier {
                             MemoryClassLoader loader, Map<String, Hir.FnDef> values,
                             Deadline deadline, EvaluationPolicy policy, Answerer answerer,
                             Supplier<PublishedClasses> declared,
-                            Map<ValueName.Behavior, Contract> contracts) {
+                            Map<ValueName.Behavior, Contract> contracts,
+                            ProbeImage probes) {
+        this.probes = probes;
         this.ensures = new EnsuresChecks(loader, contracts, sigs.keySet());
         this.module = module;
         this.symbols = symbols;
@@ -1181,14 +1188,21 @@ public final class ExampleVerifier {
         @Override
         public List<Diagnostic> call() {
             List<Diagnostic> mine = new ArrayList<>();
-            Probe.begin();
+            // Under the numbering the classes this row runs against were emitted with. Classes
+            // that record nothing start no recording, and what comes back is no account of a run.
+            if (verifier.probes
+                    instanceof ProbeImage.Instrumented(var numbering)) {
+                Probe.begin(numbering);
+            }
             // On this thread, because this thread is the evaluation: the budget belongs to the row,
             // and a worker reused for the next row would otherwise start where this one left off.
             EvaluationContext.begin(verifier.policy.stepLimit(),
                     verifier.policy.recursionDepthLimit());
             try {
                 verifier.checkRowNow(fixtures, target, sig, outCases, row, mine, state);
-                state.seen = Probe.snapshot();
+                if (verifier.probes instanceof ProbeImage.Instrumented) {
+                    state.recorded = new RunRecord.Recorded(Probe.snapshot());
+                }
             } finally {
                 // Read on every way out, not only the one where the row came back. A row stopped by
                 // its budget is the row whose cost is most worth knowing, and reading it after the
@@ -1246,11 +1260,11 @@ public final class ExampleVerifier {
          * it, and what it says then is what it said before the row began.
          */
         private volatile RowStatement statement = new RowStatement.StoppedBeforeItsValues();
-        /** What this row was seen to do, where the classes it ran were generated to say. Empty
-         * otherwise, and empty for a row that did not finish — a snapshot read from a row still
-         * running would be some of what it did rather than what it did. */
-        private souther.compiler.coverage.Observation seen =
-                souther.compiler.coverage.Observation.NONE;
+        /** What this row was seen to do, where the classes it ran were generated to say so. Nothing
+         * recorded otherwise, and nothing recorded for a row that did not finish — a snapshot read
+         * from a row still running would be some of what it did rather than what it did, and a row
+         * nobody watched did not pass nowhere. */
+        private RunRecord recorded = new RunRecord.NotRecording();
         /** What the row cost, in the unit it is held to. Written by the worker when it finishes, so
          * read only for a row that did. */
         private long stepsSpent;
@@ -1331,7 +1345,7 @@ public final class ExampleVerifier {
         return new RowOutcome(row.pos(), target.name(), row.identity(),
                 reached.stage(), state.disposition, state.failurePhase, state.expectedArm,
                 state.resultArm, state.inputCases, state.inputs, state.statement,
-                ran(reached, new Counting.Read(state.stepsSpent, state.seen)));
+                ran(reached, new Counting.Read(state.stepsSpent, state.recorded)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1264,7 +1264,7 @@ public final class ExampleVerifier {
          * recorded otherwise, and nothing recorded for a row that did not finish — a snapshot read
          * from a row still running would be some of what it did rather than what it did, and a row
          * nobody watched did not pass nowhere. */
-        private RunRecord recorded = new RunRecord.NotRecording();
+        private RunRecord recorded = new RunRecord.NoAccount();
         /** What the row cost, in the unit it is held to. Written by the worker when it finishes, so
          * read only for a row that did. */
         private long stepsSpent;

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -122,10 +122,9 @@ public final class RowTrial {
         // Under the numbering the classes about to be run were emitted with. Classes that record
         // nothing start no recording: what comes back then is no account of a run rather than an
         // account of one that went nowhere.
-        NumberingIdentity under = probes instanceof ProbeImage.Instrumented(var numbering)
-                ? numbering : null;
-        if (under != null) {
-            Probe.begin(under);
+        switch (probes) {
+            case ProbeImage.Instrumented(NumberingIdentity numbering) -> Probe.begin(numbering);
+            case ProbeImage.Uninstrumented _ -> { }
         }
         try {
             EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
@@ -150,7 +149,8 @@ public final class RowTrial {
             // Nothing was watching where the classes record nothing, so the row ran and there is no
             // account of where it went — which is not the same as an account of it reaching
             // nothing, and is what an empty answer means here.
-            return under == null ? Optional.empty() : Optional.of(Probe.snapshot());
+            return probes instanceof ProbeImage.Instrumented
+                    ? Optional.of(Probe.snapshot()) : Optional.empty();
         } finally {
             // On every way out, including one nothing here catches. A recording left installed is
             // where the next reader on this thread would start.

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -6,11 +6,13 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.BoundaryInput;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
+import souther.compiler.coverage.NumberingIdentity;
 import souther.compiler.coverage.Observation;
 import souther.compiler.coverage.Probe;
 import souther.compiler.evaluate.EvaluationContext;
 import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.generated.ProbeImage;
 import souther.compiler.jvm.ClassFileImage;
 
 import java.util.ArrayList;
@@ -64,6 +66,7 @@ public final class RowTrial {
                               Map<String, ClassFileImage> classes,
                               ClassLoader parent,
                               Map<String, Hir.FnDef> values, GeneratedImplementations generated,
+                              ProbeImage probes,
                               EvaluationPolicy steps) {
         MemoryClassLoader loader = new MemoryClassLoader(classes, parent);
         Answerer answerer = Answering.generatedHere().over(generated, loader);
@@ -75,7 +78,7 @@ public final class RowTrial {
             // expands a value is that row's, and a reader kept between them would be a session
             // spanning every candidate of every combination.
             return went(new FixtureReader(module, symbols, fields, values, loader), applies, behavior, sig,
-                    inputs, steps);
+                    inputs, probes, steps);
         };
     }
 
@@ -88,7 +91,7 @@ public final class RowTrial {
      */
     private static Optional<Observation> went(FixtureReader fixtures,
                                               Answerer.Answer.Something applies, String behavior,
-                                              Sig sig, List<Hir.Expr> inputs,
+                                              Sig sig, List<Hir.Expr> inputs, ProbeImage probes,
                                               EvaluationPolicy steps) {
         List<BoundaryInput> ins = sig.ins();
         if (inputs.size() != ins.size()) {
@@ -116,7 +119,14 @@ public final class RowTrial {
             // went is how a defect in the runner comes back as a defect in the model.
             return Optional.empty();
         }
-        Probe.begin();
+        // Under the numbering the classes about to be run were emitted with. Classes that record
+        // nothing start no recording: what comes back then is no account of a run rather than an
+        // account of one that went nowhere.
+        NumberingIdentity under = probes instanceof ProbeImage.Instrumented(var numbering)
+                ? numbering : null;
+        if (under != null) {
+            Probe.begin(under);
+        }
         try {
             EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
             try {
@@ -137,7 +147,10 @@ public final class RowTrial {
             } finally {
                 EvaluationContext.end();
             }
-            return Optional.of(Probe.snapshot());
+            // Nothing was watching where the classes record nothing, so the row ran and there is no
+            // account of where it went — which is not the same as an account of it reaching
+            // nothing, and is what an empty answer means here.
+            return under == null ? Optional.empty() : Optional.of(Probe.snapshot());
         } finally {
             // On every way out, including one nothing here catches. A recording left installed is
             // where the next reader on this thread would start.

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -85,9 +85,10 @@ public final class RowTrial {
     /**
      * One row, built and applied, and what the probe saw while it was.
      *
-     * <p>The recording is begun and read on this thread because the run is on this thread. Both it
-     * and the budget are let go on every way out, a worker being something the next row would
-     * otherwise start inside of.
+     * <p>The recording is begun and read on this thread because the run is on this thread, and it
+     * is begun only where there is something to record: classes generated without the calls that
+     * write a run down leave no account, which is not the same as an account of a run that reached
+     * nothing.
      */
     private static Optional<Observation> went(FixtureReader fixtures,
                                               Answerer.Answer.Something applies, String behavior,
@@ -119,43 +120,62 @@ public final class RowTrial {
             // went is how a defect in the runner comes back as a defect in the model.
             return Optional.empty();
         }
-        // Under the numbering the classes about to be run were emitted with. Classes that record
-        // nothing start no recording: what comes back then is no account of a run rather than an
-        // account of one that went nowhere.
-        switch (probes) {
-            case ProbeImage.Instrumented(NumberingIdentity numbering) -> Probe.begin(numbering);
-            case ProbeImage.Uninstrumented _ -> { }
-        }
-        try {
-            EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
-            try {
-                applying.to(over);
-            } catch (ImplementationNotReached e) {
-                // Not a run at all: the implementation could not be reached to apply. Saying the
-                // row did nothing would be saying it went nowhere, and those are different facts.
-                return Optional.empty();
-            } catch (InvocationFailure e) {
-                // It ran and stopped. Where it had got to is what is being asked for, and what
-                // stopped it is not: nothing here is judging the row.
-                //
-                // This one and no wider. What the applied code ends with arrives as this, so a
-                // throwable that is not one is this compiler failing to reach or drive its own
-                // output — and swallowed here it would come back as a candidate that ran and
-                // missed, which is a statement about the model. The seam says which failures it
-                // has ({@link Answerer.Applying#to}) and those are the ones read.
-            } finally {
-                EvaluationContext.end();
+        // Under the numbering the classes about to be run were emitted with, or not at all where
+        // they record nothing. Asked once and answered by the shape: the recording is begun, read
+        // and let go inside one arm, so there is no way to end one that was never begun — and what
+        // comes back where nothing was watching is no account of a run rather than an account of
+        // one that went nowhere.
+        return switch (probes) {
+            case ProbeImage.Uninstrumented _ -> {
+                applied(applying, over, steps);
+                yield Optional.empty();
             }
-            // Nothing was watching where the classes record nothing, so the row ran and there is no
-            // account of where it went — which is not the same as an account of it reaching
-            // nothing, and is what an empty answer means here.
-            return probes instanceof ProbeImage.Instrumented
-                    ? Optional.of(Probe.snapshot()) : Optional.empty();
+            case ProbeImage.Instrumented(NumberingIdentity numbering) -> {
+                Probe.begin(numbering);
+                try {
+                    yield applied(applying, over, steps)
+                            ? Optional.of(Probe.snapshot()) : Optional.empty();
+                } finally {
+                    // On every way out, including one nothing here catches. A recording left
+                    // installed is where the next reader on this thread would start.
+                    Probe.end();
+                }
+            }
+        };
+    }
+
+    /**
+     * Applies the behavior, and says whether it was applied at all.
+     *
+     * <p>A run that aborts still went where it went, so what stopped it is dropped: nothing here is
+     * judging the row, and a generator has no expectation for it to have failed against. What is
+     * not a run at all is the implementation being out of reach, and that is the false answer.
+     *
+     * <p>The budget is let go on every way out, a worker being something the next row would
+     * otherwise start inside of.
+     */
+    private static boolean applied(Answerer.Applying applying, List<Handed> over,
+                                   EvaluationPolicy steps) {
+        EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
+        try {
+            applying.to(over);
+        } catch (ImplementationNotReached e) {
+            // Not a run at all: the implementation could not be reached to apply. Saying the row
+            // did nothing would be saying it went nowhere, and those are different facts.
+            return false;
+        } catch (InvocationFailure e) {
+            // It ran and stopped. Where it had got to is what is being asked for, and what stopped
+            // it is not.
+            //
+            // This one and no wider. What the applied code ends with arrives as this, so a
+            // throwable that is not one is this compiler failing to reach or drive its own output —
+            // and swallowed here it would come back as a candidate that ran and missed, which is a
+            // statement about the model. The seam says which failures it has
+            // ({@link Answerer.Applying#to}) and those are the ones read.
         } finally {
-            // On every way out, including one nothing here catches. A recording left installed is
-            // where the next reader on this thread would start.
-            Probe.end();
+            EvaluationContext.end();
         }
+        return true;
     }
 
     private RowTrial() {}

--- a/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
+++ b/souther-compiler/src/main/java/souther/compiler/execute/jvm/JvmProgramExecution.java
@@ -152,7 +152,7 @@ public final class JvmProgramExecution implements ProgramExecution {
         return RowTrial.over(asked.forExamples(), asked.symbols(), asked.fieldTypes(),
                 image.program().classes(),
                 image.around(), asked.definitions(), image.program().implementations(),
-                asked.policy());
+                image.program().probes(), asked.policy());
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
@@ -27,15 +27,23 @@ import java.util.Objects;
  * manifest is what a run needs — and one covering every linked module would be answering for
  * behaviors no answerer here is asked about.
  *
+ * <p>{@link #probes} is here for the same reason the two above are one value. The numbers a probed
+ * class writes are of the numbering it was emitted under, and a run handed one compile's classes
+ * beside another's numbering would be recorded in numbers that address other places — silently,
+ * because a number addresses something either way.
+ *
  * @param classes         binary name to class file, for this module and the ones its rows reach
  * @param implementations what the module being evaluated generated an implementation for
+ * @param probes          whether these classes record where a run goes, and in whose numbers
  */
 public record EvaluationArtifact(Map<String, ClassFileImage> classes,
-                                 GeneratedImplementations implementations) {
+                                 GeneratedImplementations implementations,
+                                 ProbeImage probes) {
 
     public EvaluationArtifact {
         Objects.requireNonNull(classes, "a run says what classes it loads");
         Objects.requireNonNull(implementations,
                 "a run says what the compile generated an implementation for");
+        Objects.requireNonNull(probes, "a run says whether its classes record where it goes");
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/generated/ProbeImage.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/ProbeImage.java
@@ -1,0 +1,37 @@
+package souther.compiler.generated;
+
+import souther.compiler.coverage.NumberingIdentity;
+
+/**
+ * Whether the classes of an artifact record where a run goes, and under what numbering.
+ *
+ * <p>A number a probed class writes means a place only under the numbering that handed it out, and
+ * the class has nothing to say about which numbering that was: what it holds is the number. So what
+ * says it travels with the classes, because it is a fact about them — they were emitted with those
+ * numbers in those calls, and nothing else about them says so.
+ *
+ * <p>Carried as the numbering's own value and not as the numbering. What crosses from a compile to
+ * whatever runs a row is a thing two builds can be held against each other by; the capability to
+ * issue an address belongs to a computation and stays in one.
+ *
+ * <p>Two arms because a build asks for the classes either way. Every evaluation runs against
+ * counted classes and only a measurement asks for the probes, so most artifacts record nothing —
+ * and a run against those is a run with no account of where it went, which is not the same as an
+ * account of a run that went nowhere.
+ */
+public sealed interface ProbeImage {
+
+    /** Classes with no probes in them: a run through these leaves nothing behind. */
+    record Uninstrumented() implements ProbeImage {}
+
+    /** Classes that record where a run goes, in the numbers {@code numbering} handed out. */
+    record Instrumented(NumberingIdentity numbering) implements ProbeImage {
+
+        public Instrumented {
+            if (numbering == null) {
+                throw new IllegalArgumentException(
+                        "classes that record a run record it in somebody's numbers");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/observe/Counting.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Counting.java
@@ -1,6 +1,6 @@
 package souther.compiler.observe;
 
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.RunRecord;
 
 /**
  * What this compile's own counting read of one row's evaluation.
@@ -27,18 +27,22 @@ public sealed interface Counting {
      * of the budget its rows use before one of them reaches it — the only way to set the budget from
      * evidence rather than by guessing. Zero says no counted point was passed, and says only that.
      *
-     * <p>{@link #observation} is what the row was seen to do — the sites it went through and the ways
-     * its comparisons came out. Empty until branches are measured, which is a property of the compile
-     * rather than of the row.
+     * <p>{@link #recorded} is what the row was seen to do, where anything was watching — the sites it
+     * went through and the ways its comparisons came out. Whether anything was is a property of the
+     * compile rather than of the row, and it is one of that value's two answers rather than an empty
+     * account: a row nobody watched did not pass nowhere.
      *
-     * <p>One value rather than a field per shape of thing recorded. What a run leaves behind is taken
-     * of one thread between one start and one stop, and a record with a field each would let the
-     * halves of one run be filled from different ones.
+     * <p>The steps and the recording are both read here and are different questions. A compile that
+     * counts steps records nothing unless it also emitted the calls that write a run down, so a
+     * count that came back is not evidence that a run did.
      */
-    record Read(long steps, Observation observation) implements Counting {
+    record Read(long steps, RunRecord recorded) implements Counting {
 
         public Read {
-            observation = observation == null ? Observation.NONE : observation;
+            if (recorded == null) {
+                throw new IllegalArgumentException(
+                        "a row says what was recorded of it, or that nothing was");
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/observe/Run.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Run.java
@@ -33,6 +33,6 @@ public record Run(Applied applied, Counting counting) {
     /** A row that applied nothing and was read to have spent nothing. */
     public static Run nothing() {
         return new Run(new Applied.Nothing(),
-                new Counting.Read(0L, new RunRecord.NotRecording()));
+                new Counting.Read(0L, new RunRecord.NoAccount()));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/Run.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Run.java
@@ -1,5 +1,7 @@
 package souther.compiler.observe;
 
+import souther.compiler.coverage.RunRecord;
+
 import java.util.Objects;
 
 /**
@@ -31,6 +33,6 @@ public record Run(Applied applied, Counting counting) {
     /** A row that applied nothing and was read to have spent nothing. */
     public static Run nothing() {
         return new Run(new Applied.Nothing(),
-                new Counting.Read(0L, souther.compiler.coverage.Observation.NONE));
+                new Counting.Read(0L, new RunRecord.NotRecording()));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -1,7 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.AlignedObservation;
 
 import java.util.List;
 
@@ -47,12 +47,12 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
      * never reached the meeting misses the way in, and one that reached it and went the other way
      * misses an outcome, and those are different things to be told.
      */
-    public List<ControlClaim> missedBy(Observation seen) {
+    public List<ControlClaim> missedBy(AlignedObservation seen) {
         return claims.stream().filter(claim -> !claim.satisfiedBy(seen)).toList();
     }
 
     /** Whether {@code seen} did everything this names. */
-    public boolean certifiedBy(Observation seen) {
+    public boolean certifiedBy(AlignedObservation seen) {
         return claims.stream().allMatch(claim -> claim.satisfiedBy(seen));
     }
 
@@ -159,7 +159,7 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
      * A caller holding one half cannot reach for it, which is what stops the reading that composed
      * a row from being read back as evidence for itself.
      */
-    public java.util.Optional<CertifiedWitness> certifying(int[] where, Observation seen) {
+    public java.util.Optional<CertifiedWitness> certifying(int[] where, AlignedObservation seen) {
         return cell.holds(where) && certifiedBy(seen)
                 ? java.util.Optional.of(new CertifiedWitness(this, where, seen))
                 : java.util.Optional.empty();
@@ -177,9 +177,9 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
 
         private final CellSelection of;
         private final int[] where;
-        private final Observation seen;
+        private final AlignedObservation seen;
 
-        private CertifiedWitness(CellSelection of, int[] where, Observation seen) {
+        private CertifiedWitness(CellSelection of, int[] where, AlignedObservation seen) {
             this.of = of;
             this.where = where.clone();
             this.seen = seen;
@@ -196,7 +196,7 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
         }
 
         /** What the run was seen doing, which is what other combinations are asked of in turn. */
-        public Observation seen() {
+        public AlignedObservation seen() {
             return seen;
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1,5 +1,9 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.AlignedObservation;
+import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.ast.Hir;
@@ -171,7 +175,7 @@ public final class Generator {
          * name made here would be a second vocabulary for one thing, free to drift from the one the
          * finding is written in.
          */
-        record ForAnArm(int probe) implements Purpose {
+        record ForAnArm(ArmProbe probe) implements Purpose {
 
             @Override
             public List<String> labels() {
@@ -740,7 +744,7 @@ public final class Generator {
         /** It ran, something was recording, and this is what it was seen doing. Also what a row
          *  that aborted part way comes back as: it went where it went before it stopped, and that
          *  is recorded. */
-        record Ran(souther.compiler.coverage.Observation seen) implements Watched {}
+        record Ran(AlignedObservation seen) implements Watched {}
 
         /**
          * Nothing here can say what it did.
@@ -818,7 +822,7 @@ public final class Generator {
      * this takes the answer rather than the collection it was kept in.
      */
     public static GenerationPlan planOver(MeasuredInput subject, List<ClassOwed> classes,
-                                          List<Integer> arms) {
+                                          List<ArmProbe> arms) {
         return new GenerationPlan(subject, classes, arms.stream().map(ArmOwed::new).toList());
     }
 
@@ -834,7 +838,7 @@ public final class Generator {
                                         souther.compiler.reading.CoverageRead.Read read,
                                         Trial trial, List<Baseline> baselines,
                                         List<ClassOwed> classesOwed,
-                                        List<Integer> armsOwed,
+                                        List<ArmProbe> armsOwed,
                                         AdequacyPolicy.OfTheGeneration budget) {
         return fill(planOver(subject, classesOwed, armsOwed), existing, check, read, trial,
                 baselines, budget);
@@ -860,10 +864,10 @@ public final class Generator {
      * nothing to tell that from an arm nothing could be composed for. An arm asked for and not
      * found says what each place it was looked in came to.
      */
-    public static Set<Integer> everyArmACombinationMayTake(
+    public static Set<ArmProbe> everyArmACombinationMayTake(
             MeasuredInput subject, List<souther.compiler.reading.Interaction> groups,
             AdequacyPolicy.OfTheGeneration budget) {
-        Set<Integer> out = new LinkedHashSet<>();
+        Set<ArmProbe> out = new LinkedHashSet<>();
         InteractionCells.Offered offered =
                 InteractionCells.of(groups, ordered(subject).axes(), budget);
         for (InteractionCells.Group group : offered.groups()) {
@@ -895,7 +899,7 @@ public final class Generator {
      * spelled as a bare {@code int} put the obligations into two vocabularies, and anything holding
      * both had to say which kind of thing a number was every time it read one.
      */
-    public record ArmOwed(int probe) {}
+    public record ArmOwed(ArmProbe probe) {}
 
     /**
      * Every class of every position no row the author wrote sits in.
@@ -952,7 +956,7 @@ public final class Generator {
                                         AdequacyPolicy.OfTheGeneration budget) {
         MeasuredInput subject = plan.subject();
         List<ClassOwed> classesOwed = plan.classesOwed();
-        List<Integer> armsOwed = plan.armsOwed().stream().map(ArmOwed::probe).toList();
+        List<ArmProbe> armsOwed = plan.armsOwed().stream().map(ArmOwed::probe).toList();
         MeasuredInput.MeasuredAxes ordered = ordered(subject);
         // A position where some row's value could not be read is a position nothing is known about.
         // A row generated for a class there may be a row that is already written, and telling an
@@ -1073,13 +1077,13 @@ public final class Generator {
         // row found there arrives at the arm and exercises the combination at once, so it is looked
         // in first — which is a preference between two answers and not one of them standing in for
         // the other. An arm no combination is over is answered from its way in all the same.
-        Set<Integer> left = new LinkedHashSet<>(armsOwed);
-        Map<Integer, RowId> built = new LinkedHashMap<>();
-        Map<Integer, List<UnresolvedCombination>> failed = new LinkedHashMap<>();
+        Set<ArmProbe> left = new LinkedHashSet<>(armsOwed);
+        Map<ArmProbe, RowId> built = new LinkedHashMap<>();
+        Map<ArmProbe, List<UnresolvedCombination>> failed = new LinkedHashMap<>();
         // Arms the row budget ran out before, which is what the search stopping looks like from an
         // arm. Told apart from an arm with nowhere to look, because raising the budget changes one
         // of them and nothing about the other.
-        Set<Integer> cutOff = new LinkedHashSet<>();
+        Set<ArmProbe> cutOff = new LinkedHashSet<>();
         // And the arms behind a group nothing walked, which is a second silence with a different
         // cause. The one above is a budget that ran out with the arm still owed; this is a group
         // the offer never opened, and raising the budget does not reach it.
@@ -1089,12 +1093,12 @@ public final class Generator {
         // for one, so a walk per arm builds every cell of it again for an answer that does not
         // depend on which arm is asking.
         List<WhereToLook>cells = placesFor(new LinkedHashSet<>(armsOwed), offered);
-        Set<Integer> notOffered = new LinkedHashSet<>();
+        Set<ArmProbe> notOffered = new LinkedHashSet<>();
         // Which arms each held-back group could have been searched at, kept per group so that the
         // summary at the end can be counted off the entries rather than worked out a second way.
-        List<List<Integer>> behindEachHeldGroup = new ArrayList<>();
+        List<List<ArmProbe>> behindEachHeldGroup = new ArrayList<>();
         for (InteractionCells.NotOffered held : offered.notOffered()) {
-            List<Integer> behindIt = armsIn(held.claims());
+            List<ArmProbe> behindIt = armsIn(held.claims());
             behindEachHeldGroup.add(behindIt);
             notOffered.addAll(behindIt);
         }
@@ -1102,7 +1106,7 @@ public final class Generator {
         // What each set of values did when it was run, so that a row two arms were both composed
         // the same values for is applied once.
         Map<List<String>, Watched> ran = new LinkedHashMap<>();
-        for (int probe : armsOwed) {
+        for (ArmProbe probe : armsOwed) {
             if (!left.contains(probe)) {
                 // A row already composed was watched going through it, which is the one thing that
                 // says so. Nothing is composed a second time for what a run was seen doing.
@@ -1123,7 +1127,7 @@ public final class Generator {
                 // cell claims the arms a reading believes a row filling it takes, and discharging
                 // them on that belief is the reading certifying itself (issue #1009).
                 GeneratedRow row;
-                List<Integer> also;
+                List<ArmProbe> also;
                 switch (place.tried) {
                     case Witness.NoCombination none -> {
                         noRow(unresolved, failed, probe, new UnresolvedCombination(List.of(),
@@ -1193,7 +1197,7 @@ public final class Generator {
         // nothing about the ones nobody got to, and an arm answered by the first alone was reported
         // as settled by the model on the strength of a search that stopped.
         Map<ArmOwed, ArmDisposition> armAnswers = new LinkedHashMap<>();
-        for (int probe : armsOwed) {
+        for (ArmProbe probe : armsOwed) {
             RowId row = built.get(probe);
             List<UnresolvedCombination> why = new ArrayList<>(
                     failed.getOrDefault(probe, List.of()));
@@ -1234,7 +1238,7 @@ public final class Generator {
         // is not what the limit did; asked about nothing behind it, the group costs this run
         // nothing and is not named (issue #967).
         int heldBackAndAskedAbout = 0;
-        for (List<Integer> behindIt : behindEachHeldGroup) {
+        for (List<ArmProbe> behindIt : behindEachHeldGroup) {
             if (behindIt.stream().anyMatch(armsOwed::contains)) {
                 heldBackAndAskedAbout++;
             }
@@ -1286,7 +1290,7 @@ public final class Generator {
      * a comparison is one of those — it is a place a run passes and not a way through a fork, so
      * nothing about an arm is owed for it.
      */
-    private static List<Integer> claimed(CellSelection selection) {
+    private static List<ArmProbe> claimed(CellSelection selection) {
         return armsIn(selection.claims());
     }
 
@@ -1306,11 +1310,11 @@ public final class Generator {
 
         private final CellSelection at;
 
-        private final List<Integer> claims;
+        private final List<ArmProbe> claims;
 
         private Witness tried;
 
-        private WhereToLook(CellSelection at, List<Integer> claims) {
+        private WhereToLook(CellSelection at, List<ArmProbe> claims) {
             this.at = at;
             this.claims = claims;
         }
@@ -1324,7 +1328,8 @@ public final class Generator {
      * search space nobody asked about — which is what the cells were before a finding decided what
      * to look for.
      */
-    private static List<WhereToLook>placesFor(Set<Integer> armsOwed, InteractionCells.Offered offered) {
+    private static List<WhereToLook>placesFor(Set<ArmProbe> armsOwed,
+                                              InteractionCells.Offered offered) {
         List<WhereToLook>out = new ArrayList<>();
         for (InteractionCells.Group group : offered.groups()) {
             for (int index = 0; index < group.size(); index++) {
@@ -1334,7 +1339,7 @@ public final class Generator {
                 if (selection == null) {
                     continue;
                 }
-                List<Integer> claims = claimed(selection);
+                List<ArmProbe> claims = claimed(selection);
                 if (claims.stream().anyMatch(armsOwed::contains)) {
                     out.add(new WhereToLook(selection, claims));
                 }
@@ -1358,7 +1363,8 @@ public final class Generator {
      * for from one every attempt failed at.
      */
     private static List<WhereToLook>whereToLookFor(
-            int probe, souther.compiler.reading.CoverageRead.Read read, List<WhereToLook>cells,
+            ArmProbe probe, souther.compiler.reading.CoverageRead.Read read,
+            List<WhereToLook>cells,
             List<Axis> axes) {
         List<WhereToLook>out = new ArrayList<>();
         for (WhereToLook place : cells) {
@@ -1394,7 +1400,7 @@ public final class Generator {
      * account.
      */
     private static void noRow(List<UnresolvedCombination> unresolved,
-                              Map<Integer, List<UnresolvedCombination>> failed, int probe,
+                              Map<ArmProbe, List<UnresolvedCombination>> failed, ArmProbe probe,
                               UnresolvedCombination why) {
         if (!unresolved.contains(why)) {
             unresolved.add(why);
@@ -1409,11 +1415,11 @@ public final class Generator {
      * arms — every arm on the way to the one it was composed for is one it takes — and the arm it
      * was composed for is left out here because it is already answered.
      */
-    private static List<Integer> alsoThrough(souther.compiler.coverage.Observation seen,
-                                             Set<Integer> left, int probe) {
-        List<Integer> out = new ArrayList<>();
-        for (int each : left) {
-            if (each != probe && seen.taken().contains(each)) {
+    private static List<ArmProbe> alsoThrough(AlignedObservation seen,
+                                              Set<ArmProbe> left, ArmProbe probe) {
+        List<ArmProbe> out = new ArrayList<>();
+        for (ArmProbe each : left) {
+            if (!each.equals(probe) && seen.lit(each)) {
                 out.add(each);
             }
         }
@@ -1470,12 +1476,13 @@ public final class Generator {
 
     /** The arms a list of claims names, by the numbers the plan gave them. Shared with the groups
      *  the limit held back, which have claims and no cell to read them off. */
-    private static List<Integer> armsIn(List<souther.compiler.coverage.ControlClaim> claims) {
-        List<Integer> out = new ArrayList<>();
-        for (souther.compiler.coverage.ControlClaim claim : claims) {
-            if (claim.at() instanceof souther.compiler.coverage.ControlPointId.ArmOccurrence arm
+    private static List<ArmProbe> armsIn(
+            List<ControlClaim> claims) {
+        List<ArmProbe> out = new ArrayList<>();
+        for (ControlClaim claim : claims) {
+            if (claim.at() instanceof ControlPointId.ArmOccurrence arm
                     && arm.probe().isPresent()) {
-                out.add(arm.probe().getAsInt());
+                out.add(arm.probe().get());
             }
         }
         return out;
@@ -3067,7 +3074,7 @@ public final class Generator {
      */
     private static Witness witnessFor(MeasuredInput.MeasuredAxes axes,
                                       CellSelection selection, CandidateCheck check, Trial trial,
-                                      Map<List<String>, Watched> applied, List<Integer> takes,
+                                      Map<List<String>, Watched> applied, List<ArmProbe> takes,
                                       List<ResolvedOrigin> origins) {
         Reading reading =
                 new Reading(axes, selection, check, trial, applied, takes, origins);
@@ -3101,7 +3108,7 @@ public final class Generator {
 
         private final Map<List<String>, Watched> applied;
 
-        private final List<Integer> takes;
+        private final List<ArmProbe> takes;
 
         private final List<ResolvedOrigin> origins;
 
@@ -3130,7 +3137,7 @@ public final class Generator {
 
         private Reading(MeasuredInput.MeasuredAxes axes, CellSelection selection,
                         CandidateCheck check, Trial trial, Map<List<String>, Watched> applied,
-                        List<Integer> takes, List<ResolvedOrigin> origins) {
+                        List<ArmProbe> takes, List<ResolvedOrigin> origins) {
             this.axes = axes;
             this.selection = selection;
             this.check = check;

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
@@ -51,13 +51,19 @@ public record ObservedInputs(List<ObservedValue> inputs, Generator.Watched watch
      * and a reading that took it in would answer differently about one row depending on who asked.
      */
     public static ObservedInputs of(RowOutcome row,
-                                    SiteNumbering numbering) {
+                                    java.util.Optional<SiteNumbering> numbering) {
+        if (numbering.isEmpty()) {
+            // The module has no numbering, so there is nothing its numbers could be places of.
+            // What the row did is not something anything here can say, which is no account of a
+            // run rather than an account of one that went nowhere.
+            return new ObservedInputs(row.inputs(), new Generator.Watched.NoAccount());
+        }
         return new ObservedInputs(row.inputs(), switch (row.run().counting()) {
             // Read under the numbering asking, which is where the numbers a run left behind become
             // places. A recording made under another one is refused here rather than answered
             // about places it was never near.
             case Counting.Read(long _, RunRecord.Recorded(Observation seen)) ->
-                    new Generator.Watched.Ran(numbering.align(seen));
+                    new Generator.Watched.Ran(numbering.orElseThrow().align(seen));
             // And a row nothing watched has no account of where it went, whether that is because
             // the compile records nothing or because its counting was never read at all.
             case Counting.Read(long _, RunRecord.NoAccount _) ->

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
@@ -60,7 +60,7 @@ public record ObservedInputs(List<ObservedValue> inputs, Generator.Watched watch
                     new Generator.Watched.Ran(numbering.align(seen));
             // And a row nothing watched has no account of where it went, whether that is because
             // the compile records nothing or because its counting was never read at all.
-            case Counting.Read(long _, RunRecord.NotRecording _) ->
+            case Counting.Read(long _, RunRecord.NoAccount _) ->
                     new Generator.Watched.NoAccount();
             case Counting.Unread _ -> new Generator.Watched.NoAccount();
         });

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservedInputs.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.RunRecord;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.observe.Counting;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
@@ -47,9 +50,18 @@ public record ObservedInputs(List<ObservedValue> inputs, Generator.Watched watch
      * watching is the caller's own — it follows from what was asked for rather than from the row —
      * and a reading that took it in would answer differently about one row depending on who asked.
      */
-    public static ObservedInputs of(RowOutcome row) {
+    public static ObservedInputs of(RowOutcome row,
+                                    SiteNumbering numbering) {
         return new ObservedInputs(row.inputs(), switch (row.run().counting()) {
-            case Counting.Read read -> new Generator.Watched.Ran(read.observation());
+            // Read under the numbering asking, which is where the numbers a run left behind become
+            // places. A recording made under another one is refused here rather than answered
+            // about places it was never near.
+            case Counting.Read(long _, RunRecord.Recorded(Observation seen)) ->
+                    new Generator.Watched.Ran(numbering.align(seen));
+            // And a row nothing watched has no account of where it went, whether that is because
+            // the compile records nothing or because its counting was never read at all.
+            case Counting.Read(long _, RunRecord.NotRecording _) ->
+                    new Generator.Watched.NoAccount();
             case Counting.Unread _ -> new Generator.Watched.NoAccount();
         });
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -2,6 +2,8 @@ package souther.compiler.partition;
 
 import souther.compiler.core.Core;
 import souther.compiler.check.PathReachability;
+import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.types.TypeSymbol;
 
@@ -83,7 +85,8 @@ public final class ProducedCases {
      * value a {@code let} binds — is not what the behavior answers with, and counting it would keep a
      * case owed because the body happened to build one on its way past.
      */
-    private static void walk(Core e, List<Integer> under, CoverageSites.Plan plan,
+    private static void walk(Core e, List<ArmProbe> under,
+                             CoverageSites.Plan plan,
                              PathReachability.Answers arrives, Set<TypeSymbol> declared, Seen seen) {
         if (seen.anythingUnreadable) {
             return;   // nothing further can be taken away
@@ -92,19 +95,19 @@ public final class ProducedCases {
             case Core.Unreachable _ -> { }   // answers nothing, so it produces nothing
             case Core.LetIn li -> walk(li.body(), under, plan, arrives, declared, seen);
             case Core.If iff -> {
-                int[] arms = plan.probesOf(iff);
+                ControlPointId.ArmOccurrence[] arms = plan.armsOf(iff);
                 walk(iff.then(), beneath(under, arms, 0), plan, arrives, declared, seen);
                 walk(iff.els(), beneath(under, arms, 1), plan, arrives, declared, seen);
             }
             case Core.Match m -> {
-                int[] arms = plan.probesOf(m);
+                ControlPointId.ArmOccurrence[] arms = plan.armsOf(m);
                 for (int i = 0; i < m.cases().size(); i++) {
                     walk(m.cases().get(i).body(), beneath(under, arms, i), plan, arrives, declared,
                             seen);
                 }
             }
             case Core.IfConstructed ic -> {
-                int[] arms = plan.probesOf(ic);
+                ControlPointId.ArmOccurrence[] arms = plan.armsOf(ic);
                 walk(ic.then(), beneath(under, arms, 0), plan, arrives, declared, seen);
                 for (int i = 0; i < ic.els().size(); i++) {
                     walk(ic.els().get(i).body(), beneath(under, arms, i + 1), plan, arrives,
@@ -120,7 +123,8 @@ public final class ProducedCases {
     }
 
     /** Where one producer puts the case it answers with. */
-    private static void produce(TypeSymbol built, List<Integer> under, PathReachability.Answers arrives,
+    private static void produce(TypeSymbol built, List<ArmProbe> under,
+                                PathReachability.Answers arrives,
                                 Set<TypeSymbol> declared, Seen seen) {
         boolean proven = under.stream().anyMatch(arrives::nothingArrivesAt);
         if (built == null || !declared.contains(built)) {
@@ -138,12 +142,15 @@ public final class ProducedCases {
 
     /** The arms of an inner fork, added to the ones already above it. An arm with no probe adds
      * nothing: there is no site for a proof to have been about. */
-    private static List<Integer> beneath(List<Integer> under, int[] arms, int index) {
-        if (arms == null || index >= arms.length || arms[index] == CoverageSites.NO_SITE) {
+    private static List<ArmProbe> beneath(
+            List<ArmProbe> under,
+            ControlPointId.ArmOccurrence[] arms, int index) {
+        if (arms == null || index >= arms.length || arms[index] == null
+                || arms[index].probe().isEmpty()) {
             return under;
         }
-        List<Integer> out = new ArrayList<>(under);
-        out.add(arms[index]);
+        List<ArmProbe> out = new ArrayList<>(under);
+        out.add(arms[index].probe().get());
         return List.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.coverage.CoverageSites;
 import souther.compiler.types.TypeSymbol;
 
 /**
@@ -344,7 +345,7 @@ public sealed interface About {
      * one from another is the obligation, and this says so by being an {@link OfAnObligation}.
      */
     record AnArmNoRowGoesThrough(
-            souther.compiler.coverage.CoverageSites.Site arm) implements OfAnObligation {
+            CoverageSites.ArmSite arm) implements OfAnObligation {
 
         public AnArmNoRowGoesThrough {
             java.util.Objects.requireNonNull(arm, "a finding is about something");

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -7,7 +7,6 @@ import souther.compiler.observe.ArmObservation;
 import souther.compiler.inputs.TermPath;
 
 
-import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.SiteNumbering;
@@ -1129,7 +1128,7 @@ public final class Adequacy {
             Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : db.ask(new RowReadings(name)).value().values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(seenBy(row, plan).arms());
+                    lit.addAll(armsSeenIn(row, plan));
                 }
             }
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> out =
@@ -2336,7 +2335,7 @@ public final class Adequacy {
             Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : byTarget.values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(seenBy(row, plan).arms());
+                    lit.addAll(armsSeenIn(row, plan));
                 }
             }
 
@@ -5021,18 +5020,21 @@ public final class Adequacy {
     private Adequacy() {}
 
     /**
-     * What a row is known to have done.
+     * The arms {@code row} was seen at, which is none where nothing watched it.
      *
-     * <p>For the two readers here that a run reaching nothing and a run nobody watched are one
-     * answer for. A row whose counting was never read is known to have done none of it, and that it
-     * was left undecided is said where the row is reported.
+     * <p>What the two readers here are gathering is the arms some row of the module reached, so a
+     * row with no account of its run adds nothing to it. Said by adding nothing rather than by
+     * standing an empty run in for the missing one: a run that reached nowhere is a fact about a
+     * row, and one nobody watched is the absence of any — and a value made to carry the second
+     * would answer the first about every place it was asked.
+     *
+     * <p>That a row was left undecided is not lost by this: it is said where the row is reported,
+     * of the row rather than of the arms.
      */
-    private static AlignedObservation seenBy(
-            RowOutcome row, CoverageSites.Plan plan) {
+    private static Set<ArmProbe> armsSeenIn(RowOutcome row, CoverageSites.Plan plan) {
         return switch (ObservedInputs.of(row, plan.numbering()).watched()) {
-            case Generator.Watched.Ran(var account) -> account;
-            case Generator.Watched.NoAccount _ ->
-                    AlignedObservation.NONE;
+            case Generator.Watched.Ran(var account) -> account.arms();
+            case Generator.Watched.NoAccount _ -> Set.of();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -7,7 +7,10 @@ import souther.compiler.observe.ArmObservation;
 import souther.compiler.inputs.TermPath;
 
 
+import souther.compiler.coverage.AlignedObservation;
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.DeadBranchMessage;
 import souther.compiler.diag.msg.ExampleMessage;
@@ -1121,10 +1124,14 @@ public final class Adequacy {
             if (!proven.present()) {
                 return Answer.absent();
             }
-            Set<Integer> lit = new LinkedHashSet<>();
+            // The numbering the recordings below are read under, which is this module's own.
+            Bodies.Elaborated checked = db.ask(new Bodies.Checked(name)).value();
+            CoverageSites.Plan plan =
+                    checked == null ? CoverageSites.Plan.NONE : checked.plan();
+            Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : db.ask(new RowReadings(name)).value().values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(seenBy(row).taken());
+                    lit.addAll(seenBy(row, plan).arms());
                 }
             }
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> out =
@@ -1514,7 +1521,8 @@ public final class Adequacy {
             }
             return Answer.of(Coverages.merged(Coverages.searched(measured, subject,
                     probing(sig, subject, constructing(db, name),
-                            runningRowsOf(trialling(db, name), behavior, sig)),
+                            runningRowsOf(trialling(db, name), behavior, sig,
+                                    numberingOf(db, name))),
                     divided.reaching())));
         }
 
@@ -1900,6 +1908,19 @@ public final class Adequacy {
         return spec == null ? null : subjectOf(db, module, spec);
     }
 
+    /**
+     * The numbering a run of {@code module}'s classes is read under.
+     *
+     * <p>Asked of the check that holds the bodies, which is where a module's numbering is derived.
+     * A module whose bodies were not read has none, and that is handed over as a numbering of
+     * nothing: what a recording made under a real one aligns to then is nothing, which is refused
+     * where the two meet rather than answered about places it was never near.
+     */
+    static CoverageSites.Plan numberingOf(Db db, String module) {
+        Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();
+        return checked == null ? CoverageSites.Plan.NONE : checked.plan();
+    }
+
     /** The behavior of that name that has inputs of its own, or null. A composition's inputs are its
      *  first stage's and are divided there. */
     private static Hir.SpecBehavior specOf(CheckSurface prepared,
@@ -2057,12 +2078,15 @@ public final class Adequacy {
             // measured against the rows at all, which is what `off` answers.
             Level level = levelOf(db);
             return Answer.of(assess(subject,
-                    RowReadings.readingFor(db.ask(new RowReadings(name)).value(), behavior), level));
+                    RowReadings.readingFor(db.ask(new RowReadings(name)).value(), behavior), level,
+                    // The numbering the rows' recordings are read under, which is this module's own.
+                    numberingOf(db, name).numbering()));
         }
 
         /** Every line of one behavior, with what the rows and the decoder say about each. */
         private static LineReadings assess(souther.compiler.partition.MeasuredInput subject,
-                                           RowReading observed, Level level) {
+                                           RowReading observed, Level level,
+                                           SiteNumbering numbering) {
             souther.compiler.partition.Partitions.Partitioning partitioning = subject.partitioning();
             // Two sources and not one. A line drawn at a count of a position comes off that position's
             // axis; a line drawn between two positions comes off the comparison and has no axis to come
@@ -2077,9 +2101,9 @@ public final class Adequacy {
                 // is answered at cannot arrive somewhere as the wrong one of the three.
                 out.addAll(Coverages.assess(partitioning.along(axis), subject, observed, level,
                         ItemAssessment.WritabilityProjection.ofReading(
-                                partitioning.edgeIsKnownWritable(axis.term()))));
+                                partitioning.edgeIsKnownWritable(axis.term())), numbering));
             }
-            out.addAll(Coverages.assessBetween(subject, observed, level));
+            out.addAll(Coverages.assessBetween(subject, observed, level, numbering));
             return new LineReadings(out);
         }
 
@@ -2202,8 +2226,8 @@ public final class Adequacy {
          * again where the numbers are made, and a second derivation beside this one would be two
          * denominators free to disagree about one body.
          */
-        public static List<souther.compiler.coverage.CoverageSites.Site> owed(
-                List<souther.compiler.coverage.CoverageSites.Site> all,
+        public static List<CoverageSites.ArmSite> owed(
+                List<CoverageSites.ArmSite> all,
                 souther.compiler.check.PathReachability.Answers.AsRun reachable) {
             return all.stream()
                     .filter(site -> !reachable.answers().nothingArrivesAt(site.index())).toList();
@@ -2228,8 +2252,8 @@ public final class Adequacy {
          * elsewhere in the body could not be told apart.
          */
         public static BranchEvidence measured(String behavior,
-                                              List<souther.compiler.coverage.CoverageSites.Site> all,
-                                              Set<Integer> covered,
+                                              List<CoverageSites.ArmSite> all,
+                                              Set<ArmProbe> covered,
                                               souther.compiler.check.PathReachability.Answers.AsRun reachable,
                                               WeakeningSet weakenings) {
             ArmAccount account = ArmAccount.of(owed(all, reachable), covered, weakenings,
@@ -2305,10 +2329,10 @@ public final class Adequacy {
             // compile stopped in report every behavior as one with no body (issue #996).
             boolean bodiesRead = checked != null;
             Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
-            Set<Integer> lit = new LinkedHashSet<>();
+            Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : byTarget.values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(seenBy(row).taken());
+                    lit.addAll(seenBy(row, plan).arms());
                 }
             }
 
@@ -2318,7 +2342,7 @@ public final class Adequacy {
                 // The arms, and not every site of the behavior. A comparison of a guard's condition
                 // has a site of its own and is not a fork a row is in or out of, so counting it here
                 // would report an arm the body does not have.
-                List<souther.compiler.coverage.CoverageSites.Site> arms =
+                List<CoverageSites.ArmSite> arms =
                         plan.arms(behavior.name());
                 RowReading observed = RowReadings.readingFor(byTarget, behavior.name());
                 souther.compiler.check.PathReachability.Answers.AsRun arrives =
@@ -2329,9 +2353,9 @@ public final class Adequacy {
                 if (absent != null) {
                     return absent;
                 }
-                Set<Integer> covered = new LinkedHashSet<>(lit);
+                Set<ArmProbe> covered = new LinkedHashSet<>(lit);
                 covered.retainAll(arms.stream()
-                        .map(souther.compiler.coverage.CoverageSites.Site::index).toList());
+                        .map(CoverageSites.ArmSite::index).toList());
                 return BranchEvidence.measured(behavior.name(), arms, covered,
                         arrives, rowsBehind(observed));
             });
@@ -2365,7 +2389,7 @@ public final class Adequacy {
          */
         private static BranchEvidence whyNoArms(String module, boolean writesItsOwnBody,
                 boolean bodiesRead,
-                List<souther.compiler.coverage.CoverageSites.Site> arms,
+                List<CoverageSites.ArmSite> arms,
                 souther.compiler.check.PathReachability.Answers.AsRun arrives,
                 boolean instrumented, RowReading observed) {
             if (!writesItsOwnBody) {
@@ -2809,7 +2833,7 @@ public final class Adequacy {
                         constructing(db, name),
                         read,
                         runningRowsOf(trialling(db, name),
-                                behavior, sig),
+                                behavior, sig, plan),
                         levelOf(db).runsInstrumentedRows(),
                         db.ask(new Front.Adequacy()).value().generation());
             } catch (LinkageError _) {
@@ -2965,8 +2989,9 @@ public final class Adequacy {
          * this finding is one of the arms that plan names — so the entry is there whatever the run
          * did, including the runs that never looked at anything.
          */
-        private static GenerationOutcome atArm(souther.compiler.coverage.CoverageSites.Site arm,
-                                               souther.compiler.partition.FillResult composed) {
+        private static GenerationOutcome atArm(
+                CoverageSites.ArmSite arm,
+                souther.compiler.partition.FillResult composed) {
             Generator.ArmOwed owed = new Generator.ArmOwed(arm.index());
             souther.compiler.partition.ArmDisposition answer = composed.discharge().at(owed);
             if (answer == null) {
@@ -3330,7 +3355,7 @@ public final class Adequacy {
             List<Generator.ObservedRow> existing = rows.stream()
                     .map(row -> new Generator.ObservedRow(
                             InputClassifications.of(row.inputs(), axes),
-                            watched(row, recording)))
+                            watched(row, recording, plan)))
                     .toList();
             return Generator.fill(asked, existing, check,
                     souther.compiler.reading.CoverageRead
@@ -3358,11 +3383,10 @@ public final class Adequacy {
             // them in. Handed over as a list rather than as the set that kept them once apiece:
             // what the plan is asking for is the order, and this is where what the order means is
             // known.
-            Set<Integer> arms = new LinkedHashSet<>();
+            Set<ArmProbe> arms = new LinkedHashSet<>();
             for (Finding finding : owed) {
                 if (finding.about()
-                        instanceof About.AnArmNoRowGoesThrough(
-                                souther.compiler.coverage.CoverageSites.Site arm)) {
+                        instanceof About.AnArmNoRowGoesThrough(CoverageSites.ArmSite arm)) {
                     arms.add(arm.index());
                 }
             }
@@ -3468,7 +3492,8 @@ public final class Adequacy {
      * what anybody asking after one does — the search that composes them, and whoever asks what one
      * of them would settle.
      */
-    static Generator.Trial runningRowsOf(RowTrials trials, String behavior, Sig sig) {
+    static Generator.Trial runningRowsOf(RowTrials trials, String behavior, Sig sig,
+                                         CoverageSites.Plan plan) {
         if (trials == null) {
             return Generator.Trial.NOTHING_RUNS;
         }
@@ -3476,7 +3501,11 @@ public final class Adequacy {
         return inputs -> application
                 .run(inputs.stream()
                         .map(souther.compiler.partition.FixtureTemplate::value).toList())
-                .<Generator.Watched>map(Generator.Watched.Ran::new)
+                // Read under the numbering the caller is asking about. What a run left behind says
+                // which numbering it was made under, so a recording of classes numbered otherwise
+                // is refused here rather than answered about places it was never near.
+                .<Generator.Watched>map(seen -> new Generator.Watched.Ran(
+                        plan.numbering().align(seen)))
                 .orElseGet(Generator.Watched.NoAccount::new);
     }
 
@@ -4989,10 +5018,12 @@ public final class Adequacy {
      * answer for. A row whose counting was never read is known to have done none of it, and that it
      * was left undecided is said where the row is reported.
      */
-    private static souther.compiler.coverage.Observation seenBy(RowOutcome row) {
-        return switch (ObservedInputs.of(row).watched()) {
+    private static AlignedObservation seenBy(
+            RowOutcome row, CoverageSites.Plan plan) {
+        return switch (ObservedInputs.of(row, plan.numbering()).watched()) {
             case Generator.Watched.Ran(var account) -> account;
-            case Generator.Watched.NoAccount _ -> souther.compiler.coverage.Observation.NONE;
+            case Generator.Watched.NoAccount _ ->
+                    AlignedObservation.NONE;
         };
     }
 
@@ -5005,7 +5036,8 @@ public final class Adequacy {
      * may well fill reads as one it was shown not to.
      */
     private static souther.compiler.partition.Generator.Watched watched(RowOutcome row,
-                                                                        boolean recording) {
+                                                                        boolean recording,
+                                                                        CoverageSites.Plan plan) {
         if (!recording) {
             // The row ran — every row of an evaluated source does — and nothing was recording it.
             // Answered as having no account rather than as a run with an empty one, which is what a
@@ -5015,7 +5047,7 @@ public final class Adequacy {
         // What the row's own run came to, which is one reading and is made where a tuple of values
         // is read. Whether this build was recording is the question above and is this caller's: it
         // follows from what was asked for rather than from the row.
-        return ObservedInputs.of(row).watched();
+        return ObservedInputs.of(row, plan.numbering()).watched();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1125,9 +1125,7 @@ public final class Adequacy {
                 return Answer.absent();
             }
             // The numbering the recordings below are read under, which is this module's own.
-            Bodies.Elaborated checked = db.ask(new Bodies.Checked(name)).value();
-            CoverageSites.Plan plan =
-                    checked == null ? CoverageSites.Plan.NONE : checked.plan();
+            CoverageSites.Plan plan = numberingOf(db, name);
             Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : db.ask(new RowReadings(name)).value().values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
@@ -1915,6 +1913,12 @@ public final class Adequacy {
      * A module whose bodies were not read has none, and that is handed over as a numbering of
      * nothing: what a recording made under a real one aligns to then is nothing, which is refused
      * where the two meet rather than answered about places it was never near.
+     *
+     * <p><b>For a caller that wants the numbering and nothing else.</b> Several of the keys here
+     * read the checked bodies for other things beside it — what a behavior's body is, what its
+     * elements bind, whether the bodies came back at all — and those take the numbering off the
+     * value they are already holding. This is the same route rather than a second one, and calling
+     * it from there would be asking the store for something in hand.
      */
     static CoverageSites.Plan numberingOf(Db db, String module) {
         Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1123,12 +1123,13 @@ public final class Adequacy {
             if (!proven.present()) {
                 return Answer.absent();
             }
-            // The numbering the recordings below are read under, which is this module's own.
-            CoverageSites.Plan plan = numberingOf(db, name);
+            // The numbering the recordings below are read under, which is this module's own — and
+            // none where its bodies were not read, in which case there is nothing to read them as.
+            Optional<SiteNumbering> numbering = numberingOf(db, name);
             Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : db.ask(new RowReadings(name)).value().values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(armsSeenIn(row, plan));
+                    lit.addAll(armsSeenIn(row, numbering));
                 }
             }
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> out =
@@ -1909,9 +1910,11 @@ public final class Adequacy {
      * The numbering a run of {@code module}'s classes is read under.
      *
      * <p>Asked of the check that holds the bodies, which is where a module's numbering is derived.
-     * A module whose bodies were not read has none, and that is handed over as a numbering of
-     * nothing: what a recording made under a real one aligns to then is nothing, which is refused
-     * where the two meet rather than answered about places it was never near.
+     * A module whose bodies were not read has none, and none is what comes back — not a numbering
+     * of nowhere standing in for it. Such a stand-in is a numbering some other module's places
+     * would be read under, and every reader that aligned against it would be told its recordings
+     * were of somewhere else; what a reader without a numbering has is no account of any run, which
+     * is what each of them says.
      *
      * <p><b>For a caller that wants the numbering and nothing else.</b> Several of the keys here
      * read the checked bodies for other things beside it — what a behavior's body is, what its
@@ -1919,9 +1922,9 @@ public final class Adequacy {
      * value they are already holding. This is the same route rather than a second one, and calling
      * it from there would be asking the store for something in hand.
      */
-    static CoverageSites.Plan numberingOf(Db db, String module) {
+    static Optional<SiteNumbering> numberingOf(Db db, String module) {
         Bodies.Elaborated checked = db.ask(new Bodies.Checked(module)).value();
-        return checked == null ? CoverageSites.Plan.NONE : checked.plan();
+        return checked == null ? Optional.empty() : Optional.of(checked.plan().numbering());
     }
 
     /** The behavior of that name that has inputs of its own, or null. A composition's inputs are its
@@ -2083,13 +2086,13 @@ public final class Adequacy {
             return Answer.of(assess(subject,
                     RowReadings.readingFor(db.ask(new RowReadings(name)).value(), behavior), level,
                     // The numbering the rows' recordings are read under, which is this module's own.
-                    numberingOf(db, name).numbering()));
+                    numberingOf(db, name)));
         }
 
         /** Every line of one behavior, with what the rows and the decoder say about each. */
         private static LineReadings assess(souther.compiler.partition.MeasuredInput subject,
                                            RowReading observed, Level level,
-                                           SiteNumbering numbering) {
+                                           Optional<SiteNumbering> numbering) {
             souther.compiler.partition.Partitions.Partitioning partitioning = subject.partitioning();
             // Two sources and not one. A line drawn at a count of a position comes off that position's
             // axis; a line drawn between two positions comes off the comparison and has no axis to come
@@ -2331,11 +2334,16 @@ public final class Adequacy {
             // body holds could be read — and answering both from this map is what made a module the
             // compile stopped in report every behavior as one with no body (issue #996).
             boolean bodiesRead = checked != null;
+            // Off the value already in hand, which is the same answer numberingOf asks the store
+            // for: a module whose bodies were not read has no numbering, and its rows have no
+            // account of a run to be read under one.
+            Optional<SiteNumbering> numbering =
+                    checked == null ? Optional.empty() : Optional.of(checked.plan().numbering());
             Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Set<ArmProbe> lit = new LinkedHashSet<>();
             for (RowReading observed : byTarget.values()) {
                 for (RowOutcome row : observed.rowsSeen()) {
-                    lit.addAll(armsSeenIn(row, plan));
+                    lit.addAll(armsSeenIn(row, numbering));
                 }
             }
 
@@ -2763,6 +2771,11 @@ public final class Adequacy {
             souther.compiler.coverage.CoverageSites.Plan plan =
                     checked == null
                             ? souther.compiler.coverage.CoverageSites.Plan.NONE : checked.plan();
+            // And what its numbers mean, which the empty plan above has none of: it stands for
+            // every module whose bodies were not read and so is nobody's numbering. Taken off the
+            // value in hand instead, a module without one says it has none.
+            Optional<SiteNumbering> numbering =
+                    checked == null ? Optional.empty() : Optional.of(checked.plan().numbering());
             Map<String, RowReading> byTarget = db.ask(new RowReadings(name)).value();
             Map<String, InputDomain> readInputs = db.ask(new Inputs(name)).value();
             // What the guards above each place leave, asked once for the module and read by
@@ -2831,12 +2844,11 @@ public final class Adequacy {
                                 // where a body did not check — and a declaration the check said
                                 // nothing about is a value this cannot reach rather than a fault.
                                 new souther.compiler.check.ResolvedFieldTypes(symbols)),
-                        divided, bodies.get(behavior), plan,
+                        divided, bodies.get(behavior), plan, numbering,
                         RowReadings.readingFor(byTarget, behavior),
                         constructing(db, name),
                         read,
-                        runningRowsOf(trialling(db, name),
-                                behavior, sig, plan),
+                        runningRowsOf(trialling(db, name), behavior, sig, numbering),
                         levelOf(db).runsInstrumentedRows(),
                         db.ask(new Front.Adequacy()).value().generation());
             } catch (LinkageError _) {
@@ -3333,7 +3345,8 @@ public final class Adequacy {
                 List<Generator.Baseline> baselines,
                 souther.compiler.partition.Partitions.Partitioning partitioning,
                 souther.compiler.core.Core body,
-                souther.compiler.coverage.CoverageSites.Plan plan, RowReading observed,
+                souther.compiler.coverage.CoverageSites.Plan plan,
+                Optional<SiteNumbering> numbering, RowReading observed,
                 BoundaryValues building, InputDomain domain,
                 Generator.Trial trial, boolean recording,
                 souther.compiler.partition.AdequacyPolicy.OfTheGeneration budget) {
@@ -3358,7 +3371,7 @@ public final class Adequacy {
             List<Generator.ObservedRow> existing = rows.stream()
                     .map(row -> new Generator.ObservedRow(
                             InputClassifications.of(row.inputs(), axes),
-                            watched(row, recording, plan)))
+                            watched(row, recording, numbering)))
                     .toList();
             return Generator.fill(asked, existing, check,
                     souther.compiler.reading.CoverageRead
@@ -3496,8 +3509,11 @@ public final class Adequacy {
      * of them would settle.
      */
     static Generator.Trial runningRowsOf(RowTrials trials, String behavior, Sig sig,
-                                         CoverageSites.Plan plan) {
-        if (trials == null) {
+                                         Optional<SiteNumbering> numbering) {
+        if (trials == null || numbering.isEmpty()) {
+            // Nothing runs where nothing applies the behavior, and nothing is read where the module
+            // has no numbering to read it under — which is the same module, so the second follows
+            // the first and is said rather than assumed.
             return Generator.Trial.NOTHING_RUNS;
         }
         RowTrials.OfBehavior application = trials.forBehavior(behavior, sig);
@@ -3508,7 +3524,7 @@ public final class Adequacy {
                 // which numbering it was made under, so a recording of classes numbered otherwise
                 // is refused here rather than answered about places it was never near.
                 .<Generator.Watched>map(seen -> new Generator.Watched.Ran(
-                        plan.numbering().align(seen)))
+                        numbering.orElseThrow().align(seen)))
                 .orElseGet(Generator.Watched.NoAccount::new);
     }
 
@@ -5031,8 +5047,8 @@ public final class Adequacy {
      * <p>That a row was left undecided is not lost by this: it is said where the row is reported,
      * of the row rather than of the arms.
      */
-    private static Set<ArmProbe> armsSeenIn(RowOutcome row, CoverageSites.Plan plan) {
-        return switch (ObservedInputs.of(row, plan.numbering()).watched()) {
+    private static Set<ArmProbe> armsSeenIn(RowOutcome row, Optional<SiteNumbering> numbering) {
+        return switch (ObservedInputs.of(row, numbering).watched()) {
             case Generator.Watched.Ran(var account) -> account.arms();
             case Generator.Watched.NoAccount _ -> Set.of();
         };
@@ -5048,7 +5064,8 @@ public final class Adequacy {
      */
     private static souther.compiler.partition.Generator.Watched watched(RowOutcome row,
                                                                         boolean recording,
-                                                                        CoverageSites.Plan plan) {
+                                                                        Optional<SiteNumbering>
+                                                                                numbering) {
         if (!recording) {
             // The row ran — every row of an evaluated source does — and nothing was recording it.
             // Answered as having no account rather than as a run with an empty one, which is what a
@@ -5058,7 +5075,7 @@ public final class Adequacy {
         // What the row's own run came to, which is one reading and is made where a tuple of values
         // is read. Whether this build was recording is the question above and is this caller's: it
         // follows from what was asked for rather than from the row.
-        return ObservedInputs.of(row, plan.numbering()).watched();
+        return ObservedInputs.of(row, numbering).watched();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ArmAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ArmAccount.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 
 import java.util.ArrayList;
@@ -49,11 +50,11 @@ record ArmAccount(List<ArmObligation> obligations, ArmCensus census) {
      * @param rowsUnread what the reading of this behavior's rows went without
      * @param census     whether anything has shown {@code owed} to be short of an arm
      */
-    static ArmAccount of(List<CoverageSites.Site> owed, Set<Integer> covered,
+    static ArmAccount of(List<CoverageSites.ArmSite> owed, Set<ArmProbe> covered,
                          WeakeningSet rowsUnread, ArmCensus census) {
-        java.util.SequencedMap<CoverageSites.Obligation, List<CoverageSites.Site>> byObligation =
+        java.util.SequencedMap<CoverageSites.Obligation, List<CoverageSites.ArmSite>> byObligation =
                 new LinkedHashMap<>();
-        for (CoverageSites.Site site : owed) {
+        for (CoverageSites.ArmSite site : owed) {
             byObligation.computeIfAbsent(site.obligation(), _ -> new ArrayList<>()).add(site);
         }
         List<ArmObligation> arms = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/ArmCensus.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ArmCensus.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.coverage.ArmProbe;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -55,12 +57,12 @@ public sealed interface ArmCensus {
      * @param behavior     whose arms these are, which is what the fact is named by
      * @param provedWrong  arms proven unreachable that a row went through anyway
      */
-    static ArmCensus of(String behavior, Set<Integer> provedWrong) {
+    static ArmCensus of(String behavior, Set<ArmProbe> provedWrong) {
         if (provedWrong.isEmpty()) {
             return new Settled();
         }
         Set<Weakening> by = new LinkedHashSet<>();
-        for (int probe : provedWrong) {
+        for (ArmProbe probe : provedWrong) {
             by.add(new Weakening.ProofContradicted(behavior, probe));
         }
         return new Undecided(WeakeningSet.ofAll(by));

--- a/souther-compiler/src/main/java/souther/compiler/query/ArmObligation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ArmObligation.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 
 import java.util.List;
@@ -21,7 +22,7 @@ import java.util.Set;
 public sealed interface ArmObligation {
 
     /** Every copy of this arm, in the order the body holds them. Never empty. */
-    List<CoverageSites.Site> occurrences();
+    List<CoverageSites.ArmSite> occurrences();
 
     /** Where this stands in the account, which is the one question asked of it. */
     ArmDisposition disposition();
@@ -41,7 +42,7 @@ public sealed interface ArmObligation {
      * occurrence carries says the arm is written out of sight and names the declaration, so a report
      * says that however this chooses; the choice only decides which call the reader is shown.
      */
-    default CoverageSites.Site display() {
+    default CoverageSites.ArmSite display() {
         return occurrences().getFirst();
     }
 
@@ -54,7 +55,7 @@ public sealed interface ArmObligation {
      * value are not here either — where nothing read the rows there is no arm account at all, and a
      * counted arm carrying one of them would be an account holding an arm it cannot answer for.
      */
-    record Counted(List<CoverageSites.Site> occurrences, Measurement<ArmCoverage> coverage)
+    record Counted(List<CoverageSites.ArmSite> occurrences, Measurement<ArmCoverage> coverage)
             implements ArmObligation {
 
         public Counted {
@@ -86,7 +87,7 @@ public sealed interface ArmObligation {
     }
 
     /** An arm outside the count, with why it is out. */
-    record NotCounted(List<CoverageSites.Site> occurrences, ArmExclusion because)
+    record NotCounted(List<CoverageSites.ArmSite> occurrences, ArmExclusion because)
             implements ArmObligation {
 
         public NotCounted {
@@ -116,7 +117,7 @@ public sealed interface ArmObligation {
      * @param rowsUnread  what the reading of this behavior's rows went without, which is empty
      *                    where it read them all
      */
-    static ArmObligation of(List<CoverageSites.Site> occurrences, Set<Integer> covered,
+    static ArmObligation of(List<CoverageSites.ArmSite> occurrences, Set<ArmProbe> covered,
                             WeakeningSet rowsUnread) {
         // An obligation whose occurrences were put together without anything establishing that they
         // are one is not one the rows can answer: a row through either of them may or may not be a
@@ -135,7 +136,7 @@ public sealed interface ArmObligation {
     }
 
     /** The occurrences of one arm, which is what an entry of this account is over. */
-    private static List<CoverageSites.Site> oneArm(List<CoverageSites.Site> occurrences) {
+    private static List<CoverageSites.ArmSite> oneArm(List<CoverageSites.ArmSite> occurrences) {
         if (occurrences == null || occurrences.isEmpty()) {
             throw new IllegalArgumentException("an arm is somewhere the body holds it");
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -2279,13 +2279,14 @@ public final class Bodies {
          * are only as true as the caller made them — and there are a dozen callers, each holding
          * one of these and taking the parts off it.
          *
-         * <p><b>Each call walks the bodies again.</b> What comes back is a plan of its own, and two
-         * of them number one arm alike because the walk is a function of the bodies rather than
-         * because anything here hands the same one out twice. So a caller holding two — the
-         * emitter's and a measure's, say — holds two answers that agree, which is not the same as
-         * holding one answer, and nothing yet says what it would take for two numberings of one
-         * module to mean the same thing. Said here because it is asked here: a caller that had to
-         * work it out would work it out once per call site.
+         * <p><b>Each call walks the bodies again, and what comes back is the same numbering.</b> A
+         * numbering is what {@link souther.compiler.coverage.NumberingIdentity} says it is — the
+         * same places under the same numbers over the same executable — so two walks of one body
+         * come to one numbering, and an address handed out by either is an address of both. Which
+         * is a thing the values prove rather than one a caller takes on trust from having been
+         * given the same object: the emitter's arm and a measure's arm are equal because they
+         * address one place of one numbering, and they would be equal across two builds for the
+         * same reason.
          */
         public souther.compiler.coverage.CoverageSites.Plan plan() {
             return souther.compiler.coverage.CoverageSites.of(of, decisions, supplied);

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -8,6 +8,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.numeric.Place;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.RowOutcome;
@@ -604,7 +605,8 @@ final class Coverages {
             List<Border> lines, souther.compiler.partition.MeasuredInput subject,
             souther.compiler.query.Adequacy.RowReading observed,
             souther.compiler.query.Adequacy.Level level,
-            ItemAssessment.WritabilityProjection projection) {
+            ItemAssessment.WritabilityProjection projection,
+            SiteNumbering numbering) {
         // One entry per reading and not per line. A guard inside a non-recursive helper is read once
         // per call of that helper, and the rows do not owe the same border twice for having been
         // offered it twice — but each reading is reached under its caller's own conditions, so what
@@ -612,7 +614,8 @@ final class Coverages {
         // still apart. They are brought together by {@link #merged}, after that.
         List<BorderAssessment> out = new ArrayList<>();
         for (Border each : lines) {
-            out.add(assessed(each, reading(subject.at(each), projection), observed, level));
+            out.add(assessed(each, reading(subject.at(each), projection), observed, level,
+                    numbering));
         }
         return List.copyOf(out);
     }
@@ -718,7 +721,8 @@ final class Coverages {
      */
     private static BorderAssessment assessed(Border border, OneShapeOfBorder shape,
                                              souther.compiler.query.Adequacy.RowReading observed,
-                                             souther.compiler.query.Adequacy.Level level) {
+                                             souther.compiler.query.Adequacy.Level level,
+                                             SiteNumbering numbering) {
         // Whether meeting this border takes the comparison having run, asked of the rule rather than
         // read off which kind it is, and asked once for the border rather than once per point. A
         // guard's line is about a place in a body and is reached or not; an invariant's and a
@@ -732,7 +736,8 @@ final class Coverages {
         // The rows as the values they hold and what running them recorded, which is the whole of
         // what a point is met by. Read once for the border: what a row is stays the same however
         // many of the four points it is put to.
-        List<ObservedInputs> rows = observed.rowsSeen().stream().map(ObservedInputs::of).toList();
+        List<ObservedInputs> rows = observed.rowsSeen().stream()
+                .map(row -> ObservedInputs.of(row, numbering)).toList();
 
         java.util.Map<DomainPoint, ItemAssessment> items = new java.util.LinkedHashMap<>();
         for (DomainPoint point : border.answers().keySet()) {
@@ -1143,7 +1148,8 @@ final class Coverages {
     static List<BorderAssessment> assessBetween(
             souther.compiler.partition.MeasuredInput subject,
             souther.compiler.query.Adequacy.RowReading observed,
-            souther.compiler.query.Adequacy.Level level) {
+            souther.compiler.query.Adequacy.Level level,
+            SiteNumbering numbering) {
         Partitions.Partitioning partitioning = subject.partitioning();
         // One entry per reading, the way a line at a place is read: what several readings of one
         // line come to is one answer, and it is put together where the last thing that is a
@@ -1152,7 +1158,7 @@ final class Coverages {
         for (Border each : partitioning.between()) {
             out.add(assessed(each, reading(subject.at(each),
                             ItemAssessment.WritabilityProjection.NOT_COMPUTED),
-                    observed, level));
+                    observed, level, numbering));
         }
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -631,7 +631,7 @@ final class Coverages {
             souther.compiler.query.Adequacy.RowReading observed,
             souther.compiler.query.Adequacy.Level level,
             ItemAssessment.WritabilityProjection projection,
-            SiteNumbering numbering) {
+            java.util.Optional<SiteNumbering> numbering) {
         // One entry per reading and not per line. A guard inside a non-recursive helper is read once
         // per call of that helper, and the rows do not owe the same border twice for having been
         // offered it twice — but each reading is reached under its caller's own conditions, so what
@@ -747,7 +747,7 @@ final class Coverages {
     private static BorderAssessment assessed(Border border, OneShapeOfBorder shape,
                                              souther.compiler.query.Adequacy.RowReading observed,
                                              souther.compiler.query.Adequacy.Level level,
-                                             SiteNumbering numbering) {
+                                             java.util.Optional<SiteNumbering> numbering) {
         // Whether meeting this border takes the comparison having run, asked of the rule rather than
         // read off which kind it is, and asked once for the border rather than once per point. A
         // guard's line is about a place in a body and is reached or not; an invariant's and a
@@ -1174,7 +1174,7 @@ final class Coverages {
             souther.compiler.partition.MeasuredInput subject,
             souther.compiler.query.Adequacy.RowReading observed,
             souther.compiler.query.Adequacy.Level level,
-            SiteNumbering numbering) {
+            java.util.Optional<SiteNumbering> numbering) {
         Partitions.Partitioning partitioning = subject.partitioning();
         // One entry per reading, the way a line at a place is read: what several readings of one
         // line come to is one answer, and it is put together where the last thing that is a

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -9,6 +9,8 @@ import souther.compiler.source.SourceId;
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.generated.ProbeImage;
+import souther.compiler.coverage.CoverageSites;
 import souther.compiler.execute.ConstantConstruction;
 import souther.compiler.execute.ConstantOutcome;
 import souther.compiler.execute.ProgramExecution;
@@ -367,9 +369,14 @@ public final class Output {
                 return Answer.absent();
             }
             Instrumentation instrumentation = Instrumentation.COUNTING;
+            ProbeImage probes = new ProbeImage.Uninstrumented();
             if (arms == ArmObservation.RECORD) {
-                instrumentation = instrumentation.measuring(
-                        in.checked().plan());
+                CoverageSites.Plan plan = in.checked().plan();
+                instrumentation = instrumentation.measuring(plan);
+                // The numbering the calls about to be written carry, taken from the plan that is
+                // writing them. What a run leaves behind is these numbers, and this is what says
+                // whose they are.
+                probes = new ProbeImage.Instrumented(plan.identity());
             }
             try {
                 Emissions emitted = Backend.generate(
@@ -381,7 +388,8 @@ public final class Output {
                         instrumentation);
                 Classes.stamp(db, name, emitted);
                 // The classes and what they implement, from the one emission that decided both.
-                return Answer.of(new EvaluationArtifact(emitted.seal(), emitted.implemented()));
+                return Answer.of(
+                        new EvaluationArtifact(emitted.seal(), emitted.implemented(), probes));
             } catch (CompileException e) {
                 return Answer.absent(e);
             } catch (IllegalStateException _) {
@@ -429,6 +437,7 @@ public final class Output {
             Front.Layout.Of layout = db.ask(new Front.Layout()).value();
             Map<String, ClassFileImage> linked = new LinkedHashMap<>();
             GeneratedImplementations implemented = null;
+            ProbeImage probes = new ProbeImage.Uninstrumented();
             // Furthest first, so the module being evaluated is put on last, as Linked does.
             for (int i = reaches.size() - 1; i >= 0; i--) {
                 String reached = reaches.get(i);
@@ -453,6 +462,9 @@ public final class Output {
                 }
                 linked.putAll(classes.value().classes());
                 if (reached.equals(name)) {
+                    // The probes are the evaluated module's: it is the one asked for them, and the
+                    // ones it reaches were asked to record nothing.
+                    probes = classes.value().probes();
                     implemented = classes.value().implementations();
                 }
             }
@@ -463,7 +475,7 @@ public final class Output {
                 // its rows as one nothing applies.
                 return Answer.absent();
             }
-            return Answer.of(new EvaluationArtifact(Ordered.map(linked), implemented));
+            return Answer.of(new EvaluationArtifact(Ordered.map(linked), implemented, probes));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -368,7 +368,8 @@ public record Settlements(List<OfferItem> requested,
             // is nothing where nothing asked it.
             return new OneBehavior(behavior, subject, sig, building,
                     sig == null || trials == null ? Generator.Trial.NOTHING_RUNS
-                            : Adequacy.runningRowsOf(trials, behavior, sig),
+                            : Adequacy.runningRowsOf(trials, behavior, sig,
+                                    Adequacy.numberingOf(db, module)),
                     filling == null ? List.of() : filling.composed().plan().classesOwed(),
                     filling == null ? List.of() : filling.composed().plan().armsOwed(),
                     reads);
@@ -465,7 +466,7 @@ public record Settlements(List<OfferItem> requested,
          */
         private Settlement throughArm(RowAsRead asRead, Generator.ArmOwed owed) {
             return switch (asRead.watched()) {
-                case Generator.Watched.Ran(var account) -> account.taken().contains(owed.probe())
+                case Generator.Watched.Ran(var account) -> account.arms().contains(owed.probe())
                         ? new Settlement.Settles() : new Settlement.DoesNotSettle();
                 case Generator.Watched.NoAccount _ ->
                         new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);

--- a/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Settlements.java
@@ -466,7 +466,7 @@ public record Settlements(List<OfferItem> requested,
          */
         private Settlement throughArm(RowAsRead asRead, Generator.ArmOwed owed) {
             return switch (asRead.watched()) {
-                case Generator.Watched.Ran(var account) -> account.arms().contains(owed.probe())
+                case Generator.Watched.Ran(var account) -> account.lit(owed.probe())
                         ? new Settlement.Settles() : new Settlement.DoesNotSettle();
                 case Generator.Watched.NoAccount _ ->
                         new Settlement.Undetermined(Settlement.Reason.NO_ACCOUNT_OF_THE_RUN);

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.RunSensitivity;
 import souther.compiler.partition.ClosureGap;
@@ -252,7 +253,7 @@ public sealed interface Weakening {
      * is evidence that an analysis the numbers were computed with does not hold, which is why it is
      * an arm of its own and never one of {@link ObservationIncomplete}.
      */
-    record ProofContradicted(String behavior, int probe) implements Weakening {
+    record ProofContradicted(String behavior, ArmProbe probe) implements Weakening {
 
         /** An analysis that does not hold is one that does not hold however much a run allows. */
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/reach/Witness.java
+++ b/souther-compiler/src/main/java/souther/compiler/reach/Witness.java
@@ -1,5 +1,7 @@
 package souther.compiler.reach;
 
+import souther.compiler.coverage.ArmProbe;
+
 /**
  * What shows that something arrives.
  *
@@ -16,7 +18,7 @@ package souther.compiler.reach;
 public sealed interface Witness permits ARunWentThrough, EveryRuleReadAndNothingAbove {
 
     /** @see ARunWentThrough */
-    static Witness aRunWentThrough(int probe) {
+    static Witness aRunWentThrough(ArmProbe probe) {
         return new ARunWentThrough(probe);
     }
 
@@ -33,7 +35,7 @@ public sealed interface Witness permits ARunWentThrough, EveryRuleReadAndNothing
  * settles a proof that said otherwise: what a row did happened, so a reading that ruled it out was
  * wrong about the model rather than the row being wrong about the rules.
  */
-record ARunWentThrough(int probe) implements Witness {}
+record ARunWentThrough(ArmProbe probe) implements Witness {}
 
 /**
  * The rules leave the case standing, every rule reaching the position was read, and nothing stands

--- a/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
@@ -1,6 +1,7 @@
 package souther.compiler.reading;
 
 import souther.compiler.core.Core;
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
@@ -28,7 +29,8 @@ final class Arms {
 
     private final CoverageSites.Plan plan;
 
-    private final Map<Integer, PathAccess> byArm = new LinkedHashMap<>();
+    private final Map<ArmProbe, PathAccess> byArm =
+            new LinkedHashMap<>();
 
     Arms(CoverageSites.Plan plan) {
         this.plan = plan;
@@ -48,7 +50,7 @@ final class Arms {
             return;
         }
         ControlClaim.of(arms[part]).ifPresent(arrivesAt ->
-                byArm.put(arms[part].probe().getAsInt(), reach.told(arrivesAt)));
+                byArm.put(arms[part].probe().get(), reach.told(arrivesAt)));
     }
 
     /**
@@ -61,12 +63,13 @@ final class Arms {
      * really is beyond what the path language states. The check would then hold of a walk that
      * stopped early, which is the whole of what it is for.
      */
-    java.util.SequencedMap<Integer, PathAccess> found(String behavior) {
+    java.util.SequencedMap<ArmProbe, PathAccess> found(String behavior) {
         // Walked over the plan's own arms, so the order these come back in is the order the plan
         // holds the behavior's arms in. Which is what whoever asks for a row at each of them takes
         // as the order to ask in, and it is only that because this walk is where it comes from.
-        java.util.SequencedMap<Integer, PathAccess> out = new LinkedHashMap<>();
-        for (CoverageSites.Site arm : plan.arms(behavior)) {
+        java.util.SequencedMap<ArmProbe, PathAccess> out =
+                new LinkedHashMap<>();
+        for (CoverageSites.ArmSite arm : plan.arms(behavior)) {
             PathAccess access = byArm.get(arm.index());
             if (access == null) {
                 throw new IllegalStateException("the reading of `" + behavior + "` did not reach"

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageRead.java
@@ -1,5 +1,6 @@
 package souther.compiler.reading;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.check.ElementBindings;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.Symbols;
@@ -128,7 +129,7 @@ public final class CoverageRead {
      *                     have come from wherever that map put its keys
      */
     public record Read(List<Interaction> interactions,
-                       java.util.SequencedMap<Integer, PathAccess> arms) {
+                       java.util.SequencedMap<ArmProbe, PathAccess> arms) {
 
         public Read {
             interactions = List.copyOf(interactions);
@@ -137,7 +138,7 @@ public final class CoverageRead {
         }
 
         /** How arm {@code probe} is reached, by the number the plan gave it. */
-        public PathAccess armAt(int probe) {
+        public PathAccess armAt(ArmProbe probe) {
             PathAccess access = arms.get(probe);
             if (access == null) {
                 throw new IllegalArgumentException(

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -1,5 +1,6 @@
 package souther.compiler.report;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.fmt.Formatter;
 import souther.compiler.publish.PublishedIncompleteness;
@@ -306,8 +307,8 @@ public final class GeneratedRows {
      * written. An arm the search composed a row for is one a finding named, the plan being made of
      * them, so there is a name here for every arm a row is offered at.
      */
-    private static Map<Integer, String> armNames(Adequacy.Filling filling) {
-        Map<Integer, String> out = new LinkedHashMap<>();
+    private static Map<ArmProbe, String> armNames(Adequacy.Filling filling) {
+        Map<ArmProbe, String> out = new LinkedHashMap<>();
         if (filling == null) {
             // A behavior with no search of its own, which is one that composed a row a declaration
             // is owed and nothing else. A row at a line is offered without a name, so there is no
@@ -329,10 +330,11 @@ public final class GeneratedRows {
      * two things, and `a x b` spelt over the pair reads as an obligation nobody raised — the same
      * fault as naming a row for everything it turns out to settle, arriving from the other side.
      */
-    private static List<String> named(List<Generator.Purpose> purposes, Map<Integer, String> arms) {
+    private static List<String> named(List<Generator.Purpose> purposes,
+                                      Map<ArmProbe, String> arms) {
         List<String> out = new ArrayList<>();
         for (Generator.Purpose purpose : purposes) {
-            if (purpose instanceof Generator.Purpose.ForAnArm(int probe)) {
+            if (purpose instanceof Generator.Purpose.ForAnArm(ArmProbe probe)) {
                 // Left unnamed where nothing named the arm, which is the state of a row nobody has
                 // named yet and is what the language writes for one. A name invented here would be
                 // a second vocabulary for an arm.
@@ -362,7 +364,7 @@ public final class GeneratedRows {
     private static Map<String, List<Offered>> named(Offering offering) {
         Map<String, List<Offered>> out = new LinkedHashMap<>();
         offering.rowsByBehavior().forEach((behavior, rows) -> {
-            Map<Integer, String> arms = armNames(offering.searched().get(behavior));
+            Map<ArmProbe, String> arms = armNames(offering.searched().get(behavior));
             List<Offered> here = new ArrayList<>();
             for (OfferedRow row : rows) {
                 Offered offered = new Offered(row.key().inputs(), List.of());

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.coverage.Numberings;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.MeasurementStatus;
@@ -714,7 +715,8 @@ class AMeasureWithNoNumberSaysWhyTest {
      */
     @Test
     void whatAMeasurementWentWithoutIsASetAndUnionsLikeOne() {
-        Weakening a = new Weakening.ProofContradicted("take", 1);
+        Weakening a = new Weakening.ProofContradicted("take",
+                Numberings.arm(2, 1));
         Weakening b = new Weakening.ArmsUnsettled(
                 new souther.compiler.types.CoverageOrigin("m", 0, 0,
                         souther.compiler.types.CoverageConstruct.IF));

--- a/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
@@ -191,7 +191,7 @@ class ARowSaysWhatAppliedTheBehaviorTest {
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), Stage.FIXTURES_VALIDATED,
                         ran.disposition(), ran.failurePhase(), ran.expectedArm(), ran.resultArm(),
                         ran.inputCases(), ran.inputs(), ran.statement(),
-                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, new RunRecord.NotRecording()))),
+                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, new RunRecord.NoAccount()))),
                 "and one that did not has nothing to say applied it");
         assertThrows(NullPointerException.class,
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), ran.stage(),

--- a/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.meta.ModulePath;
 import souther.compiler.observe.Applied;
+import souther.compiler.coverage.RunRecord;
 import souther.compiler.observe.Counting;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.RowOutcome;
@@ -152,7 +153,9 @@ class ARowSaysWhatAppliedTheBehaviorTest {
 
         Counting.Read counted = assertInstanceOf(Counting.Read.class, held.run().counting());
         assertTrue(counted.steps() >= 0, "the count is this compile's own reading");
-        assertFalse(counted.observation().taken().isEmpty(),
+        RunRecord.Recorded recorded = assertInstanceOf(RunRecord.Recorded.class, counted.recorded(),
+                "this compile emitted what records where a row goes, so a run of one was recorded");
+        assertFalse(recorded.seen().taken().isEmpty(),
                 "and so are the arms it went through, this compile having emitted what counts them");
     }
 
@@ -188,7 +191,7 @@ class ARowSaysWhatAppliedTheBehaviorTest {
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), Stage.FIXTURES_VALIDATED,
                         ran.disposition(), ran.failurePhase(), ran.expectedArm(), ran.resultArm(),
                         ran.inputCases(), ran.inputs(), ran.statement(),
-                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, souther.compiler.coverage.Observation.NONE))),
+                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, new RunRecord.NotRecording()))),
                 "and one that did not has nothing to say applied it");
         assertThrows(NullPointerException.class,
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), ran.stage(),

--- a/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
@@ -155,7 +155,7 @@ class ARowSaysWhatAppliedTheBehaviorTest {
         assertTrue(counted.steps() >= 0, "the count is this compile's own reading");
         RunRecord.Recorded recorded = assertInstanceOf(RunRecord.Recorded.class, counted.recorded(),
                 "this compile emitted what records where a row goes, so a run of one was recorded");
-        assertFalse(recorded.seen().taken().isEmpty(),
+        assertFalse(recorded.seen().arms().isEmpty(),
                 "and so are the arms it went through, this compile having emitted what counts them");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.Compiler;
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.diag.CompileException;
 import souther.compiler.query.Adequacy;
@@ -183,7 +184,7 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
         // What that answer does with a run, at the value it is made of.
         PathReachability.Answers answers =
                 c.db().ask(new Adequacy.PathReached("demo")).value().get("charge");
-        int probe = answers.found().entrySet().stream()
+        ArmProbe probe = answers.found().entrySet().stream()
                 .filter(each -> each.getValue() instanceof Reachability.Unreachable)
                 .filter(each -> each.getKey() instanceof ControlPointId.ArmOccurrence)
                 .map(each -> (ControlPointId.ArmOccurrence) each.getKey())

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -109,6 +109,12 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "the resolved tree, which is where an operator is written down"),
             new Held("souther.compiler.core.Core.Binary#op",
                     "the tree a check produces, which carries what the source wrote"),
+            new Held("souther.compiler.coverage.Settled.Operator#op",
+                    "what a comparison of a body compares by, as part of saying what that body"
+                            + " does: two bodies alike but for an operator do different things, so"
+                            + " a numbering of one is not a numbering of the other. Copied out of"
+                            + " the tree rather than read for anything — nothing here asks what the"
+                            + " operator means, only whether two of them are the same"),
 
             new Held("souther.compiler.check.ComparisonPlacement.of",
                     "the one reading of an operator for what it places"),
@@ -160,6 +166,8 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " operators one of them may be keyed by to those answering a number"),
             new Held("souther.compiler.coverage.SourceOutcome.Compared.<init>",
                     "makes the outcome a report shows an operator for"),
+            new Held("souther.compiler.coverage.Settled.Operator.<init>",
+                    "makes the word a numbering says a comparison of a body compares by"),
             new Held("souther.compiler.semantics.Arithmetic.TheOperator.<init>",
                     "makes the fact that a library operation computes what an operator computes,"
                             + " and is what limits that to the operators answering a number"),
@@ -318,6 +326,8 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "hands back the operator an arithmetic meaning is keyed by"),
             new Held("souther.compiler.coverage.SourceOutcome.Compared.op",
                     "hands back the operator an outcome was written with"),
+            new Held("souther.compiler.coverage.Settled.Operator.op",
+                    "hands back the operator a body's comparison compares by"),
             new Held("souther.compiler.semantics.Arithmetic.TheOperator.op",
                     "hands back the operator a library operation computes"),
             new Held("souther.compiler.semantics.NumericResult.TheOtherCaseWhen.op",

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsHeldWhereverItIsWrittenTest.java
@@ -332,14 +332,15 @@ class AComparisonIsHeldWhereverItIsWrittenTest {
     void aPlanCannotNumberAComparisonItsCatalogNeverHeld() {
         Checked checked = bodiesOf(NAMED_BEFORE_THE_FORK);
         ComparisonOccurrence elsewhere = new ComparisonOccurrence("nowhere", "fee", 0);
-        Map<ComparisonOccurrence, Integer> numbered = new LinkedHashMap<>();
-        numbered.put(elsewhere, 0);
+        SiteNumbering numbering = Numberings.ofComparisons(1);
+        Map<ComparisonOccurrence, ComparisonEmissionSite> numbered = new LinkedHashMap<>();
+        numbered.put(elsewhere, numbering.comparison(0));
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new CoverageSites.Plan(List.of(), List.of(), new IdentityHashMap<>(),
                         numbered, new IdentityHashMap<>(), new LinkedHashMap<>(),
                         java.util.Set.of(), new IdentityHashMap<>(), catalogOf(checked),
-                        NumberingIdentity.of("example")));
+                        numbering));
         assertTrue(refused.getMessage().contains("one answer or they are two"),
                 refused.getMessage());
     }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonIsLitWhereverItIsWrittenTest.java
@@ -69,8 +69,10 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         ComparisonEmissionSite perElement = comparisonAt(plan, "fee", 9);
         Map<String, ClassFileImage> classes = probed(compilation);
 
-        Observation mixed = new Behavior(classes, "fee").observing(20L, List.of(1L, -1L));
-        Observation positives = new Behavior(classes, "fee").observing(20L, List.of(1L, 2L));
+        AlignedObservation mixed =
+                new Behavior(classes, plan, "fee").observing(20L, List.of(1L, -1L));
+        AlignedObservation positives =
+                new Behavior(classes, plan, "fee").observing(20L, List.of(1L, 2L));
 
         assertEquals(List.of(true, false), waysOut(mixed, perElement),
                 "one element over the line and one under it, at one comparison, in one run");
@@ -93,9 +95,9 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         Map<String, ClassFileImage> classes = probed(compilation);
 
         assertEquals(List.of(true),
-                waysOut(new Behavior(classes, "fee").observing(20L, List.of(1L)), named));
+                waysOut(new Behavior(classes, plan, "fee").observing(20L, List.of(1L)), named));
         assertEquals(List.of(false),
-                waysOut(new Behavior(classes, "fee").observing(1L, List.of(1L)), named));
+                waysOut(new Behavior(classes, plan, "fee").observing(1L, List.of(1L)), named));
     }
 
     /** The same where the comparison is the whole of what the behavior answers. */
@@ -107,16 +109,17 @@ class AComparisonIsLitWhereverItIsWrittenTest {
         Map<String, ClassFileImage> classes = probed(compilation);
 
         assertEquals(List.of(true),
-                waysOut(new Behavior(classes, "positive").observing(5L), answered));
+                waysOut(new Behavior(classes, plan, "positive").observing(5L), answered));
         assertEquals(List.of(false),
-                waysOut(new Behavior(classes, "positive").observing(-5L), answered));
+                waysOut(new Behavior(classes, plan, "positive").observing(-5L), answered));
     }
 
     /** The ways {@code seen} records out of {@code comparison}, held true first. */
-    private static List<Boolean> waysOut(Observation seen, ComparisonEmissionSite comparison) {
+    private static List<Boolean> waysOut(AlignedObservation seen,
+                                         ComparisonEmissionSite comparison) {
         List<Boolean> out = new ArrayList<>();
         for (boolean held : new boolean[] {true, false}) {
-            if (seen.saw(new ComparisonOutcome(comparison, held))) {
+            if (seen.saw(comparison, held)) {
                 out.add(held);
             }
         }
@@ -126,15 +129,16 @@ class AComparisonIsLitWhereverItIsWrittenTest {
     /** The comparison {@code behavior} writes on {@code line}, which is what a run is asked about. */
     private static ComparisonEmissionSite comparisonAt(CoverageSites.Plan plan, String behavior,
                                                      int line) {
-        List<CoverageSites.Site> found = plan.sites().stream()
+        List<CoverageSites.ComparisonSite> found = plan.sites().stream()
                 .filter(site -> site.behavior().equals(behavior))
-                .filter(site -> site.outcome() instanceof SourceOutcome.Compared)
+                .filter(site -> site instanceof CoverageSites.ComparisonSite)
+                .map(CoverageSites.ComparisonSite.class::cast)
                 .filter(site -> site.at() instanceof souther.compiler.diag.Citation.Written written
                         && written.at().line() == line)
                 .toList();
         assertEquals(1, found.size(),
                 () -> "one comparison of " + behavior + " on line " + line + ": " + plan.sites());
-        return new ComparisonEmissionSite(found.get(0).index());
+        return found.get(0).index();
     }
 
     private static Compilation compiled() {
@@ -166,9 +170,11 @@ class AComparisonIsLitWhereverItIsWrittenTest {
 
         private final Object instance;
         private final Method apply;
+        private final CoverageSites.Plan plan;
 
-        Behavior(Map<String, ClassFileImage> classes, String named) {
+        Behavior(Map<String, ClassFileImage> classes, CoverageSites.Plan plan, String named) {
             assertNotNull(classes, "the model under test compiles");
+            this.plan = plan;
             ClassLoader loader = new MemoryClassLoader(classes,
                     AComparisonIsLitWhereverItIsWrittenTest.class.getClassLoader());
             try {
@@ -185,11 +191,14 @@ class AComparisonIsLitWhereverItIsWrittenTest {
             }
         }
 
-        Observation observing(Object... given) {
-            Probe.begin();
+        AlignedObservation observing(Object... given) {
+            // Under the numbering the classes were emitted with, and read back under the same one.
+            // What the alignment is for is that those two are one, so a fixture that took them
+            // from two places would be the thing this cannot check.
+            Probe.begin(plan.identity());
             try {
                 apply.invoke(instance, given);
-                return Probe.snapshot();
+                return plan.numbering().align(Probe.snapshot());
             } catch (ReflectiveOperationException e) {
                 throw new AssertionError(e);
             } finally {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -98,10 +98,8 @@ class AComparisonSaysWhichWayItCameOutTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "the row that answered both comparisons reached the second one"));
-        assertFalse(early.taken().contains(second.at()),
-                "which the row that short-circuited never reached");
         assertFalse(early.comparisons().contains(new ComparisonOutcome(second.at(), true)),
-                "so it did not come out one way");
+                "the row that short-circuited did not have it come out one way");
         assertFalse(early.comparisons().contains(new ComparisonOutcome(second.at(), false)),
                 "nor the other");
     }
@@ -127,24 +125,32 @@ class AComparisonSaysWhichWayItCameOutTest {
     }
 
     /**
-     * A comparison recorded as having come out a way is a comparison recorded as reached.
+     * A comparison's number is recorded among the comparisons and nowhere else.
      *
-     * <p>Held by how the recording is written rather than by the emitter keeping to it: one call
-     * records both. So a run that has the first without the second is one nothing produces, and
-     * whoever reads the sites and whoever reads the ways out are reading one run.
+     * <p>What a run leaves behind is a family apiece. There is no second place a comparison could
+     * be written as reached — its having come out a way is that — so nothing has to keep two
+     * records of one comparison in step, and no reader has to work out which family a number
+     * belongs to after the numbering has already said.
      */
     @Test
-    void awayOutImpliesItsComparisonWasReached() {
+    void aComparisonIsRecordedAmongTheComparisonsAndNotAmongTheArms() {
         Compilation compilation = compiled();
-        Behavior submit = new Behavior(probed(compilation),
-                checkedPlanOf(compilation).identity());
+        CoverageSites.Plan plan = checkedPlanOf(compilation);
+        Behavior submit = new Behavior(probed(compilation), plan.identity());
+        Set<Integer> comparisons = plan.sites().stream()
+                .filter(CoverageSites.ComparisonSite.class::isInstance)
+                .map(site -> ((CoverageSites.ComparisonSite) site).index().raw())
+                .collect(java.util.stream.Collectors.toSet());
+        assertFalse(comparisons.isEmpty(), "the model under test writes comparisons");
 
         for (long cost : new long[] {-1L, 50L, 500L}) {
             Observation seen = submit.observing(cost);
-            for (ComparisonOutcome each : seen.comparisons()) {
-                assertTrue(seen.taken().contains(each.at()),
-                        "a way out of " + each.at() + " was recorded, so it was reached");
+            for (int arm : seen.arms()) {
+                assertFalse(comparisons.contains(arm),
+                        "no comparison of this plan is recorded as an arm: " + arm);
             }
+            assertFalse(seen.comparisons().isEmpty(),
+                    "and every one of these rows evaluated a comparison");
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -12,7 +12,6 @@ import souther.compiler.query.Output;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,7 +61,7 @@ class AComparisonSaysWhichWayItCameOutTest {
     void twoWaysOfFailingOneConditionAreNotOneObservation() {
         Compilation compilation = compiled();
         CoverageSites.Plan plan = checkedPlanOf(compilation);
-        Behavior submit = new Behavior(probed(compilation));
+        Behavior submit = new Behavior(probed(compilation), plan.identity());
 
         Observation early = submit.observing(-1L);
         Observation late = submit.observing(500L);
@@ -83,7 +82,8 @@ class AComparisonSaysWhichWayItCameOutTest {
     @Test
     void aComparisonNeverReachedIsAbsentAndNotFalse() {
         Compilation compilation = compiled();
-        Behavior submit = new Behavior(probed(compilation));
+        Behavior submit = new Behavior(probed(compilation),
+                checkedPlanOf(compilation).identity());
 
         Observation early = submit.observing(-1L);
 
@@ -94,15 +94,15 @@ class AComparisonSaysWhichWayItCameOutTest {
 
         Observation late = submit.observing(500L);
         ComparisonOutcome second = late.comparisons().stream()
-                .filter(each -> !each.at().equals(first.at()))
+                .filter(each -> each.at() != first.at())
                 .findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "the row that answered both comparisons reached the second one"));
-        assertFalse(early.reached(second.at()),
+        assertFalse(early.taken().contains(second.at()),
                 "which the row that short-circuited never reached");
-        assertFalse(early.saw(new ComparisonOutcome(second.at(), true)),
+        assertFalse(early.comparisons().contains(new ComparisonOutcome(second.at(), true)),
                 "so it did not come out one way");
-        assertFalse(early.saw(new ComparisonOutcome(second.at(), false)),
+        assertFalse(early.comparisons().contains(new ComparisonOutcome(second.at(), false)),
                 "nor the other");
     }
 
@@ -110,7 +110,8 @@ class AComparisonSaysWhichWayItCameOutTest {
     @Test
     void aComparisonIsRecordedComingOutEitherWay() {
         Compilation compilation = compiled();
-        Behavior submit = new Behavior(probed(compilation));
+        Behavior submit = new Behavior(probed(compilation),
+                checkedPlanOf(compilation).identity());
 
         Observation refused = submit.observing(500L);
         Observation accepted = submit.observing(50L);
@@ -119,9 +120,10 @@ class AComparisonSaysWhichWayItCameOutTest {
                 .filter(each -> !each.held())
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("the second comparison failed for this row"));
-        assertTrue(accepted.saw(new ComparisonOutcome(failed.at(), true)),
+        assertTrue(accepted.comparisons().contains(new ComparisonOutcome(failed.at(), true)),
                 "and the row inside the range answered the same comparison the other way");
-        assertFalse(accepted.saw(failed), "which is not the way this one came out");
+        assertFalse(accepted.comparisons().contains(failed),
+                "which is not the way this one came out");
     }
 
     /**
@@ -133,26 +135,22 @@ class AComparisonSaysWhichWayItCameOutTest {
      */
     @Test
     void awayOutImpliesItsComparisonWasReached() {
-        Behavior submit = new Behavior(probed(compiled()));
+        Compilation compilation = compiled();
+        Behavior submit = new Behavior(probed(compilation),
+                checkedPlanOf(compilation).identity());
 
         for (long cost : new long[] {-1L, 50L, 500L}) {
             Observation seen = submit.observing(cost);
             for (ComparisonOutcome each : seen.comparisons()) {
-                assertTrue(seen.reached(each.at()),
+                assertTrue(seen.taken().contains(each.at()),
                         "a way out of " + each.at() + " was recorded, so it was reached");
             }
         }
     }
 
     /** The sites of {@code seen} that are arms, which is what a branch measure counts. */
-    private static Set<Integer> armsOf(Observation seen, CoverageSites.Plan plan) {
-        Set<Integer> arms = new LinkedHashSet<>();
-        for (CoverageSites.Site site : plan.sites()) {
-            if (site.isArm() && seen.lit(site.index())) {
-                arms.add(site.index());
-            }
-        }
-        return arms;
+    private static Set<ArmProbe> armsOf(Observation seen, CoverageSites.Plan plan) {
+        return plan.numbering().align(seen).arms();
     }
 
     private static Compilation compiled() {
@@ -184,8 +182,10 @@ class AComparisonSaysWhichWayItCameOutTest {
 
         private final Object instance;
         private final Method apply;
+        private final NumberingIdentity under;
 
-        Behavior(Map<String, ClassFileImage> classes) {
+        Behavior(Map<String, ClassFileImage> classes, NumberingIdentity under) {
+            this.under = under;
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     AComparisonSaysWhichWayItCameOutTest.class.getClassLoader());
@@ -201,8 +201,9 @@ class AComparisonSaysWhichWayItCameOutTest {
             }
         }
 
+        /** What the classes recorded, as numbers under the numbering they were emitted with. */
         Observation observing(long cost) {
-            Probe.begin();
+            Probe.begin(under);
             try {
                 apply.invoke(instance, cost);
                 return Probe.snapshot();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ANumberMeansTheFamilyItWasIssuedToTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ANumberMeansTheFamilyItWasIssuedToTest.java
@@ -1,0 +1,62 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A number addresses the family it was issued to, and asking it as the other one is refused.
+ *
+ * <p>Both families take their numbers from one counter, because what records a run is one set of
+ * numbers: a number written for an arm and a number written for a comparison are told apart by
+ * nothing in the number. So which one a number was issued to is the numbering's answer, given once
+ * where the number was handed out — and read back as the other family it would be an address of a
+ * place the emitter never lights, which no count can tell from a real one.
+ *
+ * <p>Held here rather than left to the readers. {@link SiteNumbering#align} asks the family before
+ * it reads a number back, so nothing a run produces reaches this; what does reach it is every other
+ * caller that has a number and wants a place, and the answer has to be the same for all of them.
+ *
+ * <p>And a number the numbering never handed out at all, which is the same mistake with nothing to
+ * be confused about.
+ */
+class ANumberMeansTheFamilyItWasIssuedToTest {
+
+    /** An arm at 0 and a comparison at 1, so each family has a number the other does not. */
+    private static SiteNumbering numbering() {
+        return Numberings.of(Numberings.Family.ARM, Numberings.Family.COMPARISON);
+    }
+
+    @Test
+    void aComparisonsNumberIsNoArm() {
+        IllegalArgumentException refused =
+                assertThrows(IllegalArgumentException.class, () -> numbering().arm(1));
+
+        assertTrue(refused.getMessage().contains("which is not an arm"), refused.getMessage());
+    }
+
+    @Test
+    void anArmsNumberIsNoComparison() {
+        IllegalArgumentException refused =
+                assertThrows(IllegalArgumentException.class, () -> numbering().comparison(0));
+
+        assertTrue(refused.getMessage().contains("which is not a comparison"),
+                refused.getMessage());
+    }
+
+    /** And each family reads its own number back, which is what says the refusals above are about
+     *  the family and not about reading a number back at all. */
+    @Test
+    void andEachFamilyReadsItsOwnNumberBack() {
+        assertEquals(0, numbering().arm(0).raw());
+        assertEquals(1, numbering().comparison(1).raw());
+    }
+
+    @Test
+    void aNumberThisNumberingNeverHandedOutIsNoPlaceOfIt() {
+        assertThrows(IllegalArgumentException.class, () -> numbering().arm(2));
+        assertThrows(IllegalArgumentException.class, () -> numbering().comparison(2));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
@@ -1,0 +1,76 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A run is read as places of the numbering it was recorded under, and of no other.
+ *
+ * <p>This is the crossing the whole numbering exists for. What a run leaves behind is numbers; what
+ * a number means is a place under the numbering that handed it out. Read under another numbering,
+ * every number still resolves — the other numbering has numbers too — and what comes back is an
+ * ordinary answer about places the run was never near. Nothing downstream can tell that from a
+ * right one, so it is refused here.
+ *
+ * <p><b>The other numbering is the same size and numbers different places.</b> A numbering that is
+ * shorter would be caught by the number falling off the end, which is a different mechanism and one
+ * that happens to fire; the case to hold is the one where nothing about the numbers themselves is
+ * wrong.
+ *
+ * <p>And two numberings of the same places are one, which is the other half: the refusal is about
+ * what a numbering is rather than about which construction made it, so a recording read under a
+ * numbering derived a second time is read and not refused.
+ */
+class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
+
+    /** Two arms and a comparison, so that a number of each family is in play. */
+    private static SiteNumbering here() {
+        return Numberings.of(Numberings.Family.ARM, Numberings.Family.COMPARISON,
+                Numberings.Family.ARM);
+    }
+
+    /** The same size, and every place a different one: the comparison and the arms have swapped
+     *  round, so each number addresses something else. */
+    private static SiteNumbering elsewhere() {
+        return Numberings.of(Numberings.Family.COMPARISON, Numberings.Family.ARM,
+                Numberings.Family.COMPARISON);
+    }
+
+    @Test
+    void aRecordingOfAnotherNumberingIsRefusedRatherThanAnswered() {
+        Observation seen = new Observation(elsewhere().identity(), Set.of(0, 1),
+                Set.of(new ComparisonOutcome(0, true)));
+
+        IllegalArgumentException refused =
+                assertThrows(IllegalArgumentException.class, () -> here().align(seen));
+
+        assertTrue(refused.getMessage().contains("a number means a place under the numbering"),
+                refused.getMessage());
+    }
+
+    /**
+     * And a numbering derived a second time reads it, because it is the same numbering.
+     *
+     * <p>Which is what says the check above is about the numbering and not about the construction.
+     * Held against the refusal: a rule that turned on which walk made the numbering would refuse
+     * this one too, and every recomputation of a store would stop being able to read a recording it
+     * had just been able to read.
+     */
+    @Test
+    void aRecordingIsReadUnderANumberingDerivedASecondTime() {
+        Observation seen = new Observation(here().identity(), Set.of(0, 1, 2),
+                Set.of(new ComparisonOutcome(1, false)));
+
+        AlignedObservation read = here().align(seen);
+
+        assertEquals(Set.of(here().arm(0), here().arm(2)), read.arms(),
+                "the arms it was recorded at, as places of a numbering built for this reading");
+        assertTrue(read.saw(here().comparison(1), false),
+                "and the way its comparison came out");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
@@ -43,7 +43,9 @@ class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
 
     @Test
     void aRecordingOfAnotherNumberingIsRefusedRatherThanAnswered() {
-        Observation seen = new Observation(elsewhere().identity(), Set.of(0, 1),
+        // A run of the other numbering, recorded at its own places: its arm is 1 and its
+        // comparisons are 0 and 2, which is exactly what this numbering has the other way round.
+        Observation seen = new Observation(elsewhere().identity(), Set.of(1),
                 Set.of(new ComparisonOutcome(0, true)));
 
         IllegalArgumentException refused =
@@ -64,7 +66,7 @@ class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
      */
     @Test
     void aPlaceOfAnotherNumberingIsRefusedByARunThatWasRead() {
-        AlignedObservation read = here().align(new Observation(here().identity(), Set.of(0, 1),
+        AlignedObservation read = here().align(new Observation(here().identity(), Set.of(0, 2),
                 Set.of(new ComparisonOutcome(1, true))));
 
         assertThrows(IllegalArgumentException.class, () -> read.lit(elsewhere().arm(1)),
@@ -74,6 +76,7 @@ class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
                 "and neither is a comparison of one");
         assertThrows(IllegalArgumentException.class, () -> read.reached(elsewhere().comparison(2)),
                 "however the question is put");
+        assertTrue(read.lit(here().arm(0)), "while a place of its own is answered");
     }
 
     /**
@@ -86,7 +89,7 @@ class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
      */
     @Test
     void aRecordingIsReadUnderANumberingDerivedASecondTime() {
-        Observation seen = new Observation(here().identity(), Set.of(0, 1, 2),
+        Observation seen = new Observation(here().identity(), Set.of(0, 2),
                 Set.of(new ComparisonOutcome(1, false)));
 
         AlignedObservation read = here().align(seen);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ARunIsReadUnderTheNumberingItWasRecordedUnderTest.java
@@ -54,6 +54,29 @@ class ARunIsReadUnderTheNumberingItWasRecordedUnderTest {
     }
 
     /**
+     * And a place of another numbering put to a run that was read is refused too.
+     *
+     * <p>The other end of the same crossing, and the one a check at the door does not reach. A
+     * reader can hold two numberings — the module's own and one it took off an artifact — and what
+     * a run of the first did at a place of the second is nothing. Answered as an ordinary "no", it
+     * says the row did not reach a place it was never asked about, which is the same false answer
+     * the refusal above exists to stop, one step further along.
+     */
+    @Test
+    void aPlaceOfAnotherNumberingIsRefusedByARunThatWasRead() {
+        AlignedObservation read = here().align(new Observation(here().identity(), Set.of(0, 1),
+                Set.of(new ComparisonOutcome(1, true))));
+
+        assertThrows(IllegalArgumentException.class, () -> read.lit(elsewhere().arm(1)),
+                "an arm of another numbering is no arm this run can be asked about");
+        assertThrows(IllegalArgumentException.class,
+                () -> read.saw(elsewhere().comparison(0), true),
+                "and neither is a comparison of one");
+        assertThrows(IllegalArgumentException.class, () -> read.reached(elsewhere().comparison(2)),
+                "however the question is put");
+    }
+
+    /**
      * And a numbering derived a second time reads it, because it is the same numbering.
      *
      * <p>Which is what says the check above is about the numbering and not about the construction.

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
@@ -8,58 +8,57 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * What a record of a run may say, held where the record is made rather than where it is written.
+ * A number a run holds is one the numbering issued to the family it is recorded under.
  *
- * <p>The one producer today records a comparison being reached and the way it came out in a single
- * call, so nothing it makes can break this. That is how the producer is written and producers get
- * rewritten; what every reader of a run is entitled to is that the two agree, because a claim about
- * a place is certified against exactly that.
+ * <p>The two families take their numbers from one counter, so nothing in a number says which of
+ * them it was written for. What says it is which call wrote it down — and the recording keeps them
+ * apart, so the answer is the record's own rather than something a reader works out afterwards by
+ * asking the numbering about a set holding both.
  *
- * <p>Both directions, because either half alone is a value a reader is answered wrongly from. A way
- * out of a place the run says it never reached certifies a claim about somewhere it was not; a
- * place the run reached that no way out is recorded for reads as a comparison nothing evaluated,
- * which is what a row that short-circuited past it looks like.
+ * <p>Held where the recording is made rather than where it is read. A number written into the wrong
+ * family is the emitter having lit a place it was not at, and a reader meeting it later has a run
+ * saying something no run could say: an arm no arm was ever emitted for, or a comparison that never
+ * came out any way at all.
+ *
+ * <p>What is <em>not</em> held here, said rather than left to be looked for: nothing relates the two
+ * sets. A comparison is recorded by the way it came out and by nothing else, so there is no second
+ * record of it to agree with — which is what makes each of them mean something on its own.
  */
 class AnObservationHoldsWhatItSaysAboutItselfTest {
 
-    /** A comparison at 0 and an arm at 1, so a number of each family is in play and the numbering
-     *  can be asked which is which. */
+    /** A comparison at 0 and an arm at 1, so each family has a number the other does not. */
     private static final SiteNumbering NUMBERING =
             Numberings.of(Numberings.Family.COMPARISON, Numberings.Family.ARM);
 
     private static final NumberingIdentity UNDER = NUMBERING.identity();
 
     @Test
-    void awayOutOfAComparisonMeansTheComparisonWasReached() {
-        ComparisonOutcome held = new ComparisonOutcome(0, true);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> new Observation(UNDER, Set.of(), Set.of(held)),
-                "a run that saw a comparison come out one way reached it");
-        assertTrue(new Observation(UNDER, Set.of(0), Set.of(held)).comparisons().contains(held),
-                "and one that holds both says so");
-    }
-
-    /**
-     * And a comparison reached is one that came out some way.
-     *
-     * <p>The same call records both, so a run holding the number and no way out of it is one
-     * nothing produces. Left unheld, such a run reads as a comparison that was never evaluated —
-     * the answer a row which short-circuited past it gives — and the two would be one.
-     */
-    @Test
-    void aComparisonReachedMeansAWayOutOfItWasRecorded() {
+    void aComparisonsNumberIsNotAnArmARunPassed() {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> new Observation(UNDER, Set.of(0), Set.of()));
 
-        assertTrue(refused.getMessage().contains("come out some way"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("recorded as an arm"), refused.getMessage());
     }
 
-    /** And an arm reached is just an arm reached: what a fork's arm has is no way out to record. */
     @Test
-    void anArmReachedIsNotHeldToHavingComeOutAnyWay() {
-        assertTrue(new Observation(UNDER, Set.of(1), Set.of()).taken().contains(1),
-                "which is what says the rule above is about the comparisons");
+    void anArmsNumberIsNoComparisonARunEvaluated() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Observation(UNDER, Set.of(),
+                        Set.of(new ComparisonOutcome(1, true))));
+
+        assertTrue(refused.getMessage().contains("recorded as a comparison"),
+                refused.getMessage());
+    }
+
+    /** And each family holds its own, which is what says the refusals above are about the family
+     *  and not about holding anything at all. */
+    @Test
+    void andEachFamilyHoldsItsOwn() {
+        Observation seen = new Observation(UNDER, Set.of(1),
+                Set.of(new ComparisonOutcome(0, true)));
+
+        assertTrue(seen.arms().contains(1));
+        assertTrue(seen.comparisons().contains(new ComparisonOutcome(0, true)));
     }
 
     /**
@@ -71,7 +70,7 @@ class AnObservationHoldsWhatItSaysAboutItselfTest {
      */
     @Test
     void bothWaysOutOfOneComparisonAreARunThatCameBackToIt() {
-        Observation seen = new Observation(UNDER, Set.of(0),
+        Observation seen = new Observation(UNDER, Set.of(),
                 Set.of(new ComparisonOutcome(0, true), new ComparisonOutcome(0, false)));
 
         assertTrue(seen.comparisons().contains(new ComparisonOutcome(0, true)));

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
@@ -19,12 +19,13 @@ class AnObservationHoldsWhatItSaysAboutItselfTest {
 
     @Test
     void awayOutOfAComparisonMeansTheComparisonWasReached() {
-        ComparisonOutcome held = new ComparisonOutcome(new ComparisonEmissionSite(7), true);
+        ComparisonOutcome held = new ComparisonOutcome(7, true);
+        NumberingIdentity under = NumberingIdentity.of("fixture");
 
         assertThrows(IllegalArgumentException.class,
-                () -> new Observation(Set.of(), Set.of(held)),
+                () -> new Observation(under, Set.of(), Set.of(held)),
                 "a run that saw a comparison come out one way reached it");
-        assertTrue(new Observation(Set.of(7), Set.of(held)).saw(held),
+        assertTrue(new Observation(under, Set.of(7), Set.of(held)).comparisons().contains(held),
                 "and one that holds both says so");
     }
 
@@ -37,11 +38,10 @@ class AnObservationHoldsWhatItSaysAboutItselfTest {
      */
     @Test
     void bothWaysOutOfOneComparisonAreARunThatCameBackToIt() {
-        ComparisonEmissionSite twice = new ComparisonEmissionSite(3);
-        Observation seen = new Observation(Set.of(3),
-                Set.of(new ComparisonOutcome(twice, true), new ComparisonOutcome(twice, false)));
+        Observation seen = new Observation(NumberingIdentity.of("fixture"), Set.of(3),
+                Set.of(new ComparisonOutcome(3, true), new ComparisonOutcome(3, false)));
 
-        assertTrue(seen.saw(new ComparisonOutcome(twice, true)));
-        assertTrue(seen.saw(new ComparisonOutcome(twice, false)));
+        assertTrue(seen.comparisons().contains(new ComparisonOutcome(3, true)));
+        assertTrue(seen.comparisons().contains(new ComparisonOutcome(3, false)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
@@ -12,21 +12,54 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>The one producer today records a comparison being reached and the way it came out in a single
  * call, so nothing it makes can break this. That is how the producer is written and producers get
- * rewritten; what every reader of a run is entitled to is that a way out of a comparison means the
- * comparison was reached, because a claim about a place is certified against exactly that.
+ * rewritten; what every reader of a run is entitled to is that the two agree, because a claim about
+ * a place is certified against exactly that.
+ *
+ * <p>Both directions, because either half alone is a value a reader is answered wrongly from. A way
+ * out of a place the run says it never reached certifies a claim about somewhere it was not; a
+ * place the run reached that no way out is recorded for reads as a comparison nothing evaluated,
+ * which is what a row that short-circuited past it looks like.
  */
 class AnObservationHoldsWhatItSaysAboutItselfTest {
 
+    /** A comparison at 0 and an arm at 1, so a number of each family is in play and the numbering
+     *  can be asked which is which. */
+    private static final SiteNumbering NUMBERING =
+            Numberings.of(Numberings.Family.COMPARISON, Numberings.Family.ARM);
+
+    private static final NumberingIdentity UNDER = NUMBERING.identity();
+
     @Test
     void awayOutOfAComparisonMeansTheComparisonWasReached() {
-        ComparisonOutcome held = new ComparisonOutcome(7, true);
-        NumberingIdentity under = NumberingIdentity.of("fixture");
+        ComparisonOutcome held = new ComparisonOutcome(0, true);
 
         assertThrows(IllegalArgumentException.class,
-                () -> new Observation(under, Set.of(), Set.of(held)),
+                () -> new Observation(UNDER, Set.of(), Set.of(held)),
                 "a run that saw a comparison come out one way reached it");
-        assertTrue(new Observation(under, Set.of(7), Set.of(held)).comparisons().contains(held),
+        assertTrue(new Observation(UNDER, Set.of(0), Set.of(held)).comparisons().contains(held),
                 "and one that holds both says so");
+    }
+
+    /**
+     * And a comparison reached is one that came out some way.
+     *
+     * <p>The same call records both, so a run holding the number and no way out of it is one
+     * nothing produces. Left unheld, such a run reads as a comparison that was never evaluated —
+     * the answer a row which short-circuited past it gives — and the two would be one.
+     */
+    @Test
+    void aComparisonReachedMeansAWayOutOfItWasRecorded() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Observation(UNDER, Set.of(0), Set.of()));
+
+        assertTrue(refused.getMessage().contains("come out some way"), refused.getMessage());
+    }
+
+    /** And an arm reached is just an arm reached: what a fork's arm has is no way out to record. */
+    @Test
+    void anArmReachedIsNotHeldToHavingComeOutAnyWay() {
+        assertTrue(new Observation(UNDER, Set.of(1), Set.of()).taken().contains(1),
+                "which is what says the rule above is about the comparisons");
     }
 
     /**
@@ -38,10 +71,10 @@ class AnObservationHoldsWhatItSaysAboutItselfTest {
      */
     @Test
     void bothWaysOutOfOneComparisonAreARunThatCameBackToIt() {
-        Observation seen = new Observation(NumberingIdentity.of("fixture"), Set.of(3),
-                Set.of(new ComparisonOutcome(3, true), new ComparisonOutcome(3, false)));
+        Observation seen = new Observation(UNDER, Set.of(0),
+                Set.of(new ComparisonOutcome(0, true), new ComparisonOutcome(0, false)));
 
-        assertTrue(seen.comparisons().contains(new ComparisonOutcome(3, true)));
-        assertTrue(seen.comparisons().contains(new ComparisonOutcome(3, false)));
+        assertTrue(seen.comparisons().contains(new ComparisonOutcome(0, true)));
+        assertTrue(seen.comparisons().contains(new ComparisonOutcome(0, false)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
@@ -133,7 +133,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         // comprehension have none.
         assertEquals(List.of("constructed", "else"),
                 planOf(AN_ATTEMPTED_GUARD).sites().stream()
-                        .filter(CoverageSites.Site::isArm)
+                        .filter(site -> site instanceof CoverageSites.ArmSite)
                         .map(souther.compiler.report.ArmVocabulary::label).toList());
     }
 
@@ -156,7 +156,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         // And the two conditions stay apart, which is what `lowered` is for. Four obligations and
         // not two: each condition owes a row through each of its ways.
         assertEquals(4, planOf(THROUGH_A_HELPER).sites().stream()
-                        .filter(CoverageSites.Site::isArm)
+                        .filter(site -> site instanceof CoverageSites.ArmSite)
                         .map(CoverageSites.Site::obligation).distinct().count(),
                 "two forks of the one comprehension, two ways each");
     }
@@ -245,8 +245,8 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
     /** And a site cannot be made holding one, which is where the two halves are first put together. */
     @Test
     void aSiteCannotHoldAPairTheLanguageDoesNotHave() {
-        assertThrows(IllegalArgumentException.class, () -> new CoverageSites.Site("b", built(), null,
-                0, 0, new CoverageSites.Obligation("b",
+        assertThrows(IllegalArgumentException.class, () -> new CoverageSites.ArmSite("b", built(),
+                null, Numberings.arm(1, 0), 0, new CoverageSites.Obligation("b",
                         CoverageOrigin.written("m", 0, CoverageConstruct.COMPREHENSION), 0,
                         souther.compiler.coverage.DecidedBy.THE_DECLARATION)));
     }
@@ -269,7 +269,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
                 } catch (IllegalArgumentException _) {
                     continue;   // not a pair the language has, so nothing to agree about
                 }
-                assertEquals(outcome.isArm(), name.isArm(),
+                assertEquals(outcome instanceof SourceOutcome.Arm, name.isArm(),
                         () -> construct + " with " + outcome + " is named " + name);
             }
         }
@@ -313,19 +313,19 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
 
     // --- helpers ------------------------------------------------------------------------------------
 
-    private static SourceOutcome held() {
+    private static SourceOutcome.Arm held() {
         return new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition());
     }
 
-    private static SourceOutcome failed() {
+    private static SourceOutcome.Arm failed() {
         return new SourceOutcome.Failed(new SourceOutcome.FailedBy.Condition());
     }
 
-    private static SourceOutcome built() {
+    private static SourceOutcome.Arm built() {
         return new SourceOutcome.Held(new SourceOutcome.HeldBy.Construction());
     }
 
-    private static SourceOutcome refused() {
+    private static SourceOutcome.Arm refused() {
         return new SourceOutcome.Failed(
                 new SourceOutcome.FailedBy.Construction(Optional.empty()));
     }
@@ -333,7 +333,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
     /** Each arm as the pair that says what it is: what the author wrote, and which way through it. */
     private static List<String> namesIn(String source) {
         return planOf(source).sites().stream()
-                .filter(CoverageSites.Site::isArm)
+                .filter(site -> site instanceof CoverageSites.ArmSite)
                 .map(site -> site.construct() + " "
                         + site.name().name().toLowerCase(java.util.Locale.ROOT))
                 .toList();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest.java
@@ -35,10 +35,19 @@ class AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest {
     private static final CoverageOrigin FORK =
             CoverageOrigin.written("m", 0, CoverageConstruct.IF);
 
-    private static CoverageSites.Site arm(int index, DecidedBy decided) {
-        return new CoverageSites.Site("b",
-                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()), null, index, index,
-                new CoverageSites.Obligation("b", FORK, index, decided));
+    /** Three places of one numbering, so that arms put in one list are addresses of one. */
+    private static final java.util.Map<Integer, ArmProbe> PLACES = Numberings.arms(3);
+
+    private static CoverageSites.ArmSite arm(int index, DecidedBy decided) {
+        return arm(index, FORK, index, decided);
+    }
+
+    private static CoverageSites.ArmSite arm(int index, CoverageOrigin fork, int part,
+                                             DecidedBy decided) {
+        return new CoverageSites.ArmSite("b",
+                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()), null,
+                PLACES.get(index), index,
+                new CoverageSites.Obligation("b", fork, part, decided));
     }
 
     /** Two arms of one fork, neither of them reached. */
@@ -100,10 +109,7 @@ class AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest {
         CoverageOrigin beside = CoverageOrigin.written("m", 1, CoverageConstruct.IF);
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured("b",
                 List.of(arm(0, DecidedBy.NOT_SAID), arm(1, DecidedBy.NOT_SAID),
-                        new CoverageSites.Site("b",
-                                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()), null,
-                                2, 2, new CoverageSites.Obligation("b", beside, 0,
-                                        DecidedBy.THE_DECLARATION))),
+                        arm(2, beside, 0, DecidedBy.THE_DECLARATION)),
                 Set.of(), souther.compiler.query.Adequacy.NOTHING_PROVEN, WeakeningSet.none());
 
         assertEquals(1, measured.arms().unmet().size(),

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
@@ -342,8 +343,18 @@ class CoverageSitesTest {
 
         assertEquals(1, plan.guards().size());
         CoverageSites.GuardRef guard = plan.guards().get(0);
-        assertEquals("then", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexThen())));
-        assertEquals("else", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexElse())));
+        assertEquals("then", labelAt(plan, guard.whereThen()));
+        assertEquals("else", labelAt(plan, guard.whereElse()));
+    }
+
+    /** What the arm {@code where} numbers is called, asked of the plan that numbered it. */
+    private static String labelAt(CoverageSites.Plan plan, java.util.Optional<ArmProbe> where) {
+        CoverageSites.ArmSite found = plan.sites().stream()
+                .filter(CoverageSites.ArmSite.class::isInstance)
+                .map(CoverageSites.ArmSite.class::cast)
+                .filter(site -> site.index().equals(where.orElseThrow()))
+                .findFirst().orElseThrow();
+        return souther.compiler.report.ArmVocabulary.label(found);
     }
 
     /** The comparison was evaluated to reach the arm that is left, so the line it draws is still one
@@ -355,8 +366,8 @@ class CoverageSitesTest {
 
         assertEquals(1, plan.guards().size());
         CoverageSites.GuardRef guard = plan.guards().get(0);
-        assertEquals(CoverageSites.NO_SITE, guard.siteIndexThen());
-        assertEquals("else", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexElse())));
+        assertTrue(guard.whereThen().isEmpty(), "the `then` arm answers nothing, so it has no place");
+        assertEquals("else", labelAt(plan, guard.whereElse()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -415,7 +415,8 @@ class CoverageSitesTest {
         int[] arms = plan.probesOf(match);
         assertNotNull(arms, "the plan is keyed by the instances it was built from");
         assertEquals(2, arms.length);
-        assertEquals("case UnderThirty", souther.compiler.report.ArmVocabulary.label(plan.site(arms[0])));
+        assertEquals("case UnderThirty", labelAt(plan, java.util.Optional.of(
+                plan.numbering().arm(arms[0]))));
 
         Core.Match copy = new Core.Match(match.scrutinee(), match.cases(), match.origin(),
                 match.type(), match.pos(), java.util.List.of());

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryForkTheNumberingReachesIsOneTheDeclarationsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryForkTheNumberingReachesIsOneTheDeclarationsAnsweredForTest.java
@@ -74,7 +74,7 @@ class EveryForkTheNumberingReachesIsOneTheDeclarationsAnsweredForTest {
         List<CoverageOrigin> forks = new ArrayList<>();
         for (CoverageSites.Site site : plan.sites()) {
             CoverageOrigin origin = site.obligation().origin();
-            if (site.isArm() && !forks.contains(origin)) {
+            if (site instanceof CoverageSites.ArmSite && !forks.contains(origin)) {
                 forks.add(origin);
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
@@ -1,0 +1,114 @@
+package souther.compiler.coverage;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A numbering for a fixture that has places in mind and no bodies to walk.
+ *
+ * <p>What a test writing "the arm numbered 3" needs. An address is issued by a numbering and
+ * nothing else, which is what stops one being made up next to a run it is not about; a test that
+ * writes a number is standing in for the walk that would have handed it out, and this is that
+ * stand-in said out loud rather than a way round the rule.
+ *
+ * <p>Two calls asking for the same places come to the same numbering, so two fixtures that both
+ * write "arm 3" hold one address. That is what a numbering is — a value two derivations agree on —
+ * and it is why a fixture need not pass one construction around to keep its places together. Two
+ * calls asking for <em>different</em> places are different numberings, and an address of one is no
+ * address of the other.
+ */
+public final class Numberings {
+
+    /**
+     * A numbering of {@code many} places, alternating nothing: every one of them is an arm.
+     *
+     * <p>The addresses are of a body this fixture does not have, so what each is <em>of</em> is a
+     * path nothing walked. What a fixture uses them for is the numbers, and the places are what
+     * makes them addresses at all.
+     */
+    public static SiteNumbering ofArms(int many) {
+        Family[] families = new Family[many];
+        java.util.Arrays.fill(families, Family.ARM);
+        return of(families);
+    }
+
+    /** The arm {@code raw} of a numbering of {@code many} arms. */
+    public static ArmProbe arm(int many, int raw) {
+        return ofArms(many).arm(raw);
+    }
+
+    /** The arms of one numbering, by their numbers, so a fixture holds addresses of one. */
+    public static Map<Integer, ArmProbe> arms(int many) {
+        SiteNumbering numbering = ofArms(many);
+        Map<Integer, ArmProbe> out = new LinkedHashMap<>();
+        for (int at = 0; at < many; at++) {
+            out.put(at, numbering.arm(at));
+        }
+        return out;
+    }
+
+    /**
+     * A numbering of {@code many} places, every one of them a comparison.
+     *
+     * <p>Beside {@link #ofArms} and not mixed with it, because a fixture that wants both wants to
+     * say which number is which — {@link #of} takes that.
+     */
+    public static SiteNumbering ofComparisons(int many) {
+        Family[] families = new Family[many];
+        java.util.Arrays.fill(families, Family.COMPARISON);
+        return of(families);
+    }
+
+    /** The comparison {@code raw} of a numbering of {@code many} comparisons. */
+    public static ComparisonEmissionSite comparison(int many, int raw) {
+        return ofComparisons(many).comparison(raw);
+    }
+
+    /** The comparisons of one numbering, by their numbers. */
+    public static Map<Integer, ComparisonEmissionSite> comparisons(int many) {
+        SiteNumbering numbering = ofComparisons(many);
+        Map<Integer, ComparisonEmissionSite> out = new LinkedHashMap<>();
+        for (int at = 0; at < many; at++) {
+            out.put(at, numbering.comparison(at));
+        }
+        return out;
+    }
+
+    /** Which of the two families a fixture's number was handed out to. */
+    public enum Family { ARM, COMPARISON }
+
+    /**
+     * A numbering whose numbers were handed out to the families named, in that order.
+     *
+     * <p>For a fixture whose point is that the two are told apart: which number addresses which
+     * kind of place is what the numbering answers, so a fixture that means "3 is a comparison" says
+     * it here rather than by what it later passes 3 to.
+     */
+    public static SiteNumbering of(Family... families) {
+        java.util.List<SiteAddress> byNumber = new java.util.ArrayList<>();
+        for (int at = 0; at < families.length; at++) {
+            byNumber.add(switch (families[at]) {
+                case ARM -> armAt(at);
+                case COMPARISON -> new SiteAddress.Comparison(
+                        new NodeAddress("fixture", java.util.Set.of(pathTo(at))));
+            });
+        }
+        return SiteNumbering.of(new NumberingIdentity("fixture", Map.of(), byNumber));
+    }
+
+    private static SiteAddress.Arm armAt(int at) {
+        return new SiteAddress.Arm(
+                new NodeAddress("fixture", java.util.Set.of(pathTo(at))), 0);
+    }
+
+    /** A way down nothing walked, distinct per place so that no two are one. */
+    private static CorePath pathTo(int at) {
+        CorePath path = CorePath.ROOT;
+        for (int step = 0; step <= at; step++) {
+            path = path.then(new CoreStructure.Edge.CallArgument(step));
+        }
+        return path;
+    }
+
+    private Numberings() {}
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest.java
@@ -1,0 +1,122 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A place is asked for its number where a number is what has to be written, and nowhere else.
+ *
+ * <p>The whole of the typed vocabulary rests on the number being a thing a caller cannot get hold
+ * of. A number is a place only under the numbering that handed it out, so a caller holding a bare
+ * {@code int} can pair it with anything — another plan's site, another family's, one nothing
+ * issued — and no later check can tell what it did from a right answer. That is the defect this
+ * numbering exists to close, and it comes back the moment a reader takes the number out.
+ *
+ * <p>What is left is the one place a number is the answer: the call the emitter writes into a
+ * probed class. A probed class is handed an {@code int} because that is what {@code invokestatic}
+ * carries, and it has no numbering to ask anything of — so the emitter turns the place back into a
+ * number, and the check beside it that says every place the plan named was written is asking the
+ * same question in the same words.
+ *
+ * <p><b>Held here rather than said in a comment.</b> {@link RunSite#raw()} says it is the one way
+ * out of the typed vocabulary; a sentence saying so is true of the code that was there when it was
+ * written, and the next reader that wants a number has nothing to stop it. What stops it is this.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it — a call written inside a lambda belongs to the lambda, and
+ * this says so.
+ *
+ * <p><b>What it does not see, said rather than left to be found.</b> The tests are not in
+ * {@code target/classes}: a fixture comparing what two numberings made of one number is standing in
+ * for a reader that has both, which is not something inside the compiler. And what is read is this
+ * module's classes — a reader written in the CLI or the language server would not be counted here.
+ * Both are things to be told about rather than things this can be widened to cover.
+ */
+class OnlyWhatWritesTheCallAsksAPlaceForItsNumberTest {
+
+    /** The three ways a place can be asked: through either family, or through what they share. */
+    private static final Set<String> A_PLACE = Set.of(
+            "souther/compiler/coverage/RunSite",
+            "souther/compiler/coverage/ArmProbe",
+            "souther/compiler/coverage/ComparisonEmissionSite");
+
+    /** A method that may ask, how many times it does, and why it is one of the ones that does. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_ASK = List.of(
+            new Licence("souther.compiler.codegen.BodyGen.lambda$comparisonProbe$0", 2,
+                    "where the call is written: a probed class is handed the number because that is"
+                            + " what the instruction carries, and it has no numbering to ask what"
+                            + " the number addresses. Twice for the one act — the emitter records"
+                            + " that it wrote this number, and writes it"),
+            new Licence("souther.compiler.codegen.CodegenContext.plannedButNotEmitted", 2,
+                    "the emitter's own check that every place the plan named got a call written"
+                            + " for it, which is that same act asked the other way round and so is"
+                            + " asked in the same words"));
+
+    @Test
+    void onlyTheEmitterTakesTheNumberOutOfAPlace() throws IOException {
+        assertEquals(declared(), asked(),
+                "a number taken out anywhere else is a number a caller can pair with a place it"
+                        + " was not issued for, and nothing downstream can tell that from a right"
+                        + " answer. What may ask, and why: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_ASK.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_ASK.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler asks a place for its number. */
+    private static Map<String, Integer> asked() throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && A_PLACE.contains(call.owner().asInternalName())
+                            && call.name().stringValue().equals("raw")) {
+                        calls.merge(from + "." + method.methodName().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -119,6 +119,13 @@ class ProbedBytecodeTest {
         Set<Integer> between = new LinkedHashSet<>(negative);
         between.addAll(cheap);
         between.addAll(dear);
+        // Both families, because the sites are both and a run records each in its own. Counted
+        // over the arms alone this would be short by every comparison the plan numbered, and
+        // counted over one set holding both it would be the number this whole numbering exists to
+        // stop a reader working out for itself.
+        for (long cost : new long[] {-1L, 50L, 500L}) {
+            submit.comparisonsFor(cost).forEach(way -> between.add(way.at()));
+        }
         assertEquals(plan.sites().size(), between.size(),
                 "between them the three rows reach every site the plan numbered");
     }
@@ -135,7 +142,7 @@ class ProbedBytecodeTest {
             Probe.begin(under);
             submit.apply(50L);
             Set<Integer> there = elsewhere.submit(() -> submit.armsFor(500L)).get();
-            Set<Integer> here = Probe.snapshot().taken();
+            Set<Integer> here = Probe.snapshot().arms();
             Probe.end();
 
             assertNotEquals(here, there);
@@ -168,7 +175,7 @@ class ProbedBytecodeTest {
         // And the hits landed nowhere: a recording begun now is a recording of what happens now.
         Probe.begin(under);
         try {
-            assertEquals(Set.of(), Probe.snapshot().taken());
+            assertEquals(Set.of(), Probe.snapshot().arms());
         } finally {
             Probe.end();
         }
@@ -292,11 +299,22 @@ class ProbedBytecodeTest {
             }
         }
 
+        /** The ways out of the comparisons this run evaluated. */
+        Set<ComparisonOutcome> comparisonsFor(long cost) {
+            Probe.begin(under);
+            try {
+                apply(cost);
+                return Probe.snapshot().comparisons();
+            } finally {
+                Probe.end();
+            }
+        }
+
         Set<Integer> armsFor(long cost) {
             Probe.begin(under);
             try {
                 apply(cost);
-                return Probe.snapshot().taken();
+                return Probe.snapshot().arms();
             } finally {
                 Probe.end();
             }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -106,7 +107,7 @@ class ProbedBytecodeTest {
     void aRunRecordsTheArmsItTook() {
         Compilation compilation = compiled();
         CoverageSites.Plan plan = checkedPlanOf(compilation);
-        Behavior submit = new Behavior(probed(compilation));
+        Behavior submit = new Behavior(probed(compilation), plan.identity());
 
         Set<Integer> negative = submit.armsFor(-1L);
         Set<Integer> cheap = submit.armsFor(50L);
@@ -126,10 +127,12 @@ class ProbedBytecodeTest {
      * shared between them would put every row's arms on every row. */
     @Test
     void oneThreadsArmsAreNotAnothers() throws Exception {
-        Behavior submit = new Behavior(probed(compiled()));
+        Compilation compilation = compiled();
+        NumberingIdentity under = checkedPlanOf(compilation).identity();
+        Behavior submit = new Behavior(probed(compilation), under);
         ExecutorService elsewhere = Executors.newSingleThreadExecutor();
         try {
-            Probe.begin();
+            Probe.begin(under);
             submit.apply(50L);
             Set<Integer> there = elsewhere.submit(() -> submit.armsFor(500L)).get();
             Set<Integer> here = Probe.snapshot().taken();
@@ -142,14 +145,33 @@ class ProbedBytecodeTest {
         }
     }
 
-    /** Nothing collecting means nothing recorded, rather than something recorded somewhere. */
+    /**
+     * A run nobody is measuring lands nowhere, and there is no account of it to be had.
+     *
+     * <p>Both halves. The hits go nowhere rather than into whatever collected last, which is what
+     * the next row on this thread would otherwise start inside of; and asking what such a run did
+     * is refused rather than answered with an empty account. A number means a place under the
+     * numbering that handed it out, and a thread nothing began has none to name — so a snapshot
+     * there could only be a run under a numbering of nothing, which reads everywhere downstream as
+     * a row shown to have passed nowhere.
+     */
     @Test
-    void aRunNobodyIsMeasuringRecordsNothing() {
-        Behavior submit = new Behavior(probed(compiled()));
+    void aRunNobodyIsMeasuringLeavesNoAccountAtAll() {
+        Compilation compilation = compiled();
+        NumberingIdentity under = checkedPlanOf(compilation).identity();
+        Behavior submit = new Behavior(probed(compilation), under);
 
         submit.apply(50L);   // outside begin()/end()
 
-        assertEquals(Set.of(), Probe.snapshot().taken());
+        assertThrows(IllegalStateException.class, Probe::snapshot,
+                "a row nobody watched has no account, which is not an account of nothing");
+        // And the hits landed nowhere: a recording begun now is a recording of what happens now.
+        Probe.begin(under);
+        try {
+            assertEquals(Set.of(), Probe.snapshot().taken());
+        } finally {
+            Probe.end();
+        }
     }
 
     // --- what the shipped classes do not mention -------------------------------------------------
@@ -193,9 +215,10 @@ class ProbedBytecodeTest {
     @Test
     void aProbedClassAnswersWhatThePlainOneDoes() {
         Compilation compilation = compiled();
-        Behavior measured = new Behavior(probed(compilation));
+        NumberingIdentity under = checkedPlanOf(compilation).identity();
+        Behavior measured = new Behavior(probed(compilation), under);
         Behavior plain = new Behavior(compilation.db()
-                .ask(new Output.Linked(compilation.modules().get(0))).value());
+                .ask(new Output.Linked(compilation.modules().get(0))).value(), under);
 
         for (long cost : new long[] {-1L, 0L, 50L, 100L, 101L, 500L}) {
             assertEquals(String.valueOf(plain.apply(cost)), String.valueOf(measured.apply(cost)),
@@ -241,8 +264,10 @@ class ProbedBytecodeTest {
 
         private final Object instance;
         private final Method apply;
+        private final NumberingIdentity under;
 
-        Behavior(Map<String, ClassFileImage> classes) {
+        Behavior(Map<String, ClassFileImage> classes, NumberingIdentity under) {
+            this.under = under;
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     ProbedBytecodeTest.class.getClassLoader());
@@ -268,7 +293,7 @@ class ProbedBytecodeTest {
         }
 
         Set<Integer> armsFor(long cost) {
-            Probe.begin();
+            Probe.begin(under);
             try {
                 apply(cost);
                 return Probe.snapshot().taken();

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
@@ -11,14 +11,19 @@ import java.util.Set;
  * running produces. The places come off the claims, so a fixture cannot write a run at a place no
  * claim is about — which is the mistake that makes such a test pass for a reason nobody chose.
  *
- * <p>Already aligned, because there is nothing to align: the claims carry addresses of a numbering,
- * and a run built out of them is of that numbering by construction. A fixture that wants the
- * crossing itself tested writes an {@link Observation} and calls {@link SiteNumbering#align}.
+ * <p>Which numbering it is a run of is said rather than gathered from whatever the claims turned out
+ * to hold: a run of no claims is still a run of some numbering, and a fixture that let the claims
+ * decide would have none to name for it. A claim about a place of another numbering is refused
+ * here, because that is a fixture saying two things at once.
+ *
+ * <p>Already aligned, because there is nothing to align: the places are places. A fixture that
+ * wants the crossing itself tested writes an {@link Observation} and calls
+ * {@link SiteNumbering#align}.
  */
 public final class Runs {
 
-    /** A run that did everything {@code claims} names and nothing else. */
-    public static AlignedObservation doing(List<ControlClaim> claims) {
+    /** A run of {@code numbering} that did everything {@code claims} names and nothing else. */
+    public static AlignedObservation doing(SiteNumbering numbering, List<ControlClaim> claims) {
         Set<ArmProbe> arms = new LinkedHashSet<>();
         Set<SeenComparison> ways = new LinkedHashSet<>();
         for (ControlClaim claim : claims) {
@@ -28,7 +33,24 @@ public final class Runs {
                         ways.add(new SeenComparison(point.at(), point.held()));
             }
         }
-        return new AlignedObservation(arms, ways);
+        return new AlignedObservation(numbering.identity(), arms, ways);
+    }
+
+    /** A run of {@code numbering} at those places. */
+    public static AlignedObservation of(SiteNumbering numbering, Set<ArmProbe> arms,
+                                        Set<SeenComparison> ways) {
+        return new AlignedObservation(numbering.identity(), arms, ways);
+    }
+
+    /** A run of {@code numbering} that was at those arms and nowhere else. */
+    public static AlignedObservation at(SiteNumbering numbering, Set<ArmProbe> arms) {
+        return of(numbering, arms, Set.of());
+    }
+
+    /** A run of {@code numbering} that nothing was recorded of — which is a run, and not the
+     *  absence of one. What says nobody watched a row is said where the row is handed over. */
+    public static AlignedObservation nowhere(SiteNumbering numbering) {
+        return new AlignedObservation(numbering.identity(), Set.of(), Set.of());
     }
 
     private Runs() {}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Runs.java
@@ -1,0 +1,35 @@
+package souther.compiler.coverage;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A run made up to be exactly what some claims name.
+ *
+ * <p>What a fixture reaches for when the question is what a reader does with a run, rather than what
+ * running produces. The places come off the claims, so a fixture cannot write a run at a place no
+ * claim is about — which is the mistake that makes such a test pass for a reason nobody chose.
+ *
+ * <p>Already aligned, because there is nothing to align: the claims carry addresses of a numbering,
+ * and a run built out of them is of that numbering by construction. A fixture that wants the
+ * crossing itself tested writes an {@link Observation} and calls {@link SiteNumbering#align}.
+ */
+public final class Runs {
+
+    /** A run that did everything {@code claims} names and nothing else. */
+    public static AlignedObservation doing(List<ControlClaim> claims) {
+        Set<ArmProbe> arms = new LinkedHashSet<>();
+        Set<SeenComparison> ways = new LinkedHashSet<>();
+        for (ControlClaim claim : claims) {
+            switch (claim.at()) {
+                case ControlPointId.ArmOccurrence arm -> arm.probe().ifPresent(arms::add);
+                case ControlPointId.ComparisonPoint point ->
+                        ways.add(new SeenComparison(point.at(), point.held()));
+            }
+        }
+        return new AlignedObservation(arms, ways);
+    }
+
+    private Runs() {}
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatARunSaysAboutAPlaceIsAskedOfTheRunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatARunSaysAboutAPlaceIsAskedOfTheRunTest.java
@@ -1,0 +1,114 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Whether a run was at a place is asked of the run, and not of the set it holds.
+ *
+ * <p>{@link AlignedObservation#lit} and {@link AlignedObservation#saw} refuse a place of another
+ * numbering: what one numbering's run did at another's places is nothing, and an ordinary "no"
+ * there says a row missed somewhere it was never asked about. Reached through
+ * {@link AlignedObservation#arms} instead, the same question is a {@code Set.contains} and answers
+ * that "no" — so the refusal holds only for as long as every reader asks the run rather than
+ * reaching past it.
+ *
+ * <p><b>Which is not a reason to take the sets away.</b> Gathering what a run holds is a different
+ * act from asking it about a place: a caller unioning the arms of every row is not naming a place
+ * at all, and has nothing to be wrong about. So what is fixed is who may take the set, and each of
+ * them says which of the two it is doing.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it — a call written inside a lambda belongs to the lambda, and
+ * this says so.
+ *
+ * <p><b>What it does not see, said rather than left to be found.</b> The tests are not in
+ * {@code target/classes}, and what is read is this module's classes: a reader written in the CLI or
+ * the language server would not be counted here. Both are things to be told about rather than
+ * things this can be widened to cover.
+ */
+class WhatARunSaysAboutAPlaceIsAskedOfTheRunTest {
+
+    private static final String A_RUN = "souther/compiler/coverage/AlignedObservation";
+
+    /** The two that hand the places over whole, rather than answering about one. */
+    private static final Set<String> HANDS_THEM_OVER = Set.of("arms", "comparisons");
+
+    /** A method that may take them, how many times it does, and why it is gathering rather than
+     *  asking. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_GATHER = List.of(
+            new Licence("souther.compiler.query.Adequacy.armsSeenIn -> arms", 1,
+                    "the arms some row of the module reached, unioned over the rows: what it is"
+                            + " building is a set of places, and it names none of its own to be"
+                            + " wrong about"));
+
+    @Test
+    void whatTakesThePlacesWholeIsGatheringThemAndSaysSo() throws IOException {
+        assertEquals(declared(), taken(),
+                "a reader that takes the set to ask whether one place is in it has gone round the"
+                        + " refusal that makes an aligned run mean anything, and gets an ordinary"
+                        + " no for a place of another numbering. What may take them, and why: "
+                        + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_GATHER.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_GATHER.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler takes a run's places whole. */
+    private static Map<String, Integer> taken() throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(A_RUN)
+                            && HANDS_THEM_OVER.contains(call.name().stringValue())) {
+                        calls.merge(from + "." + method.methodName().stringValue()
+                                + " -> " + call.name().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhatMakesAPlanIsWhatNumberedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhatMakesAPlanIsWhatNumberedItTest.java
@@ -1,0 +1,112 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A plan is made where its bodies are numbered, and nowhere else in the compiler.
+ *
+ * <p>A plan holds parts that are only true together: a numbering of comparisons and the catalog
+ * that issued their names, and what each number addresses beside the sites it was handed out for.
+ * Its own constructor refuses the pairs it can see — a comparison the catalog never held, an
+ * address list of another length — and there are agreements no constructor can see. What each
+ * number is an address <em>of</em> is one: a list of the right length, of addresses of the right
+ * places, is a value anybody could build and only the walk that handed the numbers out knows.
+ *
+ * <p>So what is fixed is who may put one together. One walk numbers a module's bodies and makes the
+ * plan of them in the same breath, and a plan that exists is that walk's answer rather than parts a
+ * caller believed went together.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it.
+ *
+ * <p><b>What it does not see, said rather than left to be found.</b> The tests are not in
+ * {@code target/classes}: a fixture that hands the emitter a plan with one arm too many is standing
+ * in for a numbering that got it wrong, which is the thing under test there and is not a second
+ * answer inside the compiler. And what is read is this module's classes — a caller written in the
+ * CLI or the language server would not be counted here, and those modules are built after this one,
+ * so a walk over their output would read whatever the last build left.
+ */
+class WhatMakesAPlanIsWhatNumberedItTest {
+
+    private static final String PLAN = "souther/compiler/coverage/CoverageSites$Plan";
+
+    /** A method that may make one, how many times it does, and why it is one of the ones that
+     *  does. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_MAKE = List.of(
+            new Licence("souther.compiler.coverage.CoverageSites.of", 1,
+                    "the one walk of a module's bodies: it hands the numbers out and says what each"
+                            + " addresses in the same breath, so the two cannot have been put"
+                            + " together by anybody who believed they went together"),
+            new Licence("souther.compiler.coverage.CoverageSites.Plan.<clinit>", 1,
+                    "the plan of nothing, which is what a module the check has no answer for gets."
+                            + " It numbers no place and addresses none, so its parts agree by"
+                            + " there being none of them"));
+
+    @Test
+    void onlyTheWalkThatNumberedThemMakesAPlanOfABodysArms() throws IOException {
+        assertEquals(declared(), made(),
+                "a plan put together anywhere else is parts a caller believed went together, and"
+                        + " the agreements between them are what a reader of a run rests on."
+                        + " What may make one, and why: " + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_MAKE.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_MAKE.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler makes one. */
+    private static Map<String, Integer> made() throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(PLAN)
+                            && call.name().stringValue().equals("<init>")) {
+                        calls.merge(from + "." + method.methodName().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoNamesAComparisonAndWhoAddressesOneTest.java
@@ -53,6 +53,8 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
 
     private static final String SITE = "souther/compiler/coverage/ComparisonEmissionSite";
 
+    private static final String ARM = "souther/compiler/coverage/ArmProbe";
+
     private static final String BODIES = "souther/compiler/coverage/ModuleBodies";
 
     private static final String CATALOGUED = "souther/compiler/coverage/ComparisonCatalog$Catalogued";
@@ -70,11 +72,21 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
                             + " what it is a name of are made together"));
 
     private static final List<Licence> MAY_ADDRESS = List.of(
-            new Licence("souther.compiler.coverage.CoverageSites.Plan.emissionSiteOf", 1,
-                    "the plan's own numbering, read back for a comparison it instrumented"),
-            new Licence("souther.compiler.coverage.Probe.compared", 1,
-                    "what a probed class calls as it runs, which arrives as the number the emitter"
-                            + " wrote into the call and has no catalog to ask anything of"));
+            new Licence("souther.compiler.coverage.SiteNumbering.comparison", 1,
+                    "the numbering asked what a number of its own addresses, which is the one way"
+                            + " a number becomes a place — and it is refused where that numbering"
+                            + " handed the number out to something other than a comparison, or"
+                            + " never handed it out at all. Everything holding one of these got it"
+                            + " here: the walk that numbers the places carries numbers until the"
+                            + " numbering is finished, because until then there is no numbering"
+                            + " for an address to be of"));
+
+    private static final List<Licence> MAY_ADDRESS_AN_ARM = List.of(
+            new Licence("souther.compiler.coverage.SiteNumbering.arm", 1,
+                    "the numbering asked what a number of its own addresses, which is the one way"
+                            + " a number becomes a place — and it is refused where that numbering"
+                            + " handed the number out to something other than an arm, or never"
+                            + " handed it out at all"));
 
     /**
      * What holds a value whose parts have to agree, and where each is put together.
@@ -134,10 +146,24 @@ class WhoNamesAComparisonAndWhoAddressesOneTest {
     }
 
     @Test
-    void onlyThePlanAndTheProbeAddressARun() throws IOException {
+    void onlyTheNumberingAddressesAComparisonOfARun() throws IOException {
         assertEquals(declared(MAY_ADDRESS), callsToConstructor(SITE),
                 "an address made anywhere else is a place no run was recorded at. What may make"
                         + " one, and why: " + why(MAY_ADDRESS));
+    }
+
+    /**
+     * And the same for the other family, which is the same rule and not a second one.
+     *
+     * <p>Both or neither: the two are numbers out of one counter, and a rule that held for the
+     * comparisons alone would leave the arms — the family every branch measure counts — free to be
+     * paired with a numbering that never handed them out.
+     */
+    @Test
+    void onlyTheNumberingAddressesAnArmOfARun() throws IOException {
+        assertEquals(declared(MAY_ADDRESS_AN_ARM), callsToConstructor(ARM),
+                "an address made anywhere else is a place no run was recorded at. What may make"
+                        + " one, and why: " + why(MAY_ADDRESS_AN_ARM));
     }
 
     private static Map<String, Integer> declared(List<Licence> licences) {

--- a/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/WhoTakesAPlansNumberingHasItsBodiesTest.java
@@ -1,0 +1,120 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Who takes a plan's numbering, written down with what makes it safe where it stands.
+ *
+ * <p>{@link CoverageSites.Plan#NONE} is the plan of nothing, and two different callers reach for
+ * it: the emitter told to write no probes, and a measure of a module whose bodies did not come out.
+ * For the first it is what it says. For the second it is a stand-in — and a stand-in has a
+ * numbering, which is nobody's: not of that module, and over no places. A recording of the module
+ * aligned against that is refused as a run of somewhere read under a numbering of nowhere, which is
+ * right and is not the answer wanted. A module with no bodies has no numbering, and what a reader
+ * without one has is no account of any run.
+ *
+ * <p><b>What this holds is the population, and not that each of them is right.</b> A walk over the
+ * compiled classes sees which method takes a numbering off a plan; it does not see which plan, so
+ * it cannot tell a reader holding the checked bodies from one holding the stand-in. That is what
+ * the reason beside each entry is for, and it is read by a person. What the check itself stops is a
+ * new reader appearing without one — which is how the reader this was written for got in.
+ *
+ * <p>Read off the compiled classes, so what is counted is what a method does rather than what a
+ * reading of the sources makes of it. The tests are not in {@code target/classes}, and what is read
+ * is this module's classes.
+ */
+class WhoTakesAPlansNumberingHasItsBodiesTest {
+
+    private static final String A_PLAN = "souther/compiler/coverage/CoverageSites$Plan";
+
+    /** The two ways a plan hands its numbering over. */
+    private static final Set<String> ITS_NUMBERING = Set.of("numbering", "identity");
+
+    /** A method that may take it, how many times it does, and what says it has the bodies. */
+    private record Licence(String who, int calls, String why) { }
+
+    private static final List<Licence> MAY_TAKE = List.of(
+            new Licence("souther.compiler.query.Adequacy.numberingOf -> numbering", 1,
+                    "the one place a module is asked for its numbering, which answers with none"
+                            + " where the check produced no bodies rather than with the plan of"
+                            + " nothing's"),
+            new Licence("souther.compiler.query.Adequacy.BranchCoverage.compute -> numbering", 1,
+                    "the checked bodies are in hand for the measure's other halves, so the"
+                            + " numbering is taken off them and is absent where they are"),
+            new Licence("souther.compiler.query.Adequacy.Generated.compute -> numbering", 1,
+                    "the same, where what is being generated for is read off the same bodies"),
+            new Licence("souther.compiler.query.Output.Evaluated.compute -> identity", 1,
+                    "what the classes about to be written are numbered by, taken from the plan"
+                            + " that is instrumenting them — one value used for both, so what a"
+                            + " run records and what says whose numbers they are cannot part"));
+
+    @Test
+    void everyReaderOfAPlansNumberingIsWrittenDownWithWhatMakesItSafe() throws IOException {
+        assertEquals(declared(), taken(),
+                "a numbering taken off a plan that stands in for absent bodies is nobody's, and a"
+                        + " reader aligning a recording against it is told the run was of somewhere"
+                        + " else. So a reader arriving here is one to look at rather than one this"
+                        + " can decide about. What takes one today, and what makes each safe: "
+                        + why());
+    }
+
+    private static Map<String, Integer> declared() {
+        Map<String, Integer> out = new TreeMap<>();
+        MAY_TAKE.forEach(each -> out.put(each.who(), each.calls()));
+        return out;
+    }
+
+    private static Map<String, String> why() {
+        Map<String, String> out = new LinkedHashMap<>();
+        MAY_TAKE.forEach(each -> out.put(each.who(), each.why()));
+        return out;
+    }
+
+    /** How many times each method of the compiler takes a plan's numbering. */
+    private static Map<String, Integer> taken() throws IOException {
+        Map<String, Integer> calls = new TreeMap<>();
+        int read = 0;
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            read++;
+            String from = model.thisClass().asInternalName().replace('/', '.').replace('$', '.');
+            for (MethodModel method : model.methods()) {
+                method.code().ifPresent(code -> code.forEach(element -> {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().equals(A_PLAN)
+                            && ITS_NUMBERING.contains(call.name().stringValue())) {
+                        calls.merge(from + "." + method.methodName().stringValue()
+                                + " -> " + call.name().stringValue(), 1, Integer::sum);
+                    }
+                }));
+            }
+        }
+        assertFalse(read == 0, "no compiled class was read at all, so this says nothing");
+        return calls;
+    }
+
+    private static List<Path> classes() throws IOException {
+        Path root = Path.of("target", "classes").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            return new ArrayList<>(walk.filter(p -> p.toString().endsWith(".class")).toList());
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -193,7 +193,10 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
      * this compile's code and the row's fixture goes through it, so what is counted covers the
      * fixtures and stops at the behavior — which is injected, has no body, and has nothing to count.
      *
-     * <p>{@code hits} is empty, so a measure reading it sees no arm this row failed to reach.
+     * <p>And nothing recorded where the row went, which is the other half and is not an empty
+     * account of one. This compile was asked to leave the recording calls out, so there is no
+     * probed body for the row to be written down by — a measure reading an empty account instead
+     * would see a row shown to have reached no arm at all.
      */
     @Test
     void aBoundRowsCountingIsReadAndCoversItsFixturesOnly() throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -11,6 +11,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.meta.PublishedClasses;
 import souther.compiler.observe.Applied;
+import souther.compiler.coverage.RunRecord;
 import souther.compiler.observe.Counting;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
@@ -199,8 +200,10 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
         for (RowOutcome row : evaluated(ANSWERS).rows()) {
             Counting.Read read = assertInstanceOf(Counting.Read.class, row.run().counting(),
                     "the counting was read");
-            assertEquals(java.util.Set.of(), read.observation().taken(),
-                    "and lit no branch, there being no body to light one");
+            assertInstanceOf(RunRecord.NotRecording.class, read.recorded(),
+                    "and nothing recorded where the row went: the implementation is bound from"
+                            + " outside this compile, so there is no probed body to write anything"
+                            + " down — which is not the same as a run that lit no branch");
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -203,7 +203,7 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
         for (RowOutcome row : evaluated(ANSWERS).rows()) {
             Counting.Read read = assertInstanceOf(Counting.Read.class, row.run().counting(),
                     "the counting was read");
-            assertInstanceOf(RunRecord.NotRecording.class, read.recorded(),
+            assertInstanceOf(RunRecord.NoAccount.class, read.recorded(),
                     "and nothing recorded where the row went: the implementation is bound from"
                             + " outside this compile, so there is no probed body to write anything"
                             + " down — which is not the same as a run that lit no branch");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.Numberings;
+import souther.compiler.coverage.SiteNumbering;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.RuleReadingSource;
@@ -212,6 +215,10 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                 new Level.OnACarrier(carrier, souther.compiler.numeric.Count.of(at)));
     }
 
+    /** The numbering this fixture's places are of. One of them, so that two readings written here
+     *  as the same occurrence address one place. */
+    private static final SiteNumbering WHERE = Numberings.ofComparisons(8);
+
     /**
      * One reading of one comparison: the same rule and the same place it is written, at the
      * occurrence the call it was spliced into was numbered.
@@ -228,7 +235,7 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(15, 16))),
-                        new souther.compiler.coverage.ComparisonEmissionSite(occurrence)),
+                        WHERE.comparison(occurrence)),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(
                         souther.compiler.numeric.Towards.BELOW, true)));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -8,10 +8,9 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.Runs;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -74,7 +73,7 @@ class ACandidateThatMissedIsNotOfferedTest {
 
     /** A run that did nothing at all, which is a run that missed every combination. */
     private static final Generator.Watched MISSED =
-            new Generator.Watched.Ran(Observation.NONE);
+            new Generator.Watched.Ran(AlignedObservation.NONE);
 
     /**
      * A combination every candidate missed is not offered, and is not called impossible.
@@ -101,7 +100,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     @Test
     void aCandidateThatArrivedIsOffered() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        Observation everything = doing(everyClaimOf(model));
+        AlignedObservation everything = doing(everyClaimOf(model));
 
         FillResult filled =
                 fill(model, _ -> new Generator.Watched.Ran(everything));
@@ -186,19 +185,8 @@ class ACandidateThatMissedIsNotOfferedTest {
     }
 
     /** A run that did everything {@code claims} names. */
-    private static Observation doing(List<ControlClaim> claims) {
-        Set<Integer> taken = new LinkedHashSet<>();
-        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
-        for (ControlClaim claim : claims) {
-            switch (claim.at()) {
-                case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
-                case ControlPointId.ComparisonPoint point -> {
-                    taken.add(point.at().value());
-                    ways.add(point.way());
-                }
-            }
-        }
-        return new Observation(taken, ways);
+    private static AlignedObservation doing(List<ControlClaim> claims) {
+        return Runs.doing(claims);
     }
 
     private record Model(MeasuredInput subject, CoverageRead.Read read) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -11,6 +11,7 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.Runs;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -71,9 +72,12 @@ class ACandidateThatMissedIsNotOfferedTest {
                 Fee(baseFee(member) + expressFee(delivery))
             """;
 
-    /** A run that did nothing at all, which is a run that missed every combination. */
-    private static final Generator.Watched MISSED =
-            new Generator.Watched.Ran(AlignedObservation.NONE);
+    /** A run that did nothing at all, which is a run that missed every combination. Of the
+     *  model's own numbering: a run is a run of somewhere, and one of nowhere could be asked about
+     *  any place at all and answer. */
+    private static Generator.Watched missed(Model model) {
+        return new Generator.Watched.Ran(Runs.nowhere(model.numbering()));
+    }
 
     /**
      * A combination every candidate missed is not offered, and is not called impossible.
@@ -86,7 +90,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     void aCombinationEveryCandidateMissedIsLeftUntried() {
         Model model = Model.of(SHIPPING, "shippingFee");
 
-        FillResult filled = fill(model, _ -> MISSED);
+        FillResult filled = fill(model, _ -> missed(model));
 
         assertTrue(filled.unresolved().stream().anyMatch(each -> each.reason()
                         == Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS),
@@ -100,7 +104,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     @Test
     void aCandidateThatArrivedIsOffered() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        AlignedObservation everything = doing(everyClaimOf(model));
+        AlignedObservation everything = doing(model.numbering(), everyClaimOf(model));
 
         FillResult filled =
                 fill(model, _ -> new Generator.Watched.Ran(everything));
@@ -126,7 +130,7 @@ class ACandidateThatMissedIsNotOfferedTest {
 
         fill(model, inputs -> {
             ran.add(inputs.stream().map(FixtureTemplate::text).toList());
-            return MISSED;
+            return missed(model);
         });
 
         // The two positions the decisions read say which combination a candidate was composed for;
@@ -185,11 +189,13 @@ class ACandidateThatMissedIsNotOfferedTest {
     }
 
     /** A run that did everything {@code claims} names. */
-    private static AlignedObservation doing(List<ControlClaim> claims) {
-        return Runs.doing(claims);
+    private static AlignedObservation doing(SiteNumbering numbering,
+                                           List<ControlClaim> claims) {
+        return Runs.doing(numbering, claims);
     }
 
-    private record Model(MeasuredInput subject, CoverageRead.Read read) {
+    private record Model(MeasuredInput subject, CoverageRead.Read read,
+                         SiteNumbering numbering) {
 
         /** The groups of the one reading, for a caller asking about the combinations alone. */
         List<Interaction> groups() {
@@ -220,7 +226,7 @@ class ACandidateThatMissedIsNotOfferedTest {
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES)),
                     CoverageRead.of(spec.name(), body,
                             checked.plan(), inputs,
-                            rules));
+                            rules), checked.plan().numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ComparisonEmissionSite;
+import souther.compiler.coverage.Numberings;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.AReadingOfAPosition;
@@ -183,6 +186,10 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
                 Optional.of(new ClauseName("cap")))), 0, EndSide.LOWER, true);
     }
 
+    /** The place this fixture's comparison is at. One of them, so that two readings built here
+     *  address one place. */
+    private static final ComparisonEmissionSite WHERE = Numberings.comparison(1, 0);
+
     private static OriginRef aComparison() {
         return new OriginRef.ComparisonOrigin(new RuleRef.Comparison("weigh",
                 new souther.compiler.types.CoverageOrigin("example.weigh", 2, 0,
@@ -193,7 +200,7 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
                         new souther.compiler.check.RuleCitation.WrittenAt(
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5))),
-                        new souther.compiler.coverage.ComparisonEmissionSite(0)),
+                        WHERE),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.Numberings;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.DefaultStdlib;
@@ -41,9 +44,16 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
     private static final Generator.ClassOwed ANOTHER_CLASS =
             new Generator.ClassOwed(new AxisId("fee", "days"), "days/high");
 
-    private static final Generator.ArmOwed AN_ARM = new Generator.ArmOwed(1);
+    /** Two places of one numbering, so that the arms below are addresses of one. */
+    private static final Map<Integer, ArmProbe> PLACES = Numberings.arms(3);
 
-    private static final Generator.ArmOwed ANOTHER_ARM = new Generator.ArmOwed(2);
+    private static final ArmProbe ARM = PLACES.get(1);
+
+    private static final ArmProbe ANOTHER = PLACES.get(2);
+
+    private static final Generator.ArmOwed AN_ARM = new Generator.ArmOwed(ARM);
+
+    private static final Generator.ArmOwed ANOTHER_ARM = new Generator.ArmOwed(ANOTHER);
 
     private static final Generator.UnresolvedCombination NOTHING_CAME_OF_IT =
             new Generator.UnresolvedCombination(List.of("days=low"),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -204,9 +205,9 @@ class AGroupTooWideToWalkSaysSoTest {
         Model wide = Model.of(THIRTEEN);
         Model narrow = Model.of(TWELVE);
 
-        Set<Integer> fromWide =
+        Set<ArmProbe> fromWide =
                 Generator.everyArmACombinationMayTake(wide.subject(), wide.groups(), Budgets.generation());
-        Set<Integer> fromNarrow =
+        Set<ArmProbe> fromNarrow =
                 Generator.everyArmACombinationMayTake(narrow.subject(), narrow.groups(), Budgets.generation());
 
         assertFalse(fromWide.isEmpty(),
@@ -389,9 +390,9 @@ class AGroupTooWideToWalkSaysSoTest {
 
         // The held group is one arms were owed behind: without this, the answer below would hold of
         // a group that claimed nothing and would say nothing about when a group is named.
-        Set<Integer> owed = Generator.everyArmACombinationMayTake(
+        Set<ArmProbe> owed = Generator.everyArmACombinationMayTake(
                 model.subject(), model.groups(), budget);
-        Set<Integer> behindTheHeldGroup = new LinkedHashSet<>(armsIn(offered.notOffered().get(0)));
+        Set<ArmProbe> behindTheHeldGroup = new LinkedHashSet<>(armsIn(offered.notOffered().get(0)));
         behindTheHeldGroup.retainAll(owed);
         assertFalse(behindTheHeldGroup.isEmpty(),
                 "arms were owed behind the group that was held back");
@@ -404,12 +405,12 @@ class AGroupTooWideToWalkSaysSoTest {
     }
 
     /** Which arms a group the limit held back could have been searched at. */
-    private static List<Integer> armsIn(InteractionCells.NotOffered held) {
-        List<Integer> out = new java.util.ArrayList<>();
+    private static List<ArmProbe> armsIn(InteractionCells.NotOffered held) {
+        List<ArmProbe> out = new java.util.ArrayList<>();
         for (souther.compiler.coverage.ControlClaim claim : held.claims()) {
             if (claim.at() instanceof souther.compiler.coverage.ControlPointId.ArmOccurrence arm
                     && arm.probe().isPresent()) {
-                out.add(arm.probe().getAsInt());
+                out.add(arm.probe().get());
             }
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
@@ -13,6 +13,8 @@ import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SiteNumbering;
+import souther.compiler.coverage.Runs;
 import souther.compiler.coverage.SeenComparison;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
@@ -95,7 +97,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 // Seen doing everything the ways in name, and seen at no arm at all.
-                _ -> new Generator.Watched.Ran(waysWithoutTheArms(model.read())),
+                _ -> new Generator.Watched.Ran(waysWithoutTheArms(model)),
                 List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
         for (ArmProbe probe : everyArm) {
@@ -115,7 +117,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
-                _ -> new Generator.Watched.Ran(everywhere(model.read(), everyArm)),
+                _ -> new Generator.Watched.Ran(everywhere(model, everyArm)),
                 List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
         assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
@@ -123,20 +125,20 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
     }
 
     /** Everything the ways in name, and nothing at any arm. */
-    private static AlignedObservation waysWithoutTheArms(CoverageRead.Read read) {
+    private static AlignedObservation waysWithoutTheArms(Model model) {
         Set<ArmProbe> taken = new LinkedHashSet<>();
         Set<SeenComparison> ways = new LinkedHashSet<>();
-        collect(read, taken, ways);
-        taken.removeAll(read.arms().keySet());
-        return new AlignedObservation(taken, ways);
+        collect(model.read(), taken, ways);
+        taken.removeAll(model.read().arms().keySet());
+        return Runs.of(model.numbering(), taken, ways);
     }
 
     /** The same, and the arms as well. */
-    private static AlignedObservation everywhere(CoverageRead.Read read, Set<ArmProbe> arms) {
+    private static AlignedObservation everywhere(Model model, Set<ArmProbe> arms) {
         Set<ArmProbe> taken = new LinkedHashSet<>(arms);
         Set<SeenComparison> ways = new LinkedHashSet<>();
-        collect(read, taken, ways);
-        return new AlignedObservation(taken, ways);
+        collect(model.read(), taken, ways);
+        return Runs.of(model.numbering(), taken, ways);
     }
 
     private static void collect(CoverageRead.Read read, Set<ArmProbe> taken,
@@ -157,7 +159,8 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
         }
     }
 
-    private record Model(MeasuredInput subject, CoverageRead.Read read) {
+    private record Model(MeasuredInput subject, CoverageRead.Read read,
+                         SiteNumbering numbering) {
 
         static Model of(String source) {
             Compilation compilation = Compilation.ofSource(source, "Main");
@@ -187,7 +190,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
                     "and divides it into classes a row can be composed at");
             return new Model(MeasuredInput.of(spec.name(), inputs.reading(rules),
                     partitioning),
-                    CoverageRead.of("fee", body, plan, inputs, rules));
+                    CoverageRead.of("fee", body, plan, inputs, rules), plan.numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -8,11 +9,11 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.SeenComparison;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -65,7 +66,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
     void theWayIntoAComparisonsArmNamesTheComparisonAndNotTheArm() {
         Model model = Model.of(GATE);
 
-        for (Map.Entry<Integer, PathAccess> each : model.read().arms().entrySet()) {
+        for (Map.Entry<ArmProbe, PathAccess> each : model.read().arms().entrySet()) {
             assertInstanceOf(PathAccess.Ways.class, each.getValue(),
                     "both arms are reached: " + each);
             for (WayIn way : ((PathAccess.Ways) each.getValue()).ways()) {
@@ -89,7 +90,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
     @Test
     void aRunThatTookTheWayButNotTheArmIsNoWitness() {
         Model model = Model.of(GATE);
-        Set<Integer> everyArm = model.read().arms().keySet();
+        Set<ArmProbe> everyArm = model.read().arms().keySet();
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
@@ -97,7 +98,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
                 _ -> new Generator.Watched.Ran(waysWithoutTheArms(model.read())),
                 List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
-        for (int probe : everyArm) {
+        for (ArmProbe probe : everyArm) {
             assertFalse(filled.discharge().at(new Generator.ArmOwed(probe)) instanceof ArmDisposition.Built,
                     () -> "no row goes through an arm nothing was seen at: " + filled.discharge().arms().values());
         }
@@ -110,7 +111,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
     @Test
     void aRunSeenAtTheArmIsAWitness() {
         Model model = Model.of(GATE);
-        Set<Integer> everyArm = model.read().arms().keySet();
+        Set<ArmProbe> everyArm = model.read().arms().keySet();
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
@@ -122,24 +123,24 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
     }
 
     /** Everything the ways in name, and nothing at any arm. */
-    private static Observation waysWithoutTheArms(CoverageRead.Read read) {
-        Set<Integer> taken = new LinkedHashSet<>();
-        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
+    private static AlignedObservation waysWithoutTheArms(CoverageRead.Read read) {
+        Set<ArmProbe> taken = new LinkedHashSet<>();
+        Set<SeenComparison> ways = new LinkedHashSet<>();
         collect(read, taken, ways);
         taken.removeAll(read.arms().keySet());
-        return new Observation(taken, ways);
+        return new AlignedObservation(taken, ways);
     }
 
     /** The same, and the arms as well. */
-    private static Observation everywhere(CoverageRead.Read read, Set<Integer> arms) {
-        Set<Integer> taken = new LinkedHashSet<>(arms);
-        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
+    private static AlignedObservation everywhere(CoverageRead.Read read, Set<ArmProbe> arms) {
+        Set<ArmProbe> taken = new LinkedHashSet<>(arms);
+        Set<SeenComparison> ways = new LinkedHashSet<>();
         collect(read, taken, ways);
-        return new Observation(taken, ways);
+        return new AlignedObservation(taken, ways);
     }
 
-    private static void collect(CoverageRead.Read read, Set<Integer> taken,
-                                Set<ComparisonOutcome> ways) {
+    private static void collect(CoverageRead.Read read, Set<ArmProbe> taken,
+                                Set<SeenComparison> ways) {
         for (PathAccess access : read.arms().values()) {
             if (!(access instanceof PathAccess.Ways found)) {
                 continue;
@@ -147,11 +148,9 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
             for (WayIn way : found.ways()) {
                 for (ControlClaim claim : way.claims()) {
                     switch (claim.at()) {
-                        case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
-                        case ControlPointId.ComparisonPoint point -> {
-                            taken.add(point.at().value());
-                            ways.add(point.way());
-                        }
+                        case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().get());
+                        case ControlPointId.ComparisonPoint point ->
+                                ways.add(new SeenComparison(point.at(), point.held()));
                     }
                 }
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -8,11 +9,11 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.Observation;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Runs;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -101,7 +102,7 @@ class ARowNothingRanFillsNoCombinationTest {
         assertNotNull(first, "and its first choice is a combination");
         assertFalse(first.claims().isEmpty(), "which a run can be held to");
 
-        Set<Integer> every =
+        Set<ArmProbe> every =
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         assertTrue(offeredFor(model, every).containsAll(claimedBy(first)),
                 "asked about the arms this combination takes, a row is composed for each of them");
@@ -122,7 +123,7 @@ class ARowNothingRanFillsNoCombinationTest {
         CellSelection first = InteractionCells.of(model.groups(), model.subject().axes().axes(), Budgets.generation())
                 .groups().get(0).at(0);
         assertNotNull(first);
-        Set<Integer> takes = claimedBy(first);
+        Set<ArmProbe> takes = claimedBy(first);
         assertTrue(takes.size() > 1, "the combination takes an arm of each decision: " + takes);
 
         List<Generator.GeneratedRow> composed = Generator.fill(model.subject(), List.of(),
@@ -151,14 +152,14 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void anArmKeepsWhatEveryCombinationClaimingItCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        Set<Integer> every =
+        Set<ArmProbe> every =
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(every), Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing builds, so nothing is composed");
-        for (int probe : every) {
+        for (ArmProbe probe : every) {
             ArmDisposition at = filled.discharge().at(new Generator.ArmOwed(probe));
             assertInstanceOf(ArmDisposition.Unresolved.class, at,
                     "the arm was tried and says so: " + probe);
@@ -178,7 +179,7 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void oneRowThroughAnArmIsTheAnswerWhateverTheOthersCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        Set<Integer> every =
+        Set<ArmProbe> every =
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         // Refuses the first case of the first position, so the combinations naming it fail and the
         // ones beside them build. Every arm of the second decision is claimed by both.
@@ -189,7 +190,7 @@ class ARowNothingRanFillsNoCombinationTest {
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(every), Budgets.generation());
 
         assertFalse(filled.rows().isEmpty(), "the combinations that build compose their rows");
-        List<Integer> built = every.stream()
+        List<ArmProbe> built = every.stream()
                 .filter(probe -> filled.discharge().at(new Generator.ArmOwed(probe)) instanceof ArmDisposition.Built)
                 .toList();
         assertEquals(3, built.size(),
@@ -249,7 +250,7 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void anArmTheLimitCutOffSaysSoRatherThanReadingAsUnreachable() {
         Model model = Model.of(wide(), "submit");
-        Set<Integer> every =
+        Set<ArmProbe> every =
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms");
 
@@ -261,7 +262,7 @@ class ARowNothingRanFillsNoCombinationTest {
         assertTrue(filled.reasons().stream()
                         .anyMatch(GenerationReason.SearchLimit.class::isInstance),
                 "the classes alone spend the budget: " + filled.reasons());
-        for (int probe : every) {
+        for (ArmProbe probe : every) {
             ArmDisposition at = filled.discharge().at(new Generator.ArmOwed(probe));
             assertInstanceOf(ArmDisposition.Unresolved.class, at,
                     "the arm has an entry rather than the silence of one nothing claims: " + probe);
@@ -273,11 +274,11 @@ class ARowNothingRanFillsNoCombinationTest {
     }
 
     /** The arms one combination claims a run through. */
-    private static Set<Integer> claimedBy(CellSelection selection) {
-        Set<Integer> out = new LinkedHashSet<>();
+    private static Set<ArmProbe> claimedBy(CellSelection selection) {
+        Set<ArmProbe> out = new LinkedHashSet<>();
         for (ControlClaim claim : selection.claims()) {
             if (claim.at() instanceof ControlPointId.ArmOccurrence arm && arm.probe().isPresent()) {
-                out.add(arm.probe().getAsInt());
+                out.add(arm.probe().get());
             }
         }
         return out;
@@ -317,7 +318,7 @@ class ARowNothingRanFillsNoCombinationTest {
     }
 
     /** Which arms the generator composes a row for when it is asked about {@code arms}. */
-    private static Set<Integer> offeredFor(Model model, Set<Integer> arms) {
+    private static Set<ArmProbe> offeredFor(Model model, Set<ArmProbe> arms) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                         model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(arms), Budgets.generation())
                 .rows().stream().flatMap(row -> row.purposes().stream())
@@ -356,19 +357,8 @@ class ARowNothingRanFillsNoCombinationTest {
     }
 
     /** A run that did everything {@code claims} names and nothing else. */
-    private static Observation doing(List<ControlClaim> claims) {
-        Set<Integer> taken = new LinkedHashSet<>();
-        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
-        for (ControlClaim claim : claims) {
-            switch (claim.at()) {
-                case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
-                case ControlPointId.ComparisonPoint point -> {
-                    taken.add(point.at().value());
-                    ways.add(point.way());
-                }
-            }
-        }
-        return new Observation(taken, ways);
+    private static AlignedObservation doing(List<ControlClaim> claims) {
+        return Runs.doing(claims);
     }
 
     private record Model(MeasuredInput subject, CoverageRead.Read read) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -13,6 +13,7 @@ import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.coverage.Runs;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
@@ -357,11 +358,13 @@ class ARowNothingRanFillsNoCombinationTest {
     }
 
     /** A run that did everything {@code claims} names and nothing else. */
-    private static AlignedObservation doing(List<ControlClaim> claims) {
-        return Runs.doing(claims);
+    private static AlignedObservation doing(SiteNumbering numbering,
+                                           List<ControlClaim> claims) {
+        return Runs.doing(numbering, claims);
     }
 
-    private record Model(MeasuredInput subject, CoverageRead.Read read) {
+    private record Model(MeasuredInput subject, CoverageRead.Read read,
+                         SiteNumbering numbering) {
 
         /** The groups of the one reading, for a caller asking about the combinations alone. */
         List<Interaction> groups() {
@@ -393,7 +396,7 @@ class ARowNothingRanFillsNoCombinationTest {
             CoverageSites.Plan plan = checked.plan();
             return new Model(MeasuredInput.of(spec.name(), inputs.reading(rules),
                     partitioning),
-                    CoverageRead.of(spec.name(), body, plan, inputs, rules));
+                    CoverageRead.of(spec.name(), body, plan, inputs, rules), plan.numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -8,11 +9,10 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.Runs;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -161,8 +161,8 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     @Test
     void anotherArmIsTakenOffTheListByWhatTheRunWasSeenDoing() {
         Model model = Model.of(NESTED, "press");
-        Set<Integer> everyArm = model.read().arms().keySet();
-        Observation everywhere = doing(model.read());
+        Set<ArmProbe> everyArm = model.read().arms().keySet();
+        AlignedObservation everywhere = doing(model.read());
 
         FillResult watched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
@@ -198,7 +198,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     @Test
     void anArmWithNoWayIntoItSaysWhichKindOfSilenceItIs() {
         Model model = Model.of(NESTED, "press");
-        Set<Integer> everyArm = model.read().arms().keySet();
+        Set<ArmProbe> everyArm = model.read().arms().keySet();
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 // Refuses every value, so every way in is a search that ran and composed nothing.
@@ -206,7 +206,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(everyArm),
                 Budgets.generation());
 
-        for (int probe : everyArm) {
+        for (ArmProbe probe : everyArm) {
             assertInstanceOf(ArmDisposition.Unresolved.class, filled.discharge().at(new Generator.ArmOwed(probe)),
                     "a way in this tried and composed nothing at is not one it never had: " + probe);
         }
@@ -224,25 +224,16 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
 
     /** A run that was seen taking every arm the reading names, which is what a row through the
      *  outer arm and one of the inner ones is seen doing. */
-    private static Observation doing(CoverageRead.Read read) {
-        Set<Integer> taken = new LinkedHashSet<>();
-        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
+    private static AlignedObservation doing(CoverageRead.Read read) {
+        List<ControlClaim> claims = new java.util.ArrayList<>();
         for (PathAccess each : read.arms().values()) {
-            if (each instanceof PathAccess.Ways ways0) {
-                for (souther.compiler.reading.WayIn way : ways0.ways()) {
-                    for (ControlClaim claim : way.claims()) {
-                        switch (claim.at()) {
-                            case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
-                            case ControlPointId.ComparisonPoint point -> {
-                                taken.add(point.at().value());
-                                ways.add(point.way());
-                            }
-                        }
-                    }
+            if (each instanceof PathAccess.Ways ways) {
+                for (souther.compiler.reading.WayIn way : ways.ways()) {
+                    claims.addAll(way.claims());
                 }
             }
         }
-        return new Observation(taken, ways);
+        return Runs.doing(claims);
     }
 
     private record Model(MeasuredInput subject, CoverageRead.Read read) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
@@ -12,6 +12,7 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.coverage.Runs;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
@@ -162,7 +163,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     void anotherArmIsTakenOffTheListByWhatTheRunWasSeenDoing() {
         Model model = Model.of(NESTED, "press");
         Set<ArmProbe> everyArm = model.read().arms().keySet();
-        AlignedObservation everywhere = doing(model.read());
+        AlignedObservation everywhere = doing(model);
 
         FillResult watched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
@@ -224,19 +225,20 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
 
     /** A run that was seen taking every arm the reading names, which is what a row through the
      *  outer arm and one of the inner ones is seen doing. */
-    private static AlignedObservation doing(CoverageRead.Read read) {
+    private static AlignedObservation doing(Model model) {
         List<ControlClaim> claims = new java.util.ArrayList<>();
-        for (PathAccess each : read.arms().values()) {
+        for (PathAccess each : model.read().arms().values()) {
             if (each instanceof PathAccess.Ways ways) {
                 for (souther.compiler.reading.WayIn way : ways.ways()) {
                     claims.addAll(way.claims());
                 }
             }
         }
-        return Runs.doing(claims);
+        return Runs.doing(model.numbering(), claims);
     }
 
-    private record Model(MeasuredInput subject, CoverageRead.Read read) {
+    private record Model(MeasuredInput subject, CoverageRead.Read read,
+                         SiteNumbering numbering) {
 
         static Model of(String source, String behavior) {
             Compilation compilation = Compilation.ofSource(source, "Main");
@@ -259,7 +261,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
                     Partitions.of(spec.name(), inputs, rules, ReadAs.THE_COMPILATION_DOES);
             return new Model(MeasuredInput.of(spec.name(), inputs.reading(rules),
                     partitioning),
-                    CoverageRead.of(spec.name(), body, plan, inputs, rules));
+                    CoverageRead.of(spec.name(), body, plan, inputs, rules), plan.numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -8,7 +8,7 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -154,7 +154,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
 
     /** A run that did nothing at all, which is a run that missed every combination. */
     private static final Generator.Watched MISSED =
-            new Generator.Watched.Ran(Observation.NONE);
+            new Generator.Watched.Ran(AlignedObservation.NONE);
 
     /** What the search made of the one combination named by {@code classes}. */
     private static Generator.UnresolvedCombination.Reason reasonFor(

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -8,7 +8,7 @@ import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.AlignedObservation;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -89,7 +89,8 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void aCombinationLeftWithAnUnrunCandidateSaysTheSearchStopped() {
-        FillResult filled = fill(Model.of(TWO_FREE, "shippingFee"), _ -> MISSED);
+        Model model = Model.of(TWO_FREE, "shippingFee");
+        FillResult filled = fill(model, _ -> missed(model));
 
         assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
@@ -104,7 +105,8 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void aCombinationEveryCandidateMissedSaysTheCandidatesWereNotWitnesses() {
-        FillResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
+        Model model = Model.of(ONE_FREE, "shippingFee");
+        FillResult filled = fill(model, _ -> missed(model));
 
         assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
@@ -125,7 +127,8 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void candidatesWhoseValuesAlreadyRanDoNotStopTheSearch() {
-        FillResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
+        Model model = Model.of(ONE_FREE, "shippingFee");
+        FillResult filled = fill(model, _ -> missed(model));
 
         assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium")),
@@ -144,17 +147,21 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
     void aSetOfValuesIsRunOnceHoweverManyCombinationsWantIt() {
         int[] runs = {0};
 
-        fill(Model.of(ONE_FREE, "shippingFee"), _ -> {
+        Model model = Model.of(ONE_FREE, "shippingFee");
+        fill(model, _ -> {
             runs[0]++;
-            return MISSED;
+            return missed(model);
         });
 
         assertEquals(8, runs[0], "one run per set of values this behavior has");
     }
 
-    /** A run that did nothing at all, which is a run that missed every combination. */
-    private static final Generator.Watched MISSED =
-            new Generator.Watched.Ran(AlignedObservation.NONE);
+    /** A run that did nothing at all, which is a run that missed every combination. Of the
+     *  model's own numbering: a run is a run of somewhere, and one of nowhere could be asked about
+     *  any place at all and answer. */
+    private static Generator.Watched missed(Model model) {
+        return new Generator.Watched.Ran(souther.compiler.coverage.Runs.nowhere(model.numbering()));
+    }
 
     /** What the search made of the one combination named by {@code classes}. */
     private static Generator.UnresolvedCombination.Reason reasonFor(
@@ -173,7 +180,8 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
                 model.read(), trial, Budgets.generation());
     }
 
-    private record Model(MeasuredInput subject, CoverageRead.Read read) {
+    private record Model(MeasuredInput subject, CoverageRead.Read read,
+                         SiteNumbering numbering) {
 
         /** The groups of the one reading, for a caller asking about the combinations alone. */
         List<Interaction> groups() {
@@ -204,7 +212,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES)),
                     CoverageRead.of(spec.name(), body,
                             checked.plan(), inputs,
-                            rules));
+                            rules), checked.plan().numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.Numberings;
+import souther.compiler.coverage.Runs;
 import souther.compiler.coverage.SiteNumbering;
 
 import java.util.LinkedHashSet;
@@ -65,7 +66,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         for (int each : probes) {
             arms.add(probe(each));
         }
-        return new AlignedObservation(arms, Set.of());
+        return Runs.at(NUMBERING, arms);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -1,13 +1,17 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.AlignedObservation;
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.coverage.ControlClaim;
 import souther.compiler.coverage.ControlPointId;
-import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.Numberings;
+import souther.compiler.coverage.SiteNumbering;
 
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -40,19 +44,28 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         return new InteractionCells.Cell(new boolean[][] {allowed});
     }
 
+    /** The numbering this fixture's places are of. One of them, so that two places written here as
+     *  the same number are the same place. */
+    private static final SiteNumbering NUMBERING = Numberings.ofArms(32);
+
+    private static ArmProbe probe(int raw) {
+        return NUMBERING.arm(raw);
+    }
+
     /** A place a run can be recorded at, told from its neighbours by the probe it carries. */
     private static ControlClaim at(int probe) {
-        return ControlClaim.of(new ControlPointId.ArmOccurrence(probe, OptionalInt.of(probe),
-                        null, null))
+        return ControlClaim.of(new ControlPointId.ArmOccurrence(probe,
+                        java.util.Optional.of(probe(probe)), null, null))
                 .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"));
     }
 
-    private static Observation lit(int... probes) {
-        java.util.Set<Integer> taken = new java.util.LinkedHashSet<>();
+    /** A run read as having been at those places of this fixture's numbering. */
+    private static AlignedObservation lit(int... probes) {
+        Set<ArmProbe> arms = new LinkedHashSet<>();
         for (int each : probes) {
-            taken.add(each);
+            arms.add(probe(each));
         }
-        return new Observation(taken, java.util.Set.of());
+        return new AlignedObservation(arms, Set.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ComparisonEmissionSite;
+import souther.compiler.coverage.Numberings;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Carrier;
@@ -92,6 +95,10 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
                 Towards.BELOW, origin()));
     }
 
+    /** The numbering this fixture's places are of. One of them, so that two origins built here
+     *  address one place rather than the same number of two numberings. */
+    private static final ComparisonEmissionSite WHERE = Numberings.comparison(1, 0);
+
     /** One rule, written in one place. Two lines of it are told apart by where they part the
      *  values, which is what the account may not be asked to do by name alone. */
     private static OriginRef origin() {
@@ -102,7 +109,7 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
                         new souther.compiler.coverage.ComparisonOccurrence("example.one", "f", 0),
                         new RuleCitation.WrittenAt(Citation.of(
                                 new souther.compiler.diag.SourcePos(1, 1))),
-                        new souther.compiler.coverage.ComparisonEmissionSite(0)),
+                        WHERE),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -118,7 +119,7 @@ class AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest {
     @Test
     void aCombinationRefusedAtItsFirstAssignmentIsTriedAtAnother() {
         Model model = model();
-        Set<Integer> every = Generator.everyArmACombinationMayTake(model.subject(), model.groups(),
+        Set<ArmProbe> every = Generator.everyArmACombinationMayTake(model.subject(), model.groups(),
                 Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms a combination takes");
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
@@ -1,5 +1,8 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
+import souther.compiler.coverage.Numberings;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.DefaultStdlib;
@@ -36,6 +39,9 @@ class NoAxesByItselfIsNotAGenerationReasonTest {
     private static final RuleReadingSource SYMBOLS =
             RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get()));
 
+    /** The one place this fixture's reading is about. */
+    private static final ArmProbe ARM = Numberings.arm(2, 1);
+
     private static final PathAccess NOT_ENUMERABLE =
             new PathAccess.Unsupported(PathAccess.Unsupported.Why.WAYS_NOT_ENUMERABLE);
 
@@ -51,7 +57,7 @@ class NoAxesByItselfIsNotAGenerationReasonTest {
     void anArmIsAnsweredWhereNoPositionIsDivided() {
         FillResult filled = filledOverOneArm();
 
-        assertEquals(Map.of(new Generator.ArmOwed(1), new ArmDisposition.NoWayIn(NOT_ENUMERABLE)),
+        assertEquals(Map.of(new Generator.ArmOwed(ARM), new ArmDisposition.NoWayIn(NOT_ENUMERABLE)),
                 filled.discharge().arms(),
                 "the arm's own entry, in the words the reading of the body used");
     }
@@ -68,12 +74,12 @@ class NoAxesByItselfIsNotAGenerationReasonTest {
     private static FillResult filledOverOneArm() {
         MeasuredInput subject = MeasuredInput.of("fee", readingOf("days", Type.INT),
                 AxesATestWrote.asAMeasurement("fee", List.of()));
-        java.util.SequencedMap<Integer, PathAccess> ways = new java.util.LinkedHashMap<>();
-        ways.put(1, NOT_ENUMERABLE);
+        java.util.SequencedMap<ArmProbe, PathAccess> ways = new java.util.LinkedHashMap<>();
+        ways.put(ARM, NOT_ENUMERABLE);
         CoverageRead.Read read = new CoverageRead.Read(List.of(), ways);
 
         return Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, read,
-                Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.of(1),
+                Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.of(ARM),
                 Budgets.generation());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -82,7 +83,7 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
         Model model = Model.of(SHIPPING, "shippingFee");
         List<Axis> axes = model.subject().axes().axes();
         int asked = 0;
-        for (int probe : model.read().arms().keySet()) {
+        for (ArmProbe probe : model.read().arms().keySet()) {
             for (Map.Entry<Integer, Integer> pin : onePinWaysInto(probe, model, axes)) {
                 Axis axis = axes.get(pin.getKey());
                 assertEquals(
@@ -98,7 +99,7 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
 
     /** The ways into {@code probe} that settle exactly one position, as that position and its
      *  class. */
-    private static List<Map.Entry<Integer, Integer>> onePinWaysInto(int probe, Model model,
+    private static List<Map.Entry<Integer, Integer>> onePinWaysInto(ArmProbe probe, Model model,
                                                                     List<Axis> axes) {
         List<Map.Entry<Integer, Integer>> out = new ArrayList<>();
         if (!(model.read().armAt(probe) instanceof souther.compiler.reading.PathAccess.Ways ways)) {
@@ -123,7 +124,7 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
 
     /** What one run of the search offered, by the values each row carries. */
     private static List<List<String>> rowsOf(Model model, List<Generator.ClassOwed> classes,
-                                             List<Integer> arms) {
+                                             List<ArmProbe> arms) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                         model.read(), Generator.Trial.NOTHING_RUNS, List.of(), classes, arms,
                         Budgets.generation())

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.Numberings;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.coverage.ControlClaim;
@@ -7,7 +9,7 @@ import souther.compiler.coverage.ControlPointId;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,8 +44,8 @@ class WhatACombinationAsksIsItsOwnToSayTest {
 
     private static CellSelection over(boolean[]... positions) {
         return new CellSelection(new InteractionCells.Cell(positions),
-                List.of(ControlClaim.of(new ControlPointId.ArmOccurrence(1, OptionalInt.of(1),
-                                null, null))
+                List.of(ControlClaim.of(new ControlPointId.ArmOccurrence(1,
+                                Optional.of(Numberings.arm(2, 1)), null, null))
                         .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"))));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/AGapIsRefusedOverByWhatSettledItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AGapIsRefusedOverByWhatSettledItTest.java
@@ -2,8 +2,10 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.DecidedBy;
+import souther.compiler.coverage.Numberings;
 import souther.compiler.coverage.SourceOutcome;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
@@ -12,6 +14,7 @@ import souther.compiler.types.CoverageConstruct;
 import souther.compiler.types.CoverageOrigin;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,11 +43,15 @@ class AGapIsRefusedOverByWhatSettledItTest {
     private static final CoverageOrigin UNSETTLED =
             CoverageOrigin.written("m", 1, CoverageConstruct.IF);
 
-    private static CoverageSites.Site arm(CoverageOrigin fork, int index, DecidedBy decided) {
-        return new CoverageSites.Site("b",
+    /** Four places of one numbering, so that arms put in one list are addresses of one. */
+    private static final Map<Integer, ArmProbe> PLACES = Numberings.arms(4);
+
+    private static CoverageSites.ArmSite arm(CoverageOrigin fork, int index, DecidedBy decided) {
+        return new CoverageSites.ArmSite("b",
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()),
                 Citation.of(new SourcePos(1, 1, new SourceId("0"))),
-                index, index, new CoverageSites.Obligation("b", fork, index, decided));
+                PLACES.get(index), index,
+                new CoverageSites.Obligation("b", fork, index, decided));
     }
 
     /** Every row read; one fork settled with a row through one of its arms, and one fork beside it
@@ -55,7 +62,7 @@ class AGapIsRefusedOverByWhatSettledItTest {
                         arm(SETTLED, 1, DecidedBy.THE_DECLARATION),
                         arm(UNSETTLED, 2, DecidedBy.NOT_SAID),
                         arm(UNSETTLED, 3, DecidedBy.NOT_SAID)),
-                Set.of(0), Adequacy.NOTHING_PROVEN, WeakeningSet.none()).arms();
+                Set.of(PLACES.get(0)), Adequacy.NOTHING_PROVEN, WeakeningSet.none()).arms();
     }
 
     @Test
@@ -80,7 +87,7 @@ class AGapIsRefusedOverByWhatSettledItTest {
                         arm(SETTLED, 1, DecidedBy.THE_DECLARATION),
                         arm(UNSETTLED, 2, DecidedBy.NOT_SAID),
                         arm(UNSETTLED, 3, DecidedBy.NOT_SAID)),
-                Set.of(0), Adequacy.NOTHING_PROVEN, WeakeningSet.none());
+                Set.of(PLACES.get(0)), Adequacy.NOTHING_PROVEN, WeakeningSet.none());
 
         assertEquals(WeakeningSet.of(new Weakening.ArmsUnsettled(UNSETTLED)),
                 measured.measured().weakening(),

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.codegen.Backend;
 import souther.compiler.codegen.Instrumentation;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.NumberingIdentity;
-import souther.compiler.coverage.SiteAddress;
+import souther.compiler.coverage.Numberings;
+import souther.compiler.coverage.SiteNumbering;
 
 import java.util.List;
 
@@ -105,17 +105,37 @@ class ProbeMappingTest {
         // each number it handed out addresses, so the extra number is given an address too: a plan
         // whose sites and addresses disagree is refused where it is built, and what is under test
         // here is what the emitter does with an arm no body has.
-        CoverageSites.Site extra = real.sites().get(0);
-        List<CoverageSites.Site> longer = new java.util.ArrayList<>(real.sites());
-        longer.add(new CoverageSites.Site(extra.behavior(), extra.outcome(), extra.at(),
-                real.sites().size(), real.sites().size(), extra.obligation()));
-        List<SiteAddress> addressed = new java.util.ArrayList<>(real.identity().byNumber());
-        addressed.add(real.identity().at(0));
+        // A numbering of the same families this module's own has, and one arm more. The sites are
+        // reissued from it so that the plan is of one numbering throughout: what is being made here
+        // is a plan with an arm no body emits, and not a plan whose parts came from two.
+        Numberings.Family[] families = new Numberings.Family[real.sites().size() + 1];
+        for (int at = 0; at < real.sites().size(); at++) {
+            families[at] = real.sites().get(at) instanceof CoverageSites.ArmSite
+                    ? Numberings.Family.ARM : Numberings.Family.COMPARISON;
+        }
+        families[real.sites().size()] = Numberings.Family.ARM;
+        SiteNumbering wider = Numberings.of(families);
+
+        List<CoverageSites.Site> longer = new java.util.ArrayList<>();
+        for (int at = 0; at < real.sites().size(); at++) {
+            longer.add(switch (real.sites().get(at)) {
+                case CoverageSites.ArmSite site -> new CoverageSites.ArmSite(site.behavior(),
+                        site.outcome(), site.at(), wider.arm(at), site.ordinal(),
+                        site.obligation());
+                case CoverageSites.ComparisonSite site -> new CoverageSites.ComparisonSite(
+                        site.behavior(), site.outcome(), site.at(), wider.comparison(at),
+                        site.ordinal(), site.obligation());
+            });
+        }
+        CoverageSites.ArmSite extra = (CoverageSites.ArmSite) longer.stream()
+                .filter(CoverageSites.ArmSite.class::isInstance).findFirst().orElseThrow();
+        longer.add(new CoverageSites.ArmSite(extra.behavior(), extra.outcome(), extra.at(),
+                wider.arm(real.sites().size()), real.sites().size(), extra.obligation()));
+
         CoverageSites.Plan overcounted =
                 new CoverageSites.Plan(longer, real.guards(), real.byNode(), real.byComparison(),
                         real.armsByNode(), real.controlByComparison(), real.mayRepeat(),
-                        real.forkByNode(), real.comparisons(),
-                        new NumberingIdentity(module, real.identity().executable(), addressed));
+                        real.forkByNode(), real.comparisons(), wider);
 
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(),

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatEachWeakeningSaysAboutAWiderRunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatEachWeakeningSaysAboutAWiderRunTest.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.BehaviorContract;
+import souther.compiler.coverage.Numberings;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.RuleRef;
@@ -215,7 +216,7 @@ class WhatEachWeakeningSaysAboutAWiderRunTest {
         out.add(new Weakening.BodiesNotElaborated("m"));
         out.add(new Weakening.BoundaryNotDerived("b"));
         out.add(new Weakening.InputNotRead("b"));
-        out.add(new Weakening.ProofContradicted("b", 1));
+        out.add(new Weakening.ProofContradicted("b", Numberings.arm(2, 1)));
         out.add(new Weakening.ArmsUnsettled(
                 new CoverageOrigin("m", 1, 0, CoverageConstruct.IF)));
         out.add(new Weakening.PairSpaceTruncated("b", 9, 4));

--- a/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -8,7 +8,9 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.AlignedObservation;
 import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.SiteNumbering;
 import souther.compiler.coverage.Probe;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.inputs.InputDomain;
@@ -103,7 +105,7 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
         Model model = Model.of(FEE, "chargeFor");
         Interaction group = model.groups().get(0);
 
-        Observation seen = model.observing(500L, 50L);
+        AlignedObservation seen = model.observing(500L, 50L);
         assertEquals(List.of(), group.reachClaims().stream()
                         .filter(claim -> !claim.satisfiedBy(seen)).toList(),
                 "a row that reaches the meeting did everything the way in names");
@@ -116,7 +118,7 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
      * they are not ways of settling the same thing; none holding would say the reading named
      * something no row reaches, which is the shape every misreading of a group ends in.
      */
-    private static Map<String, Boolean> takenBy(Interaction group, Observation seen) {
+    private static Map<String, Boolean> takenBy(Interaction group, AlignedObservation seen) {
         Map<String, Boolean> settled = new java.util.LinkedHashMap<>();
         for (Factor factor : group.factors()) {
             List<Outcome> did = factor.outcomes().stream()
@@ -133,12 +135,13 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
         return settled;
     }
 
-    private static boolean satisfied(Outcome outcome, Observation seen) {
+    private static boolean satisfied(Outcome outcome, AlignedObservation seen) {
         return outcome.claims().stream().allMatch(claim -> claim.satisfiedBy(seen));
     }
 
     /** One model, read the way the generator reads it and run the way an example row is. */
-    private record Model(List<Interaction> groups, Behavior behavior) {
+    private record Model(List<Interaction> groups, SiteNumbering numbering,
+                         Behavior behavior) {
 
         static Model of(String source, String name) {
             Compilation compilation = Compilation.ofSource(source, "Main");
@@ -158,11 +161,11 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
                     .ask(new Output.Evaluated(module, ArmObservation.RECORD)).value();
             assertNotNull(artifact, "the model under test emits measured classes");
             return new Model(CoverageRead.of(name, body, plan, inputs, rules).interactions(),
-                    new Behavior(artifact.classes(), module, name));
+                    plan.numbering(), new Behavior(artifact.classes(), module, name, plan));
         }
 
-        Observation observing(Object... arguments) {
-            return behavior.observing(arguments);
+        AlignedObservation observing(Object... arguments) {
+            return numbering.align(behavior.observing(arguments));
         }
     }
 
@@ -172,7 +175,11 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
         private final Object instance;
         private final Method apply;
 
-        Behavior(Map<String, ClassFileImage> classes, String module, String name) {
+        private final CoverageSites.Plan plan;
+
+        Behavior(Map<String, ClassFileImage> classes, String module, String name,
+                 CoverageSites.Plan plan) {
+            this.plan = plan;
             assertNotNull(classes, "the model under test compiles");
             ClassLoader loader = new MemoryClassLoader(classes,
                     AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.class.getClassLoader());
@@ -192,7 +199,7 @@ class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
         }
 
         Observation observing(Object... arguments) {
-            Probe.begin();
+            Probe.begin(plan.identity());
             try {
                 apply.invoke(instance, arguments);
                 return Probe.snapshot();

--- a/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AComparisonOnANumberTakenOfALocationSteersARowTest.java
@@ -274,12 +274,19 @@ class AComparisonOnANumberTakenOfALocationSteersARowTest {
                 "no position answers the number, so no decision is said of one");
     }
 
-    /** Which arms rows were offered for, by the number the plan gave each. */
+    /**
+     * Which arms rows were offered for, by the number the plan gave each.
+     *
+     * <p>By number, because what two of these are held against each other is two compiles of two
+     * sources. Each has a numbering of its own and an address of one is an address of nothing in
+     * the other, so what "the same arms" can mean between them is the numbers — which is what the
+     * two sources being one body up to a spelling makes a claim about.
+     */
     private static List<Integer> armsAnsweredIn(String source) {
         return generated(source).composed().rows().stream()
                 .flatMap(row -> row.purposes().stream())
                 .filter(Generator.Purpose.ForAnArm.class::isInstance)
-                .map(each -> ((Generator.Purpose.ForAnArm) each).probe())
+                .map(each -> ((Generator.Purpose.ForAnArm) each).probe().raw())
                 .sorted().toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/reading/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
@@ -170,7 +170,7 @@ class AGroupIsOnlyOfferedWhereARunPassesItOnceTest {
             };
             return new CoverageSites.Plan(plan.sites(), plan.guards(), plan.byNode(),
                     plan.byComparison(), plan.armsByNode(), plan.controlByComparison(),
-                    everywhere, plan.forkByNode(), plan.comparisons(), plan.identity());
+                    everywhere, plan.forkByNode(), plan.comparisons(), plan.numbering());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/reading/AnArmThePlanNumberedIsToldHowItIsReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/reading/AnArmThePlanNumberedIsToldHowItIsReachedTest.java
@@ -1,11 +1,13 @@
 package souther.compiler.reading;
 
+import souther.compiler.coverage.ArmProbe;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Numberings;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
@@ -226,7 +228,11 @@ class AnArmThePlanNumberedIsToldHowItIsReachedTest {
         Read read = read(NESTED);
 
         assertInstanceOf(PathAccess.Ways.class, read.answer.armAt(read.armSites().iterator().next()));
-        assertThrows(IllegalArgumentException.class, () -> read.answer.armAt(-1));
+        // An arm of another numbering, which is what "no arm of this behavior" can be now that a
+        // place is an address rather than a number: a number this read never issued cannot be
+        // spelled, and one that addresses a place somewhere else is refused here.
+        assertThrows(IllegalArgumentException.class,
+                () -> read.answer.armAt(Numberings.arm(1, 0)));
     }
 
     /** What the conditions of one way say, as the report of a class would spell them. */
@@ -237,8 +243,8 @@ class AnArmThePlanNumberedIsToldHowItIsReachedTest {
     private record Read(CoverageRead.Read answer, CoverageSites.Plan plan, String behavior) {
 
         /** The arms of the behavior, by the numbers the plan gave them. */
-        Set<Integer> armSites() {
-            return plan.arms(behavior).stream().map(CoverageSites.Site::index)
+        Set<ArmProbe> armSites() {
+            return plan.arms(behavior).stream().map(CoverageSites.ArmSite::index)
                     .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
@@ -8,8 +8,10 @@ import tools.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.BehaviorImplementation;
+import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.DecidedBy;
+import souther.compiler.coverage.Numberings;
 import souther.compiler.coverage.SourceOutcome;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
@@ -40,12 +42,15 @@ class WhatWasObservedDecidesWhatAReportMayNameTest {
     private static final CoverageOrigin UNSETTLED =
             CoverageOrigin.written("m", 1, CoverageConstruct.IF);
 
-    private static CoverageSites.Site arm(CoverageOrigin fork, int index, DecidedBy decided) {
-        return new CoverageSites.Site("b",
+    /** Four places of one numbering, so that arms put in one list are addresses of one. */
+    private static final java.util.Map<Integer, ArmProbe> PLACES = Numberings.arms(4);
+
+    private static CoverageSites.ArmSite arm(CoverageOrigin fork, int index, DecidedBy decided) {
+        return new CoverageSites.ArmSite("b",
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()),
                 souther.compiler.diag.Citation.of(new souther.compiler.diag.SourcePos(1, 1,
                         new souther.compiler.source.SourceId("0"))),
-                index, index,
+                PLACES.get(index), index,
                 new CoverageSites.Obligation("b", fork, index, decided));
     }
 
@@ -56,7 +61,7 @@ class WhatWasObservedDecidesWhatAReportMayNameTest {
                         arm(SETTLED, 1, DecidedBy.THE_DECLARATION),
                         arm(UNSETTLED, 2, DecidedBy.NOT_SAID),
                         arm(UNSETTLED, 3, DecidedBy.NOT_SAID)),
-                Set.of(0), souther.compiler.query.Adequacy.NOTHING_PROVEN, WeakeningSet.none());
+                Set.of(PLACES.get(0)), souther.compiler.query.Adequacy.NOTHING_PROVEN, WeakeningSet.none());
     }
 
     /** The arm no row goes through is named, though the numbers are not a whole measure. */


### PR DESCRIPTION
A number means a place only under the numbering that handed it out, and until now an address said
so about nothing. An `int` from one build and an `int` from another are the same `int`, so a claim
answered against a run made elsewhere was answered rather than refused — and the numbers travelled
as numbers through the emitter, the recording and every reader, with nothing on the way saying
which plan they were of.

So an address is now the numbering and a number, and the numbering is a value: two derivations of
one module come to the same one, so an address of either is an address of both. That is what lets
one be held under an answer the store keeps. An address carrying a token minted per construction
would stop equalling the one a recomputation makes, and every reader of that answer would run again
on every revision — which is the shape the first attempt here took, and what the store's own census
refused.

The numbering is the only maker. A number crosses back into a place there and nowhere else, and it
is refused where that numbering never handed it out or handed it out to the other family. Which is
why the walk that numbers the places carries numbers rather than addresses: until it is over there
is no numbering for an address to be of, so the places are read back once, where the numbering is
finished. A class-file licence fixes who may make one, for both families.

Reading a run is that same crossing, and it is the one place a recording becomes places. A
recording says which numbering it was made under, so one made under another is refused rather than
answered about places it was never near.

## What the alignment could not be given

Two things had to be fixed before it could be, and neither is separable from it.

A run nobody watched had been an empty recording under a numbering of nothing. That reads
everywhere downstream as a row shown to have passed nowhere, which is the opposite of what
happened. What was recorded of a row is now one of two answers the row carries, and asking a thread
that began no recording what it did is refused rather than answered.

And what a body does had been a list of objects. It crosses the seam an execution that is not this
one's would be written against, so that seam asked such an execution to know this compiler's own
trees. What a node settles is now said as what it is.

## Notes for the reviewer

`Bodies.Elaborated.plan()` still walks the bodies on each call, and what comes back is the same
numbering. Handing out one construction was tried and taken back out: it was a repair for the
token, not for anything the numbering needs, and it put the plan into the answer graph.

Two of the refusals above had no test reaching them — a mutation of each survived. Both are held
now, the first against a numbering of the same size over different places, since a shorter one is
caught by a different mechanism and would not be checking this.
