### PR TITLE
A pass that replaces what a call applies says so, and carries what the source settled

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -133,7 +133,11 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
                             + "Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)"
                             + "Lsouther/compiler/ast/Hir$Apply;"),
             new Settler("Apply.carriedByValue", "souther/compiler/ast/Hir$Apply", "carriedByValue",
-                    "()Lsouther/compiler/ast/Hir$Apply;"));
+                    "()Lsouther/compiler/ast/Hir$Apply;"),
+            new Settler("Apply.with", "souther/compiler/ast/Hir$Apply", "with",
+                    "(Lsouther/compiler/ast/Hir$AppliedCallee;Lsouther/compiler/ast/Hir$Expr;"
+                            + "Ljava/util/List;Lsouther/compiler/diag/SourcePos;"
+                            + "Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;"));
 
     /**
      * Every member of the owning package that names an answer, by the whole of what it is — owner,
@@ -165,7 +169,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/ast/Hir$Apply#replacedBy(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#synthetic(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#wasCarriedByValue()Z",
-            "souther/compiler/ast/Hir$Apply#with(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;",
+            "souther/compiler/ast/Hir$Apply#with(Lsouther/compiler/ast/Hir$AppliedCallee;Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#withArgs(Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Fields#$values()[Lsouther/compiler/ast/Hir$Fields;",
             "souther/compiler/ast/Hir$Fields#values()[Lsouther/compiler/ast/Hir$Fields;",
@@ -207,6 +211,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/ast/Hir$Apply#synthetic(Ljava/lang/String;Lsouther/compiler/types/ReachName;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply; -> Apply.synthetic(Expr) x1",
             "souther/compiler/check/Elaborator#fromList(Ljava/lang/String;Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/ast/Hir$RowCollection;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x1",
             "souther/compiler/check/HelperInliner#etaExpand(Lsouther/compiler/ast/Hir$Var;ILjava/util/function/IntFunction;)Lsouther/compiler/ast/Hir$Block; -> Apply.synthetic(Expr) x1",
+            "souther/compiler/check/HelperInliner#rename(Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/check/HelperInliner$Renaming;)Lsouther/compiler/ast/Hir$Expr; -> Apply.with x1",
             "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> Apply.carriedByValue x1",
             "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> NewData.carriedByValue x1",
             "souther/compiler/check/HelperNames#publishedBy(Lsouther/compiler/ast/Hir$Expr;Ljava/lang/String;)Lsouther/compiler/ast/Hir$Expr; -> NewData.publishedBy x1",

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -121,8 +121,9 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             new Settler("NewData.carriedByValue", "souther/compiler/ast/Hir$NewData",
                     "carriedByValue", "()Lsouther/compiler/ast/Hir$NewData;"),
             new Settler("Apply.read", "souther/compiler/ast/Hir$Apply", "read",
-                    "(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Hir$Expr;"
-                            + "Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;"),
+                    "(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Hir$AppliedCallee;"
+                            + "Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;)"
+                            + "Lsouther/compiler/ast/Hir$Apply;"),
             new Settler("Apply.synthetic(Expr)", "souther/compiler/ast/Hir$Apply", "synthetic",
                     "(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;"
                             + "Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)"
@@ -144,8 +145,8 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
      * {@code syntheticWithEveryFieldWritten} and {@code synthetic} are a pass writing one where no
      * source did. Three move an answer along the crossings a construction has:
      * {@code publishedBy}, {@code carriedByValue} and the {@code Origins} members that say what
-     * each crossing does. The rest carry or ask — {@code with}, {@code withArgs},
-     * {@code withFunction} and {@code standingIn} put back what they were handed and
+     * each crossing does. The rest carry or ask — {@code with}, {@code withArgs} and
+     * {@code replacedBy} put back what they were handed and
      * {@code atSlots} and {@code withRegion} are the rewrites that go through them, while
      * {@code mayOmitOptionalFields}, {@code wasCarried}, {@code wasCarriedByValue} and
      * {@code Origins#carried} are the questions a check puts to a node. The accessors and the
@@ -160,13 +161,12 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/ast/Hir#withRegion(Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Expr;",
             "souther/compiler/ast/Hir$Apply#carriedByValue()Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#origin()Lsouther/compiler/ast/ConstructionOrigin;",
-            "souther/compiler/ast/Hir$Apply#read(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
-            "souther/compiler/ast/Hir$Apply#standingIn(Ljava/lang/String;)Lsouther/compiler/ast/Hir$Apply;",
+            "souther/compiler/ast/Hir$Apply#read(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Hir$AppliedCallee;Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
+            "souther/compiler/ast/Hir$Apply#replacedBy(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#synthetic(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#wasCarriedByValue()Z",
             "souther/compiler/ast/Hir$Apply#with(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Apply#withArgs(Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;",
-            "souther/compiler/ast/Hir$Apply#withFunction(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Apply;",
             "souther/compiler/ast/Hir$Fields#$values()[Lsouther/compiler/ast/Hir$Fields;",
             "souther/compiler/ast/Hir$Fields#values()[Lsouther/compiler/ast/Hir$Fields;",
             "souther/compiler/ast/Hir$NewData#carriedByValue()Lsouther/compiler/ast/Hir$NewData;",
@@ -206,13 +206,12 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
     private static final List<String> SETTLING = List.of(
             "souther/compiler/ast/Hir$Apply#synthetic(Ljava/lang/String;Lsouther/compiler/types/ReachName;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply; -> Apply.synthetic(Expr) x1",
             "souther/compiler/check/Elaborator#fromList(Ljava/lang/String;Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/ast/Hir$RowCollection;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x1",
-            "souther/compiler/check/HelperInliner#desugar(Lsouther/compiler/stdlib/Stdlib;Lsouther/compiler/ast/Hir$Apply;)Lsouther/compiler/ast/Hir$Apply; -> Apply.synthetic(Expr) x1",
             "souther/compiler/check/HelperInliner#etaExpand(Lsouther/compiler/ast/Hir$Var;ILjava/util/function/IntFunction;)Lsouther/compiler/ast/Hir$Block; -> Apply.synthetic(Expr) x1",
             "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> Apply.carriedByValue x1",
             "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> NewData.carriedByValue x1",
             "souther/compiler/check/HelperNames#publishedBy(Lsouther/compiler/ast/Hir$Expr;Ljava/lang/String;)Lsouther/compiler/ast/Hir$Expr; -> NewData.publishedBy x1",
             "souther/compiler/check/NewtypeDesugar#go(Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/check/Symbols;)Lsouther/compiler/ast/Hir$Expr; -> NewData.fromApply x1",
-            "souther/compiler/check/Resolve#applied(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
+            "souther/compiler/check/Resolve#applied(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Ast$Var;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> NewData.read x1",
             "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -19,8 +19,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,36 +41,98 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * <p>What settles an answer is a member and the calls that reach it, so both are read here. The
  * members of the owning package that name an answer are listed, each by the whole of what it is, so
  * a second one of a name is a second row. And the calls that reach the members which <em>settle</em>
- * one are listed by who makes them, because a settling member is public and being unable to reach
- * its arguments is a thing about how the passes are written rather than one the language holds.
+ * one are listed by the method that makes them and how many it makes, because a settling member is
+ * public and being unable to reach its arguments is a thing about how the passes are written rather
+ * than one the language holds.
  *
- * <p>Neither list says what a rewrite is. The first is every member of a package, read off its
- * classes; the second is every call to one of them, read off the whole reactor. A pass added
+ * <p>The method rather than the class it is in, because a class holds passes that do different
+ * things and a row naming the class says one thing about all of them. How many rather than whether,
+ * because a second call beside a first is a second place settling an answer.
+ *
+ * <p>And nothing outside the package builds one of these forms at all. The list of callers says who
+ * reaches a named way in; it says nothing about a pass that reaches past them, and a form here is a
+ * record whose constructor answers whatever it is handed. The two are separate checks because they
+ * answer different questions — which way in was used, and whether a way in was used.
+ *
+ * <p>No list here says what a rewrite is. The first is every member of a package, read off its
+ * classes; the others are the calls that reach them, read off the whole reactor. A pass added
  * tomorrow is in them or it does not settle an answer.
  */
 class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
 
     private static final String THEIRS = "souther/compiler/ast/";
 
+    /** The same package, as a call's owner says it — exactly, so one under it is not it. */
+    private static final String THEIR_PACKAGE = "souther/compiler/ast";
+
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * A member a settling call may name, and the word the edges below are written with.
+     *
+     * <p>The word is what a reader of an edge wants: which act a caller reached for. A descriptor
+     * says the same thing and says it in forty characters of type names, so an edge written with one
+     * is read by working out what it is rather than by reading it.
+     *
+     * <p>The whole signature is here beside the word, because that is what an edge is matched on. A
+     * word standing for a member is only as good as the member it stands for being the one it was
+     * written for: matched by name alone, an overload added tomorrow would be written with a word
+     * that means the other one.
+     */
+    private record Settler(String word, String owner, String name, String descriptor) {
+
+        /** The member, whichever of its overloads a call names — what says an invocation settles. */
+        String member() {
+            return owner + "#" + name;
+        }
+
+        /** The one overload, which is what an edge is written from. */
+        String signature() {
+            return member() + descriptor;
+        }
+    }
 
     /**
      * The members that settle an answer rather than carrying or asking one: a source read, the
      * translation of an application into the construction it means, a pass composing one, and the
      * two crossings that make one answer out of another.
      *
-     * <p>Named by owner and member, so every overload of one settles. Which overloads there are is
-     * the other list's to hold.
+     * <p>Every overload is here, the ones that settle nothing themselves included. {@code synthetic}
+     * taking a spelling hands its arguments to the one taking an expression, so it is not in
+     * {@link #NAMING} — and a caller naming it is still a caller reaching a settle, which the edge
+     * says by the door it came through. Whether an overload settles is what the other list answers;
+     * this one answers what a call reaches.
      */
