### PR TITLE
Read every fact about an operation once, and hand down what the binding made

### DIFF
--- a/souther-bench/src/test/java/souther/bench/WhichArgumentAnOperationAnswersIsReadOutOfItsTableOnceTest.java
+++ b/souther-bench/src/test/java/souther/bench/WhichArgumentAnOperationAnswersIsReadOutOfItsTableOnceTest.java
@@ -41,12 +41,17 @@ class WhichArgumentAnOperationAnswersIsReadOutOfItsTableOnceTest {
      * declaring one and by holding it to a signature, which is not handing it to a reader. */
     private static final String FACTS = "souther.compiler.semantics.OperationFact";
 
+    /** The row types: one case of a definition, and one relation a case is reached under. Generic
+     * in their word for an argument, so the one shape is the authored row and the bound one. */
+    private static final Set<String> ROWS = Set.of("souther.compiler.semantics.DefinitionCase",
+            "souther.compiler.semantics.ArgumentsStand");
+
     private static final Set<String> DECLARING = Set.of(FACTS,
             "souther.compiler.semantics.OperationFacts",
-            "souther.compiler.check.OperationFactBinder");
-
-    /** The row types: one case of a definition, and one relation a case is reached under. */
-    private static final Set<String> ROWS = Set.of(FACTS + "$Case", FACTS + "$ArgumentsStand");
+            "souther.compiler.check.OperationFactBinder",
+            // A row reaches itself: its own equality and rendering read its parts.
+            "souther.compiler.semantics.DefinitionCase",
+            "souther.compiler.semantics.ArgumentsStand");
 
     @Test
     void nothingButTheChoiceItselfAsksWhatAnOperationChoosesBetween() throws IOException {

--- a/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
@@ -2,8 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.core.Core;
 import souther.compiler.semantics.Accumulation;
-import souther.compiler.semantics.ArgumentRef;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.types.ValueName;
 
 import java.util.Set;
@@ -12,11 +10,11 @@ import java.util.Set;
  * What a call to an accumulating operation walks, for a reader holding the call.
  *
  * <p>A reading and not a table. Which operations accumulate, and what walking one comes to, is a
- * proposition about the operation and is declared with the rest of them
- * ({@link OperationFacts#accumulation}); what is here is the part that depends on having a call in
- * hand — which of its arguments holds the elements. Held as a table of its own, the same operation
- * was stated twice as soon as a second reader wanted it, which is the shape every list of
- * operations in this compiler has already been through once.
+ * proposition about the operation and is declared with the rest of them and read from the binding
+ * ({@link BoundOperationFacts#accumulates}); what is here is the part that depends on having a call
+ * in hand — the expression standing where the fact says the elements are. Held as a table of its
+ * own, the same operation was stated twice as soon as a second reader wanted it, which is the shape
+ * every list of operations in this compiler has already been through once.
  *
  * <p>The sibling of {@link Reductions}, and separate for the reason that is separate from
  * {@link Combinators}. A reduction is handed the step it repeats and this is not: {@code List.sum}
@@ -43,32 +41,28 @@ final class Accumulations {
 
     /** What {@code operation} accumulates, or null where it accumulates nothing. */
     static Accumulation of(ValueName operation) {
-        return OperationFacts.accumulation(operation);
+        return DefaultBoundOperationFacts.get().accumulation(operation);
     }
 
     /**
      * What {@code call} accumulates and over what, or null where it accumulates nothing.
      *
-     * <p>Which argument holds the elements is the fact's to name, and finding it in this call is
-     * this method's. Worked out here from the signature instead — the argument whose elements are
-     * of the type the operation answers — a signature that fits twice would have to be refused
-     * somewhere, and the declaration already says which one it walks.
+     * <p>Which argument holds the elements is the fact's to name and the binder's to place, and
+     * finding it in this call is {@link CallArguments}'. Worked out here from the signature instead
+     * — the argument whose elements are of the type the operation answers — a signature that fits
+     * twice would have to be refused somewhere, and the declaration already says which one it walks.
      */
     static Accumulating accumulating(Core.PreservedCall call) {
-        Accumulation what = of(call.operation());
-        ArgumentRef container = OperationFacts.accumulatedContainer(call.operation());
-        if (what == null || container == null) {
-            return null;
-        }
-        int at = CallArguments.positionIn(container, call.operation());
-        return at < 0 || at >= call.args().size() ? null
-                : new Accumulating(what, call.args().get(at));
+        BoundOperationFact.AccumulatesItsContainer walk =
+                DefaultBoundOperationFacts.get().accumulates(call.operation());
+        return walk == null ? null
+                : new Accumulating(walk.how(), CallArguments.of(walk.container(), call));
     }
 
     /** The operations there is a rule about, for the check that a rule answers a question its
      * operation is asked. */
     static Set<ValueName> answered() {
-        return OperationFacts.accumulates();
+        return DefaultBoundOperationFacts.get().accumulates();
     }
 
     private Accumulations() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -701,7 +701,7 @@ public final class AffineForms {
     private static <A, E> LinearForm<A> answered(Core call, E at, Reading<A, E> reading,
                                                  java.util.Set<BindingId> following,
                                                  Stop<A, E> stopped) {
-        LinearForm<souther.compiler.semantics.ArgumentRef> says = formSaidOf(call);
+        LinearForm<DeclaredArgument> says = formSaidOf(call);
         java.util.List<Core> args = Terms.argsOf(call);
         // The expansion's own stops, kept off the walk's. What is inside a declared form is not
         // what an author wrote: the arguments stand where they stand because the library says the
@@ -709,9 +709,10 @@ public final class AffineForms {
         // met an expression an author would change — it has met this call.
         Stop<A, E> inside = new Stop<>();
         LinearForm<A> form = LinearForm.constant(says.constant());
-        for (Map.Entry<souther.compiler.semantics.ArgumentRef, BigDecimal> each
-                : says.coefs().entrySet()) {
-            int position = CallArguments.positionIn(each.getKey(), Terms.operationOf(call));
+        for (Map.Entry<DeclaredArgument, BigDecimal> each : says.coefs().entrySet()) {
+            // The call here may be the runnable tree's and not a kept one, so its argument count
+            // is checked here rather than by a kept call's own constructor.
+            int position = CallArguments.positionOf(each.getKey(), Terms.operationOf(call));
             if (position < 0 || position >= args.size()) {
                 return stoppedAtTheCall(call, at, stopped);
             }
@@ -749,7 +750,7 @@ public final class AffineForms {
      * read in holds it another, and the fact is about the operation either way; read off one shape,
      * the same statement would be composed in one representation and left a leaf in the other.
      */
-    private static LinearForm<souther.compiler.semantics.ArgumentRef> formSaidOf(Core e) {
+    private static LinearForm<DeclaredArgument> formSaidOf(Core e) {
         souther.compiler.types.ValueName operation = Terms.operationOf(e);
         return operation == null ? null : DischargeRules.answersAFormOf(operation);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
@@ -1,6 +1,19 @@
 package souther.compiler.check;
 
 import souther.compiler.core.DeclaredOperation;
+import souther.compiler.numeric.LinearForm;
+import souther.compiler.semantics.Accumulation;
+import souther.compiler.semantics.BuiltFrom;
+import souther.compiler.semantics.DefinitionCase;
+import souther.compiler.semantics.ElementShape;
+import souther.compiler.semantics.NumericResult;
+import souther.compiler.semantics.OperationSubject;
+import souther.compiler.semantics.ResultBound;
+import souther.compiler.semantics.TakenAs;
+import souther.compiler.types.Type;
+
+import java.math.BigDecimal;
+import java.util.Set;
 
 /**
  * A fact about an operation, once it has been held to the library that declares one.
@@ -10,20 +23,116 @@ import souther.compiler.core.DeclaredOperation;
  * about, an {@link souther.compiler.semantics.ArgumentRef} for an argument it names, another name
  * for an operation it relates this one to. None of those says the library has such an operation, or
  * that it takes an argument there, or that the two signatures let one stand for the other. That is
- * what {@link OperationFactBinder} settles against {@link souther.compiler.stdlib.Stdlib}.
+ * what {@link OperationFactBinder} settles against {@link souther.compiler.stdlib.Stdlib}, and
+ * these are what the facts come to once it has: every operation is a {@link DeclaredOperation} and
+ * every argument a {@link DeclaredArgument}, each read against its declaration.
  *
- * <p>This is what a fact comes to once it has. A reader below the binding holds one of these and
- * asks nothing further: the operations it names have been read against their declarations, so what
- * is left to do with one is to use it. A reader handed the authoring value instead would have the
- * name and the table and could put the same question again — and would get an answer that agrees
- * with the binder's for exactly as long as nobody changes either.
+ * <p>A reader below the binding holds one of these and asks nothing further. Handed the authoring
+ * value instead, it would have the name and the table and could put the same question again — and
+ * would get an answer that agrees with the binder's for exactly as long as nobody changes either.
  *
- * <p><b>One arm so far.</b> Every other kind of fact is still read from the authoring index below
- * the binding, and what holds those up is that the binder walks them all and refuses a declaration
- * that does not match. That is a check and not a carrier: the fact a reader goes on to read is the
- * one that was authored, not the one that was held.
+ * <p><b>One arm per kind of authored fact, and every arm names its operation.</b> The binder's
+ * switch over the authoring kinds is an expression yielding one of these, so a kind added there is
+ * a kind that does not compile until it says what it comes to bound. The operation is on every arm
+ * because that is what the fact is about, and it is the one thing a table of these is keyed by —
+ * read off the fact itself, so no key is ever written beside a value that could disagree with it.
+ *
+ * <p><b>Two families, and every arm is in one of them.</b> {@link OneAboutAnOperation} is a kind of
+ * which an operation carries at most one — a second declaration of it would be two answers to a
+ * question that has one, and is refused where these are collected. {@link SeveralAboutAnOperation}
+ * is a kind an operation states as many of as it states: two bounds are two facts. The family is
+ * chosen where the arm is written, so a kind added cannot leave whether it may repeat to whichever
+ * collector happens to receive it.
  */
-sealed interface BoundOperationFact {
+public sealed interface BoundOperationFact permits BoundOperationFact.OneAboutAnOperation,
+        BoundOperationFact.SeveralAboutAnOperation {
+
+    /** The operation this is about, read against its declaration. */
+    DeclaredOperation operation();
+
+    /** A kind of fact an operation carries at most one of. */
+    sealed interface OneAboutAnOperation extends BoundOperationFact {}
+
+    /** A kind of fact an operation may carry several of, each a statement of its own. */
+    sealed interface SeveralAboutAnOperation extends BoundOperationFact {}
+
+    /** What the operation answers, counted, is this form of what its arguments are counted as. */
+    record AnswersAFormOfItsArguments(DeclaredOperation operation,
+                                      LinearForm<DeclaredArgument> form)
+            implements OneAboutAnOperation {}
+
+    /** The sign of what the operation answers states which of these two arguments is the greater:
+     *  {@code greater} where the answer is positive, and the other one where it is negative. */
+    record StatesTheOrderOfItsArguments(DeclaredOperation operation, DeclaredArgument greater,
+                                        DeclaredArgument lesser)
+            implements OneAboutAnOperation {}
+
+    /** The operation answers the value at {@code of} moved by {@code amount}, and how far it moved
+     *  is {@code per} of what {@code measure} counts. */
+    record ShiftsBy(DeclaredOperation operation, DeclaredOperation measure, DeclaredArgument of,
+                    DeclaredArgument amount, BigDecimal per)
+            implements OneAboutAnOperation {}
+
+    /** The operation builds a container out of another, and this says where its elements came from
+     *  and how many of them there are. */
+    record BuildsItsResultFrom(DeclaredOperation operation, BuiltFrom<DeclaredArgument> built)
+            implements OneAboutAnOperation {}
+
+    /**
+     * The operation answers what {@code container} holds accumulated: started from an identity and
+     * carried through one step, both of the type the container's elements are — which the binding
+     * held to be the type the operation answers.
+     */
+    record AccumulatesItsContainer(DeclaredOperation operation, DeclaredArgument container,
+                                   Accumulation how)
+            implements OneAboutAnOperation {
+
+        /** The type the walk carries, which is what the container holds. */
+        public Type element() {
+            return Type.elementOfAContainer(container.stands());
+        }
+
+        /**
+         * This walk put as a way of taking a number of the one value it is given, or null where it
+         * is a walk this has no such reading of.
+         *
+         * <p>Only the walk that adds. A join carries an identity and a step as much as a sum does
+         * and answers a string; a product carries them and answers a number no term-reading takes.
+         * What is derived is one account and not the family, so the reading a term gets is one
+         * something can carry out — and a walk of another kind arriving is a walk nothing here
+         * claims to read.
+         *
+         * <p>Here and nowhere else. An accumulation over one container already says what the answer
+         * is — start from this, carry that — so an account declared beside it would be the same
+         * sentence in a second vocabulary, free to disagree about what a sum is. What reads it as a
+         * term reads it off the walk, through this.
+         */
+        public TakenAs takenAs() {
+            return how.identity() == Accumulation.Identity.ZERO
+                    && how.combine() == Accumulation.Combine.ADD
+                    ? new TakenAs.TheSumOfWhatItHolds() : null;
+        }
+    }
+
+    /** The operation is a predicate over what {@code container} holds, and its statement survives a
+     *  construction of the shapes in {@code through}. */
+    record ReadsItsContainer(DeclaredOperation operation, DeclaredArgument container,
+                             Set<ElementShape> through)
+            implements OneAboutAnOperation {
+
+        public ReadsItsContainer {
+            through = Set.copyOf(through);
+        }
+    }
+
+    /** The predicate is stated over a projection of each element, and {@code projection} is where
+     *  it is written. */
+    record IsStatedOverAProjection(DeclaredOperation operation, DeclaredArgument projection)
+            implements OneAboutAnOperation {}
+
+    /** The operation states its predicate of <em>every</em> element. */
+    record StatesItsPredicateOfEveryElement(DeclaredOperation operation)
+            implements OneAboutAnOperation {}
 
     /**
      * An emptiness check and the size it means, each read against its declaration.
@@ -34,6 +143,41 @@ sealed interface BoundOperationFact {
      * under which such a rewrite says the same thing — asked once, where both declarations are in
      * hand, rather than by the reader that has a call and a name.
      */
-    record MeansTheSameAsSizeOfNought(DeclaredOperation predicate, DeclaredOperation size)
-            implements BoundOperationFact {}
+    record MeansTheSameAsASizeOfNought(DeclaredOperation operation, DeclaredOperation size)
+            implements OneAboutAnOperation {}
+
+    /** The operation computes a number, and this says which arithmetic and where it answers it. */
+    record ComputesANumber(DeclaredOperation operation, NumericResult<DeclaredArgument> result)
+            implements OneAboutAnOperation {}
+
+    /** The operation answers a number taken of the one value it is given — {@code of}, the one
+     *  argument its declaration takes — and {@code how} is what it takes of it; {@code answers} is
+     *  the number it was held to answer. */
+    record AnswersANumberTakenOfTheOneValueItIsGiven(DeclaredOperation operation,
+                                                     DeclaredArgument of, Type answers,
+                                                     TakenAs how)
+            implements OneAboutAnOperation {}
+
+    /** Every number the operation could answer is one some value it could be given answers. */
+    record EveryAnswerItCanGiveHasASourceValue(DeclaredOperation operation)
+            implements OneAboutAnOperation {}
+
+    /** Something that holds of the number the operation answers, wherever it is called. One per
+     *  bound: an operation with two ends states two of these. */
+    record BoundsItsResult(DeclaredOperation operation, ResultBound<DeclaredArgument> bound)
+            implements SeveralAboutAnOperation {}
+
+    /** The operation's result is never smaller than what {@code container} holds. One per
+     *  container: {@code a ++ b} is as long as either half. */
+    record ResultIsNoSmallerThan(DeclaredOperation operation, DeclaredArgument container)
+            implements SeveralAboutAnOperation {}
+
+    /** One case of the definition the operation is written in. The cases of one operation are
+     *  exhaustive between them, in the order they are declared. */
+    record IsDefinedByCases(DeclaredOperation operation, DefinitionCase<DeclaredArgument> one)
+            implements SeveralAboutAnOperation {}
+
+    /** There is nothing to say of the operation under {@code subject}. One per subject. */
+    record SaysNothingOf(DeclaredOperation operation, OperationSubject subject)
+            implements SeveralAboutAnOperation {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
@@ -43,8 +43,18 @@ import java.util.Set;
  * is a kind an operation states as many of as it states: two bounds are two facts. The family is
  * chosen where the arm is written, so a kind added cannot leave whether it may repeat to whichever
  * collector happens to receive it.
+ *
+ * <p><b>Made by the binder and by nothing else.</b> One of these says a fact was held to the
+ * library, and that is true of a value only where the holding made it: an arm a reader wrote for
+ * itself would say the same thing about a fact nothing checked. So this package's, and the
+ * constructor of every arm is called by {@link OperationFactBinder} alone — counted from the class
+ * files ({@code OnlyTheBinderReadsTheAuthoringVocabularyTest}) rather than trusted to a modifier,
+ * since a name this package can reach is a name this package can call. The same is held of what
+ * the arguments are made of ({@link DeclaredArgument}) and of what the arms are gathered into
+ * ({@link BoundOperationFacts}), so the three steps from an authored fact to a fact a reader holds
+ * are each taken in one place.
  */
-public sealed interface BoundOperationFact permits BoundOperationFact.OneAboutAnOperation,
+sealed interface BoundOperationFact permits BoundOperationFact.OneAboutAnOperation,
         BoundOperationFact.SeveralAboutAnOperation {
 
     /** The operation this is about, read against its declaration. */

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFact.java
@@ -177,7 +177,9 @@ public sealed interface BoundOperationFact permits BoundOperationFact.OneAboutAn
     record IsDefinedByCases(DeclaredOperation operation, DefinitionCase<DeclaredArgument> one)
             implements SeveralAboutAnOperation {}
 
-    /** There is nothing to say of the operation under {@code subject}. One per subject. */
+    /** There is nothing to say of the operation under {@code subject}. As many as there are
+     *  subjects it is silent under, and one per subject — a second under one subject is refused
+     *  where the silences are gathered ({@link BoundOperationFacts}). */
     record SaysNothingOf(DeclaredOperation operation, OperationSubject subject)
             implements SeveralAboutAnOperation {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
@@ -69,7 +69,9 @@ public final class BoundOperationFacts {
     private final Map<ValueName, List<DefinitionCase<DeclaredArgument>>> cases;
     private final Map<OperationSubject, Set<ValueName>> silences;
 
-    /** Made by the binder and by nothing else: what these are is what a binding came to. */
+    /** Made by the binder and by nothing else: what these are is what a binding came to, and a
+     *  set of facts gathered anywhere else would say so of facts nothing bound. Counted from the
+     *  class files, as the arms' own constructors are. */
     BoundOperationFacts(List<BoundOperationFact> bound) {
         this.held = List.copyOf(bound);
         for (BoundOperationFact fact : held) {

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * What one binding of the declarations came to: every fact about the language's operations, held to
@@ -50,6 +51,10 @@ import java.util.Set;
  * that has one, and a map written into keeps whichever arrived last. A
  * {@link BoundOperationFact.SeveralAboutAnOperation} is appended, in the order declared. Which of
  * the two a kind is was chosen where the arm was written, so nothing here has to be told.
+ *
+ * <p>Filed once, at construction, into what each query answers with. A query is asked per
+ * expression per pass, so what it hands back is the list that was filed and not a projection made
+ * for the ask.
  */
 public final class BoundOperationFacts {
 
@@ -59,7 +64,10 @@ public final class BoundOperationFacts {
     private final Map<Class<? extends BoundOperationFact.SeveralAboutAnOperation>,
             Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>>> several =
             new LinkedHashMap<>();
-    private final Map<OperationSubject, Set<ValueName>> silences = new LinkedHashMap<>();
+    private final Map<ValueName, List<ResultBound<DeclaredArgument>>> bounds;
+    private final Map<ValueName, List<DeclaredArgument>> noSmallerThan;
+    private final Map<ValueName, List<DefinitionCase<DeclaredArgument>>> cases;
+    private final Map<OperationSubject, Set<ValueName>> silences;
 
     /** Made by the binder and by nothing else: what these are is what a binding came to. */
     BoundOperationFacts(List<BoundOperationFact> bound) {
@@ -80,10 +88,53 @@ public final class BoundOperationFacts {
                         several.computeIfAbsent(many.getClass(), _ -> new LinkedHashMap<>())
                                 .computeIfAbsent(key, _ -> new ArrayList<>()).add(many);
             }
-            if (fact instanceof BoundOperationFact.SaysNothingOf silence) {
-                silences.computeIfAbsent(silence.subject(), _ -> new LinkedHashSet<>()).add(key);
-            }
         }
+        // What each query over a family answers with, projected once from what was filed.
+        bounds = projected(BoundOperationFact.BoundsItsResult.class,
+                BoundOperationFact.BoundsItsResult::bound);
+        noSmallerThan = projected(BoundOperationFact.ResultIsNoSmallerThan.class,
+                BoundOperationFact.ResultIsNoSmallerThan::container);
+        cases = projected(BoundOperationFact.IsDefinedByCases.class,
+                BoundOperationFact.IsDefinedByCases::one);
+        silences = silences();
+    }
+
+    /** The facts of {@code kind} an operation carries, each read as {@code part}, by operation. */
+    private <F extends BoundOperationFact.SeveralAboutAnOperation, V> Map<ValueName, List<V>>
+            projected(Class<F> kind, Function<F, V> part) {
+        Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>> byOperation =
+                several.getOrDefault(kind, Map.of());
+        Map<ValueName, List<V>> out = new LinkedHashMap<>();
+        byOperation.forEach((operation, facts) -> {
+            List<V> parts = new ArrayList<>(facts.size());
+            facts.forEach(each -> parts.add(part.apply(kind.cast(each))));
+            out.put(operation, List.copyOf(parts));
+        });
+        return Collections.unmodifiableMap(out);
+    }
+
+    /**
+     * The silences by what they are about, read off the filed facts.
+     *
+     * <p>A silence is a fact an operation carries several of — one per subject — so it is filed
+     * with that family and this is a second reading of the same list, by the subject a reader asks
+     * under. Two silences of one operation under one subject are refused here: the family admits
+     * several of a kind, and this is where what several may not be is said.
+     */
+    private Map<OperationSubject, Set<ValueName>> silences() {
+        Map<OperationSubject, Set<ValueName>> out = new LinkedHashMap<>();
+        several.getOrDefault(BoundOperationFact.SaysNothingOf.class, Map.of())
+                .forEach((operation, facts) -> facts.forEach(each -> {
+                    OperationSubject subject =
+                            ((BoundOperationFact.SaysNothingOf) each).subject();
+                    if (!out.computeIfAbsent(subject, _ -> new LinkedHashSet<>())
+                            .add(operation)) {
+                        throw new IllegalStateException(operation
+                                + " is declared to say nothing under " + subject + " twice");
+                    }
+                }));
+        out.replaceAll((_, named) -> Collections.unmodifiableSet(named));
+        return Collections.unmodifiableMap(out);
     }
 
     /**
@@ -111,27 +162,6 @@ public final class BoundOperationFacts {
 
     private Set<ValueName> ones(Class<? extends BoundOperationFact.OneAboutAnOperation> kind) {
         Map<ValueName, BoundOperationFact.OneAboutAnOperation> byOperation = ones.get(kind);
-        return byOperation == null ? Set.of() : Collections.unmodifiableSet(byOperation.keySet());
-    }
-
-    private <F extends BoundOperationFact.SeveralAboutAnOperation> List<F> several(
-            Class<F> kind, ValueName operation) {
-        Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>> byOperation =
-                several.get(kind);
-        List<BoundOperationFact.SeveralAboutAnOperation> held =
-                byOperation == null || operation == null ? null : byOperation.get(operation);
-        if (held == null) {
-            return List.of();
-        }
-        List<F> out = new ArrayList<>(held.size());
-        held.forEach(each -> out.add(kind.cast(each)));
-        return Collections.unmodifiableList(out);
-    }
-
-    private Set<ValueName> several(
-            Class<? extends BoundOperationFact.SeveralAboutAnOperation> kind) {
-        Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>> byOperation =
-                several.get(kind);
         return byOperation == null ? Set.of() : Collections.unmodifiableSet(byOperation.keySet());
     }
 
@@ -173,15 +203,12 @@ public final class BoundOperationFacts {
     /** What holds of the number {@code operation} answers, wherever it is called, in the order
      *  declared. */
     public List<ResultBound<DeclaredArgument>> boundsOnTheResult(ValueName operation) {
-        List<ResultBound<DeclaredArgument>> out = new ArrayList<>();
-        several(BoundOperationFact.BoundsItsResult.class, operation)
-                .forEach(each -> out.add(each.bound()));
-        return Collections.unmodifiableList(out);
+        return operation == null ? List.of() : bounds.getOrDefault(operation, List.of());
     }
 
     /** The operations something holds of the result of. */
     public Set<ValueName> boundsOnTheResult() {
-        return several(BoundOperationFact.BoundsItsResult.class);
+        return bounds.keySet();
     }
 
     /** What {@code operation} builds its result from, or null where it builds none. */
@@ -198,10 +225,7 @@ public final class BoundOperationFacts {
 
     /** The containers {@code operation}'s result is never smaller than, in the order declared. */
     public List<DeclaredArgument> resultIsNoSmallerThan(ValueName operation) {
-        List<DeclaredArgument> out = new ArrayList<>();
-        several(BoundOperationFact.ResultIsNoSmallerThan.class, operation)
-                .forEach(each -> out.add(each.container()));
-        return Collections.unmodifiableList(out);
+        return operation == null ? List.of() : noSmallerThan.getOrDefault(operation, List.of());
     }
 
     /** Where {@code operation} reads the container its predicate is about, or null where it is no
@@ -265,21 +289,17 @@ public final class BoundOperationFacts {
     /** The cases {@code operation}'s definition is written in, in the order declared, or an empty
      *  list where it answers none of the values it was given. */
     public List<DefinitionCase<DeclaredArgument>> isDefinedByCases(ValueName operation) {
-        List<DefinitionCase<DeclaredArgument>> out = new ArrayList<>();
-        several(BoundOperationFact.IsDefinedByCases.class, operation)
-                .forEach(each -> out.add(each.one()));
-        return Collections.unmodifiableList(out);
+        return operation == null ? List.of() : cases.getOrDefault(operation, List.of());
     }
 
     /** The operations that answer one of the values they were given. */
     public Set<ValueName> isDefinedByCases() {
-        return several(BoundOperationFact.IsDefinedByCases.class);
+        return cases.keySet();
     }
 
     /** The operations declared to say nothing under {@code subject}. */
     public Set<ValueName> saysNothingOf(OperationSubject subject) {
-        Set<ValueName> held = silences.get(subject);
-        return held == null ? Set.of() : Collections.unmodifiableSet(held);
+        return silences.getOrDefault(subject, Set.of());
     }
 
     /** What walking {@code operation}'s container comes to, and over which argument — or null where

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
@@ -53,7 +53,7 @@ import java.util.Set;
  */
 public final class BoundOperationFacts {
 
-    private final List<BoundOperationFact> all;
+    private final List<BoundOperationFact> held;
     private final Map<Class<? extends BoundOperationFact.OneAboutAnOperation>,
             Map<ValueName, BoundOperationFact.OneAboutAnOperation>> ones = new LinkedHashMap<>();
     private final Map<Class<? extends BoundOperationFact.SeveralAboutAnOperation>,
@@ -63,8 +63,8 @@ public final class BoundOperationFacts {
 
     /** Made by the binder and by nothing else: what these are is what a binding came to. */
     BoundOperationFacts(List<BoundOperationFact> bound) {
-        this.all = List.copyOf(bound);
-        for (BoundOperationFact fact : all) {
+        this.held = List.copyOf(bound);
+        for (BoundOperationFact fact : held) {
             ValueName key = fact.operation().operation();
             // No default. A family added is a family this has to say how to collect.
             switch (fact) {
@@ -86,9 +86,20 @@ public final class BoundOperationFacts {
         }
     }
 
-    /** Every bound fact, in the order the declarations were held. */
-    public List<BoundOperationFact> all() {
-        return all;
+    /**
+     * Every bound fact, in the order the declarations were held.
+     *
+     * <p>This package's and not everybody's, and read by two callers — the binder, which asks what
+     * it has just bound before publishing it, and {@link NumericReadings}, which counts the
+     * representations of a number across every kind of fact — and
+     * {@code OnlyTheBinderReadsTheAuthoringVocabularyTest} counts them. Published, this would be
+     * a way for a reader to sort the facts for itself and arrive at a second reading of what one
+     * of the queries above already answers: a reader that picked the walks out of the list and
+     * decided which of them add would own, beside {@link #takenAs}, the question of what a sum
+     * is.
+     */
+    List<BoundOperationFact> all() {
+        return held;
     }
 
     private <F extends BoundOperationFact.OneAboutAnOperation> F one(Class<F> kind,

--- a/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BoundOperationFacts.java
@@ -1,0 +1,345 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.LinearForm;
+import souther.compiler.semantics.Accumulation;
+import souther.compiler.semantics.BuiltFrom;
+import souther.compiler.semantics.DefinitionCase;
+import souther.compiler.semantics.NumericResult;
+import souther.compiler.semantics.OperationSubject;
+import souther.compiler.semantics.ResultBound;
+import souther.compiler.semantics.TakenAs;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What one binding of the declarations came to: every fact about the language's operations, held to
+ * a library, keyed by the operation each is about.
+ *
+ * <p>The one place a fact is looked up. The declarations ({@link
+ * souther.compiler.semantics.OperationFacts}) publish a list and no index, so that a reader cannot
+ * reach a fact except through what the binder made of it; this is what the binder makes, and a
+ * reader that wants a fact asks here. Every value here is a {@link BoundOperationFact}, in which
+ * every operation and every argument has already been read against its declaration, so what a
+ * reader does with one is use it.
+ *
+ * <p><b>Keyed by the fact's own operation, and by a name.</b> The key under which a fact is filed is
+ * read off the fact — {@code fact.operation().operation()} — and never written beside it, so no key
+ * can say the fact is about one operation while the fact says another. And it is the name, because
+ * that is the identity of a declaration ({@link souther.compiler.core.DeclaredOperation#equals}) and
+ * because a reader holding a call the language resolved but did not keep standing has the name and
+ * nothing else. Asking by name is a lookup among values the binding made and not a second reading of
+ * the authored word: nothing here reads a declaration, a signature, or an {@link
+ * souther.compiler.semantics.ArgumentRef}, and nothing here can be answered for an operation the
+ * binding did not hold.
+ *
+ * <p><b>Bound to bound, and nothing else.</b> The two answers here that are not a plain lookup —
+ * what an operation takes of its argument, which operations answer a number taken of one — are put
+ * together from bound facts and the derivation those facts carry themselves
+ * ({@link BoundOperationFact.AccumulatesItsContainer#takenAs}). No library and no authoring
+ * vocabulary is read to answer them, so what they say cannot come apart from what was held.
+ *
+ * <p>Collected by family. A {@link BoundOperationFact.OneAboutAnOperation} is filed under its
+ * operation once and a second of the same kind is refused: it would be two answers to a question
+ * that has one, and a map written into keeps whichever arrived last. A
+ * {@link BoundOperationFact.SeveralAboutAnOperation} is appended, in the order declared. Which of
+ * the two a kind is was chosen where the arm was written, so nothing here has to be told.
+ */
+public final class BoundOperationFacts {
+
+    private final List<BoundOperationFact> all;
+    private final Map<Class<? extends BoundOperationFact.OneAboutAnOperation>,
+            Map<ValueName, BoundOperationFact.OneAboutAnOperation>> ones = new LinkedHashMap<>();
+    private final Map<Class<? extends BoundOperationFact.SeveralAboutAnOperation>,
+            Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>>> several =
+            new LinkedHashMap<>();
+    private final Map<OperationSubject, Set<ValueName>> silences = new LinkedHashMap<>();
+
+    /** Made by the binder and by nothing else: what these are is what a binding came to. */
+    BoundOperationFacts(List<BoundOperationFact> bound) {
+        this.all = List.copyOf(bound);
+        for (BoundOperationFact fact : all) {
+            ValueName key = fact.operation().operation();
+            // No default. A family added is a family this has to say how to collect.
+            switch (fact) {
+                case BoundOperationFact.OneAboutAnOperation one -> {
+                    Map<ValueName, BoundOperationFact.OneAboutAnOperation> byOperation =
+                            ones.computeIfAbsent(one.getClass(), _ -> new LinkedHashMap<>());
+                    if (byOperation.put(key, one) != null) {
+                        throw new IllegalStateException(key + " is declared to "
+                                + one.getClass().getSimpleName() + " twice");
+                    }
+                }
+                case BoundOperationFact.SeveralAboutAnOperation many ->
+                        several.computeIfAbsent(many.getClass(), _ -> new LinkedHashMap<>())
+                                .computeIfAbsent(key, _ -> new ArrayList<>()).add(many);
+            }
+            if (fact instanceof BoundOperationFact.SaysNothingOf silence) {
+                silences.computeIfAbsent(silence.subject(), _ -> new LinkedHashSet<>()).add(key);
+            }
+        }
+    }
+
+    /** Every bound fact, in the order the declarations were held. */
+    public List<BoundOperationFact> all() {
+        return all;
+    }
+
+    private <F extends BoundOperationFact.OneAboutAnOperation> F one(Class<F> kind,
+                                                                    ValueName operation) {
+        Map<ValueName, BoundOperationFact.OneAboutAnOperation> byOperation = ones.get(kind);
+        return byOperation == null || operation == null ? null
+                : kind.cast(byOperation.get(operation));
+    }
+
+    private Set<ValueName> ones(Class<? extends BoundOperationFact.OneAboutAnOperation> kind) {
+        Map<ValueName, BoundOperationFact.OneAboutAnOperation> byOperation = ones.get(kind);
+        return byOperation == null ? Set.of() : Collections.unmodifiableSet(byOperation.keySet());
+    }
+
+    private <F extends BoundOperationFact.SeveralAboutAnOperation> List<F> several(
+            Class<F> kind, ValueName operation) {
+        Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>> byOperation =
+                several.get(kind);
+        List<BoundOperationFact.SeveralAboutAnOperation> held =
+                byOperation == null || operation == null ? null : byOperation.get(operation);
+        if (held == null) {
+            return List.of();
+        }
+        List<F> out = new ArrayList<>(held.size());
+        held.forEach(each -> out.add(kind.cast(each)));
+        return Collections.unmodifiableList(out);
+    }
+
+    private Set<ValueName> several(
+            Class<? extends BoundOperationFact.SeveralAboutAnOperation> kind) {
+        Map<ValueName, List<BoundOperationFact.SeveralAboutAnOperation>> byOperation =
+                several.get(kind);
+        return byOperation == null ? Set.of() : Collections.unmodifiableSet(byOperation.keySet());
+    }
+
+    /** What {@code operation} answers, counted, in what its arguments are counted as — or null
+     *  where it states no such form. */
+    public LinearForm<DeclaredArgument> answersAFormOfItsArguments(ValueName operation) {
+        BoundOperationFact.AnswersAFormOfItsArguments held =
+                one(BoundOperationFact.AnswersAFormOfItsArguments.class, operation);
+        return held == null ? null : held.form();
+    }
+
+    /** The operations declared to answer a form of their arguments. */
+    public Set<ValueName> answersAFormOfItsArguments() {
+        return ones(BoundOperationFact.AnswersAFormOfItsArguments.class);
+    }
+
+    /** Which of {@code operation}'s two arguments a positive answer names as the greater, or null
+     *  where the sign of what it answers is not their order. */
+    public BoundOperationFact.StatesTheOrderOfItsArguments statesTheOrderOfItsArguments(
+            ValueName operation) {
+        return one(BoundOperationFact.StatesTheOrderOfItsArguments.class, operation);
+    }
+
+    /** The operations whose answer states the order of their arguments. */
+    public Set<ValueName> statesTheOrderOfItsArguments() {
+        return ones(BoundOperationFact.StatesTheOrderOfItsArguments.class);
+    }
+
+    /** How {@code operation} moves the value it is given, or null where it moves none. */
+    public BoundOperationFact.ShiftsBy shiftsBy(ValueName operation) {
+        return one(BoundOperationFact.ShiftsBy.class, operation);
+    }
+
+    /** The operations that move a value by an amount. */
+    public Set<ValueName> shiftsBy() {
+        return ones(BoundOperationFact.ShiftsBy.class);
+    }
+
+    /** What holds of the number {@code operation} answers, wherever it is called, in the order
+     *  declared. */
+    public List<ResultBound<DeclaredArgument>> boundsOnTheResult(ValueName operation) {
+        List<ResultBound<DeclaredArgument>> out = new ArrayList<>();
+        several(BoundOperationFact.BoundsItsResult.class, operation)
+                .forEach(each -> out.add(each.bound()));
+        return Collections.unmodifiableList(out);
+    }
+
+    /** The operations something holds of the result of. */
+    public Set<ValueName> boundsOnTheResult() {
+        return several(BoundOperationFact.BoundsItsResult.class);
+    }
+
+    /** What {@code operation} builds its result from, or null where it builds none. */
+    public BuiltFrom<DeclaredArgument> buildsItsResultFrom(ValueName operation) {
+        BoundOperationFact.BuildsItsResultFrom held =
+                one(BoundOperationFact.BuildsItsResultFrom.class, operation);
+        return held == null ? null : held.built();
+    }
+
+    /** The operations that build a container out of another. */
+    public Set<ValueName> buildsItsResultFrom() {
+        return ones(BoundOperationFact.BuildsItsResultFrom.class);
+    }
+
+    /** The containers {@code operation}'s result is never smaller than, in the order declared. */
+    public List<DeclaredArgument> resultIsNoSmallerThan(ValueName operation) {
+        List<DeclaredArgument> out = new ArrayList<>();
+        several(BoundOperationFact.ResultIsNoSmallerThan.class, operation)
+                .forEach(each -> out.add(each.container()));
+        return Collections.unmodifiableList(out);
+    }
+
+    /** Where {@code operation} reads the container its predicate is about, or null where it is no
+     *  such predicate. */
+    public BoundOperationFact.ReadsItsContainer readsItsContainer(ValueName operation) {
+        return one(BoundOperationFact.ReadsItsContainer.class, operation);
+    }
+
+    /** The operations that are predicates over what a container holds. */
+    public Set<ValueName> readsItsContainer() {
+        return ones(BoundOperationFact.ReadsItsContainer.class);
+    }
+
+    /** Where {@code operation}'s predicate is stated over a projection, or null where it is stated
+     *  over the element itself. */
+    public DeclaredArgument isStatedOverAProjection(ValueName operation) {
+        BoundOperationFact.IsStatedOverAProjection held =
+                one(BoundOperationFact.IsStatedOverAProjection.class, operation);
+        return held == null ? null : held.projection();
+    }
+
+    /** The operations whose predicate is stated over a projection. */
+    public Set<ValueName> isStatedOverAProjection() {
+        return ones(BoundOperationFact.IsStatedOverAProjection.class);
+    }
+
+    /** Whether {@code operation} states its predicate of every element. */
+    public boolean statesItsPredicateOfEveryElement(ValueName operation) {
+        return one(BoundOperationFact.StatesItsPredicateOfEveryElement.class, operation) != null;
+    }
+
+    /** The operations that do. */
+    public Set<ValueName> statesItsPredicateOfEveryElement() {
+        return ones(BoundOperationFact.StatesItsPredicateOfEveryElement.class);
+    }
+
+    /** The rewrite an emptiness check stands for, or null where {@code operation} is not one. */
+    public BoundOperationFact.MeansTheSameAsASizeOfNought meansTheSameAsASizeOfNought(
+            ValueName operation) {
+        return one(BoundOperationFact.MeansTheSameAsASizeOfNought.class, operation);
+    }
+
+    /** The emptiness checks. */
+    public Set<ValueName> meansTheSameAsASizeOfNought() {
+        return ones(BoundOperationFact.MeansTheSameAsASizeOfNought.class);
+    }
+
+    /** What {@code operation} computes and where it answers it, or null where it computes no
+     *  arithmetic of its own. */
+    public NumericResult<DeclaredArgument> computesANumber(ValueName operation) {
+        BoundOperationFact.ComputesANumber held =
+                one(BoundOperationFact.ComputesANumber.class, operation);
+        return held == null ? null : held.result();
+    }
+
+    /** The operations that compute arithmetic of their own. */
+    public Set<ValueName> computesANumber() {
+        return ones(BoundOperationFact.ComputesANumber.class);
+    }
+
+    /** The cases {@code operation}'s definition is written in, in the order declared, or an empty
+     *  list where it answers none of the values it was given. */
+    public List<DefinitionCase<DeclaredArgument>> isDefinedByCases(ValueName operation) {
+        List<DefinitionCase<DeclaredArgument>> out = new ArrayList<>();
+        several(BoundOperationFact.IsDefinedByCases.class, operation)
+                .forEach(each -> out.add(each.one()));
+        return Collections.unmodifiableList(out);
+    }
+
+    /** The operations that answer one of the values they were given. */
+    public Set<ValueName> isDefinedByCases() {
+        return several(BoundOperationFact.IsDefinedByCases.class);
+    }
+
+    /** The operations declared to say nothing under {@code subject}. */
+    public Set<ValueName> saysNothingOf(OperationSubject subject) {
+        Set<ValueName> held = silences.get(subject);
+        return held == null ? Set.of() : Collections.unmodifiableSet(held);
+    }
+
+    /** What walking {@code operation}'s container comes to, and over which argument — or null where
+     *  it accumulates nothing, including where the name is no operation of the library. */
+    public BoundOperationFact.AccumulatesItsContainer accumulates(ValueName operation) {
+        return one(BoundOperationFact.AccumulatesItsContainer.class, operation);
+    }
+
+    /** What walking {@code operation}'s container comes to, or null where it accumulates nothing. */
+    public Accumulation accumulation(ValueName operation) {
+        BoundOperationFact.AccumulatesItsContainer held = accumulates(operation);
+        return held == null ? null : held.how();
+    }
+
+    /** The operations that answer what a container holds accumulated. */
+    public Set<ValueName> accumulates() {
+        return ones(BoundOperationFact.AccumulatesItsContainer.class);
+    }
+
+    /**
+     * What {@code operation} takes of the one value it is given, or null where the number it
+     * answers is not taken of one value.
+     *
+     * <p>Declared, or read off the walk where the operation is one — and the second is the walk's
+     * own reading ({@link BoundOperationFact.AccumulatesItsContainer#takenAs}), put beside the first
+     * here so that a reader asks one question. That the two cannot both hold of one operation is
+     * held where the declarations are bound ({@link NumericReadings}).
+     */
+    public TakenAs takenAs(ValueName operation) {
+        BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven declared =
+                one(BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven.class, operation);
+        if (declared != null) {
+            return declared.how();
+        }
+        BoundOperationFact.AccumulatesItsContainer walk = accumulates(operation);
+        return walk == null ? null : walk.takenAs();
+    }
+
+    /**
+     * The operations that answer a number taken of the one value they are given.
+     *
+     * <p>The ones {@link #takenAs} answers for, which is not the same as the ones an account is
+     * declared of: a walk that adds up a container is read as one and its account is that walk.
+     */
+    public Set<ValueName> answersANumberTakenOfItsArgument() {
+        Set<ValueName> out = new LinkedHashSet<>(
+                ones(BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven.class));
+        for (ValueName operation : accumulates()) {
+            if (takenAs(operation) != null) {
+                out.add(operation);
+            }
+        }
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** The operations that count what they are given, which is the narrower vocabulary a size is
+     *  asked for under. Read off the account rather than declared beside it. */
+    public Set<ValueName> countsWhatItIsGiven() {
+        Set<ValueName> out = new LinkedHashSet<>();
+        for (ValueName operation
+                : ones(BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven.class)) {
+            if (takenAs(operation) instanceof TakenAs.HowManyItHolds) {
+                out.add(operation);
+            }
+        }
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** Whether every number {@code operation} could answer is one some value it could be given
+     *  answers. */
+    public boolean everyAnswerItCanGiveHasASourceValue(ValueName operation) {
+        return one(BoundOperationFact.EveryAnswerItCanGiveHasASourceValue.class, operation) != null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/CallArguments.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallArguments.java
@@ -1,8 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.core.Core;
-import souther.compiler.semantics.ArgumentRef;
-import souther.compiler.semantics.Combinator;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.types.ValueName;
 
@@ -10,55 +8,39 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The argument a fact about an operation names, found in a call to it.
+ * The argument a bound fact names, found in a call to the operation the fact is about.
  *
- * <p>Between the word and the call. What {@link ArgumentRef#TheContainer} and
- * {@link ArgumentRef#TheClosure} are positions of is read off the library's own declaration
- * ({@link Combinators}), and a fact that had to reach for that to say which argument it is about
- * would be a fact written where name resolution can be seen — which is the arrangement the
- * declarations were moved out of.
+ * <p>Between the fact and the call. A {@link DeclaredArgument} already carries its position — the
+ * binder settled it against the declaration — so nothing here interprets a word or reads a
+ * signature; what is here is the one step from "argument three of {@code List.take}" to the
+ * expression standing there in this call.
  *
- * <p>So this is not a reader reinterpreting the cases. It is the one that has both halves: the word
- * a fact wrote, and the environment it takes to read that word. The same division
- * {@link AffineForms.Reading} already makes.
- *
- * <p>Nothing outside this asks for the number. A caller is answered with the argument.
+ * <p><b>The call has to be a call of the declaration the argument is of.</b> A position is a number,
+ * and a number is right in a call of any operation that takes enough arguments — so an argument of
+ * {@code List.filter} handed a call of {@code List.map} would answer with whatever stands third in
+ * the map, with nothing looking wrong. The argument knows what it is an argument of and the call
+ * knows what it calls, and the two are held to each other here, at the one place a position is
+ * applied.
  */
 public final class CallArguments {
 
-    /** The argument {@code call} passes where {@code ref} names. */
-    public static Core of(ArgumentRef ref, Core.PreservedCall call) {
-        return call.args().get(positionIn(ref, call.operation()));
+    /** The argument {@code call} passes where {@code argument} stands. */
+    public static Core of(DeclaredArgument argument, Core.PreservedCall call) {
+        return call.args().get(positionOf(argument, call));
     }
 
     /** {@code call} with that argument replaced by {@code value}. */
-    public static Core.PreservedCall replacedIn(ArgumentRef ref, Core.PreservedCall call,
-                                                Core value) {
+    public static Core.PreservedCall replacedIn(DeclaredArgument argument,
+                                                Core.PreservedCall call, Core value) {
         List<Core> args = new ArrayList<>(call.args());
-        args.set(positionIn(ref, call.operation()), value);
+        args.set(positionOf(argument, call), value);
         return new Core.PreservedCall(call.declared(), args, call.type(), call.pos());
-    }
-
-    /**
-     * Which parameter of {@code operation} {@code ref} names.
-     *
-     * <p>A written position is itself. The two that are named by the part they play are the
-     * library's to say, and an operation whose signature hands its closure nothing a container
-     * holds has neither — a fact naming one of them there is a fact about an argument that is not
-     * there, and it is said rather than answered with a number that would be wrong.
-     */
-    public static int positionIn(ArgumentRef ref, ValueName operation) {
-        return switch (ref) {
-            case ArgumentRef.At at -> at.position();
-            case ArgumentRef.TheContainer _ -> handing(operation, "the container").containerArg();
-            case ArgumentRef.TheClosure _ -> handing(operation, "the closure").closureArg();
-        };
     }
 
     /**
      * What {@code call}'s arguments read as, for a fact that names one of them.
      *
-     * <p>Between the word and the call, as everything here is: the fact names an argument and this
+     * <p>Between the fact and the call, as everything here is: the fact names an argument and this
      * finds it, and what the value there reads as is the caller's answer — a name given a constant
      * is that constant — so the reading is handed in rather than taken off the syntax at the call.
      *
@@ -66,20 +48,33 @@ public final class CallArguments {
      * one question asked by two readers ({@link ConstantArguments#satisfy}), and answering it here
      * as well would be the second place it is read.
      */
-    public static ConstantArguments readAs(Core.PreservedCall call,
-                                           java.util.function.Function<Core,
-                                                   java.math.BigDecimal> folded) {
+    public static ConstantArguments<DeclaredArgument> readAs(
+            Core.PreservedCall call,
+            java.util.function.Function<Core, java.math.BigDecimal> folded) {
         return argument -> java.util.Optional.ofNullable(folded.apply(of(argument, call)));
     }
 
-    private static Combinator handing(ValueName operation, String part) {
-        Combinator handed = Combinators.of(operation);
-        if (handed == null) {
-            throw new IllegalStateException("a rule about " + operation + " names " + part
-                    + " of what it hands its closure, and its signature says it hands one nothing"
-                    + " a container holds");
+    private static int positionOf(DeclaredArgument argument, Core.PreservedCall call) {
+        return positionOf(argument, call.declared().operation());
+    }
+
+    /**
+     * Where {@code argument} stands among the arguments of a call of {@code operation}.
+     *
+     * <p>For a reader holding a call the language resolved but did not keep standing — the
+     * runnable tree's call, or an expansion the inliner is reading — which has the operation's
+     * name and its arguments and no {@link Core.PreservedCall}. The one thing a kept call answers
+     * for that such a call does not is that its argument count is the declaration's, so what a
+     * caller here does with the position is index its own argument list; what is held here, as
+     * for a kept call, is that the argument is an argument of this operation.
+     */
+    public static int positionOf(DeclaredArgument argument, ValueName operation) {
+        if (!argument.of().operation().equals(operation)) {
+            throw new IllegalStateException("argument " + (argument.position() + 1) + " of `"
+                    + argument.of() + "` was asked for in a call of `" + operation
+                    + "`, which is another declaration");
         }
-        return handed;
+        return argument.position();
     }
 
     private CallArguments() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/CallArguments.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallArguments.java
@@ -4,8 +4,11 @@ import souther.compiler.core.Core;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.types.ValueName;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * The argument a bound fact names, found in a call to the operation the fact is about.
@@ -50,8 +53,8 @@ public final class CallArguments {
      */
     public static ConstantArguments<DeclaredArgument> readAs(
             Core.PreservedCall call,
-            java.util.function.Function<Core, java.math.BigDecimal> folded) {
-        return argument -> java.util.Optional.ofNullable(folded.apply(of(argument, call)));
+            Function<Core, BigDecimal> folded) {
+        return argument -> Optional.ofNullable(folded.apply(of(argument, call)));
     }
 
     private static int positionOf(DeclaredArgument argument, Core.PreservedCall call) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Choice.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Choice.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
-import souther.compiler.semantics.OperationFact;
+import souther.compiler.semantics.ArgumentsStand;
+import souther.compiler.semantics.DefinitionCase;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Rel;
 
@@ -178,15 +179,14 @@ record Choice(Kind kind, List<Arm> arms) {
      * question about the library, and it is answered by the time an arm exists.
      */
     private static Choice defined(Core.PreservedCall call) {
-        List<OperationFact.Case> defined =
-                DischargeRules.chosenBy(call);
+        List<DefinitionCase<DeclaredArgument>> defined = DischargeRules.chosenBy(call);
         if (defined.isEmpty()) {
             return null;
         }
         List<Arm> arms = new ArrayList<>(defined.size());
-        for (OperationFact.Case one : defined) {
+        for (DefinitionCase<DeclaredArgument> one : defined) {
             List<ArgumentRelation> relations = new ArrayList<>(one.given().size());
-            for (OperationFact.ArgumentsStand stands : one.given()) {
+            for (ArgumentsStand<DeclaredArgument> stands : one.given()) {
                 relations.add(new ArgumentRelation(CallArguments.of(stands.left(), call), stands.rel(),
                         CallArguments.of(stands.right(), call)));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -282,8 +282,8 @@ final class Conditions {
                 java.util.Map.of(sign, terms.granularityOf(call.type()));
         LinearForm<Object> answered = LinearForm.atom(sign);
         NumericDomain<Object> known = NumericDomain.<Object>top()
-                .assuming(sign, ResultRange.of(DischargeRules.boundsOn(call.operation(),
-                        ConstantArguments.none()), ConstantArguments.none()), spacing)
+                .assuming(sign, ResultRange.of(DefaultBoundOperationFacts.get()
+                        .boundsOnTheResult(call.operation()), ConstantArguments.none()), spacing)
                 .assume(answered.minus(LinearForm.constant(read.constant())), rel, spacing);
         if (known.isBottom()) {
             return null;

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.semantics.PositiveOrder;
 import souther.compiler.core.Core;
 import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
@@ -233,7 +232,7 @@ final class Conditions {
         if (!(side instanceof Core.PreservedCall call) || call.args().size() != 2) {
             return null;
         }
-        PositiveOrder positive =
+        BoundOperationFact.StatesTheOrderOfItsArguments positive =
                 DischargeRules.orderStatedBy(call.operation());
         if (positive == null
                 || terms.bodyKey(call.args().get(0), at) == null
@@ -283,7 +282,8 @@ final class Conditions {
                 java.util.Map.of(sign, terms.granularityOf(call.type()));
         LinearForm<Object> answered = LinearForm.atom(sign);
         NumericDomain<Object> known = NumericDomain.<Object>top()
-                .assuming(sign, ResultRange.of(call.operation(), ConstantArguments.NONE), spacing)
+                .assuming(sign, ResultRange.of(DischargeRules.boundsOn(call.operation(),
+                        ConstantArguments.none()), ConstantArguments.none()), spacing)
                 .assume(answered.minus(LinearForm.constant(read.constant())), rel, spacing);
         if (known.isBottom()) {
             return null;
@@ -308,8 +308,8 @@ final class Conditions {
      */
     static Core asSizeComparison(Core e) {
         if (e instanceof Core.PreservedCall call
-                && DischargeRules.sizeMeantBy(call.declared())
-                        instanceof BoundOperationFact.MeansTheSameAsSizeOfNought means) {
+                && DischargeRules.sizeMeantBy(call.operation())
+                        instanceof BoundOperationFact.MeansTheSameAsASizeOfNought means) {
             Core size = new Core.PreservedCall(means.size(), call.args(), Type.INT, call.pos());
             return new Core.Binary(BinOp.EQ, size, new Core.Int(0, Type.INT, call.pos()),
                     CoverageOrigin.unwritten(), Type.BOOL, call.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredArgument.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredArgument.java
@@ -1,0 +1,81 @@
+package souther.compiler.check;
+
+import souther.compiler.core.DeclaredOperation;
+import souther.compiler.types.Type;
+
+/**
+ * One argument of a declaration, as the declaration has it: which operation, which position, and
+ * what stands there.
+ *
+ * <p>The word a fact writes for an argument ({@link souther.compiler.semantics.ArgumentRef}) says
+ * which argument it means and nothing about where that argument is in a call — the position of
+ * "the container" is the library's to say. This is that word once it has been read against the
+ * declaration: the position is settled, the type at it is settled, and the operation it is an
+ * argument of is part of the value rather than something a reader pairs it with. A reader holding
+ * one has nothing left to resolve, and nothing to resolve it with.
+ *
+ * <p>Made in one place, {@link OperationFactBinder}, which is the one reader of the authoring word
+ * and the library together. The constructor is this package's for the same reason
+ * {@link DeclaredOperation}'s is its own: who may make one is answered by counting callers, and a
+ * name a package can reach is a name that package can call.
+ *
+ * <p><b>The type is not the identity.</b> Two of these are the same argument when they are the same
+ * position of the same declaration; what stands there is a fact the library settled about it, and a
+ * second reading of one declaration that disagreed about the type would be a binding that has come
+ * apart rather than a different argument. So a {@link souther.compiler.numeric.LinearForm} keyed on
+ * these keys on the position, as it should.
+ */
+public final class DeclaredArgument {
+
+    private final DeclaredOperation of;
+    private final int position;
+    private final Type stands;
+
+    DeclaredArgument(DeclaredOperation of, int position, Type stands) {
+        if (of == null) {
+            throw new IllegalArgumentException("a declared argument is an argument of something");
+        }
+        if (position < 0 || position >= of.arity()) {
+            throw new IllegalArgumentException("`" + of + "` takes " + of.arity()
+                    + " argument(s), and argument " + (position + 1) + " was read against it");
+        }
+        if (stands == null) {
+            throw new IllegalArgumentException("argument " + (position + 1) + " of `" + of
+                    + "` stands at some type");
+        }
+        this.of = of;
+        this.position = position;
+        this.stands = stands;
+    }
+
+    /** The declaration this is an argument of. */
+    public DeclaredOperation of() {
+        return of;
+    }
+
+    /** Where in that declaration's parameters it stands, from nought. */
+    public int position() {
+        return position;
+    }
+
+    /** The type the declaration has at that position. */
+    public Type stands() {
+        return stands;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof DeclaredArgument each
+                && of.equals(each.of) && position == each.position;
+    }
+
+    @Override
+    public int hashCode() {
+        return of.hashCode() * 31 + position;
+    }
+
+    @Override
+    public String toString() {
+        return of + "#" + (position + 1);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DefaultBoundOperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DefaultBoundOperationFacts.java
@@ -1,0 +1,37 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+
+/**
+ * The facts about the language's operations, held to the library this compiler ships, read once
+ * for the process.
+ *
+ * <p>A lifecycle and nothing else, as {@link DefaultStdlib} is for the library. What is held is a
+ * pure function of the declarations and the shipped library ({@link OperationFactBinder#bindAll}),
+ * so it is a constant of this compiler — the same for every compilation and under any backend —
+ * and threading it from a construction site would put a value in a dozen signatures to say
+ * something none of them varies in. A reader that binds against a library of its own asks the
+ * binder with that library and holds the answer itself.
+ *
+ * <p>What it publishes is a complete {@link BoundOperationFacts} or nothing at all: the holder's
+ * class initializer runs the binding to completion before {@link #get} can return, so no reader
+ * can catch the facts half held. That, and not an initialization order somewhere else, is what
+ * says the binding has run for every fact a reader reaches through here — there is no other way to
+ * one.
+ */
+public final class DefaultBoundOperationFacts {
+
+    private DefaultBoundOperationFacts() {
+    }
+
+    /** Bound when first asked for, not when this class is mentioned. */
+    private static final class Holder {
+        private static final BoundOperationFacts INSTANCE =
+                OperationFactBinder.bindAll(DefaultStdlib.get());
+    }
+
+    /** The facts, held to the shipped library. */
+    public static BoundOperationFacts get() {
+        return Holder.INSTANCE;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.stdlib.Stdlib;
+import souther.compiler.numeric.LinearForm;
 import souther.compiler.semantics.Arithmetic;
 import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.ConstantArguments;
@@ -185,75 +186,27 @@ final class DischargeRules {
 
     /** What {@code operation} answers, counted, in what its arguments are counted as — or null
      *  where it states no such form. */
-    static souther.compiler.numeric.LinearForm<DeclaredArgument> answersAFormOf(
-            ValueName operation) {
+    static LinearForm<DeclaredArgument> answersAFormOf(ValueName operation) {
         return facts().answersAFormOfItsArguments(operation);
     }
 
     /**
-     * Those of them this check can carry, by name.
+     * The declared forms, by name, for the test that holds each to a construction it discharges.
      *
-     * <p>Every declaration is about the operation and not about a reader, so the ones here are a
-     * subset of what is declared: what an operation answers is stated over the counts of its
-     * arguments, and what this check can do with such a statement is settled by whether it can name
-     * those counts. A carrier that counts has an internal coordinate this reasons over — a date's is
-     * its day — and reasoning over it does not make the value a number the model wrote.
+     * <p>Every one of them, and not a subset this check can carry. What this check can do with a
+     * form is settled by whether it can name the counts the form is written over, and that is the
+     * requirement every declared form was held to where it was bound
+     * ({@link TypeRequirement#COUNTED}, on the result and on every argument named) — so a form that
+     * is bound is a form this carries, and a second reading of the carriers here would be the
+     * binder's question asked again below the binding.
      *
-     * <p>Derived from what this side relates and not written as a list. A list is a second copy of
-     * a capability, wrong the day the capability changes; asked this way, the operations that arrive
-     * are exactly the ones an author could write a discharging program for.
+     * <p>Over the declared forms and not over everything that answers the question. A sum and a
+     * difference answer it by being the arithmetic they are, and what reads them is the grammar; a
+     * program firing one would be firing the operator.
      */
-    private static Set<ValueName> formOperationsThisCarries(Stdlib stdlib) {
-        Set<ValueName> carried = new LinkedHashSet<>();
-        // Over the declared forms and not over everything that answers the question. A sum and a
-        // difference answer it by being the arithmetic they are, and what reads them is the
-        // grammar; a program firing one would be firing the operator.
-        for (ValueName operation : facts().answersAFormOfItsArguments()) {
-            if (everyPartHasACountedCarrier(stdlib, operation)) {
-                carried.add(operation);
-            }
-        }
-        return carried;
-    }
-
-    /**
-     * Whether the result and every argument the declared form names stand on a carrier that counts.
-     *
-     * <p>Both ends, because the fact is an equation between them: what the operation answers,
-     * counted, and what it was given, counted. A form whose arguments this can carry and whose
-     * result it cannot is a form it cannot carry.
-     *
-     * <p><b>Asked of the carrier, which is the one authority for what counts.</b> A count is an
-     * internal coordinate and need not itself be a value the model calls a number: a date counts
-     * days, and reasoning over that day does not make the date an {@code Int}. Asked of whether the
-     * type is a number the model wrote, this would be a second capability beside the term reader's —
-     * and two capabilities over one arithmetic answer apart on the spelling, carrying a statement
-     * written as a shift and refusing the same statement written as the count.
-     *
-     * <p>Nothing here asks whether the parts share one count space. What a declared form does with
-     * two of them is what the declaration says: an operation answering seconds in days writes the
-     * conversion as its coefficients, and a rule requiring one space would refuse the conversions
-     * the library states. Where an expression rather than a declared form puts two counts together,
-     * keeping them apart is the expression reader's.
-     *
-     * <p>What stands at each argument the form names is the bound argument's own: the binder read
-     * it off the declaration, so nothing here goes back to the signature for it.
-     */
-    private static boolean everyPartHasACountedCarrier(Stdlib stdlib, ValueName operation) {
-        Stdlib.Signature signature =
-                stdlib.entry(OperationFactBinder.theLibraryOperation(operation)).signature();
-        if (!Carrier.countsToANumber(signature.result())) {
-            return false;
-        }
-        return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument ->
-                Carrier.countsToANumber(argument.stands()));
-    }
-
-    /** Those of them the read-through table has, by name, for the test that holds each to a
-     * construction it discharges. */
-    static Set<String> formNames(Stdlib stdlib) {
+    static Set<String> formNames() {
         Set<String> names = new LinkedHashSet<>();
-        formOperationsThisCarries(stdlib).forEach(operation -> names.add(operation.toString()));
+        facts().answersAFormOfItsArguments().forEach(operation -> names.add(operation.toString()));
         return names;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1,34 +1,24 @@
 package souther.compiler.check;
 
-import souther.compiler.DefaultStdlib;
 import souther.compiler.stdlib.Stdlib;
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.Arithmetic;
 import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.ConstantArguments;
+import souther.compiler.semantics.DefinitionCase;
 import souther.compiler.semantics.ElementLineage;
 import souther.compiler.semantics.ElementShape;
 import souther.compiler.semantics.NumericResult;
-import souther.compiler.semantics.OperationFact;
-import souther.compiler.semantics.OperationFacts;
-import souther.compiler.semantics.PositiveOrder;
 import souther.compiler.semantics.ResultBound;
 import souther.compiler.semantics.SizeAgainstItsSource;
 import souther.compiler.types.BinOp;
-import souther.compiler.core.CompleteSignature;
 import souther.compiler.core.Core;
-import souther.compiler.core.DeclaredOperation;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -38,15 +28,16 @@ import java.util.function.Function;
  * (spec §invariant-discharge-guarantees).
  *
  * <p>What the operations are is not here. That is declared where nothing reads it
- * ({@link OperationFacts}); what is here is this check's reading of it — the shape a rule is read
- * at a call, and what the check concludes from one. A fact about an operation held in a procedure
- * that reads it is a fact its second reader has to be given by that procedure, which is the
- * arrangement the declarations were moved out of.
+ * ({@link souther.compiler.semantics.OperationFacts}), held to the library once
+ * ({@link OperationFactBinder}), and read from what that binding made
+ * ({@link BoundOperationFacts}); what is here is this check's reading of it — the shape a rule is
+ * read at a call, and what the check concludes from one. A fact about an operation held in a
+ * procedure that reads it is a fact its second reader has to be given by that procedure, which is
+ * the arrangement the declarations were moved out of.
  *
- * <p>What each declaration is held to is here too, since holding one reads the library's own
- * signatures and asks what this check makes of a type. Every declaration is walked before any call
- * is read ({@link OperationFactBinder}), so a fact nothing here looks up is one this has held all
- * the same.
+ * <p>Everything below asks the bound facts and interprets nothing of its own: which argument a fact
+ * names is a position the binder settled, and the one step left — from a position to the expression
+ * standing there in a call — is {@link CallArguments}'.
  */
 final class DischargeRules {
 
@@ -57,26 +48,16 @@ final class DischargeRules {
         return ValueName.Stdlib.operation(alias, name);
     }
 
-    /** The argument the signature already says the elements come from, where the operation takes a
-     * closure at all — so a rule about such an operation writes no position of its own. */
-    private static final ArgumentRef CONTAINER = new ArgumentRef.TheContainer();
-
-    /** The closure itself, for a rule stated over what the closure answers. */
-    private static final ArgumentRef CLOSURE = new ArgumentRef.TheClosure();
-
-    /** The argument at {@code position}, for an operation whose signature does not say which one it
-     * is: one that takes no closure, or one given two containers. */
-    private static ArgumentRef at(int position) {
-        return new ArgumentRef.At(position);
+    /** The facts about the language's operations, held to the library this compiler ships. */
+    private static BoundOperationFacts facts() {
+        return DefaultBoundOperationFacts.get();
     }
 
     /** The container {@code call} built its result from, and what the building kept of it. */
     record Source(Core container, ElementShape shape, SizeAgainstItsSource size) {}
 
-
-
     /** Where a predicate reads its container at a call, and how far its statement travels. */
-    record Carrying(Core.PreservedCall stated, ArgumentRef at, Set<ElementShape> through) {
+    record Carrying(Core.PreservedCall stated, DeclaredArgument at, Set<ElementShape> through) {
 
         Core container() {
             return CallArguments.of(at, stated);
@@ -92,9 +73,8 @@ final class DischargeRules {
         }
     }
 
-
     /** The projection a predicate at a call is stated over, as the block it answers with. */
-    record Projection(Core.PreservedCall stated, ArgumentRef at, Core.Block projection) {
+    record Projection(Core.PreservedCall stated, DeclaredArgument at, Core.Block projection) {
 
         /** The call this was read for, stated over {@code value} instead. */
         Core.PreservedCall over(Core value) {
@@ -102,19 +82,17 @@ final class DischargeRules {
         }
     }
 
-
-
     /** Denial, which the analysis representation keeps as the call it is. */
     static final ValueName NOT = op("Bool", "not");
 
     /** The operations each table has a rule for. What is asked of them is {@link Question}'s to
      * settle; these are so it can hold a rule to being one an operation is asked for. */
     static Set<ValueName> builtOperations() {
-        return Bound.buildsItsResultFrom();
+        return facts().buildsItsResultFrom();
     }
 
     static Set<ValueName> carryingOperations() {
-        return OperationFacts.readsItsContainer();
+        return facts().readsItsContainer();
     }
 
     /**
@@ -129,8 +107,8 @@ final class DischargeRules {
      */
     static Set<String> constructionKinds(Stdlib stdlib) {
         Set<String> kinds = new LinkedHashSet<>();
-        Bound.buildsItsResultFrom().forEach(operation -> {
-            BuiltFrom built = Bound.buildsItsResultFrom(operation);
+        facts().buildsItsResultFrom().forEach(operation -> {
+            BuiltFrom<DeclaredArgument> built = facts().buildsItsResultFrom(operation);
             Stdlib.Entry entry = operation instanceof ValueName.Stdlib.Operation library
                     ? stdlib.entry(library) : null;
             String kind = entry == null ? null : kindOf(entry.signature().result());
@@ -153,15 +131,15 @@ final class DischargeRules {
     }
 
     static Set<ValueName> emptinessChecks() {
-        return Bound.meansTheSameAsASizeOfNought();
+        return facts().meansTheSameAsASizeOfNought();
     }
 
     static Set<ValueName> quantifiers() {
-        return Bound.statesItsPredicateOfEveryElement();
+        return facts().statesItsPredicateOfEveryElement();
     }
 
     static Set<ValueName> projections() {
-        return Bound.isStatedOverAProjection();
+        return facts().isStatedOverAProjection();
     }
 
     static Set<ValueName> sizeCalls() {
@@ -169,21 +147,21 @@ final class DischargeRules {
     }
 
     static Set<ValueName> numericResultOperations() {
-        return Bound.computesANumber();
+        return facts().computesANumber();
     }
 
     static Set<ValueName> orderings() {
-        return Bound.statesTheOrder();
+        return facts().statesTheOrderOfItsArguments();
     }
 
     /**
      * The operations that answer, counted, some arithmetic over what they were given.
      *
      * <p>Two sources and one question. Most of them say so by declaring the form
-     * ({@link OperationFacts#answersAFormOfItsArguments}); a sum and a difference say it by being
-     * the arithmetic they are. Declaring the form for those as well would be the same statement
-     * twice, and leaving them out of the question altogether would be worse: the silence beside it
-     * says there is nothing true here, and of {@code Int.add} that is false.
+     * ({@link BoundOperationFacts#answersAFormOfItsArguments}); a sum and a difference say it by
+     * being the arithmetic they are. Declaring the form for those as well would be the same
+     * statement twice, and leaving them out of the question altogether would be worse: the silence
+     * beside it says there is nothing true here, and of {@code Int.add} that is false.
      *
      * <p>Which of them are is {@link #operator} and not a reading of its own. What that answers is
      * what a call to such an operation is read as where it stands ({@link Terms#asOperator}), so
@@ -195,8 +173,8 @@ final class DischargeRules {
      * multiplies each is the other.
      */
     static Set<ValueName> formOperations() {
-        Set<ValueName> answered = new LinkedHashSet<>(Bound.answersAFormOfItsArguments());
-        for (ValueName operation : Bound.computesANumber()) {
+        Set<ValueName> answered = new LinkedHashSet<>(facts().answersAFormOfItsArguments());
+        for (ValueName operation : facts().computesANumber()) {
             BinOp written = operator(operation);
             if (written == BinOp.ADD || written == BinOp.SUB) {
                 answered.add(operation);
@@ -207,9 +185,9 @@ final class DischargeRules {
 
     /** What {@code operation} answers, counted, in what its arguments are counted as — or null
      *  where it states no such form. */
-    static souther.compiler.numeric.LinearForm<ArgumentRef> answersAFormOf(
+    static souther.compiler.numeric.LinearForm<DeclaredArgument> answersAFormOf(
             ValueName operation) {
-        return Bound.answersAFormOfItsArguments(operation);
+        return facts().answersAFormOfItsArguments(operation);
     }
 
     /**
@@ -230,7 +208,7 @@ final class DischargeRules {
         // Over the declared forms and not over everything that answers the question. A sum and a
         // difference answer it by being the arithmetic they are, and what reads them is the
         // grammar; a program firing one would be firing the operator.
-        for (ValueName operation : Bound.answersAFormOfItsArguments()) {
+        for (ValueName operation : facts().answersAFormOfItsArguments()) {
             if (everyPartHasACountedCarrier(stdlib, operation)) {
                 carried.add(operation);
             }
@@ -258,19 +236,17 @@ final class DischargeRules {
      * the library states. Where an expression rather than a declared form puts two counts together,
      * keeping them apart is the expression reader's.
      *
-     * <p>The library has the operation and the argument is one it takes, both of which
-     * {@link OperationFactBinder} held before any of this was asked. What is left to decide is what
-     * stands there.
+     * <p>What stands at each argument the form names is the bound argument's own: the binder read
+     * it off the declaration, so nothing here goes back to the signature for it.
      */
     private static boolean everyPartHasACountedCarrier(Stdlib stdlib, ValueName operation) {
-        Stdlib.Signature signature = stdlib.entry(theLibraryOperation(operation)).signature();
+        Stdlib.Signature signature =
+                stdlib.entry(OperationFactBinder.theLibraryOperation(operation)).signature();
         if (!Carrier.countsToANumber(signature.result())) {
             return false;
         }
-        List<Type> params = signature.params();
         return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument ->
-                Carrier.countsToANumber(
-                        params.get(CallArguments.positionIn(argument, operation))));
+                Carrier.countsToANumber(argument.stands()));
     }
 
     /** Those of them the read-through table has, by name, for the test that holds each to a
@@ -281,12 +257,20 @@ final class DischargeRules {
         return names;
     }
 
+    /** Those of them the building table has, by name, for the test that holds each to a construction
+     * it discharges. */
+    static Set<String> builtNames() {
+        Set<String> names = new LinkedHashSet<>();
+        builtOperations().forEach(operation -> names.add(operation.toString()));
+        return names;
+    }
+
     static Set<ValueName> boundedOperations() {
-        return Bound.boundsOnTheResult();
+        return facts().boundsOnTheResult();
     }
 
     static Set<ValueName> choosingOperations() {
-        return Bound.isDefinedByCases();
+        return facts().isDefinedByCases();
     }
 
     /** Those of them the choosing table has, by name, for the test that holds each case to a
@@ -298,7 +282,7 @@ final class DischargeRules {
     }
 
     static Set<ValueName> shiftingOperations() {
-        return Bound.shiftsBy();
+        return facts().shiftsBy();
     }
 
     /** Those of them the shifting table has, by name, for the test that holds each to a construction
@@ -311,21 +295,26 @@ final class DischargeRules {
 
     /** What {@code e} states through a measure, or null where it is not a shift this has a rule
      * about. */
-    static OperationFact.ShiftsBy shiftBy(Core e) {
-        return e instanceof Core.PreservedCall call ? Bound.shiftsBy(call.operation()) : null;
+    static BoundOperationFact.ShiftsBy shiftBy(Core e) {
+        return e instanceof Core.PreservedCall call ? facts().shiftsBy(call.operation()) : null;
     }
 
     /** Whether {@code operation} counts what two values stand apart by — the other side of the row a
      * shift is written in, read off that row rather than listed again. A measure named in a second
      * place is a measure the day somebody adds a shift and updates one of them. */
     static boolean isAMeasure(ValueName operation) {
-        return Bound.measures().contains(operation);
+        for (ValueName shift : facts().shiftsBy()) {
+            if (facts().shiftsBy(shift).measure().operation().equals(operation)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    /** The cases {@code e} is defined in, or null where it is not a call to an operation that
-     * answers one of the values it was given. */
-    static List<OperationFact.Case> chosenBy(Core e) {
-        return e instanceof Core.PreservedCall call ? Bound.isDefinedByCases(call.operation())
+    /** The cases {@code e} is defined in, or an empty list where it is not a call to an operation
+     * that answers one of the values it was given. */
+    static List<DefinitionCase<DeclaredArgument>> chosenBy(Core e) {
+        return e instanceof Core.PreservedCall call ? facts().isDefinedByCases(call.operation())
                 : List.of();
     }
 
@@ -339,8 +328,8 @@ final class DischargeRules {
      */
     static List<String> boundedRows() {
         List<String> rows = new ArrayList<>();
-        for (ValueName operation : Bound.boundsOnTheResult()) {
-            Bound.boundsOnTheResult(operation).forEach(bound -> rows.add(operation.toString()));
+        for (ValueName operation : facts().boundsOnTheResult()) {
+            facts().boundsOnTheResult(operation).forEach(bound -> rows.add(operation.toString()));
         }
         return rows;
     }
@@ -353,8 +342,8 @@ final class DischargeRules {
      *                 caller because what a value is read as is the reading's answer and not a
      *                 property of the syntax at the call.
      */
-    static List<ResultBound> boundsOn(Core.PreservedCall call,
-                                      Function<Core, BigDecimal> constant) {
+    static List<ResultBound<DeclaredArgument>> boundsOn(Core.PreservedCall call,
+                                                        Function<Core, BigDecimal> constant) {
         return boundsOn(call.operation(), CallArguments.readAs(call, constant));
     }
 
@@ -362,714 +351,21 @@ final class DischargeRules {
      * The same, for a reader holding the operation and not a call to it: the rows whose condition is
      * met by what {@code constants} can say about the arguments.
      *
-     * <p>{@link ConstantArguments#NONE} therefore leaves the rows an operation states whatever it is
-     * given, which for an operation the language hands no number is every row it has — a bound may
-     * only name an argument that is a number ({@link #holdBound}), so there is no other kind for
-     * such an operation to have.
+     * <p>{@link ConstantArguments#none()} therefore leaves the rows an operation states whatever it
+     * is given, which for an operation the language hands no number is every row it has — a bound
+     * may only name an argument that is a number, which the binder holds, so there is no other kind
+     * for such an operation to have.
      */
-    static List<ResultBound> boundsOn(ValueName operation, ConstantArguments constants) {
-        List<ResultBound> rows = Bound.boundsOnTheResult(operation);
-        List<ResultBound> holding = new ArrayList<>(rows.size());
-        for (ResultBound row : rows) {
+    static List<ResultBound<DeclaredArgument>> boundsOn(
+            ValueName operation, ConstantArguments<DeclaredArgument> constants) {
+        List<ResultBound<DeclaredArgument>> rows = facts().boundsOnTheResult(operation);
+        List<ResultBound<DeclaredArgument>> holding = new ArrayList<>(rows.size());
+        for (ResultBound<DeclaredArgument> row : rows) {
             if (constants.satisfy(row.provided())) {
                 holding.add(row);
             }
         }
         return holding;
-    }
-
-    /** Those of them the building table has, by name, for the test that holds each to a construction
-     * it discharges. */
-    static Set<String> builtNames() {
-        Set<String> names = new LinkedHashSet<>();
-        builtOperations().forEach(operation -> names.add(operation.toString()));
-        return names;
-    }
-
-    /**
-     * The tables, held to the declarations they were written for.
-     *
-     * <p>A row names an argument of an operation, and what an operation's arguments are is the
-     * library's to say. Where the two disagree there is nothing to be done at a call — the rule is
-     * about an argument that is not there, or is not the kind of thing the rule is about — so it is
-     * said here, once, before any call is read, rather than met as a missing answer at whichever
-     * reader arrives first.
-     *
-     * <p>Every row of every table, not the row a call happens to reach: a rule that disagrees with a
-     * declaration is wrong whether or not a program calls it, and finding out when one does is the
-     * same silence deferred.
-     *
-     * <p>A numeric rule names no part of what an operation hands a closure, since such an operation
-     * hands none, so it is bound with no derived position for a written one to be held against.
-     *
-     * <p>Read on the first ask and not before, as {@link Combinators} and {@link Preserved} are: what
-     * this requires of the library is required of a check that reads these rules, and a checker that
-     * reads none must not be held to it.
-     */
-    private static final class Bound {
-
-        private static Set<ValueName> buildsItsResultFrom() {
-            return OperationFacts.buildsItsResultFrom();
-        }
-
-        private static BuiltFrom buildsItsResultFrom(ValueName operation) {
-            return OperationFacts.buildsItsResultFrom(operation);
-        }
-        private static OperationFact.ReadsItsContainer readsItsContainer(
-                ValueName operation) {
-            return OperationFacts.readsItsContainer(operation);
-        }
-
-        private static ArgumentRef isStatedOverAProjection(ValueName operation) {
-            return OperationFacts.isStatedOverAProjection(operation);
-        }
-
-        private static Set<ValueName> isStatedOverAProjection() {
-            return OperationFacts.isStatedOverAProjection();
-        }
-
-        private static List<ArgumentRef> resultIsNoSmallerThan(ValueName operation) {
-            return OperationFacts.resultIsNoSmallerThan(operation);
-        }
-
-        private static boolean statesItsPredicateOfEveryElement(ValueName operation) {
-            return OperationFacts
-                    .statesItsPredicateOfEveryElement(operation);
-        }
-
-        private static Set<ValueName> statesItsPredicateOfEveryElement() {
-            return OperationFacts.statesItsPredicateOfEveryElement();
-        }
-
-        /* Read off what the binding produced rather than out of the authoring index beside it.
-         * This one fact is carried by a value the binding made, so the answer a reader gets is the
-         * answer that was held — not the same lookup done again, which agrees with it only for as
-         * long as nobody changes either. */
-        private static BoundOperationFact.MeansTheSameAsSizeOfNought meansTheSameAsASizeOfNought(
-                DeclaredOperation operation) {
-            return operation == null ? null : SEMANTICS.sizes().get(operation);
-        }
-
-        private static Set<ValueName> meansTheSameAsASizeOfNought() {
-            return EMPTINESS_CHECKS;
-        }
-        /** What the declarations came to, held to the library. The list is walked whole, so a fact
-         *  nothing here looks up is one this has held all the same. */
-        private static final OperationFactBinder.Binding SEMANTICS =
-                OperationFactBinder.bindAll(DefaultStdlib.get());
-        /* Holding the declarations to the library is a pure function of it, so this holder is the
-         * only thing here that reaches for the process's own — {@link DefaultStdlib} says who may
-         * and why the loader may not. */
-
-        /* The bound emptiness checks under the names a census asks by. Built once, here and after
-         * the binding it reads: a set worked out at each ask is one more place the bound facts are
-         * taken apart, and would be taken apart the same way every time. */
-        private static final Set<ValueName> EMPTINESS_CHECKS = emptinessChecks(SEMANTICS);
-
-        private static Set<ValueName> emptinessChecks(OperationFactBinder.Binding bound) {
-            Set<ValueName> named = new LinkedHashSet<>();
-            bound.sizes().keySet().forEach(each -> named.add(each.operation()));
-            return Collections.unmodifiableSet(named);
-        }
-
-        /**
-         * What the language declares an operation answers.
-         *
-         * <p>Here rather than at the call site so that asking runs the binding above, which is what
-         * the rest of this holder does for the tables beside it. The answer itself is the
-         * declaration's; what asking through here adds is that it has been held to the library
-         * first.
-         */
-        private static souther.compiler.numeric.LinearForm<ArgumentRef>
-                answersAFormOfItsArguments(ValueName operation) {
-            return OperationFacts.answersAFormOfItsArguments(operation);
-        }
-
-        /** The operations declared to answer a form of their arguments, for the checks that hold
-         *  each of them to firing. */
-        private static Set<ValueName> answersAFormOfItsArguments() {
-            return OperationFacts.answersAFormOfItsArguments();
-        }
-
-        private static Set<ValueName> statesTheOrder() {
-            return OperationFacts.statesTheOrderOfItsArguments();
-        }
-
-        private static PositiveOrder statesTheOrder(
-                ValueName operation) {
-            return OperationFacts
-                    .statesTheOrderOfItsArguments(operation);
-        }
-
-        private static Set<ValueName> shiftsBy() {
-            return OperationFacts.shiftsBy();
-        }
-
-        private static OperationFact.ShiftsBy shiftsBy(
-                ValueName operation) {
-            return OperationFacts.shiftsBy(operation);
-        }
-
-        /** The measures the shifts are stated through, read off those rather than listed again. A
-         *  measure named in a second place is a measure the day somebody adds a shift and updates
-         *  one of them. */
-        private static Set<ValueName> measures() {
-            Set<ValueName> out = new LinkedHashSet<>();
-            shiftsBy().forEach(operation -> out.add(shiftsBy(operation).measure()));
-            return out;
-        }
-
-        private static Set<ValueName> boundsOnTheResult() {
-            return OperationFacts.boundsOnTheResult();
-        }
-
-        private static List<ResultBound> boundsOnTheResult(
-                ValueName operation) {
-            return OperationFacts.boundsOnTheResult(operation);
-        }
-        private static Set<ValueName> isDefinedByCases() {
-            return OperationFacts.isDefinedByCases();
-        }
-
-        private static List<OperationFact.Case> isDefinedByCases(
-                ValueName operation) {
-            return OperationFacts.isDefinedByCases(operation);
-        }
-
-        private static Set<ValueName> computesANumber() {
-            return OperationFacts.computesANumber();
-        }
-
-        private static NumericResult computesANumber(
-                ValueName operation) {
-            return OperationFacts.computesANumber(operation);
-        }
-    }
-
-    /**
-     * As {@link #holdToTheDeclaration}, for the arithmetic an operation computes: it takes as many
-     * arguments as the row hands over, and it answers its number where the row says it does.
-     *
-     * <p>The result position is the half a signature can disagree with silently. A row saying the
-     * number arrives in the case carrying {@code Int} is read at an arm, and an arm that never
-     * matches is an arm that reports nothing — so a union that gained a case, or lost the one the
-     * row names, would leave the operation with a meaning no program reaches and no diagnostic
-     * anywhere. Held here, before any call is read.
-     */
-    static void holdNumericResult(Stdlib stdlib, ValueName operation, NumericResult rule) {
-        Stdlib.Signature signature = holdTheOperationToTheLibrary(stdlib, operation).signature();
-        Type answers = NumericAnswers.in(signature.result());
-        List<Arithmetic.Reads> reads = rule.computes().reads();
-        if (signature.params().size() != reads.size()) {
-            throw new IllegalStateException(operation + " takes " + signature.params().size()
-                    + " argument(s), and the arithmetic written for it reads " + reads.size());
-        }
-        for (int i = 0; i < reads.size(); i++) {
-            if (!heldBy(stdlib, reads.get(i), signature.params().get(i), answers)) {
-                throw new IllegalStateException("argument " + (i + 1) + " of " + operation
-                        + " is " + Type.show(signature.params().get(i))
-                        + ", which the arithmetic written for it reads as " + reads.get(i));
-            }
-        }
-        switch (rule.at()) {
-            case NumericResult.Answered.Directly ignored ->
-                    holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
-                            "where the arithmetic it computes is answered");
-            case NumericResult.Answered.InTheCaseCarrying(Type carried) -> {
-                if (!(signature.result() instanceof Type.Union(Set<TypeSymbol> members))) {
-                    throw new IllegalStateException(operation + " answers "
-                            + Type.show(signature.result())
-                            + ", which has no case for the number it computes to arrive in");
-                }
-                if (!carried.equals(answers)) {
-                    throw new IllegalStateException(operation + " answers no case carrying "
-                            + Type.show(carried));
-                }
-                if (rule.unless() == null) {
-                    throw new IllegalStateException(operation + " answers its number as one case"
-                            + " of a union, so when the other case comes back is what that case"
-                            + " means and is not written down");
-                }
-                // The condition names no case, so it says what every case that is not the
-                // number's says — which is one statement only where there is one such case. A
-                // union that gained a third would have an arm establishing a condition it was
-                // not taken under, which is a wrong fact rather than a missing one, and nothing
-                // downstream could tell: an arm is read the same way whichever case it names.
-                // Where a second failure is wanted, the condition is what has to name its case.
-                if (members.size() != 2) {
-                    throw new IllegalStateException(operation + " answers "
-                            + members.size() + " cases, and when it answers no number is"
-                            + " written as one condition — which says what one other case"
-                            + " means and cannot say what several do");
-                }
-            }
-        }
-        if (rule.unless() != null) {
-            holdToTheDeclaration(stdlib, operation, rule.unless().argument(), null,
-                    TypeRequirement.NUMBER, "the argument a failure is decided by");
-        }
-    }
-
-    /**
-     * As {@link #holdToTheDeclaration}, for a rule stating a shift through a measure: the amount is
-     * a number, the value shifted is of the type the measure counts, and the measure counts two of
-     * what the operation answers. A rule pairing an operation with a measure of something else
-     * would state a relation between two values that have none.
-     */
-    static void holdShift(Stdlib stdlib, ValueName operation, OperationFact.ShiftsBy
-            shift) {
-        holdToTheDeclaration(stdlib, operation, shift.amount(), null, TypeRequirement.NUMBER,
-                "the amount a shift moves by");
-        Stdlib.Entry counts = stdlib.entry(shift.measure());
-        if (counts == null) {
-            throw new IllegalStateException("the rule about " + operation + " counts through "
-                    + shift.measure().qualified() + ", which the library does not declare");
-        }
-        Stdlib.Entry shifted = holdTheOperationToTheLibrary(stdlib, operation);
-        List<Type> counted = counts.signature().params();
-        if (counted.size() != 2 || !NumericAnswers.isANumber(counts.signature().result())
-                || !counted.get(0).equals(shifted.signature().result())
-                || !counted.get(1).equals(shifted.signature().result())) {
-            throw new IllegalStateException(shift.measure().qualified()
-                    + " does not count two of what " + operation + " answers apart as a number");
-        }
-        Type moved = holdToTheDeclaration(stdlib, operation, shift.of(), null,
-                TypeRequirement.ANY, "the value a shift moves from");
-        // Not a requirement on the type, which is why it is stated here rather than passed as one.
-        // What this asks is that two positions of one signature stand at the same type, and nothing
-        // about a type on its own answers that — a requirement able to say it would be one carrying
-        // the signature it was written for.
-        if (!moved.equals(shifted.signature().result())) {
-            throw new IllegalStateException("the value " + ((ValueName.Stdlib) operation).qualified()
-                    + " shifts is " + Type.show(moved) + " and what it answers is "
-                    + Type.show(shifted.signature().result())
-                    + ", so what it moves is not what the measure counts");
-        }
-    }
-
-    /** As {@link #holdToTheDeclaration}, for the arguments a case names: the one it answers, and
-     * the two sides of each condition it is reached under. */
-    static void holdCase(Stdlib stdlib, ValueName operation, OperationFact.Case one) {
-        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
-                "what a case of the definition answers");
-        List<ArgumentRef> named = new ArrayList<>();
-        named.add(one.answers());
-        one.given().forEach(stands -> {
-            named.add(stands.left());
-            named.add(stands.right());
-        });
-        named.forEach(each -> holdToTheDeclaration(stdlib, operation, each, null,
-                TypeRequirement.NUMBER, "an argument a case of the definition names"));
-    }
-
-    /** As {@link #holdToTheDeclaration}, for the arguments a bound names: the one the result is
-     * bounded against, and the one a condition on the rule reads. Each is a separate claim about a
-     * separate argument. */
-    static void holdBound(Stdlib stdlib, ValueName operation, ResultBound bound) {
-        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
-                "what a bound on the result holds of");
-        List<ArgumentRef> named = new ArrayList<>();
-        if (bound.against() != null) {
-            named.add(bound.against());
-        }
-        if (bound.provided()
-                instanceof ResultBound.Provided.ConstantAboveZero
-                constant) {
-            named.add(constant.argument());
-        }
-        named.forEach(one -> holdToTheDeclaration(stdlib, operation, one, null,
-                TypeRequirement.NUMBER, "an argument a bound on the result names"));
-    }
-
-    /**
-     * Whether the argument declared {@code at} is what the row says that position reads, for an
-     * operation answering {@code answered}.
-     *
-     * <p>Here and not on {@link Arithmetic.Reads}, which says what a position is and stops there.
-     * Holding one of those to a declaration is a question about the library, and this is the reader
-     * that has the library — the same reader that holds the operation's arity and its result to it.
-     *
-     * <p>Two of them are answered from the row itself: the number the operation answers is the one
-     * its result carries, and a scale is a count. The third is answered from a declaration, because
-     * there is nothing about a rounding policy that a type says of itself — and reading it off a
-     * name written here would be a second answer to which type it is, which is what ADR-0087 ends.
-     */
-    private static boolean heldBy(Stdlib stdlib, Arithmetic.Reads reads, Type at, Type answered) {
-        return switch (reads) {
-            case THE_NUMBER_IT_ANSWERS -> at.equals(answered);
-            case A_SCALE -> at == Type.Prim.INT;
-            case A_ROUNDING_MODE -> at.equals(theRoundingPolicyTheLibraryDeclares(stdlib));
-        };
-    }
-
-    /** Which library operation the rounding policy is read off, and where in its arguments. */
-    private static final ValueName.Stdlib ROUNDING_POLICY_ANCHOR =
-            ValueName.Stdlib.operation("Decimal", "round");
-
-    /** {@code round(scale, mode, d)} — the second of them. */
-    private static final int ROUNDING_POLICY_ARGUMENT = 1;
-
-    /**
-     * The type the library declares for a rounding policy, taken from the operation that declares
-     * one and read as whatever that operation declares there.
-     *
-     * <p>Whatever it declares there, and never a type this checks against. A rule that said the
-     * anchor's argument must be {@code RoundingMode} would be the spelling back again, one operation
-     * further along. What is held is that two declarations agree: {@code Decimal.divide} takes at
-     * its policy position the type {@code Decimal.round} takes at its own, and either of them
-     * drifting alone fails this. Both moving to a new policy type together passes, and should —
-     * that is the library being redesigned rather than the table and the library disagreeing.
-     *
-     * <p>The anchor is a choice and is written down as one. What it is not is a second definition
-     * of which type the policy is: the library's declaration remains the only one.
-     *
-     * @throws IllegalStateException where the anchor no longer declares the argument it is read off
-     */
-    private static Type theRoundingPolicyTheLibraryDeclares(Stdlib stdlib) {
-        List<Type> params = holdTheOperationToTheLibrary(stdlib, ROUNDING_POLICY_ANCHOR)
-                .signature().params();
-        if (params.size() <= ROUNDING_POLICY_ARGUMENT) {
-            throw new IllegalStateException(ROUNDING_POLICY_ANCHOR.qualified() + " takes "
-                    + params.size() + " argument(s), and the rounding policy every arithmetic over"
-                    + " one is held to is read off argument " + (ROUNDING_POLICY_ARGUMENT + 1)
-                    + " of it");
-        }
-        return params.get(ROUNDING_POLICY_ARGUMENT);
-    }
-
-    /** The library operation {@code operation} names. Every fact is declared of one, so the name
-     *  says which library and which operation rather than a spelling a reader would have to take
-     *  apart — and a reader that has held a name to the library holds this rather than narrowing the
-     *  name a second time.
-     *
-     *  @throws IllegalStateException where the name is no library operation. */
-    static ValueName.Stdlib.Operation theLibraryOperation(ValueName operation) {
-        if (!(operation instanceof ValueName.Stdlib.Operation library)) {
-            throw new IllegalStateException("a fact is declared of " + operation
-                    + ", which is not a library operation");
-        }
-        return library;
-    }
-
-    /**
-     * The library's declaration of {@code operation}, or a build that does not start.
-     *
-     * <p>What every fact owes, whatever else it says. A fact is a proposition about an operation,
-     * so an operation the library does not have is a fact about nothing — and that is true of a
-     * fact naming no argument as much as of one that names three.
-     *
-     * <p>Its own step rather than the first half of {@link #holdToTheDeclaration}, because there it
-     * was reached only by a fact that had an argument to check. A fact naming none went through an
-     * arm with nothing in it and was never held to anything, so which declarations were bound
-     * depended on which kinds of fact happened to name an argument. A kind added later would have
-     * lost the same way, silently, on the day its arm was written empty.
-     */
-    static Stdlib.Entry holdTheOperationToTheLibrary(Stdlib stdlib, ValueName operation) {
-        ValueName.Stdlib.Operation library = theLibraryOperation(operation);
-        Stdlib.Entry entry = stdlib.entry(library);
-        if (entry == null) {
-            throw new IllegalStateException("a fact is declared of " + library.qualified()
-                    + ", which the library does not declare");
-        }
-        return entry;
-    }
-
-    /**
-     * Holds an emptiness check and the size it is said to mean to each other's declarations, and
-     * answers with the two as the library declares them.
-     *
-     * <p>What a reader does with this fact is write the second call where the first stands, keeping
-     * the arguments. So what has to hold is that the arguments the first takes are the ones the
-     * second takes, and that the two answer the kinds of thing the rewrite turns into each other: a
-     * truth on one side, a number to compare against nought on the other. Two operations of one
-     * argument each is not enough — a check on strings and a length of lists agree on how many
-     * arguments they take and on nothing else.
-     *
-     * <p>Asked here, where both declarations are in hand, and not by the reader doing the rewriting.
-     * That reader has a call and a name, which is enough to put the same question a second way and
-     * not enough to answer it.
-     */
-    static BoundOperationFact.MeansTheSameAsSizeOfNought holdSizeEquivalence(
-            Stdlib stdlib, ValueName operation, ValueName size) {
-        CompleteSignature asks = declaredSignature(stdlib, operation);
-        CompleteSignature counts = declaredSignature(stdlib, size);
-        if (asks.params().size() != 1 || asks.result() != Type.BOOL) {
-            throw new IllegalStateException(theLibraryOperation(operation).qualified()
-                    + " is declared to say whether one container is empty, and it takes "
-                    + asks.params().size() + " argument(s) and answers "
-                    + Type.show(asks.result()));
-        }
-        if (counts.params().size() != 1 || counts.result() != Type.INT) {
-            throw new IllegalStateException(theLibraryOperation(size).qualified()
-                    + " is named as the size " + theLibraryOperation(operation).qualified()
-                    + " means, and it takes " + counts.params().size()
-                    + " argument(s) and answers " + Type.show(counts.result()));
-        }
-        if (!sameShape(asks.params().get(0), counts.params().get(0),
-                new HashMap<>(), new HashMap<>())) {
-            throw new IllegalStateException(theLibraryOperation(operation).qualified() + " asks of "
-                    + Type.show(asks.params().get(0)) + " and "
-                    + theLibraryOperation(size).qualified() + " counts "
-                    + Type.show(counts.params().get(0))
-                    + ", so a call of the first is no call of the second");
-        }
-        return new BoundOperationFact.MeansTheSameAsSizeOfNought(asks.declaring(),
-                counts.declaring());
-    }
-
-    /** The library's declaration of {@code operation}, read whole. */
-    private static CompleteSignature declaredSignature(Stdlib stdlib, ValueName operation) {
-        Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
-        return CompleteSignature.ofDeclaration(operation, entry.signature().params(),
-                entry.signature().result());
-    }
-
-    /**
-     * Whether the two are the same shape, telling type variables apart only by where they stand.
-     *
-     * <p>{@code List<'a>} and {@code List<'b>} are one shape and {@code List<'a>} and
-     * {@code List<Int>} are not, which is what a rewrite between two declarations needs and what
-     * unifying them does not answer: those two unify, by deciding that {@code 'a} is {@code Int},
-     * and a rewrite is not free to decide anything. The pairing is carried both ways so that two
-     * variables on one side cannot both stand for one on the other.
-     */
-    private static boolean sameShape(Type left, Type right, Map<String, String> paired,
-                                     Map<String, String> back) {
-        // A variable of an application, which no declaration holds: this compares what two
-        // declarations state. One arriving here is a caller having handed over something else, and
-        // answering "a different shape" would report that as the two operations disagreeing.
-        if (left instanceof Type.MetaVar || right instanceof Type.MetaVar) {
-            throw new IllegalStateException("a declared signature is being compared with "
-                    + Type.show(left instanceof Type.MetaVar ? left : right)
-                    + ", which belongs to an application rather than to a declaration");
-        }
-        return switch (left) {
-            case Type.Var l when right instanceof Type.Var r ->
-                    r.name().equals(paired.computeIfAbsent(l.name(), _ -> r.name()))
-                            && l.name().equals(back.computeIfAbsent(r.name(), _ -> l.name()));
-            case Type.ListOf l when right instanceof Type.ListOf r ->
-                    sameShape(l.element(), r.element(), paired, back);
-            case Type.SetOf l when right instanceof Type.SetOf r ->
-                    sameShape(l.element(), r.element(), paired, back);
-            case Type.OptionOf l when right instanceof Type.OptionOf r ->
-                    sameShape(l.element(), r.element(), paired, back);
-            case Type.MapOf l when right instanceof Type.MapOf r ->
-                    sameShape(l.key(), r.key(), paired, back)
-                            && sameShape(l.value(), r.value(), paired, back);
-            case Type.FnOf l when right instanceof Type.FnOf r ->
-                    sameShapes(l.params(), r.params(), paired, back)
-                            && sameShape(l.result(), r.result(), paired, back);
-            case Type.TupleOf l when right instanceof Type.TupleOf r ->
-                    sameShapes(l.elements(), r.elements(), paired, back);
-            // Everything else a declaration can hold stands for itself: a primitive, a declaration,
-            // a union of them, and a variable that did not pair with one above. Being the same
-            // shape is being the same type.
-            case Type.Leaf _ -> left.equals(right);
-            default -> false;
-        };
-    }
-
-    private static boolean sameShapes(List<Type> left, List<Type> right, Map<String, String> paired,
-                                      Map<String, String> back) {
-        if (left.size() != right.size()) {
-            return false;
-        }
-        for (int i = 0; i < left.size(); i++) {
-            if (!sameShape(left.get(i), right.get(i), paired, back)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * The library's declaration of {@code operation}, once what it answers is what a fact about its
-     * result is about.
-     *
-     * <p>Beside {@link #holdToTheDeclaration} and for the half it cannot reach. That one names an
-     * argument, so a fact whose proposition mentions the result had nothing to say it with, and
-     * each kind that needed the result said it its own way or not at all: {@code BoundsItsResult}
-     * and {@code IsDefinedByCases} are stated of a number and were held only of their arguments.
-     * Improvising a check per kind defaults to omitting it, which is how a fact naming no argument
-     * once went through an empty arm ({@link #holdTheOperationToTheLibrary}).
-     *
-     * <p>Which requirement is the caller's, since what a fact says of the result is the fact's. A
-     * form is about a count and a bound about a number, and the difference between those two is a
-     * difference between the propositions and not between two ways of holding one. Which it may
-     * choose from is not the caller's ({@link TypeRequirement}).
-     */
-    static void holdTheResultToTheDeclaration(Stdlib stdlib, ValueName operation,
-            TypeRequirement required, String role) {
-        Type result = holdTheOperationToTheLibrary(stdlib, operation).signature().result();
-        if (result == null || !required.admits(result)) {
-            throw new IllegalStateException("what " + ((ValueName.Stdlib) operation).qualified()
-                    + " answers is " + (result == null ? "left to its body" : Type.show(result))
-                    + ", not " + required + "; it is named as " + role);
-        }
-    }
-
-    /**
-     * Holds a declared account of what an operation takes of the one value it is given.
-     *
-     * <p>Two different things, and they are kept apart. Three of these hold the declaration and the
-     * signature to each other: the operation takes exactly one value, since what such a term is read
-     * off is one location and a term names one path; it answers a number, since a boundary is drawn
-     * on one; and what it takes it of is the shape the account is written for — a count is taken of
-     * something that holds things, a magnitude of the operation's own kind of number. None of the
-     * three is checked anywhere else, and each is about this fact and this declaration.
-     *
-     * <p>The one that is not about this fact at all is that the number the operation answers is read
-     * by one representation. That is a property of the operation and holds whichever of the accounts
-     * was declared last. Asked as "is there already a form, an arithmetic, a body", it is one
-     * condition per representation there is, so a fourth has to be named in each of them and in
-     * whatever the next such procedure turns out to be. Asked as how many readings the operation has
-     * ({@link NumericReadings}), a representation added is refused against every existing one
-     * without being paired with any of them.
-     *
-     * <p>Counted over the declarations being held and not over a table read from elsewhere, so the
-     * answer does not depend on the order the facts were declared in or on whether they have
-     * reached a table yet. What is required is that the count comes to one and that the one is this
-     * account — a term found beside a form fails the same way whether the term or the form was
-     * written first.
-     *
-     * <p>Held here rather than trusted at the reader. The reader applies the account to whatever
-     * observation stands at the path, so an account declared of an operation it is not the shape of
-     * is a row read as a number nobody named, with nothing about it looking like a failure (#1027).
-     * Refused where the declaration is written, that reading cannot be reached.
-     */
-    static void holdTakenOf(Stdlib stdlib, List<OperationFacts.Declared> declared,
-            ValueName operation, souther.compiler.semantics.TakenAs how) {
-        Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
-        Stdlib.Signature signature = entry.signature();
-        String named = ((ValueName.Stdlib) operation).qualified();
-        if (signature.params().size() != 1) {
-            throw new IllegalStateException(named + " takes " + signature.params().size()
-                    + " arguments, and a number taken of the one value an operation is given is"
-                    + " taken of one");
-        }
-        // A number and not a number at one case of a union. A term names one path and stands for
-        // what the operation answered there, and what an operation answering `Int | NotANumber`
-        // answers at that path is the union — which case it is in is a question this account has no
-        // room for. Narrower than the range of whatever asks for such an account, and deliberately:
-        // what may be declared and what is asked about are two ranges.
-        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
-                "what a term of its answer is about");
-        // Before the shape below, because it is the operation that is being asked about and not
-        // this fact. An account that does not fit the operation is still an account of a number
-        // some other representation may already read, and asked the other way round the exclusivity
-        // would be reachable only through arms that happen to fit.
-        NumericReadings.Resolution read = NumericReadings.resolve(stdlib, declared, operation);
-        if (!(read instanceof NumericReadings.Resolution.One(
-                NumericReading.AsATermTakenOfItsArgument(souther.compiler.semantics.TakenAs held)))
-                || !held.equals(how)) {
-            throw new IllegalStateException("the number " + named + " answers is read as "
-                    + NumericReadings.describe(read) + ", and one numeric call is read by one"
-                    + " representation — which of them a report showed would be whichever reader"
-                    + " arrived");
-        }
-        Type source = signature.params().get(0);
-        Type answered = signature.result();
-        if (!how.takenOf(source, answered)) {
-            throw new IllegalStateException(named + " is declared to answer "
-                    + how.getClass().getSimpleName() + " of a " + Type.show(source)
-                    + ", which is not what that is taken of");
-        }
-    }
-
-    /**
-     * Holds a declared form to the library: what it answers counts, and so does every argument it
-     * is written over.
-     *
-     * <p>Both ends, because the fact is an equation between them —
-     * {@code count(result) = Σ cᵢ·count(argᵢ) + k}. Held of the arguments alone it was half a
-     * statement: {@code List.take(n, xs)} declared to answer the number of its first argument
-     * passed, that argument being an {@code Int}, while what it answers is a list and has no count
-     * for the equation to be about.
-     *
-     * <p>Counted rather than a number, because that is what the fact says. A date is no number and
-     * counts days; whether this check can then do anything with such a form is a different question
-     * and belongs to the check ({@link #formOperationsThisCarries}).
-     */
-    static void holdAFormOfItsArguments(Stdlib stdlib, ValueName operation,
-            souther.compiler.numeric.LinearForm<ArgumentRef> form) {
-        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.COUNTED,
-                "what a form of its arguments is about");
-        for (ArgumentRef argument : form.coefs().keySet()) {
-            holdToTheDeclaration(stdlib, operation, argument, null, TypeRequirement.COUNTED,
-                    "an argument the result is a form of");
-        }
-    }
-
-    /**
-     * Holds one rule to the operation it is about: the operation is one the library declares, the
-     * argument it names is one that declaration has, and what stands there is what the rule
-     * requires. A rule naming a part of something the signature says the operation does not hand is
-     * caught by {@link ArgumentRef}; one that writes a position the signature already answers is
-     * caught here, since two answers to one question are what come apart later.
-     *
-     * <p>Asked per rule so that whatever holds a whole declaration source can walk it and hold each
-     * of them, rather than reaching for a table of its own. Holding a table at a time was two
-     * wrappers over this, and neither was reached: what walks the declarations walks them one rule
-     * at a time, so an entry point taking a map of them said there was a way of binding that
-     * nothing binds.
-     *
-     * <p>Answers what stands at the position it held. A caller with something to state that a
-     * requirement cannot — that two positions of one signature stand at one type — then says it
-     * without reading the position over again, and two readings of where an argument is are two
-     * answers to it.
-     */
-    static Type holdToTheDeclaration(Stdlib stdlib, ValueName operation, ArgumentRef at,
-                                     ArgumentRef derived, TypeRequirement required, String role) {
-        Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
-        ValueName.Stdlib library = (ValueName.Stdlib) operation;
-        List<Type> params = entry.signature().params();
-        int position = CallArguments.positionIn(at, operation);
-        if (position < 0 || position >= params.size()) {
-            throw new IllegalStateException(library.qualified() + " takes " + params.size()
-                    + " argument(s), and the rule about " + role + " reads argument "
-                    + (position + 1));
-        }
-        Type stands = params.get(position);
-        if (!required.admits(stands)) {
-            throw new IllegalStateException("argument " + (position + 1) + " of "
-                    + library.qualified() + " is " + Type.show(stands) + ", not " + required
-                    + "; it is named as " + role);
-        }
-        if (at instanceof ArgumentRef.At && derived != null && Combinators.of(operation) != null
-                && CallArguments.positionIn(derived, operation) == position) {
-            throw new IllegalStateException("the rule about " + role + " for "
-                    + library.qualified()
-                    + " writes the argument its signature already answers — say which part it is"
-                    + " rather than where, so the two cannot come apart");
-        }
-        return stands;
-    }
-
-    /**
-     * Holds an accumulation to the library: the argument it names holds elements, and they are of
-     * the type the operation answers.
-     *
-     * <p>Both halves, because an accumulation carries what it has so far in the answer's own type.
-     * A step over what it has and an element is written over two values of one type, so an argument
-     * whose elements are something else is one this walk could not be over, and the identity it
-     * starts from would be a value of a type nothing here names.
-     *
-     * <p>Which argument is named rather than searched for. A signature says of as many arguments as
-     * fit that they could be the one, and an operation given two containers of what it answers has
-     * a signature admitting two walks; the fact says which, and this says whether the signature
-     * bears it out.
-     */
-    static void holdAccumulation(Stdlib stdlib, ValueName operation, ArgumentRef container) {
-        Type stands = holdToTheDeclaration(stdlib, operation, container, null,
-                TypeRequirement.CONTAINER, "the container it accumulates");
-        Type answers = holdTheOperationToTheLibrary(stdlib, operation).signature().result();
-        Type element = Type.elementOfAContainer(stands);
-        if (!element.equals(answers)) {
-            throw new IllegalStateException(((ValueName.Stdlib) operation).qualified()
-                    + " is declared to accumulate a container of " + Type.show(element)
-                    + " and answers " + Type.show(answers)
-                    + ", and a walk carries what it has so far in the type it answers");
-        }
     }
 
     /**
@@ -1100,7 +396,7 @@ final class DischargeRules {
      * there: without one container there is nothing to ask the question of.
      */
     static Kept keptFrom(Core.PreservedCall call) {
-        BuiltFrom built = Bound.buildsItsResultFrom(call.operation());
+        BuiltFrom<DeclaredArgument> built = facts().buildsItsResultFrom(call.operation());
         if (built == null || built.outputs().size() != 1 || built.lineage().source() == null) {
             return null;
         }
@@ -1108,12 +404,12 @@ final class DischargeRules {
     }
 
     /** A construction's source container and the lineage of the elements it answers. */
-    record Kept(Core container, ElementLineage lineage) {}
+    record Kept(Core container, ElementLineage<DeclaredArgument> lineage) {}
 
     /** The container {@code call} built its result from, or null where the check has no rule about
      * what the operation keeps. */
     static Source builtFrom(Core.PreservedCall call) {
-        BuiltFrom built = Bound.buildsItsResultFrom(call.operation());
+        BuiltFrom<DeclaredArgument> built = facts().buildsItsResultFrom(call.operation());
         return built == null ? null
                 : new Source(CallArguments.of(built.from(), call), built.shape(), built.size());
     }
@@ -1134,12 +430,9 @@ final class DischargeRules {
         if (!(e instanceof Core.PreservedCall call)) {
             return List.of();
         }
-        List<ArgumentRef> reads = Bound.resultIsNoSmallerThan(call.operation());
-        if (reads == null) {
-            return List.of();
-        }
+        List<DeclaredArgument> reads = facts().resultIsNoSmallerThan(call.operation());
         List<Core> containers = new ArrayList<>(reads.size());
-        for (ArgumentRef one : reads) {
+        for (DeclaredArgument one : reads) {
             containers.add(CallArguments.of(one, call));
         }
         return containers;
@@ -1148,15 +441,14 @@ final class DischargeRules {
     /** Where {@code call} reads the container it states its predicate of, or null where it is not a
      * predicate this carries anywhere. */
     static Carrying carried(Core.PreservedCall call) {
-        OperationFact.ReadsItsContainer carried =
-                Bound.readsItsContainer(call.operation());
+        BoundOperationFact.ReadsItsContainer carried = facts().readsItsContainer(call.operation());
         return carried == null ? null : new Carrying(call, carried.container(), carried.through());
     }
 
     /** The projection {@code call}'s predicate is stated over, or null where it is stated over the
      * element itself — or where what stands in that argument is not a block this can read. */
     static Projection projectionOf(Core.PreservedCall call, Denotations at) {
-        ArgumentRef reads = Bound.isStatedOverAProjection(call.operation());
+        DeclaredArgument reads = facts().isStatedOverAProjection(call.operation());
         if (reads == null) {
             return null;
         }
@@ -1181,39 +473,36 @@ final class DischargeRules {
      * answered a number without counting anything was left out of it silently (#1027).
      */
     static boolean answersANumberTakenOfItsArgument(ValueName operation) {
-        return OperationFacts.takenAs(operation) != null;
+        return facts().takenAs(operation) != null;
     }
 
     static boolean isQuantifier(ValueName operation) {
-        return Bound.statesItsPredicateOfEveryElement(operation);
+        return facts().statesItsPredicateOfEveryElement(operation);
     }
 
     /**
      * The rewrite an emptiness check stands for, or null where {@code operation} is not one.
      *
-     * <p>Asked with the operation as it was read against its declaration, and answered with the
-     * size operation read against its own. A reader with this has what it takes to write the second
-     * call where the first stands and nothing left to check: that the two take the same argument,
-     * and that a size is what one compares against nought, was settled where both declarations were
-     * in hand ({@link #holdSizeEquivalence}).
+     * <p>Answered with both operations read against their declarations. A reader with this has
+     * what it takes to write the second call where the first stands and nothing left to check: that
+     * the two take the same argument, and that a size is what one compares against nought, was
+     * settled where both declarations were in hand.
      */
-    static BoundOperationFact.MeansTheSameAsSizeOfNought sizeMeantBy(DeclaredOperation operation) {
-        return Bound.meansTheSameAsASizeOfNought(operation);
+    static BoundOperationFact.MeansTheSameAsASizeOfNought sizeMeantBy(ValueName operation) {
+        return facts().meansTheSameAsASizeOfNought(operation);
     }
 
     /** What {@code operation} computes and where it answers it, or null where the table says
      * nothing of it. */
-    static NumericResult numericResult(ValueName operation) {
-        // An expression that calls nothing is asked this, and answering it is what says so. The
-        // tables are immutable maps, which refuse a null key rather than answering for it, and a
-        // reader that guarded the call itself would be one guard per reader.
-        return Bound.computesANumber(operation);
+    static NumericResult<DeclaredArgument> numericResult(ValueName operation) {
+        // An expression that calls nothing is asked this, and answering it is what says so.
+        return facts().computesANumber(operation);
     }
 
     /** The operator {@code operation} is, where it answers one directly and the language writes it
      * as an operator too — else null. What a call to it is read as where it stands. */
     static BinOp operator(ValueName operation) {
-        NumericResult result = numericResult(operation);
+        NumericResult<DeclaredArgument> result = numericResult(operation);
         return result != null
                 && result.at() instanceof NumericResult.Answered.Directly
                 && result.computes()
@@ -1221,10 +510,10 @@ final class DischargeRules {
                 ? written.op() : null;
     }
 
-    /** Which argument a positive answer from {@code operation} names as the greater, or null where
-     * its sign is not an order. */
-    static PositiveOrder orderStatedBy(ValueName operation) {
-        return Bound.statesTheOrder(operation);
+    /** Which argument a positive answer from {@code operation} names as the greater, and which as
+     * the lesser — or null where its sign is not an order. */
+    static BoundOperationFact.StatesTheOrderOfItsArguments orderStatedBy(ValueName operation) {
+        return facts().statesTheOrderOfItsArguments(operation);
     }
 
     /** Whether {@code operation} answers the order of its two arguments as a sign. */

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -432,7 +432,6 @@ final class DischargeRules {
     static boolean isQuantifier(ValueName operation) {
         return facts().statesItsPredicateOfEveryElement(operation);
     }
-
     /**
      * The rewrite an emptiness check stands for, or null where {@code operation} is not one.
      *

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1,9 +1,8 @@
 package souther.compiler.check;
 
 import souther.compiler.stdlib.Stdlib;
-import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.Combinator;
-import souther.compiler.semantics.ElementLineage;
 import souther.compiler.ast.DefinitionName;
 import souther.compiler.ast.Hir;
 import souther.compiler.ast.StructuralCost;
@@ -455,9 +454,13 @@ public final class HelperInliner {
         if (!(argument instanceof Hir.Expansion expansion)) {
             return;
         }
-        ArgumentRef holds = ElementLineage.holdsTheElementsOf(expansion.callee());
-        ArgumentRef made = holds != null ? null
-                : ElementLineage.derivesItsElementsFrom(expansion.callee());
+        BuiltFrom<DeclaredArgument> built =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(expansion.callee());
+        if (built == null) {
+            return;
+        }
+        DeclaredArgument holds = built.holdsTheElementsOf();
+        DeclaredArgument made = holds != null ? null : built.derivesItsElementsFrom();
         BindingId container = boundFor(expansion, holds != null ? holds : made);
         if (container == null) {
             return;
@@ -479,11 +482,11 @@ public final class HelperInliner {
      * no function has none to skip, which is why the closure is asked for separately rather than
      * assumed.
      */
-    private static BindingId boundFor(Hir.Expansion expansion, ArgumentRef which) {
+    private static BindingId boundFor(Hir.Expansion expansion, DeclaredArgument which) {
         if (which == null) {
             return null;
         }
-        int parameter = CallArguments.positionIn(which, expansion.callee());
+        int parameter = CallArguments.positionOf(which, expansion.callee());
         Combinator handed = Combinators.of(expansion.callee());
         int at = parameter - (handed != null && handed.closureArg() < parameter ? 1 : 0);
         return at < 0 || at >= expansion.bound().size() ? null
@@ -1420,7 +1423,10 @@ public final class HelperInliner {
         // And where this call is the operation that hands such a lambda its elements, the two ends
         // of that fact are among the arguments: the lambda is one and the container is another. Both
         // are gathered as they are met and joined once the loop has them.
-        ArgumentRef mapsEach = ElementLineage.mapsEachElementOf(calleeOf(call));
+        BuiltFrom<DeclaredArgument> builtByCallee =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(calleeOf(call));
+        DeclaredArgument mapsEach = builtByCallee == null ? null
+                : builtByCallee.mapsEachElementOf();
         BindingId theLambda = null;
         BindingId theContainer = null;
         for (int i = 0; i < helper.params().size(); i++) {
@@ -1524,7 +1530,7 @@ public final class HelperInliner {
                     provenance.projectsEachElementOf(f.id(), walked);
                 }
                 if (mapsEach != null
-                        && i == CallArguments.positionIn(mapsEach, calleeOf(call))) {
+                        && i == CallArguments.positionOf(mapsEach, calleeOf(call))) {
                     theContainer = f.id();
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
@@ -1,8 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.ConstantArguments;
-import souther.compiler.semantics.OperationFact;
 import souther.compiler.semantics.ResultBound;
 import souther.compiler.semantics.SizeAgainstItsSource;
 import souther.compiler.core.Core;
@@ -51,12 +49,12 @@ final class IntrinsicNumericFacts {
 
     /**
      * A call whose arguments none of its operation's rows name, which is what a measure is: it is
-     * given a container, and a bound may only name an argument that is a number
-     * ({@link DischargeRules#holdBound}). So the rows read under this are all of them, and the one
+     * given a container, and a bound may only name an argument that is a number, which
+     * {@link OperationFactBinder} holds. So the rows read under this are all of them, and the one
      * premise is written here rather than once for the condition on the arguments and again for the
      * argument a row stands against.
      */
-    private static final java.util.function.Function<ArgumentRef, LinearForm<FactSubject>>
+    private static final java.util.function.Function<DeclaredArgument, LinearForm<FactSubject>>
             NO_ARGUMENTS = _ -> null;
 
     private IntrinsicNumericFacts() {}
@@ -77,7 +75,7 @@ final class IntrinsicNumericFacts {
         // nought. Read off the operation's rows and not written here: it is the same proposition as
         // `Int.abs(x) >= 0`, and a copy of it here was the half of it a partition could not reach
         // (#1016).
-        bounding(DischargeRules.boundsOn(size, ConstantArguments.NONE), atom, NO_ARGUMENTS, out);
+        bounding(DischargeRules.boundsOn(size, ConstantArguments.none()), atom, NO_ARGUMENTS, out);
         // A construction's result is no smaller than each source the rule names for it. A rule may
         // name more than one — `a ++ b` is as long as either half — so this is a loop where the
         // building below is one answer.
@@ -143,11 +141,11 @@ final class IntrinsicNumericFacts {
      * <p>{@code against} answers the argument a row names. A row it cannot answer states nothing,
      * which is what a bound against a quantity this reader has no name for comes to.
      */
-    private static void bounding(List<ResultBound> rows, FactSubject atom,
-                                 java.util.function.Function<ArgumentRef,
+    private static void bounding(List<ResultBound<DeclaredArgument>> rows, FactSubject atom,
+                                 java.util.function.Function<DeclaredArgument,
                                          LinearForm<FactSubject>> against,
                                  List<NumericConstraint> out) {
-        for (ResultBound bound : rows) {
+        for (ResultBound<DeclaredArgument> bound : rows) {
             LinearForm<FactSubject> stands = bound.against() == null
                     ? LinearForm.constant(bound.offset())
                     : addTo(against.apply(bound.against()), bound.offset());
@@ -179,8 +177,8 @@ final class IntrinsicNumericFacts {
                 instanceof Core.PreservedCall moved)) {
             return;
         }
-        OperationFact.ShiftsBy shift = DischargeRules.shiftBy(moved);
-        if (shift == null || !shift.measure().equals(call.operation())
+        BoundOperationFact.ShiftsBy shift = DischargeRules.shiftBy(moved);
+        if (shift == null || !shift.measure().operation().equals(call.operation())
                 || !sameValue(CallArguments.of(shift.of(), moved), call.args().get(0), at, terms)) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
@@ -11,6 +11,7 @@ import souther.compiler.types.ValueName;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * What a value carries by being the value it is, read off the operation that answered it.
@@ -54,7 +55,7 @@ final class IntrinsicNumericFacts {
      * premise is written here rather than once for the condition on the arguments and again for the
      * argument a row stands against.
      */
-    private static final java.util.function.Function<DeclaredArgument, LinearForm<FactSubject>>
+    private static final Function<DeclaredArgument, LinearForm<FactSubject>>
             NO_ARGUMENTS = _ -> null;
 
     private IntrinsicNumericFacts() {}
@@ -142,7 +143,7 @@ final class IntrinsicNumericFacts {
      * which is what a bound against a quantity this reader has no name for comes to.
      */
     private static void bounding(List<ResultBound<DeclaredArgument>> rows, FactSubject atom,
-                                 java.util.function.Function<DeclaredArgument,
+                                 Function<DeclaredArgument,
                                          LinearForm<FactSubject>> against,
                                  List<NumericConstraint> out) {
         for (ResultBound<DeclaredArgument> bound : rows) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.semantics.NumericResult;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -128,7 +127,7 @@ public final class NumericAnswers {
      * the day one of them moved would be the day they disagreed.
      */
     public static Type typeOf(ValueName operation, Type source, Symbols symbols) {
-        if (OperationFacts.accumulatedContainer(operation) == null) {
+        if (DefaultBoundOperationFacts.get().accumulation(operation) == null) {
             return typeOf(operation, symbols.library());
         }
         Type element = source == null ? null
@@ -169,11 +168,12 @@ public final class NumericAnswers {
      * identity through a step exactly as a sum does, and what it answers is declared: no call of it
      * answers a number, and the walk says nothing about that either way.
      */
-    static boolean mayAnswerANumber(ValueName operation, Stdlib library) {
+    static boolean mayAnswerANumber(BoundOperationFacts facts, ValueName operation,
+                                    Stdlib library) {
         if (typeOf(operation, library) != null) {
             return true;
         }
-        if (OperationFacts.accumulatedContainer(operation) == null
+        if (facts.accumulation(operation) == null
                 || !(operation instanceof ValueName.Stdlib.Operation named)) {
             return false;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
@@ -168,18 +168,12 @@ public final class NumericAnswers {
      * identity through a step exactly as a sum does, and what it answers is declared: no call of it
      * answers a number, and the walk says nothing about that either way.
      */
-    static boolean mayAnswerANumber(BoundOperationFacts facts, ValueName operation,
-                                    Stdlib library) {
-        if (typeOf(operation, library) != null) {
+    static boolean mayAnswerANumber(BoundOperationFacts facts, ValueName.Stdlib.Operation named,
+                                    Stdlib.Signature signature) {
+        if (in(signature.result()) != null) {
             return true;
         }
-        if (facts.accumulation(operation) == null
-                || !(operation instanceof ValueName.Stdlib.Operation named)) {
-            return false;
-        }
-        Stdlib.Entry entry = library.entry(named);
-        return entry != null && entry.signature() != null
-                && answerIsLeftToTheCall(entry.signature().result());
+        return facts.accumulation(named) != null && answerIsLeftToTheCall(signature.result());
     }
 
     private NumericAnswers() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericMeasures.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericMeasures.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.core.Core;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
@@ -25,7 +24,8 @@ import java.util.Set;
  * what this class was made for the first time it happened.
  *
  * <p>Which they are is declared with the rest of what is true of the language's operations
- * ({@link OperationFacts}) and read from there. This once held the list
+ * ({@link souther.compiler.semantics.OperationFacts}) and read from what binds those to the
+ * library ({@link BoundOperationFacts}). This once held the list
  * itself, which is what made it the first fact promoted out of a check when a second reader wanted
  * it — two lists of the same operations disagreed, and a rule discharged in one place was reported
  * in the other as a rule the model does not state.
@@ -49,7 +49,7 @@ public final class NumericMeasures {
 
     /** Every operation that counts what it is given, which is the narrow set. */
     public static Set<ValueName> calls() {
-        return OperationFacts.countsWhatItIsGiven();
+        return DefaultBoundOperationFacts.get().countsWhatItIsGiven();
     }
 
     /** Whether {@code operation} counts what it is given. Not whether it answers a number taken of
@@ -92,7 +92,7 @@ public final class NumericMeasures {
         // `s`, and a reading that asked the narrower question drew a line on the second and none on
         // the first — with nothing said about the guard it passed over (#1027).
         return operation instanceof ValueName.Stdlib named
-                && OperationFacts.takenAs(named) != null
+                && DefaultBoundOperationFacts.get().takenAs(named) != null
                 && args.size() == 1
                 ? new Measured(named, args.get(0)) : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReading.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.numeric.LinearForm;
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.NumericResult;
 import souther.compiler.semantics.TakenAs;
 
@@ -46,7 +45,7 @@ sealed interface NumericReading {
 
     /** The number is arithmetic over what the arguments are counted as, and {@code form} is that
      *  arithmetic. */
-    record AsAFormOfItsArguments(LinearForm<ArgumentRef> form)
+    record AsAFormOfItsArguments(LinearForm<DeclaredArgument> form)
             implements NumericReading {
 
         public AsAFormOfItsArguments {
@@ -61,7 +60,8 @@ sealed interface NumericReading {
 
     /** The number is the arithmetic the operation computes, and {@code result} says which and where
      *  it is answered. */
-    record AsTheArithmeticItComputes(NumericResult result) implements NumericReading {
+    record AsTheArithmeticItComputes(NumericResult<DeclaredArgument> result)
+            implements NumericReading {
 
         public AsTheArithmeticItComputes {
             java.util.Objects.requireNonNull(result, "this one says what it computes");

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -1,10 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.numeric.LinearForm;
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.NumericResult;
-import souther.compiler.semantics.OperationFact;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.ValueName;
@@ -28,7 +25,7 @@ import java.util.List;
  *   <li>{@link Resolution.None} is valid globally; a question may make it invalid within its range.
  *       Most of the library answers numbers nothing reads, and that is ordinary. Where a check
  *       needs a reading, it is that check's range that says so and its silence
- *       ({@code OperationFact.SaysNothingOf}) that is the other answer.
+ *       ({@code BoundOperationFact.SaysNothingOf}) that is the other answer.
  * </ul>
  *
  * <p>The third is the one worth keeping. Made to answer {@code One} wherever a number is answered,
@@ -39,11 +36,16 @@ import java.util.List;
  * range moved.
  *
  * <p><b>Counted, and not asked one representation at a time.</b> Written as a condition per
- * representation inside whatever holds a declaration ({@link DischargeRules#holdTakenOf}), a
- * representation added is one every existing representation has to be told about, and the pair
- * nobody writes down is the pair that goes unchecked. Counted here, an account added is one arm on
- * {@link NumericReading} and one line here, and every pair it makes with an existing arm is refused
- * without being named.
+ * representation inside whatever holds a declaration, a representation added is one every existing
+ * representation has to be told about, and the pair nobody writes down is the pair that goes
+ * unchecked. Counted here, an account added is one arm on {@link NumericReading} and one line here,
+ * and every pair it makes with an existing arm is refused without being named.
+ *
+ * <p><b>Over the bound facts.</b> What is counted is what the binding made, so the readings an
+ * operation has are read off the same values every other reader holds. The binder asks this of the
+ * facts it has just bound, before it publishes them ({@code OperationFactBinder}), and a question
+ * about the range asks it of the published ones ({@link Question}); both are the one procedure over
+ * one vocabulary.
  */
 final class NumericReadings {
 
@@ -75,20 +77,18 @@ final class NumericReadings {
     }
 
     /**
-     * The representations that read the number {@code operation} answers, counted, over the
-     * declarations in {@code declared}.
+     * The representations that read the number {@code operation} answers, counted, over the bound
+     * facts in {@code facts}.
      *
-     * <p>Over a source that is handed in and not over the table the process happens to hold. What
-     * holds the declarations to the library is given its source for the same reason
-     * ({@code OperationFactBinder#bindAll}): a fact reaches it before it reaches any table, so a
-     * check reading the table instead would be blind to exactly the declaration being held. It
-     * would also be asking that table to finish building while it was being built.
+     * <p>Over facts that are handed in and not over the ones the process happens to hold, for the
+     * reason the binder is given its source: the binder asks this of facts it has not yet
+     * published, and a reader of the process's own would be asking that holder to finish building
+     * while it was being built.
      *
      * @throws IllegalStateException where the library declares no such operation
      */
-    static Resolution resolve(Stdlib stdlib, List<OperationFacts.Declared> declared,
-            ValueName operation) {
-        List<NumericReading> found = readingsOf(stdlib, declared, operation);
+    static Resolution resolve(Stdlib stdlib, BoundOperationFacts facts, ValueName operation) {
+        List<NumericReading> found = readingsOf(stdlib, facts, operation);
         return switch (found.size()) {
             case 0 -> new Resolution.None();
             case 1 -> new Resolution.One(found.get(0));
@@ -112,69 +112,69 @@ final class NumericReadings {
      * <p>In the order the arms are written and not in the order the facts were declared, so a
      * message naming two readings names them the same way whichever of them was written first.
      */
-    private static List<NumericReading> readingsOf(Stdlib stdlib,
-            List<OperationFacts.Declared> declared, ValueName operation) {
-        Stdlib.Entry entry = DischargeRules.holdTheOperationToTheLibrary(stdlib, operation);
-        ValueName.Stdlib.Operation named = DischargeRules.theLibraryOperation(operation);
+    private static List<NumericReading> readingsOf(Stdlib stdlib, BoundOperationFacts facts,
+                                                   ValueName operation) {
+        OperationFactBinder.holdTheOperationToTheLibrary(stdlib, operation);
+        ValueName.Stdlib.Operation named = OperationFactBinder.theLibraryOperation(operation);
         // Whether a number is answered for some value the operation could be given, which is what a
         // reader of declarations can ask. Asked as "is the declared result a number", an operation
         // whose answer is what its container holds was read as answering none — and a walk that
         // adds up whole numbers answers one at every call it is given whole numbers.
-        if (!NumericAnswers.mayAnswerANumber(operation, stdlib)) {
+        if (!NumericAnswers.mayAnswerANumber(facts, operation, stdlib)) {
             return List.of();
         }
         List<NumericReading> terms = new ArrayList<>();
         List<NumericReading> forms = new ArrayList<>();
         List<NumericReading> arithmetic = new ArrayList<>();
-        for (OperationFacts.Declared each : declared) {
-            if (!operation.equals(each.operation())) {
+        for (BoundOperationFact each : facts.all()) {
+            if (!operation.equals(each.operation().operation())) {
                 continue;
             }
             // No default. A kind of fact added is a kind this has to answer for — whether it is an
             // account of the number an operation answers is a question about the fact, and one
             // nobody would think to come here and ask. Answered by falling through a default, the
             // fifth representation would be exclusive with nothing.
-            switch (each.fact()) {
-                case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven(TakenAs how) ->
-                        terms.add(new NumericReading.AsATermTakenOfItsArgument(how));
-                case OperationFact.AnswersAFormOfItsArguments(
-                        LinearForm<ArgumentRef> form) ->
+            switch (each) {
+                case BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
+                        terms.add(new NumericReading.AsATermTakenOfItsArgument(taken.how()));
+                case BoundOperationFact.AnswersAFormOfItsArguments(
+                        var _, LinearForm<DeclaredArgument> form) ->
                         forms.add(new NumericReading.AsAFormOfItsArguments(form));
-                case OperationFact.ComputesANumber(NumericResult result) ->
+                case BoundOperationFact.ComputesANumber(
+                        var _, NumericResult<DeclaredArgument> result) ->
                         arithmetic.add(new NumericReading.AsTheArithmeticItComputes(result));
-                // The cases a definition is written in name which argument is answered under which
-                // relation between the arguments. A reader still reads the argument, so what the
-                // call answers has no account of its own here — and every operation carrying one
-                // today is written in the language as well, so nothing here has to tell the two
-                // apart.
                 // A walk that adds up what a container holds is a way of reading the number a call
                 // answered, and it is read as the account it already is rather than as a second
                 // one declared beside it. A walk of another kind carries an identity and a step
                 // and answers no number this reads — a join of strings, a product — so what it
                 // contributes here is nothing, and that it answers this question at all is said
                 // where the silences are.
-                case OperationFact.AccumulatesItsContainer _ -> {
-                    TakenAs how = OperationFacts.takenAs(operation);
+                case BoundOperationFact.AccumulatesItsContainer walk -> {
+                    TakenAs how = walk.takenAs();
                     if (how != null) {
                         terms.add(new NumericReading.AsATermTakenOfItsArgument(how));
                     }
                 }
-                case OperationFact.IsDefinedByCases _,
-                     // The rest say something else about the operation: where a number runs, what
-                     // an operation keeps of a container, what a predicate travels through, what a
-                     // shift is stated through, whether every answer has a value that gives it.
-                     // None of them is a way of reading the number a call answered.
-                     OperationFact.BoundsItsResult _,
-                     OperationFact.StatesTheOrderOfItsArguments _,
-                     OperationFact.ShiftsBy _,
-                     OperationFact.BuildsItsResultFrom _,
-                     OperationFact.ResultIsNoSmallerThan _,
-                     OperationFact.ReadsItsContainer _,
-                     OperationFact.IsStatedOverAProjection _,
-                     OperationFact.StatesItsPredicateOfEveryElement _,
-                     OperationFact.MeansTheSameAsASizeOfNought _,
-                     OperationFact.EveryAnswerItCanGiveHasASourceValue _,
-                     OperationFact.SaysNothingOf _ -> { }
+                // The cases a definition is written in name which argument is answered under which
+                // relation between the arguments. A reader still reads the argument, so what the
+                // call answers has no account of its own here — and every operation carrying one
+                // today is written in the language as well, so nothing here has to tell the two
+                // apart. The rest say something else about the operation: where a number runs,
+                // what an operation keeps of a container, what a predicate travels through, what a
+                // shift is stated through, whether every answer has a value that gives it. None
+                // of them is a way of reading the number a call answered.
+                case BoundOperationFact.IsDefinedByCases _,
+                     BoundOperationFact.BoundsItsResult _,
+                     BoundOperationFact.StatesTheOrderOfItsArguments _,
+                     BoundOperationFact.ShiftsBy _,
+                     BoundOperationFact.BuildsItsResultFrom _,
+                     BoundOperationFact.ResultIsNoSmallerThan _,
+                     BoundOperationFact.ReadsItsContainer _,
+                     BoundOperationFact.IsStatedOverAProjection _,
+                     BoundOperationFact.StatesItsPredicateOfEveryElement _,
+                     BoundOperationFact.MeansTheSameAsASizeOfNought _,
+                     BoundOperationFact.EveryAnswerItCanGiveHasASourceValue _,
+                     BoundOperationFact.SaysNothingOf _ -> { }
             }
         }
         List<NumericReading> found = new ArrayList<>(terms);

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -114,13 +114,13 @@ final class NumericReadings {
      */
     private static List<NumericReading> readingsOf(Stdlib stdlib, BoundOperationFacts facts,
                                                    ValueName operation) {
-        OperationFactBinder.holdTheOperationToTheLibrary(stdlib, operation);
+        Stdlib.Entry entry = OperationFactBinder.holdTheOperationToTheLibrary(stdlib, operation);
         ValueName.Stdlib.Operation named = OperationFactBinder.theLibraryOperation(operation);
         // Whether a number is answered for some value the operation could be given, which is what a
         // reader of declarations can ask. Asked as "is the declared result a number", an operation
         // whose answer is what its container holds was read as answering none — and a walk that
         // adds up whole numbers answers one at every call it is given whole numbers.
-        if (!NumericAnswers.mayAnswerANumber(facts, operation, stdlib)) {
+        if (!NumericAnswers.mayAnswerANumber(facts, named, entry.signature())) {
             return List.of();
         }
         List<NumericReading> terms = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -686,8 +686,9 @@ final class OperationFactBinder {
     }
 
     /**
-     * Holds every operation declared to answer a number taken of its argument to being read by
-     * that one representation, and then to the account fitting what the operation takes.
+     * Holds every operation the library declares to having its number read by at most one
+     * representation, and then each account of a number taken of one value to fitting what the
+     * operation takes.
      *
      * <p>Asked of the bound facts together and after every one is bound, because the first is a
      * claim about the set: an account declared beside a form is two readings whichever was written
@@ -696,25 +697,30 @@ final class OperationFactBinder {
      * readings the operation has ({@link NumericReadings}), a representation added is refused
      * against every existing one without being paired with any of them.
      *
-     * <p>The shape second, since a shape that does not fit is a fact about this account, and the
+     * <p><b>Over the library's operations, and not over the facts of one kind.</b> Two readings of
+     * one number are an invalid definition of the operation whichever two they are — a form beside
+     * an arithmetic, a walk that adds beside a form — so the population the claim is about is every
+     * operation there is, and a walk that started from the accounts of one kind would hold only
+     * the pairs that kind is half of. What is refused here is what
+     * {@link NumericReadings.Resolution.Multiple} is defined to be, before any reader can meet it.
+     *
+     * <p>The shape second, since a shape that does not fit is a fact about one account, and the
      * exclusivity is a fact about the operation whatever account was written for it.
      */
     private static void holdEachNumberToOneReading(Stdlib stdlib, BoundOperationFacts facts) {
+        for (ValueName.Stdlib.Operation operation : stdlib.entries().keySet()) {
+            NumericReadings.Resolution read = NumericReadings.resolve(stdlib, facts, operation);
+            if (read instanceof NumericReadings.Resolution.Multiple) {
+                throw new IllegalStateException("the number " + operation.qualified()
+                        + " answers is read as " + NumericReadings.describe(read)
+                        + ", and one numeric call is read by one representation — which of them a"
+                        + " report showed would be whichever reader arrived");
+            }
+        }
         for (BoundOperationFact fact : facts.all()) {
             if (!(fact instanceof BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven
                     taken)) {
                 continue;
-            }
-            ValueName operation = taken.operation().operation();
-            String named = theLibraryOperation(operation).qualified();
-            NumericReadings.Resolution read = NumericReadings.resolve(stdlib, facts, operation);
-            if (!(read instanceof NumericReadings.Resolution.One(
-                    NumericReading.AsATermTakenOfItsArgument(TakenAs held)))
-                    || !held.equals(taken.how())) {
-                throw new IllegalStateException("the number " + named + " answers is read as "
-                        + NumericReadings.describe(read) + ", and one numeric call is read by one"
-                        + " representation — which of them a report showed would be whichever"
-                        + " reader arrived");
             }
             // What it takes it of is the shape the account is written for — a count is taken of
             // something that holds things, a magnitude of the operation's own kind of number.
@@ -722,7 +728,8 @@ final class OperationFactBinder {
             // declaration had them.
             Type source = taken.of().stands();
             if (!taken.how().takenOf(source, taken.answers())) {
-                throw new IllegalStateException(named + " is declared to answer "
+                throw new IllegalStateException(theLibraryOperation(taken.operation().operation())
+                        .qualified() + " is declared to answer "
                         + taken.how().getClass().getSimpleName() + " of a " + Type.show(source)
                         + ", which is not what that is taken of");
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -6,6 +6,7 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.ArgumentsStand;
 import souther.compiler.semantics.Arithmetic;
+import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.Combinator;
 import souther.compiler.semantics.DefinitionCase;
 import souther.compiler.semantics.NumericResult;
@@ -250,8 +251,9 @@ final class OperationFactBinder {
      * for the equation to be about.
      *
      * <p>Counted rather than a number, because that is what the fact says. A date is no number and
-     * counts days; whether a check can then do anything with such a form is a different question
-     * and belongs to the check ({@code DischargeRules.formOperationsThisCarries}).
+     * counts days. And counted is what the discharge check needs of every part to carry a form —
+     * a carrier that counts has the coordinate it reasons over — so a form held here is a form
+     * that check carries, and it does not ask again.
      */
     private static LinearForm<DeclaredArgument> holdAFormOfItsArguments(
             CompleteSignature declaration, LinearForm<ArgumentRef> form) {
@@ -361,7 +363,7 @@ final class OperationFactBinder {
      * place names each of them, and each is a claim about an argument; held for the source alone,
      * a second argument named by an alternative was one nothing had read.
      */
-    private static souther.compiler.semantics.BuiltFrom<DeclaredArgument> holdBuilding(
+    private static BuiltFrom<DeclaredArgument> holdBuilding(
             CompleteSignature declaration, OperationFact.BuildsItsResultFrom builds) {
         Map<ArgumentRef, DeclaredArgument> held = new HashMap<>();
         return builds.built().withArguments(named -> held.computeIfAbsent(named,

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -1,18 +1,33 @@
 package souther.compiler.check;
 
-import souther.compiler.stdlib.Stdlib;
+import souther.compiler.core.CompleteSignature;
+import souther.compiler.core.DeclaredOperation;
+import souther.compiler.numeric.LinearForm;
 import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.ArgumentsStand;
+import souther.compiler.semantics.Arithmetic;
+import souther.compiler.semantics.Combinator;
+import souther.compiler.semantics.DefinitionCase;
+import souther.compiler.semantics.NumericResult;
 import souther.compiler.semantics.OperationFact;
 import souther.compiler.semantics.OperationFacts;
-import souther.compiler.core.DeclaredOperation;
+import souther.compiler.semantics.ResultBound;
+import souther.compiler.semantics.TakenAs;
+import souther.compiler.stdlib.Stdlib;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.ValueName;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * Holds what is declared of the language's operations to what the library declares.
+ * Holds what is declared of the language's operations to what the library declares, and answers
+ * with the facts as bound.
  *
  * <p>A fact names an argument of an operation, and what an operation's arguments are is the
  * library's to say. Where the two disagree there is nothing to be done at a call — the fact is
@@ -20,45 +35,37 @@ import java.util.Map;
  * said before any call is read rather than met as a missing answer at whichever reader arrives
  * first.
  *
+ * <p><b>The one reader of the authoring vocabulary below the declarations, and the one place an
+ * {@link ArgumentRef} becomes a position.</b> Everything below the binding holds a
+ * {@link BoundOperationFact}, in which every operation is a {@link DeclaredOperation} and every
+ * argument a {@link DeclaredArgument}; what those are made of — a word, a name, a signature, what
+ * {@link Combinators} says an operation hands its closure — is read here and nowhere after.
+ * {@code OnlyTheBinderReadsTheAuthoringVocabularyTest} counts that.
+ *
  * <p><b>Over the declarations and not over what a reader asked for.</b> Bound one fact at a time as
  * it was looked up, a fact nothing looked up was a fact nothing checked, and how much of the
  * declaration was validated depended on which consumers a compilation happened to have. This walks
  * the whole list, so a fact declared is a fact held to the library whether or not anything reads
  * it.
  *
- * <p><b>And bound, not merely visited.</b> A fact is not held to the library because its kind was
- * reached: the operation it is declared of is resolved against the library for every declaration,
- * outside the switch. Held inside it, the resolution was reached only by the kinds that name an
- * argument — the ones whose arm calls {@link DischargeRules#holdToTheDeclaration} — so a kind that
- * names none passed through an empty arm having been held to nothing. Whether a declaration was
- * checked depended on what its fact happened to mention, and the next kind of fact would have lost
- * the same way on the day its arm was written empty.
+ * <p><b>Each declaration read once, before the switch.</b> The operation a fact is about is read
+ * against the library into a {@link CompleteSignature} for every declaration, outside the switch,
+ * and every arm is handed that reading. So being declared is what holds a fact to the library
+ * rather than being a kind that happens to name an argument, and no arm reads the operation a
+ * second time to ask where an argument is.
  *
- * <p>Here and not with the declarations, because holding them takes the library's signatures and
- * the questions this check asks of a type — which is this side's, and is what the declarations were
- * given a home away from.
+ * <p><b>The switch is an expression.</b> Every arm yields the bound fact its kind comes to, so a
+ * kind of fact added to the declarations is a kind that does not compile until this says what it
+ * is once bound — an empty arm was how a kind went through held to nothing, and there is no empty
+ * arm in an expression.
  *
- * <p>Read on the first ask, as {@link Combinators} and {@link Preserved} are: what this requires of
- * the library is required of a check that reads these facts, and a checker that reads none must not
- * be held to it.
+ * <p>The second way into {@link CompleteSignature#ofDeclaration} beside {@link Preserved}, and on
+ * the same warrant: a library declaration, read whole. {@code Preserved} is what a representation
+ * keeps standing, which is a policy about representations and not about which operations the
+ * library has, so a fact about an operation nothing keeps standing could not borrow its reading
+ * from there.
  */
 final class OperationFactBinder {
-
-    /**
-     * What one walk of the declarations came to.
-     *
-     * <p>{@code visited} is the authoring declarations themselves, in the order they were held.
-     * That is what they are: this says a declaration was held to the library and does not say it in
-     * the type of what it hands back. A reader that wants a fact asks {@link OperationFacts} for
-     * the authoring value, so what holds such a reader up is that this walk refused a declaration
-     * the library disagrees with — a check that ran, rather than a value carrying what it settled.
-     *
-     * <p>{@code sizes} is the exception and the shape the rest are headed for: an emptiness check,
-     * against the size it means, with both operations read against their declarations. Keyed by the
-     * emptiness check, which is what a reader holding a call has.
-     */
-    record Binding(List<OperationFacts.Declared> visited,
-                   Map<DeclaredOperation, BoundOperationFact.MeansTheSameAsSizeOfNought> sizes) {}
 
     /**
      * Holds every fact of {@code declared} to the library, and answers with what the walk came to.
@@ -66,111 +73,690 @@ final class OperationFactBinder {
      * <p>The source is a parameter so that what this covers can be asked of it with a source of
      * one's own. Reading {@link OperationFacts#declarations()} directly, a test could show that the
      * facts there are valid and not that a fact added later would be visited at all.
+     *
+     * <p>Two passes and not one. Each fact is held to its own declaration as it is met; what one
+     * fact may not say beside another — that a number is read by one representation — is asked of
+     * all of them together once every one is bound, since a question about the set cannot be
+     * answered from the order the declarations happen to come in.
      */
-    static Binding bindAll(Stdlib stdlib, List<OperationFacts.Declared> declared) {
-        List<OperationFacts.Declared> visited = new ArrayList<>();
-        Map<DeclaredOperation, BoundOperationFact.MeansTheSameAsSizeOfNought> sizes = new LinkedHashMap<>();
+    static BoundOperationFacts bindAll(Stdlib stdlib, List<OperationFacts.Declared> declared) {
+        List<BoundOperationFact> bound = new ArrayList<>();
         for (OperationFacts.Declared each : declared) {
-            // Before the switch and outside it, so that being declared is what holds a fact to the
-            // library rather than being a kind that happens to name an argument. An arm below with
-            // nothing in it then says what it means — there is nothing to check beyond the
-            // operation — instead of standing for a declaration nothing looked at.
-            DischargeRules.holdTheOperationToTheLibrary(stdlib, each.operation());
-            // No default. A kind of fact added is a kind this has to say how to hold, rather than
-            // one that passes through unchecked because nothing here mentions it.
-            switch (each.fact()) {
-                case OperationFact.AnswersAFormOfItsArguments answers ->
-                        DischargeRules.holdAFormOfItsArguments(stdlib, each.operation(), answers.form());
-                // Both arguments, because which is the greater and which the lesser are one
-                // statement and a signature could disagree with either half.
-                case OperationFact.StatesTheOrderOfItsArguments states -> {
-                    DischargeRules.holdToTheDeclaration(stdlib, each.operation(), states.order().greater(),
-                            null, TypeRequirement.ANY,
-                            "the argument a positive answer names as greater");
-                    DischargeRules.holdToTheDeclaration(stdlib, each.operation(), states.order().lesser(),
-                            null, TypeRequirement.ANY,
-                            "the argument a positive answer names as lesser");
-                }
-                case OperationFact.ShiftsBy shifts -> DischargeRules.holdShift(stdlib, each.operation(),
-                        shifts);
-                case OperationFact.BoundsItsResult bounded ->
-                        DischargeRules.holdBound(stdlib, each.operation(), bounded.bound());
-                case OperationFact.BuildsItsResultFrom builds ->
-                        DischargeRules.holdToTheDeclaration(stdlib, each.operation(),
-                                builds.built().from(),
-                                new ArgumentRef.TheContainer(),
-                                TypeRequirement.CONTAINER,
-                                "the container something is built from");
-                case OperationFact.ResultIsNoSmallerThan bounded ->
-                        DischargeRules.holdToTheDeclaration(stdlib, each.operation(), bounded.container(),
-                                new ArgumentRef.TheContainer(),
-                                TypeRequirement.CONTAINER,
-                                "a container the result is no smaller than");
-                case OperationFact.ReadsItsContainer reads ->
-                        DischargeRules.holdToTheDeclaration(stdlib, each.operation(), reads.container(),
-                                new ArgumentRef.TheContainer(),
-                                TypeRequirement.CONTAINER,
-                                "the container a predicate reads");
-                case OperationFact.IsStatedOverAProjection over ->
-                        DischargeRules.holdToTheDeclaration(stdlib, each.operation(), over.projection(),
-                                new ArgumentRef.TheClosure(),
-                                TypeRequirement.CLOSURE,
-                                "the projection a predicate is stated over");
-                // Names no argument, but it does name another operation — and what a reader does
-                // with it is write a call of that one where a call of this one stands. So the two
-                // declarations are held to each other, and what comes back is the fact with both
-                // operations read against them.
-                case OperationFact.MeansTheSameAsASizeOfNought means -> {
-                    BoundOperationFact.MeansTheSameAsSizeOfNought bound =
-                            DischargeRules.holdSizeEquivalence(stdlib, each.operation(),
-                                    means.size());
-                    // One operation, one bound fact of a kind. A second declaration of the same
-                    // kind about one operation is two answers to a question that has one, and a map
-                    // written into keeps whichever arrived last — so the rewrite a call gets would
-                    // depend on the order the declarations are written in.
-                    // One operation, one bound fact of a kind. A second declaration of the same kind
-                    // about one operation is two answers to a question that has one, and a map
-                    // written into keeps whichever arrived last — so the rewrite a call gets would
-                    // depend on the order the declarations are written in. The authoring index that
-                    // used to refuse this answers nothing now, and refusing it belongs where the
-                    // bound facts are collected.
-                    if (sizes.put(bound.predicate(), bound) != null) {
-                        throw new IllegalStateException(bound.predicate()
-                                + " is declared to mean a size of nought twice");
-                    }
-                }
-                // Neither of these names anything beyond the operation it is about — a silence names
-                // nothing by definition — so there is nothing about one to hold to a signature.
-                // Their operation is held above with every other, which is what makes this arm a
-                // statement about these facts rather than a gap.
-                case OperationFact.StatesItsPredicateOfEveryElement _,
-                     OperationFact.SaysNothingOf _ -> { }
-                // Stated of the number an operation answers, so an operation that answers none is
-                // one the proposition is not about. Waved through, it was a fact anything could
-                // carry — which is what an arm that does nothing promises, and the promise is
-                // wrong here (#1027).
-                case OperationFact.EveryAnswerItCanGiveHasASourceValue _ ->
-                        DischargeRules.holdTheResultToTheDeclaration(stdlib, each.operation(),
-                                TypeRequirement.NUMBER,
-                                "what every answer of it has a value for");
-                case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
-                        DischargeRules.holdTakenOf(stdlib, declared, each.operation(), taken.how());
-                case OperationFact.AccumulatesItsContainer accumulates ->
-                        DischargeRules.holdAccumulation(stdlib, each.operation(),
-                                accumulates.container());
-                case OperationFact.ComputesANumber computes ->
-                        DischargeRules.holdNumericResult(stdlib, each.operation(), computes.result());
-                case OperationFact.IsDefinedByCases defined ->
-                        DischargeRules.holdCase(stdlib, each.operation(), defined.one());
-            }
-            visited.add(each);
+            CompleteSignature declaration = declaredSignature(stdlib, each.operation());
+            bound.add(bind(stdlib, declaration, each.fact()));
         }
-        return new Binding(List.copyOf(visited), Map.copyOf(sizes));
+        BoundOperationFacts facts = new BoundOperationFacts(bound);
+        holdEachNumberToOneReading(stdlib, facts);
+        return facts;
     }
 
     /** The same, over what the language declares. */
-    static Binding bindAll(Stdlib stdlib) {
+    static BoundOperationFacts bindAll(Stdlib stdlib) {
         return bindAll(stdlib, OperationFacts.declarations());
+    }
+
+    /** One fact held to the declaration it is about. No default: a kind of fact added is a kind
+     *  this has to say how to hold and what it comes to, rather than one that passes through
+     *  unchecked because nothing here mentions it. */
+    private static BoundOperationFact bind(Stdlib stdlib, CompleteSignature declaration,
+                                           OperationFact fact) {
+        DeclaredOperation operation = declaration.declaring();
+        return switch (fact) {
+            case OperationFact.AnswersAFormOfItsArguments answers ->
+                    new BoundOperationFact.AnswersAFormOfItsArguments(operation,
+                            holdAFormOfItsArguments(declaration, answers.form()));
+            // Both arguments, because which is the greater and which the lesser are one
+            // statement and a signature could disagree with either half.
+            case OperationFact.StatesTheOrderOfItsArguments states ->
+                    new BoundOperationFact.StatesTheOrderOfItsArguments(operation,
+                            holdToTheDeclaration(declaration, states.order().greater(), null,
+                                    TypeRequirement.ANY,
+                                    "the argument a positive answer names as greater"),
+                            holdToTheDeclaration(declaration, states.order().lesser(), null,
+                                    TypeRequirement.ANY,
+                                    "the argument a positive answer names as lesser"));
+            case OperationFact.ShiftsBy shifts -> holdShift(stdlib, declaration, shifts);
+            case OperationFact.BoundsItsResult bounded ->
+                    new BoundOperationFact.BoundsItsResult(operation,
+                            holdBound(declaration, bounded.bound()));
+            case OperationFact.BuildsItsResultFrom builds ->
+                    new BoundOperationFact.BuildsItsResultFrom(operation,
+                            holdBuilding(declaration, builds));
+            case OperationFact.ResultIsNoSmallerThan bounded ->
+                    new BoundOperationFact.ResultIsNoSmallerThan(operation,
+                            holdToTheDeclaration(declaration, bounded.container(),
+                                    new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
+                                    "a container the result is no smaller than"));
+            case OperationFact.ReadsItsContainer reads ->
+                    new BoundOperationFact.ReadsItsContainer(operation,
+                            holdToTheDeclaration(declaration, reads.container(),
+                                    new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
+                                    "the container a predicate reads"),
+                            reads.through());
+            case OperationFact.IsStatedOverAProjection over ->
+                    new BoundOperationFact.IsStatedOverAProjection(operation,
+                            holdToTheDeclaration(declaration, over.projection(),
+                                    new ArgumentRef.TheClosure(), TypeRequirement.CLOSURE,
+                                    "the projection a predicate is stated over"));
+            // Names no argument, but it does name another operation — and what a reader does
+            // with it is write a call of that one where a call of this one stands. So the two
+            // declarations are held to each other.
+            case OperationFact.MeansTheSameAsASizeOfNought means ->
+                    holdSizeEquivalence(stdlib, declaration, means.size());
+            // Neither of these names anything beyond the operation it is about — a silence names
+            // nothing by definition — so there is nothing about one to hold to a signature beyond
+            // the declaration every fact is held to above. What each comes to bound is the fact
+            // about that declaration.
+            case OperationFact.StatesItsPredicateOfEveryElement _ ->
+                    new BoundOperationFact.StatesItsPredicateOfEveryElement(operation);
+            case OperationFact.SaysNothingOf silence ->
+                    new BoundOperationFact.SaysNothingOf(operation, silence.subject());
+            // Stated of the number an operation answers, so an operation that answers none is
+            // one the proposition is not about. Waved through, it was a fact anything could
+            // carry (#1027).
+            case OperationFact.EveryAnswerItCanGiveHasASourceValue _ -> {
+                holdTheResultToTheDeclaration(declaration, TypeRequirement.NUMBER,
+                        "what every answer of it has a value for");
+                yield new BoundOperationFact.EveryAnswerItCanGiveHasASourceValue(operation);
+            }
+            case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
+                    holdTakenOf(declaration, taken.how());
+            case OperationFact.AccumulatesItsContainer accumulates ->
+                    new BoundOperationFact.AccumulatesItsContainer(operation,
+                            holdAccumulation(declaration, accumulates.container()),
+                            accumulates.how());
+            case OperationFact.ComputesANumber computes ->
+                    new BoundOperationFact.ComputesANumber(operation,
+                            holdNumericResult(stdlib, declaration, computes.result()));
+            case OperationFact.IsDefinedByCases defined ->
+                    new BoundOperationFact.IsDefinedByCases(operation,
+                            holdCase(declaration, defined.one()));
+        };
+    }
+
+    /**
+     * Holds one rule to the operation it is about: the argument it names is one the declaration
+     * has, and what stands there is what the rule requires. A rule naming a part of something the
+     * signature says the operation does not hand is caught by the word itself; one that writes a
+     * position the signature already answers is caught here, since two answers to one question are
+     * what come apart later.
+     *
+     * <p><b>The one place a word becomes a position.</b> What {@link ArgumentRef.TheContainer} and
+     * {@link ArgumentRef.TheClosure} are positions of is read off the library's own declaration
+     * ({@link Combinators}), here and nowhere below: what comes back is a {@link DeclaredArgument},
+     * which carries the position, and a reader below has that and no word to resolve.
+     */
+    static DeclaredArgument holdToTheDeclaration(CompleteSignature declaration, ArgumentRef at,
+                                                 ArgumentRef derived, TypeRequirement required,
+                                                 String role) {
+        ValueName.Stdlib library = (ValueName.Stdlib) declaration.declaring().operation();
+        List<Type> params = declaration.params();
+        int position = positionIn(at, library);
+        if (position < 0 || position >= params.size()) {
+            throw new IllegalStateException(library.qualified() + " takes " + params.size()
+                    + " argument(s), and the rule about " + role + " reads argument "
+                    + (position + 1));
+        }
+        Type stands = params.get(position);
+        if (!required.admits(stands)) {
+            throw new IllegalStateException("argument " + (position + 1) + " of "
+                    + library.qualified() + " is " + Type.show(stands) + ", not " + required
+                    + "; it is named as " + role);
+        }
+        if (at instanceof ArgumentRef.At && derived != null && Combinators.of(library) != null
+                && positionIn(derived, library) == position) {
+            throw new IllegalStateException("the rule about " + role + " for "
+                    + library.qualified()
+                    + " writes the argument its signature already answers — say which part it is"
+                    + " rather than where, so the two cannot come apart");
+        }
+        return new DeclaredArgument(declaration.declaring(), position, stands);
+    }
+
+    /**
+     * Which parameter of {@code operation} {@code ref} names.
+     *
+     * <p>A written position is itself. The two that are named by the part they play are the
+     * library's to say, and an operation whose signature hands its closure nothing a container
+     * holds has neither — a fact naming one of them there is a fact about an argument that is not
+     * there, and it is said rather than answered with a number that would be wrong.
+     */
+    private static int positionIn(ArgumentRef ref, ValueName operation) {
+        return switch (ref) {
+            case ArgumentRef.At at -> at.position();
+            case ArgumentRef.TheContainer _ -> handing(operation, "the container").containerArg();
+            case ArgumentRef.TheClosure _ -> handing(operation, "the closure").closureArg();
+        };
+    }
+
+    private static Combinator handing(ValueName operation, String part) {
+        Combinator handed = Combinators.of(operation);
+        if (handed == null) {
+            throw new IllegalStateException("a rule about " + operation + " names " + part
+                    + " of what it hands its closure, and its signature says it hands one nothing"
+                    + " a container holds");
+        }
+        return handed;
+    }
+
+    /**
+     * Holds a declared form to the library: what it answers counts, and so does every argument it
+     * is written over.
+     *
+     * <p>Both ends, because the fact is an equation between them —
+     * {@code count(result) = Σ cᵢ·count(argᵢ) + k}. Held of the arguments alone it was half a
+     * statement: {@code List.take(n, xs)} declared to answer the number of its first argument
+     * passed, that argument being an {@code Int}, while what it answers is a list and has no count
+     * for the equation to be about.
+     *
+     * <p>Counted rather than a number, because that is what the fact says. A date is no number and
+     * counts days; whether a check can then do anything with such a form is a different question
+     * and belongs to the check ({@code DischargeRules.formOperationsThisCarries}).
+     */
+    private static LinearForm<DeclaredArgument> holdAFormOfItsArguments(
+            CompleteSignature declaration, LinearForm<ArgumentRef> form) {
+        holdTheResultToTheDeclaration(declaration, TypeRequirement.COUNTED,
+                "what a form of its arguments is about");
+        LinearForm<DeclaredArgument> bound = LinearForm.constant(form.constant());
+        for (Map.Entry<ArgumentRef, BigDecimal> each : form.coefs().entrySet()) {
+            DeclaredArgument argument = holdToTheDeclaration(declaration, each.getKey(), null,
+                    TypeRequirement.COUNTED, "an argument the result is a form of");
+            bound = bound.plus(LinearForm.<DeclaredArgument>atom(argument).times(each.getValue()));
+        }
+        return bound;
+    }
+
+    /**
+     * As {@link #holdToTheDeclaration}, for a rule stating a shift through a measure: the amount is
+     * a number, the value shifted is of the type the measure counts, and the measure counts two of
+     * what the operation answers. A rule pairing an operation with a measure of something else
+     * would state a relation between two values that have none.
+     */
+    private static BoundOperationFact.ShiftsBy holdShift(Stdlib stdlib,
+                                                         CompleteSignature declaration,
+                                                         OperationFact.ShiftsBy shift) {
+        ValueName.Stdlib library = (ValueName.Stdlib) declaration.declaring().operation();
+        DeclaredArgument amount = holdToTheDeclaration(declaration, shift.amount(), null,
+                TypeRequirement.NUMBER, "the amount a shift moves by");
+        Stdlib.Entry counts = stdlib.entry(shift.measure());
+        if (counts == null) {
+            throw new IllegalStateException("the rule about " + library.qualified()
+                    + " counts through " + shift.measure().qualified()
+                    + ", which the library does not declare");
+        }
+        List<Type> counted = counts.signature().params();
+        if (counted.size() != 2 || !NumericAnswers.isANumber(counts.signature().result())
+                || !counted.get(0).equals(declaration.result())
+                || !counted.get(1).equals(declaration.result())) {
+            throw new IllegalStateException(shift.measure().qualified()
+                    + " does not count two of what " + library.qualified()
+                    + " answers apart as a number");
+        }
+        DeclaredArgument moved = holdToTheDeclaration(declaration, shift.of(), null,
+                TypeRequirement.ANY, "the value a shift moves from");
+        // Not a requirement on the type, which is why it is stated here rather than passed as one.
+        // What this asks is that two positions of one signature stand at the same type, and nothing
+        // about a type on its own answers that — a requirement able to say it would be one carrying
+        // the signature it was written for.
+        if (!moved.stands().equals(declaration.result())) {
+            throw new IllegalStateException("the value " + library.qualified()
+                    + " shifts is " + Type.show(moved.stands()) + " and what it answers is "
+                    + Type.show(declaration.result())
+                    + ", so what it moves is not what the measure counts");
+        }
+        return new BoundOperationFact.ShiftsBy(declaration.declaring(),
+                declaredSignature(stdlib, shift.measure()).declaring(), moved, amount, shift.per());
+    }
+
+    /** As {@link #holdToTheDeclaration}, for the arguments a case names: the one it answers, and
+     *  the two sides of each condition it is reached under. */
+    private static DefinitionCase<DeclaredArgument> holdCase(CompleteSignature declaration,
+                                                             DefinitionCase<ArgumentRef> one) {
+        holdTheResultToTheDeclaration(declaration, TypeRequirement.NUMBER,
+                "what a case of the definition answers");
+        DeclaredArgument answers = holdCaseArgument(declaration, one.answers());
+        List<ArgumentsStand<DeclaredArgument>> given = new ArrayList<>();
+        for (ArgumentsStand<ArgumentRef> stands : one.given()) {
+            given.add(new ArgumentsStand<>(holdCaseArgument(declaration, stands.left()),
+                    stands.rel(), holdCaseArgument(declaration, stands.right())));
+        }
+        return new DefinitionCase<>(answers, given);
+    }
+
+    private static DeclaredArgument holdCaseArgument(CompleteSignature declaration,
+                                                     ArgumentRef named) {
+        return holdToTheDeclaration(declaration, named, null, TypeRequirement.NUMBER,
+                "an argument a case of the definition names");
+    }
+
+    /** As {@link #holdToTheDeclaration}, for the arguments a bound names: the one the result is
+     *  bounded against, and the one a condition on the rule reads. Each is a separate claim about a
+     *  separate argument. */
+    private static ResultBound<DeclaredArgument> holdBound(CompleteSignature declaration,
+                                                           ResultBound<ArgumentRef> bound) {
+        holdTheResultToTheDeclaration(declaration, TypeRequirement.NUMBER,
+                "what a bound on the result holds of");
+        DeclaredArgument against = bound.against() == null ? null
+                : holdBoundArgument(declaration, bound.against());
+        ResultBound.Provided<DeclaredArgument> provided = switch (bound.provided()) {
+            case ResultBound.Provided.Always<ArgumentRef> _ -> new ResultBound.Provided.Always<>();
+            case ResultBound.Provided.ConstantAboveZero<ArgumentRef> constant ->
+                    new ResultBound.Provided.ConstantAboveZero<>(
+                            holdBoundArgument(declaration, constant.argument()));
+        };
+        return new ResultBound<>(against, bound.offset(), bound.rel(), provided);
+    }
+
+    private static DeclaredArgument holdBoundArgument(CompleteSignature declaration,
+                                                      ArgumentRef named) {
+        return holdToTheDeclaration(declaration, named, null, TypeRequirement.NUMBER,
+                "an argument a bound on the result names");
+    }
+
+    /**
+     * Holds a building to the library: every argument the lineage names is a container the
+     * declaration has.
+     *
+     * <p>Every argument and not the one source. A lineage whose elements come from more than one
+     * place names each of them, and each is a claim about an argument; held for the source alone,
+     * a second argument named by an alternative was one nothing had read.
+     */
+    private static souther.compiler.semantics.BuiltFrom<DeclaredArgument> holdBuilding(
+            CompleteSignature declaration, OperationFact.BuildsItsResultFrom builds) {
+        Map<ArgumentRef, DeclaredArgument> held = new HashMap<>();
+        return builds.built().withArguments(named -> held.computeIfAbsent(named,
+                each -> holdToTheDeclaration(declaration, each, new ArgumentRef.TheContainer(),
+                        TypeRequirement.CONTAINER, "the container something is built from")));
+    }
+
+    /**
+     * As {@link #holdToTheDeclaration}, for the arithmetic an operation computes: it takes as many
+     * arguments as the row hands over, and it answers its number where the row says it does.
+     *
+     * <p>The result position is the half a signature can disagree with silently. A row saying the
+     * number arrives in the case carrying {@code Int} is read at an arm, and an arm that never
+     * matches is an arm that reports nothing — so a union that gained a case, or lost the one the
+     * row names, would leave the operation with a meaning no program reaches and no diagnostic
+     * anywhere. Held here, before any call is read.
+     */
+    private static NumericResult<DeclaredArgument> holdNumericResult(
+            Stdlib stdlib, CompleteSignature declaration, NumericResult<ArgumentRef> rule) {
+        DeclaredOperation operation = declaration.declaring();
+        Type answers = NumericAnswers.in(declaration.result());
+        List<Arithmetic.Reads> reads = rule.computes().reads();
+        if (declaration.params().size() != reads.size()) {
+            throw new IllegalStateException(operation + " takes " + declaration.params().size()
+                    + " argument(s), and the arithmetic written for it reads " + reads.size());
+        }
+        for (int i = 0; i < reads.size(); i++) {
+            if (!heldBy(stdlib, reads.get(i), declaration.params().get(i), answers)) {
+                throw new IllegalStateException("argument " + (i + 1) + " of " + operation
+                        + " is " + Type.show(declaration.params().get(i))
+                        + ", which the arithmetic written for it reads as " + reads.get(i));
+            }
+        }
+        switch (rule.at()) {
+            case NumericResult.Answered.Directly _ ->
+                    holdTheResultToTheDeclaration(declaration, TypeRequirement.NUMBER,
+                            "where the arithmetic it computes is answered");
+            case NumericResult.Answered.InTheCaseCarrying(Type carried) -> {
+                if (!(declaration.result() instanceof Type.Union(Set<TypeSymbol> members))) {
+                    throw new IllegalStateException(operation + " answers "
+                            + Type.show(declaration.result())
+                            + ", which has no case for the number it computes to arrive in");
+                }
+                if (!carried.equals(answers)) {
+                    throw new IllegalStateException(operation + " answers no case carrying "
+                            + Type.show(carried));
+                }
+                if (rule.unless() == null) {
+                    throw new IllegalStateException(operation + " answers its number as one case"
+                            + " of a union, so when the other case comes back is what that case"
+                            + " means and is not written down");
+                }
+                // The condition names no case, so it says what every case that is not the
+                // number's says — which is one statement only where there is one such case. A
+                // union that gained a third would have an arm establishing a condition it was
+                // not taken under, which is a wrong fact rather than a missing one, and nothing
+                // downstream could tell: an arm is read the same way whichever case it names.
+                // Where a second failure is wanted, the condition is what has to name its case.
+                if (members.size() != 2) {
+                    throw new IllegalStateException(operation + " answers "
+                            + members.size() + " cases, and when it answers no number is"
+                            + " written as one condition — which says what one other case"
+                            + " means and cannot say what several do");
+                }
+            }
+        }
+        NumericResult.TheOtherCaseWhen<DeclaredArgument> unless = rule.unless() == null ? null
+                : new NumericResult.TheOtherCaseWhen<>(
+                        holdToTheDeclaration(declaration, rule.unless().argument(), null,
+                                TypeRequirement.NUMBER, "the argument a failure is decided by"),
+                        rule.unless().op(), rule.unless().than());
+        return new NumericResult<>(rule.at(), rule.computes(), unless);
+    }
+
+    /**
+     * Whether the argument declared {@code at} is what the row says that position reads, for an
+     * operation answering {@code answered}.
+     *
+     * <p>Here and not on {@link Arithmetic.Reads}, which says what a position is and stops there.
+     * Holding one of those to a declaration is a question about the library, and this is the reader
+     * that has the library — the same reader that holds the operation's arity and its result to it.
+     *
+     * <p>Two of them are answered from the row itself: the number the operation answers is the one
+     * its result carries, and a scale is a count. The third is answered from a declaration, because
+     * there is nothing about a rounding policy that a type says of itself — and reading it off a
+     * name written here would be a second answer to which type it is, which is what ADR-0087 ends.
+     */
+    private static boolean heldBy(Stdlib stdlib, Arithmetic.Reads reads, Type at, Type answered) {
+        return switch (reads) {
+            case THE_NUMBER_IT_ANSWERS -> at.equals(answered);
+            case A_SCALE -> at == Type.Prim.INT;
+            case A_ROUNDING_MODE -> at.equals(theRoundingPolicyTheLibraryDeclares(stdlib));
+        };
+    }
+
+    /** Which library operation the rounding policy is read off, and where in its arguments. */
+    private static final ValueName.Stdlib ROUNDING_POLICY_ANCHOR =
+            ValueName.Stdlib.operation("Decimal", "round");
+
+    /** {@code round(scale, mode, d)} — the second of them. */
+    private static final int ROUNDING_POLICY_ARGUMENT = 1;
+
+    /**
+     * The type the library declares for a rounding policy, taken from the operation that declares
+     * one and read as whatever that operation declares there.
+     *
+     * <p>Whatever it declares there, and never a type this checks against. A rule that said the
+     * anchor's argument must be {@code RoundingMode} would be the spelling back again, one operation
+     * further along. What is held is that two declarations agree: {@code Decimal.divide} takes at
+     * its policy position the type {@code Decimal.round} takes at its own, and either of them
+     * drifting alone fails this. Both moving to a new policy type together passes, and should —
+     * that is the library being redesigned rather than the table and the library disagreeing.
+     *
+     * <p>The anchor is a choice and is written down as one. What it is not is a second definition
+     * of which type the policy is: the library's declaration remains the only one.
+     *
+     * @throws IllegalStateException where the anchor no longer declares the argument it is read off
+     */
+    private static Type theRoundingPolicyTheLibraryDeclares(Stdlib stdlib) {
+        List<Type> params = holdTheOperationToTheLibrary(stdlib, ROUNDING_POLICY_ANCHOR)
+                .signature().params();
+        if (params.size() <= ROUNDING_POLICY_ARGUMENT) {
+            throw new IllegalStateException(ROUNDING_POLICY_ANCHOR.qualified() + " takes "
+                    + params.size() + " argument(s), and the rounding policy every arithmetic over"
+                    + " one is held to is read off argument " + (ROUNDING_POLICY_ARGUMENT + 1)
+                    + " of it");
+        }
+        return params.get(ROUNDING_POLICY_ARGUMENT);
+    }
+
+    /** The library operation {@code operation} names. Every fact is declared of one, so the name
+     *  says which library and which operation rather than a spelling a reader would have to take
+     *  apart.
+     *
+     *  @throws IllegalStateException where the name is no library operation. */
+    static ValueName.Stdlib.Operation theLibraryOperation(ValueName operation) {
+        if (!(operation instanceof ValueName.Stdlib.Operation library)) {
+            throw new IllegalStateException("a fact is declared of " + operation
+                    + ", which is not a library operation");
+        }
+        return library;
+    }
+
+    /**
+     * The library's declaration of {@code operation}, or a build that does not start.
+     *
+     * <p>What every fact owes, whatever else it says. A fact is a proposition about an operation,
+     * so an operation the library does not have is a fact about nothing — and that is true of a
+     * fact naming no argument as much as of one that names three.
+     */
+    static Stdlib.Entry holdTheOperationToTheLibrary(Stdlib stdlib, ValueName operation) {
+        ValueName.Stdlib.Operation library = theLibraryOperation(operation);
+        Stdlib.Entry entry = stdlib.entry(library);
+        if (entry == null) {
+            throw new IllegalStateException("a fact is declared of " + library.qualified()
+                    + ", which the library does not declare");
+        }
+        return entry;
+    }
+
+    /** The library's declaration of {@code operation}, read whole. */
+    static CompleteSignature declaredSignature(Stdlib stdlib, ValueName operation) {
+        Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
+        return CompleteSignature.ofDeclaration(operation, entry.signature().params(),
+                entry.signature().result());
+    }
+
+    /**
+     * Holds an emptiness check and the size it is said to mean to each other's declarations, and
+     * answers with the two as the library declares them.
+     *
+     * <p>What a reader does with this fact is write the second call where the first stands, keeping
+     * the arguments. So what has to hold is that the arguments the first takes are the ones the
+     * second takes, and that the two answer the kinds of thing the rewrite turns into each other: a
+     * truth on one side, a number to compare against nought on the other. Two operations of one
+     * argument each is not enough — a check on strings and a length of lists agree on how many
+     * arguments they take and on nothing else.
+     */
+    private static BoundOperationFact.MeansTheSameAsASizeOfNought holdSizeEquivalence(
+            Stdlib stdlib, CompleteSignature asks, ValueName size) {
+        ValueName operation = asks.declaring().operation();
+        CompleteSignature counts = declaredSignature(stdlib, size);
+        if (asks.params().size() != 1 || asks.result() != Type.BOOL) {
+            throw new IllegalStateException(theLibraryOperation(operation).qualified()
+                    + " is declared to say whether one container is empty, and it takes "
+                    + asks.params().size() + " argument(s) and answers "
+                    + Type.show(asks.result()));
+        }
+        if (counts.params().size() != 1 || counts.result() != Type.INT) {
+            throw new IllegalStateException(theLibraryOperation(size).qualified()
+                    + " is named as the size " + theLibraryOperation(operation).qualified()
+                    + " means, and it takes " + counts.params().size()
+                    + " argument(s) and answers " + Type.show(counts.result()));
+        }
+        if (!sameShape(asks.params().get(0), counts.params().get(0),
+                new HashMap<>(), new HashMap<>())) {
+            throw new IllegalStateException(theLibraryOperation(operation).qualified() + " asks of "
+                    + Type.show(asks.params().get(0)) + " and "
+                    + theLibraryOperation(size).qualified() + " counts "
+                    + Type.show(counts.params().get(0))
+                    + ", so a call of the first is no call of the second");
+        }
+        return new BoundOperationFact.MeansTheSameAsASizeOfNought(asks.declaring(),
+                counts.declaring());
+    }
+
+    /**
+     * Whether the two are the same shape, telling type variables apart only by where they stand.
+     *
+     * <p>{@code List<'a>} and {@code List<'b>} are one shape and {@code List<'a>} and
+     * {@code List<Int>} are not, which is what a rewrite between two declarations needs and what
+     * unifying them does not answer: those two unify, by deciding that {@code 'a} is {@code Int},
+     * and a rewrite is not free to decide anything. The pairing is carried both ways so that two
+     * variables on one side cannot both stand for one on the other.
+     */
+    private static boolean sameShape(Type left, Type right, Map<String, String> paired,
+                                     Map<String, String> back) {
+        // A variable of an application, which no declaration holds: this compares what two
+        // declarations state. One arriving here is a caller having handed over something else, and
+        // answering "a different shape" would report that as the two operations disagreeing.
+        if (left instanceof Type.MetaVar || right instanceof Type.MetaVar) {
+            throw new IllegalStateException("a declared signature is being compared with "
+                    + Type.show(left instanceof Type.MetaVar ? left : right)
+                    + ", which belongs to an application rather than to a declaration");
+        }
+        return switch (left) {
+            case Type.Var l when right instanceof Type.Var r ->
+                    r.name().equals(paired.computeIfAbsent(l.name(), _ -> r.name()))
+                            && l.name().equals(back.computeIfAbsent(r.name(), _ -> l.name()));
+            case Type.ListOf l when right instanceof Type.ListOf r ->
+                    sameShape(l.element(), r.element(), paired, back);
+            case Type.SetOf l when right instanceof Type.SetOf r ->
+                    sameShape(l.element(), r.element(), paired, back);
+            case Type.OptionOf l when right instanceof Type.OptionOf r ->
+                    sameShape(l.element(), r.element(), paired, back);
+            case Type.MapOf l when right instanceof Type.MapOf r ->
+                    sameShape(l.key(), r.key(), paired, back)
+                            && sameShape(l.value(), r.value(), paired, back);
+            case Type.FnOf l when right instanceof Type.FnOf r ->
+                    sameShapes(l.params(), r.params(), paired, back)
+                            && sameShape(l.result(), r.result(), paired, back);
+            case Type.TupleOf l when right instanceof Type.TupleOf r ->
+                    sameShapes(l.elements(), r.elements(), paired, back);
+            // Everything else a declaration can hold stands for itself: a primitive, a declaration,
+            // a union of them, and a variable that did not pair with one above. Being the same
+            // shape is being the same type.
+            case Type.Leaf _ -> left.equals(right);
+            default -> false;
+        };
+    }
+
+    private static boolean sameShapes(List<Type> left, List<Type> right, Map<String, String> paired,
+                                      Map<String, String> back) {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (int i = 0; i < left.size(); i++) {
+            if (!sameShape(left.get(i), right.get(i), paired, back)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Holds what a fact says of the result to the declaration.
+     *
+     * <p>Beside {@link #holdToTheDeclaration} and for the half it cannot reach. That one names an
+     * argument, so a fact whose proposition mentions the result had nothing to say it with, and
+     * each kind that needed the result said it its own way or not at all. Improvising a check per
+     * kind defaults to omitting it.
+     *
+     * <p>Which requirement is the caller's, since what a fact says of the result is the fact's. A
+     * form is about a count and a bound about a number, and the difference between those two is a
+     * difference between the propositions and not between two ways of holding one.
+     */
+    private static void holdTheResultToTheDeclaration(CompleteSignature declaration,
+                                                      TypeRequirement required, String role) {
+        Type result = declaration.result();
+        if (!required.admits(result)) {
+            throw new IllegalStateException("what "
+                    + ((ValueName.Stdlib) declaration.declaring().operation()).qualified()
+                    + " answers is " + Type.show(result) + ", not " + required
+                    + "; it is named as " + role);
+        }
+    }
+
+    /**
+     * Holds a declared account of what an operation takes of the one value it is given to the
+     * operation: it takes exactly one value, since what such a term is read off is one location and
+     * a term names one path; and it answers a number, since a boundary is drawn on one.
+     *
+     * <p>Two of the four things such an account is held to, the two that are about this fact and
+     * this declaration alone. The other two are about the operation — that its number is read by
+     * one representation, and that what it is taken of is the shape the account is written for —
+     * and are asked once every fact is bound ({@link #holdEachNumberToOneReading}), in that order:
+     * an account that does not fit the operation is still an account of a number some other
+     * representation may already read, and asked the other way round the exclusivity would be
+     * reachable only through accounts that happen to fit.
+     */
+    private static BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven holdTakenOf(
+            CompleteSignature declaration, TakenAs how) {
+        String named = ((ValueName.Stdlib) declaration.declaring().operation()).qualified();
+        if (declaration.params().size() != 1) {
+            throw new IllegalStateException(named + " takes " + declaration.params().size()
+                    + " arguments, and a number taken of the one value an operation is given is"
+                    + " taken of one");
+        }
+        // A number and not a number at one case of a union. A term names one path and stands for
+        // what the operation answered there, and what an operation answering `Int | NotANumber`
+        // answers at that path is the union — which case it is in is a question this account has no
+        // room for. Narrower than the range of whatever asks for such an account, and deliberately:
+        // what may be declared and what is asked about are two ranges.
+        holdTheResultToTheDeclaration(declaration, TypeRequirement.NUMBER,
+                "what a term of its answer is about");
+        // The one value, as the declaration has it, carried so that what the account is held to
+        // fit is read off the bound fact and not off the declaration a second time.
+        DeclaredArgument of = holdToTheDeclaration(declaration, new ArgumentRef.At(0), null,
+                TypeRequirement.ANY, "the one value a number is taken of");
+        return new BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven(
+                declaration.declaring(), of, declaration.result(), how);
+    }
+
+    /**
+     * Holds every operation declared to answer a number taken of its argument to being read by
+     * that one representation, and then to the account fitting what the operation takes.
+     *
+     * <p>Asked of the bound facts together and after every one is bound, because the first is a
+     * claim about the set: an account declared beside a form is two readings whichever was written
+     * first. Asked as "is there already a form, an arithmetic, a body", it is one condition per
+     * representation there is, so a fourth has to be named in each of them; asked as how many
+     * readings the operation has ({@link NumericReadings}), a representation added is refused
+     * against every existing one without being paired with any of them.
+     *
+     * <p>The shape second, since a shape that does not fit is a fact about this account, and the
+     * exclusivity is a fact about the operation whatever account was written for it.
+     */
+    private static void holdEachNumberToOneReading(Stdlib stdlib, BoundOperationFacts facts) {
+        for (BoundOperationFact fact : facts.all()) {
+            if (!(fact instanceof BoundOperationFact.AnswersANumberTakenOfTheOneValueItIsGiven
+                    taken)) {
+                continue;
+            }
+            ValueName operation = taken.operation().operation();
+            String named = theLibraryOperation(operation).qualified();
+            NumericReadings.Resolution read = NumericReadings.resolve(stdlib, facts, operation);
+            if (!(read instanceof NumericReadings.Resolution.One(
+                    NumericReading.AsATermTakenOfItsArgument(TakenAs held)))
+                    || !held.equals(taken.how())) {
+                throw new IllegalStateException("the number " + named + " answers is read as "
+                        + NumericReadings.describe(read) + ", and one numeric call is read by one"
+                        + " representation — which of them a report showed would be whichever"
+                        + " reader arrived");
+            }
+            // What it takes it of is the shape the account is written for — a count is taken of
+            // something that holds things, a magnitude of the operation's own kind of number.
+            // Read off the bound fact, which carries the one argument and the answer as the
+            // declaration had them.
+            Type source = taken.of().stands();
+            if (!taken.how().takenOf(source, taken.answers())) {
+                throw new IllegalStateException(named + " is declared to answer "
+                        + taken.how().getClass().getSimpleName() + " of a " + Type.show(source)
+                        + ", which is not what that is taken of");
+            }
+        }
+    }
+
+    /**
+     * Holds an accumulation to the library: the argument it names holds elements, and they are of
+     * the type the operation answers.
+     *
+     * <p>Both halves, because an accumulation carries what it has so far in the answer's own type.
+     * A step over what it has and an element is written over two values of one type, so an argument
+     * whose elements are something else is one this walk could not be over, and the identity it
+     * starts from would be a value of a type nothing here names.
+     *
+     * <p>Which argument is named rather than searched for. A signature says of as many arguments as
+     * fit that they could be the one, and an operation given two containers of what it answers has
+     * a signature admitting two walks; the fact says which, and this says whether the signature
+     * bears it out.
+     */
+    private static DeclaredArgument holdAccumulation(CompleteSignature declaration,
+                                                     ArgumentRef container) {
+        DeclaredArgument walked = holdToTheDeclaration(declaration, container, null,
+                TypeRequirement.CONTAINER, "the container it accumulates");
+        Type answers = declaration.result();
+        Type element = Type.elementOfAContainer(walked.stands());
+        if (!element.equals(answers)) {
+            throw new IllegalStateException(
+                    ((ValueName.Stdlib) declaration.declaring().operation()).qualified()
+                    + " is declared to accumulate a container of " + Type.show(element)
+                    + " and answers " + Type.show(answers)
+                    + ", and a walk carries what it has so far in the type it answers");
+        }
+        return walked;
     }
 
     private OperationFactBinder() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.stdlib.Stdlib;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.OperationSubject;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -58,7 +57,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.COMBINATOR);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.COMBINATOR);
         }
     },
 
@@ -186,7 +185,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.BUILT);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.BUILT);
         }
     },
 
@@ -212,7 +211,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.PREDICATE_CARRY);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.PREDICATE_CARRY);
         }
     },
 
@@ -239,7 +238,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.EMPTINESS);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.EMPTINESS);
         }
     },
 
@@ -267,7 +266,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.QUANTIFICATION);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.QUANTIFICATION);
         }
     },
 
@@ -296,7 +295,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.PROJECTION);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.PROJECTION);
         }
     },
 
@@ -320,7 +319,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.SIZE);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.SIZE);
         }
     },
 
@@ -349,7 +348,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.ORDER);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.ORDER);
         }
     },
 
@@ -366,7 +365,7 @@ enum Question {
      * was true of one was written wherever a reader happened to want it (#1016).
      *
      * <p>A bound that does name an argument is still held to a signature that has one:
-     * {@link DischargeRules#holdBound} reads the argument it names, so an operation given no number
+     * {@link OperationFactBinder} reads the argument it names, so an operation given no number
      * cannot declare one — which is where that requirement belongs, since it is about a fact and a
      * declaration agreeing rather than about which operations are asked.
      */
@@ -388,7 +387,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.BOUNDS);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.BOUNDS);
         }
     },
 
@@ -418,7 +417,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.MEASURE);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.MEASURE);
         }
     },
 
@@ -446,7 +445,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.CHOICE);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.CHOICE);
         }
     },
 
@@ -480,7 +479,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.FORM);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.FORM);
         }
     },
 
@@ -517,7 +516,7 @@ enum Question {
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.NUMERIC_RESULT);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.NUMERIC_RESULT);
         }
     },
 
@@ -541,7 +540,7 @@ enum Question {
      * and the answer is that none does.
      *
      * <p>Wider than what may be declared. A term is held to a result that is a bare number
-     * ({@link DischargeRules#holdTakenOf}), because what stands at the path a term names is the
+     * (held by {@link OperationFactBinder}), because what stands at the path a term names is the
      * union and which case it is in is not something such an account has room for. The two ranges
      * are different on purpose: an operation may be asked a question whose only available answer is
      * that nothing reads it.
@@ -563,18 +562,18 @@ enum Question {
 
         @Override
         boolean answeredFor(Stdlib stdlib, ValueName operation) {
-            return NumericReadings.resolve(stdlib, OperationFacts.declarations(), operation)
+            return NumericReadings.resolve(stdlib, DefaultBoundOperationFacts.get(), operation)
                     instanceof NumericReadings.Resolution.One;
         }
 
         @Override
         Set<ValueName> answeredOperations() {
-            return OperationFacts.answersANumberTakenOfItsArgument();
+            return DefaultBoundOperationFacts.get().answersANumberTakenOfItsArgument();
         }
 
         @Override
         Set<ValueName> nothingSaidOf() {
-            return OperationFacts.saysNothingOf(OperationSubject.READING);
+            return DefaultBoundOperationFacts.get().saysNothingOf(OperationSubject.READING);
         }
     };
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1233,7 +1233,7 @@ final class Terms {
      */
     private Opens arithmetic(Type carried, Core scrutinee, Denotations at) {
         Core called = originating(scrutinee, at, new HashSet<>());
-        NumericResult result = called == null ? null
+        NumericResult<DeclaredArgument> result = called == null ? null
                 : DischargeRules.numericResult(operationOf(called));
         if (result == null || !(result.at() instanceof NumericResult.Answered.InTheCaseCarrying(
                 Type answersIn)) || !answersIn.equals(carried)) {
@@ -1752,8 +1752,7 @@ final class Terms {
         // answered for was a row this could not see, which is the silence the table exists to
         // remove. `asOperator` still writes a call as the operator it stands for, which is what
         // names the value; what it computes is answered here.
-        NumericResult result =
-                DischargeRules.numericResult(operationOf(e));
+        NumericResult<DeclaredArgument> result = DischargeRules.numericResult(operationOf(e));
         if (result != null && answersIn(result, answered)) {
             return computedBy(result, argsOf(e), answered);
         }
@@ -1765,7 +1764,7 @@ final class Terms {
 
     /** Whether {@code result} says the operation answers a value of {@code answered}: its own, or
      * the one the case carrying that type holds. */
-    private static boolean answersIn(NumericResult result, Type answered) {
+    private static boolean answersIn(NumericResult<DeclaredArgument> result, Type answered) {
         return result.at() instanceof NumericResult.Answered.Directly
                 || result.at() instanceof NumericResult.Answered.InTheCaseCarrying(Type carried)
                         && carried.equals(answered);
@@ -1782,7 +1781,8 @@ final class Terms {
      * come through here, which is what keeps one value from being two meanings depending on which
      * of the two reached it.
      */
-    NumericMeaning computedBy(NumericResult result, List<Core> args, Type answered) {
+    NumericMeaning computedBy(NumericResult<DeclaredArgument> result, List<Core> args,
+                              Type answered) {
         return theOneOf(NumericMeanings.of(result.computes(), args), answered);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TheOtherCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TheOtherCase.java
@@ -31,14 +31,14 @@ final class TheOtherCase {
      * @param called the call as the naming resolved it ({@link Terms#originating})
      */
     static Core conditionAt(Core called) {
-        NumericResult result = called == null ? null
+        NumericResult<DeclaredArgument> result = called == null ? null
                 : DischargeRules.numericResult(Terms.operationOf(called));
         if (result == null || result.unless() == null
                 || !(result.at() instanceof NumericResult.Answered.InTheCaseCarrying)) {
             return null;
         }
-        Core argument = Terms.argsOf(called)
-                .get(CallArguments.positionIn(result.unless().argument(), Terms.operationOf(called)));
+        Core argument = Terms.argsOf(called).get(CallArguments.positionOf(
+                result.unless().argument(), Terms.operationOf(called)));
         return new Core.Binary(result.unless().op(), argument,
                 numberOf(result.unless().than(), argument.type(), argument.pos()),
                 CoverageOrigin.unwritten(), Type.BOOL, argument.pos());
@@ -47,7 +47,7 @@ final class TheOtherCase {
     /** The type the number's case carries, or null where {@code called} answers no number as a
      * case. Asked beside the condition because an arm is told apart by what it names. */
     static Type theCaseItAnswersIn(Core called) {
-        NumericResult result = called == null ? null
+        NumericResult<DeclaredArgument> result = called == null ? null
                 : DischargeRules.numericResult(Terms.operationOf(called));
         return result != null
                 && result.at() instanceof NumericResult.Answered.InTheCaseCarrying(Type answersIn)

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeRequirement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeRequirement.java
@@ -22,8 +22,8 @@ import souther.compiler.types.Type;
  *
  * <p>What is asked of a type, and not what is asked of a signature. That two positions stand at one
  * type is a condition no constant here could answer, because nothing about a type on its own decides
- * it; {@link DischargeRules#holdShift} states that one where both ends are known, and holds the
- * position itself to {@link #ANY}.
+ * it; {@link OperationFactBinder} states that one where it holds a shift and both ends are known,
+ * and holds the position itself to {@link #ANY}.
  *
  * <p>Not read by {@link Question}, which reads the owners directly. The two sides ask the same
  * things of a type, but this is the vocabulary of one of them — what a fact requires of a

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -167,17 +167,19 @@ record UniversalElementFacts(Map<RuleKey, Bounds> byPath) {
     }
 
     /** What one lineage keeps of {@code source}, by the path under an element. */
-    private static Map<RuleKey, Bounds> keptBy(ElementLineage lineage, Core.PreservedCall call,
+    private static Map<RuleKey, Bounds> keptBy(ElementLineage<DeclaredArgument> lineage,
+                                              Core.PreservedCall call,
                                               Core source, Denotations at, Terms terms,
                                               RuleReadingSource rules, ReadingPolicy policy) {
         return switch (lineage) {
-            case ElementLineage.SameAs _ -> of(source, at, terms, rules, policy).byPath();
-            case ElementLineage.ClosureResult _ ->
+            case ElementLineage.SameAs<DeclaredArgument> _ ->
+                    of(source, at, terms, rules, policy).byPath();
+            case ElementLineage.ClosureResult<DeclaredArgument> _ ->
                     throughTheClosure(call, source, at, terms, rules, policy);
-            case ElementLineage.InsideClosureResult _ -> Map.of();
-            case ElementLineage.OneOf one -> {
+            case ElementLineage.InsideClosureResult<DeclaredArgument> _ -> Map.of();
+            case ElementLineage.OneOf<DeclaredArgument> one -> {
                 Map<RuleKey, Bounds> both = null;
-                for (ElementLineage alternative : one.alternatives()) {
+                for (ElementLineage<DeclaredArgument> alternative : one.alternatives()) {
                     Map<RuleKey, Bounds> keeps =
                             keptBy(alternative, call, source, at, terms, rules, policy);
                     both = both == null ? keeps : spanning(both, keeps);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputPath.java
@@ -1,11 +1,12 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.CallArguments;
+import souther.compiler.check.DeclaredArgument;
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.semantics.ArgumentRef;
-import souther.compiler.semantics.ElementLineage;
+import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.types.BindingId;
 
 /**
@@ -256,8 +257,12 @@ final class InputPath {
         if (!(e instanceof Core.Call call) || !(call.fn() instanceof Core.Reached reached)) {
             return new PathResolution.NotAPosition();
         }
-        ArgumentRef holds = ElementLineage.holdsTheElementsOf(reached.denotes());
-        int argument = holds == null ? -1 : CallArguments.positionIn(holds, reached.denotes());
+        BuiltFrom<DeclaredArgument> built =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(reached.denotes());
+        DeclaredArgument holds = built == null ? null : built.holdsTheElementsOf();
+        // The call is the runnable tree's and not a kept one, so its argument count is checked
+        // here rather than by a kept call's own constructor.
+        int argument = holds == null ? -1 : CallArguments.positionOf(holds, reached.denotes());
         return argument < 0 || argument >= call.args().size() ? new PathResolution.NotAPosition()
                 : containerPath(call.args().get(argument), names);
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -1,13 +1,13 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.Carrier;
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.NumericAnswers;
 import souther.compiler.check.Symbols;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.semantics.ConstantArguments;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.ResultRange;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
@@ -158,7 +158,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
          */
         public static TakenOf of(ValueName.Stdlib operation, TermPath position, Type at,
                                  Symbols symbols) {
-            TakenAs how = OperationFacts.takenAs(operation);
+            TakenAs how = DefaultBoundOperationFacts.get().takenAs(operation);
             // Of what stands here, because for an operation that walks a container the answer is
             // what the container holds. Asked of the operation alone, a sum answered no number this
             // could name and no term was made for any rule written on one.
@@ -183,7 +183,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
         /** What this operation takes of the value at {@link #position()}. Never null: one of these
          *  cannot be built for an operation that declares none. */
         public TakenAs takenAs() {
-            return OperationFacts.takenAs(operation);
+            return DefaultBoundOperationFacts.get().takenAs(operation);
         }
 
         /** By the operation and the location, which is what makes two of these one term. */
@@ -249,7 +249,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
          */
         public static TakenOver of(ValueName.Stdlib operation, RunSource source, Type each,
                                    Symbols symbols) {
-            TakenAs how = OperationFacts.takenAs(operation);
+            TakenAs how = DefaultBoundOperationFacts.get().takenAs(operation);
             // A container of what the run holds, with the names its values are written under taken
             // off — the same reach {@link TakenOf#of} takes of the value at a place, and for the
             // same reason: a name wrapped round a whole number is what the account is taken of.
@@ -274,7 +274,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
         /** What this operation takes of what it is given. Never null: one of these cannot be made
          *  for an operation that declares none. */
         public TakenAs takenAs() {
-            return OperationFacts.takenAs(operation);
+            return DefaultBoundOperationFacts.get().takenAs(operation);
         }
 
         /** By the operation and where its values come from, which is what makes two of these one
@@ -381,7 +381,7 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
      *
      * <p>Read with nothing said about the arguments, because a term of this kind carries none: what
      * a size is taken of is a container and what a magnitude is taken of is the one number, and a
-     * bound may only name an argument that is a number ({@code check.DischargeRules.holdBound}), so
+     * bound may only name an argument that is a number ({@code check.OperationFactBinder}), so
      * an operation like these declares no row that names one. A term whose operation does take
      * numbers would have to answer them here rather than be read the same way and quietly come back
      * wider.
@@ -389,14 +389,18 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
     default NumericDomain.Bounds intrinsicBounds() {
         return switch (this) {
             case ValueOf _ -> NumericDomain.Bounds.OPEN;
-            case TakenOf taken -> ResultRange.of(taken.operation(), ConstantArguments.NONE);
+            case TakenOf taken -> ResultRange.of(
+                    DefaultBoundOperationFacts.get().boundsOnTheResult(taken.operation()),
+                    ConstantArguments.none());
             // Asked of the operation, as a taking is. That a total of non-negative amounts is
             // itself non-negative is not among the answers: it follows from what the values the run
             // walks guarantee, together with the value the operation starts from and the step it
             // repeats. That is a statement about the run and not about the operation, and it is the
             // run's own reading to make. Declared here as a range of the operation, it would be
             // wrong for a run whose elements may be negative.
-            case TakenOver over -> ResultRange.of(over.operation(), ConstantArguments.NONE);
+            case TakenOver over -> ResultRange.of(
+                    DefaultBoundOperationFacts.get().boundsOnTheResult(over.operation()),
+                    ConstantArguments.none());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RunReach.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RunReach.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.RuleReadingSource;
@@ -12,7 +13,6 @@ import souther.compiler.numeric.Intervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.semantics.Accumulation;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.types.Type;
 
 import java.math.BigDecimal;
@@ -98,7 +98,7 @@ final class RunReach {
                                    Function<TermPath, Type> typeAt, RuleReadingSource rules,
                                    ReadingPolicy policy) {
         orders.areOf(over);
-        Accumulation walk = OperationFacts.accumulation(over.operation());
+        Accumulation walk = DefaultBoundOperationFacts.get().accumulation(over.operation());
         NumericDomain.Bounds element = ofTheValuesWalked(over.source(), typeAt, rules, policy);
         Granularity answeredOn = spacingOf(orders.answered());
         Granularity observedOn = spacingOf(orders.observed());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.ast.Hir;
@@ -230,9 +231,8 @@ public final class Partitions {
                 // And what an operation answered is the operation's to say. Asked of the arm it is
                 // taken as instead, every operation sharing an arm would carry one answer: a string
                 // of any length exists and a `Set<Bool>` of three does not, and both are counts.
-                case NumericTerm.TakenOf taken ->
-                        souther.compiler.semantics.OperationFacts
-                                .everyAnswerItCanGiveHasASourceValue(taken.operation());
+                case NumericTerm.TakenOf taken -> DefaultBoundOperationFacts.get()
+                        .everyAnswerItCanGiveHasASourceValue(taken.operation());
                 // A run has as many values as a row wrote and each of them is chosen, so whether
                 // some run adds up to a given total is a question about what the elements may hold
                 // and how many there may be — not one the operation answers about itself. Nothing

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ArgumentRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ArgumentRef.java
@@ -10,12 +10,10 @@ package souther.compiler.semantics;
  * <p><b>What this cannot answer is which position {@link TheContainer} and {@link TheClosure}
  * are.</b> That is read off the library's declaration, which is the frontend's to interpret, and
  * asking it here would bring the whole of name resolution into a package that is supposed to hold
- * propositions about operations. Resolving one of these against a call is
- * {@link souther.compiler.check.CallArguments}'s, which has both this word and the environment it
- * takes to read it — the same division the arithmetic reading already makes, where the grammar is
- * in one place and the environment's answers come from the reader.
- *
- * <p>Nothing outside that reader asks for a number. A reader is answered with the argument.
+ * propositions about operations. Resolving one of these is {@code check.OperationFactBinder}'s,
+ * which has both this word and the declaration it takes to read it, and does it once: what it
+ * answers with is the declaration's own argument ({@code check.DeclaredArgument}), position and
+ * all, and that is what every reader below holds. Nothing below the binding holds one of these.
  */
 public sealed interface ArgumentRef {
 

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ArgumentsStand.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ArgumentsStand.java
@@ -1,0 +1,18 @@
+package souther.compiler.semantics;
+
+import souther.compiler.numeric.Rel;
+
+/**
+ * A relation between two arguments: {@code left rel right}. What a case is reached under, written
+ * in the arguments the operation was given and in nothing else.
+ *
+ * @param <A> the word for an argument of the operation
+ */
+public record ArgumentsStand<A>(A left, Rel rel, A right) {
+
+    public ArgumentsStand {
+        java.util.Objects.requireNonNull(left, "a relation has two sides");
+        java.util.Objects.requireNonNull(rel, "and stands some way");
+        java.util.Objects.requireNonNull(right, "a relation has two sides");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/semantics/BuiltFrom.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/BuiltFrom.java
@@ -1,6 +1,7 @@
 package souther.compiler.semantics;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Where a construction's elements came from, and how many of them the result has.
@@ -42,7 +43,7 @@ public record BuiltFrom<A>(List<ElementLineage.OutputLineage<A>> outputs,
 
     /** The same proposition with every argument it names read as {@code word} reads it — how it
      *  crosses from the vocabulary it was authored in to the one a reader is handed. */
-    public <B> BuiltFrom<B> withArguments(java.util.function.Function<A, B> word) {
+    public <B> BuiltFrom<B> withArguments(Function<A, B> word) {
         return new BuiltFrom<>(outputs.stream()
                 .map(each -> new ElementLineage.OutputLineage<>(each.at(),
                         each.origin().withArguments(word)))

--- a/souther-compiler/src/main/java/souther/compiler/semantics/BuiltFrom.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/BuiltFrom.java
@@ -14,8 +14,17 @@ import java.util.List;
  * thrown away. Written this way round, a reader that wants where an element came from asks
  * {@link ElementLineage} and a reader that wants whether a property survives asks here, and neither
  * is recovering the other's answer.
+ *
+ * <p><b>Projections and no lookup.</b> Everything below is read off this value and nothing else:
+ * which argument the elements are the argument's own, which one each is a closure's answer on. A
+ * reader holding one of these has the whole proposition, and what it asks is answered from the
+ * proposition rather than by going back to wherever the proposition was found — so the answer is
+ * the same whichever table, if any, it was found in.
+ *
+ * @param <A> the word for an argument of the operation, as {@link ElementLineage} is generic in
  */
-public record BuiltFrom(List<ElementLineage.OutputLineage> outputs, SizeAgainstItsSource size) {
+public record BuiltFrom<A>(List<ElementLineage.OutputLineage<A>> outputs,
+                           SizeAgainstItsSource size) {
 
     public BuiltFrom {
         outputs = List.copyOf(outputs);
@@ -26,13 +35,22 @@ public record BuiltFrom(List<ElementLineage.OutputLineage> outputs, SizeAgainstI
     }
 
     /** The one place its elements stand, for a construction that answers one run of them. */
-    public BuiltFrom(ElementLineage lineage, SizeAgainstItsSource size) {
-        this(List.of(new ElementLineage.OutputLineage(
+    public BuiltFrom(ElementLineage<A> lineage, SizeAgainstItsSource size) {
+        this(List.of(new ElementLineage.OutputLineage<>(
                 ElementLineage.ResultPath.elements(), lineage)), size);
     }
 
+    /** The same proposition with every argument it names read as {@code word} reads it — how it
+     *  crosses from the vocabulary it was authored in to the one a reader is handed. */
+    public <B> BuiltFrom<B> withArguments(java.util.function.Function<A, B> word) {
+        return new BuiltFrom<>(outputs.stream()
+                .map(each -> new ElementLineage.OutputLineage<>(each.at(),
+                        each.origin().withArguments(word)))
+                .toList(), size);
+    }
+
     /** Where its elements came from, where they all came from one place. */
-    public ElementLineage lineage() {
+    public ElementLineage<A> lineage() {
         if (outputs.size() != 1) {
             throw new IllegalStateException(
                     "a construction answering more than one run of elements was asked for one"
@@ -42,14 +60,78 @@ public record BuiltFrom(List<ElementLineage.OutputLineage> outputs, SizeAgainstI
     }
 
     /** Which argument it was built from, where one argument is what it was built from. */
-    public ArgumentRef from() {
-        ElementLineage.Source source = lineage().source();
+    public A from() {
+        ElementLineage.Source<A> source = lineage().source();
         if (source == null) {
             throw new IllegalStateException(
                     "a construction whose elements come from more than one place was asked which"
                             + " one: " + outputs);
         }
         return source.argument();
+    }
+
+    /**
+     * The argument the answer holds the elements of, or null where its elements are not the
+     * argument's own.
+     *
+     * <p>The one thing a reader walking backwards from a value needs, and the only part of a lineage
+     * that can be walked that way as it stands: where the elements are the same values, an element
+     * of the answer is an element of the argument. Where the answer holds what a closure made, the
+     * element came from somewhere and is not it, and this says nothing rather than saying where.
+     */
+    public A holdsTheElementsOf() {
+        return outputs.size() == 1
+                && lineage() instanceof ElementLineage.SameAs<A> same
+                && same.source().elements() == 1
+                ? same.source().argument() : null;
+    }
+
+    /**
+     * The argument each of whose elements the answer holds exactly one closure result of, or null
+     * where it answers no such run.
+     *
+     * <p>The two halves together and neither alone. What the closure answered is the lineage
+     * ({@link ElementLineage.ClosureResult}), and that there is one answer per element is the count
+     * ({@link SizeAgainstItsSource#SAME}) — two statements about one operation, kept apart because
+     * they are different algebras and asked together here because a correspondence needs both.
+     * {@code Set.map} has the first and not the second: two elements may answer one, so what its
+     * result holds is a subset of what the closure made rather than one per element.
+     *
+     * <p>Read off the lineage and not off {@link #shape}. The four words are a lossy reading of the
+     * pair — {@code List.filterMap} and {@code Set.map} share one — and a correspondence rested on
+     * them would be true of operations that do not have it.
+     *
+     * <p><b>What this licenses is a correspondence and not an order.</b> As many answers as
+     * elements, each of them the closure's on one of them; which came first is not stated by either
+     * half and is not claimed here.
+     */
+    public A mapsEachElementOf() {
+        if (outputs.size() != 1 || size != SizeAgainstItsSource.SAME) {
+            return null;
+        }
+        ElementLineage<A> lineage = lineage();
+        return lineage instanceof ElementLineage.ClosureResult<A>
+                && lineage.source().elements() == 1
+                ? lineage.source().argument() : null;
+    }
+
+    /**
+     * The argument the answer holds elements <em>made from</em>, or null where its elements are not
+     * made from an argument's.
+     *
+     * <p>Beside {@link #holdsTheElementsOf} and licensing less. That one says a reader that reached
+     * an element of the answer has reached an element of the argument; this says only that the value
+     * came from there. What a rule about it means for the position it came from is a question about
+     * the closure that made it, and knowing where it came from does not answer it.
+     */
+    public A derivesItsElementsFrom() {
+        if (outputs.size() != 1) {
+            return null;
+        }
+        ElementLineage<A> lineage = lineage();
+        return (lineage instanceof ElementLineage.ClosureResult<A>
+                || lineage instanceof ElementLineage.InsideClosureResult<A>)
+                && lineage.source().elements() == 1 ? lineage.source().argument() : null;
     }
 
     /**
@@ -74,23 +156,24 @@ public record BuiltFrom(List<ElementLineage.OutputLineage> outputs, SizeAgainstI
      * {@code PERMUTES} nor {@code MAPS} is true of the run, and what a reader of the four words may
      * assume of it is nothing.
      */
-    private ElementShape wordFor(ElementLineage lineage, boolean asMany) {
+    private ElementShape wordFor(ElementLineage<A> lineage, boolean asMany) {
         return switch (lineage) {
-            case ElementLineage.SameAs _ -> asMany ? ElementShape.PERMUTES : ElementShape.SUBSET;
-            case ElementLineage.ClosureResult _ ->
+            case ElementLineage.SameAs<A> _ ->
+                    asMany ? ElementShape.PERMUTES : ElementShape.SUBSET;
+            case ElementLineage.ClosureResult<A> _ ->
                     asMany ? ElementShape.MAPS : ElementShape.COLLAPSES;
             // What the closure answered holds it, so what was stated of the source says nothing
             // of it, and there may be any number of them. No word of the four is about that,
             // and the nearest is the one for elements nothing was kept of.
-            case ElementLineage.InsideClosureResult _ -> ElementShape.COLLAPSES;
-            case ElementLineage.OneOf one -> {
+            case ElementLineage.InsideClosureResult<A> _ -> ElementShape.COLLAPSES;
+            case ElementLineage.OneOf<A> one -> {
                 if (one.source() == null) {
                     throw new IllegalStateException(
                             "a construction whose elements come from more than one place has no"
                                     + " single source for a shape to be about: " + outputs);
                 }
                 ElementShape word = null;
-                for (ElementLineage alternative : one.alternatives()) {
+                for (ElementLineage<A> alternative : one.alternatives()) {
                     ElementShape read = wordFor(alternative, asMany);
                     word = word == null || word == read ? read : ElementShape.COLLAPSES;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ConstantArguments.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ConstantArguments.java
@@ -16,16 +16,20 @@ import java.util.Optional;
  * <p>Asked rather than handed over as a map, because what a value reads as is the reading's answer
  * and not a property of the syntax at the call: a name given a constant is that constant, wherever
  * it was written.
+ *
+ * @param <A> the word for an argument, the one the bounds being read are written in
  */
 @FunctionalInterface
-public interface ConstantArguments {
+public interface ConstantArguments<A> {
 
     /** The constant {@code argument} reads as, or empty where this reader cannot say. */
-    Optional<BigDecimal> at(ArgumentRef argument);
+    Optional<BigDecimal> at(A argument);
 
     /** A reader that knows no argument's value — what an operation's own facts are read under where
      *  there is no call in hand, and what an operation given no number is read under always. */
-    ConstantArguments NONE = _ -> Optional.empty();
+    static <A> ConstantArguments<A> none() {
+        return _ -> Optional.empty();
+    }
 
     /**
      * Whether these meet the condition a bound was stated under.
@@ -35,10 +39,10 @@ public interface ConstantArguments {
      * knows none of them meets only the condition that asks nothing, which is the bound the
      * operation states whatever it is given.
      */
-    default boolean satisfy(ResultBound.Provided provided) {
+    default boolean satisfy(ResultBound.Provided<A> provided) {
         return switch (provided) {
-            case ResultBound.Provided.Always _ -> true;
-            case ResultBound.Provided.ConstantAboveZero above ->
+            case ResultBound.Provided.Always<A> _ -> true;
+            case ResultBound.Provided.ConstantAboveZero<A> above ->
                     at(above.argument()).filter(read -> read.signum() > 0).isPresent();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/semantics/DefinitionCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/DefinitionCase.java
@@ -1,0 +1,20 @@
+package souther.compiler.semantics;
+
+import java.util.List;
+
+/**
+ * One case of a piecewise definition: the argument it answers, and what the arguments stand as for
+ * it to be reached.
+ *
+ * <p>Generic in the word for an argument, as {@link ElementLineage} is: authored, a case names its
+ * arguments as the fact writes them; held to the library, as the declaration has them.
+ *
+ * @param <A> the word for an argument of the operation
+ */
+public record DefinitionCase<A>(A answers, List<ArgumentsStand<A>> given) {
+
+    public DefinitionCase {
+        java.util.Objects.requireNonNull(answers, "a case answers an argument");
+        given = List.copyOf(given);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ElementLineage.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ElementLineage.java
@@ -1,6 +1,7 @@
 package souther.compiler.semantics;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Where an element of what an operation answers came from, said the way it runs.
@@ -125,7 +126,7 @@ public sealed interface ElementLineage<A> {
         }
 
         /** The same source with its argument read as {@code word} reads it. */
-        public <B> Source<B> withArgument(java.util.function.Function<A, B> word) {
+        public <B> Source<B> withArgument(Function<A, B> word) {
             return new Source<>(word.apply(argument), elements);
         }
     }
@@ -142,7 +143,7 @@ public sealed interface ElementLineage<A> {
      * lineage crosses from the vocabulary a fact is authored in to the one a reader is handed,
      * without the reader rebuilding the shape.
      */
-    default <B> ElementLineage<B> withArguments(java.util.function.Function<A, B> word) {
+    default <B> ElementLineage<B> withArguments(Function<A, B> word) {
         return switch (this) {
             case SameAs<A> same -> new SameAs<>(same.source().withArgument(word));
             case ClosureResult<A> made -> new ClosureResult<>(made.source().withArgument(word));

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ElementLineage.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ElementLineage.java
@@ -30,79 +30,16 @@ import java.util.List;
  * {@code Set.map} have one lineage — the closure's answer on an element of the source — and
  * different counts, because two elements of a set may map onto one. Folded together, the count would
  * decide the provenance.
+ *
+ * <p><b>Generic in the word for an argument</b>, as {@link souther.compiler.numeric.LinearForm} is.
+ * A lineage names the argument its elements come from, and what that name is depends on which side
+ * of the binding it stands: authored, it is an {@link ArgumentRef}, the word a fact is written in;
+ * held to the library, it is the declaration's own argument. The structure between the two is one
+ * structure, so it is written once and the word is a parameter.
+ *
+ * @param <A> the word for an argument of the operation
  */
-public sealed interface ElementLineage {
-
-    /**
-     * The argument an operation's answer holds the elements of, or null where its elements are not
-     * the argument's own.
-     *
-     * <p>The one thing a reader walking backwards from a value needs, and the only part of a lineage
-     * that can be walked that way as it stands: where the elements are the same values, an element
-     * of the answer is an element of the argument. Where the answer holds what a closure made, the
-     * element came from somewhere and is not it, and this says nothing rather than saying where.
-     *
-     * <p>Asked here and not of the reader that happens to hold the table today. What an operation
-     * does to the values it is given is declared once and read by whoever has a use for it; a caller
-     * reaching through the invariant-discharge check for it would depend on that check to learn what
-     * the library says.
-     */
-    static ArgumentRef holdsTheElementsOf(souther.compiler.types.ValueName operation) {
-        BuiltFrom built = OperationFacts.buildsItsResultFrom(operation);
-        return built != null && built.outputs().size() == 1
-                && built.lineage() instanceof SameAs same
-                && same.source().elements() == 1
-                ? same.source().argument() : null;
-    }
-
-    /**
-     * The argument each of whose elements {@code operation} answers exactly one closure result of,
-     * or null where it answers no such run.
-     *
-     * <p>The two halves together and neither alone. What the closure answered is the lineage
-     * ({@link ClosureResult}), and that there is one answer per element is the count
-     * ({@link SizeAgainstItsSource#SAME}) — two statements about one operation, kept apart because
-     * they are different algebras and asked together here because a correspondence needs both.
-     * {@code Set.map} has the first and not the second: two elements may answer one, so what its
-     * result holds is a subset of what the closure made rather than one per element.
-     *
-     * <p>Read off the declarations and not off {@link BuiltFrom#shape}. The four words are a lossy
-     * reading of the pair — {@code List.filterMap} and {@code Set.map} share one — and a
-     * correspondence rested on them would be true of operations that do not have it.
-     *
-     * <p><b>What this licenses is a correspondence and not an order.</b> As many answers as
-     * elements, each of them the closure's on one of them; which came first is not stated by either
-     * half and is not claimed here.
-     */
-    public static ArgumentRef mapsEachElementOf(souther.compiler.types.ValueName operation) {
-        BuiltFrom built = OperationFacts.buildsItsResultFrom(operation);
-        if (built == null || built.outputs().size() != 1
-                || built.size() != SizeAgainstItsSource.SAME) {
-            return null;
-        }
-        ElementLineage lineage = built.lineage();
-        return lineage instanceof ClosureResult && lineage.source().elements() == 1
-                ? lineage.source().argument() : null;
-    }
-
-    /**
-     * The argument an operation's answer holds elements <em>made from</em>, or null where its
-     * elements are not made from an argument's.
-     *
-     * <p>Beside {@link #holdsTheElementsOf} and licensing less. That one says a reader that reached
-     * an element of the answer has reached an element of the argument; this says only that the value
-     * came from there. What a rule about it means for the position it came from is a question about
-     * the closure that made it, and knowing where it came from does not answer it.
-     */
-    static ArgumentRef derivesItsElementsFrom(souther.compiler.types.ValueName operation) {
-        BuiltFrom built = OperationFacts.buildsItsResultFrom(operation);
-        if (built == null || built.outputs().size() != 1) {
-            return null;
-        }
-        ElementLineage lineage = built.lineage();
-        return (lineage instanceof ClosureResult || lineage instanceof InsideClosureResult)
-                && lineage.source().elements() == 1 ? lineage.source().argument() : null;
-    }
+public sealed interface ElementLineage<A> {
 
     /**
      * Where in what an operation answers the elements this is about stand.
@@ -164,7 +101,7 @@ public sealed interface ElementLineage {
     }
 
     /** One run of elements in what an operation answers, and where they came from. */
-    record OutputLineage(ResultPath at, ElementLineage origin) {}
+    record OutputLineage<A>(ResultPath at, ElementLineage<A> origin) {}
 
     /**
      * How far inside an argument the elements come from.
@@ -177,19 +114,44 @@ public sealed interface ElementLineage {
      *                 their own and are not this, so a lineage into either wants a path here rather
      *                 than a larger number
      */
-    record Source(ArgumentRef argument, int elements) {
+    record Source<A>(A argument, int elements) {
 
         public Source {
+            java.util.Objects.requireNonNull(argument, "a lineage names the argument it is from");
             if (elements < 1) {
                 throw new IllegalArgumentException(
                         "a lineage is about the elements of something: " + elements);
             }
         }
+
+        /** The same source with its argument read as {@code word} reads it. */
+        public <B> Source<B> withArgument(java.util.function.Function<A, B> word) {
+            return new Source<>(word.apply(argument), elements);
+        }
     }
 
     /** Where the elements this is about come from, or null where they come from more than one
      *  place. */
-    Source source();
+    Source<A> source();
+
+    /**
+     * The same lineage with every argument it names read as {@code word} reads it.
+     *
+     * <p>Structure and nothing else: which arguments there are, and where each stands in the
+     * lineage, are what this keeps, and what an argument becomes is the caller's. This is how a
+     * lineage crosses from the vocabulary a fact is authored in to the one a reader is handed,
+     * without the reader rebuilding the shape.
+     */
+    default <B> ElementLineage<B> withArguments(java.util.function.Function<A, B> word) {
+        return switch (this) {
+            case SameAs<A> same -> new SameAs<>(same.source().withArgument(word));
+            case ClosureResult<A> made -> new ClosureResult<>(made.source().withArgument(word));
+            case InsideClosureResult<A> inside ->
+                    new InsideClosureResult<>(inside.source().withArgument(word));
+            case OneOf<A> one -> new OneOf<>(one.alternatives().stream()
+                    .map(each -> each.withArguments(word)).toList());
+        };
+    }
 
     /**
      * The value at the output position is the value at the source position.
@@ -204,10 +166,10 @@ public sealed interface ElementLineage {
      * <p>The one lineage a rule about the output can be pushed back through as it stands, since
      * there is nothing between the two values to push it through.
      */
-    record SameAs(Source source) implements ElementLineage {
+    record SameAs<A>(Source<A> source) implements ElementLineage<A> {
 
         @Override
-        public Source source() {
+        public Source<A> source() {
             return source;
         }
     }
@@ -223,13 +185,13 @@ public sealed interface ElementLineage {
      * many elements as the source — {@code Set.map} answers no more, since two elements may map onto
      * one — and nothing about the order they come in. A reader wanting a correspondence between the
      * two runs asks for this together with {@link SizeAgainstItsSource#SAME}
-     * ({@link #mapsEachElementOf}), and a reader wanting the order asks for something nobody
-     * declares yet.
+     * ({@link BuiltFrom#mapsEachElementOf}), and a reader wanting the order asks for something
+     * nobody declares yet.
      */
-    record ClosureResult(Source source) implements ElementLineage {
+    record ClosureResult<A>(Source<A> source) implements ElementLineage<A> {
 
         @Override
-        public Source source() {
+        public Source<A> source() {
             return source;
         }
     }
@@ -241,10 +203,10 @@ public sealed interface ElementLineage {
      * closure answers an optional. One case for both: what differs is the shape the closure answers
      * with, which its own signature already says.
      */
-    record InsideClosureResult(Source source) implements ElementLineage {
+    record InsideClosureResult<A>(Source<A> source) implements ElementLineage<A> {
 
         @Override
-        public Source source() {
+        public Source<A> source() {
             return source;
         }
     }
@@ -262,7 +224,7 @@ public sealed interface ElementLineage {
      * either that argument's own value or what the closure made of it. Read as one alternative, it
      * would say of every value what is true of one of them.
      */
-    record OneOf(List<ElementLineage> alternatives) implements ElementLineage {
+    record OneOf<A>(List<ElementLineage<A>> alternatives) implements ElementLineage<A> {
 
         public OneOf {
             alternatives = List.copyOf(alternatives);
@@ -281,9 +243,9 @@ public sealed interface ElementLineage {
          * about {@code List.append} from being read as a rule about its first argument.
          */
         @Override
-        public Source source() {
-            Source common = alternatives.get(0).source();
-            for (ElementLineage alternative : alternatives) {
+        public Source<A> source() {
+            Source<A> common = alternatives.get(0).source();
+            for (ElementLineage<A> alternative : alternatives) {
                 if (common == null || !common.equals(alternative.source())) {
                     return null;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/semantics/NumericResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/NumericResult.java
@@ -6,12 +6,16 @@ import souther.compiler.types.Type;
 /**
  * What an operation computes, where it answers it, and when it answers nothing.
  *
+ * <p>Generic in the word for an argument, as {@link ResultBound} is, since the condition under
+ * which the other case comes back names one.
+ *
  * @param at       where in what the operation answers the number stands
  * @param computes which arithmetic it is
  * @param unless   the condition under which the union comes back as a case other than the number's,
  *                 or null for an operation whose result is the number itself
+ * @param <A>      the word for an argument of the operation
  */
-public record NumericResult(Answered at, Arithmetic computes, TheOtherCaseWhen unless) {
+public record NumericResult<A>(Answered at, Arithmetic computes, TheOtherCaseWhen<A> unless) {
 
     public NumericResult {
         java.util.Objects.requireNonNull(at, "a number is answered somewhere");
@@ -35,7 +39,7 @@ public record NumericResult(Answered at, Arithmetic computes, TheOtherCaseWhen u
     }
 
     /** The condition under which the operation answers a case other than the number's. */
-    public record TheOtherCaseWhen(ArgumentRef argument, BinOp op, long than) {
+    public record TheOtherCaseWhen<A>(A argument, BinOp op, long than) {
 
         public TheOtherCaseWhen {
             java.util.Objects.requireNonNull(argument, "this one names an argument");

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFact.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFact.java
@@ -12,6 +12,14 @@ package souther.compiler.semantics;
  *
  * <p>Sealed, so the procedures that hold these to the library's declarations answer for a kind
  * added rather than passing over it.
+ *
+ * <p><b>The authoring vocabulary, and nothing below the binding reads it.</b> An argument is named
+ * here as {@link ArgumentRef}, a word; another operation as a {@link souther.compiler.types.ValueName},
+ * a name. Neither says the library has such an operation or such an argument. What holds these to
+ * the library ({@code check.OperationFactBinder}) answers with a value of another kind, in which
+ * every argument and every operation has been read against its declaration, and every reader of a
+ * fact reads that one. So a kind added here is a kind the binder must say what it comes to bound,
+ * which the exhaustive switch there refuses to leave unsaid.
  */
 public sealed interface OperationFact {
 
@@ -99,7 +107,7 @@ public sealed interface OperationFact {
      * <p>One fact per bound rather than a list in one: an operation with two bounds carries two
      * statements, and they are added and read one at a time.
      */
-    record BoundsItsResult(ResultBound bound) implements OperationFact {
+    record BoundsItsResult(ResultBound<ArgumentRef> bound) implements OperationFact {
 
         public BoundsItsResult {
             java.util.Objects.requireNonNull(bound, "this one states a bound");
@@ -110,7 +118,7 @@ public sealed interface OperationFact {
      * The operation builds a container out of another, and this says where its elements came from
      * and how many of them there are.
      */
-    record BuildsItsResultFrom(BuiltFrom built) implements OperationFact {
+    record BuildsItsResultFrom(BuiltFrom<ArgumentRef> built) implements OperationFact {
 
         public BuildsItsResultFrom {
             java.util.Objects.requireNonNull(built, "this one says what it was built from");
@@ -215,7 +223,7 @@ public sealed interface OperationFact {
     }
 
     /** The operation computes a number, and this says which arithmetic and where it answers it. */
-    record ComputesANumber(NumericResult result) implements OperationFact {
+    record ComputesANumber(NumericResult<ArgumentRef> result) implements OperationFact {
 
         public ComputesANumber {
             java.util.Objects.requireNonNull(result, "this one says what it computes");
@@ -233,20 +241,10 @@ public sealed interface OperationFact {
      * out does not make the others wrong, it makes a clause provable that the values can fail. So
      * they are declared as the library writes them, in the order it writes them.
      */
-    record IsDefinedByCases(Case one) implements OperationFact {
+    record IsDefinedByCases(DefinitionCase<ArgumentRef> one) implements OperationFact {
 
         public IsDefinedByCases {
             java.util.Objects.requireNonNull(one, "this one states a case");
-        }
-    }
-
-    /** One case of a piecewise definition: the argument it answers, and what the arguments stand as
-     *  for it to be reached. */
-    record Case(ArgumentRef answers, java.util.List<ArgumentsStand> given) {
-
-        public Case {
-            java.util.Objects.requireNonNull(answers, "a case answers an argument");
-            given = java.util.List.copyOf(given);
         }
     }
 
@@ -319,18 +317,6 @@ public sealed interface OperationFact {
 
         public SaysNothingOf {
             java.util.Objects.requireNonNull(subject, "a silence is about something");
-        }
-    }
-
-    /** A relation between two arguments: {@code left rel right}. What a case is reached under,
-     *  written in the arguments the operation was given and in nothing else. */
-    record ArgumentsStand(ArgumentRef left, souther.compiler.numeric.Rel rel,
-                          ArgumentRef right) {
-
-        public ArgumentsStand {
-            java.util.Objects.requireNonNull(left, "a relation has two sides");
-            java.util.Objects.requireNonNull(rel, "and stands some way");
-            java.util.Objects.requireNonNull(right, "a relation has two sides");
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -6,23 +6,24 @@ import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
- * What is true of the language's own operations.
+ * What is true of the language's own operations, as somebody wrote it down.
  *
- * <p>The declarations are the list, and everything else here is read off it. An index is derived
- * rather than declared beside the list, so a fact cannot exist without being among the
- * declarations — which is what the procedures that validate these enumerate, and what a fact added
- * later is therefore part of without anyone remembering to add it anywhere.
+ * <p>The declarations are the list, and the list is the whole of what this publishes. A fact is
+ * written here in the authoring vocabulary — a name for the operation, a word for an argument —
+ * and nothing here says the library has such an operation or such an argument. Holding every one
+ * of these to the library's own declarations reads signatures, which is the frontend's; it happens
+ * once over the whole list ({@code check.OperationFactBinder}), and what comes out of that walk is
+ * a value of another kind, in which every name has been read against its declaration
+ * ({@code check.BoundOperationFacts}). Every reader of a fact reads that one.
  *
- * <p><b>Looking one up is a lookup and nothing else.</b> Holding these to the library's own
- * declarations reads signatures, which is the frontend's; it happens once over the whole list
- * ({@code check.OperationFactBinder}) rather than on the first ask for each fact. Bound the second
- * way, a fact nothing asked for was a fact nothing checked, and the completeness of the checking
- * depended on which consumers there happened to be.
+ * <p><b>No lookup here, by design.</b> An index keyed by operation and read off this list would be
+ * a way to a fact that does not pass through the binding, and a reader that took it would be
+ * holding the authored word and putting the binder's question a second time — with an answer that
+ * agrees with the binder's for exactly as long as nobody changes either. So this list is read by
+ * one caller, and a reader that wants a fact asks what the binding made of it.
  */
 public final class OperationFacts {
 
@@ -221,18 +222,18 @@ public final class OperationFacts {
             // Every value in the answer came from the map it was given: the one under the key is
             // what the closure made of it, and every other is the value that was there. Read as a
             // closure result alone, what is true of one value would be said of all of them.
-            about("Map", "updateIfPresent", new OperationFact.BuildsItsResultFrom(new BuiltFrom(
-                    new ElementLineage.OneOf(List.of(
-                            new ElementLineage.SameAs(new ElementLineage.Source(CONTAINER, 1)),
-                            new ElementLineage.ClosureResult(
-                                    new ElementLineage.Source(CONTAINER, 1)))),
+            about("Map", "updateIfPresent", new OperationFact.BuildsItsResultFrom(new BuiltFrom<>(
+                    new ElementLineage.OneOf<>(List.of(
+                            new ElementLineage.SameAs<>(new ElementLineage.Source<>(CONTAINER, 1)),
+                            new ElementLineage.ClosureResult<>(
+                                    new ElementLineage.Source<>(CONTAINER, 1)))),
                     SizeAgainstItsSource.SAME))),
             // Inside what the closure answered, which is an optional here and a list in a
             // `flatMap`. One lineage for the two, told apart by what the closure's own signature
             // says it answers with.
-            about("List", "filterMap", new OperationFact.BuildsItsResultFrom(new BuiltFrom(
-                    new ElementLineage.InsideClosureResult(
-                            new ElementLineage.Source(CONTAINER, 1)), SizeAgainstItsSource.AT_MOST))),
+            about("List", "filterMap", new OperationFact.BuildsItsResultFrom(new BuiltFrom<>(
+                    new ElementLineage.InsideClosureResult<>(
+                            new ElementLineage.Source<>(CONTAINER, 1)), SizeAgainstItsSource.AT_MOST))),
             about("Set", "map", maps(CONTAINER, SizeAgainstItsSource.AT_MOST)),
 
             // The containers a construction's result is never smaller than. A union answers one of
@@ -505,26 +506,30 @@ public final class OperationFacts {
     }
 
     private static OperationFact computes(Arithmetic arithmetic) {
-        return new OperationFact.ComputesANumber(new NumericResult(
+        return new OperationFact.ComputesANumber(new NumericResult<>(
                 new NumericResult.Answered.Directly(), arithmetic, null));
     }
 
     /** The condition every division comes back as {@code DivisionByZero} under. */
     private static OperationFact computesInTheCaseCarrying(Type carried, Arithmetic arithmetic) {
-        return new OperationFact.ComputesANumber(new NumericResult(
+        return new OperationFact.ComputesANumber(new NumericResult<>(
                 new NumericResult.Answered.InTheCaseCarrying(carried), arithmetic,
-                new NumericResult.TheOtherCaseWhen(at(1), BinOp.EQ, 0)));
+                new NumericResult.TheOtherCaseWhen<>(at(1), BinOp.EQ, 0)));
     }
 
+    @SafeVarargs
     private static OperationFact answers(ArgumentRef argument,
-                                         OperationFact.ArgumentsStand... given) {
-        return new OperationFact.IsDefinedByCases(
-                new OperationFact.Case(argument, List.of(given)));
+                                         ArgumentsStand<ArgumentRef>... given) {
+        List<ArgumentsStand<ArgumentRef>> reached = new ArrayList<>(given.length);
+        for (ArgumentsStand<ArgumentRef> stands : given) {
+            reached.add(stands);
+        }
+        return new OperationFact.IsDefinedByCases(new DefinitionCase<>(argument, reached));
     }
 
-    private static OperationFact.ArgumentsStand stands(ArgumentRef left, Rel rel,
-                                                       ArgumentRef right) {
-        return new OperationFact.ArgumentsStand(left, rel, right);
+    private static ArgumentsStand<ArgumentRef> stands(ArgumentRef left, Rel rel,
+                                                      ArgumentRef right) {
+        return new ArgumentsStand<>(left, rel, right);
     }
 
     private static OperationFact noSmallerThan(ArgumentRef container) {
@@ -554,14 +559,14 @@ public final class OperationFacts {
 
     /** The answer holds the very elements {@code source} held. */
     private static OperationFact keeps(ArgumentRef source, SizeAgainstItsSource size) {
-        return new OperationFact.BuildsItsResultFrom(new BuiltFrom(
-                new ElementLineage.SameAs(new ElementLineage.Source(source, 1)), size));
+        return new OperationFact.BuildsItsResultFrom(new BuiltFrom<>(
+                new ElementLineage.SameAs<>(new ElementLineage.Source<>(source, 1)), size));
     }
 
     /** The answer holds what a closure made of each of {@code source}'s elements. */
     private static OperationFact maps(ArgumentRef source, SizeAgainstItsSource size) {
-        return new OperationFact.BuildsItsResultFrom(new BuiltFrom(
-                new ElementLineage.ClosureResult(new ElementLineage.Source(source, 1)), size));
+        return new OperationFact.BuildsItsResultFrom(new BuiltFrom<>(
+                new ElementLineage.ClosureResult<>(new ElementLineage.Source<>(source, 1)), size));
     }
 
     /** {@code times} of what one argument is counted as. */
@@ -577,25 +582,26 @@ public final class OperationFacts {
     }
 
     private static OperationFact bounded(Rel rel, long n) {
-        return bounded(rel, null, n, new ResultBound.Provided.Always());
+        return bounded(rel, null, n, always());
     }
 
-    private static OperationFact bounded(Rel rel, long n, ResultBound.Provided provided) {
+    private static OperationFact bounded(Rel rel, long n,
+                                         ResultBound.Provided<ArgumentRef> provided) {
         return bounded(rel, null, n, provided);
     }
 
     private static OperationFact bounded(Rel rel, ArgumentRef against, long offset,
-                                         ResultBound.Provided provided) {
+                                         ResultBound.Provided<ArgumentRef> provided) {
         return new OperationFact.BoundsItsResult(
-                new ResultBound(against, java.math.BigDecimal.valueOf(offset), rel, provided));
+                new ResultBound<>(against, java.math.BigDecimal.valueOf(offset), rel, provided));
     }
 
-    private static ResultBound.Provided always() {
-        return new ResultBound.Provided.Always();
+    private static ResultBound.Provided<ArgumentRef> always() {
+        return new ResultBound.Provided.Always<>();
     }
 
-    private static ResultBound.Provided aboveZero(ArgumentRef argument) {
-        return new ResultBound.Provided.ConstantAboveZero(argument);
+    private static ResultBound.Provided<ArgumentRef> aboveZero(ArgumentRef argument) {
+        return new ResultBound.Provided.ConstantAboveZero<>(argument);
     }
 
     private static OperationFact shifts(String module, String measure, ArgumentRef of,
@@ -604,363 +610,15 @@ public final class OperationFacts {
                 java.math.BigDecimal.valueOf(per));
     }
 
-    /** Every fact declared, for whatever holds them to the library's declarations. */
+    /**
+     * Every fact declared, for what holds them to the library's declarations.
+     *
+     * <p>The one thing this publishes, and read by one caller ({@code check.OperationFactBinder}).
+     * A second reader of this list would be a reader of the authoring vocabulary below the
+     * binding, which is what {@code OnlyTheBinderReadsTheAuthoringVocabularyTest} counts.
+     */
     public static List<Declared> declarations() {
         return DECLARED;
-    }
-
-    /** What {@code operation} answers, counted, in what its arguments are counted as — or null
-     *  where it states no such form. */
-    public static souther.compiler.numeric.LinearForm<ArgumentRef>
-            answersAFormOfItsArguments(ValueName operation) {
-        return Index.ANSWERS_A_FORM.get(operation);
-    }
-
-    /** The operations declared to answer a form of their arguments. */
-    public static java.util.Set<ValueName> answersAFormOfItsArguments() {
-        return Index.ANSWERS_A_FORM.keySet();
-    }
-
-    /** Which of {@code operation}'s two arguments a positive answer names as the greater, or null
-     *  where the sign of what it answers is not their order. */
-    public static PositiveOrder statesTheOrderOfItsArguments(ValueName operation) {
-        return Index.ORDERS.get(operation);
-    }
-
-    /** The operations whose answer states the order of their arguments. */
-    public static java.util.Set<ValueName> statesTheOrderOfItsArguments() {
-        return Index.ORDERS.keySet();
-    }
-
-    /** How {@code operation} moves the value it is given, or null where it moves none. */
-    public static OperationFact.ShiftsBy shiftsBy(ValueName operation) {
-        return Index.SHIFTS.get(operation);
-    }
-
-    /** The operations that move a value by an amount. */
-    public static java.util.Set<ValueName> shiftsBy() {
-        return Index.SHIFTS.keySet();
-    }
-
-    /** What holds of the number {@code operation} answers, wherever it is called. */
-    public static List<ResultBound> boundsOnTheResult(ValueName operation) {
-        return Index.BOUNDS.getOrDefault(operation, List.of());
-    }
-
-    /** The operations something holds of the result of. */
-    public static java.util.Set<ValueName> boundsOnTheResult() {
-        return Index.BOUNDS.keySet();
-    }
-
-    /** What {@code operation} builds its result from, or null where it builds none. */
-    public static BuiltFrom buildsItsResultFrom(ValueName operation) {
-        return Index.BUILDINGS.get(operation);
-    }
-
-    /** The operations that build a container out of another. */
-    public static java.util.Set<ValueName> buildsItsResultFrom() {
-        return Index.BUILDINGS.keySet();
-    }
-
-    /** The containers {@code operation}'s result is never smaller than, in the order they are
-     *  declared. */
-    public static List<ArgumentRef> resultIsNoSmallerThan(ValueName operation) {
-        return Index.NO_SMALLER_THAN.getOrDefault(operation, List.of());
-    }
-
-    /** Where {@code operation} reads the container its predicate is about, or null where it is no
-     *  such predicate. */
-    public static OperationFact.ReadsItsContainer readsItsContainer(ValueName operation) {
-        return Index.READS.get(operation);
-    }
-
-    /** The operations that are predicates over what a container holds. */
-    public static java.util.Set<ValueName> readsItsContainer() {
-        return Index.READS.keySet();
-    }
-
-    /** Where {@code operation}'s predicate is stated over a projection, or null where it is stated
-     *  over the element itself. */
-    public static ArgumentRef isStatedOverAProjection(ValueName operation) {
-        return Index.PROJECTIONS.get(operation);
-    }
-
-    /** The operations whose predicate is stated over a projection. */
-    public static java.util.Set<ValueName> isStatedOverAProjection() {
-        return Index.PROJECTIONS.keySet();
-    }
-
-    /** Whether {@code operation} states its predicate of every element. */
-    public static boolean statesItsPredicateOfEveryElement(ValueName operation) {
-        return Index.QUANTIFIERS.contains(operation);
-    }
-
-    /** The operations that do. */
-    public static java.util.Set<ValueName> statesItsPredicateOfEveryElement() {
-        return Index.QUANTIFIERS;
-    }
-
-    /* No index for what an emptiness check means. What a reader does with that fact is write a
-     * call of the size where a call of the check stands, and the two declarations have to admit
-     * that — so the fact is answered only once it has been held to them, and reading it from here
-     * would be reading it before anything asked. The fact is still declared below with the rest and
-     * reaches its reader through the binding. */
-
-    /** What {@code operation} computes and where it answers it, or null where it computes no
-     *  arithmetic of its own. */
-    public static NumericResult computesANumber(ValueName operation) {
-        return operation == null ? null : Index.ARITHMETIC.get(operation);
-    }
-
-    /** The operations that compute arithmetic of their own. */
-    public static java.util.Set<ValueName> computesANumber() {
-        return Index.ARITHMETIC.keySet();
-    }
-
-    /** The cases {@code operation}'s definition is written in, in the order they are declared, or
-     *  an empty list where it answers none of the values it was given. */
-    public static List<OperationFact.Case> isDefinedByCases(ValueName operation) {
-        return Index.CASES.getOrDefault(operation, List.of());
-    }
-
-    /** The operations that answer one of the values they were given. */
-    public static java.util.Set<ValueName> isDefinedByCases() {
-        return Index.CASES.keySet();
-    }
-
-    /** The operations declared to say nothing under {@code subject}. */
-    public static java.util.Set<ValueName> saysNothingOf(OperationSubject subject) {
-        return Index.SILENCES.getOrDefault(subject, java.util.Set.of());
-    }
-
-    /** What walking {@code operation}'s container comes to, or null where it accumulates nothing —
-     *  including where the name is no operation of the library. */
-    public static Accumulation accumulation(ValueName operation) {
-        OperationFact.AccumulatesItsContainer stated = Index.ACCUMULATES.get(operation);
-        return stated == null ? null : stated.how();
-    }
-
-    /** Which argument {@code operation} accumulates, or null where it accumulates nothing. */
-    public static ArgumentRef accumulatedContainer(ValueName operation) {
-        OperationFact.AccumulatesItsContainer stated = Index.ACCUMULATES.get(operation);
-        return stated == null ? null : stated.container();
-    }
-
-    /** The operations that answer what a container holds accumulated. */
-    public static java.util.Set<ValueName> accumulates() {
-        return Index.ACCUMULATES.keySet();
-    }
-
-    /**
-     * What {@code operation} takes of the one value it is given, or null where the number it
-     * answers is not taken of one value.
-     *
-     * <p>Declared, or read off the walk where the operation is one. An accumulation over one
-     * container already says what the answer is — start from this, carry that — so an arm declared
-     * beside it would be the same sentence in a second vocabulary, and the two would be free to
-     * disagree about what a sum is. What is read here is that statement put as a way of taking a
-     * number.
-     *
-     * <p>Only the walk that adds. A join carries an identity and a step as much as a sum does and
-     * answers a string; a product carries them and answers a number this measure has no reading
-     * for. What is derived is one account and not the family, so the reading a term gets is one
-     * something here can carry out — and a walk of another kind arriving is a walk nothing here
-     * claims to read.
-     *
-     * <p>Nothing here about how many arguments the operation takes. A number taken of the one value
-     * an operation is given is taken of one, and that is held where every taking is held to its
-     * declaration — so a walk that adds over a container beside other arguments stops the
-     * compilation rather than arriving as a term about whichever argument was written first.
-     */
-    public static TakenAs takenAs(ValueName operation) {
-        TakenAs declared = Index.TAKEN_AS.get(operation);
-        return declared != null ? declared : theSumItAccumulates(operation);
-    }
-
-    /** The sum arm where {@code operation} is a walk that adds up what it holds, or null. */
-    private static TakenAs theSumItAccumulates(ValueName operation) {
-        Accumulation walk = accumulation(operation);
-        return walk != null
-                && walk.identity() == Accumulation.Identity.ZERO
-                && walk.combine() == Accumulation.Combine.ADD
-                ? new TakenAs.TheSumOfWhatItHolds() : null;
-    }
-
-    /**
-     * The operations that answer a number taken of the one value they are given.
-     *
-     * <p>The ones {@link #takenAs} answers for, which is not the same as the ones an account is
-     * declared of: a walk that adds up a container is read as one and its account is that walk.
-     * Answered off the declarations alone, this set and the accessor beside it would disagree about
-     * an operation, and every reader of the set — what a question is asked of, what a check
-     * enumerates — would be missing whichever operations the accessor derives.
-     */
-    public static java.util.Set<ValueName> answersANumberTakenOfItsArgument() {
-        java.util.Set<ValueName> out = new java.util.LinkedHashSet<>(Index.TAKEN_AS.keySet());
-        Index.ACCUMULATES.keySet().forEach(operation -> {
-            if (takenAs(operation) != null) {
-                out.add(operation);
-            }
-        });
-        return java.util.Set.copyOf(out);
-    }
-
-    /**
-     * The operations that count what they are given, which is the narrower vocabulary a size is
-     * asked for under.
-     *
-     * <p>Read off the arm rather than declared beside it. Being a size is being taken as how many
-     * the value holds, so a second list would be the same statement written twice and would drift
-     * the way the two lists of measures this package was made out of did.
-     */
-    public static java.util.Set<ValueName> countsWhatItIsGiven() {
-        java.util.Set<ValueName> out = new java.util.LinkedHashSet<>();
-        Index.TAKEN_AS.forEach((operation, how) -> {
-            if (how instanceof TakenAs.HowManyItHolds) {
-                out.add(operation);
-            }
-        });
-        return java.util.Set.copyOf(out);
-    }
-
-    /** Whether every number {@code operation} could answer is one some value it could be given
-     *  answers. */
-    public static boolean everyAnswerItCanGiveHasASourceValue(ValueName operation) {
-        return Index.EVERY_ANSWER_HAS_A_SOURCE.contains(operation);
-    }
-
-    /** The indexes, read off the declarations on the first ask. */
-    private static final class Index {
-
-        private static final Map<ValueName,
-                souther.compiler.numeric.LinearForm<ArgumentRef>> ANSWERS_A_FORM =
-                index(OperationFact.AnswersAFormOfItsArguments.class,
-                        OperationFact.AnswersAFormOfItsArguments::form);
-
-        private static final Map<ValueName, PositiveOrder> ORDERS =
-                index(OperationFact.StatesTheOrderOfItsArguments.class,
-                        OperationFact.StatesTheOrderOfItsArguments::order);
-
-        private static final Map<ValueName, OperationFact.ShiftsBy> SHIFTS =
-                index(OperationFact.ShiftsBy.class, java.util.function.Function.identity());
-
-        private static final Map<ValueName, BuiltFrom> BUILDINGS =
-                index(OperationFact.BuildsItsResultFrom.class,
-                        OperationFact.BuildsItsResultFrom::built);
-
-        private static final Map<ValueName, OperationFact.ReadsItsContainer> READS =
-                index(OperationFact.ReadsItsContainer.class,
-                        java.util.function.Function.identity());
-
-        private static final Map<ValueName, ArgumentRef> PROJECTIONS =
-                index(OperationFact.IsStatedOverAProjection.class,
-                        OperationFact.IsStatedOverAProjection::projection);
-
-        private static final java.util.Set<ValueName> QUANTIFIERS =
-                stating(OperationFact.StatesItsPredicateOfEveryElement.class);
-
-        private static final Map<ValueName, TakenAs> TAKEN_AS =
-                index(OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven.class,
-                        OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven::how);
-
-        private static final Map<ValueName, OperationFact.AccumulatesItsContainer> ACCUMULATES =
-                index(OperationFact.AccumulatesItsContainer.class, each -> each);
-
-        private static final java.util.Set<ValueName> EVERY_ANSWER_HAS_A_SOURCE =
-                stating(OperationFact.EveryAnswerItCanGiveHasASourceValue.class);
-
-        /** The silences, by what they are about. */
-        private static final Map<OperationSubject, java.util.Set<ValueName>> SILENCES = silences();
-
-        private static Map<OperationSubject, java.util.Set<ValueName>> silences() {
-            Map<OperationSubject, java.util.Set<ValueName>> out = new LinkedHashMap<>();
-            for (Declared each : DECLARED) {
-                if (each.fact() instanceof OperationFact.SaysNothingOf said) {
-                    out.computeIfAbsent(said.subject(), subject -> new java.util.LinkedHashSet<>())
-                            .add(each.operation());
-                }
-            }
-            out.replaceAll((subject, held) -> java.util.Set.copyOf(held));
-            return Map.copyOf(out);
-        }
-
-        private static final Map<ValueName, NumericResult> ARITHMETIC =
-                index(OperationFact.ComputesANumber.class, OperationFact.ComputesANumber::result);
-
-        /** In the order they are declared, which is the order the library writes them: what holds
-         *  in every case holds of the result, and that is a claim about the run of them. */
-        private static final Map<ValueName, List<OperationFact.Case>> CASES = cases();
-
-        private static Map<ValueName, List<OperationFact.Case>> cases() {
-            Map<ValueName, List<OperationFact.Case>> out = new LinkedHashMap<>();
-            for (Declared each : DECLARED) {
-                if (each.fact() instanceof OperationFact.IsDefinedByCases defined) {
-                    out.computeIfAbsent(each.operation(), operation -> new ArrayList<>())
-                            .add(defined.one());
-                }
-            }
-            out.replaceAll((operation, held) -> List.copyOf(held));
-            return Map.copyOf(out);
-        }
-
-        /** Gathered rather than indexed one to one: an operation is no smaller than as many
-         *  containers as it names, and each is a fact of its own. */
-        private static final Map<ValueName, List<ArgumentRef>> NO_SMALLER_THAN = noSmallerThan();
-
-        private static Map<ValueName, List<ArgumentRef>> noSmallerThan() {
-            Map<ValueName, List<ArgumentRef>> out = new LinkedHashMap<>();
-            for (Declared each : DECLARED) {
-                if (each.fact() instanceof OperationFact.ResultIsNoSmallerThan bounded) {
-                    out.computeIfAbsent(each.operation(), operation -> new ArrayList<>())
-                            .add(bounded.container());
-                }
-            }
-            out.replaceAll((operation, held) -> List.copyOf(held));
-            return Map.copyOf(out);
-        }
-
-        /** Gathered rather than indexed one to one: an operation states as many bounds as it
-         *  states, and each is a fact of its own. */
-        private static final Map<ValueName, List<ResultBound>> BOUNDS = bounds();
-
-        private static Map<ValueName, List<ResultBound>> bounds() {
-            Map<ValueName, List<ResultBound>> out = new LinkedHashMap<>();
-            for (Declared each : DECLARED) {
-                if (each.fact() instanceof OperationFact.BoundsItsResult bounded) {
-                    out.computeIfAbsent(each.operation(), operation -> new ArrayList<>())
-                            .add(bounded.bound());
-                }
-            }
-            out.replaceAll((operation, held) -> List.copyOf(held));
-            return Map.copyOf(out);
-        }
-
-        /** The operations that carry a fact of {@code kind}, for a fact that says nothing beside
-         *  being declared at all. */
-        private static java.util.Set<ValueName> stating(Class<? extends OperationFact> kind) {
-            java.util.Set<ValueName> out = new java.util.LinkedHashSet<>();
-            for (Declared each : DECLARED) {
-                if (kind.isInstance(each.fact())) {
-                    out.add(each.operation());
-                }
-            }
-            return java.util.Set.copyOf(out);
-        }
-
-        private static <F extends OperationFact, V> Map<ValueName, V> index(
-                Class<F> kind, java.util.function.Function<F, V> read) {
-            Map<ValueName, V> out = new LinkedHashMap<>();
-            for (Declared each : DECLARED) {
-                if (kind.isInstance(each.fact())) {
-                    V value = read.apply(kind.cast(each.fact()));
-                    if (out.put(each.operation(), value) != null) {
-                        throw new IllegalStateException(each.operation()
-                                + " is declared to " + kind.getSimpleName() + " twice");
-                    }
-                }
-            }
-            return Map.copyOf(out);
-        }
     }
 
     private OperationFacts() {}

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ResultBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ResultBound.java
@@ -19,13 +19,17 @@ import java.math.BigDecimal;
  * at the check that holds a fact to the library's signatures. That one asks whether a fact and a
  * declaration agree; this one is about what a bound is.
  *
+ * <p>Generic in the word for an argument, as {@link ElementLineage} is: authored, the argument is
+ * named as a fact writes it; held to the library, as the declaration has it.
+ *
  * @param against  the argument the result is bounded against, or null where the bound is a constant
  *                 one
  * @param offset   added to that argument, or the constant itself where there is no argument
  * @param rel      how the result stands to it
  * @param provided what has to hold of the arguments for this to be the operation's answer
+ * @param <A>      the word for an argument of the operation
  */
-public record ResultBound(ArgumentRef against, BigDecimal offset, Rel rel, Provided provided) {
+public record ResultBound<A>(A against, BigDecimal offset, Rel rel, Provided<A> provided) {
 
     public ResultBound {
         java.util.Objects.requireNonNull(offset, "a bound stands somewhere");
@@ -48,10 +52,10 @@ public record ResultBound(ArgumentRef against, BigDecimal offset, Rel rel, Provi
      *
      * <p>Whether a call meets one is read where calls are read; this says which condition it is.
      */
-    public sealed interface Provided {
+    public sealed interface Provided<A> {
 
         /** Nothing: the bound is what the operation does, whatever it is given. */
-        record Always() implements Provided {}
+        record Always<A>() implements Provided<A> {}
 
         /**
          * An argument that reads as a constant above zero.
@@ -61,7 +65,7 @@ public record ResultBound(ArgumentRef against, BigDecimal offset, Rel rel, Provi
          * {@code floorMod(x, 100)}. Requiring the digits at the call would make a rule an author
          * cannot predict from what the value is, only from where it was written.
          */
-        record ConstantAboveZero(ArgumentRef argument) implements Provided {
+        record ConstantAboveZero<A>(A argument) implements Provided<A> {
 
             public ConstantAboveZero {
                 java.util.Objects.requireNonNull(argument, "this one names an argument");

--- a/souther-compiler/src/main/java/souther/compiler/semantics/ResultRange.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/ResultRange.java
@@ -3,9 +3,9 @@ package souther.compiler.semantics;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
-import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -15,9 +15,9 @@ import java.util.Optional;
  * of rows relating that result to the arguments and to constants, under conditions on the arguments;
  * a range holds two ends and nothing else. So a row this cannot put on an end is left out, and what
  * comes back is where the result is known to run and not everything that is known about it. A reader
- * wanting the relations reads the rows ({@code OperationFacts.boundsOnTheResult}) — that is what the
- * discharge does, which is why a row bounding {@code Int.floorMod(x, k)} by {@code k} is not lost by
- * anyone: it is lost here, where a range has no name for {@code k}, and read there, where it has.
+ * wanting the relations reads the rows — that is what the discharge does, which is why a row
+ * bounding {@code Int.floorMod(x, k)} by {@code k} is not lost by anyone: it is lost here, where a
+ * range has no name for {@code k}, and read there, where it has.
  *
  * <p>Leaving a row out is always the wider answer. Every row narrows, so a range that dropped one
  * holds every value the whole list holds and possibly more — this can be read where a fact was never
@@ -25,22 +25,29 @@ import java.util.Optional;
  *
  * <p>Which rows come out therefore depends on what the reader can say about the arguments, and that
  * is the parameter. A reader holding a call answers them all; one holding only the operation answers
- * {@link ConstantArguments#NONE} and gets the rows that name nothing, which for an operation the
- * language gives no number is every row it has ({@code check.DischargeRules.holdBound} is what makes
- * that so).
+ * {@link ConstantArguments#none()} and gets the rows that name nothing, which for an operation the
+ * language gives no number is every row it has ({@code check.OperationFactBinder} holds a bound to
+ * naming only an argument that is a number, which is what makes that so).
+ *
+ * <p><b>Handed the rows, and looking nothing up.</b> Whose rows they are, and whether they have
+ * been held to the library, is the caller's to know; what this does is read the ones it is given.
+ * Given a name and left to find the rows itself, this would be a second place the rows are looked
+ * for, and the one place a reader could reach them without whatever holds them having run.
  */
 public final class ResultRange {
 
     /**
-     * Where {@code operation}'s result runs, under what {@code arguments} can say.
+     * Where a result runs, under what {@code arguments} can say, given the {@code rows} declared of
+     * it.
      *
      * <p>Every end, so two rows about one side leave the tighter of them: the rows are one statement
      * about one number, and reading them one at a time would answer with whichever was written
      * last.
      */
-    public static NumericDomain.Bounds of(ValueName operation, ConstantArguments arguments) {
+    public static <A> NumericDomain.Bounds of(List<ResultBound<A>> rows,
+                                              ConstantArguments<A> arguments) {
         NumericDomain.Bounds runs = NumericDomain.Bounds.OPEN;
-        for (ResultBound row : OperationFacts.boundsOnTheResult(operation)) {
+        for (ResultBound<A> row : rows) {
             if (!arguments.satisfy(row.provided())) {
                 continue;
             }
@@ -54,7 +61,8 @@ public final class ResultRange {
 
     /** The end one row puts on the result, or null where this reader cannot say where that end
      *  stands. */
-    private static NumericDomain.Bounds endOf(ResultBound row, ConstantArguments arguments) {
+    private static <A> NumericDomain.Bounds endOf(ResultBound<A> row,
+                                                  ConstantArguments<A> arguments) {
         Count at = standsAt(row, arguments);
         if (at == null) {
             return null;
@@ -74,7 +82,7 @@ public final class ResultRange {
     }
 
     /** The count the row's end is at, or null where the argument it is against says nothing here. */
-    private static Count standsAt(ResultBound row, ConstantArguments arguments) {
+    private static <A> Count standsAt(ResultBound<A> row, ConstantArguments<A> arguments) {
         if (row.against() == null) {
             return Count.of(row.offset());
         }

--- a/souther-compiler/src/test/java/souther/compiler/OnlyABoundaryOrAProcessConstantReadsTheDefaultLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OnlyABoundaryOrAProcessConstantReadsTheDefaultLibraryTest.java
@@ -45,12 +45,13 @@ class OnlyABoundaryOrAProcessConstantReadsTheDefaultLibraryTest {
             "check/Combinators.java",
             "check/Preserved.java",
             "check/Reductions.java",
-            "check/DischargeRules.java");
+            // The facts about the language's operations, held to the shipped library once.
+            "check/DefaultBoundOperationFacts.java");
 
     /** What building a library must not need, because it is what building one produces. */
     private static final List<String> WHAT_THE_LOADER_MAY_NOT_READ = List.of(
             "DefaultStdlib", "Combinators", "Preserved", "Accumulations", "Reductions",
-            "DischargeRules");
+            "DischargeRules", "DefaultBoundOperationFacts", "OperationFactBinder");
 
     @Test
     void theseAreTheOnlyReadersOfTheProcessLibrary() throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/check/ABoundFactIsFiledByItsFamilyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABoundFactIsFiledByItsFamilyTest.java
@@ -6,6 +6,7 @@ import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.semantics.OperationFact;
 import souther.compiler.semantics.OperationFacts;
+import souther.compiler.semantics.OperationSubject;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -66,6 +67,29 @@ class ABoundFactIsFiledByItsFamilyTest {
                 () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained));
 
         assertTrue(refused.getMessage().contains("List.length"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("twice"), refused.getMessage());
+    }
+
+    /**
+     * A silence is a kind an operation carries several of — one per subject — and a second under
+     * one subject is refused where the silences are gathered, since the family alone would keep
+     * both and answer as if there were one.
+     */
+    @Test
+    void aSecondSilenceUnderOneSubjectIsRefused() {
+        ValueName product = ValueName.Stdlib.operation("List", "product");
+        assertTrue(DefaultBoundOperationFacts.get()
+                        .saysNothingOf(OperationSubject.READING)
+                        .contains(product),
+                "the premise: List.product is declared silent under what reads its number");
+        List<OperationFacts.Declared> gained = new ArrayList<>(OperationFacts.declarations());
+        gained.add(new OperationFacts.Declared(product, new OperationFact.SaysNothingOf(
+                OperationSubject.READING)));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained));
+
+        assertTrue(refused.getMessage().contains("List.product"), refused.getMessage());
         assertTrue(refused.getMessage().contains("twice"), refused.getMessage());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ABoundFactIsFiledByItsFamilyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABoundFactIsFiledByItsFamilyTest.java
@@ -1,0 +1,144 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.KeptCalls;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.semantics.OperationFact;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.semantics.TakenAs;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the binding makes is filed by the family the arm was written in, and applied to a call of
+ * the declaration it is about.
+ *
+ * <p>Two rules a reader below the binding stands on without checking. A kind of fact an operation
+ * carries one of is filed once and a second is refused — a map written into keeps whichever arrived
+ * last, and a reader would get an answer that depended on the order the declarations were written
+ * in. And a bound argument names the declaration it is an argument of, so a call it is applied to
+ * has to be a call of that declaration: a position is a number, and a number is right in any call
+ * that takes enough arguments.
+ */
+class ABoundFactIsFiledByItsFamilyTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final ValueName.Stdlib.Operation LIST_LENGTH =
+            ValueName.Stdlib.operation("List", "length");
+
+    private static final ValueName.Stdlib.Operation LIST_APPEND =
+            ValueName.Stdlib.operation("List", "append");
+
+    private static final ValueName.Stdlib.Operation LIST_REVERSE =
+            ValueName.Stdlib.operation("List", "reverse");
+
+    private static final ValueName.Stdlib.Operation LIST_DISTINCT =
+            ValueName.Stdlib.operation("List", "distinct");
+
+    /**
+     * A kind an operation carries one of, declared twice, is refused where the bound facts are
+     * collected.
+     *
+     * <p>Each declaration holds on its own — {@code List.length} does count what it holds — so
+     * nothing about either is wrong where it is bound. What is wrong is the pair, and the pair is
+     * seen where the facts are filed.
+     */
+    @Test
+    void aSecondFactOfAKindAnOperationCarriesOneOfIsRefused() {
+        List<OperationFacts.Declared> gained = new ArrayList<>(OperationFacts.declarations());
+        gained.add(new OperationFacts.Declared(LIST_LENGTH,
+                new OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven(
+                        new TakenAs.HowManyItHolds())));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained));
+
+        assertTrue(refused.getMessage().contains("List.length"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("twice"), refused.getMessage());
+    }
+
+    /** And a kind an operation may carry several of is kept whole, in the order declared. */
+    @Test
+    void aKindAnOperationCarriesSeveralOfIsKeptWhole() {
+        List<DeclaredArgument> noSmallerThan =
+                DefaultBoundOperationFacts.get().resultIsNoSmallerThan(LIST_APPEND);
+        assertEquals(List.of(0, 1),
+                noSmallerThan.stream().map(DeclaredArgument::position).toList(),
+                "`a ++ b` is as long as either half, which is two facts about one operation");
+        for (DeclaredArgument each : noSmallerThan) {
+            assertEquals(LIST_APPEND, each.of().operation(),
+                    "and each names the declaration it is an argument of");
+        }
+    }
+
+    /** A bound argument applied to a call of the declaration it is an argument of answers the
+     *  expression standing there. */
+    @Test
+    void aBoundArgumentIsFoundInACallOfItsOwnDeclaration() {
+        Core.PreservedCall reverse = KeptCalls.to(LIST_REVERSE, POS);
+        DeclaredArgument from =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(LIST_REVERSE).from();
+
+        assertSame(reverse.args().get(0), CallArguments.of(from, reverse));
+    }
+
+    /**
+     * And applied to a call of another declaration it is refused, however many arguments that call
+     * takes.
+     *
+     * <p>{@code List.distinct} takes one argument as {@code List.reverse} does, so the position is
+     * in range and the answer would have been an expression, standing where the wrong declaration
+     * put it. The argument knows what it is an argument of, and that is what is held.
+     */
+    @Test
+    void aBoundArgumentAppliedToACallOfAnotherDeclarationIsRefused() {
+        Core.PreservedCall distinct = KeptCalls.to(LIST_DISTINCT, POS);
+        DeclaredArgument from =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(LIST_REVERSE).from();
+        assertEquals(distinct.args().size(), from.of().arity(),
+                "the premise: the two take as many arguments, so a position alone would answer");
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> CallArguments.of(from, distinct));
+        assertTrue(refused.getMessage().contains("another declaration"), refused.getMessage());
+        assertThrows(IllegalStateException.class,
+                () -> CallArguments.replacedIn(from, distinct, distinct.args().get(0)),
+                "and a rebuild is refused the same way");
+    }
+
+    /**
+     * And the same for a reader holding the operation's name and its arguments rather than a kept
+     * call — the runnable tree's call, an expansion — which asks the position through the same
+     * check rather than reading it off the argument.
+     */
+    @Test
+    void aBoundArgumentAskedForUnderAnotherOperationsNameIsRefused() {
+        DeclaredArgument from =
+                DefaultBoundOperationFacts.get().buildsItsResultFrom(LIST_REVERSE).from();
+
+        assertEquals(0, CallArguments.positionOf(from, LIST_REVERSE));
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> CallArguments.positionOf(from, LIST_DISTINCT));
+        assertTrue(refused.getMessage().contains("another declaration"), refused.getMessage());
+    }
+
+    /** A bound argument outside its declaration's arity cannot be made at all. */
+    @Test
+    void aBoundArgumentOutsideTheDeclarationIsRefusedWhereItIsMade() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new DeclaredArgument(KeptCalls.declared(LIST_REVERSE), 1, Type.INT));
+        assertTrue(refused.getMessage().contains("List.reverse"), refused.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeclaredBoundIsWhereTheCarrierStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeclaredBoundIsWhereTheCarrierStopsTest.java
@@ -30,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ADeclaredBoundIsWhereTheCarrierStopsTest {
 
     private static NumericDomain.Bounds declaredFor(String module, String operation) {
-        return ResultRange.of(ValueName.Stdlib.operation(module, operation), ConstantArguments.NONE);
+        return ResultRange.of(DefaultBoundOperationFacts.get().boundsOnTheResult(
+                ValueName.Stdlib.operation(module, operation)), ConstantArguments.none());
     }
 
     /** A pair of ends, both counts and both of the range's own. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.DefaultStdlib;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.ValueName;
 
@@ -48,7 +47,7 @@ class ANumberIsReadByAtMostOneRepresentationTest {
                 : DefaultStdlib.get().entries().entrySet()) {
             ValueName operation = e.getKey();
             NumericReadings.Resolution read = NumericReadings.resolve(
-                    DefaultStdlib.get(), OperationFacts.declarations(), operation);
+                    DefaultStdlib.get(), DefaultBoundOperationFacts.get(), operation);
             if (read instanceof NumericReadings.Resolution.Multiple) {
                 // Named by whatever names them in a refusal, so what a reader is told here and what
                 // the library is refused with are one sentence rather than two that drift.

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.DefaultStdlib;
 import souther.compiler.Compiler;
 import souther.compiler.check.InvariantChecker.GaveUp;
 import souther.compiler.check.InvariantChecker.Said;
@@ -439,7 +438,7 @@ class ARuleAboutAnOperationsResultCarriesSomethingTest {
 
     @Test
     void everyReadThroughHasAConstructionThatFiresIt() {
-        assertEquals(new TreeSet<>(DischargeRules.formNames(DefaultStdlib.get())), namesOf(READ_AS_THEIR_ARGUMENT));
+        assertEquals(new TreeSet<>(DischargeRules.formNames()), namesOf(READ_AS_THEIR_ARGUMENT));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.DefaultStdlib;
+import souther.compiler.core.CompleteSignature;
 import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.ElementLineage;
@@ -31,15 +32,22 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         return ValueName.Stdlib.operation(qualified.substring(0, dot), qualified.substring(dot + 1));
     }
 
+    /** The operation read against the library, as the binder reads every one before holding a
+     *  fact to it — so an operation the library does not have is refused here, one question before
+     *  the argument. */
+    private static CompleteSignature declared(String operation) {
+        return OperationFactBinder.declaredSignature(DefaultStdlib.get(), op(operation));
+    }
+
     private static void bindCarried(String operation, ArgumentRef container) {
-        DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation), container,
+        OperationFactBinder.holdToTheDeclaration(declared(operation), container,
                 new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
                 "the container a predicate reads");
     }
 
     private static void bindBuilt(String operation, ArgumentRef from) {
-        DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation),
-                new BuiltFrom(new ElementLineage.SameAs(new ElementLineage.Source(from, 1)),
+        OperationFactBinder.holdToTheDeclaration(declared(operation),
+                new BuiltFrom<>(new ElementLineage.SameAs<>(new ElementLineage.Source<>(from, 1)),
                         SizeAgainstItsSource.AT_MOST).from(),
                 new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
                 "the container something is built from");
@@ -104,8 +112,8 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
     /** The binding reads what the declaration says, so a rule it agrees with binds. */
     @Test
     void aRuleThatAgreesWithTheDeclaration() {
-        assertDoesNotThrow(() -> DischargeRules.holdToTheDeclaration(DefaultStdlib.get(),
-                op("List.reverse"), new ArgumentRef.At(0), new ArgumentRef.TheContainer(),
+        assertDoesNotThrow(() -> OperationFactBinder.holdToTheDeclaration(declared("List.reverse"),
+                new ArgumentRef.At(0), new ArgumentRef.TheContainer(),
                 TypeRequirement.CONTAINER, "the container something is built from"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ARunIsReadOnlyWhereBothHalvesAreProvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARunIsReadOnlyWhereBothHalvesAreProvedTest.java
@@ -7,6 +7,7 @@ import souther.compiler.core.GrowingFold;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.ValueName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -124,8 +125,7 @@ class ARunIsReadOnlyWhereBothHalvesAreProvedTest {
      *  building — which every operation asked here has, so a null is the projection's answer. */
     private static DeclaredArgument mapsEachElementOf(String module, String operation) {
         return DefaultBoundOperationFacts.get()
-                .buildsItsResultFrom(souther.compiler.types.ValueName.Stdlib.operation(module,
-                        operation))
+                .buildsItsResultFrom(ValueName.Stdlib.operation(module, operation))
                 .mapsEachElementOf();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ARunIsReadOnlyWhereBothHalvesAreProvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARunIsReadOnlyWhereBothHalvesAreProvedTest.java
@@ -111,16 +111,22 @@ class ARunIsReadOnlyWhereBothHalvesAreProvedTest {
      */
     @Test
     void bothStatementsAreAskedAndNeitherAlone() {
-        assertNotNull(souther.compiler.semantics.ElementLineage.mapsEachElementOf(
-                        souther.compiler.types.ValueName.Stdlib.operation("List", "map")),
+        assertNotNull(mapsEachElementOf("List", "map"),
                 "a mapping answers what the closure made and as many as it was given");
-        assertNull(souther.compiler.semantics.ElementLineage.mapsEachElementOf(
-                        souther.compiler.types.ValueName.Stdlib.operation("Set", "map")),
+        assertNull(mapsEachElementOf("Set", "map"),
                 "a mapping into a set answers what the closure made and no more than it was given,"
                         + " which is not one per element");
-        assertNull(souther.compiler.semantics.ElementLineage.mapsEachElementOf(
-                        souther.compiler.types.ValueName.Stdlib.operation("List", "filter")),
+        assertNull(mapsEachElementOf("List", "filter"),
                 "a filter answers the elements it was given rather than what a closure made");
+    }
+
+    /** The argument the operation answers one closure result per element of, read off the bound
+     *  building — which every operation asked here has, so a null is the projection's answer. */
+    private static DeclaredArgument mapsEachElementOf(String module, String operation) {
+        return DefaultBoundOperationFacts.get()
+                .buildsItsResultFrom(souther.compiler.types.ValueName.Stdlib.operation(module,
+                        operation))
+                .mapsEachElementOf();
     }
 
     /** With both halves, the closure's answer is kept as the way from the element to it. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
@@ -57,7 +57,13 @@ class AnAnswersIdentityCoversEverythingItAnswersWithTest {
             "the hash is of the shape and the parts, and is compared first as a way of saying no",
             "souther.compiler.check.CheckSurface.operandMethods",
             "keyed on operand identity, over the very nodes the tree hands out — it says nothing"
-                    + " the tree and the definitions built from it do not already say");
+                    + " the tree and the definitions built from it do not already say",
+            "souther.compiler.check.DeclaredArgument.stands",
+            "the type at a position is a fact the library settled about that position and not a"
+                    + " second thing to tell two arguments apart by: two readings of one declaration"
+                    + " that disagreed about it would be a binding that has come apart, not two"
+                    + " arguments — the same reason a declared operation's arity is outside its"
+                    + " identity");
 
     @Test
     void everyHandWrittenIdentityReadsEveryFieldItsStateHolds() throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEmptinessCheckAndTheSizeItMeansAreHeldToEachOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEmptinessCheckAndTheSizeItMeansAreHeldToEachOtherTest.java
@@ -34,7 +34,8 @@ class AnEmptinessCheckAndTheSizeItMeansAreHeldToEachOtherTest {
 
     @Test
     void theOnesTheLanguageDeclaresAreHeld() {
-        assertFalse(OperationFactBinder.bindAll(DefaultStdlib.get()).sizes().isEmpty(),
+        assertFalse(OperationFactBinder.bindAll(DefaultStdlib.get())
+                        .meansTheSameAsASizeOfNought().isEmpty(),
                 "nothing is declared to mean a size, so the rules below saw nothing");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest.java
@@ -3,7 +3,8 @@ package souther.compiler.check;
 import souther.compiler.DefaultStdlib;
 import souther.compiler.KeptCalls;
 import souther.compiler.stdlib.Stdlib;
-import souther.compiler.semantics.OperationFact;
+import souther.compiler.semantics.ArgumentsStand;
+import souther.compiler.semantics.DefinitionCase;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
@@ -53,7 +54,7 @@ class EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest {
                         + " that nothing was wrong");
         for (ValueName operation : DischargeRules.choosingOperations()) {
             Core.PreservedCall call = callTo(operation);
-            java.util.List<OperationFact.Case> defined = DischargeRules.chosenBy(call);
+            java.util.List<DefinitionCase<DeclaredArgument>> defined = DischargeRules.chosenBy(call);
             Choice choice = Choice.of(call);
 
             assertNotNull(choice, operation + " is defined in cases and answers no choice");
@@ -63,7 +64,7 @@ class EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest {
                     operation + " has an arm per case it is defined in");
 
             for (int i = 0; i < defined.size(); i++) {
-                OperationFact.Case row = defined.get(i);
+                DefinitionCase<DeclaredArgument> row = defined.get(i);
                 Choice.Arm arm = choice.arms().get(i);
                 String where = operation + " case " + (i + 1);
 
@@ -91,10 +92,10 @@ class EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest {
     }
 
     /** The relations the row names, written in the values this call was given. */
-    private static List<Choice.ArgumentRelation> expected(OperationFact.Case row,
+    private static List<Choice.ArgumentRelation> expected(DefinitionCase<DeclaredArgument> row,
                                                           Core.PreservedCall call) {
         List<Choice.ArgumentRelation> out = new ArrayList<>(row.given().size());
-        for (OperationFact.ArgumentsStand stands : row.given()) {
+        for (ArgumentsStand<DeclaredArgument> stands : row.given()) {
             out.add(new Choice.ArgumentRelation(CallArguments.of(stands.left(), call), stands.rel(),
                     CallArguments.of(stands.right(), call)));
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest.java
@@ -54,7 +54,7 @@ class EveryCaseALibraryDefinitionIsWrittenInBecomesAnArmTest {
                         + " that nothing was wrong");
         for (ValueName operation : DischargeRules.choosingOperations()) {
             Core.PreservedCall call = callTo(operation);
-            java.util.List<DefinitionCase<DeclaredArgument>> defined = DischargeRules.chosenBy(call);
+            List<DefinitionCase<DeclaredArgument>> defined = DischargeRules.chosenBy(call);
             Choice choice = Choice.of(call);
 
             assertNotNull(choice, operation + " is defined in cases and answers no choice");

--- a/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
@@ -231,6 +231,38 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
     }
 
     /**
+     * Two readings of one number are refused whichever two they are, with no account of a number
+     * taken of one value among them.
+     *
+     * <p>The two above each pair such an account with something, so what they show is that pairs
+     * with that account in them are refused. The claim is about the operation and not about the
+     * account: {@code Int.add} computes its number as the arithmetic it is, and a form declared
+     * beside that is a second reading of the same number — one nothing here has to be told about,
+     * since what is held is how many readings every operation of the library has.
+     */
+    @Test
+    void twoReadingsOfOneNumberAreRefusedWhicheverTwoTheyAre() {
+        List<OperationFacts.Declared> gained =
+                new ArrayList<>(OperationFacts.declarations());
+        gained.add(new OperationFacts.Declared(
+                ValueName.Stdlib.operation("Int", "add"),
+                new OperationFact.AnswersAFormOfItsArguments(
+                        souther.compiler.numeric.LinearForm.<ArgumentRef>atom(
+                                new ArgumentRef.At(0)).plus(
+                                souther.compiler.numeric.LinearForm.atom(
+                                        new ArgumentRef.At(1))))));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained));
+
+        assertTrue(refused.getMessage().contains("Int.add"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("form"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("arithmetic"),
+                "and names both readings, so what was refused was the pair: "
+                        + refused.getMessage());
+    }
+
+    /**
      * And a fact about an operation the library does not declare at all.
      *
      * <p>Beside the above because it fails one question earlier: there is no signature to read the

--- a/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
@@ -36,13 +36,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class EverySemanticDeclarationIsHeldToTheLibraryTest {
 
-    /** Everything the language declares is visited, and the visiting is over the declarations. */
+    /** Everything the language declares is bound, one bound fact per declaration and in the order
+     *  declared, and the binding is over the declarations. */
     @Test
     void theBindingIsOverTheDeclarations() {
-        assertEquals(OperationFacts.declarations(),
+        assertEquals(OperationFacts.declarations().stream()
+                        .map(OperationFacts.Declared::operation).toList(),
                 OperationFactBinder.bindAll(DefaultStdlib.get(), OperationFacts.declarations())
-                        .visited(),
-                "what the binding visited is what is declared");
+                        .all().stream().map(each -> each.operation().operation()).toList(),
+                "what the binding bound is what is declared, about the operations it is declared"
+                        + " of");
         assertTrue(!OperationFacts.declarations().isEmpty(),
                 "and there is something declared for that to mean anything");
     }
@@ -120,8 +123,8 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
                 new ArrayList<>(OperationFacts.declarations());
         gained.add(new OperationFacts.Declared(
                 ValueName.Stdlib.operation("List", "get"),
-                new OperationFact.BoundsItsResult(new ResultBound(null, BigDecimal.ZERO,
-                        Rel.GE, new ResultBound.Provided.Always()))));
+                new OperationFact.BoundsItsResult(new ResultBound<>(null, BigDecimal.ZERO,
+                        Rel.GE, new ResultBound.Provided.Always<>()))));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained),

--- a/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.DefaultStdlib;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -81,6 +80,6 @@ class NumericReadingsFindTheAccountsTheLibraryDeclaresTest {
     private static NumericReadings.Resolution resolutionOf(String qualified) {
         ValueName operation = DefaultStdlib.get().operation(qualified);
         return NumericReadings.resolve(
-                DefaultStdlib.get(), OperationFacts.declarations(), operation);
+                DefaultStdlib.get(), DefaultBoundOperationFacts.get(), operation);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
@@ -1,0 +1,229 @@
+package souther.compiler.check;
+
+import souther.compiler.WhatWasCompiled;
+import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.OperationFact;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A fact about an operation is read against the library once, and everything below reads what that
+ * made.
+ *
+ * <p>The declarations ({@link OperationFacts}) are written in an authoring vocabulary — a name for
+ * the operation, a word for an argument ({@link ArgumentRef}) — that says nothing about whether the
+ * library has such an operation or such an argument. {@link OperationFactBinder} holds every one of
+ * them to the library and answers with {@link BoundOperationFact}s, in which every name has been
+ * read against its declaration; a reader below it holds one of those and has nothing left to
+ * resolve. What that arrangement can lose is a second reader of the authoring vocabulary: one that
+ * takes the authored word and puts the binder's question again, by reading the declarations, or
+ * the signature, or what {@link Combinators} says an operation hands its closure — and gets an
+ * answer that agrees with the binder's for exactly as long as nobody changes either.
+ *
+ * <p>So the boundary is counted from what javac made of the module, on both sides. Above it, the
+ * authoring vocabulary is named by its own package and by the binder and by nothing else; the
+ * declarations are read by the binder alone; a bound argument is minted by the binder alone. Below
+ * it, no arm of a bound fact carries an authored name or word, and the readers of what an operation
+ * hands its closure are each written down with what they want it for — since a reader that wanted
+ * it to find a fact's argument would be the binder's question asked again.
+ *
+ * <p>Each set is compared whole rather than counted. A count lets one name be dropped and another
+ * added and says nothing about it, which is exactly the edit this is here to catch.
+ */
+class OnlyTheBinderReadsTheAuthoringVocabularyTest {
+
+    private static final String AUTHORING_PACKAGE = OperationFacts.class.getPackageName() + ".";
+
+    private static final String BINDER = OperationFactBinder.class.getName();
+
+    /** The authoring vocabulary: the declarations, the facts, and the word for an argument. Named
+     *  by outer class, so an arm nested in one counts as the class that nests it. */
+    private static final List<Class<?>> AUTHORING =
+            List.of(OperationFacts.class, OperationFact.class, ArgumentRef.class);
+
+    /** The names no bound fact may carry: the authoring word for an argument, the authored fact,
+     *  and the bare name of an operation — the last because a bound fact names an operation as a
+     *  declaration read, and a name beside that would be the half a reader could re-derive from. */
+    private static final List<Class<?>> NOT_BELOW_THE_BINDING =
+            List.of(ArgumentRef.class, OperationFact.class, ValueName.class);
+
+    private static boolean names(Set<String> named, Class<?> type) {
+        String outer = type.getName();
+        return named.stream().anyMatch(each -> each.equals(outer) || each.startsWith(outer + "$"));
+    }
+
+    /** Every class outside the authoring package that names any of the authoring vocabulary. */
+    private static Set<String> readersOfTheAuthoringVocabulary() {
+        Set<String> readers = new TreeSet<>();
+        for (String each : WhatWasCompiled.classes()) {
+            if (each.startsWith(AUTHORING_PACKAGE)) {
+                continue;
+            }
+            Set<String> named = WhatWasCompiled.typesNamedBy(each);
+            if (AUTHORING.stream().anyMatch(type -> names(named, type))) {
+                readers.add(each);
+            }
+        }
+        return readers;
+    }
+
+    @Test
+    void onlyTheBinderNamesTheAuthoringVocabularyOutsideItsOwnPackage() {
+        assertEquals(Set.of(BINDER), readersOfTheAuthoringVocabulary(),
+                "a class below the binding that names the declarations, an authored fact or the"
+                        + " word for an argument is a reader that can put the binder's question"
+                        + " again, and would get an answer that agrees with the binder's only for"
+                        + " as long as nobody changes either");
+    }
+
+    /** And the binder is such a reader, so the assertion above counted something. */
+    @Test
+    void andTheBinderDoesNameIt() {
+        Set<String> named = WhatWasCompiled.typesNamedBy(BINDER);
+        for (Class<?> type : AUTHORING) {
+            assertTrue(names(named, type), BINDER + " does not name " + type.getSimpleName()
+                    + ", so it is not reading the authoring vocabulary and the census above is"
+                    + " counting nothing");
+        }
+    }
+
+    @Test
+    void onlyTheBinderReadsTheDeclarations() {
+        assertEquals(Set.of(BINDER),
+                WhatWasCompiled.callersOf(OperationFacts.class, "declarations"),
+                "the declarations are the one thing the authoring side publishes, and the binder"
+                        + " is their one reader: a second is a way to a fact that does not pass"
+                        + " through the binding");
+    }
+
+    @Test
+    void onlyTheBinderMintsABoundArgument() {
+        Set<String> minting = WhatWasCompiled.callersOf(DeclaredArgument.class, "<init>");
+        assertEquals(Set.of(BINDER), minting,
+                "a bound argument says a word was read against a declaration, and the binder is"
+                        + " where that is done; one made anywhere else was read against nothing");
+    }
+
+    /** The other half of the pair: somebody does mint one, so the rule above is about something. */
+    @Test
+    void andTheBinderDoesMintOne() {
+        assertFalse(WhatWasCompiled.callersOf(DeclaredArgument.class, "<init>").isEmpty(),
+                "nothing mints a bound argument, so the rule about who may is about nothing");
+    }
+
+    /**
+     * Every arm of a bound fact is in one of the two families, and no arm carries an authored name
+     * or word.
+     *
+     * <p>The families are what decide how an arm is collected — once per operation, or as many
+     * times as declared — so an arm answering the sealed type directly would be one nothing knows
+     * how to file. And an arm carrying a {@link ValueName} or an {@link ArgumentRef} would be a
+     * bound fact with an unbound half, which is the shape a reader re-derives from.
+     */
+    @Test
+    void everyBoundArmIsInAFamilyAndCarriesOnlyBoundNames() {
+        assertEquals(Set.of(BoundOperationFact.OneAboutAnOperation.class,
+                        BoundOperationFact.SeveralAboutAnOperation.class),
+                Set.of(BoundOperationFact.class.getPermittedSubclasses()),
+                "a bound fact is one of two families, and an arm is in one of them");
+        List<Class<?>> arms = new ArrayList<>();
+        for (Class<?> family : BoundOperationFact.class.getPermittedSubclasses()) {
+            arms.addAll(List.of(family.getPermittedSubclasses()));
+        }
+        assertFalse(arms.isEmpty(), "there are arms for this to be about");
+        Map<String, String> unbound = new TreeMap<>();
+        for (Class<?> arm : arms) {
+            assertTrue(arm.isRecord(), arm + " is a bound fact and is not a record");
+            for (RecordComponent component : arm.getRecordComponents()) {
+                String type = component.getGenericType().getTypeName();
+                for (Class<?> forbidden : NOT_BELOW_THE_BINDING) {
+                    if (type.equals(forbidden.getName()) || type.contains(forbidden.getName() + "<")
+                            || type.contains(forbidden.getName() + "$")
+                            || type.contains("<" + forbidden.getName() + ">")
+                            || type.contains(", " + forbidden.getName() + ">")
+                            || type.contains("<" + forbidden.getName() + ",")) {
+                        unbound.put(arm.getSimpleName() + "." + component.getName(), type);
+                    }
+                }
+            }
+        }
+        assertEquals(Map.of(), unbound,
+                "a bound fact carries an authored name or word, which is the half a reader below"
+                        + " the binding could re-derive from");
+    }
+
+    /** A reader of what an operation hands its closure, and what it wants it for. */
+    private record Reader(String who, String why) { }
+
+    /**
+     * The readers of {@link Combinators}, each with what it asks.
+     *
+     * <p>What {@code Combinators} answers is which argument of an operation hands a closure the
+     * contents of which container. Asked to find the argument a fact names, that is the binder's
+     * question — the one {@link ArgumentRef.TheContainer} and {@link ArgumentRef.TheClosure} are
+     * resolved by — and a second asker would be a second binding. So every reader is written down
+     * with what it wants the answer for, and a reader arriving here is a finding before it is a
+     * line.
+     */
+    private static final List<Reader> READERS_OF_COMBINATORS = List.of(
+            new Reader(BINDER,
+                    "the one place the authored word for an argument becomes a position, which is"
+                            + " what the combinator's positions are read for"),
+            new Reader("souther.compiler.check.HelperInliner",
+                    "which binding an expansion wrote for a parameter: a function argument leaves"
+                            + " none, so the closure's own position is asked to count past it —"
+                            + " about the expansion's bindings, and not about which argument a fact"
+                            + " names"),
+            new Reader("souther.compiler.check.ElementBindings",
+                    "what a call hands its closure, for the value a closure parameter is bound to"),
+            new Reader("souther.compiler.check.Reductions",
+                    "what a call hands its closure, for a walk from a seed"),
+            new Reader("souther.compiler.check.Predicates",
+                    "what a call hands its closure, for what a predicate over the elements"
+                            + " establishes"),
+            new Reader("souther.compiler.check.UniversalElementFacts",
+                    "what a call hands its closure, for what holds of what the closure answered"),
+            new Reader("souther.compiler.check.TotalityChecker",
+                    "what a call hands its closure, for crediting an element as a sub-term of its"
+                            + " container"),
+            new Reader("souther.compiler.check.InvariantChecker",
+                    "what a call hands its closure, for a construction inside the closure"),
+            new Reader("souther.compiler.check.Question",
+                    "which operations are answered for what they hand their closure, for the range"
+                            + " a question is asked over"));
+
+    @Test
+    void everyReaderOfWhatAnOperationHandsItsClosureIsWrittenDownWithWhatItAsks() {
+        String combinators = Combinators.class.getName();
+        Set<String> found = new TreeSet<>();
+        for (String each : WhatWasCompiled.classes()) {
+            if (each.equals(combinators) || each.startsWith(combinators + "$")) {
+                continue;
+            }
+            if (names(WhatWasCompiled.typesNamedBy(each), Combinators.class)) {
+                found.add(each.contains("$") ? each.substring(0, each.indexOf('$')) : each);
+            }
+        }
+        Map<String, String> declared = new LinkedHashMap<>();
+        READERS_OF_COMBINATORS.forEach(reader -> declared.put(reader.who(), reader.why()));
+        assertEquals(new TreeSet<>(declared.keySet()), found,
+                "a reader of what an operation hands its closure is written here with what it asks."
+                        + " Asked to find the argument a fact names, it is the binder's question"
+                        + " put a second time. What each of these asks: " + declared);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
@@ -102,6 +102,53 @@ class OnlyTheBinderReadsTheAuthoringVocabularyTest {
         }
     }
 
+    /**
+     * The declarations are the whole of what the authoring side publishes.
+     *
+     * <p>Not read off who calls what today, since that would hold only until a lookup was added
+     * beside the list and read from inside the authoring package — where the census above does not
+     * look, because the vocabulary itself lives there. What is held is the surface: every method
+     * and field of the declarations that is not private is the one that hands the list to the
+     * binder. Non-private and not merely public, because a package-private lookup would be
+     * reachable from exactly the readers the census above cannot see.
+     */
+    @Test
+    void theDeclarationsPublishTheListAndNothingElse() {
+        Set<String> surface = new TreeSet<>();
+        for (java.lang.reflect.Method method : OperationFacts.class.getDeclaredMethods()) {
+            if (!java.lang.reflect.Modifier.isPrivate(method.getModifiers())
+                    && !method.isSynthetic()) {
+                surface.add(method.getName());
+            }
+        }
+        for (java.lang.reflect.Field field : OperationFacts.class.getDeclaredFields()) {
+            if (!java.lang.reflect.Modifier.isPrivate(field.getModifiers())
+                    && !field.isSynthetic()) {
+                surface.add(field.getName());
+            }
+        }
+        assertEquals(Set.of("declarations"), surface,
+                "the authoring side publishes the list of declarations and nothing else: a lookup"
+                        + " beside it would be a way to a fact that does not pass through the"
+                        + " binding, whoever could reach it");
+    }
+
+    /**
+     * And the bound facts are read whole by two callers and no others.
+     *
+     * <p>The binder asks what it has just bound before publishing it, and the one procedure that
+     * counts the readings of a number across every kind of fact walks them. A third reader of the
+     * list would be sorting the facts for itself, and could arrive at a second answer to a question
+     * one of the holder's queries already owns.
+     */
+    @Test
+    void onlyTheBinderAndTheReadingsWalkTheBoundFactsWhole() {
+        assertEquals(Set.of(BINDER, NumericReadings.class.getName()),
+                WhatWasCompiled.callersOf(BoundOperationFacts.class, "all"),
+                "a reader walking every bound fact is one that can classify them for itself,"
+                        + " beside the query that already does");
+    }
+
     @Test
     void onlyTheBinderReadsTheDeclarations() {
         assertEquals(Set.of(BINDER),

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyTheBinderReadsTheAuthoringVocabularyTest.java
@@ -36,11 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * answer that agrees with the binder's for exactly as long as nobody changes either.
  *
  * <p>So the boundary is counted from what javac made of the module, on both sides. Above it, the
- * authoring vocabulary is named by its own package and by the binder and by nothing else; the
- * declarations are read by the binder alone; a bound argument is minted by the binder alone. Below
- * it, no arm of a bound fact carries an authored name or word, and the readers of what an operation
- * hands its closure are each written down with what they want it for — since a reader that wanted
- * it to find a fact's argument would be the binder's question asked again.
+ * authoring vocabulary is named by its own package and by the binder and by nothing else, and the
+ * declarations are read by the binder alone. Across it, each of the three steps from an authored
+ * fact to a fact a reader holds is taken by the binder alone: a bound argument, a bound fact, and
+ * the gathering of them are each minted nowhere else — since a bound fact a reader wrote for itself
+ * would say a fact was held to the library where nothing held it, and would read no authoring
+ * vocabulary for the census above to see. Below it, no arm of a bound fact carries an authored name
+ * or word, and the readers of what an operation hands its closure are each written down with what
+ * they want it for — since a reader that wanted it to find a fact's argument would be the binder's
+ * question asked again.
  *
  * <p>Each set is compared whole rather than counted. A count lets one name be dropped and another
  * added and says nothing about it, which is exactly the edit this is here to catch.
@@ -173,6 +177,60 @@ class OnlyTheBinderReadsTheAuthoringVocabularyTest {
                 "nothing mints a bound argument, so the rule about who may is about nothing");
     }
 
+    /** Every concrete arm of a bound fact, through both families. */
+    private static List<Class<?>> boundArms() {
+        List<Class<?>> arms = new ArrayList<>();
+        for (Class<?> family : BoundOperationFact.class.getPermittedSubclasses()) {
+            arms.addAll(List.of(family.getPermittedSubclasses()));
+        }
+        assertFalse(arms.isEmpty(), "there are arms for this to be about");
+        return arms;
+    }
+
+    /**
+     * Every arm of a bound fact is made by the binder and by nothing else.
+     *
+     * <p>A bound fact says a fact was held to the library, which is true of a value only where the
+     * holding made it. An arm a reader wrote for itself — one naming no argument needs nothing but
+     * an operation to be written — would say the same thing about a fact nothing checked, and no
+     * census of who reads the authoring vocabulary would see it, since it reads none. So who calls
+     * each arm's constructor is counted, arm by arm, and the answer is the binder.
+     */
+    @Test
+    void onlyTheBinderMintsABoundFact() {
+        Map<String, Set<String>> minted = new TreeMap<>();
+        for (Class<?> arm : boundArms()) {
+            Set<String> minting = WhatWasCompiled.callersOf(arm, "<init>");
+            if (!minting.equals(Set.of(BINDER))) {
+                minted.put(arm.getSimpleName(), minting);
+            }
+        }
+        assertEquals(Map.of(), minted,
+                "a bound fact made anywhere but the binder says a fact was held to the library"
+                        + " where nothing held it");
+    }
+
+    /** And the binder makes every one of them, so the rule above is about every arm. */
+    @Test
+    void andTheBinderMintsEveryArm() {
+        Set<String> unmade = new TreeSet<>();
+        for (Class<?> arm : boundArms()) {
+            if (WhatWasCompiled.callersOf(arm, "<init>").isEmpty()) {
+                unmade.add(arm.getSimpleName());
+            }
+        }
+        assertEquals(Set.of(), unmade,
+                "an arm nothing makes is one the rule about who may make it is about nothing");
+    }
+
+    /** And the facts are gathered by the binder alone: a set gathered anywhere else would say
+     *  every fact in it was bound. */
+    @Test
+    void onlyTheBinderGathersTheBoundFacts() {
+        assertEquals(Set.of(BINDER), WhatWasCompiled.callersOf(BoundOperationFacts.class, "<init>"),
+                "the bound facts are what a binding came to, and are gathered where it ran");
+    }
+
     /**
      * Every arm of a bound fact is in one of the two families, and no arm carries an authored name
      * or word.
@@ -188,13 +246,8 @@ class OnlyTheBinderReadsTheAuthoringVocabularyTest {
                         BoundOperationFact.SeveralAboutAnOperation.class),
                 Set.of(BoundOperationFact.class.getPermittedSubclasses()),
                 "a bound fact is one of two families, and an arm is in one of them");
-        List<Class<?>> arms = new ArrayList<>();
-        for (Class<?> family : BoundOperationFact.class.getPermittedSubclasses()) {
-            arms.addAll(List.of(family.getPermittedSubclasses()));
-        }
-        assertFalse(arms.isEmpty(), "there are arms for this to be about");
         Map<String, String> unbound = new TreeMap<>();
-        for (Class<?> arm : arms) {
+        for (Class<?> arm : boundArms()) {
             assertTrue(arm.isRecord(), arm + " is a bound fact and is not a record");
             for (RecordComponent component : arm.getRecordComponents()) {
                 String type = component.getGenericType().getTypeName();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest.java
@@ -4,7 +4,6 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Rel;
 import souther.compiler.numeric.NumericDomain;
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.semantics.ResultBound;
 import souther.compiler.semantics.ResultRange;
@@ -31,9 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
 
+    private static NumericDomain.Bounds asked(ValueName operation,
+                                              ConstantArguments<DeclaredArgument> arguments) {
+        return ResultRange.of(DefaultBoundOperationFacts.get().boundsOnTheResult(operation),
+                arguments);
+    }
+
     private static NumericDomain.Bounds asked(String module, String operation,
-                                              ConstantArguments arguments) {
-        return ResultRange.of(ValueName.Stdlib.operation(module, operation), arguments);
+                                              ConstantArguments<DeclaredArgument> arguments) {
+        return asked(ValueName.Stdlib.operation(module, operation), arguments);
     }
 
     private static NumericDomain.Bounds atLeast(long count) {
@@ -43,8 +48,8 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
     /** The half that was declared, asked with nothing standing at the call. */
     @Test
     void anAbsoluteValueIsNotNegativeWithNothingToAsk() {
-        assertEquals(atLeast(0), asked("Int", "abs", ConstantArguments.NONE));
-        assertEquals(atLeast(0), asked("Decimal", "abs", ConstantArguments.NONE));
+        assertEquals(atLeast(0), asked("Int", "abs", ConstantArguments.none()));
+        assertEquals(atLeast(0), asked("Decimal", "abs", ConstantArguments.none()));
     }
 
     /** The half that was written into the term, asked the same way. Four operations and one
@@ -52,7 +57,7 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
     @Test
     void everyMeasureAnswersACountThatIsNotNegative() {
         for (ValueName measure : NumericMeasures.calls()) {
-            assertEquals(atLeast(0), ResultRange.of(measure, ConstantArguments.NONE),
+            assertEquals(atLeast(0), asked(measure, ConstantArguments.none()),
                     measure + " counts what it is given, and there is no negative number of them");
         }
     }
@@ -69,7 +74,7 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
     @Test
     void aBoundAgainstAnArgumentIsThereWhenTheArgumentIs() {
         assertEquals(NumericDomain.Bounds.OPEN,
-                asked("Int", "floorMod", ConstantArguments.NONE),
+                asked("Int", "floorMod", ConstantArguments.none()),
                 "nothing is known of the divisor, so neither end of the remainder is");
         assertEquals(new NumericDomain.Bounds(Endpoint.inclusive(Count.of(0)),
                         Endpoint.exclusive(Count.of(100))),
@@ -89,7 +94,7 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
     @Test
     void aBoundHoldingAlwaysIsStillDroppedWhereItsArgumentCannotBeNamed() {
         assertEquals(NumericDomain.Bounds.OPEN,
-                asked("Decimal", "toInt", ConstantArguments.NONE),
+                asked("Decimal", "toInt", ConstantArguments.none()),
                 "what it rounds is not known here, so neither end of what it rounds to is");
         assertEquals(new NumericDomain.Bounds(Endpoint.exclusive(Count.of(2)),
                         Endpoint.exclusive(Count.of(4))),
@@ -97,9 +102,10 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
                 "rounding a three lands within one of it, and reaches neither end");
     }
 
-    /** A reader that knows one argument's value and nothing else. */
-    private static ConstantArguments constantAt(int position, long value) {
-        return argument -> argument.equals(new ArgumentRef.At(position))
+    /** A reader that knows one argument's value and nothing else. The argument is the bound one,
+     *  so what is matched is the position the binder settled. */
+    private static ConstantArguments<DeclaredArgument> constantAt(int position, long value) {
+        return argument -> argument.position() == position
                 ? Optional.of(BigDecimal.valueOf(value)) : Optional.empty();
     }
 
@@ -111,8 +117,8 @@ class WhatAnOperationAnswersIsBoundedBeforeAnythingAsksTest {
     @Test
     void aBoundCannotBeWrittenAsADisequality() {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> new ResultBound(null, BigDecimal.ZERO, Rel.NE,
-                        new ResultBound.Provided.Always()));
+                () -> new ResultBound<>(null, BigDecimal.ZERO, Rel.NE,
+                        new ResultBound.Provided.Always<>()));
         assertTrue(refused.getMessage().contains("NE"), refused.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatReadsADeclarationIntoASignatureIsWrittenDownTest.java
@@ -90,7 +90,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
                     "a declaration that states what it takes and what it answers"),
             new Licence("souther.compiler.core.CompleteSignature.ofSettledValue",
                     "a value: no parameters, and what its own check settled it as"),
-            new Licence("souther.compiler.check.DischargeRules.declaredSignature",
+            new Licence("souther.compiler.check.OperationFactBinder.declaredSignature",
                     "reads a library declaration where a fact about that operation is held to it"),
             new Licence("souther.compiler.check.Preserved.signatureOf",
                     "hands on the one the library was read into, for an operation this"
@@ -108,7 +108,7 @@ class WhatReadsADeclarationIntoASignatureIsWrittenDownTest {
     private static final List<Licence> MAY_ASSEMBLE = List.of(
             new Licence("souther.compiler.check.Preserved.lambda$readTheLibrary$0",
                     "reads the library's own declarations, which state both halves"),
-            new Licence("souther.compiler.check.DischargeRules.declaredSignature",
+            new Licence("souther.compiler.check.OperationFactBinder.declaredSignature",
                     "the same declarations, read where a fact about an operation is held to them"),
             new Licence("souther.compiler.check.HelperTyping.checkHelpers",
                     "a value of this module, written with no parameters and just checked for what"

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnAnswersElementsCameFromCanBeSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnAnswersElementsCameFromCanBeSaidTest.java
@@ -46,8 +46,8 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
     /** {@code flatMap}: the element is inside what the closure answered of an input element. */
     @Test
     void anElementFromInsideWhatAClosureAnswered() {
-        OutputLineage said = new OutputLineage(ResultPath.elements(),
-                new ElementLineage.InsideClosureResult(new Source(CONTAINER, 1)));
+        OutputLineage<ArgumentRef> said = new OutputLineage<>(ResultPath.elements(),
+                new ElementLineage.InsideClosureResult<>(new Source<>(CONTAINER, 1)));
 
         assertEquals("result[*]", said.at().toString());
         assertEquals(CONTAINER, said.origin().source().argument());
@@ -61,8 +61,8 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void anElementFromTwoStepsInsideAnArgument() {
-        OutputLineage said = new OutputLineage(ResultPath.elements(),
-                new ElementLineage.SameAs(new Source(FIRST, 2)));
+        OutputLineage<ArgumentRef> said = new OutputLineage<>(ResultPath.elements(),
+                new ElementLineage.SameAs<>(new Source<>(FIRST, 2)));
 
         assertEquals(2, said.origin().source().elements());
     }
@@ -70,13 +70,13 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
     /** {@code partition}: two runs of elements, each the input's own. */
     @Test
     void anAnswerHoldingTwoRunsOfElements() {
-        List<OutputLineage> said = List.of(
-                new OutputLineage(new ResultPath(List.of(new ResultPath.Step.Component(0),
+        List<OutputLineage<ArgumentRef>> said = List.of(
+                new OutputLineage<>(new ResultPath(List.of(new ResultPath.Step.Component(0),
                                 new ResultPath.Step.Element())),
-                        new ElementLineage.SameAs(new Source(CONTAINER, 1))),
-                new OutputLineage(new ResultPath(List.of(new ResultPath.Step.Component(1),
+                        new ElementLineage.SameAs<>(new Source<>(CONTAINER, 1))),
+                new OutputLineage<>(new ResultPath(List.of(new ResultPath.Step.Component(1),
                                 new ResultPath.Step.Element())),
-                        new ElementLineage.SameAs(new Source(CONTAINER, 1))));
+                        new ElementLineage.SameAs<>(new Source<>(CONTAINER, 1))));
 
         assertEquals(List.of("result.0[*]", "result.1[*]"),
                 said.stream().map(each -> each.at().toString()).toList());
@@ -90,11 +90,11 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void anAnswerWhosePartsCameFromDifferentArguments() {
-        List<OutputLineage> said = List.of(
-                new OutputLineage(elementThen(new ResultPath.Step.Component(0)),
-                        new ElementLineage.SameAs(new Source(FIRST, 1))),
-                new OutputLineage(elementThen(new ResultPath.Step.Component(1)),
-                        new ElementLineage.SameAs(new Source(SECOND, 1))));
+        List<OutputLineage<ArgumentRef>> said = List.of(
+                new OutputLineage<>(elementThen(new ResultPath.Step.Component(0)),
+                        new ElementLineage.SameAs<>(new Source<>(FIRST, 1))),
+                new OutputLineage<>(elementThen(new ResultPath.Step.Component(1)),
+                        new ElementLineage.SameAs<>(new Source<>(SECOND, 1))));
 
         assertEquals(List.of("result[*].0", "result[*].1"),
                 said.stream().map(each -> each.at().toString()).toList());
@@ -105,9 +105,9 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
     /** {@code append}: the element came from one of two arguments, and nothing says which. */
     @Test
     void anElementFromOneOfSeveralArguments() {
-        ElementLineage said = new ElementLineage.OneOf(List.of(
-                new ElementLineage.SameAs(new Source(FIRST, 1)),
-                new ElementLineage.SameAs(new Source(SECOND, 1))));
+        ElementLineage<ArgumentRef> said = new ElementLineage.OneOf<>(List.of(
+                new ElementLineage.SameAs<>(new Source<>(FIRST, 1)),
+                new ElementLineage.SameAs<>(new Source<>(SECOND, 1))));
 
         assertEquals(null, said.source(),
                 "which argument is not settled, so there is no one argument to answer with");
@@ -127,10 +127,10 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void andNoShapeIsReadOffElementsFromMoreThanOnePlace() {
-        BuiltFrom built = new BuiltFrom(
-                new ElementLineage.OneOf(List.of(
-                        new ElementLineage.SameAs(new Source(FIRST, 1)),
-                        new ElementLineage.SameAs(new Source(SECOND, 1)))),
+        BuiltFrom<ArgumentRef>built = new BuiltFrom<>(
+                new ElementLineage.OneOf<>(List.of(
+                        new ElementLineage.SameAs<>(new Source<>(FIRST, 1)),
+                        new ElementLineage.SameAs<>(new Source<>(SECOND, 1)))),
                 SizeAgainstItsSource.AT_MOST);
 
         assertThrows(IllegalStateException.class, built::shape);
@@ -145,11 +145,11 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void anElementThatIsOneOfSeveralThingsAtOnePlace() {
-        ElementLineage said = new ElementLineage.OneOf(List.of(
-                new ElementLineage.SameAs(new Source(CONTAINER, 1)),
-                new ElementLineage.ClosureResult(new Source(CONTAINER, 1))));
+        ElementLineage<ArgumentRef> said = new ElementLineage.OneOf<>(List.of(
+                new ElementLineage.SameAs<>(new Source<>(CONTAINER, 1)),
+                new ElementLineage.ClosureResult<>(new Source<>(CONTAINER, 1))));
 
-        assertEquals(new Source(CONTAINER, 1), said.source(),
+        assertEquals(new Source<>(CONTAINER, 1), said.source(),
                 "they came from one place, whatever happened to them there");
     }
 
@@ -164,10 +164,10 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void aRunHoldingSomeOfEachIsProjectedToTheWordThatLicensesNothing() {
-        BuiltFrom updated = new BuiltFrom(
-                new ElementLineage.OneOf(List.of(
-                        new ElementLineage.SameAs(new Source(CONTAINER, 1)),
-                        new ElementLineage.ClosureResult(new Source(CONTAINER, 1)))),
+        BuiltFrom<ArgumentRef>updated = new BuiltFrom<>(
+                new ElementLineage.OneOf<>(List.of(
+                        new ElementLineage.SameAs<>(new Source<>(CONTAINER, 1)),
+                        new ElementLineage.ClosureResult<>(new Source<>(CONTAINER, 1)))),
                 SizeAgainstItsSource.SAME);
 
         assertEquals(ElementShape.COLLAPSES, updated.shape());
@@ -185,11 +185,11 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
      */
     @Test
     void aShapeIsCoarserThanTheLineageItIsReadOff() {
-        BuiltFrom collapsingMap = new BuiltFrom(
-                new ElementLineage.ClosureResult(new Source(CONTAINER, 1)),
+        BuiltFrom<ArgumentRef>collapsingMap = new BuiltFrom<>(
+                new ElementLineage.ClosureResult<>(new Source<>(CONTAINER, 1)),
                 SizeAgainstItsSource.AT_MOST);
-        BuiltFrom collapsingInside = new BuiltFrom(
-                new ElementLineage.InsideClosureResult(new Source(CONTAINER, 1)),
+        BuiltFrom<ArgumentRef>collapsingInside = new BuiltFrom<>(
+                new ElementLineage.InsideClosureResult<>(new Source<>(CONTAINER, 1)),
                 SizeAgainstItsSource.AT_MOST);
 
         assertEquals(collapsingMap.shape(), collapsingInside.shape(),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -366,6 +366,10 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " computes"),
             new Held("souther.compiler.semantics.OperationFacts.computesInTheCaseCarrying",
                     "the same, for an operation whose other case is stated as a comparison"),
+            new Held("souther.compiler.check.OperationFactBinder.holdNumericResult",
+                    "carries the operator that fact states its other case by across into the"
+                            + " bound fact, unchanged: what changes in the binding is the argument"
+                            + " it compares, not how"),
             new Held("souther.compiler.check.ArithmeticCheck.of",
                     "names the constants it has rules for, against the operator it was handed"),
             new Held("souther.compiler.check.BinaryElaborator.operandBeside",

--- a/souther-compiler/src/test/java/souther/compiler/core/ACallStandsWithTheArgumentsItsDeclarationTakesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/ACallStandsWithTheArgumentsItsDeclarationTakesTest.java
@@ -4,8 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.KeptCalls;
 import souther.compiler.check.CallArguments;
+import souther.compiler.check.DeclaredArgument;
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.diag.SourcePos;
-import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
@@ -105,13 +106,18 @@ class ACallStandsWithTheArgumentsItsDeclarationTakesTest {
      * <p>The rebuild carries the operation rather than looking it up again, so what the rebuilt call
      * is held to is what the original was — and the rebuild goes through the same constructor, so a
      * pass that put back a different number of arguments would be refused where it wrote them.
+     *
+     * <p>The argument replaced is the one the bound fact about the operation names, which is the
+     * only kind of argument a pass holds: {@code List.reverse} is built from its one argument.
      */
     @Test
     void replacingAnArgumentLeavesACallOfTheSameDeclaration() {
-        Core.PreservedCall call = KeptCalls.to(LENGTH, POS);
+        ValueName.Stdlib.Operation reverse = ValueName.Stdlib.operation("List", "reverse");
+        Core.PreservedCall call = KeptCalls.to(reverse, POS);
         Core other = new Core.Read("other", new BindingId(OWNER, 1),
                 new Type.ListOf(Type.INT), POS);
-        Core.PreservedCall rebuilt = CallArguments.replacedIn(new ArgumentRef.At(0), call, other);
+        DeclaredArgument from = DefaultBoundOperationFacts.get().buildsItsResultFrom(reverse).from();
+        Core.PreservedCall rebuilt = CallArguments.replacedIn(from, call, other);
 
         assertEquals(call.declared(), rebuilt.declared());
         assertEquals(call.args().size(), rebuilt.args().size());

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
@@ -805,15 +806,15 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
      */
     @Test
     void onlyAStringsLengthIsACountEveryValueHas() {
-        assertTrue(souther.compiler.semantics.OperationFacts.everyAnswerItCanGiveHasASourceValue(
+        assertTrue(DefaultBoundOperationFacts.get().everyAnswerItCanGiveHasASourceValue(
                         ValueName.Stdlib.operation("String", "length")),
                 "a string of any length is a character repeated");
-        assertFalse(souther.compiler.semantics.OperationFacts.everyAnswerItCanGiveHasASourceValue(
+        assertFalse(DefaultBoundOperationFacts.get().everyAnswerItCanGiveHasASourceValue(
                         ValueName.Stdlib.operation("List", "length")),
                 "a list of one needs an element, and a type nothing inhabits has none");
-        assertFalse(souther.compiler.semantics.OperationFacts.everyAnswerItCanGiveHasASourceValue(ValueName.Stdlib.operation("Set", "size")),
+        assertFalse(DefaultBoundOperationFacts.get().everyAnswerItCanGiveHasASourceValue(ValueName.Stdlib.operation("Set", "size")),
                 "a set of three needs three that differ");
-        assertFalse(souther.compiler.semantics.OperationFacts.everyAnswerItCanGiveHasASourceValue(ValueName.Stdlib.operation("Map", "size")),
+        assertFalse(DefaultBoundOperationFacts.get().everyAnswerItCanGiveHasASourceValue(ValueName.Stdlib.operation("Map", "size")),
                 "and a map of three needs three keys that differ");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
@@ -2,10 +2,10 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -77,7 +77,8 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
     /** Every operation declared to answer a form of its arguments is measured here. */
     @Test
     void everyDeclaredFormIsMeasuredHere() {
-        assertEquals(OperationFacts.answersAFormOfItsArguments(), MEASURED.keySet(),
+        assertEquals(DefaultBoundOperationFacts.get().answersAFormOfItsArguments(),
+                MEASURED.keySet(),
                 "an operation declared to answer a form of its arguments has its coefficients"
                         + " measured, and one measured here is one that is declared");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
@@ -7,6 +7,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Carrier;
+import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.NumericAnswers;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.Symbols;
@@ -15,7 +16,6 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.observe.ObservedValue;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -106,8 +106,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
         List<Class<?>> arms = List.of(TakenAs.class.getPermittedSubclasses());
         assertFalse(arms.isEmpty(), "the accounts are a sealed set and there is at least one");
         for (Class<?> arm : arms) {
-            assertTrue(OperationFacts.answersANumberTakenOfItsArgument().stream()
-                            .anyMatch(each -> arm.isInstance(OperationFacts.takenAs(each))),
+            assertTrue(DefaultBoundOperationFacts.get().answersANumberTakenOfItsArgument().stream()
+                            .anyMatch(each -> arm.isInstance(DefaultBoundOperationFacts.get().takenAs(each))),
                     arm.getSimpleName() + " is an account no operation is declared under, so"
                             + " nothing reads or writes it");
         }
@@ -124,7 +124,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     @Test
     void everyValueBuiltForANumberReadsBackAsIt() {
         int checked = 0;
-        for (ValueName operation : OperationFacts.answersANumberTakenOfItsArgument()) {
+        for (ValueName operation : DefaultBoundOperationFacts.get().answersANumberTakenOfItsArgument()) {
             Type source = sourceOf(operation);
             NumericTerm.TakenOf term = NumericTerm.TakenOf.of(
                     (ValueName.Stdlib) operation, AT, source, SYMBOLS);
@@ -168,8 +168,8 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
      */
     @Test
     void everyNumberAnOperationSaysHasAValueIsOneSomethingIsBuiltFor() {
-        for (ValueName operation : OperationFacts.answersANumberTakenOfItsArgument()) {
-            if (!OperationFacts.everyAnswerItCanGiveHasASourceValue(operation)) {
+        for (ValueName operation : DefaultBoundOperationFacts.get().answersANumberTakenOfItsArgument()) {
+            if (!DefaultBoundOperationFacts.get().everyAnswerItCanGiveHasASourceValue(operation)) {
                 continue;
             }
             Type source = sourceOf(operation);
@@ -318,7 +318,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
      */
     @Test
     void aTermCannotBeBuiltForAnOperationThatDeclaresNoAccount() {
-        assertTrue(OperationFacts.takenAs(ValueName.Stdlib.operation("Int", "abs")) == null,
+        assertTrue(DefaultBoundOperationFacts.get().takenAs(ValueName.Stdlib.operation("Int", "abs")) == null,
                 "the premise: what it answers is read by reading its body, so no account is"
                         + " declared of it and none may be");
         assertNull(NumericTerm.TakenOf.of(ValueName.Stdlib.operation("Int", "abs"), AT,


### PR DESCRIPTION
Closes #1304.

## The cause

`OperationFacts` was two things at once: the list of declarations, and an index over them, built from the same list at class initialization and keyed by name. The binder walked the list and held every fact to the library, but what it handed back was the authoring declarations themselves — so every reader below went back to the index for the fact, holding a `ValueName` and an `ArgumentRef`, and put the binder's question a second time. `CallArguments.positionIn` re-read `Combinators` to find out which argument "the container" was. The two answers agreed for as long as nobody changed either, and nothing said the binding had run on the path a reader took: `DischargeRules.Bound` was private, so the readers in `inputs` and in `semantics` itself read the index directly. That is not a matter of discipline; there was no other way in.

## What changes

The declarations publish the list and nothing else, and `OperationFactBinder` is its one reader. What the binder makes is `BoundOperationFacts`: one bound fact per declaration, each naming its operation as a `DeclaredOperation` and each argument as a `DeclaredArgument` — which declaration, which position, and what stands there — minted in the binder's one hold procedure and nowhere else. The binder reads each declaration into a `CompleteSignature` once, before the switch, and every arm is handed that reading; the switch is an expression, so a kind of fact added does not compile until it says what it comes to bound.

A bound fact is in one of two families, chosen where the arm is written: one per operation, with a second refused where the facts are filed, or as many as declared. Lookups are by name into what the binding made — a lookup among values the binder produced, not a second reading of the authored word — and `DefaultBoundOperationFacts` is the one way to the shipped library's facts, so there is no path to a fact on which the binding has not run.

The vocabulary a fact is written in — lineage, bound, case, numeric result, constant arguments — is generic in its word for an argument, as `LinearForm` already was: authored over `ArgumentRef`, read over `DeclaredArgument`, one shape. `ElementLineage` and `ResultRange` no longer look anything up; they project what they are handed. `CallArguments` applies a bound argument to a call and refuses a call of another declaration, since a position alone is right in any call that takes enough arguments.

## What holds it

A class-file census: only the binder names the authoring vocabulary outside its own package, reads the declarations, or mints a bound argument; no arm of a bound fact carries an authored name or word; and every reader of what an operation hands its closure is written down with what it asks. A second test holds the two families to how they are filed, and a bound argument to the declaration it is an argument of. The existing censuses over the process constants, over who assembles a `CompleteSignature`, over who holds an operator, and over which hand-written identities cover their fields each found the new entry and each carries its reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