-    private static final Set<String> SETTLES = Set.of(
-            "souther/compiler/ast/Hir$NewData#read",
-            "souther/compiler/ast/Hir$NewData#fromApply",
-            "souther/compiler/ast/Hir$NewData#syntheticWithEveryFieldWritten",
-            "souther/compiler/ast/Hir$NewData#publishedBy",
-            "souther/compiler/ast/Hir$NewData#carriedByValue",
-            "souther/compiler/ast/Hir$Apply#read",
-            "souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/ast/Hir$Apply#carriedByValue");
+    private static final List<Settler> SETTLERS = List.of(
+            new Settler("NewData.read", "souther/compiler/ast/Hir$NewData", "read",
+                    "(Lsouther/compiler/ast/Ast$NewData;Lsouther/compiler/ast/Hir$Name;"
+                            + "Ljava/util/List;Ljava/util/List;Lsouther/compiler/ast/Reading;)"
+                            + "Lsouther/compiler/ast/Hir$NewData;"),
+            new Settler("NewData.fromApply", "souther/compiler/ast/Hir$NewData", "fromApply",
+                    "(Lsouther/compiler/ast/Hir$Apply;Lsouther/compiler/ast/Hir$Name;"
+                            + "Ljava/util/List;)Lsouther/compiler/ast/Hir$NewData;"),
+            new Settler("NewData.syntheticWithEveryFieldWritten",
+                    "souther/compiler/ast/Hir$NewData", "syntheticWithEveryFieldWritten",
+                    "(Lsouther/compiler/ast/Hir$Name;Ljava/util/List;Ljava/util/List;"
+                            + "Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)"
+                            + "Lsouther/compiler/ast/Hir$NewData;"),
+            new Settler("NewData.publishedBy", "souther/compiler/ast/Hir$NewData", "publishedBy",
+                    "(Ljava/lang/String;)Lsouther/compiler/ast/Hir$NewData;"),
+            new Settler("NewData.carriedByValue", "souther/compiler/ast/Hir$NewData",
+                    "carriedByValue", "()Lsouther/compiler/ast/Hir$NewData;"),
+            new Settler("Apply.read", "souther/compiler/ast/Hir$Apply", "read",
+                    "(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Hir$Expr;"
+                            + "Ljava/util/List;)Lsouther/compiler/ast/Hir$Apply;"),
+            new Settler("Apply.synthetic(Expr)", "souther/compiler/ast/Hir$Apply", "synthetic",
+                    "(Lsouther/compiler/ast/Hir$Expr;Ljava/util/List;"
+                            + "Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)"
+                            + "Lsouther/compiler/ast/Hir$Apply;"),
+            new Settler("Apply.synthetic(String)", "souther/compiler/ast/Hir$Apply", "synthetic",
+                    "(Ljava/lang/String;Lsouther/compiler/types/ReachName;Ljava/util/List;"
+                            + "Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)"
+                            + "Lsouther/compiler/ast/Hir$Apply;"),
+            new Settler("Apply.carriedByValue", "souther/compiler/ast/Hir$Apply", "carriedByValue",
+                    "()Lsouther/compiler/ast/Hir$Apply;"));
 
     /**
      * Every member of the owning package that names an answer, by the whole of what it is — owner,
@@ -120,7 +185,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/ast/Origins$Published#module()Ljava/lang/String;");
 
     /**
-     * Every call that settles an answer, and who makes it.
+     * Every call that settles an answer, by the method that makes it and how many it makes.
      *
      * <p>A source is read in one place: {@code Resolve} is what reads one, and it is the only caller
      * of either {@code read}. The crossings are {@code HelperNames}', which is what carries a body
@@ -130,20 +195,31 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
      * <p>A row whose caller is not one of those is a pass answering for something it did not read.
      * Being able to call one of these is not what stops it — the forms are public and a parsed node
      * is a record anyone can build — so what stops it is this list.
+     *
+     * <p>The method and not the class, and how many and not whether. A class holds passes that do
+     * different things: {@code HelperInliner} both writes a call for a name used as a value and
+     * rewrites an application a source wrote, and a row naming the class says one thing about both.
+     * The count is the same question a step in: a second call added beside a first is a second place
+     * settling an answer, and a row that says only that its caller settles one somewhere would not
+     * move for it.
      */
     private static final List<String> SETTLING = List.of(
-            "souther/compiler/ast/Hir$Apply -> souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/check/Elaborator -> souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/check/HelperInliner -> souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/check/HelperNames -> souther/compiler/ast/Hir$Apply#carriedByValue",
-            "souther/compiler/check/HelperNames -> souther/compiler/ast/Hir$NewData#carriedByValue",
-            "souther/compiler/check/HelperNames -> souther/compiler/ast/Hir$NewData#publishedBy",
-            "souther/compiler/check/NewtypeDesugar -> souther/compiler/ast/Hir$NewData#fromApply",
-            "souther/compiler/check/Resolve -> souther/compiler/ast/Hir$Apply#read",
-            "souther/compiler/check/Resolve -> souther/compiler/ast/Hir$NewData#read",
-            "souther/compiler/check/Terms -> souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/partition/FixtureTemplate -> souther/compiler/ast/Hir$Apply#synthetic",
-            "souther/compiler/partition/FixtureTemplate -> souther/compiler/ast/Hir$NewData#syntheticWithEveryFieldWritten");
+            "souther/compiler/ast/Hir$Apply#synthetic(Ljava/lang/String;Lsouther/compiler/types/ReachName;Ljava/util/List;Lsouther/compiler/diag/SourcePos;Lsouther/compiler/diag/Region;)Lsouther/compiler/ast/Hir$Apply; -> Apply.synthetic(Expr) x1",
+            "souther/compiler/check/Elaborator#fromList(Ljava/lang/String;Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/ast/Hir$RowCollection;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x1",
+            "souther/compiler/check/HelperInliner#desugar(Lsouther/compiler/stdlib/Stdlib;Lsouther/compiler/ast/Hir$Apply;)Lsouther/compiler/ast/Hir$Apply; -> Apply.synthetic(Expr) x1",
+            "souther/compiler/check/HelperInliner#etaExpand(Lsouther/compiler/ast/Hir$Var;ILjava/util/function/IntFunction;)Lsouther/compiler/ast/Hir$Block; -> Apply.synthetic(Expr) x1",
+            "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> Apply.carriedByValue x1",
+            "souther/compiler/check/HelperNames#carriedByValue(Lsouther/compiler/ast/Hir$Expr;)Lsouther/compiler/ast/Hir$Expr; -> NewData.carriedByValue x1",
+            "souther/compiler/check/HelperNames#publishedBy(Lsouther/compiler/ast/Hir$Expr;Ljava/lang/String;)Lsouther/compiler/ast/Hir$Expr; -> NewData.publishedBy x1",
+            "souther/compiler/check/NewtypeDesugar#go(Lsouther/compiler/ast/Hir$Expr;Lsouther/compiler/check/Symbols;)Lsouther/compiler/ast/Hir$Expr; -> NewData.fromApply x1",
+            "souther/compiler/check/Resolve#applied(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
+            "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
+            "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> NewData.read x1",
+            "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
+            "souther/compiler/partition/FixtureTemplate#newtype(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1",
+            "souther/compiler/partition/FixtureTemplate#record(Lsouther/compiler/types/TypeReachName$Written;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
+            "souther/compiler/partition/FixtureTemplate#spreading(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
+            "souther/compiler/partition/FixtureTemplate#temporal(Ljava/lang/String;Ljava/lang/String;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1");
 
     @Test
     void everyMemberOfTheOwningPackageThatNamesAnAnswerIsWrittenDown() {
@@ -152,12 +228,48 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
                         + " say which it is and why it is not the node's own answer carried");
     }
 
+    /** The words the edges are written with stand for the members they say they do — the table an
+     *  edge is rendered through, checked against the package before anything is rendered. */
+    @Test
+    void andEachWordTheEdgesAreWrittenWithStandsForOneMember() {
+        assertEquals(SETTLERS.stream().map(Settler::signature).sorted().toList(),
+                SETTLERS.stream().map(Settler::signature).distinct().sorted().toList(),
+                "two rows of the settlers table name one member");
+        assertEquals(SETTLERS.stream().map(Settler::word).sorted().toList(),
+                SETTLERS.stream().map(Settler::word).distinct().sorted().toList(),
+                "two members of the settlers table are written with one word");
+        assertEquals(List.of(), SETTLERS.stream().map(Settler::signature)
+                        .filter(each -> !declaredInThatPackage().contains(each)).toList(),
+                "a settlers row names a member this package does not declare");
+    }
+
     @Test
     void andEveryCallThatSettlesOneIsWrittenDownWithWhoMakesIt() {
-        assertEquals(SETTLING, new ArrayList<>(settlingAnAnswer()),
+        assertEquals(SETTLING, settlingAnAnswer(),
                 "settling an answer is the reading's to do and the crossings': a pass that rewrites"
                         + " a body carries what it was handed, and a row here that is not a reading"
                         + " or a crossing is a pass answering for a construction it did not read");
+    }
+
+    /**
+     * And nobody outside the package that declares these forms builds one without going through
+     * them.
+     *
+     * <p>The list above says who reaches a named way in. It says nothing about a pass that reaches
+     * past them: a form here is a record, its canonical constructor is as accessible as the record,
+     * and one called with an origin in hand answers whatever the caller put there. The way in being
+     * named is what the list is about, and this is what makes it the way.
+     *
+     * <p>Inside the package the constructor is how a form is made — a reading builds one, a crossing
+     * builds the next, a rewrite puts back what it was handed — so the boundary is the package and
+     * not the record. What a member of it may answer is the {@link #NAMING} list's to say, which is
+     * why one rule does not do for both.
+     */
+    @Test
+    void andNobodyOutsideThatPackageBuildsOneOfItsFormsDirectly() {
+        assertEquals(List.of(), buildingAFormDirectly(),
+                "a form of this package is built where nothing names what it answers: reach it"
+                        + " through the reading, the crossing or the rewrite that says which");
     }
 
     /** The control: the walk reads the whole reactor and not only the package it is about, which is
@@ -189,23 +301,115 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
         return found;
     }
 
-    /** Every call to a settling member, as the class that makes it and what it settles. */
-    private static Set<String> settlingAnAnswer() {
+    /** Every call to a settling member, as the method that makes it, what it settles and how many
+     *  of them that method makes. */
+    private static List<String> settlingAnAnswer() {
+        Map<String, Integer> counted = new TreeMap<>();
+        walkEveryCall((caller, invoked) -> {
+            if (!settlingMembers().contains(memberOf(invoked))) {
+                return;
+            }
+            counted.merge(caller + " -> " + wordFor(invoked), 1, Integer::sum);
+        });
+        return counted.entrySet().stream().map(row -> row.getKey() + " x" + row.getValue()).toList();
+    }
+
+    /**
+     * The word {@code invoked} is written with, and a failure where nothing here holds one for it.
+     *
+     * <p>Not a spelling worked out from the descriptor. An overload nobody has written down is an
+     * overload nobody has said settles what: rendered by falling back to its signature it would join
+     * the list as one more row, which reads as a caller to look at rather than as a way in that
+     * nobody has ruled on.
+     */
+    private static String wordFor(InvokeInstruction invoked) {
+        for (Settler settler : SETTLERS) {
+            if (settler.signature().equals(signatureOf(invoked))) {
+                return settler.word();
+            }
+        }
+        throw new AssertionError("`" + signatureOf(invoked) + "` settles an answer and is written"
+                + " with no word: add it to the settlers table, saying which act it is");
+    }
+
+    /** Every call this package's forms are built by, from outside the package that declares them. */
+    private static List<String> buildingAFormDirectly() {
         Set<String> found = new TreeSet<>();
+        walkEveryCall((caller, invoked) -> {
+            if (!"<init>".equals(invoked.name().stringValue())
+                    || !theForms().contains(invoked.owner().name().stringValue())
+                    || THEIR_PACKAGE.equals(packageOf(caller))) {
+                return;
+            }
+            found.add(caller + " -> " + invoked.owner().name().stringValue() + "#<init>");
+        });
+        return new ArrayList<>(found);
+    }
+
+    /** The forms whose answers this is about, as a call names their class. */
+    private static Set<String> theForms() {
+        Set<String> forms = new LinkedHashSet<>();
+        for (Settler settler : SETTLERS) {
+            forms.add(settler.owner());
+        }
+        return forms;
+    }
+
+    /** The members a settling call names, whichever overload it names. */
+    private static Set<String> settlingMembers() {
+        Set<String> members = new LinkedHashSet<>();
+        for (Settler settler : SETTLERS) {
+            members.add(settler.member());
+        }
+        return members;
+    }
+
+    private static String memberOf(InvokeInstruction invoked) {
+        return invoked.owner().name().stringValue() + "#" + invoked.name().stringValue();
+    }
+
+    private static String signatureOf(InvokeInstruction invoked) {
+        return memberOf(invoked) + invoked.typeSymbol().descriptorString();
+    }
+
+    /** Where a class is declared: the whole of its internal name but the class, so a package under
+     *  this one is a package under it and not this one. */
+    private static String packageOf(String member) {
+        int hash = member.indexOf('#');
+        String owner = hash < 0 ? member : member.substring(0, hash);
+        int last = owner.lastIndexOf('/');
+        return last < 0 ? "" : owner.substring(0, last);
+    }
+
+    /** Every method this reactor compiles, and every call it makes, as the method that makes it. */
+    private static void walkEveryCall(BiConsumer<String, InvokeInstruction> to) {
         for (Path each : everyCompiledClass()) {
             ClassModel model = parse(each);
             for (MethodModel method : model.methods()) {
+                String caller = internalName(each) + "#" + method.methodName().stringValue()
+                        + method.methodType().stringValue();
                 method.code().ifPresent(code -> {
                     for (CodeElement element : code) {
-                        if (element instanceof InvokeInstruction invoked
-                                && SETTLES.contains(invoked.owner().name().stringValue() + "#"
-                                        + invoked.name().stringValue())) {
-                            found.add(internalName(each) + " -> "
-                                    + invoked.owner().name().stringValue() + "#"
-                                    + invoked.name().stringValue());
+                        if (element instanceof InvokeInstruction invoked) {
+                            to.accept(caller, invoked);
                         }
                     }
                 });
+            }
+        }
+    }
+
+    /** Every method the package that declares these forms holds, by the whole of what it is. */
+    private static Set<String> declaredInThatPackage() {
+        Set<String> found = new TreeSet<>();
+        for (Path each : everyCompiledClass()) {
+            if (!internalName(each).startsWith(THEIRS)) {
+                continue;
+            }
+            ClassModel model = parse(each);
+            for (MethodModel method : model.methods()) {
+                found.add(model.thisClass().name().stringValue() + "#"
+                        + method.methodName().stringValue() + method.methodType().stringValue());
             }
         }
         return found;

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -240,6 +240,12 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
         assertEquals(List.of(), SETTLERS.stream().map(Settler::signature)
                         .filter(each -> !declaredInThatPackage().contains(each)).toList(),
                 "a settlers row names a member this package does not declare");
+        // And the other way round, which is what makes the table the members rather than the ones
+        // that happen to be called. An overload nobody calls yet settles what its siblings settle,
+        // and a table that waited for a caller would be answered about it by whoever wrote one.
+        assertEquals(everyOverloadOfASettler(),
+                SETTLERS.stream().map(Settler::signature).sorted().toList(),
+                "an overload of a settling member is a way in whether or not anything uses it yet");
     }
 
     @Test
@@ -396,6 +402,14 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
                 });
             }
         }
+    }
+
+    /** Every overload the package declares of a member the table names, by the whole of what it is
+     *  — what the table is required to hold, read off the classes rather than off the calls. */
+    private static List<String> everyOverloadOfASettler() {
+        return declaredInThatPackage().stream()
+                .filter(each -> settlingMembers().contains(each.substring(0, each.indexOf('('))))
+                .sorted().toList();
     }
 
     /** Every method the package that declares these forms holds, by the whole of what it is. */

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1183,72 +1183,12 @@ public interface Ast {
      * carries what it denotes — a helper, a library function, an injected behavior, a function-typed
      * binding, or the type a newtype construction wraps — answered once during resolution.
      */
-    record Apply(Expr function, List<Expr> args, String appliedAs, SourcePos pos, Region region)
-            implements Expr {
-
-        /** Applying whatever {@code function} is, with nothing standing in for what the source
-         * wrote — every application but one a lowering rewrote. */
-        public Apply(Expr function, List<Expr> args, SourcePos pos, Region region) {
-            this(function, args, null, pos, region);
-        }
-
-
-        /** Whether what this applies is a name. A reader that wants the name itself matches on
-         * {@link #function()}, which is where it is. */
-        public boolean appliesAName() {
-            return function instanceof Var;
-        }
-
-        /**
-         * The name this applies as the source writes it, or the empty spelling where what it
-         * applies is not a name. What a report quotes and underlines.
-         *
-         * <p><b>Never a lookup key.</b> An import lets a library name be written without its
-         * qualifier, so a table keyed by a declaration's name misses on the spelling — silently,
-         * because a miss is what a table keyed by names does with one it has not got. Every
-         * question of the form "which declaration is this" asks {@link #reaches()}.
-         *
-         * <p>{@link #appliedAs} answers where a lowering replaced what was written with a binding
-         * it introduced: applying something other than a name binds it first, and the binding is
-         * named nothing an author could have typed. The two are separate for that reason — this
-         * one is read by reports and nothing else.
-         */
-        public String written() {
-            return name().canonical();
-        }
-
-        /**
-         * The name this applies, with the occurrence of it a report underlines.
-         *
-         * <p>Where a lowering replaced what was written with a binding it introduced
-         * ({@link #appliedAs}), that binding is written nowhere: the characters at {@link #pos()}
-         * spell whatever the author applied, which is no longer this.
-         */
-        public WrittenName name() {
-            if (appliedAs != null) {
-                return WrittenName.synthetic(appliedAs, pos);
-            }
-            return function instanceof Var v ? v.written() : WrittenName.synthetic("", pos);
-        }
-
-        /**
-         * Where a report about what this applies points: the characters the callee was written over.
-         *
-         * <p>Not {@link #name()}'s. The name is what a report quotes, and where a lowering replaced
-         * what was written with a binding it introduced ({@link #appliedAs}) that name is written
-         * nowhere — while the characters the binding stands for are still there, being whatever the
-         * author applied. Asking the callee gets those; asking the name gets a point at best.
-         */
-        public Region appliedAt() {
-            Region written = function.reportedAt();
-            return written != null ? written : name().reportedAt();
-        }
+    record Apply(Expr function, List<Expr> args, SourcePos pos, Region region) implements Expr {
 
         /** The same application over rewritten arguments — a pass that touches only the arguments
-         *  says so here rather than listing the slots it is not changing, which is how
-         *  {@link #appliedAs} would be dropped by a rewrite that has no opinion about it. */
+         *  says so here rather than listing the slots it is not changing. */
         public Apply withArgs(List<Expr> args) {
-            return new Apply(function, args, appliedAs, pos, region);
+            return new Apply(function, args, pos, region);
         }
     }
 
@@ -1285,7 +1225,7 @@ public interface Ast {
             case Neg x -> new Neg(x.operand(), x.pos(), region);
             case FieldAccess x -> new FieldAccess(x.target(), x.name(), x.pos(), region);
             case Binary x -> new Binary(x.op(), x.left(), x.right(), x.origin(), x.pos(), region);
-            case Apply x -> new Apply(x.function(), x.args(), x.appliedAs(), x.pos(), region);
+            case Apply x -> new Apply(x.function(), x.args(), x.pos(), region);
             case If x -> new If(x.cond(), x.then(), x.els(), x.origin(), x.pos(), region);
             case IfConstructed x ->
                     new IfConstructed(x.construct(), x.binder(), x.then(), x.els(), x.origin(), x.pos(),

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -2108,6 +2108,21 @@ public interface Hir {
         public Region reportedAt() {
             return name == null ? at : name.reportedAt();
         }
+
+        /**
+         * The same applied callee in a file this copy is not read against — the name it was, written
+         * nowhere here, applied over {@code over} and complained about at {@code at}.
+         *
+         * <p>What the author applied travels with the copy; where they wrote it does not. A body
+         * spliced in from a source this compile cannot show carries no coordinate of that source, so
+         * the occurrence goes and the places are the ones the copy stands at — the same answer a
+         * field read taken off a copied value gives, and for the same reason.
+         */
+        public AppliedCallee restamped(SourcePos at, Region over) {
+            return new AppliedCallee(name == null ? null
+                    : WrittenName.synthetic(name.canonical(), at),
+                    over != null ? over : Region.point(at));
+        }
     }
 
     /**
@@ -2302,10 +2317,19 @@ public interface Hir {
             return new Apply(function, args, origin, applied, pos, region);
         }
 
-        /** The same application rewritten and stamped where the copy of it stands — what a pass
-         *  that copies a body into another one writes. What it does not name it carries, which is
-         *  where the construction came from and what the author applied. */
-        public Apply with(Expr function, List<Expr> args, SourcePos pos, Region region) {
+        /**
+         * The same application rewritten and stamped where the copy of it stands — what a pass that
+         * copies a body into another one writes. Where the construction came from it carries.
+         *
+         * <p>What the author applied it takes, because a copy is where that answer stops being one
+         * place. The name travels: a call the copy holds applies what it applied wherever the copy
+         * is read. Where they wrote it does not, and a copy read against another file carrying a
+         * coordinate of the first is a report pointing at a line its reader is not looking at.
+         * Which of the two this copy is, the pass making it knows and this does not
+         * ({@link AppliedCallee#restamped}).
+         */
+        public Apply with(AppliedCallee applied, Expr function, List<Expr> args, SourcePos pos,
+                          Region region) {
             return new Apply(function, args, origin, applied, pos, region);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -2053,6 +2053,64 @@ public interface Hir {
     }
 
     /**
+     * What an application applies, as a report says it: the name the author applied, and the
+     * characters they applied it over.
+     *
+     * <p>Settled where the application is read and carried from there. A lowering replaces what is
+     * in the callee position — a field read is bound to a name of its own before it is applied, a
+     * sugared library name becomes the operation it stands for, a helper of another module is
+     * written qualified — and a reader that asked the callee what the author applied would be told
+     * whatever the last pass put there. So no reader asks it: the answer is read off the source
+     * once, and every rewrite of the application hands it on.
+     *
+     * <p>Both halves, because they are two answers and the second cannot be worked out from the
+     * first. A name the author parenthesized is written over five characters and applied over
+     * seven, and a report about what is applied underlines the seven. The pair is what the reading
+     * already holds, so keeping it is keeping what was read rather than working anything out.
+     *
+     * <p>{@code name} is null where what the author applied is not a name: the result of a call, a
+     * lambda, a conditional. That is one of the three states this has, the others being a name the
+     * author wrote ({@link WrittenName#authored()}) and one a pass reached for, and none of them is
+     * an empty spelling.
+     *
+     * <p>{@code at} is never null. An application stands somewhere — where a source wrote it, or
+     * where the pass composing it put it — and a report about what it applies points there. There
+     * is no application with nowhere to point at what it applies.
+     */
+    record AppliedCallee(WrittenName name, Region at) {
+
+        public AppliedCallee {
+            Objects.requireNonNull(at, "an application is applied somewhere, and a report about"
+                    + " what it applies points there");
+        }
+
+        /** Whether what the author applied is a name — which is not whether a name is what stands
+         *  in the callee position now, a lowering having been free to put a binding of its own
+         *  there. */
+        public boolean isAName() {
+            return name != null;
+        }
+
+        /** The name as a report quotes it, or the empty spelling where what is applied is not a
+         *  name. */
+        public String quoted() {
+            return name == null ? "" : name.canonical();
+        }
+
+        /**
+         * Where a report about the name this applies points: the occurrence of the name, or the
+         * characters applied where the author applied no name.
+         *
+         * <p>The choice between two answers already held. A report about what is applied has
+         * somewhere to point either way, and where there is no name the place is the expression
+         * that stood in the callee position — which is what the author applied, being not a name.
+         */
+        public Region reportedAt() {
+            return name == null ? at : name.reportedAt();
+        }
+    }
+
+    /**
      * A function applied to arguments. {@code function} is the thing being applied, and it is an
      * expression like any other: what is applied is what it answers, not how the application was
      * written.
@@ -2061,7 +2119,7 @@ public interface Hir {
      * carries what it denotes — a helper, a library function, an injected behavior, a function-typed
      * binding, or the type a newtype construction wraps — answered once during resolution.
      */
-    record Apply(Expr function, List<Expr> args, ConstructionOrigin origin, String appliedAs,
+    record Apply(Expr function, List<Expr> args, ConstructionOrigin origin, AppliedCallee applied,
                  SourcePos pos, Region region) implements Expr {
 
         /**
@@ -2069,26 +2127,47 @@ public interface Hir {
          * application is made from a source that writes one.
          *
          * <p>Where it came from is the body's own, because a source spells an application in the
-         * body it is written in. What a lowering replaced the written name with, where it stands
-         * and what it covers are the surface node's, which is what this is the reading of.
+         * body it is written in. What the author applied is {@code applied}, read off the surface
+         * callee by the reading that has it: which name a chain of field reads spells is a question
+         * about the source, and the answer is settled once here rather than worked out again from
+         * whatever the passes leave in the callee position.
          */
-        public static Apply read(Ast.Apply surface, Expr function, List<Expr> args) {
-            return new Apply(function, args, Origins.Own.IT_IS, surface.appliedAs(), surface.pos(),
+        public static Apply read(Ast.Apply surface, AppliedCallee applied, Expr function,
+                                 List<Expr> args) {
+            return new Apply(function, args, Origins.Own.IT_IS, applied, surface.pos(),
                     surface.region());
         }
 
         /**
          * An application a pass composed, standing where it puts it — a call that stands for a name
-         * used as a value, a library operation a rewrite reached for.
+         * used as a value, a library operation a fixture reached for.
          *
          * <p>Nobody's reading, so it says what it is in its name. Where it came from is the body it
-         * is written into: a pass composing an application is writing one there, and a pass moving
-         * an application that was already written carries what it was handed instead
-         * ({@link #with}, {@link #withArgs}, {@link #withFunction}).
+         * is written into: a pass composing an application is writing one there, and a pass
+         * rewriting one that was already written carries what it was handed instead
+         * ({@link #replacedBy}, {@link #with}, {@link #withArgs}).
+         *
+         * <p>What the author applied is whatever the callee already answers, and no more than that.
+         * A synthetic application may apply a name occurrence somebody wrote — {@code etaExpand}
+         * composes the block a bare {@code List.map} stands for, and the application is this pass's
+         * while the occurrence is the author's — so the two are not one question and this settles
+         * only the first. Where the callee is a name, its own is taken; where it is not, there is no
+         * name to answer with and nothing is invented. A chain of field reads is not read back into
+         * a name here either: which of those spells one is the source reading's answer, and a pass
+         * holding a resolved expression is not reading a source.
          */
         public static Apply synthetic(Expr function, List<Expr> args, SourcePos pos,
                                       Region region) {
-            return new Apply(function, args, Origins.Own.IT_IS, null, pos, region);
+            return new Apply(function, args, Origins.Own.IT_IS, appliedCallee(function, pos), pos,
+                    region);
+        }
+
+        /** What {@code function} answers as the applied callee, anchored at {@code where} it stands
+         *  when the callee is written nowhere at all. */
+        private static AppliedCallee appliedCallee(Expr function, SourcePos where) {
+            Region at = function.reportedAt();
+            return new AppliedCallee(function instanceof Var v ? v.written() : null,
+                    at != null ? at : Region.point(where));
         }
 
         /**
@@ -2126,55 +2205,43 @@ public interface Hir {
                     + " reaches, and the spelling would be resolved again wherever this is read";
         }
 
-        /** Whether what this applies is a name. A reader that wants the name itself matches on
-         * {@link #function()}, which is where it is. */
-        public boolean appliesAName() {
+        /**
+         * Whether a name is what stands in the callee position now.
+         *
+         * <p>Not whether the author applied one, which is {@link AppliedCallee#isAName()}. The two
+         * differ wherever a lowering has been: {@code deps.count(x)} binds the field read to a name
+         * of its own and applies the binding, so a name is what is applied here and a field read is
+         * what the author applied. A reader wanting the name itself matches on {@link #function()},
+         * which is where it is.
+         */
+        public boolean calleeIsAName() {
             return function instanceof Var;
         }
 
         /**
          * The name this applies as the source writes it, or the empty spelling where what it
-         * applies is not a name. What a report quotes and underlines.
+         * applies is not a name. What a report quotes.
          *
          * <p><b>Never a lookup key.</b> An import lets a library name be written without its
          * qualifier, so a table keyed by a declaration's name misses on the spelling — silently,
          * because a miss is what a table keyed by names does with one it has not got. Every
-         * question of the form "which declaration is this" asks {@link #reaches()}.
-         *
-         * <p>{@link #appliedAs} answers where a lowering replaced what was written with a binding
-         * it introduced: applying something other than a name binds it first, and the binding is
-         * named nothing an author could have typed. The two are separate for that reason — this
-         * one is read by reports and nothing else.
+         * question of the form "which declaration is this" asks {@link #answered()}.
          */
         public String written() {
-            return name().canonical();
+            return applied.quoted();
         }
 
         /**
-         * The name this applies, with the occurrence of it a report underlines.
+         * Where a report about what this applies points: the characters the author applied it over.
          *
-         * <p>Where a lowering replaced what was written with a binding it introduced
-         * ({@link #appliedAs}), that binding is written nowhere: the characters at {@link #pos()}
-         * spell whatever the author applied, which is no longer this.
-         */
-        public WrittenName name() {
-            if (appliedAs != null) {
-                return WrittenName.synthetic(appliedAs, pos);
-            }
-            return function instanceof Var v ? v.written() : WrittenName.synthetic("", pos);
-        }
-
-        /**
-         * Where a report about what this applies points: the characters the callee was written over.
-         *
-         * <p>Not {@link #name()}'s. The name is what a report quotes, and where a lowering replaced
-         * what was written with a binding it introduced ({@link #appliedAs}) that name is written
-         * nowhere — while the characters the binding stands for are still there, being whatever the
-         * author applied. Asking the callee gets those; asking the name gets a point at best.
+         * <p>Read off {@link #applied} and not off the callee. A lowering is free to replace what is
+         * in the callee position — with a binding it introduced, with the operation a sugared name
+         * stands for, with a helper's qualified spelling — and the characters those stand for are
+         * still whatever the author wrote. Asking the callee gets the answer only until a pass has
+         * been through.
          */
         public Region appliedAt() {
-            Region written = function.reportedAt();
-            return written != null ? written : name().reportedAt();
+            return applied.at();
         }
 
         /**
@@ -2201,40 +2268,45 @@ public interface Hir {
          * where its constructions would otherwise stand, and it is what has to say where it came
          * from. */
         public Apply carriedByValue() {
-            return new Apply(function, args, Origins.carriedByValue(origin), appliedAs, pos, region);
+            return new Apply(function, args, Origins.carriedByValue(origin), applied, pos, region);
         }
 
         /** The same application over rewritten arguments — a pass that touches only the arguments
-         *  says so here rather than listing the slots it is not changing, which is how
-         *  {@link #appliedAs} would be dropped by a rewrite that has no opinion about it. */
+         *  says so here rather than listing the slots it is not changing, which is how what the
+         *  author applied would be dropped by a rewrite that has no opinion about it. */
         public Apply withArgs(List<Expr> args) {
-            return new Apply(function, args, origin, appliedAs, pos, region);
+            return new Apply(function, args, origin, applied, pos, region);
         }
 
-        /** The same application of another spelling of what it applies — a pass that rewrites the
-         *  callee and nothing else, which is how where the construction came from would be dropped
-         *  by a rewrite that has no opinion about it. */
-        public Apply withFunction(Expr function) {
-            return new Apply(function, args, origin, appliedAs, pos, region);
+        /**
+         * The same application, of something else — the one rewrite that puts another thing in the
+         * callee position of an application a source already wrote.
+         *
+         * <p>What is applied is the pass's; where the application stands, where it came from and
+         * what the author applied there are not. A sugared library name becomes the operation it
+         * stands for, a field read applied is bound to a name of its own and the binding applied,
+         * a helper of another module is written qualified — each replaces what is applied and none
+         * of them replaces what was written over those characters.
+         *
+         * <p>Taking no place to stand is what makes it that rewrite rather than {@link #with}. A
+         * replacement stands where the thing it replaces stood, so a caller choosing somewhere for
+         * it would be choosing whether this is a replacement at all.
+         */
+        public Apply replacedBy(Expr function) {
+            return replacedBy(function, args);
+        }
+
+        /** The same application, of something else and over rewritten arguments — the rewrite above,
+         *  where what is supplied to the new callee is not what was supplied to the old one. */
+        public Apply replacedBy(Expr function, List<Expr> args) {
+            return new Apply(function, args, origin, applied, pos, region);
         }
 
         /** The same application rewritten and stamped where the copy of it stands — what a pass
          *  that copies a body into another one writes. What it does not name it carries, which is
-         *  where the construction came from and what stands in for the written name. */
+         *  where the construction came from and what the author applied. */
         public Apply with(Expr function, List<Expr> args, SourcePos pos, Region region) {
-            return new Apply(function, args, origin, appliedAs, pos, region);
-        }
-
-        /**
-         * The same application, saying that {@code appliedAs} is what a lowering replaced the
-         * written name with.
-         *
-         * <p>Said here rather than by writing the application again, because the pass that
-         * introduces one is replacing what was applied with a binding it made: what it has an
-         * opinion about is the callee and this, and the rest of the application is the author's.
-         */
-        public Apply standingIn(String appliedAs) {
-            return new Apply(function, args, origin, appliedAs, pos, region);
+            return new Apply(function, args, origin, applied, pos, region);
         }
 
         /** Whether a value this body named is what carried the construction this stands for in —
@@ -2275,7 +2347,7 @@ public interface Hir {
             case Neg x -> new Neg(x.operand(), x.pos(), region);
             case FieldAccess x -> new FieldAccess(x.target(), x.name(), x.pos(), region);
             case Binary x -> new Binary(x.op(), x.left(), x.right(), x.origin(), x.pos(), region);
-            case Apply x -> new Apply(x.function(), x.args(), x.origin(), x.appliedAs(), x.pos(),
+            case Apply x -> new Apply(x.function(), x.args(), x.origin(), x.applied(), x.pos(),
                     region);
             case If x -> new If(x.cond(), x.then(), x.els(), x.origin(), x.pos(), region);
             case IfConstructed x ->
@@ -2339,7 +2411,7 @@ public interface Hir {
                 Expr function = atExpr.apply(a.function());
                 List<Expr> args = each(a.args(), atExpr);
                 yield function == a.function() && args == a.args() ? a
-                        : new Apply(function, args, a.origin(), a.appliedAs(), a.pos(), a.region());
+                        : new Apply(function, args, a.origin(), a.applied(), a.pos(), a.region());
             }
             case If iff -> {
                 Expr cond = atExpr.apply(iff.cond());

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -642,8 +642,13 @@ public final class CallElaborator {
         // arguments — f(x) (spec §fn-declaration). A newtype construction 金額(500) never
         // reaches here — NewtypeDesugar has lowered it to a NewData literal.
         // a function value in force, or a recursive helper's signature: which of the two
-        // is the denotation's to say, and only one of them is bound here
-        if (env.of(callee.denotes(), call.written()) instanceof Type.FnOf fn) {
+        // is the denotation's to say, and only one of them is bound here.
+        //
+        // Looked up by what the callee reaches. The signatures are keyed by the reference a call is
+        // left standing on, and what a report quotes is the name the author applied — which a
+        // rewrite of the callee leaves alone, so a lookup on that finds the sugar and not the
+        // operation it stands for.
+        if (env.of(callee.denotes(), callee.reaches()) instanceof Type.FnOf fn) {
             if (args.size() != fn.params().size()) {
                 throw CompileException.of(Diagnostic
                                 .at(call.appliedAt())
@@ -702,7 +707,7 @@ public final class CallElaborator {
             Elaborator.optionCaseWritten(call.written(), call.pos());
             CompileException bareLibraryName = StdlibNames.writtenBare(
                     ctx.symbols().library().names(), call.written(), call.written(),
-                    call.name().region());
+                    call.applied().reportedAt());
             if (bareLibraryName != null) {
                 throw bareLibraryName;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -185,8 +185,11 @@ public final class CallElaborator {
         // declared elsewhere, and it is the only one that carries a binding into the emitted tree
         if (callee != null && callee.denotes() instanceof ValueName.Local local
                 && env.typeOf(local.id()) instanceof Type.FnOf) {
+            // The binding's own name, as every other read of one is built with. What the author
+            // applied is the application's answer and not this read's: where a lowering bound what
+            // was applied, the two are a field read and the name it was bound to.
             return new Core.Apply(
-                    new Core.Read(call.written(), local.id(), env.typeOf(local.id()), call.pos()),
+                    new Core.Read(local.name(), local.id(), env.typeOf(local.id()), call.pos()),
                     ca.cores(), result, call.pos());
         }
         // Typing the call above refuses what is not a name outright, so what is left here names a

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -640,11 +640,10 @@ public final class HelperInliner {
         if (rewrite == null) {
             return call;
         }
-        List<Hir.Expr> args = new ArrayList<>(call.args());
-        for (int supplied : rewrite.supplied()) {
-            // an argument the rewrite supplies, which no one wrote
-            args.add(new Hir.IntLit(supplied, call.pos(), null));
-        }
+        // Where the supplied arguments go is the rewrite's, which is why the list is built there:
+        // this writes each of them out as the literal no one wrote, and puts none of them anywhere.
+        List<Hir.Expr> args = rewrite.arguments(call.args(),
+                constant -> new Hir.IntLit(constant, call.pos(), null));
         // The library name this reaches for is the pass's; the application is the author's, and so
         // is what they applied there — a report about this call quotes the sugar they wrote and not
         // the operation it stands for, which is private to the library and takes another argument.

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -645,12 +645,14 @@ public final class HelperInliner {
             // an argument the rewrite supplies, which no one wrote
             args.add(new Hir.IntLit(supplied, call.pos(), null));
         }
-        // The library name this reaches for is the pass's; where it stands is the callee's.
-        return Hir.Apply.synthetic(
+        // The library name this reaches for is the pass's; the application is the author's, and so
+        // is what they applied there — a report about this call quotes the sugar they wrote and not
+        // the operation it stands for, which is private to the library and takes another argument.
+        return call.replacedBy(
                 Hir.Var.respelled(rewrite.target().qualified(),
                         new ReachName.OfLibrary(rewrite.target()), call.function().pos(),
                         call.function().region()),
-                args, call.pos(), call.region());
+                args);
     }
 
     /** Inlines a recursive helper's own body, expanding the non-recursive helper calls it makes while
@@ -1100,18 +1102,6 @@ public final class HelperInliner {
         return written.merge(writing.into(), 1, Integer::sum) - 1;
     }
 
-    /** How the source wrote an expression that is a name or a chain of field reads off one, or null
-     *  where it wrote something with no spelling of its own — a call's result, a lambda. */
-    private static String spelling(Hir.Expr e) {
-        return switch (e) {
-            case Hir.Var v -> v.name();
-            case Hir.FieldAccess fa -> {
-                String target = spelling(fa.target());
-                yield target == null ? null : target + "." + fa.field();
-            }
-            default -> null;
-        };
-    }
 
     /** Rewrites every helper call in {@code e} to its inlined body, into the body this writing names.
      * Private, because there is no body to write into until a writing says which, and the writings
@@ -1122,18 +1112,17 @@ public final class HelperInliner {
             // application reads the binding, which is the shape every reader downstream already has
             // — and which says outright what the order is: the function is worked out once, before
             // any argument, and the binding is what is applied.
-            case Hir.Apply raw when !raw.appliesAName() -> {
+            case Hir.Apply raw when !raw.calleeIsAName() -> {
                 Hir.Binder f = writing.binders().binder("$fn" + next(), raw.function().pos());
-                // What the application reaches is the binding, and what a report about it quotes is
-                // what the author wrote — a field read applied (`deps.count(x)`) has a spelling, and
-                // quoting the binding would name `$fn0`, which is nowhere in the source. The two are
-                // separate slots: the binding is in the callee position, the spelling beside it.
+                // What the application reaches is the binding. What a report about it quotes is
+                // what the author wrote — a field read applied (`deps.count(x)`) has a spelling,
+                // and quoting the binding would name `$fn0`, which is nowhere in the source — and
+                // the application carries that, this being a rewrite of what it applies.
                 ValueName.Local applied = new ValueName.Local(f.name(), f.id());
                 yield inline(new Hir.LetIn(f, raw.function(), null, false, null,
-                        raw.withFunction(Hir.Var.respelled(f.name(),
+                        raw.replacedBy(Hir.Var.respelled(f.name(),
                                 new ReachName.InScope(applied), raw.function().pos(),
-                                raw.function().region()))
-                                .standingIn(spelling(raw.function())),
+                                raw.function().region())),
                         raw.pos(), raw.region()));
             }
             case Hir.Apply rawCall -> expandCall(rawCall);
@@ -1256,7 +1245,7 @@ public final class HelperInliner {
      * callee's signature is one statement and this call decides its variables once.
      */
     private Hir.Expr expandCall(Hir.Apply rawCall) {
-        if (rawCall.answered() == null && rawCall.appliesAName()) {
+        if (rawCall.answered() == null && rawCall.calleeIsAName()) {
             // The callee names nothing, which was reported where it is written. No body stands
             // behind it, no library sugar reaches for it, and no parameter list holds its arguments
             // against anything — so the call stays as it is and only its arguments are expanded.
@@ -1297,7 +1286,7 @@ public final class HelperInliner {
         // takes nothing. The value is substituted and the arguments are applied to it.
         if (helper.params().isEmpty() && !args.isEmpty()
                 && call.function() instanceof Hir.Var named) {
-            return inline(call.withFunction(valueOf(named)).withArgs(args));
+            return inline(call.replacedBy(valueOf(named), args));
         }
         if (args.size() != helper.params().size()) {
             throw wrongArity(call, helper, args.size());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -2016,8 +2016,17 @@ public final class HelperInliner {
                     : fa.withTarget(rename(fa.target(), renaming));
             // the callee is renamed as the expression it is, like every other subexpression. A name
             // applied is an `Hir.Var` held here, so it goes through the arm above and is substituted
-            // exactly as a read of it would be — the position cannot ask a different question.
+            // exactly as a read of it would be.
+            //
+            // What the author applied is the application's own answer and is not read off that, so
+            // it is stamped here beside it: the name travels with the copy and the place it was
+            // written at is in the callee's file, which a copy read against another one may not
+            // carry — the rule the field read above goes by.
             case Hir.Apply call -> call.with(
+                    renaming.stamps()
+                            ? call.applied().restamped(renaming.at(call.function().pos()),
+                                    renaming.over(call.function().region()))
+                            : call.applied(),
                     rename(call.function(), renaming),
                     renameList(call.args(), renaming),
                     renaming.at(call.pos()), renaming.over(call.region()));

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -177,10 +177,13 @@ public final class HelperNames {
         return switch (rebuilt) {
             // The name is this pass's and the place is the callee's: only the spelling changes, so
             // what is underlined for it is the stretch the name it replaced was read over — not the
-            // application's, which takes in arguments this pass did not touch.
+            // application's, which takes in arguments this pass did not touch. What the author
+            // applied is neither, and the rewrite carries it: a reader reaching this helper writes
+            // it qualified because that is how a reader reaches it, and the author of the call
+            // wrote it bare.
             case Hir.Apply call when call.answered() != null
                     && foreign(call.answered().denotes(), which) ->
-                    call.withFunction(
+                    call.replacedBy(
                             Hir.Var.respelled(qualifiedName(call.answered().denotes()),
                                     ofModule(call.answered().denotes()), call.function().pos(),
                                     call.function().region()));

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -477,7 +477,7 @@ public final class HelperTyping {
         String reached = path.get(path.size() - 1).rendered();
         String rendered = "invariant -> " + PartialReachability.render(path);
         Hir.Apply at = firstCallTo(e, path.get(0));
-        throw CompileException.of(Diagnostic.at(at == null ? null : at.name().reportedAt())
+        throw CompileException.of(Diagnostic.at(at == null ? null : at.applied().reportedAt())
                 .say(new InvariantMessage.TheInvariantReachesAPartialHelper(data, reached, rendered))
                 .build());
     }
@@ -492,7 +492,7 @@ public final class HelperTyping {
         String reached = path.get(path.size() - 1).rendered();
         String rendered = "ensures -> " + PartialReachability.render(path);
         Hir.Apply at = firstCallTo(e, path.get(0));
-        throw CompileException.of(Diagnostic.at(at == null ? null : at.name().reportedAt())
+        throw CompileException.of(Diagnostic.at(at == null ? null : at.applied().reportedAt())
                 .say(new BehaviorMessage.TheEnsuresReachesAPartialHelper(
                         behavior, reached, rendered)).build());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.ast.WrittenName;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 
@@ -93,12 +94,15 @@ public final class NewtypeDesugar {
                 TypeSymbol built = call.answered() != null
                         && call.answered().denotes() instanceof ValueName.OfType named
                         ? named.type() : null;
-                if (built != null && symbols.declaredNode(built) instanceof Hir.Data nt
+                // The type name is the one the author applied, which a construction is named by. A
+                // callee denoting a type is one they wrote, so this holds wherever the branch is
+                // taken; asked of the callee it would be whatever a lowering had put there.
+                if (built != null && call.applied().name() instanceof WrittenName wrote
+                        && symbols.declaredNode(built) instanceof Hir.Data nt
                         && nt.newtype() && args.size() == 1) {
                     // `T(v)` is what the author wrote and a construction is what it means, so the
                     // node that replaces the application stands over the same characters.
-                    yield Hir.NewData.fromApply(call,
-                            new Hir.Name.Denoting(call.name(), built),
+                    yield Hir.NewData.fromApply(call, new Hir.Name.Denoting(wrote, built),
                             List.of(new Hir.FieldInit("value", args.get(0), call.pos())));
                 }
                 yield call.withArgs(args);

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -13,6 +13,7 @@ import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.msg.NameMessage;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.msg.ModuleMessage;
+import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
@@ -1082,7 +1083,7 @@ public final class Resolve {
             // is answered as the expression it is, and what may be applied is the check's to say.
             case Ast.Apply call when call.function() instanceof Ast.Var callee ->
                     applied(call, callee, bound);
-            case Ast.Apply call -> Hir.Apply.read(call, appliedCallee(call.function()),
+            case Ast.Apply call -> Hir.Apply.read(call, appliedCallee(call),
                     callee(call.function(), bound), exprs(call.args(), bound));
             // `Map.empty`, `String.isEmpty`, `up.Amount` — a namespace and a member of it, which
             // the parser read as a field taken off a name because it reads no case at all. Folded
@@ -1229,7 +1230,7 @@ public final class Resolve {
                     ReachName.of(denotes, written.canonical(), reachable.module()),
                     callee.region());
         }
-        return Hir.Apply.read(call, appliedCallee(call.function()), name,
+        return Hir.Apply.read(call, appliedCallee(call), name,
                 exprs(call.args(), bound));
     }
 
@@ -1248,8 +1249,15 @@ public final class Resolve {
      * be read two ways depending on what it turned out to reach — and what the author wrote is not
      * a thing that turns on that.
      */
-    private static Hir.AppliedCallee appliedCallee(Ast.Expr callee) {
-        return new Hir.AppliedCallee(dottedName(callee), callee.reportedAt());
+    private static Hir.AppliedCallee appliedCallee(Ast.Apply call) {
+        Ast.Expr callee = call.function();
+        // Where the callee is written, or where the application is where the callee says nowhere at
+        // all. A report about what is applied points somewhere either way, and an application the
+        // parser read is somewhere — so this is the choice between two answers already held, and
+        // not a place worked out from one of them.
+        Region at = callee.reportedAt();
+        return new Hir.AppliedCallee(dottedName(callee),
+                at != null ? at : Region.point(call.pos()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -13,7 +13,6 @@ import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.msg.NameMessage;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.msg.ModuleMessage;
-import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
@@ -1081,9 +1080,10 @@ public final class Resolve {
             // Applying a name is answered as a name: which of a binding, a helper, a library
             // function or a type it is decides what the application means. Applying anything else
             // is answered as the expression it is, and what may be applied is the check's to say.
-            case Ast.Apply call when call.appliesAName() -> applied(call, bound);
-            case Ast.Apply call -> Hir.Apply.read(call, callee(call.function(), bound),
-                    exprs(call.args(), bound));
+            case Ast.Apply call when call.function() instanceof Ast.Var callee ->
+                    applied(call, callee, bound);
+            case Ast.Apply call -> Hir.Apply.read(call, appliedCallee(call.function()),
+                    callee(call.function(), bound), exprs(call.args(), bound));
             // `Map.empty`, `String.isEmpty`, `up.Amount` — a namespace and a member of it, which
             // the parser read as a field taken off a name because it reads no case at all. Folded
             // here and nowhere earlier: `Map` may be a parameter, and a binding in force wins over
@@ -1214,24 +1214,42 @@ public final class Resolve {
 
     /** An application of a name, with what the name denotes and how this module reaches it answered
      * here — the same pair, from the same place, as a name standing on its own. */
-    private Hir.Expr applied(Ast.Apply call, InForce bound) {
-        ValueName denotes = calledName(call, bound);
+    private Hir.Expr applied(Ast.Apply call, Ast.Var callee, InForce bound) {
         // Answered rather than rebuilt: what the callee means is settled here and where it is
         // written is not this pass's to decide. Building one from the name would take its extent
         // from the characters that spell it, which is short of what a parenthesized callee covers.
-        WrittenName written = call.function() instanceof Ast.Var applied ? applied.written()
-                : call.name();
-        Region over = call.function() instanceof Ast.Var applied ? applied.region()
-                : written.region();
+        WrittenName written = callee.written();
+        ValueName denotes = calledName(written, bound);
         Hir.Var name;
         if (denotes == null) {
-            name = new Hir.Var.Unanswered(written, over);
+            name = new Hir.Var.Unanswered(written, callee.region());
         } else {
-            answered(call.name(), denotes);
+            answered(written, denotes);
             name = new Hir.Var.Denoting(written,
-                    ReachName.of(denotes, call.written(), reachable.module()), over);
+                    ReachName.of(denotes, written.canonical(), reachable.module()),
+                    callee.region());
         }
-        return Hir.Apply.read(call, name, exprs(call.args(), bound));
+        return Hir.Apply.read(call, appliedCallee(call.function()), name,
+                exprs(call.args(), bound));
+    }
+
+    /**
+     * What the author applied, as a report says it — the name they wrote in the callee position and
+     * the characters they wrote it over.
+     *
+     * <p>Read here and nowhere later. A lowering replaces what is applied, and every one of them
+     * leaves the characters where they are: a report that asked the callee afterwards would quote
+     * the binding, the operation or the qualified spelling a pass put there. Which of the shapes
+     * spells a name is {@link #dottedName}'s answer, which is the same one a field read written on
+     * its own gets.
+     *
+     * <p>The name is taken from the surface and not from what the callee resolved to. A member of a
+     * namespace is folded into a name and a field of a value is not, so the same source shape would
+     * be read two ways depending on what it turned out to reach — and what the author wrote is not
+     * a thing that turns on that.
+     */
+    private static Hir.AppliedCallee appliedCallee(Ast.Expr callee) {
+        return new Hir.AppliedCallee(dottedName(callee), callee.reportedAt());
     }
 
     /**
@@ -1514,11 +1532,11 @@ public final class Resolve {
      * what a miss means does not. A name that resolved to nothing resolved to nothing, and the
      * position it was written in is a fact about the source rather than about the name.
      */
-    private ValueName calledName(Ast.Apply call, InForce bound) {
-        return switch (lookup(call.name(), true, bound)) {
+    private ValueName calledName(WrittenName applied, InForce bound) {
+        return switch (lookup(applied, true, bound)) {
             case Reach.Reaches(ValueName named) -> named;
             case Reach.StandsForNothing _ -> unanswered();
-            case Reach.NotInScope _ -> nothing(unknownIdentifier(call.name(), bound));
+            case Reach.NotInScope _ -> nothing(unknownIdentifier(applied, bound));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -324,8 +324,12 @@ final class TotalityChecker {
                 walk(li.body(), group, paramNames, ltInner, eqInner, calls);
             }
             case Hir.Apply call -> {
+                // Named by what it reaches, which is what the group holds and what the definitions
+                // are keyed by. The spelling is what a report quotes: a helper of another module is
+                // written qualified where a reader reaches it and bare where its author wrote it,
+                // and the same call answers both.
                 if (call.answered() != null && group.contains(call.answered().reaches())) {
-                    calls.add(new RecCall(call.written(), call, lt, eq));
+                    calls.add(new RecCall(call.answered().reaches(), call, lt, eq));
                 }
                 Combinators.Written handed = Combinators.handedTo(call);
                 for (Hir.Expr arg : call.args()) {

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntFunction;
 
 /**
  * What the standard library declares: every operation's declaration and resolved signature, which
@@ -79,12 +80,62 @@ public final class Stdlib {
      * cannot be read without the rest of it, which is the ambient dependency this value exists to
      * end.
      *
-     * <p>A sugar supplies constants and nothing else, which is why {@code supplied} holds numbers;
-     * one that had to supply anything else could not be written down as this and would say so.
+     * <p>A sugar supplies constants and nothing else, which is why what it supplies is numbers; one
+     * that had to supply anything else could not be written down as this and would say so.
+     *
+     * <p>The constants are not handed out. Where they go is what this says and not something a
+     * caller works out from them: the arguments the author wrote keep the places they were written
+     * in and the supplied ones follow, which is what makes the numbering in a report about the call
+     * the author's own. Given the list, a caller could put them anywhere and every reader of a
+     * position — the report, the combinator's block argument, the reduction's seed — would be
+     * reading a different call from the one the author wrote. A sugar that has to supply an
+     * argument somewhere else cannot be written down as this, and the day one is wanted this is
+     * where it is said, beside what the numbering then means.
      */
-    public record Rewrite(ValueName.Stdlib.Operation target, List<Integer> supplied, int keptArgs) {
-        public Rewrite {
-            supplied = List.copyOf(supplied);
+    public static final class Rewrite {
+
+        private final ValueName.Stdlib.Operation target;
+        private final List<Integer> supplied;
+        private final int keptArgs;
+
+        Rewrite(ValueName.Stdlib.Operation target, List<Integer> supplied, int keptArgs) {
+            this.target = target;
+            this.supplied = List.copyOf(supplied);
+            this.keptArgs = keptArgs;
+        }
+
+        /** The operation the sugared name becomes. */
+        public ValueName.Stdlib.Operation target() {
+            return target;
+        }
+
+        /** How many of the target's arguments a call of the sugar writes — the prefix, so that an
+         *  argument the author counts to is the one the target takes at that position. */
+        public int keptArgs() {
+            return keptArgs;
+        }
+
+        /**
+         * The arguments of the call this rewrites to: the {@code written} ones where they were
+         * written, then the ones this supplies, each made by {@code supplying} from the constant it
+         * is.
+         *
+         * <p>Generic in what an argument is because two callers want two things of it. The pass
+         * writing the rewrite out wants expressions; a reader working out what a position of the
+         * target a written argument lands on wants the position. Both are this same placing, and
+         * a second statement of it is a second answer to where a supplied argument goes.
+         */
+        public <T> List<T> arguments(List<T> written, IntFunction<T> supplying) {
+            if (written.size() != keptArgs) {
+                throw new IllegalArgumentException("`" + target.qualified() + "` is written with "
+                        + keptArgs + " argument(s) where it is sugar, and this was given "
+                        + written.size());
+            }
+            List<T> all = new ArrayList<>(written);
+            for (int constant : supplied) {
+                all.add(supplying.apply(constant));
+            }
+            return List.copyOf(all);
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -1,6 +1,8 @@
 package souther.compiler;
 
+import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
+import souther.compiler.ast.WrittenName;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
@@ -317,11 +319,11 @@ class CompilePostfixApplicationTest {
                 new Hir.IntLit(1, at, null), souther.compiler.types.RuleOrigin.unwritten(), at, null),
                 java.util.List.of(), at, null);
 
-        assertTrue(named.appliesAName());
+        assertTrue(named.applied().isAName());
         assertEquals("List.map", named.written());
         assertEquals("List.map", named.answered().reaches());
 
-        assertFalse(nameless.appliesAName());
+        assertFalse(nameless.applied().isAName());
         assertEquals("", nameless.written(), "there is no spelling to quote");
         assertNull(nameless.answered(), "and no declaration to look up");
     }
@@ -331,18 +333,34 @@ class CompilePostfixApplicationTest {
      * application of something other than a name binds it first, so what this reaches is that
      * binding — and every table in the compiler is keyed by declarations, so a spelling reaching one
      * would be a miss that looked like a hit for whatever happened to be filed under it.
+     *
+     * <p>The rewrite is where the two part company, and it is the rewrite that keeps them together:
+     * what the author applied was settled when the application was read, and putting the binding in
+     * the callee position does not re-settle it.
      */
     @Test
     void whatAnApplicationReachesIsNeverTheSpellingAReportQuotes() {
         SourcePos at = new SourcePos(1, 1);
         BindingId id = new BindingId(new BindingOwner.OfValue("demo", "go"), 0);
         ValueName.Local fn0 = new ValueName.Local("$fn0", id);
-        Hir.Apply lowered = Hir.Apply.synthetic(
-                Hir.Var.denoting("$fn0", new ReachName.InScope(fn0), at),
-                java.util.List.of(), at, null).standingIn("d.count");
+        WrittenName applied = WrittenName.of("d", at)
+                .then(WrittenName.of("count", new SourcePos(1, 3)));
+        Hir.Apply lowered = readApplying(applied, at)
+                .replacedBy(Hir.Var.denoting("$fn0", new ReachName.InScope(fn0), at));
 
         assertEquals("d.count", lowered.written(), "a report quotes what the author wrote");
+        assertEquals(applied.region(), lowered.appliedAt(),
+                "and underlines the characters they wrote it over");
         assertEquals("$fn0", lowered.answered().reaches(),
                 "a table is looked up with the binding");
+    }
+
+    /** An application a source wrote, applying {@code applied} — as much of the reading as a
+     *  question about what a report quotes needs. */
+    private static Hir.Apply readApplying(WrittenName applied, SourcePos at) {
+        Ast.Expr callee = new Ast.Var(applied, applied.region());
+        return Hir.Apply.read(new Ast.Apply(callee, java.util.List.of(), at, null),
+                new Hir.AppliedCallee(applied, callee.reportedAt()),
+                new Hir.Var.Unanswered(applied, applied.region()), java.util.List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
+import souther.compiler.ast.WrittenName;
+import souther.compiler.diag.Region;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.SourceProvenance;
@@ -169,11 +171,40 @@ class ACopiedBodyIsReadAgainstAFileThisCompileHasTest {
         return out;
     }
 
+    /**
+     * Every coordinate {@code e} holds, and not only the one it stands at.
+     *
+     * <p>A node holds places besides its own: the occurrence of a name it applies, the stretch that
+     * name was applied over. Each of them is read by a report, so each of them is one of the
+     * coordinates this is about — and a walk that took the node's own would be answering about a
+     * projection of the tree while the claim is about the tree.
+     */
     private static void walk(Hir.Expr e, List<SourcePos> out) {
         if (e.pos() != null) {
             out.add(e.pos());
         }
+        if (e instanceof Hir.Apply call) {
+            placesIn(call.applied().name(), out);
+            starts(call.applied().at(), out);
+        }
         Hir.forEachChild(e, c -> walk(c, out));
+    }
+
+    /** Where {@code name} is written, or where a complaint about one nobody wrote belongs. */
+    private static void placesIn(WrittenName name, List<SourcePos> out) {
+        if (name == null) {
+            return;
+        }
+        name.segments().forEach(segment -> starts(segment, out));
+        if (name.anchor() != null) {
+            out.add(name.anchor());
+        }
+    }
+
+    private static void starts(Region region, List<SourcePos> out) {
+        if (region != null && region.start() != null) {
+            out.add(region.start());
+        }
     }
 
     private static List<SourcePos> positionsIn(Core e) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AReportQuotesTheNameTheAuthorAppliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReportQuotesTheNameTheAuthorAppliedTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A report about what a call applies quotes the name its author wrote, whatever a pass has since
+ * put in the callee position.
+ *
+ * <p>{@code List.fold} is sugar for {@code List.foldFrom} from index zero, and the rewrite runs
+ * before anything types the call. So every report about the call is written after the name the
+ * author wrote has been replaced — and the operation it was replaced with is one the library keeps
+ * to itself and takes another argument. A report quoting that sends its reader to look up a name
+ * they may not write, in a call of a length they did not make.
+ *
+ * <p>Three reports, because the rewrite is one and the readers are not. They go through one
+ * accessor today, and what they have in common is the question rather than the accessor: each is
+ * about what this call applies, and the answer to that was settled when the call was read.
+ *
+ * <p>The negative is what carries the test. {@code List.foldFrom} contains {@code List.fold}, so a
+ * report that quotes the operation passes a test that only looks for the sugar.
+ */
+class AReportQuotesTheNameTheAuthorAppliedTest {
+
+    /** What the author wrote at every call below. */
+    private static final String WROTE = "List.fold";
+
+    /** What the rewrite puts there: a private operation of the library, taking one argument more. */
+    private static final String STANDS_FOR = "List.foldFrom";
+
+    @Test
+    void whereTheStepAnswersSomethingTheAccumulatorCannotHold() {
+        quotesWhatWasWritten("""
+                module m
+
+                behavior tally : (xs: List<Int>) -> Int
+                let tally (xs) = List.fold((acc, x) -> "no", 0, xs)
+                """);
+    }
+
+    @Test
+    void whereAnArgumentIsNotWhatItsPositionTakes() {
+        quotesWhatWasWritten("""
+                module m
+
+                behavior tally : (xs: List<Int>) -> Int
+                let tally (xs) = List.fold((acc, x) -> acc + x, "seed", xs)
+                """);
+    }
+
+    @Test
+    void whereTheBlockItTakesIsNotWritten() {
+        quotesWhatWasWritten("""
+                module m
+
+                behavior tally : (xs: List<Int>) -> Int
+                let tally (xs) = List.fold(1, 0, xs)
+                """);
+    }
+
+    /**
+     * And the numbering is the author's too. The rewrite supplies its argument after the ones that
+     * were written, so an argument the author can count to is the one the report names.
+     */
+    @Test
+    void andAnArgumentIsNumberedAmongTheOnesThatWereWritten() {
+        CompileException refused = quotesWhatWasWritten("""
+                module m
+
+                behavior tally : (n: Int) -> Int
+                let tally (n) = List.fold((acc, x) -> acc + x, 0, n)
+                """);
+
+        assertTrue(refused.getMessage().contains("argument 3 of " + WROTE),
+                () -> "the list is the third of the three the author wrote: " + refused.getMessage());
+    }
+
+    private static CompileException quotesWhatWasWritten(String source) {
+        CompileException refused = refusing(source);
+
+        assertFalse(refused.getMessage().contains(STANDS_FOR),
+                () -> "`" + STANDS_FOR + "` is not a name this author wrote, nor one they may: "
+                        + refused.getMessage());
+        assertTrue(refused.getMessage().contains(WROTE),
+                () -> "and `" + WROTE + "` is what they did write: " + refused.getMessage());
+        return refused;
+    }
+
+    private static CompileException refusing(String source) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(source));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
@@ -85,8 +85,8 @@ class TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest {
             Set<String> reached = callsIn(callTo(sugar, rewrite.keptArgs()));
 
             assertEquals(Set.of(rewrite.target().qualified()), reached,
-                    sugar + " is " + rewrite.target().qualified() + " with "
-                            + rewrite.supplied().size() + " argument(s) supplied");
+                    sugar + " is " + rewrite.target().qualified()
+                            + " with the rest of its arguments supplied");
         });
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasAppliedAndWhatIsAppliedAreTwoAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasAppliedAndWhatIsAppliedAreTwoAnswersTest.java
@@ -1,0 +1,188 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.DefaultStdlib;
+import souther.compiler.ast.Ast;
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
+import souther.compiler.frontend.CstFrontend;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an author applied and what is applied now are two answers, and the first is not read off the
+ * second.
+ *
+ * <p>The states they differ in are the passes that replace what a call applies, and there are three.
+ * A field read applied is bound to a name of its own and the binding applied. A sugared library name
+ * becomes the operation it stands for. A helper of another module is written qualified where a
+ * reader reaches it. Each is written down here, because a law with no state that tells its two
+ * answers apart is a law two accessors could be collapsed under without anything moving.
+ *
+ * <p>The sugar is the one this began with and is
+ * {@link AReportQuotesTheNameTheAuthorAppliedTest}'s, where what a reader is told is the whole
+ * question. The other two are here.
+ *
+ * <p>And the applied answer is itself a pair, for a reason the same shape: a name the author
+ * parenthesized is written over fewer characters than it is applied over. Reading the second off
+ * the first is what putting them in one value rules out, so a state where they differ is written
+ * down too.
+ */
+class WhatWasAppliedAndWhatIsAppliedAreTwoAnswersTest {
+
+    /**
+     * A field read applied: the author applied something that is not a name, and a name is what is
+     * applied once the lowering has bound it.
+     *
+     * <p>Both are names after the lowering, and neither answer is the other's before it. Told apart
+     * by the node they are read from and not by which pass has run, which is what a reader holding
+     * one of these has to hand.
+     */
+    @Test
+    void aFieldReadAppliedIsANameTheAuthorDidNotApply() {
+        Hir.Apply read = theCallIn("""
+                module demo
+
+                data Deps = { count: (Int) -> Int }
+
+                behavior go : (d: Deps) -> Int
+                let go (d) = d.count(1)
+                """);
+
+        assertTrue(read.applied().isAName(), "`d.count` is a name, written as a chain of reads");
+        assertEquals("d.count", read.written());
+        assertFalse(read.calleeIsAName(), "and a field read is what stands in the callee position");
+
+        Hir.Apply lowered = read.replacedBy(binding("$fn0", read));
+
+        assertTrue(lowered.applied().isAName(), "what was applied is what it was");
+        assertEquals("d.count", lowered.written());
+        assertTrue(lowered.calleeIsAName(), "and a name is what is applied now");
+        assertNotEquals(lowered.written(), lowered.answered().reaches(),
+                "the two are not one answer, which is the whole of it");
+    }
+
+    /**
+     * A name the author parenthesized: written over the name and applied over the parentheses.
+     *
+     * <p>Both are the reading's, and the second is not the first widened by a rule. What the callee
+     * covers is whatever the source put there, and a report about what is applied underlines it.
+     */
+    @Test
+    void aParenthesizedNameIsAppliedOverMoreThanItIsWrittenOver() {
+        Hir.Apply read = theCallIn("""
+                module demo
+
+                data Deps = { f: (Int) -> Int }
+
+                behavior go : (d: Deps) -> Int
+                let go (d) = (d.f)(1)
+                """);
+
+        assertEquals("d.f", read.written());
+        assertNotEquals(read.applied().name().region(), read.appliedAt(),
+                "the parentheses are applied over and are not part of the name");
+        assertTrue(souther.compiler.diag.Region.encloses(read.appliedAt(),
+                        read.applied().name().region()),
+                "and what is applied over takes the name in");
+
+        Hir.Apply lowered = read.replacedBy(binding("$fn0", read));
+
+        assertEquals(read.appliedAt(), lowered.appliedAt(),
+                "a rewrite of what is applied moves no characters");
+        assertEquals(read.applied().name().region(), lowered.applied().name().region());
+    }
+
+    /**
+     * A helper of another module, reached by the qualified name a reader writes it under.
+     *
+     * <p>The author wrote it bare, an import having brought it in, and the pass that settles how a
+     * reader reaches it replaces the callee. A recursive one is lowered to a method rather than
+     * expanded, so the call is still a call where it is typed — which is where a reader is told
+     * about it.
+     */
+    @Test
+    void anImportedHelperIsReportedByTheNameItsCallerWrote() {
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SPINNING, """
+                        module order exposing ( Receipt, bill )
+
+                        import maths ( spin )
+
+                        data Receipt = { total: Int }
+
+                        behavior bill : (n: Int) -> Receipt constructs Receipt
+                        let bill (n) = Receipt { total = spin(n, n) }
+                        """)));
+
+        assertFalse(refused.getMessage().contains("maths.spin"),
+                () -> "the reader reaches it under that name and its author wrote another: "
+                        + refused.getMessage());
+        assertTrue(refused.getMessage().contains("`spin`"),
+                () -> "which is `spin`: " + refused.getMessage());
+    }
+
+    /** And the same where what is wrong is an argument rather than how many there are. */
+    @Test
+    void andWhereWhatIsWrongIsAnArgumentRatherThanTheirNumber() {
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SPINNING, """
+                        module order exposing ( Receipt, bill )
+
+                        import maths ( spin )
+
+                        data Receipt = { total: Int }
+
+                        behavior bill : (n: Int) -> Receipt constructs Receipt
+                        let bill (n) = Receipt { total = spin("no") }
+                        """)));
+
+        assertFalse(refused.getMessage().contains("maths.spin"), refused::getMessage);
+        assertTrue(refused.getMessage().contains("of spin"), refused::getMessage);
+    }
+
+    private static final String SPINNING = """
+            module maths exposing ( spin )
+
+            partial let spin (n: Int) : Int = if n == 0 then 0 else spin(n - 1)
+            """;
+
+    /** The one application {@code source} writes, as the reading answered it. */
+    private static Hir.Apply theCallIn(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        List<Hir.Apply> found = new ArrayList<>();
+        for (Hir.FnDef fn : Resolve.module(parsed, SyntaxSymbols.of(parsed, DefaultStdlib.get()))
+                .fns()) {
+            if (fn.body() instanceof Hir.FnBody.Written written) {
+                applicationsIn(written.expr(), found);
+            }
+        }
+        assertEquals(1, found.size(), "this test is about the one application the source writes");
+        return found.get(0);
+    }
+
+    private static void applicationsIn(Hir.Expr e, List<Hir.Apply> out) {
+        if (e instanceof Hir.Apply call) {
+            out.add(call);
+        }
+        TypeChecker.forEachChild(e, child -> applicationsIn(child, out));
+    }
+
+    /** A binding a lowering would put in the callee position, standing where the callee stood. */
+    private static Hir.Var binding(String name, Hir.Apply call) {
+        souther.compiler.types.ValueName.Local local = new souther.compiler.types.ValueName.Local(
+                name, new souther.compiler.types.BindingId(
+                        new souther.compiler.types.BindingOwner.OfValue("demo", "go"), 0));
+        return Hir.Var.respelled(name, new souther.compiler.types.ReachName.InScope(local),
+                call.function().pos(), call.function().region());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/stdlib/WhereASugarPutsWhatItSuppliesIsTheSugarsToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/stdlib/WhereASugarPutsWhatItSuppliesIsTheSugarsToSayTest.java
@@ -1,0 +1,64 @@
+package souther.compiler.stdlib;
+
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A sugar places the arguments it supplies, and a caller writing the rewrite out does not.
+ *
+ * <p>The arguments an author wrote keep the places they were written in and the supplied ones
+ * follow. That is what makes a report about the call the author's: {@code argument 3} of a call of
+ * {@code List.fold} is the third of the three they wrote, and the position a combinator's block or
+ * a reduction's seed is read at is the position it was written at. A caller handed the constants
+ * could put them anywhere, and every one of those readers would then be reading a call the author
+ * did not write.
+ *
+ * <p>So the placing is here, and a sugar that has to supply an argument somewhere else cannot be
+ * written down as a {@link Stdlib.Rewrite}. Wanting one is the occasion to say what a report's
+ * numbering then means, which is a decision and not a list to lengthen.
+ */
+class WhereASugarPutsWhatItSuppliesIsTheSugarsToSayTest {
+
+    private static final ValueName.Stdlib.Operation TARGET =
+            ValueName.Stdlib.operation("List", "foldFrom");
+
+    /** A sugar of three written arguments that supplies one more. */
+    private static final Stdlib.Rewrite FOLD = new Stdlib.Rewrite(TARGET, List.of(0), 3);
+
+    @Test
+    void whatWasWrittenKeepsItsPlaceAndWhatIsSuppliedFollows() {
+        assertEquals(List.of("step", "seed", "xs", "<0>"),
+                FOLD.arguments(List.of("step", "seed", "xs"), constant -> "<" + constant + ">"));
+    }
+
+    @Test
+    void andASugarSupplyingSeveralKeepsThemInTheOrderItSaysThem() {
+        Stdlib.Rewrite two = new Stdlib.Rewrite(TARGET, List.of(7, 9), 1);
+
+        assertEquals(List.of("a", "<7>", "<9>"),
+                two.arguments(List.of("a"), constant -> "<" + constant + ">"));
+    }
+
+    /**
+     * And a call written with another number of arguments is refused rather than placed.
+     *
+     * <p>Whether a call is the sugar at all is asked before this, of the number of arguments it was
+     * written with — the same comparison, and not the same question. That one decides whether the
+     * rewrite is taken; this one is the rewrite being handed something it cannot place, which is a
+     * caller that took it without asking.
+     */
+    @Test
+    void andACallOfAnotherLengthIsRefusedRatherThanPlaced() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FOLD.arguments(List.of("step", "seed"), constant -> "<" + constant + ">"));
+        assertThrows(IllegalArgumentException.class,
+                () -> FOLD.arguments(List.of("step", "seed", "xs", "0"),
+                        constant -> "<" + constant + ">"));
+    }
+}


### PR DESCRIPTION
Closes #1297.

## What the measurement said

The issue was written as an origin being lost: a rewrite replaces a sugared
library call with the operation it stands for, goes through the constructor for
an application no source wrote, and thereby answers that the body it stands in
composed it. A probe at the accounting that asks an application where it came
from says otherwise. Every call the rewrite is handed answers `own` at the
moment it runs, because the mark a value's substitution writes is written over
the whole expansion afterwards. The accounting does read what the rewrite
produces, and reads it correctly.

What the same choice does lose is observable. The reports at a sugared call
quote the operation the rewrite reached for, which is private to the library and
takes an argument more than the author wrote — including the one that suggests a
fix, which suggested a call of a length its reader cannot write.

## What is here

An application's applied callee — the name the author wrote and the characters
they wrote it over — is settled where the source is read and carried by every
rewrite of the application. No reader works it out from what is in the callee
position, which is where this went wrong: three passes replace what a call
applies, and only one of them carried the spelling, by a second call the others
had no reason to make. There is one crossing for the replacement now and it
takes no place to stand, a replacement standing where the thing it replaces
stood.

Two passes are fixed by that one law. The sugared library call quotes the sugar
the author wrote. A helper of another module, written qualified where a reader
reaches it, quotes the bare name its author wrote — which a reader was told the
qualified spelling of wherever a recursive one is left standing.

The class-file check that says who may settle an answer about a construction now
names the method that makes each call, the overload it reaches and how many it
makes. A row naming the class had covered both of `HelperInliner`'s uses, which
is how the second could be added and nothing move. Beside it, nothing outside
the package that declares these forms builds one directly.

And a sugar places the arguments it supplies rather than handing them out. The
arguments an author writes are a prefix of the target's and the constants
follow, which is what makes the numbering in a report the author's own; a sugar
that needs to supply one elsewhere cannot be written down this way, and wanting
one is the occasion to decide what a report's numbering then means.

## Read it commit by commit

The first commit changes no production code. It makes the violating call visible
as its own row in the authority graph — `HelperInliner#desugar` beside
`HelperInliner#etaExpand`, where one row had stood for both. The second removes
that row.

## What the states are

The last commit writes down the states the two answers differ in, which is what
the tests were short of: they had been written from the report that was wrong
rather than from the law that makes it right, so each fixed one answer where the
point is that there are two. The states are the passes that replace a callee —
a field read bound to a name of its own, a foreign helper written qualified, the
sugared library call — and the pair inside the applied answer, where a name
written inside parentheses is applied over them.

## Two lookups keyed by a spelling

Making the applied name the author's surfaced two readers that had been keyed by
it and had been finding the rewritten callee instead: the signature a call left
standing is typed against, and the definition a recursive call descends on. Both
now ask what the call reaches, which is the answer the membership test beside
each already used. A third consumer carried it rather than looking with it — the
read a call of a binding is emitted as — and it carries the binding's own name
again, as every other read of one is built with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)