### PR TITLE
An invariant admitting a run of the strings is a bound and is owed its edge

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -12,6 +12,7 @@ import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
 import java.math.BigDecimal;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,13 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * afterwards ({@code InvariantChecker}) spend from the same purse.
      */
     private final Allowance<FactSubject> allowed;
+    /**
+     * What each node was read as, so that reading it is done once.
+     *
+     * <p>By the node itself and not by what a node is equal to: two clauses written the same way
+     * are two places in a declaration, and what each of them is about is asked of the one in hand.
+     */
+    private final Map<Core, StringPredicates.Stated> asStated = new IdentityHashMap<>();
 
     private AdmissibleReading(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                               Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
@@ -162,7 +170,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * reading stopped at something other than this reading's own limit.
      */
     private PlannedValues<FactSubject> pattern(Core e, boolean states) {
-        StringPredicates.Stated stated = StringPredicates.statedByChecked(e, symbols);
+        StringPredicates.Stated stated = statedIn(e);
         FactSubject position = stated == null ? null : positionIn(stated.subject());
         if (position == null) {
             return null;
@@ -268,6 +276,58 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
         Value value = type == null ? null : valueOf(what);
         return value == null ? null
                 : PlannedValues.at(position, AdmittedPlan.of(admits(value, states, type)));
+    }
+
+    /**
+     * The positions the clause {@code e} states a rule about the strings of.
+     *
+     * <p><b>Whatever became of the rule.</b> Which position a predicate over strings is about is
+     * settled by the call, and it is settled whether or not this could work out the text written in
+     * it: {@code String.matches("001" ++ tail, value)} is a rule about {@code value} in a module
+     * that cannot reach {@code tail} exactly as it is in the one that can. Answered off what the
+     * reading came to, the same declaration would be a rule about a position for one reader and
+     * about nothing for another.
+     *
+     * <p>Which is why this is beside the reading and not a projection of it. What the position
+     * finally admits is what this reading leaves; that it is a position the model wrote a string
+     * rule about is a fact about the clause, and both are wanted by the readers that decide which
+     * of a position's numbers it is measured at and where its values stop.
+     *
+     * <p>Over the whole of {@code e} and not its leaves as this folds them. A clause is walked
+     * elsewhere by a reader holding a conjunct, and what that reader is asking is which positions
+     * the conjunct states such a rule about — a denial and a choice inside it are still the
+     * conjunct's.
+     */
+    Set<FactSubject> stringSubjectsIn(Core e) {
+        Set<FactSubject> found = new LinkedHashSet<>();
+        gatherStringSubjects(e, found);
+        return found;
+    }
+
+    private void gatherStringSubjects(Core e, Set<FactSubject> found) {
+        StringPredicates.Stated stated = statedIn(e);
+        FactSubject position = stated == null ? null : positionIn(stated.subject());
+        if (position != null) {
+            found.add(position);
+            return;   // what a predicate is about is the call's, and nothing under it is another
+        }
+        Core.forEachChild(e, child -> gatherStringSubjects(child, found));
+    }
+
+    /**
+     * What {@code e} states as a predicate over strings, worked out once for the node.
+     *
+     * <p>One derivation and two readers of it: what the rule admits, and which position it is
+     * about. Asked twice of the table, the two would be one question with two derivations — which
+     * is the arrangement {@link StringPredicates} exists to stop, one file further down.
+     */
+    private StringPredicates.Stated statedIn(Core e) {
+        if (asStated.containsKey(e)) {
+            return asStated.get(e);
+        }
+        StringPredicates.Stated said = StringPredicates.statedByChecked(e, symbols);
+        asStated.put(e, said);
+        return said;
     }
 
     /** The position {@code e} is, or null where it is not one of the positions being read for. */

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.core.Core;
 import souther.compiler.regex.PatternPlan;
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.regex.PatternRead;
 import souther.compiler.types.Type;
 import souther.compiler.values.AdmittedPlan;
@@ -65,15 +66,6 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * are two places in a declaration, and what each of them is about is asked of the one in hand.
      */
     private final Map<Core, StringPredicates.Stated> asStated = new IdentityHashMap<>();
-    /**
-     * What each node's whole subtree states about the strings, worked out once for the node.
-     *
-     * <p>The walk that reads a clause asks this of every node it passes, and each answer is the
-     * answer of everything under it — so a clause of any depth would be walked once per node
-     * without this, which is the reading paying for the shape of the tree rather than for what is
-     * written in it.
-     */
-    private final Map<Core, StringRestriction.Found> stringRules = new IdentityHashMap<>();
 
     private AdmissibleReading(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                               Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
@@ -307,29 +299,40 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * the conjunct states such a rule about — a denial and a choice inside it are still the
      * conjunct's.
      */
-    StringRestriction.Found stringRulesIn(Core e) {
-        StringRestriction.Found had = stringRules.get(e);
-        if (had != null) {
-            return had;
-        }
-        Set<FactSubject> read = new LinkedHashSet<>();
-        Set<FactSubject> notRead = new LinkedHashSet<>();
-        gatherStringRules(e, read, notRead);
-        read.removeAll(notRead);
-        StringRestriction.Found found = new StringRestriction.Found(read, notRead);
-        stringRules.put(e, found);
-        return found;
-    }
-
-    private void gatherStringRules(Core e, Set<FactSubject> read, Set<FactSubject> notRead) {
+    Map<FactSubject, StringRestriction> stringRuleIn(Core e, PlannedValues<FactSubject> said) {
         StringPredicates.Stated stated = statedIn(e);
         FactSubject position = stated == null ? null : positionIn(stated.subject());
-        if (position != null) {
-            (stated.reading() instanceof StringPredicates.Reading.Accepting ? read : notRead)
-                    .add(position);
-            return;   // what a predicate is about is the call's, and nothing under it is another
+        if (position == null) {
+            return Map.of();
         }
-        Core.forEachChild(e, child -> gatherStringRules(child, read, notRead));
+        // What the rule admits where it was worked out, and what stopped the reading where it was
+        // not. The reading is the one recognition's and is projected here once: a reader working out
+        // where the values stop and a reader saying what a rule left unread want the same fact, and
+        // asking the table twice is one question with two derivations.
+        //
+        // Exhaustive with no `default`: an outcome added to the recognition is one somebody decides
+        // about here, rather than one that quietly takes the answer its neighbours were given.
+        return Map.of(position, switch (stated.reading()) {
+            case StringPredicates.Reading.Accepting _ ->
+                    new StringRestriction.Admitting(said.at(position));
+            case StringPredicates.Reading.PatternNotRead it ->
+                    new StringRestriction.NotKnown(stoppedAt(it.why()));
+            case StringPredicates.Reading.WrittenArgumentNotKnown _ ->
+                    new StringRestriction.NotKnown(new BlockReason.UnreadValueRule());
+        });
+    }
+
+    /**
+     * What a pattern this reading stopped short of is, in the words a rule left unread is said in.
+     *
+     * <p>The same two answers {@link #stoppedBy} gives the values, said for the other reader. A
+     * construct the subset does not hold is a rule this could not read; one written more deeply
+     * than this reads is the reading's own limit and is said as itself, so that an author is sent to
+     * the brackets rather than to a construct that was never the trouble.
+     */
+    private static BlockReason.RuleReadingStopped stoppedAt(PatternRead.Unsupported why) {
+        return why == PatternRead.Unsupported.NESTED_TOO_DEEPLY
+                ? new BlockReason.PatternTooDeeplyNested() : new BlockReason.UnreadValueRule();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -65,6 +65,15 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * are two places in a declaration, and what each of them is about is asked of the one in hand.
      */
     private final Map<Core, StringPredicates.Stated> asStated = new IdentityHashMap<>();
+    /**
+     * What each node's whole subtree states about the strings, worked out once for the node.
+     *
+     * <p>The walk that reads a clause asks this of every node it passes, and each answer is the
+     * answer of everything under it — so a clause of any depth would be walked once per node
+     * without this, which is the reading paying for the shape of the tree rather than for what is
+     * written in it.
+     */
+    private final Map<Core, StringRestriction.Found> stringRules = new IdentityHashMap<>();
 
     private AdmissibleReading(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                               Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
@@ -298,20 +307,29 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * the conjunct states such a rule about — a denial and a choice inside it are still the
      * conjunct's.
      */
-    Set<FactSubject> stringSubjectsIn(Core e) {
-        Set<FactSubject> found = new LinkedHashSet<>();
-        gatherStringSubjects(e, found);
+    StringRestriction.Found stringRulesIn(Core e) {
+        StringRestriction.Found had = stringRules.get(e);
+        if (had != null) {
+            return had;
+        }
+        Set<FactSubject> read = new LinkedHashSet<>();
+        Set<FactSubject> notRead = new LinkedHashSet<>();
+        gatherStringRules(e, read, notRead);
+        read.removeAll(notRead);
+        StringRestriction.Found found = new StringRestriction.Found(read, notRead);
+        stringRules.put(e, found);
         return found;
     }
 
-    private void gatherStringSubjects(Core e, Set<FactSubject> found) {
+    private void gatherStringRules(Core e, Set<FactSubject> read, Set<FactSubject> notRead) {
         StringPredicates.Stated stated = statedIn(e);
         FactSubject position = stated == null ? null : positionIn(stated.subject());
         if (position != null) {
-            found.add(position);
+            (stated.reading() instanceof StringPredicates.Reading.Accepting ? read : notRead)
+                    .add(position);
             return;   // what a predicate is about is the call's, and nothing under it is another
         }
-        Core.forEachChild(e, child -> gatherStringSubjects(child, found));
+        Core.forEachChild(e, child -> gatherStringRules(child, read, notRead));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
@@ -66,7 +66,7 @@ sealed interface ClauseStates {
      *              and the second is a question with no answer rather than one nobody asked
      */
     record ABound(Set<NumberAt<RuleKey>> lines, Set<RuleKey> named,
-                  SequencedMap<RuleKey, BlockReason.RuleReadingStopped> unread)
+                  SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> unread)
             implements ClauseStates {
 
         public ABound {
@@ -166,7 +166,7 @@ sealed interface ClauseStates {
      *              would lose it to a name beside it that was not
      */
     record SomethingElse(Set<RuleKey> named,
-                         SequencedMap<RuleKey, BlockReason.RuleReadingStopped> unread)
+                         SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> unread)
             implements ClauseStates {
 
         public SomethingElse {
@@ -183,8 +183,10 @@ sealed interface ClauseStates {
                     new java.util.LinkedHashMap<>());
         }
 
-        /** The same, told which names the reading of the form left a line undecided at. */
-        SomethingElse unread(SequencedMap<RuleKey, BlockReason.RuleReadingStopped> why) {
+        /** The same, told which names the reading of the form left a line undecided at, and what
+         *  stopped it at each — every reason, since one clause read a branch at a time can be
+         *  stopped by one thing in one branch and another in the next. */
+        SomethingElse unread(SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> why) {
             return why.isEmpty() ? this : new SomethingElse(named, why);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
@@ -37,30 +37,73 @@ import java.util.Set;
 sealed interface ClauseStates {
 
     /**
-     * Where the values stop: a coordinate compared for order against an expression naming no
-     * coordinate of this value.
+     * The clause states where the values stop on one or more of the numbers it writes about.
+     *
+     * <p>What states it is not said here. A coordinate compared for order against an expression
+     * naming no coordinate of this value does; so does a rule admitting a run of the strings at a
+     * position, which is no comparison and has no sides. What is common is what the clause says —
+     * that the values stop somewhere on a number it names — and this is that and nothing about the
+     * shape it was written in.
      *
      * <p>Whether an end came of it is not asked here, and neither is whether the order has a value
-     * at the end. A rule states where the values stop by being written that way; what this compiler
-     * made of the number on the other side is what answers the question, not what raises it.
+     * at the end. A rule states where the values stop by stating it; what this compiler made of the
+     * number on the other side is what answers the question, not what raises it.
      *
-     * @param line  the number the end is on, which is the value at a name or a number an operation
-     *              answers of it. The operation itself, since two operations over one name are two
-     *              lines and a flag saying one was taken cannot tell them apart
+     * <p><b>The lines are a set, and a clause can state one on a number while leaving another
+     * undecided.</b> One clause is read a branch at a time and the branches are joined, so what it
+     * comes to is an answer per number — held as a single line, a clause bounding two of them had
+     * to be refused or picked between, and one bounding one number while nothing settled the next
+     * lost the second question entirely.
+     *
+     * @param lines the numbers the clause stops the values on. Each is the value at a name or a
+     *              number an operation answers of it — the operation itself, since two operations
+     *              over one name are two lines and a flag saying one was taken cannot tell them
+     *              apart
      * @param named the ones the clause is about, which is what a rule can cost. Never empty: a
      *              clause bounding a coordinate writes the name it sits at
+     * @param unread the names whose line nothing worked out, and what stopped it. A clause can
+     *              state a line on one number and leave whether it states one on another standing,
+     *              and the second is a question with no answer rather than one nobody asked
      */
-    record ABound(NumberAt<RuleKey> line, Set<RuleKey> named) implements ClauseStates {
+    record ABound(Set<NumberAt<RuleKey>> lines, Set<RuleKey> named,
+                  SequencedMap<RuleKey, BlockReason.RuleReadingStopped> unread)
+            implements ClauseStates {
 
         public ABound {
-            if (line == null) {
+            if (lines.isEmpty()) {
                 throw new IllegalArgumentException("a bound is a line on some number");
             }
             if (named.isEmpty()) {
                 throw new IllegalArgumentException("a bound is written about a name of the value");
             }
+            lines = java.util.Collections.unmodifiableSet(
+                    new java.util.LinkedHashSet<>(lines));
             named = java.util.Collections.unmodifiableSet(
                     new java.util.LinkedHashSet<>(named));
+            unread = java.util.Collections.unmodifiableSequencedMap(
+                    new java.util.LinkedHashMap<>(unread));
+            for (NumberAt<RuleKey> each : lines) {
+                if (!named.contains(each.position())) {
+                    throw new IllegalArgumentException("`" + each + "` is a line on a name this"
+                            + " clause does not write: " + named);
+                }
+            }
+        }
+
+        /** One line on one number, which is what a comparison states. */
+        ABound(NumberAt<RuleKey> line, Set<RuleKey> named) {
+            this(Set.of(line), named, new java.util.LinkedHashMap<>());
+        }
+
+        /** The line this clause stops the values on at {@code name}, or null where it states
+         *  none there. */
+        NumberAt<RuleKey> lineAt(RuleKey name) {
+            for (NumberAt<RuleKey> each : lines) {
+                if (each.position().equals(name)) {
+                    return each;
+                }
+            }
+            return null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1051,12 +1051,31 @@ public final class FieldDomains {
      *
      */
     public List<Placed> placed() {
-        List<Placed> out = new ArrayList<>(directs.stream()
-                .map(each -> new Placed(each.at(), each.from(),
-                        each.bound().lower(), each.bound().end(), each.conjunct()))
-                .toList());
+        List<Placed> out = new ArrayList<>(stated());
         out.addAll(movedEnds());
         return List.copyOf(out);
+    }
+
+    /**
+     * The ends the conjuncts state, each against the conjunct that states it.
+     *
+     * <p>Apart from {@link #movedEnds}, and the difference is where the answer comes from. An end
+     * here is in the conjunct: an ordering places one, and a rule about the strings at a position
+     * leaves them running from one place to another. Those are read off the rule alone, so which
+     * conjunct they belong to needs no working out. What the other list holds is the ends the rules
+     * leave together, attributed by asking what they would leave without each conjunct.
+     *
+     * <p>For a reader that has its own way to the first kind and wants only what that way cannot
+     * see. A newtype's own comparisons are read off the clauses as they are written
+     * ({@link DeclaredBounds#of}), and a rule stating no comparison is invisible there — so such a
+     * reader takes these and drops what it already has, which two ends at one value with one rule
+     * behind them come to anyway ({@link DeclaredBounds.End#tighter}).
+     */
+    public List<Placed> stated() {
+        return directs.stream()
+                .map(each -> new Placed(each.at(), each.from(),
+                        each.bound().lower(), each.bound().end(), each.conjunct()))
+                .toList();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -66,7 +66,7 @@ public final class FieldDomains {
      */
     public static final FieldDomains NONE =
             new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), Set.of(), List.of(), List.of(),
-                    List.of(), List.of(), PartsLeftOut.NONE, Map.of(),
+                    List.of(), List.of(), List.of(), PartsLeftOut.NONE, Map.of(),
                     Map.of(), Map.of(), new ReadingEvidence(), Map.of(),
                     Map.of(RuleKey.THE_VALUE, Set.of(new RulesMissed.NoReadingWasMade())), Set.of(),
                     NOTHING_NAMED,
@@ -86,6 +86,16 @@ public final class FieldDomains {
     private final List<WithoutAnEnd> withoutAnEnd;
     /** The conjuncts whose quantity is over one number — see {@link #aboutOneCoordinate}. */
     private final List<AboutOneCoordinate> aboutOneCoordinate;
+    /**
+     * The conjuncts stating a rule about the strings at one number.
+     *
+     * <p>Beside the list above and read by one question of the two that one answers. Both say which
+     * number a conjunct is written about, and only the first are candidates for working out which
+     * conjuncts account for where the values stop — a candidate that placed no end turns that
+     * working out on for every conjunct about the number, and each of those readings reads the
+     * declaration again. A conjunct stating a run states its own ends and needs no such attribution.
+     */
+    private final List<AboutOneCoordinate> aboutTheStrings;
     /**
      * Which conjunct this reading was asked to leave out, so that a reading standing in for a
      * counterfactual is not asked one of its own.
@@ -177,6 +187,7 @@ public final class FieldDomains {
                          Set<RuleKey> notSeparatedByName,
                          List<InvariantChecker.Direct> directs, List<NoLine> noLines,
                          List<WithoutAnEnd> withoutAnEnd, List<AboutOneCoordinate> aboutOneCoordinate,
+                         List<AboutOneCoordinate> aboutTheStrings,
                          PartsLeftOut withoutParts,
                          Map<RuleRef, Required> raised,
                          Map<RuleRef, Map<Core, Required>> raisedByPart,
@@ -200,6 +211,7 @@ public final class FieldDomains {
         this.noLines = noLines;
         this.withoutAnEnd = List.copyOf(withoutAnEnd);
         this.aboutOneCoordinate = List.copyOf(aboutOneCoordinate);
+        this.aboutTheStrings = List.copyOf(aboutTheStrings);
         this.withoutParts = withoutParts;
         this.raised = raised;
         this.raisedByPart = raisedByPart;
@@ -445,6 +457,7 @@ public final class FieldDomains {
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
                 Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().noLines(),
                 seeded.reading().withoutAnEnd(), seeded.reading().aboutOneCoordinate(),
+                seeded.reading().aboutTheStrings(),
                 reach.withoutParts(),
                 seeded.reading().raised(), seeded.reading().raisedByPart(),
                 seeded.reading().standing(), seeded.took(),
@@ -1270,6 +1283,11 @@ public final class FieldDomains {
         Set<NumberAt<RuleKey>> out = new java.util.LinkedHashSet<>();
         directs.forEach(each -> out.add(each.at()));
         aboutOneCoordinate.forEach(each -> out.add(each.at()));
+        // And the numbers a rule about the strings is written about. Which number such a rule is
+        // about is settled by the call it is written as, so it is here whatever the reading made of
+        // the strings — a reader choosing which of a position's numbers it is measured at wants
+        // every rule written about one, and a rule read no further than the call is one of them.
+        aboutTheStrings.forEach(each -> out.add(each.at()));
         return java.util.Collections.unmodifiableSet(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -6,6 +6,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.PathEngine.Entered;
 import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.core.Core;
@@ -21,6 +22,8 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
+import souther.compiler.values.TextExtent;
+import souther.compiler.values.TextExtents;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -1480,7 +1483,15 @@ public final class InvariantChecker {
         if (withoutParts.excludes(from, clause)) {
             return;
         }
-        restricting(clause, from, part, byName, parts, noLines);
+        // What a rule about the strings at a position says about where they stop, which is a rule
+        // of this conjunct as much as an ordering written here is. Beside the reading of
+        // comparisons and not inside it: what such a rule states is not a comparison and has no
+        // sides to walk, and it reaches a position a comparison could reach as readily.
+        //
+        // Before the reading below, which needs to know: a conjunct that stated where the values
+        // stop has a line, and is not one an author is owed a sentence about for having drawn none.
+        restricting(clause, from, part, byName, parts, noLines,
+                runsOf(clause, from, part, byName, parts, naming, out));
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
             // the classification to be handed.
@@ -1940,7 +1951,7 @@ public final class InvariantChecker {
      */
     private void restricting(Core clause, RuleRef.Invariant from, int part,
                              Map<FactSubject, Coordinate> byName, PartsRead parts,
-                             List<FieldDomains.NoLine> noLines) {
+                             List<FieldDomains.NoLine> noLines, Set<FactSubject> bounded) {
         ReadByClauses.OfAPart account = parts.accountIn(from, clause);
         ReadByClauses.OfARule rule = parts.ruleIn(from);
         if (account == null || rule == null) {
@@ -1952,7 +1963,11 @@ public final class InvariantChecker {
             // part that put no constraint on the values restricts nothing, whatever else it settled
             // — a dead branch settles every position it named by imposing nothing on it — and one
             // that placed an end has a line, which is accounted for by whoever draws lines.
-            if (!account.restricts(position) || account.bounds(position)) {
+            // A part that put no constraint on the values restricts nothing, and one that placed an
+            // end has a line — from the ordering it wrote, or from the run of the strings it
+            // admits, which are the two ways a conjunct states where the values stop.
+            if (!account.restricts(position) || account.bounds(position)
+                    || bounded.contains(position)) {
                 continue;
             }
             // And what the rule itself came to once its own choices are decided and its own
@@ -1968,6 +1983,67 @@ public final class InvariantChecker {
                 noLines.add(said);
             }
         }
+    }
+
+    /**
+     * Where a rule about the strings at a position leaves that position, and which number it is
+     * about.
+     *
+     * <p>Two answers of one recognition and neither read off the other. Which of a position's
+     * numbers such a rule is written about is settled by the call, so it is written down whatever
+     * became of the text in it — a format written out of a constant a module cannot reach is a rule
+     * about the string as plainly as one written out. Where the strings stop is a further question,
+     * asked only of a language this has, and answered under its own allowance.
+     *
+     * <p><b>Nothing here reads the rule.</b> What each conjunct states about the strings at a
+     * position is worked out once, by the reading that turns clauses into sets, and arrives as the
+     * position and the plan it left there. Read a second time here, this walk would be deciding for
+     * itself what a predicate means about a position.
+     *
+     * <p>The ends stand beside the ends an ordering places and are the same kind of thing: this
+     * conjunct states them, and which of them survives the rules beside it is
+     * {@link DeclaredBounds.End#tighter}'s. So they go where a comparison's own end goes and not
+     * among the ends worked out from what the rules leave together — a run is what this conjunct
+     * admits, and no counterfactual is needed to find out that it placed it.
+     *
+     * <p>Only on the position's own value. A string is the one value with two numbers, and what a
+     * run of the strings says is about the order they are written on and not about how many
+     * characters they hold; a rule about the length is a rule about a whole number and is read
+     * where whole numbers are.
+     */
+    private Set<FactSubject> runsOf(Core clause, RuleRef.Invariant from, int part,
+                        Map<FactSubject, Coordinate> byName, PartsRead parts,
+                        List<FieldDomains.AboutOneCoordinate> naming, List<Direct> out) {
+        ReadByClauses.OfAPart account = parts.accountIn(from, clause);
+        if (account == null) {
+            return Set.of();
+        }
+        Set<FactSubject> bounded = new LinkedHashSet<>();
+        account.aboutStrings().forEach((position, plan) -> {
+            Coordinate found = byName.get(position);
+            if (found == null) {
+                return;
+            }
+            // The value's own number, built here rather than taken from the coordinate in hand: a
+            // position measured by a count of itself has one of those, and a rule about the strings
+            // is about neither that count nor whichever of the two this map happens to hold.
+            NumberAt<RuleKey> value = NumberAt.valueOf(found.path());
+            naming.add(new FieldDomains.AboutOneCoordinate(value, from, clause, part));
+            // A run holding one string is the rule naming a value rather than bounding a range, and
+            // a value it names is a distinction of the position rather than an edge on it. What
+            // such a rule leaves is what the reading of the values says it leaves.
+            if (TextExtents.of(plan) instanceof TextExtent.One run && !run.holdsOneValue()) {
+                bounded.add(position);
+                out.add(new Direct(value, from,
+                        new InvariantBound(true, Endpoint.inclusive(run.first())), clause, part));
+                if (run.after() != null) {
+                    out.add(new Direct(value, from,
+                            new InvariantBound(false, Endpoint.exclusive(run.after())),
+                            clause, part));
+                }
+            }
+        });
+        return bounded;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1717,16 +1717,16 @@ public final class InvariantChecker {
         })) {
             return new ClauseStates.ARelation();
         }
-        // What a rule about the strings at a position came to, where this conjunct is one. Such a
-        // rule states where the values stop exactly when the strings it admits run between places
-        // the order does not already hold them, which is the reading's own answer and not something
-        // read back off the ends it produced.
-        SequencedMap<RuleKey, BlockReason.RuleReadingStopped> stopped =
+        SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> stopped =
                 stoppedOnTheFormOf(found, read, byName);
         // And where whether it states one was not worked out, the question stands with no answer.
         // Left out, a limit of this compiler would come out as a rule that raises no such question,
         // which is what a rule read to the end and stating no bound comes out as.
-        stopped.putAll(runs.undecided(byName));
+        //
+        // Both readings' reasons at a name either of them stopped at, since either is a thing that
+        // would have to change: written over the other, whichever ran second would be the only one
+        // an author was sent to.
+        runs.undecided(byName).forEach((name, why) -> stopped.merge(name, why, InvariantChecker::alsoSaying));
         // What a rule about the strings at a position came to, where this conjunct is one. Such a
         // rule states where the values stop exactly when the strings it admits run between places
         // the order does not already hold them, which is the reading's own answer and not something
@@ -1754,9 +1754,9 @@ public final class InvariantChecker {
      * classification is given in, and taking one would put the answer inside the thing it is an
      * answer about.
      */
-    private SequencedMap<RuleKey, BlockReason.RuleReadingStopped> stoppedOnTheFormOf(
+    private SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> stoppedOnTheFormOf(
             List<RuleKey> found, CanonicalForm read, Map<FactSubject, Coordinate> byName) {
-        SequencedMap<RuleKey, BlockReason.RuleReadingStopped> out = new LinkedHashMap<>();
+        SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> out = new LinkedHashMap<>();
         // Only a rule that orders the values. An equality singles one out and puts no end anywhere,
         // which is what it states and not what a reading of it managed — so however little of the
         // form was read, there is no line for anything to be undecided about.
@@ -1771,7 +1771,7 @@ public final class InvariantChecker {
         // rather than said once of the clause.
         BlockReason.RuleReadingStopped why = UnreadComparison.notAboutOwnValues(
                 placesIn(stopped.stoppedAt(), stopped.under(), byName).origin());
-        found.forEach(each -> out.put(each, why));
+        found.forEach(each -> out.put(each, List.of(why)));
         return out;
     }
 
@@ -2016,10 +2016,14 @@ public final class InvariantChecker {
             // established about that. What is written down is what stopped it: said as a rule read
             // to the end without a line, a limit of this compiler would be published as a fact
             // about the model.
-            BlockReason.RuleReadingStopped stopped = runs.stoppedAt(position);
-            if (stopped != null) {
-                add(noLines, new FieldDomains.NoLine(each.getValue().at(), from, clause, part,
-                        stopped));
+            // One finding per reason. A clause read a branch at a time can be stopped by one thing
+            // in one branch and another in the next, and those send an author to two different
+            // places; the first of them standing for the rest would make which one they are sent to
+            // turn on which branch was written first.
+            List<BlockReason.RuleReadingStopped> stopped = runs.stoppedAt(position);
+            if (!stopped.isEmpty()) {
+                stopped.forEach(why -> add(noLines,
+                        new FieldDomains.NoLine(each.getValue().at(), from, clause, part, why)));
                 continue;
             }
             // And what the rule itself came to once its own choices are decided and its own
@@ -2033,6 +2037,15 @@ public final class InvariantChecker {
                     part, new BlockReason.RuleRestrictingToAdmittedValues());
             add(noLines, said);
         }
+    }
+
+    /** Both lists, the second's after the first's, each reason once. */
+    private static List<BlockReason.RuleReadingStopped> alsoSaying(
+            List<BlockReason.RuleReadingStopped> these,
+            List<BlockReason.RuleReadingStopped> those) {
+        List<BlockReason.RuleReadingStopped> out = new ArrayList<>(these);
+        those.stream().filter(each -> !out.contains(each)).forEach(out::add);
+        return List.copyOf(out);
     }
 
     /** One finding per rule and reason, however many readers arrive at it. */
@@ -2211,16 +2224,13 @@ public final class InvariantChecker {
         }
 
         /** What stopped the reading at each name it stopped at, for the classification to carry. */
-        SequencedMap<RuleKey, BlockReason.RuleReadingStopped> undecided(
+        SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> undecided(
                 Map<FactSubject, Coordinate> byName) {
-            SequencedMap<RuleKey, BlockReason.RuleReadingStopped> out = new LinkedHashMap<>();
+            SequencedMap<RuleKey, List<BlockReason.RuleReadingStopped>> out = new LinkedHashMap<>();
             byPosition.forEach((position, run) -> {
                 Coordinate found = byName.get(position);
                 if (run instanceof Run.Undecided it && found != null) {
-                    // The first of them, which is the one the clause writes first. This door holds
-                    // one reason per name; the rest are kept where they were established, so that
-                    // the day it holds more they are there to be said.
-                    out.put(found.path(), it.why().get(0));
+                    out.put(found.path(), it.why());
                 }
             });
             return out;
@@ -2232,8 +2242,8 @@ public final class InvariantChecker {
         }
 
         /** What stopped the reading at {@code position}, or null where nothing did. */
-        BlockReason.RuleReadingStopped stoppedAt(FactSubject position) {
-            return byPosition.get(position) instanceof Run.Undecided it ? it.why().get(0) : null;
+        List<BlockReason.RuleReadingStopped> stoppedAt(FactSubject position) {
+            return byPosition.get(position) instanceof Run.Undecided it ? it.why() : List.of();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1616,12 +1616,17 @@ public final class InvariantChecker {
         // What a part met afterwards adds is itself.
         if (shape instanceof ClauseStates.ABound stated
                 && end instanceof InvariantBound.Read.NoEnd) {
-            standing.compute(new FieldDomains.BoundaryQuestion(from, stated.line()),
-                    (question, had) -> had == null
-                            ? new FieldDomains.BoundaryStanding(
-                                    UnreadComparison.whereALineWouldFall(about.carrier() != null),
-                                    List.of(part))
-                            : had.and(part));
+            // Once per number the clause stops the values on. A comparison states one, which is
+            // what this arm is reached from; written for that one alone, a clause stating two would
+            // leave the second question with nothing standing against it.
+            stated.lines().forEach(line ->
+                    standing.compute(new FieldDomains.BoundaryQuestion(from, line),
+                            (question, had) -> had == null
+                                    ? new FieldDomains.BoundaryStanding(
+                                            UnreadComparison.whereALineWouldFall(
+                                                    about.carrier() != null),
+                                            List.of(part))
+                                    : had.and(part)));
         }
         settle(bin, from, shape, end, at, byName, raised, took, typeAt, parts, raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
@@ -1716,17 +1721,21 @@ public final class InvariantChecker {
         // rule states where the values stop exactly when the strings it admits run between places
         // the order does not already hold them, which is the reading's own answer and not something
         // read back off the ends it produced.
-        NumberAt<RuleKey> run = runs.bounding();
-        if (run != null) {
-            return new ClauseStates.ABound(run, Set.copyOf(found));
-        }
         SequencedMap<RuleKey, BlockReason.RuleReadingStopped> stopped =
                 stoppedOnTheFormOf(found, read, byName);
         // And where whether it states one was not worked out, the question stands with no answer.
         // Left out, a limit of this compiler would come out as a rule that raises no such question,
         // which is what a rule read to the end and stating no bound comes out as.
         stopped.putAll(runs.undecided(byName));
-        return ClauseStates.SomethingElse.naming(found).unread(stopped);
+        // What a rule about the strings at a position came to, where this conjunct is one. Such a
+        // rule states where the values stop exactly when the strings it admits run between places
+        // the order does not already hold them, which is the reading's own answer and not something
+        // read back off the ends it produced. Every number it came to, because one clause read a
+        // branch at a time can state a line on one and leave the next standing.
+        Set<NumberAt<RuleKey>> lines = runs.bounding();
+        return lines.isEmpty()
+                ? ClauseStates.SomethingElse.naming(found).unread(stopped)
+                : new ClauseStates.ABound(lines, new LinkedHashSet<>(found), stopped);
     }
 
     /**
@@ -2176,22 +2185,22 @@ public final class InvariantChecker {
 
         static final RunsRead NOTHING = new RunsRead(Map.of());
 
-        /** The number this conjunct states the values stop on, or null where it states none. */
-        NumberAt<RuleKey> bounding() {
-            NumberAt<RuleKey> found = null;
-            for (Run each : byPosition.values()) {
+        /**
+         * The numbers this conjunct states the values stop on, in the order they were read.
+         *
+         * <p>Every one of them. One clause is read a branch at a time and the branches are joined,
+         * so what it comes to is an answer per position — and a clause whose branches all state a
+         * run at two positions states one at each. Held as one number, which of them a reader is
+         * told about would be a choice nothing here may make.
+         */
+        Set<NumberAt<RuleKey>> bounding() {
+            Set<NumberAt<RuleKey>> out = new LinkedHashSet<>();
+            byPosition.values().forEach(each -> {
                 if (each instanceof Run.Bounding it) {
-                    if (found != null && !found.equals(it.number())) {
-                        // One clause, two numbers it stops the values on. A classification says one
-                        // ({@link ClauseStates.ABound}), and which of them a reader would be told
-                        // about is nothing this may choose — so it is refused rather than picked.
-                        throw new IllegalStateException("one conjunct states where the values stop"
-                                + " on two numbers: " + found + " and " + it.number());
-                    }
-                    found = it.number();
+                    out.add(it.number());
                 }
-            }
-            return found;
+            });
+            return out;
         }
 
         /** What stopped the reading at each name it stopped at, for the classification to carry. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -22,7 +22,6 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
-import souther.compiler.regex.Meter;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.TextExtent;
 import souther.compiler.values.TextExtents;
@@ -1510,12 +1509,12 @@ public final class InvariantChecker {
         //
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
-        restricting(clause, from, part, byName, parts, noLines,
-                runsOf(clause, from, part, byName, parts, namingTheStrings, out));
+        RunsRead runs = runsOf(clause, from, part, byName, parts, namingTheStrings, out);
+        restricting(clause, from, part, byName, parts, noLines, runs);
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
             // the classification to be handed.
-            settle(clause, from, states(clause, at, byName, null),
+            settle(clause, from, states(clause, at, byName, null, runs),
                     new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
@@ -1538,7 +1537,7 @@ public final class InvariantChecker {
         // value states.
         ComparisonClaim asWritten = comparison == null ? null : comparison.claim();
         if (asWritten == null) {
-            settle(bin, from, states(bin, at, byName, read),
+            settle(bin, from, states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
@@ -1564,7 +1563,7 @@ public final class InvariantChecker {
             said = said.turned();
         }
         if (asWritten instanceof ComparisonClaim.Singled named && !named.holdsAtTheValue()) {
-            settle(bin, from, states(bin, at, byName, read),
+            settle(bin, from, states(bin, at, byName, read, runs),
                     new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             // And handed on, which is not the same as being reported. A rule that rules one value
@@ -1589,7 +1588,7 @@ public final class InvariantChecker {
         // What the clause is about, asked of the comparison and not of what `end` came to. A
         // coordinate compared for order against something naming no other coordinate states where
         // the values stop, whether or not the number on the other side is one this could fold.
-        ClauseStates shape = states(bin, at, byName, read);
+        ClauseStates shape = states(bin, at, byName, read, runs);
         // And nothing of this value on the other side. `ARelation` is only what
         // `Relates.twoPositions` recognises, which wants each whole side to be a position — so
         // `width <= height + 1` is not one, and read as a bound it raised a question about where
@@ -1682,7 +1681,8 @@ public final class InvariantChecker {
      *             answer to that question
      */
     private ClauseStates states(Core clause, Denotations at,
-                                Map<FactSubject, Coordinate> byName, CanonicalForm read) {
+                                Map<FactSubject, Coordinate> byName, CanonicalForm read,
+                                RunsRead runs) {
         List<RuleKey> found = new ArrayList<>();
         namedIn(clause, at, byName, found);
         // What the rule cuts, ahead of what it looks like. Which values a rule restricts is settled
@@ -1712,8 +1712,21 @@ public final class InvariantChecker {
         })) {
             return new ClauseStates.ARelation();
         }
-        return ClauseStates.SomethingElse.naming(found)
-                .unread(stoppedOnTheFormOf(found, read, byName));
+        // What a rule about the strings at a position came to, where this conjunct is one. Such a
+        // rule states where the values stop exactly when the strings it admits run between places
+        // the order does not already hold them, which is the reading's own answer and not something
+        // read back off the ends it produced.
+        NumberAt<RuleKey> run = runs.bounding();
+        if (run != null) {
+            return new ClauseStates.ABound(run, Set.copyOf(found));
+        }
+        SequencedMap<RuleKey, BlockReason.RuleReadingStopped> stopped =
+                stoppedOnTheFormOf(found, read, byName);
+        // And where whether it states one was not worked out, the question stands with no answer.
+        // Left out, a limit of this compiler would come out as a rule that raises no such question,
+        // which is what a rule read to the end and stating no bound comes out as.
+        stopped.putAll(runs.undecided(byName));
+        return ClauseStates.SomethingElse.naming(found).unread(stopped);
     }
 
     /**
@@ -1987,16 +2000,17 @@ public final class InvariantChecker {
             // end has a line — from the ordering it wrote, or from the run of the strings it
             // admits, which are the two ways a conjunct states where the values stop.
             if (!account.restricts(position) || account.bounds(position)
-                    || runs.bounded().contains(position)) {
+                    || runs.bounds(position)) {
                 continue;
             }
-            // And where the reading of the run ran out of what it may build, nothing was
-            // established about where the values stop. What is written down is that it stopped:
-            // said as a rule read to the end without a line, a limit of this compiler would be
-            // published as a fact about the model.
-            if (runs.stopped().containsKey(position)) {
+            // And where whether it states where the values stop was not worked out, nothing was
+            // established about that. What is written down is what stopped it: said as a rule read
+            // to the end without a line, a limit of this compiler would be published as a fact
+            // about the model.
+            BlockReason.RuleReadingStopped stopped = runs.stoppedAt(position);
+            if (stopped != null) {
                 add(noLines, new FieldDomains.NoLine(each.getValue().at(), from, clause, part,
-                        new BlockReason.PatternTooCostly()));
+                        stopped));
                 continue;
             }
             // And what the rule itself came to once its own choices are decided and its own
@@ -2052,8 +2066,7 @@ public final class InvariantChecker {
         if (account == null) {
             return RunsRead.NOTHING;
         }
-        Set<FactSubject> bounded = new LinkedHashSet<>();
-        Map<FactSubject, Meter.Stopped> stopped = new LinkedHashMap<>();
+        Map<FactSubject, Run> byPosition = new LinkedHashMap<>();
         account.aboutStrings().forEach((position, stated) -> {
             Coordinate found = byName.get(position);
             if (found == null) {
@@ -2066,13 +2079,13 @@ public final class InvariantChecker {
             naming.add(new FieldDomains.AboutOneCoordinate(value, from, clause, part));
             // And the strings only where the rule was read to them. What a rule this could not read
             // admits is not every string; it is not known, and a run read off what the reading left
-            // would be a run of a set the rule does not have.
-            if (!(stated instanceof StringRestriction.Admitting admitting)) {
-                return;
-            }
-            placed(admitting.plan(), value, from, clause, part, position, bounded, stopped, out);
+            // would be a run of a set the rule does not have. Whether it states where the values
+            // stop is undecided, which is not the same as its stating that they stop nowhere.
+            byPosition.put(position, stated instanceof StringRestriction.Admitting admitting
+                    ? placed(admitting.plan(), value, from, clause, part, out)
+                    : new Run.Undecided(((StringRestriction.NotKnown) stated).why()));
         });
-        return new RunsRead(bounded, stopped);
+        return new RunsRead(byPosition);
     }
 
     /**
@@ -2090,30 +2103,36 @@ public final class InvariantChecker {
      * with no end above them has said where none of them stop — and it is a run all the same, which
      * is why what is asked of it is which of its ends the rule placed.
      */
-    private void placed(AdmittedPlan plan, NumberAt<RuleKey> value, RuleRef.Invariant from,
-                        Core clause, int part, FactSubject position,
-                        Set<FactSubject> bounded, Map<FactSubject, Meter.Stopped> stopped,
-                        List<Direct> out) {
+    private Run placed(AdmittedPlan plan, NumberAt<RuleKey> value, RuleRef.Invariant from,
+                       Core clause, int part, List<Direct> out) {
         switch (extentOf(plan)) {
             // A run holding one string is the rule naming a value rather than bounding a range, and
             // a value it names is a distinction of the position rather than an edge on it.
-            case TextExtent.One run when run.holdsOneValue() -> { }
+            case TextExtent.One run when run.holdsOneValue() -> {
+                return new Run.NotBounding();
+            }
             case TextExtent.One run -> {
+                boolean placed = false;
                 if (run.holdsFromAbove()) {
-                    bounded.add(position);
+                    placed = true;
                     out.add(new Direct(value, from,
                             new InvariantBound(true, Endpoint.inclusive(run.first())),
                             clause, part));
                 }
                 if (run.after() != null) {
-                    bounded.add(position);
+                    placed = true;
                     out.add(new Direct(value, from,
                             new InvariantBound(false, Endpoint.exclusive(run.after())),
                             clause, part));
                 }
+                return placed ? new Run.Bounding(value) : new Run.NotBounding();
             }
-            case TextExtent.NoNamedRun _ -> { }
-            case TextExtent.NotBuilt it -> stopped.put(position, it.stopped());
+            case TextExtent.NoNamedRun _ -> {
+                return new Run.NotBounding();
+            }
+            case TextExtent.NotBuilt it -> {
+                return new Run.Undecided(new BlockReason.OrderedExtentTooCostly(it.stopped()));
+            }
         }
     }
 
@@ -2131,15 +2150,72 @@ public final class InvariantChecker {
     }
 
     /**
-     * What the runs of one conjunct's strings came to, per position.
+     * What one conjunct's rule about the strings at one position came to.
      *
-     * <p>Two answers and not one. A position this conjunct bounds has a line and is not one an
-     * author is owed a word about for having drawn none; a position where the reading ran out has
-     * neither, and saying so is not the same as saying the rule draws no line.
+     * <p>Three answers, and every reader of them takes the one it is given rather than working it
+     * out again from what was produced. The ends this conjunct placed, the question it raises about
+     * where the values stop, and whether an author is owed a word about a rule that drew no line
+     * are three readings of this one answer — read back off the ends instead, the classification
+     * would be derived from the thing it classifies.
      */
-    record RunsRead(Set<FactSubject> bounded, Map<FactSubject, Meter.Stopped> stopped) {
+    sealed interface Run {
 
-        static final RunsRead NOTHING = new RunsRead(Set.of(), Map.of());
+        /** The conjunct states where the values stop on {@code number}. */
+        record Bounding(NumberAt<RuleKey> number) implements Run {}
+
+        /** It states which strings stand there and stops them nowhere: the strings it admits are
+         *  not one stretch of the order, or the stretch they make is one the order already holds. */
+        record NotBounding() implements Run {}
+
+        /** Whether it states where the values stop was not worked out, and what stopped it. */
+        record Undecided(BlockReason.RuleReadingStopped why) implements Run {}
+    }
+
+    /** What one conjunct's rules about strings came to, per position. */
+    record RunsRead(Map<FactSubject, Run> byPosition) {
+
+        static final RunsRead NOTHING = new RunsRead(Map.of());
+
+        /** The number this conjunct states the values stop on, or null where it states none. */
+        NumberAt<RuleKey> bounding() {
+            NumberAt<RuleKey> found = null;
+            for (Run each : byPosition.values()) {
+                if (each instanceof Run.Bounding it) {
+                    if (found != null && !found.equals(it.number())) {
+                        // One clause, two numbers it stops the values on. A classification says one
+                        // ({@link ClauseStates.ABound}), and which of them a reader would be told
+                        // about is nothing this may choose — so it is refused rather than picked.
+                        throw new IllegalStateException("one conjunct states where the values stop"
+                                + " on two numbers: " + found + " and " + it.number());
+                    }
+                    found = it.number();
+                }
+            }
+            return found;
+        }
+
+        /** What stopped the reading at each name it stopped at, for the classification to carry. */
+        SequencedMap<RuleKey, BlockReason.RuleReadingStopped> undecided(
+                Map<FactSubject, Coordinate> byName) {
+            SequencedMap<RuleKey, BlockReason.RuleReadingStopped> out = new LinkedHashMap<>();
+            byPosition.forEach((position, run) -> {
+                Coordinate found = byName.get(position);
+                if (run instanceof Run.Undecided it && found != null) {
+                    out.put(found.path(), it.why());
+                }
+            });
+            return out;
+        }
+
+        /** Whether this conjunct has a line at {@code position} — see {@link Run.Bounding}. */
+        boolean bounds(FactSubject position) {
+            return byPosition.get(position) instanceof Run.Bounding;
+        }
+
+        /** What stopped the reading at {@code position}, or null where nothing did. */
+        BlockReason.RuleReadingStopped stoppedAt(FactSubject position) {
+            return byPosition.get(position) instanceof Run.Undecided it ? it.why() : null;
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -22,6 +22,8 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
+import souther.compiler.regex.Meter;
+import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.TextExtent;
 import souther.compiler.values.TextExtents;
 
@@ -243,6 +245,14 @@ public final class InvariantChecker {
     private final Predicates predicates;
     /** Whether an evaluation can answer, which is what decides that a continuation is reached. */
     private final PathCompletion completion;
+    /**
+     * Where the strings each plan admits stop, worked out once per plan.
+     *
+     * <p>A declaration is read again for every conjunct whose contribution to an end has to be
+     * worked out by asking what the rules leave without it, and each of those readings meets the
+     * same plans. What a plan admits does not turn on which reading is asking.
+     */
+    private final Map<AdmittedPlan, TextExtent> extents = new LinkedHashMap<>();
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 
@@ -482,8 +492,8 @@ public final class InvariantChecker {
          *  every position, since nothing here knows which of them the rules were about. */
         static Seeded nothingRead() {
             return new Seeded(ConstraintState.<FactSubject>top(), Map.of(), Map.of(), Map.of(),
-                    new Reading(List.of(), List.of(), List.of(), List.of(), Map.of(), Map.of(),
-                            Map.of(), Map.of()),
+                    new Reading(List.of(), List.of(), List.of(), List.of(), List.of(), Map.of(),
+                            Map.of(), Map.of(), Map.of()),
                     new ReadingEvidence(),
                     false, Map.of(RuleKey.THE_VALUE,
                             Set.of(new RulesMissed.ReadingFellOver())),
@@ -1303,6 +1313,7 @@ public final class InvariantChecker {
     record Reading(List<Direct> directs, List<FieldDomains.NoLine> noLines,
                    List<FieldDomains.WithoutAnEnd> withoutAnEnd,
                    List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate,
+                   List<FieldDomains.AboutOneCoordinate> aboutTheStrings,
                    Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                    Map<RuleRef, Required> raised,
                    Map<RuleRef, Map<Core, Required>> raisedByPart,
@@ -1334,6 +1345,12 @@ public final class InvariantChecker {
         List<FieldDomains.NoLine> noLines = new ArrayList<>();
         List<FieldDomains.WithoutAnEnd> withoutAnEnd = new ArrayList<>();
         List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate = new ArrayList<>();
+        // Beside them and not among them. Both say which number a conjunct is written about; only
+        // the first are candidates for working out which conjuncts account for where the values
+        // stop, and a candidate that placed no end turns that working out on for the whole number.
+        // A conjunct that states a run states its own ends, so it needs no such attribution — and
+        // put among them it would set every other conjunct about the number to be read again.
+        List<FieldDomains.AboutOneCoordinate> aboutTheStrings = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
@@ -1341,12 +1358,12 @@ public final class InvariantChecker {
                 new LinkedHashMap<>();
         stated.forEach(each ->
                 direct(each.clause(), each.from(), new int[1], at, byName, out, noLines,
-                        withoutAnEnd, aboutOneCoordinate, narrowers, raised,
+                        withoutAnEnd, aboutOneCoordinate, aboutTheStrings, narrowers, raised,
                         took, typeAt, parts, raisedByPart, standing, withoutParts));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines), List.copyOf(withoutAnEnd),
-                List.copyOf(aboutOneCoordinate),
+                List.copyOf(aboutOneCoordinate), List.copyOf(aboutTheStrings),
                 Map.copyOf(narrowers),
                 Collections.unmodifiableMap(new LinkedHashMap<>(raised)),
                 Collections.unmodifiableMap(new LinkedHashMap<>(raisedByPart)),
@@ -1447,6 +1464,7 @@ public final class InvariantChecker {
                         List<FieldDomains.NoLine> noLines,
                         List<FieldDomains.WithoutAnEnd> withoutAnEnd,
                         List<FieldDomains.AboutOneCoordinate> naming,
+                        List<FieldDomains.AboutOneCoordinate> namingTheStrings,
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                         Map<RuleRef, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
@@ -1463,9 +1481,11 @@ public final class InvariantChecker {
             // its conjuncts alike, which is what lets a line drawn here be recognised as the line
             // the declaration's own reading drew (issue #1062).
             direct(and.left(), from, conjunct, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, parts, raisedByPart, standing, withoutParts);
+                    namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart,
+                    standing, withoutParts);
             direct(and.right(), from, conjunct, at, byName, out, noLines, withoutAnEnd, naming,
-                    narrowers, raised, took, typeAt, parts, raisedByPart, standing, withoutParts);
+                    namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart,
+                    standing, withoutParts);
             return;
         }
         // Which conjunct of the clause this is, taken here so that every one of them is numbered —
@@ -1491,7 +1511,7 @@ public final class InvariantChecker {
         // Before the reading below, which needs to know: a conjunct that stated where the values
         // stop has a line, and is not one an author is owed a sentence about for having drawn none.
         restricting(clause, from, part, byName, parts, noLines,
-                runsOf(clause, from, part, byName, parts, naming, out));
+                runsOf(clause, from, part, byName, parts, namingTheStrings, out));
         if (!(clause instanceof Core.Binary bin)) {
             // Nothing but a binary is written as a comparison, so there is no reading of one for
             // the classification to be handed.
@@ -1951,7 +1971,7 @@ public final class InvariantChecker {
      */
     private void restricting(Core clause, RuleRef.Invariant from, int part,
                              Map<FactSubject, Coordinate> byName, PartsRead parts,
-                             List<FieldDomains.NoLine> noLines, Set<FactSubject> bounded) {
+                             List<FieldDomains.NoLine> noLines, RunsRead runs) {
         ReadByClauses.OfAPart account = parts.accountIn(from, clause);
         ReadByClauses.OfARule rule = parts.ruleIn(from);
         if (account == null || rule == null) {
@@ -1967,7 +1987,16 @@ public final class InvariantChecker {
             // end has a line — from the ordering it wrote, or from the run of the strings it
             // admits, which are the two ways a conjunct states where the values stop.
             if (!account.restricts(position) || account.bounds(position)
-                    || bounded.contains(position)) {
+                    || runs.bounded().contains(position)) {
+                continue;
+            }
+            // And where the reading of the run ran out of what it may build, nothing was
+            // established about where the values stop. What is written down is that it stopped:
+            // said as a rule read to the end without a line, a limit of this compiler would be
+            // published as a fact about the model.
+            if (runs.stopped().containsKey(position)) {
+                add(noLines, new FieldDomains.NoLine(each.getValue().at(), from, clause, part,
+                        new BlockReason.PatternTooCostly()));
                 continue;
             }
             // And what the rule itself came to once its own choices are decided and its own
@@ -1979,9 +2008,14 @@ public final class InvariantChecker {
             }
             FieldDomains.NoLine said = new FieldDomains.NoLine(each.getValue().at(), from, clause,
                     part, new BlockReason.RuleRestrictingToAdmittedValues());
-            if (!noLines.contains(said)) {
-                noLines.add(said);
-            }
+            add(noLines, said);
+        }
+    }
+
+    /** One finding per rule and reason, however many readers arrive at it. */
+    private static void add(List<FieldDomains.NoLine> noLines, FieldDomains.NoLine said) {
+        if (!noLines.contains(said)) {
+            noLines.add(said);
         }
     }
 
@@ -2011,15 +2045,16 @@ public final class InvariantChecker {
      * characters they hold; a rule about the length is a rule about a whole number and is read
      * where whole numbers are.
      */
-    private Set<FactSubject> runsOf(Core clause, RuleRef.Invariant from, int part,
+    private RunsRead runsOf(Core clause, RuleRef.Invariant from, int part,
                         Map<FactSubject, Coordinate> byName, PartsRead parts,
                         List<FieldDomains.AboutOneCoordinate> naming, List<Direct> out) {
         ReadByClauses.OfAPart account = parts.accountIn(from, clause);
         if (account == null) {
-            return Set.of();
+            return RunsRead.NOTHING;
         }
         Set<FactSubject> bounded = new LinkedHashSet<>();
-        account.aboutStrings().forEach((position, plan) -> {
+        Map<FactSubject, Meter.Stopped> stopped = new LinkedHashMap<>();
+        account.aboutStrings().forEach((position, stated) -> {
             Coordinate found = byName.get(position);
             if (found == null) {
                 return;
@@ -2029,21 +2064,82 @@ public final class InvariantChecker {
             // is about neither that count nor whichever of the two this map happens to hold.
             NumberAt<RuleKey> value = NumberAt.valueOf(found.path());
             naming.add(new FieldDomains.AboutOneCoordinate(value, from, clause, part));
+            // And the strings only where the rule was read to them. What a rule this could not read
+            // admits is not every string; it is not known, and a run read off what the reading left
+            // would be a run of a set the rule does not have.
+            if (!(stated instanceof StringRestriction.Admitting admitting)) {
+                return;
+            }
+            placed(admitting.plan(), value, from, clause, part, position, bounded, stopped, out);
+        });
+        return new RunsRead(bounded, stopped);
+    }
+
+    /**
+     * One position's ends, where the rule's strings are a run that holds it.
+     *
+     * <p>Three answers of the reading and three things to do. A run holds the values between two
+     * places, and each of those the order does not already hold is an end this conjunct placed. A
+     * language that is not one run leaves the position where it was. And a reading that ran out of
+     * what it may build has established nothing, so what is written down is that it stopped —
+     * folded into the second, a limit of this compiler would be published as a rule that draws no
+     * line, which is a sentence about the model.
+     *
+     * <p>A run holding the position where the order already holds it is not one it bounds. Every
+     * string is at or above the string of nothing, so a rule leaving the values from there upwards
+     * with no end above them has said where none of them stop — and it is a run all the same, which
+     * is why what is asked of it is which of its ends the rule placed.
+     */
+    private void placed(AdmittedPlan plan, NumberAt<RuleKey> value, RuleRef.Invariant from,
+                        Core clause, int part, FactSubject position,
+                        Set<FactSubject> bounded, Map<FactSubject, Meter.Stopped> stopped,
+                        List<Direct> out) {
+        switch (extentOf(plan)) {
             // A run holding one string is the rule naming a value rather than bounding a range, and
-            // a value it names is a distinction of the position rather than an edge on it. What
-            // such a rule leaves is what the reading of the values says it leaves.
-            if (TextExtents.of(plan) instanceof TextExtent.One run && !run.holdsOneValue()) {
-                bounded.add(position);
-                out.add(new Direct(value, from,
-                        new InvariantBound(true, Endpoint.inclusive(run.first())), clause, part));
+            // a value it names is a distinction of the position rather than an edge on it.
+            case TextExtent.One run when run.holdsOneValue() -> { }
+            case TextExtent.One run -> {
+                if (run.holdsFromAbove()) {
+                    bounded.add(position);
+                    out.add(new Direct(value, from,
+                            new InvariantBound(true, Endpoint.inclusive(run.first())),
+                            clause, part));
+                }
                 if (run.after() != null) {
+                    bounded.add(position);
                     out.add(new Direct(value, from,
                             new InvariantBound(false, Endpoint.exclusive(run.after())),
                             clause, part));
                 }
             }
-        });
-        return bounded;
+            case TextExtent.NoNamedRun _ -> { }
+            case TextExtent.NotBuilt it -> stopped.put(position, it.stopped());
+        }
+    }
+
+    /**
+     * Where the strings {@code plan} admits stop, worked out once for the plan.
+     *
+     * <p>The same plan comes back as often as the declaration is read, and it is read again for
+     * every conjunct whose contribution to an end is worked out by asking what the rules leave
+     * without it. What a plan admits does not turn on which of those readings is asking, so it is
+     * answered once — the allowance each answer is made under is the same, which is what makes the
+     * second asking the same question rather than a cheaper one.
+     */
+    private TextExtent extentOf(AdmittedPlan plan) {
+        return extents.computeIfAbsent(plan, TextExtents::of);
+    }
+
+    /**
+     * What the runs of one conjunct's strings came to, per position.
+     *
+     * <p>Two answers and not one. A position this conjunct bounds has a line and is not one an
+     * author is owed a word about for having drawn none; a position where the reading ran out has
+     * neither, and saying so is not the same as saying the rule draws no line.
+     */
+    record RunsRead(Set<FactSubject> bounded, Map<FactSubject, Meter.Stopped> stopped) {
+
+        static final RunsRead NOTHING = new RunsRead(Set.of(), Map.of());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2140,7 +2140,8 @@ public final class InvariantChecker {
                 return new Run.NotBounding();
             }
             case TextExtent.NotBuilt it -> {
-                return new Run.Undecided(new BlockReason.OrderedExtentTooCostly(it.stopped()));
+                return new Run.Undecided(
+                        List.of(new BlockReason.OrderedExtentTooCostly(it.stopped())));
             }
         }
     }
@@ -2176,8 +2177,14 @@ public final class InvariantChecker {
          *  not one stretch of the order, or the stretch they make is one the order already holds. */
         record NotBounding() implements Run {}
 
-        /** Whether it states where the values stop was not worked out, and what stopped it. */
-        record Undecided(BlockReason.RuleReadingStopped why) implements Run {}
+        /**
+         * Whether it states where the values stop was not worked out, and what stopped it.
+         *
+         * <p>Every reason, in the order the clause writes them. Two branches of one choice can be
+         * stopped by two different things and those go out under two different words, so which of
+         * them a reader is shown may not turn on which branch was written first.
+         */
+        record Undecided(List<BlockReason.RuleReadingStopped> why) implements Run {}
     }
 
     /** What one conjunct's rules about strings came to, per position. */
@@ -2210,7 +2217,10 @@ public final class InvariantChecker {
             byPosition.forEach((position, run) -> {
                 Coordinate found = byName.get(position);
                 if (run instanceof Run.Undecided it && found != null) {
-                    out.put(found.path(), it.why());
+                    // The first of them, which is the one the clause writes first. This door holds
+                    // one reason per name; the rest are kept where they were established, so that
+                    // the day it holds more they are there to be said.
+                    out.put(found.path(), it.why().get(0));
                 }
             });
             return out;
@@ -2223,7 +2233,7 @@ public final class InvariantChecker {
 
         /** What stopped the reading at {@code position}, or null where nothing did. */
         BlockReason.RuleReadingStopped stoppedAt(FactSubject position) {
-            return byPosition.get(position) instanceof Run.Undecided it ? it.why() : null;
+            return byPosition.get(position) instanceof Run.Undecided it ? it.why().get(0) : null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ObligationClassification.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ObligationClassification.java
@@ -46,13 +46,15 @@ sealed interface ObligationClassification {
      * further — which is why the measure that answers this question stays open, and why the answer
      * is not that the model says nothing.
      */
-    record Undetermined(BlockReason.RuleReadingStopped why) implements ObligationClassification {
+    record Undetermined(java.util.List<BlockReason.RuleReadingStopped> why)
+            implements ObligationClassification {
 
         public Undetermined {
-            if (why == null) {
+            if (why.isEmpty()) {
                 throw new IllegalArgumentException(
                         "a classification that did not come out says what stopped it");
             }
+            why = java.util.List.copyOf(why);
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
-import souther.compiler.values.AdmittedPlan;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -71,17 +70,17 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
      * never needed to find out.
      *
      * @param aboutARule what a rule of this part is answerable for, per position
-     * @param aboutStrings the positions this part states a rule about the strings of, each with
-     *                     what the part plans to admit there. Beside the adoptions and not among
-     *                     them: what a part took a position in at is what the readings settled, and
-     *                     this is what the clause states — a rule whose written text nothing worked
-     *                     out is still a rule about the position it names, and a reader deciding
-     *                     which of the position's numbers it is measured at wants exactly that
+     * @param aboutStrings what this part states about the strings at each position it states a rule
+     *                     about. Beside the adoptions and not among them: what a part took a
+     *                     position in at is what the readings settled, and this is what the clause
+     *                     states — a rule whose written text nothing worked out is still a rule
+     *                     about the position it names, and a reader deciding which of the position's
+     *                     numbers it is measured at wants exactly that
      */
     record OfAPart(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                    java.util.Map<FactSubject,
                            java.util.List<souther.compiler.values.UnreadReason>> aboutARule,
-                   java.util.Map<FactSubject, AdmittedPlan> aboutStrings) {
+                   java.util.Map<FactSubject, StringRestriction> aboutStrings) {
 
         /** The positions some reading took the whole of this part in at. */
         java.util.Set<FactSubject> adopted() {

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -70,10 +71,17 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
      * never needed to find out.
      *
      * @param aboutARule what a rule of this part is answerable for, per position
+     * @param aboutStrings the positions this part states a rule about the strings of, each with
+     *                     what the part plans to admit there. Beside the adoptions and not among
+     *                     them: what a part took a position in at is what the readings settled, and
+     *                     this is what the clause states — a rule whose written text nothing worked
+     *                     out is still a rule about the position it names, and a reader deciding
+     *                     which of the position's numbers it is measured at wants exactly that
      */
     record OfAPart(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                    java.util.Map<FactSubject,
-                           java.util.List<souther.compiler.values.UnreadReason>> aboutARule) {
+                           java.util.List<souther.compiler.values.UnreadReason>> aboutARule,
+                   java.util.Map<FactSubject, AdmittedPlan> aboutStrings) {
 
         /** The positions some reading took the whole of this part in at. */
         java.util.Set<FactSubject> adopted() {

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -282,6 +282,22 @@ public sealed interface Required {
     }
 
     /**
+     * The names whose line nothing worked out, whichever arm the clause came out as.
+     *
+     * <p>A clause that states no line anywhere carries them, and so does one that states a line on
+     * a number and left the next standing. Read off one arm alone, the second clause's open
+     * question went out as one nobody asked.
+     */
+    private static java.util.Map<RuleKey, BlockReason.RuleReadingStopped> unreadIn(
+            ClauseStates states) {
+        return switch (states) {
+            case ClauseStates.ABound it -> it.unread();
+            case ClauseStates.SomethingElse it -> it.unread();
+            case ClauseStates.ARelation _, ClauseStates.NoRestriction _ -> java.util.Map.of();
+        };
+    }
+
+    /**
      * Whether the rule raises {@code kind} at {@code at}, said of the clause as a reader found it.
      *
      * <p>One switch over the questions and no {@code default}, which is where a question added to
@@ -304,15 +320,16 @@ public sealed interface Required {
             // nothing took apart may place one at any name it writes, and which of those it is,
             // is what reading further would answer.
             case BOUNDARY -> {
-                if (bound != null) {
-                    yield new ObligationClassification.Raised(new Owed.Boundary(bound.line()));
+                // Asked at this name, because one clause can stop the values on the number at one
+                // name and leave the number at the next undecided. Answered off the clause as a
+                // whole, the second question went out as one the rule does not raise.
+                if (bound != null && bound.lineAt(at) != null) {
+                    yield new ObligationClassification.Raised(
+                            new Owed.Boundary(bound.lineAt(at)));
                 }
-                if (!(states instanceof ClauseStates.SomethingElse it)) {
-                    yield new ObligationClassification.NotRaised();
-                }
-                // Asked at this name, because the reading is answered at each of them. A name it
+                // And the reading that stopped, whichever arm the clause came out as. A name it
                 // settled is settled whatever it left beside it.
-                BlockReason.RuleReadingStopped why = it.unread().get(at);
+                BlockReason.RuleReadingStopped why = unreadIn(states).get(at);
                 yield why == null ? new ObligationClassification.NotRaised()
                         : new ObligationClassification.Undetermined(why);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -289,7 +289,8 @@ public sealed interface Required {
      * a number and left the next standing. Read off one arm alone, the second clause's open
      * question went out as one nobody asked.
      */
-    private static Map<RuleKey, BlockReason.RuleReadingStopped> unreadIn(ClauseStates states) {
+    private static Map<RuleKey, java.util.List<BlockReason.RuleReadingStopped>> unreadIn(
+            ClauseStates states) {
         return switch (states) {
             case ClauseStates.ABound it -> it.unread();
             case ClauseStates.SomethingElse it -> it.unread();
@@ -329,7 +330,7 @@ public sealed interface Required {
                 }
                 // And the reading that stopped, whichever arm the clause came out as. A name it
                 // settled is settled whatever it left beside it.
-                BlockReason.RuleReadingStopped why = unreadIn(states).get(at);
+                java.util.List<BlockReason.RuleReadingStopped> why = unreadIn(states).get(at);
                 yield why == null ? new ObligationClassification.NotRaised()
                         : new ObligationClassification.Undetermined(why);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -4,6 +4,7 @@ import souther.compiler.inputs.BlockReason;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -288,12 +289,11 @@ public sealed interface Required {
      * a number and left the next standing. Read off one arm alone, the second clause's open
      * question went out as one nobody asked.
      */
-    private static java.util.Map<RuleKey, BlockReason.RuleReadingStopped> unreadIn(
-            ClauseStates states) {
+    private static Map<RuleKey, BlockReason.RuleReadingStopped> unreadIn(ClauseStates states) {
         return switch (states) {
             case ClauseStates.ABound it -> it.unread();
             case ClauseStates.SomethingElse it -> it.unread();
-            case ClauseStates.ARelation _, ClauseStates.NoRestriction _ -> java.util.Map.of();
+            case ClauseStates.ARelation _, ClauseStates.NoRestriction _ -> Map.of();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Requirement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Requirement.java
@@ -59,16 +59,24 @@ public sealed interface Requirement {
      *
      * @param at  where the classification stopped, in the vocabulary of the value being read
      * @param why what this compiler could not do there, which is what would have to change before
-     *            the rule could be classified
+     *            the rule could be classified. Every one of them, in the order the clause writes
+     *            them: one clause read a branch at a time can be stopped by one thing in one branch
+     *            and another in the next, and those go out under different words — so which of them
+     *            a reader is shown may not turn on which branch was written first
      */
-    record BoundaryUndetermined(RuleKey at, BlockReason.RuleReadingStopped why)
+    record BoundaryUndetermined(RuleKey at, java.util.List<BlockReason.RuleReadingStopped> why)
             implements Requirement {
 
         public BoundaryUndetermined {
-            if (at == null || why == null) {
+            if (at == null || why.isEmpty()) {
                 throw new IllegalArgumentException("a classification that did not come out"
                         + " stopped somewhere, for a reason");
             }
+            why = java.util.List.copyOf(why);
+        }
+
+        BoundaryUndetermined(RuleKey at, BlockReason.RuleReadingStopped one) {
+            this(at, java.util.List.of(one));
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -4,12 +4,9 @@ import souther.compiler.core.Core;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.types.Type;
 import souther.compiler.values.AdmissibleValues;
-import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Emptiness;
 
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,6 +55,7 @@ sealed interface StatedByClauses {
     record Said(souther.compiler.values.PlannedValues<FactSubject> values,
                 OrderedIntervals<FactSubject> ordered,
                 Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
+                Map<FactSubject, StringRestriction> strings,
                 Map<Core, Part> parts)
             implements StatedByClauses {
 
@@ -67,35 +65,10 @@ sealed interface StatedByClauses {
 
         /** The same, remembering that it is what {@code e} came to. */
         @Override
-        public StatedByClauses from(Core e, StringRestriction.Found aboutStrings) {
+        public StatedByClauses from(Core e) {
             Map<Core, Part> out = new java.util.IdentityHashMap<>(parts);
-            out.put(e, new Part(byValues, byOrder, values.standing(), strings(aboutStrings)));
-            return new Said(values, ordered, byValues, byOrder, out);
-        }
-
-        /**
-         * What this part states about the strings at each position it states a rule about.
-         *
-         * <p>What the reading came to and not what it left. A rule whose text nothing worked out
-         * leaves the position every value, which is what a position nothing was read about holds —
-         * so the plan alone cannot tell a rule this could not read from one that admits every
-         * string, and only the first of those has nothing to say about where the values stop.
-         *
-         * <p>Per branch, because the plan is the branch's own reading. A part inside a choice is
-         * read once in each branch and the two admit different things; taken from outside, a branch
-         * nobody can be in would lend its plan to the one that stands. Which of the rules were read
-         * is the clause's and is the same in both.
-         */
-        private Map<FactSubject, StringRestriction> strings(StringRestriction.Found aboutStrings) {
-            if (aboutStrings.isEmpty()) {
-                return Map.of();
-            }
-            Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
-            aboutStrings.read().forEach(position ->
-                    out.put(position, new StringRestriction.Admitting(values.at(position))));
-            aboutStrings.notRead().forEach(position ->
-                    out.put(position, new StringRestriction.NotKnown()));
-            return Map.copyOf(out);
+            out.put(e, new Part(byValues, byOrder, values.standing(), strings));
+            return new Said(values, ordered, byValues, byOrder, strings, out);
         }
     }
 
@@ -161,54 +134,7 @@ sealed interface StatedByClauses {
                         reachedBy(other.byValues()));
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
-                    why, eitherAboutStrings(other));
-        }
-
-        /**
-         * What the same part of two branches states about the strings at a position.
-         *
-         * <p>Either branch's, which is what a choice leaves: what stands there is what one branch
-         * admits or what the other does, so the plans join and not knowing one of them is not
-         * knowing the pair. A position only one branch states a rule about is left every string by
-         * the branch that does not, so it joins with that — read as the one branch's, a choice
-         * would bound a position where only one of its branches bounds it.
-         */
-        private Map<FactSubject, StringRestriction> eitherAboutStrings(Part other) {
-            if (aboutStrings.equals(other.aboutStrings())) {
-                return aboutStrings;
-            }
-            Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
-            for (FactSubject position : bothNaming(other)) {
-                out.put(position,
-                        joined(aboutStrings.get(position), other.aboutStrings().get(position)));
-            }
-            return Map.copyOf(out);
-        }
-
-        /** Every position either of them states a rule about the strings of. */
-        private java.util.Set<FactSubject> bothNaming(Part other) {
-            java.util.Set<FactSubject> out = new LinkedHashSet<>(aboutStrings.keySet());
-            out.addAll(other.aboutStrings().keySet());
-            return out;
-        }
-
-        /**
-         * What one position comes to across the two, either side missing being every string.
-         *
-         * <p>A branch that states no rule about the strings at a position leaves every string
-         * standing there, which is what the plans are joined with — so the join is what either
-         * branch admits, and a branch that says nothing does not lend the other its bound.
-         */
-        private static StringRestriction joined(StringRestriction one, StringRestriction other) {
-            if (one instanceof StringRestriction.NotKnown
-                    || other instanceof StringRestriction.NotKnown) {
-                return new StringRestriction.NotKnown();
-            }
-            AdmittedPlan here = one instanceof StringRestriction.Admitting it
-                    ? it.plan() : AdmittedPlan.ANY;
-            AdmittedPlan there = other instanceof StringRestriction.Admitting it
-                    ? it.plan() : AdmittedPlan.ANY;
-            return new StringRestriction.Admitting(AdmittedPlan.joining(List.of(here, there)));
+                    why, StringRestriction.over(aboutStrings, other.aboutStrings(), false));
         }
 
         /** The positions a rule of this copy reached and did not merely settle: what it
@@ -249,8 +175,8 @@ sealed interface StatedByClauses {
 
         /** Into both branches, since which of them survives is not known yet. */
         @Override
-        public StatedByClauses from(Core e, StringRestriction.Found aboutStrings) {
-            return new Choice(id, left.from(e, aboutStrings), right.from(e, aboutStrings));
+        public StatedByClauses from(Core e) {
+            return new Choice(id, left.from(e), right.from(e));
         }
     }
 
@@ -258,7 +184,7 @@ sealed interface StatedByClauses {
     static StatedByClauses top() {
         return new Said(souther.compiler.values.PlannedValues.top(),
                 OrderedIntervals.top(),
-                Adoption.nothing(), Adoption.nothing(), Map.of());
+                Adoption.nothing(), Adoption.nothing(), Map.of(), Map.of());
     }
 
     /**
@@ -283,12 +209,8 @@ sealed interface StatedByClauses {
      * whose branch turns out dead is a part nothing transformed, and the account it gives is the one
      * it gave before anybody knew.
      *
-     * @param aboutStrings what {@code e} states a rule about the strings of, and which of those
-     *                     rules were read, which is a fact about the clause and the same in every
-     *                     branch. What each branch admits at one of them is the branch's own and is
-     *                     read there
      */
-    StatedByClauses from(Core e, StringRestriction.Found aboutStrings);
+    StatedByClauses from(Core e);
 
     /**
      * What this rule's own clauses leave, with its choices decided by its own clauses and by
@@ -418,6 +340,10 @@ sealed interface StatedByClauses {
                     // a leaf it read leaves at least one.
                     Adoption.at(mentions, said.adoptedAt(), said.dropped()),
                     Adoption.at(mentions, range.ranges().keySet(), range.ranges().isEmpty()),
+                    // And what the leaf states about the strings at a position, where it is a rule
+                    // about them. Asked of the reading that recognises one, so this is where the
+                    // answer enters and the connectives below are what compose it.
+                    values.stringRuleIn(e, said),
                     Map.of());
         }
 
@@ -469,6 +395,7 @@ sealed interface StatedByClauses {
             return new Said(here.values().meet(there.values()),
                     here.ordered().meet(there.ordered()),
                     here.byValues().both(there.byValues()), here.byOrder().both(there.byOrder()),
+                    StringRestriction.over(here.strings(), there.strings(), true),
                     // The parts of both, since a conjunction is every clause of it holding at once
                     // and each of them is still the part it was.
                     bothParts(here.parts(), there.parts()));
@@ -483,7 +410,7 @@ sealed interface StatedByClauses {
          */
         @Override
         public StatedByClauses from(Core e, StatedByClauses out) {
-            return out.from(e, values.stringRulesIn(e));
+            return out.from(e);
         }
 
         /**
@@ -791,6 +718,7 @@ sealed interface StatedByClauses {
             return new Said(read.values().alsoStanding(known.standing()), read.ordered(),
                     read.byValues().unbuiltAt(known.unbuilt()),
                     read.byOrder().unbuiltAt(known.unbuilt()),
+                    read.strings(),
                     parts);
         }
 
@@ -845,6 +773,9 @@ sealed interface StatedByClauses {
                             there.ordered().leavingNothing()),
                     here.byValues().bothDead(there.byValues()),
                     here.byOrder().bothDead(there.byOrder()),
+                    // And what either of them said about the strings goes with them. A run drawn
+                    // from a branch nobody can take is a line the model does not draw.
+                    Map.of(),
                     branchParts(here.parts(), there.parts(), Part::bothDead,
                             Part::inADeadBranch));
         }
@@ -861,6 +792,9 @@ sealed interface StatedByClauses {
             return new Said(alive.values(), alive.ordered(),
                     alive.byValues().beside(gone.byValues()),
                     alive.byOrder().beside(gone.byOrder()),
+                    // The branch that stands, and what the other could not read is not its
+                    // business: a rule of a branch nothing satisfies hides no run of this one.
+                    alive.strings(),
                     branchParts(alive.parts(), gone.parts(), Part::beside,
                             Part::inADeadBranch));
         }
@@ -871,6 +805,7 @@ sealed interface StatedByClauses {
                     ordered.either(here.ordered(), there.ordered()),
                     here.byValues().either(there.byValues()),
                     here.byOrder().either(there.byOrder()),
+                    StringRestriction.over(here.strings(), there.strings(), false),
                     branchParts(here.parts(), there.parts(), Part::either,
                             java.util.function.UnaryOperator.identity()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -67,32 +67,34 @@ sealed interface StatedByClauses {
 
         /** The same, remembering that it is what {@code e} came to. */
         @Override
-        public StatedByClauses from(Core e, Set<FactSubject> aboutStrings) {
+        public StatedByClauses from(Core e, StringRestriction.Found aboutStrings) {
             Map<Core, Part> out = new java.util.IdentityHashMap<>(parts);
             out.put(e, new Part(byValues, byOrder, values.standing(), strings(aboutStrings)));
             return new Said(values, ordered, byValues, byOrder, out);
         }
 
         /**
-         * What this part plans to admit at each position it states a rule about the strings of.
+         * What this part states about the strings at each position it states a rule about.
          *
-         * <p>The plan and not the set. Which strings a rule leaves is a machine somebody has to pay
-         * for, and what wants it here is a reader working out where the values stop — so what is
-         * kept is the description, and whether it is ever built is settled under that reader's own
-         * allowance. Held as the set, every rule about a string would be a machine made while the
-         * clause was read, for a question nobody may go on to ask.
+         * <p>What the reading came to and not what it left. A rule whose text nothing worked out
+         * leaves the position every value, which is what a position nothing was read about holds —
+         * so the plan alone cannot tell a rule this could not read from one that admits every
+         * string, and only the first of those has nothing to say about where the values stop.
          *
-         * <p>Per branch, because this is the branch's own reading. A part inside a choice is read
-         * once in each branch and the two admit different things; taken from outside, a branch
-         * nobody can be in would lend its plan to the one that stands.
+         * <p>Per branch, because the plan is the branch's own reading. A part inside a choice is
+         * read once in each branch and the two admit different things; taken from outside, a branch
+         * nobody can be in would lend its plan to the one that stands. Which of the rules were read
+         * is the clause's and is the same in both.
          */
-        private Map<FactSubject, AdmittedPlan> strings(
-                Set<FactSubject> aboutStrings) {
+        private Map<FactSubject, StringRestriction> strings(StringRestriction.Found aboutStrings) {
             if (aboutStrings.isEmpty()) {
                 return Map.of();
             }
-            Map<FactSubject, AdmittedPlan> out = new LinkedHashMap<>();
-            aboutStrings.forEach(position -> out.put(position, values.at(position)));
+            Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
+            aboutStrings.read().forEach(position ->
+                    out.put(position, new StringRestriction.Admitting(values.at(position))));
+            aboutStrings.notRead().forEach(position ->
+                    out.put(position, new StringRestriction.NotKnown()));
             return Map.copyOf(out);
         }
     }
@@ -110,17 +112,15 @@ sealed interface StatedByClauses {
      * finally admits is not among them — that is the whole value's answer and belongs to the whole.
      *
      * @param standing what this part's reading recorded about positions it was short of
-     * @param aboutStrings the positions this part states a rule about the strings of, each with
-     *                     what the part plans to admit there. Both halves, because they answer two
-     *                     questions and one of them has an answer where the other has none: which
-     *                     of a position's numbers a rule is written about is settled by the call,
-     *                     and it is settled whether or not this could work out the text written in
-     *                     it. Kept as the position alone, a reader working out where the values
-     *                     stop would go back to the clause for the rest
+     * @param aboutStrings what this part states about the strings at each position it states a rule
+     *                     about. The position is here whether or not the rule was read, because
+     *                     which of a position's numbers a rule is written about is settled by the
+     *                     call; what the rule leaves is the other half, and a rule this could not
+     *                     read has none
      */
     record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                 Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing,
-                Map<FactSubject, AdmittedPlan> aboutStrings) {
+                Map<FactSubject, StringRestriction> aboutStrings) {
 
         /** The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}. */
         Part inADeadBranch() {
@@ -167,21 +167,48 @@ sealed interface StatedByClauses {
         /**
          * What the same part of two branches states about the strings at a position.
          *
-         * <p>Either branch's, which is what a choice leaves: a position one of them wrote a string
-         * rule about is one the clause writes a string rule about, and what stands there is what
-         * one branch admits or what the other does. So the plans join, and a position only one
-         * branch spoke about is left every string by the branch that did not.
+         * <p>Either branch's, which is what a choice leaves: what stands there is what one branch
+         * admits or what the other does, so the plans join and not knowing one of them is not
+         * knowing the pair. A position only one branch states a rule about is left every string by
+         * the branch that does not, so it joins with that — read as the one branch's, a choice
+         * would bound a position where only one of its branches bounds it.
          */
-        private Map<FactSubject, AdmittedPlan> eitherAboutStrings(
-                Part other) {
+        private Map<FactSubject, StringRestriction> eitherAboutStrings(Part other) {
             if (aboutStrings.equals(other.aboutStrings())) {
                 return aboutStrings;
             }
-            Map<FactSubject, AdmittedPlan> out =
-                    new LinkedHashMap<>(aboutStrings);
-            other.aboutStrings().forEach((position, plan) -> out.merge(position, plan,
-                    (here, there) -> AdmittedPlan.joining(List.of(here, there))));
+            Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
+            for (FactSubject position : bothNaming(other)) {
+                out.put(position,
+                        joined(aboutStrings.get(position), other.aboutStrings().get(position)));
+            }
             return Map.copyOf(out);
+        }
+
+        /** Every position either of them states a rule about the strings of. */
+        private java.util.Set<FactSubject> bothNaming(Part other) {
+            java.util.Set<FactSubject> out = new LinkedHashSet<>(aboutStrings.keySet());
+            out.addAll(other.aboutStrings().keySet());
+            return out;
+        }
+
+        /**
+         * What one position comes to across the two, either side missing being every string.
+         *
+         * <p>A branch that states no rule about the strings at a position leaves every string
+         * standing there, which is what the plans are joined with — so the join is what either
+         * branch admits, and a branch that says nothing does not lend the other its bound.
+         */
+        private static StringRestriction joined(StringRestriction one, StringRestriction other) {
+            if (one instanceof StringRestriction.NotKnown
+                    || other instanceof StringRestriction.NotKnown) {
+                return new StringRestriction.NotKnown();
+            }
+            AdmittedPlan here = one instanceof StringRestriction.Admitting it
+                    ? it.plan() : AdmittedPlan.ANY;
+            AdmittedPlan there = other instanceof StringRestriction.Admitting it
+                    ? it.plan() : AdmittedPlan.ANY;
+            return new StringRestriction.Admitting(AdmittedPlan.joining(List.of(here, there)));
         }
 
         /** The positions a rule of this copy reached and did not merely settle: what it
@@ -222,7 +249,7 @@ sealed interface StatedByClauses {
 
         /** Into both branches, since which of them survives is not known yet. */
         @Override
-        public StatedByClauses from(Core e, Set<FactSubject> aboutStrings) {
+        public StatedByClauses from(Core e, StringRestriction.Found aboutStrings) {
             return new Choice(id, left.from(e, aboutStrings), right.from(e, aboutStrings));
         }
     }
@@ -256,11 +283,12 @@ sealed interface StatedByClauses {
      * whose branch turns out dead is a part nothing transformed, and the account it gives is the one
      * it gave before anybody knew.
      *
-     * @param aboutStrings the positions {@code e} states a rule about the strings of, which is a
-     *                     fact about the clause and the same in every branch. What each branch
-     *                     admits at one of them is the branch's own and is read there
+     * @param aboutStrings what {@code e} states a rule about the strings of, and which of those
+     *                     rules were read, which is a fact about the clause and the same in every
+     *                     branch. What each branch admits at one of them is the branch's own and is
+     *                     read there
      */
-    StatedByClauses from(Core e, Set<FactSubject> aboutStrings);
+    StatedByClauses from(Core e, StringRestriction.Found aboutStrings);
 
     /**
      * What this rule's own clauses leave, with its choices decided by its own clauses and by
@@ -455,7 +483,7 @@ sealed interface StatedByClauses {
          */
         @Override
         public StatedByClauses from(Core e, StatedByClauses out) {
-            return out.from(e, values.stringSubjectsIn(e));
+            return out.from(e, values.stringRulesIn(e));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -4,9 +4,12 @@ import souther.compiler.core.Core;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.types.Type;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Emptiness;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -64,10 +67,33 @@ sealed interface StatedByClauses {
 
         /** The same, remembering that it is what {@code e} came to. */
         @Override
-        public StatedByClauses from(Core e) {
+        public StatedByClauses from(Core e, Set<FactSubject> aboutStrings) {
             Map<Core, Part> out = new java.util.IdentityHashMap<>(parts);
-            out.put(e, new Part(byValues, byOrder, values.standing()));
+            out.put(e, new Part(byValues, byOrder, values.standing(), strings(aboutStrings)));
             return new Said(values, ordered, byValues, byOrder, out);
+        }
+
+        /**
+         * What this part plans to admit at each position it states a rule about the strings of.
+         *
+         * <p>The plan and not the set. Which strings a rule leaves is a machine somebody has to pay
+         * for, and what wants it here is a reader working out where the values stop — so what is
+         * kept is the description, and whether it is ever built is settled under that reader's own
+         * allowance. Held as the set, every rule about a string would be a machine made while the
+         * clause was read, for a question nobody may go on to ask.
+         *
+         * <p>Per branch, because this is the branch's own reading. A part inside a choice is read
+         * once in each branch and the two admit different things; taken from outside, a branch
+         * nobody can be in would lend its plan to the one that stands.
+         */
+        private Map<FactSubject, AdmittedPlan> strings(
+                Set<FactSubject> aboutStrings) {
+            if (aboutStrings.isEmpty()) {
+                return Map.of();
+            }
+            Map<FactSubject, AdmittedPlan> out = new LinkedHashMap<>();
+            aboutStrings.forEach(position -> out.put(position, values.at(position)));
+            return Map.copyOf(out);
         }
     }
 
@@ -84,27 +110,38 @@ sealed interface StatedByClauses {
      * finally admits is not among them — that is the whole value's answer and belongs to the whole.
      *
      * @param standing what this part's reading recorded about positions it was short of
+     * @param aboutStrings the positions this part states a rule about the strings of, each with
+     *                     what the part plans to admit there. Both halves, because they answer two
+     *                     questions and one of them has an answer where the other has none: which
+     *                     of a position's numbers a rule is written about is settled by the call,
+     *                     and it is settled whether or not this could work out the text written in
+     *                     it. Kept as the position alone, a reader working out where the values
+     *                     stop would go back to the clause for the rest
      */
     record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
-                Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing) {
+                Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing,
+                Map<FactSubject, AdmittedPlan> aboutStrings) {
 
         /** The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}. */
         Part inADeadBranch() {
             // The reasons go with it too. A rule of a branch nothing satisfies is not a rule of
             // this declaration that went unread; there is no branch for an author to look at.
-            return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of());
+            //
+            // And neither is what it said about the strings at a position. A line drawn from a
+            // branch nobody can be in is a line the model does not draw.
+            return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(), Map.of());
         }
 
         /** This part of the branch that stands, beside the same part of one nobody can be in. */
         Part beside(Part gone) {
             return new Part(byValues.beside(gone.byValues()), byOrder.beside(gone.byOrder()),
-                    standing);
+                    standing, aboutStrings);
         }
 
         /** The same part of two branches, neither of which anybody can be in. */
         Part bothDead(Part other) {
             return new Part(byValues.bothDead(other.byValues()),
-                    byOrder.bothDead(other.byOrder()), Map.of());
+                    byOrder.bothDead(other.byOrder()), Map.of(), Map.of());
         }
 
         /** The same part of two branches somebody can be in. */
@@ -124,7 +161,27 @@ sealed interface StatedByClauses {
                         reachedBy(other.byValues()));
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
-                    why);
+                    why, eitherAboutStrings(other));
+        }
+
+        /**
+         * What the same part of two branches states about the strings at a position.
+         *
+         * <p>Either branch's, which is what a choice leaves: a position one of them wrote a string
+         * rule about is one the clause writes a string rule about, and what stands there is what
+         * one branch admits or what the other does. So the plans join, and a position only one
+         * branch spoke about is left every string by the branch that did not.
+         */
+        private Map<FactSubject, AdmittedPlan> eitherAboutStrings(
+                Part other) {
+            if (aboutStrings.equals(other.aboutStrings())) {
+                return aboutStrings;
+            }
+            Map<FactSubject, AdmittedPlan> out =
+                    new LinkedHashMap<>(aboutStrings);
+            other.aboutStrings().forEach((position, plan) -> out.merge(position, plan,
+                    (here, there) -> AdmittedPlan.joining(List.of(here, there))));
+            return Map.copyOf(out);
         }
 
         /** The positions a rule of this copy reached and did not merely settle: what it
@@ -165,8 +222,8 @@ sealed interface StatedByClauses {
 
         /** Into both branches, since which of them survives is not known yet. */
         @Override
-        public StatedByClauses from(Core e) {
-            return new Choice(id, left.from(e), right.from(e));
+        public StatedByClauses from(Core e, Set<FactSubject> aboutStrings) {
+            return new Choice(id, left.from(e, aboutStrings), right.from(e, aboutStrings));
         }
     }
 
@@ -198,8 +255,12 @@ sealed interface StatedByClauses {
      * known yet and the part is in each of them until it is. Recorded on the outside instead, a part
      * whose branch turns out dead is a part nothing transformed, and the account it gives is the one
      * it gave before anybody knew.
+     *
+     * @param aboutStrings the positions {@code e} states a rule about the strings of, which is a
+     *                     fact about the clause and the same in every branch. What each branch
+     *                     admits at one of them is the branch's own and is read there
      */
-    StatedByClauses from(Core e);
+    StatedByClauses from(Core e, Set<FactSubject> aboutStrings);
 
     /**
      * What this rule's own clauses leave, with its choices decided by its own clauses and by
@@ -394,7 +455,7 @@ sealed interface StatedByClauses {
          */
         @Override
         public StatedByClauses from(Core e, StatedByClauses out) {
-            return out.from(e);
+            return out.from(e, values.stringSubjectsIn(e));
         }
 
         /**
@@ -643,7 +704,8 @@ sealed interface StatedByClauses {
             said.parts().forEach((each, part) -> parts.put(each, new ReadByClauses.OfAPart(
                     part.byValues().unbuiltAt(unbuilt),
                     part.byOrder().unbuiltAt(unbuilt),
-                    aRuleIsAnswerableFor(part, made.made()))));
+                    aRuleIsAnswerableFor(part, made.made()),
+                    part.aboutStrings())));
             return parts;
         }
 
@@ -696,7 +758,8 @@ sealed interface StatedByClauses {
             read.parts().forEach((each, part) -> parts.put(each, new Part(
                     part.byValues().unbuiltAt(known.unbuilt()),
                     part.byOrder().unbuiltAt(known.unbuilt()),
-                    ReadByClauses.alsoSaying(part.standing(), known.standing()))));
+                    ReadByClauses.alsoSaying(part.standing(), known.standing()),
+                    part.aboutStrings())));
             return new Said(read.values().alsoStanding(known.standing()), read.ordered(),
                     read.byValues().unbuiltAt(known.unbuilt()),
                     read.byOrder().unbuiltAt(known.unbuilt()),

--- a/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
@@ -3,8 +3,11 @@ package souther.compiler.check;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.values.AdmittedPlan;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,14 +59,44 @@ sealed interface StringRestriction {
      * fact itself is the recognition's ({@link StringPredicates.Reading}); this is that one fact
      * said in the words a rule left unread is written down in.
      */
-    record NotKnown(BlockReason.RuleReadingStopped why) implements StringRestriction {
+    record NotKnown(List<BlockReason.RuleReadingStopped> why) implements StringRestriction {
 
         public NotKnown {
-            if (why == null) {
+            if (why.isEmpty()) {
                 throw new IllegalArgumentException("a reading that stopped was stopped by something");
             }
+            why = List.copyOf(why);
+        }
+
+        NotKnown(BlockReason.RuleReadingStopped one) {
+            this(List.of(one));
+        }
+
+        /**
+         * Both of them, each reason once and in the order the clause writes them.
+         *
+         * <p>Every reason and not the first. Two branches of one choice can be stopped by two
+         * different things — one written more deeply than this reads, one written in a form it does
+         * not enter — and those go out under two different words. Keeping one, which of them a
+         * reader is shown would turn on which branch the author wrote first.
+         */
+        NotKnown and(NotKnown other) {
+            List<BlockReason.RuleReadingStopped> out = new ArrayList<>(why);
+            other.why().stream().filter(each -> !out.contains(each)).forEach(out::add);
+            return new NotKnown(out);
         }
     }
+
+    /**
+     * What a reading that states no rule about the strings at a position leaves there.
+     *
+     * <p>Every string, and known to be: a reading says nothing about a position by not writing
+     * about it, which is a fact about the clause and not something it could not work out. Written as
+     * an absence and read as one, the two operations below would each need a case for it — and the
+     * one that got a case was right at the first level and wrong as soon as its answer was composed
+     * again.
+     */
+    StringRestriction EVERY_STRING = new Admitting(AdmittedPlan.ANY);
 
     /**
      * What two readings of one position come to, held together or as a choice between them.
@@ -79,24 +112,61 @@ sealed interface StringRestriction {
      */
     static StringRestriction over(StringRestriction one, StringRestriction other, boolean met) {
         // A reading that states no rule about the strings here leaves every string standing, and
-        // every string is what a choice between it and anything else leaves. So for a choice it
-        // takes the answer over and there is nothing left to not know; for a conjunction it changes
-        // nothing and the other side stands as it is.
-        if (one == null || other == null) {
-            StringRestriction had = one == null ? other : one;
-            return met ? had : new Admitting(AdmittedPlan.ANY);
+        // that is a value like any other. Lifted first, so that everything below is one algebra
+        // over three kinds of answer rather than an algebra with a case for an absence — a case is
+        // what makes the first level right and the composition of its answer wrong.
+        StringRestriction here = one == null ? EVERY_STRING : one;
+        StringRestriction there = other == null ? EVERY_STRING : other;
+        // The laws about what is known, before what is not. Every string absorbs a choice and is
+        // the identity of a conjunction, and nothing at all absorbs a conjunction — each of them
+        // settles the pair whether or not the other side was worked out, so a reading that stopped
+        // does not make the answer unknown where the law already gives it.
+        if (met) {
+            if (admits(here, AdmittedPlan.Nothing.class)
+                    || admits(there, AdmittedPlan.Nothing.class)) {
+                return new Admitting(AdmittedPlan.NONE);
+            }
+            if (admits(here, AdmittedPlan.Everything.class)) {
+                return there;
+            }
+            if (admits(there, AdmittedPlan.Everything.class)) {
+                return here;
+            }
+        } else if (admits(here, AdmittedPlan.Everything.class)
+                || admits(there, AdmittedPlan.Everything.class)) {
+            return EVERY_STRING;
         }
-        if (one instanceof NotKnown it) {
-            return it;
+        // And then what neither law reaches. A pair one side of which was not worked out admits
+        // something this cannot name, and a run read off the side that was read is a run of a set
+        // the rule does not have.
+        if (here instanceof NotKnown a && there instanceof NotKnown b) {
+            return a.and(b);
         }
-        if (other instanceof NotKnown it) {
-            return it;
+        if (here instanceof NotKnown a) {
+            return a;
         }
-        AdmittedPlan here = ((Admitting) one).plan();
-        AdmittedPlan there = ((Admitting) other).plan();
+        if (there instanceof NotKnown b) {
+            return b;
+        }
+        AdmittedPlan first = ((Admitting) here).plan();
+        AdmittedPlan second = ((Admitting) there).plan();
         return new Admitting(met
-                ? AdmittedPlan.meeting(java.util.List.of(here, there))
-                : AdmittedPlan.joining(java.util.List.of(here, there)));
+                ? AdmittedPlan.meeting(List.of(first, second))
+                : AdmittedPlan.joining(List.of(first, second)));
+    }
+
+    /**
+     * Whether {@code said} is known to admit what {@code shape} names, read off the plan and
+     * nothing built.
+     *
+     * <p>A plan written as every value or as none says so by being that shape. One written as a
+     * pattern may come to either and is not read as one here: what would settle it is making the
+     * machine, and the laws above are the ones that hold without making anything. Where a plan
+     * that would have absorbed goes unrecognised, the answer falls through to the algebra over the
+     * plans, which normalises the same absorbers itself.
+     */
+    private static boolean admits(StringRestriction said, Class<? extends AdmittedPlan> shape) {
+        return said instanceof Admitting it && shape.isInstance(it.plan());
     }
 
     /**
@@ -124,6 +194,6 @@ sealed interface StringRestriction {
                 out.put(position, over(these.get(position), those.get(position), met)));
         // The order the positions were read in, kept: what is written out of these reaches a
         // report, and the iteration order of an immutable copy is salted once per run.
-        return java.util.Collections.unmodifiableMap(out);
+        return Collections.unmodifiableMap(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
@@ -1,0 +1,103 @@
+package souther.compiler.check;
+
+import souther.compiler.values.AdmittedPlan;
+
+/**
+ * What one part of a clause states about the strings at one position.
+ *
+ * <p>Two answers because the reading of such a rule has two outcomes a later reader has to tell
+ * apart: it worked out which strings the rule admits, or it did not. Which position the rule is
+ * about is settled either way and is not here — it is what this is filed under, so a rule whose
+ * text nothing worked out is still a rule about the position it names.
+ *
+ * <p><b>Which is why the plan is not carried on its own.</b> What a reading leaves where it worked
+ * nothing out is every value ({@link souther.compiler.values.ValueSet#ANY}), and that is what a
+ * position nothing was read about holds — the same value for two opposite facts. Carried as the
+ * plan alone, a rule this could not read arrived at the reading of where the values stop looking
+ * like a rule that admits every string, and a run would have been read off it.
+ *
+ * <p>Why the reading stopped is not here either. That is the accounting's, said once where the rule
+ * was read, and a second copy of it travelling beside this would be a second answer to a question
+ * that has an owner.
+ */
+sealed interface StringRestriction {
+
+    /**
+     * The rule admits what the plan admits.
+     *
+     * <p>The plan and not the set. Which strings a rule leaves is a machine somebody has to pay
+     * for, and whether one is ever made is settled under the allowance of whoever asks — held as
+     * the set, every rule about a string would be a machine made while the clause was read, for a
+     * question nobody may go on to ask.
+     */
+    record Admitting(AdmittedPlan plan) implements StringRestriction {
+
+        public Admitting {
+            if (plan == null) {
+                throw new IllegalArgumentException("a rule that was read admits something");
+            }
+        }
+    }
+
+    /**
+     * The rule is one of these and what it admits was not worked out.
+     *
+     * <p>A pattern written more deeply than the subset read, a text composed out of something this
+     * could not fold. What follows is that nothing is known about where the values stop — not that
+     * they stop nowhere.
+     */
+    record NotKnown() implements StringRestriction {}
+
+    /**
+     * The two of them together, which is what a part holding both comes to.
+     *
+     * <p>Not knowing wins. A part whose strings are the ones one leaf admits together with the ones
+     * another leaf admits, where the second was not read, admits something this cannot name — and a
+     * run read off the half that was read would be a run of a set the rule does not have.
+     */
+    static StringRestriction and(StringRestriction one, StringRestriction other) {
+        if (one == null) {
+            return other;
+        }
+        if (other == null) {
+            return one;
+        }
+        return one instanceof NotKnown || other instanceof NotKnown ? new NotKnown() : one;
+    }
+
+    /**
+     * The positions a clause states a rule about the strings of, told apart by whether the rule was
+     * read to the strings it admits.
+     *
+     * <p>A fact about the clause and the same in every branch of a choice in it, which is why it is
+     * worked out where the clause is walked and handed to each branch. What each branch admits at
+     * one of those positions is the branch's own and is read there.
+     *
+     * @param read    the positions every such rule about which was read to its strings
+     * @param notRead the positions some such rule about which was not. A position is in one of the
+     *                two and never both: a part admitting what one rule leaves together with what
+     *                another leaves, where the second was not read, admits something this cannot
+     *                name
+     */
+    record Found(java.util.Set<FactSubject> read, java.util.Set<FactSubject> notRead) {
+
+        static final Found NONE = new Found(java.util.Set.of(), java.util.Set.of());
+
+        public Found {
+            read = java.util.Set.copyOf(read);
+            notRead = java.util.Set.copyOf(notRead);
+        }
+
+        /** Whether the clause states no rule about the strings anywhere. */
+        boolean isEmpty() {
+            return read.isEmpty() && notRead.isEmpty();
+        }
+
+        /** Every position, whichever of the two it is in. */
+        java.util.Set<FactSubject> anywhere() {
+            java.util.Set<FactSubject> out = new java.util.LinkedHashSet<>(read);
+            out.addAll(notRead);
+            return out;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
@@ -49,23 +49,6 @@ sealed interface StringRestriction {
     record NotKnown() implements StringRestriction {}
 
     /**
-     * The two of them together, which is what a part holding both comes to.
-     *
-     * <p>Not knowing wins. A part whose strings are the ones one leaf admits together with the ones
-     * another leaf admits, where the second was not read, admits something this cannot name — and a
-     * run read off the half that was read would be a run of a set the rule does not have.
-     */
-    static StringRestriction and(StringRestriction one, StringRestriction other) {
-        if (one == null) {
-            return other;
-        }
-        if (other == null) {
-            return one;
-        }
-        return one instanceof NotKnown || other instanceof NotKnown ? new NotKnown() : one;
-    }
-
-    /**
      * The positions a clause states a rule about the strings of, told apart by whether the rule was
      * read to the strings it admits.
      *
@@ -81,8 +64,6 @@ sealed interface StringRestriction {
      */
     record Found(java.util.Set<FactSubject> read, java.util.Set<FactSubject> notRead) {
 
-        static final Found NONE = new Found(java.util.Set.of(), java.util.Set.of());
-
         public Found {
             read = java.util.Set.copyOf(read);
             notRead = java.util.Set.copyOf(notRead);
@@ -91,13 +72,6 @@ sealed interface StringRestriction {
         /** Whether the clause states no rule about the strings anywhere. */
         boolean isEmpty() {
             return read.isEmpty() && notRead.isEmpty();
-        }
-
-        /** Every position, whichever of the two it is in. */
-        java.util.Set<FactSubject> anywhere() {
-            java.util.Set<FactSubject> out = new java.util.LinkedHashSet<>(read);
-            out.addAll(notRead);
-            return out;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
@@ -1,9 +1,15 @@
 package souther.compiler.check;
 
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.values.AdmittedPlan;
 
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
- * What one part of a clause states about the strings at one position.
+ * What one reading of a clause states about the strings at one position.
  *
  * <p>Two answers because the reading of such a rule has two outcomes a later reader has to tell
  * apart: it worked out which strings the rule admits, or it did not. Which position the rule is
@@ -16,9 +22,11 @@ import souther.compiler.values.AdmittedPlan;
  * plan alone, a rule this could not read arrived at the reading of where the values stop looking
  * like a rule that admits every string, and a run would have been read off it.
  *
- * <p>Why the reading stopped is not here either. That is the accounting's, said once where the rule
- * was read, and a second copy of it travelling beside this would be a second answer to a question
- * that has an owner.
+ * <p><b>A branch's answer and not a clause's.</b> Which strings a part admits is what its own
+ * branch of every choice in it leaves, and so is whether they were worked out: a branch nobody can
+ * take is dropped, and what it could not read goes with it. Read off the clause as a whole, a rule
+ * this could not read in a branch that turns out impossible would hide the run the branch that
+ * stands does state. So these compose where the readings do.
  */
 sealed interface StringRestriction {
 
@@ -40,38 +48,64 @@ sealed interface StringRestriction {
     }
 
     /**
-     * The rule is one of these and what it admits was not worked out.
+     * The rule is one of these and what it admits was not worked out, and what stopped the reading.
      *
-     * <p>A pattern written more deeply than the subset read, a text composed out of something this
-     * could not fold. What follows is that nothing is known about where the values stop — not that
-     * they stop nowhere.
+     * <p>The reason travels because a reader of this decides more than whether to ask where the
+     * values stop. Whether the rule states a boundary at all is undecided here — not answered no —
+     * and what a report says about a question nothing settled is the reason it was not settled. The
+     * fact itself is the recognition's ({@link StringPredicates.Reading}); this is that one fact
+     * said in the words a rule left unread is written down in.
      */
-    record NotKnown() implements StringRestriction {}
+    record NotKnown(BlockReason.RuleReadingStopped why) implements StringRestriction {
+
+        public NotKnown {
+            if (why == null) {
+                throw new IllegalArgumentException("a reading that stopped was stopped by something");
+            }
+        }
+    }
 
     /**
-     * The positions a clause states a rule about the strings of, told apart by whether the rule was
-     * read to the strings it admits.
+     * What two readings of one position come to, held together or as a choice between them.
      *
-     * <p>A fact about the clause and the same in every branch of a choice in it, which is why it is
-     * worked out where the clause is walked and handed to each branch. What each branch admits at
-     * one of those positions is the branch's own and is read there.
+     * <p>The same rule either way, because what is being asked is what the strings at the position
+     * are and a plan already knows how to be met and joined. Not knowing wins: a part admitting what
+     * one reading leaves together with what another leaves, where the second was not worked out,
+     * admits something this cannot name — and what would be read off the half that was read is a run
+     * of a set the rule does not have, which is what tells a boundary from a distinction.
      *
-     * @param read    the positions every such rule about which was read to its strings
-     * @param notRead the positions some such rule about which was not. A position is in one of the
-     *                two and never both: a part admitting what one rule leaves together with what
-     *                another leaves, where the second was not read, admits something this cannot
-     *                name
+     * @param one the reading on one side, or null where that side states no rule about this
+     *            position — which leaves every string standing there
      */
-    record Found(java.util.Set<FactSubject> read, java.util.Set<FactSubject> notRead) {
-
-        public Found {
-            read = java.util.Set.copyOf(read);
-            notRead = java.util.Set.copyOf(notRead);
+    static StringRestriction over(StringRestriction one, StringRestriction other, boolean met) {
+        if (one instanceof NotKnown it) {
+            return it;
         }
-
-        /** Whether the clause states no rule about the strings anywhere. */
-        boolean isEmpty() {
-            return read.isEmpty() && notRead.isEmpty();
+        if (other instanceof NotKnown it) {
+            return it;
         }
+        AdmittedPlan here = one instanceof Admitting it ? it.plan() : AdmittedPlan.ANY;
+        AdmittedPlan there = other instanceof Admitting it ? it.plan() : AdmittedPlan.ANY;
+        return new Admitting(met
+                ? AdmittedPlan.meeting(java.util.List.of(here, there))
+                : AdmittedPlan.joining(java.util.List.of(here, there)));
+    }
+
+    /** The same over every position either of them states a rule about. */
+    static Map<FactSubject, StringRestriction> over(Map<FactSubject, StringRestriction> these,
+                                                    Map<FactSubject, StringRestriction> those,
+                                                    boolean met) {
+        if (those.isEmpty()) {
+            return these;
+        }
+        if (these.isEmpty()) {
+            return those;
+        }
+        Set<FactSubject> named = new LinkedHashSet<>(these.keySet());
+        named.addAll(those.keySet());
+        Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
+        named.forEach(position ->
+                out.put(position, over(these.get(position), those.get(position), met)));
+        return Map.copyOf(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringRestriction.java
@@ -78,34 +78,52 @@ sealed interface StringRestriction {
      *            position — which leaves every string standing there
      */
     static StringRestriction over(StringRestriction one, StringRestriction other, boolean met) {
+        // A reading that states no rule about the strings here leaves every string standing, and
+        // every string is what a choice between it and anything else leaves. So for a choice it
+        // takes the answer over and there is nothing left to not know; for a conjunction it changes
+        // nothing and the other side stands as it is.
+        if (one == null || other == null) {
+            StringRestriction had = one == null ? other : one;
+            return met ? had : new Admitting(AdmittedPlan.ANY);
+        }
         if (one instanceof NotKnown it) {
             return it;
         }
         if (other instanceof NotKnown it) {
             return it;
         }
-        AdmittedPlan here = one instanceof Admitting it ? it.plan() : AdmittedPlan.ANY;
-        AdmittedPlan there = other instanceof Admitting it ? it.plan() : AdmittedPlan.ANY;
+        AdmittedPlan here = ((Admitting) one).plan();
+        AdmittedPlan there = ((Admitting) other).plan();
         return new Admitting(met
                 ? AdmittedPlan.meeting(java.util.List.of(here, there))
                 : AdmittedPlan.joining(java.util.List.of(here, there)));
     }
 
-    /** The same over every position either of them states a rule about. */
+    /**
+     * The same over every position either of them states a rule about.
+     *
+     * <p>Every position and no shortcut for an empty side. What one reading says nothing about is
+     * every string on that side, and for a choice that absorbs whatever the other says — so a side
+     * with nothing in it is exactly where the answer changes, and taking the other side whole is
+     * the one case that must not be waved through.
+     *
+     * <p>A position stays here whichever way it came out, because the key is also what says this
+     * clause writes about the strings at it. Dropped where the answer came to every string, a rule
+     * about a position would stop being a rule about it.
+     */
     static Map<FactSubject, StringRestriction> over(Map<FactSubject, StringRestriction> these,
                                                     Map<FactSubject, StringRestriction> those,
                                                     boolean met) {
-        if (those.isEmpty()) {
-            return these;
-        }
-        if (these.isEmpty()) {
-            return those;
+        if (these.isEmpty() && those.isEmpty()) {
+            return Map.of();
         }
         Set<FactSubject> named = new LinkedHashSet<>(these.keySet());
         named.addAll(those.keySet());
         Map<FactSubject, StringRestriction> out = new LinkedHashMap<>();
         named.forEach(position ->
                 out.put(position, over(these.get(position), those.get(position), met)));
-        return Map.copyOf(out);
+        // The order the positions were read in, kept: what is written out of these reaches a
+        // report, and the iteration order of an immutable copy is salted once per run.
+        return java.util.Collections.unmodifiableMap(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -151,16 +151,18 @@ public sealed interface BlockReason {
             AboutARule {
 
         /**
-         * One switch over the nine, and the reason for it being one: a division of these into two
-         * is only reviewable where all nine answers are visible together.
+         * One switch over the ten, and the reason for it being one: a division of these into two
+         * is only reviewable where all ten answers are visible together.
          */
         @Override
         default RunSensitivity runSensitivity() {
             return switch (this) {
-                // Two figures this compiler compared a rule against: the states a pattern is built
-                // into, and how deeply one may be bracketed. A run allowed more of either need not
-                // stop at the same rule.
-                case PatternTooCostly _, PatternTooDeeplyNested _ -> RunSensitivity.MAY_CHANGE;
+                // Three figures this compiler compared a rule against: the states a pattern is
+                // built into, how deeply one may be bracketed, and the machines that say where the
+                // strings it admits stop. A run allowed more of any of them need not stop at the
+                // same rule.
+                case PatternTooCostly _, PatternTooDeeplyNested _,
+                     OrderedExtentTooCostly _ -> RunSensitivity.MAY_CHANGE;
                 // And seven where nothing was compared against anything. A form nothing takes
                 // apart, values no line can be drawn on, a rule about a value made from this one, a
                 // relation between two positions, two rules about two coordinates and a pairing
@@ -411,6 +413,32 @@ public sealed interface BlockReason {
      * write differently.
      */
     record PatternTooDeeplyNested() implements RuleReadingStopped {}
+
+    /**
+     * A rule whose strings this read, and whose place on the order they are measured on would take
+     * more machines than this compiler will make.
+     *
+     * <p>Its own case beside {@link PatternTooCostly}, and the difference is what was too large. That
+     * one is the pattern an author wrote turned into the strings it accepts, which is a machine as
+     * big as the pattern is written and is something they can write differently. This is the further
+     * work of asking where those strings begin and end — the strings above the first of them, the
+     * ones the rule leaves out, and the two put together — and none of those is a machine anybody
+     * wrote. Told the other, an author would go looking at a pattern that was read perfectly.
+     *
+     * <p>Which limit refused it is kept. A machine larger than one machine may be is a shape
+     * somebody wrote and could write smaller; an answer that had already spent what it was allowed
+     * is not, and the same rule asked first would have been read.
+     */
+    record OrderedExtentTooCostly(souther.compiler.regex.Meter.Stopped stopped)
+            implements RuleReadingStopped {
+
+        public OrderedExtentTooCostly {
+            if (stopped == null) {
+                throw new IllegalArgumentException(
+                        "a construction that stopped was stopped by a limit");
+            }
+        }
+    }
 
     /**
      * The rules about this position were followed, every one of them became the set it names, and

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1352,14 +1352,18 @@ public final class InputDomain {
         // are written cannot see: no comparison places them, and where they are is in what the
         // other rules leave.
         List<FieldDomains.Placed> moved = placed.movedAtTheValue();
-        // Three sources and not two: what the type's own clauses wrote, what a conjunct of them
-        // moved, and what the value this position sits in placed. Each is ends of one coordinate
-        // and they are intersected, every rule that put an end where it is kept.
+        // Four sources and not two: what the type's own comparisons wrote, what its conjuncts state
+        // that no comparison says — a rule about the strings at a position leaves them running
+        // between two places and orders nothing — what a conjunct of them moved, and what the value
+        // this position sits in placed. Each is ends of one coordinate and they are intersected,
+        // every rule that put an end where it is kept.
         NumberAt.OfWhatNumber kind = bySize ? answeredBy(taken) : ITS_OWN_VALUE;
         Carrier on = bySize ? Carrier.WHOLE : carried;
         DeclaredBounds.Bounds own = !bySize && carried == null ? null
                 : DeclaredBounds.and(
-                        DeclaredBounds.and(bySize ? ofType : valueOfType,
+                        DeclaredBounds.and(
+                                DeclaredBounds.and(bySize ? ofType : valueOfType,
+                                        DeclaredBounds.placed(placed.statedAtTheValue(), kind, on)),
                                 DeclaredBounds.placed(moved, kind, on)),
                         DeclaredBounds.placed(stated, kind, on));
         // A value whose rules contradict has no positions to cover: every edge of every field of it

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1633,8 +1633,13 @@ public final class InputDomain {
                                                      RulesWithNoLine.Gathered found) {
         List<StandingQuestion> out = new ArrayList<>();
         for (PlacedRules.RuleUnclassifiedAt each : placed.unclassified(path)) {
-            found.asked(StandingQuestion.BoundaryUndetermined.of(each.rule(), each.cited(),
-                    FilingCoordinate.at(path), each.at().why()));
+            // One question per thing that stopped it. A published question carries one reason, and
+            // a classification can have been stopped by more than one — a clause read a branch at a
+            // time is stopped by whatever stopped each branch — so they are asked as the several
+            // questions they are rather than one of them standing for the rest.
+            each.at().why().forEach(why ->
+                    found.asked(StandingQuestion.BoundaryUndetermined.of(each.rule(), each.cited(),
+                            FilingCoordinate.at(path), why)));
         }
         for (souther.compiler.check.RuleAccounting.Unanswered each : placed.unanswered(path)) {
             out.add(StandingQuestion.Exact.of(each.rule(), each.cited(),

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -485,6 +485,25 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
     }
 
     /**
+     * The ends the value's own conjuncts state on its own coordinates.
+     *
+     * <p>What {@link #placedAt} leaves out for the same reason it leaves the moved ones out: the
+     * ends of a value's own coordinates are read off the clauses as they are written, and this is
+     * the rest of them. A rule about the strings at a position leaves them running from one place
+     * to another and states no comparison, so that reading sees nothing of it.
+     *
+     * <p>The comparisons are here too and are not left out. An end two readings both saw is one
+     * end drawn by one conjunct of one rule, and putting the two together is what
+     * {@link souther.compiler.check.DeclaredBounds.End#tighter} does with them — a second copy adds
+     * no name and moves nothing.
+     */
+    List<FieldDomains.Placed> statedAtTheValue() {
+        return bounds().stated().stream()
+                .filter(each -> each.path().isTheValueItself())
+                .toList();
+    }
+
+    /**
      * The rules saying where the coordinate at {@code path} stops that no end came out of.
      *
      * <p>At every path the value has, its own included — unlike {@link #placedAt}, whose empty

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Text.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Text.java
@@ -47,6 +47,23 @@ public record Text(String at) implements Place {
         return at.compareTo(text.at);
     }
 
+    /**
+     * The least string above this one, which every string has.
+     *
+     * <p>The order has no predecessor and this is not one: a string above another either begins
+     * with it and goes on, or parts from it at a unit and is above every string that begins with
+     * it — so the least of them is this string and the smallest unit there is. What has no answer is
+     * the other direction, which is why a row just below a line cannot be written
+     * ({@link souther.compiler.check.Carrier.Text}).
+     *
+     * <p>Here because the order is here. A reader working out whether two places have anything
+     * between them is asking about the order, and one that spelled the answer for itself would be a
+     * second definition of what "just above" means.
+     */
+    public Text justAbove() {
+        return new Text(at + (char) 0);
+    }
+
     /** What makes two of these one line: the string. There is no second spelling of one to fold. */
     @Override
     public String key() {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -75,7 +75,13 @@ public final class ReportedReason {
             // question about what this compiler may say next rather than about what a document
             // promises its reader. Out there both are the same kind of thing: the values are wider
             // than the rules leave them, because working them out was too much.
-            case BlockReason.PatternTooCostly _, BlockReason.ExactValuesTooCostly _ ->
+            // And a third with them, for the same reason and about further work again: where the
+            // strings a rule admits stop is asked of machines made out of the ones the rule named,
+            // and a limit reached there is the values coming out wider than the rules leave them.
+            // Which of the three it was decides what may be said next and not what a reader is
+            // promised.
+            case BlockReason.PatternTooCostly _, BlockReason.ExactValuesTooCostly _,
+                 BlockReason.OrderedExtentTooCostly _ ->
                     UndividedPosition.Reason.EXACT_VALUES_TOO_COSTLY;
             // And its own word again, because this one never reached the values at all. A reader
             // told the values were too much would go looking for what makes them so, and what is

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -55,6 +55,43 @@ final class Automaton {
     }
 
     /**
+     * A machine written out state by state, for a builder in this package that has one to write.
+     *
+     * <p>Beside {@link #of} and not instead of it. That one is handed a pattern and works out the
+     * states; a builder here holds a machine whose states follow from something that is not a
+     * pattern — where a string sits against another on the runtime's order, which no pattern says —
+     * and has nothing to be read from. Both end in the same three tables, which is what keeps a
+     * machine made this way answerable to everything below.
+     *
+     * <p>No free steps: a builder writing its own states writes what each one leads to, so a step
+     * costing no symbol is a state it did not need. One that wants them builds through {@link #of}.
+     */
+    static Automaton madeOf(List<List<Step>> steps, BitSet accepting) {
+        List<int[]> free = new ArrayList<>();
+        for (int at = 0; at < steps.size(); at++) {
+            free.add(new int[0]);
+        }
+        return new Automaton(steps, free, accepting);
+    }
+
+    /**
+     * The steps out of one state, for a reader in this package walking a canonical machine.
+     *
+     * <p>Only ever asked of one that is canonical, where a walk is the whole of what there is to do:
+     * the machine is deterministic and complete, so every symbol leads somewhere and where it leads
+     * is a fact about the symbol. Asked of a machine that is not, a reader would be walking one of
+     * the ways the pattern happened to be written.
+     */
+    List<Step> stepsFrom(int state) {
+        return steps.get(state);
+    }
+
+    /** Whether a walk may stop at {@code state}. */
+    boolean stopsAt(int state) {
+        return accepting.get(state);
+    }
+
+    /**
      * The machine for {@code syntax}, or null where building it would take more than
      * {@code mostStates}.
      *

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -92,26 +92,66 @@ final class Automaton {
     }
 
     /**
-     * Whether any step of this is over a high surrogate.
+     * Whether a walk over this may stop having read a high surrogate and a low one in turn.
      *
-     * <p>Asked to find out whether taking the sequences no string is read as out of this would
-     * change it. Such a sequence holds a high surrogate standing as a symbol of its own, so a
-     * machine no step of which is over one accepts none of them and is already the strings it holds.
+     * <p>That pair of symbols is the one thing no string is read as, so a machine that stops on no
+     * sequence holding them already accepts nothing but strings and taking them out would change
+     * nothing.
      *
-     * <p>A walk over the steps and nothing built, which is the point: what it saves is a product
-     * every language would otherwise be put through, and the patterns a model writes name no
-     * surrogate at all. What it costs where the answer is yes is one comparison.
+     * <p><b>Whether it stops, and not whether it has a step.</b> A canonical machine is complete —
+     * every symbol leads somewhere from every state — so every one of them has a step over a high
+     * surrogate and asking that says only that the machine is complete. Where such a step leads is
+     * the question: a pattern naming no surrogate leads to the state nothing stops at, and the
+     * sequence is refused there as it always was.
+     *
+     * <p>A walk over the states and nothing built. What it saves is a product every language would
+     * otherwise be put through.
      */
-    boolean mayReadALoneHighSurrogate() {
+    boolean mayStopHavingReadALoneSurrogatePair() {
         CodePoints high = CodePoints.between(0xD800, 0xDBFF);
-        for (List<Step> out : steps) {
-            for (Step each : out) {
-                if (!each.over().and(high).isEmpty()) {
-                    return true;
+        CodePoints low = CodePoints.between(0xDC00, 0xDFFF);
+        boolean[] reaches = reaching();
+        for (int at = 0; at < steps.size(); at++) {
+            for (Step first : steps.get(at)) {
+                if (first.over().and(high).isEmpty()) {
+                    continue;
+                }
+                for (Step second : steps.get(first.to())) {
+                    if (!second.over().and(low).isEmpty() && reaches[second.to()]) {
+                        return true;
+                    }
                 }
             }
         }
         return false;
+    }
+
+    /** For each state, whether a walk from it may still reach one it stops at. */
+    private boolean[] reaching() {
+        List<List<Integer>> back = new ArrayList<>();
+        for (int at = 0; at < steps.size(); at++) {
+            back.add(new ArrayList<>());
+        }
+        for (int at = 0; at < steps.size(); at++) {
+            for (Step each : steps.get(at)) {
+                back.get(each.to()).add(at);
+            }
+        }
+        boolean[] out = new boolean[steps.size()];
+        List<Integer> waiting = new ArrayList<>();
+        for (int at = accepting.nextSetBit(0); at >= 0; at = accepting.nextSetBit(at + 1)) {
+            out[at] = true;
+            waiting.add(at);
+        }
+        for (int at = 0; at < waiting.size(); at++) {
+            for (int from : back.get(waiting.get(at))) {
+                if (!out[from]) {
+                    out[from] = true;
+                    waiting.add(from);
+                }
+            }
+        }
+        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -92,6 +92,29 @@ final class Automaton {
     }
 
     /**
+     * Whether any step of this is over a high surrogate.
+     *
+     * <p>Asked to find out whether taking the sequences no string is read as out of this would
+     * change it. Such a sequence holds a high surrogate standing as a symbol of its own, so a
+     * machine no step of which is over one accepts none of them and is already the strings it holds.
+     *
+     * <p>A walk over the steps and nothing built, which is the point: what it saves is a product
+     * every language would otherwise be put through, and the patterns a model writes name no
+     * surrogate at all. What it costs where the answer is yes is one comparison.
+     */
+    boolean mayReadALoneHighSurrogate() {
+        CodePoints high = CodePoints.between(0xD800, 0xDBFF);
+        for (List<Step> out : steps) {
+            for (Step each : out) {
+                if (!each.over().and(high).isEmpty()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * The machine for {@code syntax}, or null where building it would take more than
      * {@code mostStates}.
      *

--- a/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Automaton.java
@@ -110,7 +110,7 @@ final class Automaton {
     boolean mayStopHavingReadALoneSurrogatePair() {
         CodePoints high = CodePoints.between(0xD800, 0xDBFF);
         CodePoints low = CodePoints.between(0xDC00, 0xDFFF);
-        boolean[] reaches = reaching();
+        boolean[] reaches = reachingSomewhereItStops();
         for (int at = 0; at < steps.size(); at++) {
             for (Step first : steps.get(at)) {
                 if (first.over().and(high).isEmpty()) {
@@ -126,8 +126,15 @@ final class Automaton {
         return false;
     }
 
-    /** For each state, whether a walk from it may still reach one it stops at. */
-    private boolean[] reaching() {
+    /**
+     * For each state, whether a walk from it may still reach one it stops at.
+     *
+     * <p>Here because it is a fact about the machine and about nothing else, and because more than
+     * one reader wants it: what a walk looking for a string does with a step is settled by whether
+     * anything is stopped at past it, and so is whether a shape the machine has is one a string
+     * ever reaches. Worked out by each of them, the two would be one walk written twice.
+     */
+    boolean[] reachingSomewhereItStops() {
         List<List<Integer>> back = new ArrayList<>();
         for (int at = 0; at < steps.size(); at++) {
             back.add(new ArrayList<>());

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -63,6 +63,39 @@ public final class Language {
         return machine.accepts(value);
     }
 
+    /**
+     * Every string that comes before {@code than} on the strings' own order, or null past what
+     * {@code meter} allows.
+     *
+     * <p>The order the runtime makes and a model's {@code <} is, which is not the order the symbols
+     * of a machine are in — so this is built rather than read off an alphabet, and where it is built
+     * is {@link RuntimeOrder}. Metered like every other way to a language: what a caller is told
+     * past the allowance is that this was not made.
+     *
+     * <p>Here rather than in the layer that reasons about where a language stops, because a language
+     * is what this returns and a machine is what makes one. What such a caller does with it — meet
+     * it, take it away, ask whether two of them are one — is what a language already answers.
+     */
+    public static Language before(String than, Meter meter) {
+        return canonical(RuntimeOrder.before(than, meter), meter);
+    }
+
+    /**
+     * The least string it holds, or null where it holds none and where the ones it holds have no
+     * least among them.
+     *
+     * <p>Free, like everything else asked of one of these: read off the canonical machine, and
+     * nothing is built. The two nulls are one answer here because neither is a string — a caller
+     * telling them apart asks {@link #isEmpty}, which is free as well.
+     *
+     * <p>Not {@link #some}. That one answers with the shortest, which is a different string: a
+     * language of two-letter words holds no shorter one, and which of them comes first is what this
+     * is about.
+     */
+    public String least() {
+        return RuntimeOrder.leastOf(machine);
+    }
+
     /** The strings both hold, or null where making them ran past what {@code meter} allows. */
     public Language and(Language other, Meter meter) {
         return canonical(machine.and(other.machine, meter), meter);

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -61,18 +61,30 @@ public final class Language {
      * that and take them out for itself — which is the reading of one thing in two places this file
      * exists to stop.
      *
-     * <p>Skipped where it can change nothing. Such a sequence holds a high surrogate standing as a
-     * symbol of its own, so a machine no step of which is over one already accepts none of them —
-     * which is every pattern a model writes.
+     * <p>Skipped where it can change nothing, which is asked of the one machine and not of the
+     * steps it is written with. A canonical machine is complete, so every one of them has a step
+     * over a high surrogate and having one says nothing; what says something is whether such a step
+     * leads anywhere a walk that then reads a low surrogate may stop. A pattern naming no surrogate
+     * leads to the state nothing stops at, and nothing is built for it.
+     *
+     * <p>Which is why the one machine is made first and made again only where the answer is yes.
+     * Asked of what came in, the walk would have to follow the steps that cost no symbol, and what
+     * it is looking for is two symbols in turn.
      */
     static Language canonical(Automaton made, Meter meter) {
         if (made == null) {
             return null;
         }
-        Automaton held = made.mayReadALoneHighSurrogate()
-                ? made.and(RuntimeOrder.EVERY_STRING, meter) : made;
-        Automaton one = held == null ? null : held.canonical(meter);
-        return one == null ? null : new Language(one);
+        Automaton one = made.canonical(meter);
+        if (one == null) {
+            return null;
+        }
+        if (!one.mayStopHavingReadALoneSurrogatePair()) {
+            return new Language(one);
+        }
+        Automaton held = one.and(RuntimeOrder.READS_ONLY_STRINGS, meter);
+        Automaton settled = held == null ? null : held.canonical(meter);
+        return settled == null ? null : new Language(settled);
     }
 
     /** Whether the whole of {@code value} is in it. A walk over the value, which builds nothing. */
@@ -99,6 +111,19 @@ public final class Language {
 
     /** Every string there is, which is what a rule saying nothing leaves. */
     public static final Language EVERY_STRING = new Language(RuntimeOrder.EVERY_STRING);
+
+    /**
+     * The strings {@code words} and no others, or null past what {@code meter} allows.
+     *
+     * <p>For a caller holding values a rule wrote out rather than a pattern. What they are is a set
+     * of strings like any other, and a reader asking where a rule's values stop has one question
+     * whichever way the rule named them — handed only the patterns, it would have to ask the values
+     * written out something else, and the two answers would be about the same strings.
+     */
+    public static Language ofWords(java.util.Collection<String> words, Meter meter) {
+        Automaton made = Automaton.ofWords(words, meter);
+        return made == null ? null : canonical(made, meter);
+    }
 
     /**
      * The least string it holds, or null where it holds none and where the ones it holds have no

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -29,10 +29,10 @@ public final class Language {
     /**
      * The one machine that accepts these strings, which is what everything here is read off.
      *
-     * <p>Canonical, and that is the type's invariant rather than a thing a caller arranges. Every
-     * way to a language ends in {@link Automaton#canonical}, so two of these hold the same table
-     * exactly when they hold the same strings — and the questions below are a look at what is in
-     * front of them rather than a search nobody counted.
+     * <p>Canonical, and stopping on nothing but strings. Both are the type's invariant rather than
+     * things a caller arranges, and every way to a language goes through {@link #canonical} — so
+     * two of these hold the same table exactly when they hold the same strings, and the questions
+     * below are a look at what is in front of them rather than a search nobody counted.
      */
     private final Automaton machine;
 
@@ -44,17 +44,34 @@ public final class Language {
     }
 
     /**
-     * The same language, where making it canonical is within what {@code meter} allows.
+     * The strings {@code made} stops on, where making the one machine for them is within what
+     * {@code meter} allows.
      *
      * <p>Null and never a machine short of canonical. What is being decided is whether this
      * compiler can afford to answer exactly, and a half-made answer handed out is one whose next
      * question does the rest of the work somewhere nobody is counting.
+     *
+     * <p><b>The sequences no string is read as are taken out here, and nowhere else.</b> A machine
+     * steps over what a matcher reads, and a high surrogate followed by a low one is one symbol
+     * rather than two — so there are sequences of symbols no string is written as, and a complement
+     * holds them like anything else. Left in, two machines telling each other apart only over those
+     * would be two languages holding the same strings and comparing unequal, and a machine holding
+     * nothing but them would say it holds something. Every question below would then be about
+     * sequences where the type says it is about strings, and each of its callers would have to know
+     * that and take them out for itself — which is the reading of one thing in two places this file
+     * exists to stop.
+     *
+     * <p>Skipped where it can change nothing. Such a sequence holds a high surrogate standing as a
+     * symbol of its own, so a machine no step of which is over one already accepts none of them —
+     * which is every pattern a model writes.
      */
-    private static Language canonical(Automaton made, Meter meter) {
+    static Language canonical(Automaton made, Meter meter) {
         if (made == null) {
             return null;
         }
-        Automaton one = made.canonical(meter);
+        Automaton held = made.mayReadALoneHighSurrogate()
+                ? made.and(RuntimeOrder.EVERY_STRING, meter) : made;
+        Automaton one = held == null ? null : held.canonical(meter);
         return one == null ? null : new Language(one);
     }
 
@@ -80,21 +97,8 @@ public final class Language {
         return canonical(RuntimeOrder.before(than, meter), meter);
     }
 
-    /**
-     * Every string there is, or null past what {@code meter} allows.
-     *
-     * <p>Which is not what {@link #not} of nothing comes to. A machine steps over what a matcher
-     * reads, and a high surrogate followed by a low one is one symbol rather than two — so there are
-     * sequences of symbols no string is read as, and a complement holds them like anything else.
-     * Where a caller is asking whether two languages hold the same strings, two machines that differ
-     * only over those are two spellings of one answer, and this is what takes them out.
-     *
-     * <p>For a caller composing an answer out of complements. One asking whether a string is held
-     * needs nothing of it: that walk is over the string, and a string is never read as one of them.
-     */
-    public static Language everyString(Meter meter) {
-        return canonical(RuntimeOrder.everyString(meter), meter);
-    }
+    /** Every string there is, which is what a rule saying nothing leaves. */
+    public static final Language EVERY_STRING = new Language(RuntimeOrder.EVERY_STRING);
 
     /**
      * The least string it holds, or null where it holds none and where the ones it holds have no
@@ -142,11 +146,14 @@ public final class Language {
      *
      * <p>Asked of the strings and not of how it was written. {@code .*} is not everything — the
      * five line terminators are outside it — and a reader answering from the shape of a pattern
-     * would say it was. Read off the canonical machine, which for that language is the one state
-     * every string stops at.
+     * would say it was.
+     *
+     * <p>Which is the one machine every string stops at and not the one state every symbol does:
+     * the sequences no string is read as are not in any language here, so a language holding every
+     * string is a machine that turns those away and stops on the rest.
      */
     public boolean isEverything() {
-        return machine.holdsEverything();
+        return equals(EVERY_STRING);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/Language.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/Language.java
@@ -81,6 +81,22 @@ public final class Language {
     }
 
     /**
+     * Every string there is, or null past what {@code meter} allows.
+     *
+     * <p>Which is not what {@link #not} of nothing comes to. A machine steps over what a matcher
+     * reads, and a high surrogate followed by a low one is one symbol rather than two — so there are
+     * sequences of symbols no string is read as, and a complement holds them like anything else.
+     * Where a caller is asking whether two languages hold the same strings, two machines that differ
+     * only over those are two spellings of one answer, and this is what takes them out.
+     *
+     * <p>For a caller composing an answer out of complements. One asking whether a string is held
+     * needs nothing of it: that walk is over the string, and a string is never read as one of them.
+     */
+    public static Language everyString(Meter meter) {
+        return canonical(RuntimeOrder.everyString(meter), meter);
+    }
+
+    /**
      * The least string it holds, or null where it holds none and where the ones it holds have no
      * least among them.
      *

--- a/souther-compiler/src/main/java/souther/compiler/regex/PatternPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/PatternPlan.java
@@ -72,6 +72,22 @@ public final class PatternPlan {
          * constant, the day either question wants a different size the other would move with it.
          */
         public static final Budget OF_A_WITNESS = new Budget(50_000, 200_000);
+
+        /**
+         * What working out where one rule's strings stop on the order is allowed to cost.
+         *
+         * <p>One rule's and not one position's. What is being asked is where the strings a single
+         * conjunct admits begin and end, and the answer is a line that conjunct drew — so a rule
+         * whose language is expensive taking the allowance the rule beside it needed would leave a
+         * line standing or going by the order the two happened to be read in.
+         *
+         * <p>Apart from what the values cost for the same reason {@link #OF_A_WITNESS} is: this is
+         * a question asked to write a report, and paying for it out of what the position's own
+         * answer is allowed would let a diagnostic decide what the model is read to admit.
+         *
+         * <p>The same numbers as the two above, and a coincidence rather than a fact.
+         */
+        public static final Budget OF_AN_ORDERED_EXTENT = new Budget(50_000, 200_000);
     }
 
     /** What one step of a plan does. */

--- a/souther-compiler/src/main/java/souther/compiler/regex/PatternPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/PatternPlan.java
@@ -327,9 +327,7 @@ public final class PatternPlan {
         // accepts its strings, and turning a machine into that one is the largest thing this does —
         // left to the reader, it would happen inside whichever question was asked first, where
         // there is no allowance and nobody counting.
-        Automaton made = built(step, meter);
-        Automaton one = made == null ? null : made.canonical(meter);
-        return one == null ? null : new Language(one);
+        return Language.canonical(built(step, meter), meter);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
@@ -1,0 +1,346 @@
+package souther.compiler.regex;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * The strings' own order, asked of a language.
+ *
+ * <p>{@link String#compareTo}, which is the comparison the runtime makes and the one a model's
+ * {@code <} is (spec §primitives). It orders UTF-16 code units, and a symbol here is what a matcher
+ * reads — a code point where a string holds a well-formed pair, a unit where it holds half of one
+ * ({@link CodePoints}). Those are not the same order and no relabelling of the symbols makes them
+ * one: {@code "\uD800￿"} is one unit above {@code "𐀀"} on the runtime's order and
+ * one symbol below it here, because the two spend a different number of units on their first
+ * symbol. So everything below reads a language a unit at a time, and the symbols are taken apart
+ * where they are read.
+ *
+ * <p>Which is the whole of why this is a place rather than a comparator handed to a language. A
+ * comparator can order two symbols and cannot say that one of them ends where the other has more to
+ * come — and the answer to that is what the two questions here are about.
+ *
+ * <p><b>Answerable to the order itself.</b> Nothing here is a second definition of {@code <} on
+ * strings: what is built is a machine and what is walked is a machine, and both are held to
+ * {@code String.compareTo} by the laws over them
+ * ({@code TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest}).
+ */
+final class RuntimeOrder {
+
+    /** The greatest UTF-16 code unit, which is where a unit stops being one. */
+    private static final int LAST_UNIT = 0xFFFF;
+
+    private static final int HIGH_FROM = 0xD800;
+    private static final int HIGH_TO = 0xDBFF;
+    private static final int LOW_FROM = 0xDC00;
+    private static final int LOW_TO = 0xDFFF;
+
+    /** The first symbol past the units, which is where a pair's two units stand for one symbol. */
+    private static final int PAIRED_FROM = 0x10000;
+
+    /**
+     * The machine accepting every string that comes before {@code than}, or null past what
+     * {@code meter} allows.
+     *
+     * <p>One state per unit of {@code than} and two besides. A walk is at the state saying how many
+     * of those units the string has matched exactly; a unit below the next one settles the answer
+     * and a unit above it leads nowhere, so the states a walk can be in are that count, the state
+     * where the whole of {@code than} has been matched, and the one where the answer is already
+     * yes.
+     *
+     * <p>A walk that stops having matched some of {@code than} and no more is a string that is a
+     * proper prefix of it, which is below it — so those states are where a walk may stop, and the
+     * one that matched all of it is not, since that string is {@code than} itself.
+     */
+    static Automaton before(String than, Meter meter) {
+        int units = than.length();
+        Meter.Making making = meter.making();
+        if (!making.states(units + 2L)) {
+            return null;
+        }
+        int below = units + 1;
+        List<List<Automaton.Step>> steps = new ArrayList<>();
+        for (int at = 0; at <= below; at++) {
+            steps.add(new ArrayList<>());
+        }
+        BitSet accepting = new BitSet();
+        for (int at = 0; at < units; at++) {
+            accepting.set(at);
+            written(steps.get(at), than, at, below);
+        }
+        accepting.set(below);
+        steps.get(below).add(new Automaton.Step(CodePoints.EVERYTHING, below));
+        return Automaton.madeOf(steps, accepting);
+    }
+
+    /**
+     * What one symbol read at {@code at} does, as the steps out of that state.
+     *
+     * <p>Two kinds of symbol and not one. A symbol below the units is a unit and is compared with
+     * the one wanted here; a symbol above them is a pair, and its first unit is compared here while
+     * its second is compared against the unit after — so a pair can settle the answer, carry the
+     * walk two units on, or lead nowhere, and which of the three is read off both units together.
+     */
+    private static void written(List<Automaton.Step> out, String than, int at, int below) {
+        char want = than.charAt(at);
+        CodePoints lower = want > 0 ? CodePoints.between(0, want - 1) : CodePoints.NONE;
+        lower = lower.or(pairsBefore(want));
+        if (!lower.isEmpty()) {
+            out.add(new Automaton.Step(lower, below));
+        }
+        out.add(new Automaton.Step(CodePoints.of(want), at + 1));
+        pairAt(out, than, at, below);
+    }
+
+    /**
+     * The pairs whose first unit is already below {@code want}.
+     *
+     * <p>A pair's first unit is a high surrogate, so which pairs these are turns on where
+     * {@code want} sits against that range: above all of them every pair is below, below all of them
+     * none is, and inside them it is the pairs written with a smaller high surrogate.
+     */
+    private static CodePoints pairsBefore(char want) {
+        if (want > HIGH_TO) {
+            return CodePoints.between(PAIRED_FROM, CodePoints.LAST);
+        }
+        if (want <= HIGH_FROM) {
+            return CodePoints.NONE;
+        }
+        return CodePoints.between(PAIRED_FROM, blockOf(want) - 1);
+    }
+
+    /**
+     * What a pair whose first unit is exactly the one wanted here comes to.
+     *
+     * <p>Its second unit is compared against the unit after this one. Where there is none —
+     * {@code than} ends on the high surrogate — the string has all of {@code than} and goes on, so
+     * it is above it and the pair leads nowhere.
+     */
+    private static void pairAt(List<Automaton.Step> out, String than, int at, int below) {
+        char want = than.charAt(at);
+        if (want < HIGH_FROM || want > HIGH_TO) {
+            return;
+        }
+        int block = blockOf(want);
+        if (at + 1 >= than.length()) {
+            return;
+        }
+        char next = than.charAt(at + 1);
+        if (next < LOW_FROM) {
+            return;
+        }
+        if (next > LOW_TO) {
+            out.add(new Automaton.Step(CodePoints.between(block, block + (LOW_TO - LOW_FROM)),
+                    below));
+            return;
+        }
+        int same = block + (next - LOW_FROM);
+        if (same > block) {
+            out.add(new Automaton.Step(CodePoints.between(block, same - 1), below));
+        }
+        out.add(new Automaton.Step(CodePoints.of(same), at + 2));
+    }
+
+    /** The first symbol written with {@code high} as its first unit. */
+    private static int blockOf(int high) {
+        return PAIRED_FROM + ((high - HIGH_FROM) << 10);
+    }
+
+    /**
+     * The least string {@code machine} accepts, or null where it accepts none and where the ones it
+     * accepts have no least among them.
+     *
+     * <p>Two answers under one null on purpose: neither is a place on the order, and a caller
+     * wanting them apart asks whether the language holds anything, which is free. What has no least
+     * is a language whose strings descend without stopping — {@code a*b} holds {@code b} above
+     * {@code ab} above {@code aab} and so on down — and the greatest lower bound of those is not a
+     * string. There is nothing to write down, and a reading that answered with the one it had
+     * reached would be naming a value the rules do not stop at.
+     *
+     * <p>Free, as everything asked of a language is: the machine is in front of this and nothing is
+     * built. A walk a unit at a time over a machine whose steps are symbols, which is why the states
+     * are a set rather than one — a high surrogate is a symbol of its own and the first unit of
+     * every pair, so a unit read here can leave the walk in both.
+     *
+     * <p>Least by taking the least unit that still leads to somewhere a walk may stop, and stopping
+     * at the first place it may. A shorter string is below every string it begins, so where the walk
+     * may stop it has the least; and where it comes back to a set of states it has been in, it never
+     * will — the same units are chosen again, and each time round leaves a string below the last.
+     */
+    static String leastOf(Automaton machine) {
+        boolean[] reaches = reaching(machine);
+        if (!reaches[Automaton.START]) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder();
+        Set<Where> here = Set.of(new Where(Automaton.START, null));
+        Set<Set<Where>> been = new LinkedHashSet<>();
+        while (been.add(here)) {
+            if (stops(here, machine)) {
+                return out.toString();
+            }
+            int unit = leastUnit(here, machine, reaches);
+            if (unit < 0) {
+                return null;
+            }
+            out.append((char) unit);
+            here = after(here, unit, machine);
+        }
+        return null;
+    }
+
+    /**
+     * Where a walk is, which is a state of the machine or half way into a pair.
+     *
+     * @param state where the walk is, or where the pair being read leads
+     * @param lows  the second units the pair may be finished with, or null where the walk is at a
+     *              symbol boundary. A high surrogate read at a boundary is both a symbol and the
+     *              first unit of a pair, so both are held and the walk is in as many places as the
+     *              units so far leave it
+     */
+    private record Where(int state, CodePoints lows) {}
+
+    /** Whether a walk in one of these may stop, which it may only at a symbol boundary. */
+    private static boolean stops(Set<Where> here, Automaton machine) {
+        return here.stream().anyMatch(each -> each.lows() == null && machine.stopsAt(each.state()));
+    }
+
+    /** Whether a walk in one of these may still reach somewhere it stops. */
+    private static boolean reachable(Set<Where> here, boolean[] reaches) {
+        return here.stream().anyMatch(each -> reaches[each.state()]);
+    }
+
+    /**
+     * The least unit that leaves the walk somewhere it may still stop, or -1 where no unit does.
+     *
+     * <p>Over the units the steps change at rather than over every unit there is. What a step is
+     * over is runs of symbols, so two units inside one run of every step here lead to the same
+     * places — and the least of a run is the one to try.
+     */
+    private static int leastUnit(Set<Where> here, Automaton machine, boolean[] reaches) {
+        for (int unit : boundaries(here, machine)) {
+            if (reachable(after(here, unit, machine), reaches)) {
+                return unit;
+            }
+        }
+        return -1;
+    }
+
+    /** The units where what a step leads to can change, in order. */
+    private static Set<Integer> boundaries(Set<Where> here, Automaton machine) {
+        Set<Integer> out = new TreeSet<>();
+        for (Where each : here) {
+            if (each.lows() != null) {
+                starts(out, each.lows());
+                continue;
+            }
+            for (Automaton.Step step : machine.stepsFrom(each.state())) {
+                starts(out, unitsOf(step.over()));
+                starts(out, highsOf(step.over()));
+            }
+        }
+        return out;
+    }
+
+    private static void starts(Set<Integer> out, CodePoints over) {
+        for (CodePoints.Range each : over.ranges()) {
+            out.add(each.from());
+        }
+    }
+
+    /** Where the walk is once {@code unit} has been read. */
+    private static Set<Where> after(Set<Where> here, int unit, Automaton machine) {
+        Set<Where> out = new LinkedHashSet<>();
+        for (Where each : here) {
+            if (each.lows() != null) {
+                if (each.lows().has(unit)) {
+                    out.add(new Where(each.state(), null));
+                }
+                continue;
+            }
+            for (Automaton.Step step : machine.stepsFrom(each.state())) {
+                if (step.over().has(unit) && unit <= LAST_UNIT) {
+                    out.add(new Where(step.to(), null));
+                }
+                CodePoints lows = lowsOf(step.over(), unit);
+                if (!lows.isEmpty()) {
+                    out.add(new Where(step.to(), lows));
+                }
+            }
+        }
+        return out;
+    }
+
+    /** The symbols in {@code over} that are units, as those units. */
+    private static CodePoints unitsOf(CodePoints over) {
+        return over.and(CodePoints.between(0, LAST_UNIT));
+    }
+
+    /** The first units of the pairs in {@code over}. */
+    private static CodePoints highsOf(CodePoints over) {
+        List<CodePoints.Range> out = new ArrayList<>();
+        for (CodePoints.Range each : over.ranges()) {
+            int from = Math.max(each.from(), PAIRED_FROM);
+            if (from > each.to()) {
+                continue;
+            }
+            out.add(new CodePoints.Range(highOf(from), highOf(each.to())));
+        }
+        return new CodePoints(out);
+    }
+
+    /** The second units a pair beginning with {@code high} may be finished with, here. */
+    private static CodePoints lowsOf(CodePoints over, int high) {
+        if (high < HIGH_FROM || high > HIGH_TO) {
+            return CodePoints.NONE;
+        }
+        int block = blockOf(high);
+        CodePoints inside = over.and(CodePoints.between(block, block + (LOW_TO - LOW_FROM)));
+        List<CodePoints.Range> out = new ArrayList<>();
+        for (CodePoints.Range each : inside.ranges()) {
+            out.add(new CodePoints.Range(LOW_FROM + each.from() - block,
+                    LOW_FROM + each.to() - block));
+        }
+        return new CodePoints(out);
+    }
+
+    /** The first unit of the pair {@code symbol} is written as. */
+    private static int highOf(int symbol) {
+        return HIGH_FROM + ((symbol - PAIRED_FROM) >> 10);
+    }
+
+    /** For each state, whether a walk from it may still reach somewhere it stops. */
+    private static boolean[] reaching(Automaton machine) {
+        List<List<Integer>> back = new ArrayList<>();
+        for (int at = 0; at < machine.size(); at++) {
+            back.add(new ArrayList<>());
+        }
+        for (int at = 0; at < machine.size(); at++) {
+            for (Automaton.Step each : machine.stepsFrom(at)) {
+                back.get(each.to()).add(at);
+            }
+        }
+        boolean[] out = new boolean[machine.size()];
+        List<Integer> waiting = new ArrayList<>();
+        for (int at = 0; at < machine.size(); at++) {
+            if (machine.stopsAt(at)) {
+                out[at] = true;
+                waiting.add(at);
+            }
+        }
+        for (int at = 0; at < waiting.size(); at++) {
+            for (int from : back.get(waiting.get(at))) {
+                if (!out[from]) {
+                    out[from] = true;
+                    waiting.add(from);
+                }
+            }
+        }
+        return out;
+    }
+
+    private RuntimeOrder() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
@@ -157,12 +157,31 @@ final class RuntimeOrder {
      * wrote — charged to an allowance, every language would be a little smaller than the one before
      * it for a reason nobody could see.
      */
-    static final Automaton EVERY_STRING = onlyStrings();
+    static final Automaton EVERY_STRING = canonicalOnlyStrings();
+
+    /**
+     * The same machine as it is written, which is what a product is taken against.
+     *
+     * <p>Two states and not the canonical three. A machine is not required to be complete, so the
+     * state a walk goes to when it is already refused need not be there — and a product is charged
+     * for the states it will make, so leaving it out is a third off every restriction.
+     */
+    static final Automaton READS_ONLY_STRINGS = onlyStrings();
 
     private static Automaton onlyStrings() {
+        Automaton made = everyString(new Meter(16, 64));
+        if (made == null) {
+            throw new IllegalStateException("the machine that reads only strings is two states");
+        }
+        return made;
+    }
+
+    private static Automaton canonicalOnlyStrings() {
+        // Its own, and not the constant beside it. A constant made out of another is made after it
+        // whatever a reader expects of the order they are written in, and one made first reads
+        // nothing where the other will be.
         Meter meter = new Meter(16, 64);
-        Automaton made = everyString(meter);
-        Automaton one = made == null ? null : made.canonical(meter);
+        Automaton one = onlyStrings().canonical(meter);
         if (one == null) {
             throw new IllegalStateException("the machine for every string is three states");
         }

--- a/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
@@ -150,6 +150,40 @@ final class RuntimeOrder {
     }
 
     /**
+     * The symbol sequences some string is read as, or null past what {@code meter} allows.
+     *
+     * <p>Not every sequence of symbols is one. A high surrogate followed by a low one is the pair —
+     * that is what a matcher reads and what a walk over a string takes in — so those two symbols
+     * never stand beside each other, and a sequence holding them is one no string produces.
+     *
+     * <p>Which matters wherever a set question is asked rather than a membership one. Whether a
+     * string is held is walked out of the string and never meets such a sequence; whether two
+     * languages hold the same strings is a walk over two machines, and two machines telling the
+     * same strings apart from each other only over sequences no string reads as are two spellings of
+     * one set. So a reader taking a complement to ask about strings meets it with this, and a reader
+     * asking whether a string is in something does not need it.
+     */
+    static Automaton everyString(Meter meter) {
+        Meter.Making making = meter.making();
+        if (!making.states(2)) {
+            return null;
+        }
+        CodePoints high = CodePoints.between(HIGH_FROM, HIGH_TO);
+        CodePoints low = CodePoints.between(LOW_FROM, LOW_TO);
+        List<List<Automaton.Step>> steps = new ArrayList<>();
+        steps.add(new ArrayList<>(List.of(
+                new Automaton.Step(CodePoints.EVERYTHING.less(high), 0),
+                new Automaton.Step(high, 1))));
+        steps.add(new ArrayList<>(List.of(
+                new Automaton.Step(CodePoints.EVERYTHING.less(high).less(low), 0),
+                new Automaton.Step(high, 1))));
+        BitSet accepting = new BitSet();
+        accepting.set(0);
+        accepting.set(1);
+        return Automaton.madeOf(steps, accepting);
+    }
+
+    /**
      * The least string {@code machine} accepts, or null where it accepts none and where the ones it
      * accepts have no least among them.
      *
@@ -176,7 +210,7 @@ final class RuntimeOrder {
             return null;
         }
         StringBuilder out = new StringBuilder();
-        Set<Where> here = Set.of(new Where(Automaton.START, null));
+        Set<Where> here = Set.of(new Where(Automaton.START, null, false));
         Set<Set<Where>> been = new LinkedHashSet<>();
         while (been.add(here)) {
             if (stops(here, machine)) {
@@ -200,8 +234,13 @@ final class RuntimeOrder {
      *              symbol boundary. A high surrogate read at a boundary is both a symbol and the
      *              first unit of a pair, so both are held and the walk is in as many places as the
      *              units so far leave it
+     * @param loneHigh whether the last symbol read was a high surrogate standing alone. A string
+     *              holding one followed by a low surrogate is a string holding the pair — that is
+     *              what a matcher reads and what {@link Automaton#accepts} walks — so the two
+     *              symbols never stand beside each other and a walk that let them would answer with
+     *              a string the language does not hold
      */
-    private record Where(int state, CodePoints lows) {}
+    private record Where(int state, CodePoints lows, boolean loneHigh) {}
 
     /** Whether a walk in one of these may stop, which it may only at a symbol boundary. */
     private static boolean stops(Set<Where> here, Automaton machine) {
@@ -257,17 +296,20 @@ final class RuntimeOrder {
         for (Where each : here) {
             if (each.lows() != null) {
                 if (each.lows().has(unit)) {
-                    out.add(new Where(each.state(), null));
+                    out.add(new Where(each.state(), null, false));
                 }
                 continue;
             }
+            // A low surrogate after a high one standing alone is the pair, not two symbols, so the
+            // walk that read the high one alone has nowhere to go.
+            boolean paired = each.loneHigh() && unit >= LOW_FROM && unit <= LOW_TO;
             for (Automaton.Step step : machine.stepsFrom(each.state())) {
-                if (step.over().has(unit) && unit <= LAST_UNIT) {
-                    out.add(new Where(step.to(), null));
+                if (!paired && unit <= LAST_UNIT && step.over().has(unit)) {
+                    out.add(new Where(step.to(), null, unit >= HIGH_FROM && unit <= HIGH_TO));
                 }
                 CodePoints lows = lowsOf(step.over(), unit);
                 if (!lows.isEmpty()) {
-                    out.add(new Where(step.to(), lows));
+                    out.add(new Where(step.to(), lows, false));
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
@@ -150,6 +150,26 @@ final class RuntimeOrder {
     }
 
     /**
+     * The symbol sequences some string is read as, canonical and made once.
+     *
+     * <p>A constant and not a construction a caller pays for. It is three states whatever is asked
+     * of it, and what it says is a fact about how a string is read rather than anything a model
+     * wrote — charged to an allowance, every language would be a little smaller than the one before
+     * it for a reason nobody could see.
+     */
+    static final Automaton EVERY_STRING = onlyStrings();
+
+    private static Automaton onlyStrings() {
+        Meter meter = new Meter(16, 64);
+        Automaton made = everyString(meter);
+        Automaton one = made == null ? null : made.canonical(meter);
+        if (one == null) {
+            throw new IllegalStateException("the machine for every string is three states");
+        }
+        return one;
+    }
+
+    /**
      * The symbol sequences some string is read as, or null past what {@code meter} allows.
      *
      * <p>Not every sequence of symbols is one. A high surrogate followed by a low one is the pair —
@@ -199,6 +219,12 @@ final class RuntimeOrder {
      * are a set rather than one — a high surrogate is a symbol of its own and the first unit of
      * every pair, so a unit read here can leave the walk in both.
      *
+     * <p><b>Asked of a machine that stops only on strings</b>, which every {@link Language} holds
+     * ({@link Language#canonical}). So a walk that reads a high surrogate as a symbol of its own and
+     * a low one after it — two symbols no string is read as — reaches nothing it may stop at, and
+     * the least is a string the machine accepts. Asked of a machine that stops on such a sequence,
+     * this would answer with it and the language would say it holds no such string.
+     *
      * <p>Least by taking the least unit that still leads to somewhere a walk may stop, and stopping
      * at the first place it may. A shorter string is below every string it begins, so where the walk
      * may stop it has the least; and where it comes back to a set of states it has been in, it never
@@ -210,7 +236,7 @@ final class RuntimeOrder {
             return null;
         }
         StringBuilder out = new StringBuilder();
-        Set<Where> here = Set.of(new Where(Automaton.START, null, false));
+        Set<Where> here = Set.of(new Where(Automaton.START, null));
         Set<Set<Where>> been = new LinkedHashSet<>();
         while (been.add(here)) {
             if (stops(here, machine)) {
@@ -234,13 +260,8 @@ final class RuntimeOrder {
      *              symbol boundary. A high surrogate read at a boundary is both a symbol and the
      *              first unit of a pair, so both are held and the walk is in as many places as the
      *              units so far leave it
-     * @param loneHigh whether the last symbol read was a high surrogate standing alone. A string
-     *              holding one followed by a low surrogate is a string holding the pair — that is
-     *              what a matcher reads and what {@link Automaton#accepts} walks — so the two
-     *              symbols never stand beside each other and a walk that let them would answer with
-     *              a string the language does not hold
      */
-    private record Where(int state, CodePoints lows, boolean loneHigh) {}
+    private record Where(int state, CodePoints lows) {}
 
     /** Whether a walk in one of these may stop, which it may only at a symbol boundary. */
     private static boolean stops(Set<Where> here, Automaton machine) {
@@ -296,20 +317,17 @@ final class RuntimeOrder {
         for (Where each : here) {
             if (each.lows() != null) {
                 if (each.lows().has(unit)) {
-                    out.add(new Where(each.state(), null, false));
+                    out.add(new Where(each.state(), null));
                 }
                 continue;
             }
-            // A low surrogate after a high one standing alone is the pair, not two symbols, so the
-            // walk that read the high one alone has nowhere to go.
-            boolean paired = each.loneHigh() && unit >= LOW_FROM && unit <= LOW_TO;
             for (Automaton.Step step : machine.stepsFrom(each.state())) {
-                if (!paired && unit <= LAST_UNIT && step.over().has(unit)) {
-                    out.add(new Where(step.to(), null, unit >= HIGH_FROM && unit <= HIGH_TO));
+                if (unit <= LAST_UNIT && step.over().has(unit)) {
+                    out.add(new Where(step.to(), null));
                 }
                 CodePoints lows = lowsOf(step.over(), unit);
                 if (!lows.isEmpty()) {
-                    out.add(new Where(step.to(), lows, false));
+                    out.add(new Where(step.to(), lows));
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/regex/RuntimeOrder.java
@@ -250,7 +250,7 @@ final class RuntimeOrder {
      * will — the same units are chosen again, and each time round leaves a string below the last.
      */
     static String leastOf(Automaton machine) {
-        boolean[] reaches = reaching(machine);
+        boolean[] reaches = machine.reachingSomewhereItStops();
         if (!reaches[Automaton.START]) {
             return null;
         }
@@ -389,36 +389,6 @@ final class RuntimeOrder {
     /** The first unit of the pair {@code symbol} is written as. */
     private static int highOf(int symbol) {
         return HIGH_FROM + ((symbol - PAIRED_FROM) >> 10);
-    }
-
-    /** For each state, whether a walk from it may still reach somewhere it stops. */
-    private static boolean[] reaching(Automaton machine) {
-        List<List<Integer>> back = new ArrayList<>();
-        for (int at = 0; at < machine.size(); at++) {
-            back.add(new ArrayList<>());
-        }
-        for (int at = 0; at < machine.size(); at++) {
-            for (Automaton.Step each : machine.stepsFrom(at)) {
-                back.get(each.to()).add(at);
-            }
-        }
-        boolean[] out = new boolean[machine.size()];
-        List<Integer> waiting = new ArrayList<>();
-        for (int at = 0; at < machine.size(); at++) {
-            if (machine.stopsAt(at)) {
-                out[at] = true;
-                waiting.add(at);
-            }
-        }
-        for (int at = 0; at < waiting.size(); at++) {
-            for (int from : back.get(waiting.get(at))) {
-                if (!out[from]) {
-                    out[from] = true;
-                    waiting.add(from);
-                }
-            }
-        }
-        return out;
     }
 
     private RuntimeOrder() {}

--- a/souther-compiler/src/main/java/souther/compiler/values/Sets.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Sets.java
@@ -140,7 +140,7 @@ public final class Sets {
 
 
     /** The strings among {@code values}, which are the only ones a language has a word for. */
-    private static Set<String> textsIn(Set<Value> values) {
+    static Set<String> textsIn(Set<Value> values) {
         Set<String> out = new LinkedHashSet<>();
         values.forEach(each -> {
             if (each instanceof Value.Text text) {

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
@@ -61,6 +61,18 @@ public sealed interface TextExtent {
         public boolean holdsOneValue() {
             return after != null && after.equals(first.justAbove());
         }
+
+        /**
+         * Whether the rule holds the values above where the strings begin.
+         *
+         * <p>Every string is at or above the string of nothing, so a run beginning there is held
+         * below by the order and not by the rule. A line drawn at it would be the carrier's own end
+         * written down as something an author placed, and a row owed at it would be owed to a rule
+         * that does not stop the values anywhere.
+         */
+        public boolean holdsFromAbove() {
+            return !first.at().isEmpty();
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
@@ -45,6 +45,22 @@ public sealed interface TextExtent {
                         "a run ends above where it begins: " + first + " up to " + after);
             }
         }
+
+        /**
+         * Whether the run holds one string and no other.
+         *
+         * <p>Asked of the order and not of the language: a run ends where the next string above its
+         * first one begins exactly when there is nothing between them, and what is just above a
+         * string is the order's answer ({@link Text#justAbove}).
+         *
+         * <p>Here because a reader that draws lines has to tell the two apart. A rule leaving a
+         * position between two places bounds it and is owed its edge; one leaving it a single
+         * string names a value, which is a distinction of the position and not a boundary on it.
+         * Both are runs, and only the first is a bound.
+         */
+        public boolean holdsOneValue() {
+            return after != null && after.equals(first.justAbove());
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtent.java
@@ -1,0 +1,81 @@
+package souther.compiler.values;
+
+import souther.compiler.numeric.Text;
+import souther.compiler.regex.Meter;
+
+/**
+ * Where the strings one rule admits begin and end on the order they are measured on, or why that
+ * has no answer.
+ *
+ * <p>Asked of a language and of nothing else. Whether a rule was read at all, and which position it
+ * is about, are settled before this and travel beside it — a rule whose pattern nothing worked out
+ * never reaches here, so no arm below stands for one.
+ *
+ * <p><b>Three answers about three different things.</b> {@link One} is what the model says. {@link
+ * NoNamedRun} is what this reading established about a language it had: the strings it admits are
+ * not one stretch of the order with a string at either end. {@link NotBuilt} is about this compiler
+ * and says nothing about the model. Folded into one "no edge", a rule an author can rewrite and a
+ * limit they cannot see would read alike, and the second is the one a report has to name
+ * ({@code UnreadReason}).
+ */
+public sealed interface TextExtent {
+
+    /**
+     * The strings run from {@code first} up to {@code after}, or from {@code first} without end.
+     *
+     * <p>The lower end is one of them and the upper is not, and there is no other shape. A run of
+     * the strings begins at its least — which is a string, or there would be no run named here —
+     * and a string just below another is a thing this order does not have, so an upper end that
+     * were one of them would have to be the greatest string admitted and there is none. Written as
+     * a pair of endpoints either of which could be open, the shapes nothing can mean would be
+     * spellable.
+     *
+     * @param first the least string the rule admits, which it admits
+     * @param after the least string above every one it admits, which it does not admit, or null
+     *              where there is no such string and the run has no end
+     */
+    record One(Text first, Text after) implements TextExtent {
+
+        public One {
+            if (first == null) {
+                throw new IllegalArgumentException("a run begins at a string");
+            }
+            if (after != null && after.compareTo(first) <= 0) {
+                throw new IllegalArgumentException(
+                        "a run ends above where it begins: " + first + " up to " + after);
+            }
+        }
+    }
+
+    /**
+     * The language is not one run of the order with a string at either end.
+     *
+     * <p>What was established and not what was noticed. Reached only by having the language, having
+     * asked, and having been answered — either there is no least string among the ones it admits,
+     * or what it leaves above that least is not everything from some string upwards. Both are facts
+     * about the strings, and neither is convexity: {@code startsWith("JP") || startsWith("US")} is
+     * two runs and this says so, while a language that is one run whose ends no string names says
+     * the same thing for another reason. What follows from either is that no edge is owed here, and
+     * a reading that answered "not convex" would be answering a question nobody asked.
+     *
+     * <p>Never a fallback. A reader arriving here without having run the reading would be calling a
+     * language something it had not looked at.
+     */
+    record NoNamedRun() implements TextExtent {}
+
+    /**
+     * The machines this needed were more than the allowance let it make.
+     *
+     * <p>A fact about this compiler. Which limit refused it is kept, since a language larger than
+     * any one machine may be is one somebody wrote and can write differently, and an answer that
+     * had already spent what it was allowed is not.
+     */
+    record NotBuilt(Meter.Stopped stopped) implements TextExtent {
+
+        public NotBuilt {
+            if (stopped == null) {
+                throw new IllegalArgumentException("a construction that stopped was stopped by a limit");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
@@ -59,9 +59,8 @@ public final class TextExtents {
             // is what is being asked for, and neither is a limit of this compiler.
             return new TextExtent.NoNamedRun();
         }
-        Language strings = Language.everyString(meter);
-        Language above = strings == null ? null : notBefore(first, strings, meter);
-        Language outside = above == null ? null : strings.and(language.not(meter), meter);
+        Language above = notBefore(first, meter);
+        Language outside = above == null ? null : language.not(meter);
         // What the language leaves out from its least string upwards. Where that is nothing, the
         // language is everything from the least upwards; where it is everything from some string
         // upwards, the language is what lies between the two.
@@ -76,7 +75,7 @@ public final class TextExtents {
         if (after == null) {
             return new TextExtent.NoNamedRun();
         }
-        Language beyond = notBefore(after, strings, meter);
+        Language beyond = notBefore(after, meter);
         if (beyond == null) {
             return new TextExtent.NotBuilt(stopped(meter));
         }
@@ -85,18 +84,10 @@ public final class TextExtents {
                 : new TextExtent.NoNamedRun();
     }
 
-    /**
-     * Every string from {@code from} upwards, or null past what {@code meter} allows.
-     *
-     * <p>Met with the strings, because what is wanted is a set two of these can be compared as. A
-     * complement holds every sequence of symbols the machine does not stop on, and some of those are
-     * sequences no string is read as — kept, two answers holding the same strings would compare
-     * unequal, and a rule that names a run would be read as naming none.
-     */
-    private static Language notBefore(String from, Language strings, Meter meter) {
+    /** Every string from {@code from} upwards, or null past what {@code meter} allows. */
+    private static Language notBefore(String from, Meter meter) {
         Language before = Language.before(from, meter);
-        Language above = before == null ? null : before.not(meter);
-        return above == null ? null : strings.and(above, meter);
+        return before == null ? null : before.not(meter);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
@@ -1,0 +1,120 @@
+package souther.compiler.values;
+
+import souther.compiler.numeric.Text;
+import souther.compiler.regex.Language;
+import souther.compiler.regex.Meter;
+import souther.compiler.regex.PatternPlan;
+
+/**
+ * Where a language stops on the order the strings it holds are measured on.
+ *
+ * <p>The one place a set of strings and the order a position's values are counted on are brought
+ * together. A {@link Language} is its strings and knows nothing about positions; {@link Text} is
+ * where a string sits on the carrier's order and holds one string at a time. What a rule leaves a
+ * position between is a question about both, and answering it anywhere else would be answering it
+ * with whichever half was to hand.
+ *
+ * <p><b>Apart from {@link Sets}, which is the algebra of two sets.</b> This takes one and asks
+ * something about the order — a different question, and the one that costs machines nobody else
+ * needs. Written there, a caller meeting two sets would be holding an operation that projects.
+ *
+ * <p><b>What a run is established by.</b> A language is a run when the strings above its least that
+ * it does not admit are everything from some string upwards. That is asked of the languages
+ * themselves — the ones above a string, the ones this does not hold, and whether two of them are
+ * one set — so nothing here decides what "between" means a second time. Convexity is not a word
+ * used or wanted: a language that is not one run is one whichever way it fails to be, and a reading
+ * that answered with the reason would be answering about the shape rather than about the edge.
+ *
+ * <p><b>All of it or none of it.</b> A reading stopped part way answers {@link
+ * TextExtent.NotBuilt}, and never with the end it had reached. Half an answer would put a line on a
+ * position when the machine for the other half happened to be affordable, which makes what a report
+ * says about a model turn on what this compiler could build that day.
+ */
+public final class TextExtents {
+
+    /**
+     * Where {@code language} begins and ends, or why it names no run.
+     *
+     * <p>Its own allowance, spent whole here: what this asks for is machines nothing else wants,
+     * and a caller with several rules pays for each of them on its own so that one expensive rule
+     * does not take the line another rule drew.
+     */
+    public static TextExtent of(Language language) {
+        return of(language, PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter());
+    }
+
+    /**
+     * The same under a meter handed in, for a reader here that wants to see what running out comes
+     * to.
+     *
+     * <p>Not the way in. A meter carries which limit refused the last thing built out of it, so one
+     * that has been spent on something else answers this reading with a reason belonging to that —
+     * which is why what a caller outside gets is the one above, with an allowance of its own.
+     */
+    static TextExtent of(Language language, Meter meter) {
+        String first = language.least();
+        if (first == null) {
+            // Either it holds nothing, or its strings descend without stopping and what is below
+            // all of them is not a string. Neither is a run with a string at its lower end, which
+            // is what is being asked for, and neither is a limit of this compiler.
+            return new TextExtent.NoNamedRun();
+        }
+        Language strings = Language.everyString(meter);
+        Language above = strings == null ? null : notBefore(first, strings, meter);
+        Language outside = above == null ? null : strings.and(language.not(meter), meter);
+        // What the language leaves out from its least string upwards. Where that is nothing, the
+        // language is everything from the least upwards; where it is everything from some string
+        // upwards, the language is what lies between the two.
+        Language left = outside == null ? null : above.and(outside, meter);
+        if (left == null) {
+            return new TextExtent.NotBuilt(stopped(meter));
+        }
+        if (left.isEmpty()) {
+            return new TextExtent.One(Text.of(first), null);
+        }
+        String after = left.least();
+        if (after == null) {
+            return new TextExtent.NoNamedRun();
+        }
+        Language beyond = notBefore(after, strings, meter);
+        if (beyond == null) {
+            return new TextExtent.NotBuilt(stopped(meter));
+        }
+        return beyond.equals(left)
+                ? new TextExtent.One(Text.of(first), Text.of(after))
+                : new TextExtent.NoNamedRun();
+    }
+
+    /**
+     * Every string from {@code from} upwards, or null past what {@code meter} allows.
+     *
+     * <p>Met with the strings, because what is wanted is a set two of these can be compared as. A
+     * complement holds every sequence of symbols the machine does not stop on, and some of those are
+     * sequences no string is read as — kept, two answers holding the same strings would compare
+     * unequal, and a rule that names a run would be read as naming none.
+     */
+    private static Language notBefore(String from, Language strings, Meter meter) {
+        Language before = Language.before(from, meter);
+        Language above = before == null ? null : before.not(meter);
+        return above == null ? null : strings.and(above, meter);
+    }
+
+    /**
+     * Which limit refused the machine that did not come back.
+     *
+     * <p>Read off the meter rather than guessed at: a language larger than one machine may be is one
+     * an author wrote and can write differently, and a build that had already spent this answer's
+     * allowance is not. A meter that came back with nothing and names no limit is this compiler
+     * having lost the reason on the way, which is a mistake here and not a model anybody can write.
+     */
+    private static Meter.Stopped stopped(Meter meter) {
+        Meter.Stopped why = meter.stoppedBy();
+        if (why == null) {
+            throw new IllegalStateException(
+                    "a machine was not built and the allowance refused nothing");
+        }
+        return why;
+    }
+
+    private TextExtents() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
@@ -44,29 +44,73 @@ public final class TextExtents {
      * <p>Its own allowance per plan, spent whole here: a caller with several rules pays for each of
      * them on its own, so that one expensive rule does not take the line another rule drew.
      *
-     * <p><b>Only what a language admits has a run.</b> A plan that comes to values written out, or
-     * to every value, or to none, is answered {@link TextExtent.NoNamedRun} — which is what those
-     * are: a position the rules divide into named values is divided rather than bounded, and one
-     * they leave every string is bounded nowhere. It is not that this could not answer.
+     * <p>What a run is and what a caller should do about it are two questions, and only the first is
+     * answered here. A run holding one string and a run holding every string are runs; whether
+     * either is a boundary somebody is owed a row at is read off the run by whoever draws lines.
      */
     public static TextExtent of(AdmittedPlan plan) {
         Meter meter = PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter();
+        Language admitted = admitted(plan, meter);
+        return admitted == null
+                ? new TextExtent.NotBuilt(stopped(meter)) : of(admitted, meter);
+    }
+
+    /**
+     * The strings {@code plan} admits, or null past what {@code meter} allows.
+     *
+     * <p>Every set of values a rule about a string can leave is a set of strings, so every one of
+     * them is a language: the ones a pattern named, the ones written out, everything but the ones
+     * written out, all of them, and none. Which of those a plan came to is how the answer is held
+     * and not what the rule said — so the question below is asked of a language whichever it was,
+     * and the shape a set happens to be written in decides nothing.
+     *
+     * <p>Which is what keeps the run out of that decision. Read off the shape, a rule naming one
+     * string would have no geometry while a pattern accepting that same string had one, and where
+     * the values stop would turn on how the answer got written down.
+     */
+    private static Language admitted(AdmittedPlan plan, Meter meter) {
         return switch (new Realizer(meter).of(plan)) {
-            case Realization.Exact it -> it.set() instanceof ValueSet.Matching matching
-                    ? of(matching.language(), meter) : new TextExtent.NoNamedRun();
-            case Realization.OverTheMachineLimit _ ->
-                    new TextExtent.NotBuilt(Meter.Stopped.ONE_MACHINE);
-            case Realization.OverTheAnswerLimit _ ->
-                    new TextExtent.NotBuilt(Meter.Stopped.THE_ANSWER);
+            case Realization.Exact it -> languageOf(it.set(), meter);
+            case Realization.OverTheMachineLimit _, Realization.OverTheAnswerLimit _ -> null;
         };
+    }
+
+    /** The same for a set already worked out. */
+    private static Language languageOf(ValueSet set, Meter meter) {
+        return switch (set) {
+            case ValueSet.Matching it -> it.language();
+            case ValueSet.Finite it -> Language.ofWords(texts(it.values()), meter);
+            case ValueSet.Cofinite it ->
+                    Language.EVERY_STRING.without(texts(it.excluded()), meter);
+        };
+    }
+
+    /**
+     * The strings among {@code values}.
+     *
+     * <p>All of them or this compiler has gone wrong. A set stands at one position and a position
+     * holds values of its type, so a set reaching here beside a rule about a string holds strings —
+     * one holding anything else belongs to no position at all ({@link ValueSet}), which is nothing a
+     * model can write.
+     */
+    private static java.util.List<String> texts(java.util.Set<Value> values) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        for (Value each : values) {
+            if (!(each instanceof Value.Text text)) {
+                throw new IllegalStateException(
+                        "a rule about the strings at a position left " + each + " standing there");
+            }
+            out.add(text.value());
+        }
+        return out;
     }
 
     /**
      * Where {@code language} begins and ends, or why it names no run.
      *
-     * <p>For a caller holding the language already, which is what a test does.
+     * <p>For a caller holding the language already, which is what a reader here does.
      */
-    public static TextExtent of(Language language) {
+    static TextExtent of(Language language) {
         return of(language, PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
@@ -33,11 +33,38 @@ import souther.compiler.regex.PatternPlan;
 public final class TextExtents {
 
     /**
+     * Where what {@code plan} admits begins and ends, or why it names no run.
+     *
+     * <p>The way in, and the plan rather than the set on purpose. Which strings a rule leaves is a
+     * machine somebody has to pay for; a caller here is asking where the values stop, which is a
+     * question a report asks, and paying for it out of what a position's own answer is allowed
+     * would let a diagnostic decide what the model is read to admit. So the plan is built again
+     * under this question's own allowance, and what the position's answer cost is untouched.
+     *
+     * <p>Its own allowance per plan, spent whole here: a caller with several rules pays for each of
+     * them on its own, so that one expensive rule does not take the line another rule drew.
+     *
+     * <p><b>Only what a language admits has a run.</b> A plan that comes to values written out, or
+     * to every value, or to none, is answered {@link TextExtent.NoNamedRun} — which is what those
+     * are: a position the rules divide into named values is divided rather than bounded, and one
+     * they leave every string is bounded nowhere. It is not that this could not answer.
+     */
+    public static TextExtent of(AdmittedPlan plan) {
+        Meter meter = PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter();
+        return switch (new Realizer(meter).of(plan)) {
+            case Realization.Exact it -> it.set() instanceof ValueSet.Matching matching
+                    ? of(matching.language(), meter) : new TextExtent.NoNamedRun();
+            case Realization.OverTheMachineLimit _ ->
+                    new TextExtent.NotBuilt(Meter.Stopped.ONE_MACHINE);
+            case Realization.OverTheAnswerLimit _ ->
+                    new TextExtent.NotBuilt(Meter.Stopped.THE_ANSWER);
+        };
+    }
+
+    /**
      * Where {@code language} begins and ends, or why it names no run.
      *
-     * <p>Its own allowance, spent whole here: what this asks for is machines nothing else wants,
-     * and a caller with several rules pays for each of them on its own so that one expensive rule
-     * does not take the line another rule drew.
+     * <p>For a caller holding the language already, which is what a test does.
      */
     public static TextExtent of(Language language) {
         return of(language, PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter());

--- a/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TextExtents.java
@@ -75,34 +75,21 @@ public final class TextExtents {
         };
     }
 
-    /** The same for a set already worked out. */
+    /**
+     * The same for a set already worked out.
+     *
+     * <p>Which strings a set of values holds is {@link Sets}', asked here rather than picked out
+     * again: a set stands at one position and a position holds values of its type, so what a set
+     * beside a rule about a string holds is strings, and a second reader deciding that for itself
+     * is a second answer to it.
+     */
     private static Language languageOf(ValueSet set, Meter meter) {
         return switch (set) {
             case ValueSet.Matching it -> it.language();
-            case ValueSet.Finite it -> Language.ofWords(texts(it.values()), meter);
+            case ValueSet.Finite it -> Language.ofWords(Sets.textsIn(it.values()), meter);
             case ValueSet.Cofinite it ->
-                    Language.EVERY_STRING.without(texts(it.excluded()), meter);
+                    Language.EVERY_STRING.without(Sets.textsIn(it.excluded()), meter);
         };
-    }
-
-    /**
-     * The strings among {@code values}.
-     *
-     * <p>All of them or this compiler has gone wrong. A set stands at one position and a position
-     * holds values of its type, so a set reaching here beside a rule about a string holds strings —
-     * one holding anything else belongs to no position at all ({@link ValueSet}), which is nothing a
-     * model can write.
-     */
-    private static java.util.List<String> texts(java.util.Set<Value> values) {
-        java.util.List<String> out = new java.util.ArrayList<>();
-        for (Value each : values) {
-            if (!(each instanceof Value.Text text)) {
-                throw new IllegalStateException(
-                        "a rule about the strings at a position left " + each + " standing there");
-            }
-            out.add(text.value());
-        }
-        return out;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -176,11 +176,11 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
         StatedByClauses.Part read = new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
                         java.util.Set.of(), false),
-                Adoption.nothing(), Map.of());
+                Adoption.nothing(), Map.of(), Map.of());
         StatedByClauses.Part unread = new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
                         true),
-                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)));
+                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of());
 
         assertEquals(Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ),
                         CONSTRAINED, List.of(UnreadReason.ALTERNATIVE_NOT_READ)),

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -195,21 +195,45 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
                         + " them on");
     }
 
+    /**
+     * One clause can state where the values stop on two numbers, and both questions are raised.
+     *
+     * <p>Both branches of the choice state a run at each of the two positions, so the choice states
+     * one at each. Held as the number a clause stops the values on, one of them would have to be
+     * chosen between or refused — and read as the count of questions, the two collapse into one
+     * word, so what is asked here is which numbers they are about.
+     */
+    @Test
+    void oneClauseCanBoundTwoNumbers() {
+        String source = """
+                module example.rooms
+
+                data Code = { a: String, b: String }
+                    invariant one =
+                        (String.startsWith("A", a) && String.startsWith("B", b))
+                            || (String.startsWith("A", a) && String.startsWith("B", b))
+                """;
+        assertEquals(Set.of(RuleKey.of("a"), RuleKey.of("b")), boundedIn(source, "Code"),
+                "a line on each, and neither chosen between");
+    }
+
+    /** The numbers the one clause of {@code named} states the values stop on. */
+    private static Set<RuleKey> boundedIn(String source, String named) {
+        Set<RuleKey> out = new LinkedHashSet<>();
+        rulesOf(source, named).required().values().forEach(required ->
+                required.obligations().forEach(owed -> {
+                    if (owed instanceof Owed.Boundary line) {
+                        out.add(line.on().position());
+                    }
+                }));
+        return out;
+    }
+
     /** The names whose line the one clause of {@code named} leaves undecided. */
     private static Set<RuleKey> undeterminedIn(String source, String named) {
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.answerEverything();
-        String module = compilation.modules().get(0);
-        Symbols symbols = Scopes.derived(compilation.db(), module).value();
-        assertNotNull(symbols);
-        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
-        assertNotNull(data);
         Set<RuleKey> out = new LinkedHashSet<>();
-        FieldDomains.of(at, data, RuleReadings.of(compilation, module),
-                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
-                .required().values().forEach(required ->
-                        required.undetermined().forEach(each -> out.add(each.at())));
+        rulesOf(source, named).required().values().forEach(required ->
+                required.undetermined().forEach(each -> out.add(each.at())));
         return out;
     }
 
@@ -257,6 +281,14 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
 
     /** What the one clause of {@code named} raises, over every place it writes. */
     private static Set<CoverageObligation> raisedIn(String source, String named) {
+        Set<CoverageObligation> out = new LinkedHashSet<>();
+        rulesOf(source, named).required().values().forEach(required ->
+                required.obligations().forEach(owed -> out.add(owed.obligation())));
+        return out;
+    }
+
+    /** The rules of {@code named} in {@code source}, read as the compilation reads them. */
+    private static FieldDomains rulesOf(String source, String named) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
@@ -265,12 +297,8 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
         Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
         assertNotNull(data, "no `" + named + "` declared");
-        FieldDomains domains = FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+        return FieldDomains.of(at, data, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-        Set<CoverageObligation> out = new LinkedHashSet<>();
-        domains.required().values().forEach(required ->
-                required.obligations().forEach(owed -> out.add(owed.obligation())));
-        return out;
     }
 
     /** The same of a declaration over strings, since a run is a statement about those. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -117,6 +117,62 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
     }
 
     /**
+     * A rule about the strings at the position states where they stop, and raises the question
+     * about it like any other rule that does.
+     *
+     * <p>Not a comparison, and that is the point. What the model states is where the values stop —
+     * {@code String.startsWith("JP", value)} admits the strings from {@code "JP"} up to but not
+     * including {@code "JQ"} — and which call an author wrote it as is no part of that. Raised off
+     * the shape of the clause, the question existed for one of the two spellings and the accounting
+     * for the other came back complete.
+     */
+    @Test
+    void aRuleAboutTheStringsThatStatesWhereTheyStopRaisesTheQuestionAboutItsLine() {
+        String clause = "invariant top = String.startsWith(\"JP\", value)";
+        assertEquals(BOTH, onAString(clause),
+                "the model states where the strings stop, so both are asked about");
+    }
+
+    /**
+     * And one whose strings stop nowhere raises no question about a line.
+     *
+     * <p>{@code [0-9]{4}} leaves out a string between two it admits, so there is no stretch of the
+     * order it holds the values between — which is what the rule states and not what a reading of it
+     * managed. A question raised here would be one no line could ever answer.
+     */
+    @Test
+    void aRuleWhoseStringsStopNowhereRaisesNoQuestionAboutALine() {
+        assertEquals(Set.of(CoverageObligation.ADMITTED_VALUES),
+                onAString("invariant top = String.matches(\"[0-9]{4}\", value)"));
+    }
+
+    /** The same of a declaration over strings, since a run is a statement about those. */
+    private static Set<CoverageObligation> onAString(String clause) {
+        String source = """
+                module example.rooms
+
+                data Code = String
+                    %s
+                """.formatted(clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        assertNotNull(symbols);
+        TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Code"));
+        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
+        assertNotNull(data, "no `Code` declared");
+        FieldDomains domains = FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        assertEquals(1, domains.required().size(),
+                () -> "one clause, one rule: " + domains.required().keySet());
+        Set<CoverageObligation> out = new LinkedHashSet<>();
+        domains.required().values().iterator().next().obligations()
+                .forEach(owed -> out.add(owed.obligation()));
+        return out;
+    }
+
+    /**
      * A bound the order has no value past, which is a rule read to the end and not a rule missed.
      *
      * <p>{@code value > 9223372036854775807} steps off the order: the count beside the one named is

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -3,13 +3,16 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -217,6 +220,41 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
                 "a line on each, and neither chosen between");
     }
 
+    /**
+     * Two branches stopped by two things leave both of them standing, all the way to the accounting.
+     *
+     * <p>One branch is written more deeply than this reads and the other is written in a form it
+     * does not enter, and those go out under two different words. Kept as one, which of them an
+     * author is sent to would turn on which branch they wrote first — and each of the two is a thing
+     * that would have to change before the question could be answered, so neither stands for the
+     * other.
+     */
+    @Test
+    void twoBranchesStoppedByTwoThingsLeaveBothStanding() {
+        String deep = "(".repeat(201) + "x" + ")".repeat(201);
+        String source = """
+                module example.rooms
+
+                data Code = String
+                    invariant one =
+                        String.matches("%s", value) || String.matches(value, value)
+                """.formatted(deep);
+
+        assertEquals(List.of(new BlockReason.PatternTooDeeplyNested(),
+                        new BlockReason.UnreadValueRule()),
+                whyUndeterminedIn(source, "Code"),
+                "both of them, in the order the clause writes them");
+    }
+
+    /** What the one clause of {@code named} leaves the line question standing for. */
+    private static List<BlockReason.RuleReadingStopped> whyUndeterminedIn(String source,
+                                                                          String named) {
+        List<BlockReason.RuleReadingStopped> out = new ArrayList<>();
+        rulesOf(source, named).required().values().forEach(required ->
+                required.undetermined().forEach(each -> out.addAll(each.why())));
+        return out;
+    }
+
     /** The numbers the one clause of {@code named} states the values stop on. */
     private static Set<RuleKey> boundedIn(String source, String named) {
         Set<RuleKey> out = new LinkedHashSet<>();
@@ -249,12 +287,11 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
     void whereTheRunRanOutTheReasonIsTheRunsOwn() {
         FieldDomains domains = read("invariant top = String.matches(\"[0-9]{300}\", value)",
                 "Code", "String");
-        java.util.List<souther.compiler.inputs.BlockReason.RuleWithoutLineReason> why =
-                domains.noLineAt(RuleKey.THE_VALUE).stream()
-                        .map(FieldDomains.NoLine::why).toList();
+        List<BlockReason.RuleWithoutLineReason> why = domains.noLineAt(RuleKey.THE_VALUE).stream()
+                .map(FieldDomains.NoLine::why).toList();
         assertEquals(1, why.size(), () -> "one rule, one reason: " + why);
-        souther.compiler.inputs.BlockReason.OrderedExtentTooCostly stopped = assertInstanceOf(
-                souther.compiler.inputs.BlockReason.OrderedExtentTooCostly.class, why.get(0));
+        BlockReason.OrderedExtentTooCostly stopped = assertInstanceOf(
+                BlockReason.OrderedExtentTooCostly.class, why.get(0));
         assertEquals(souther.compiler.regex.Meter.Stopped.ONE_MACHINE, stopped.stopped(),
                 "the machine the run wanted is larger than a machine may be");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -146,6 +146,133 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
                 onAString("invariant top = String.matches(\"[0-9]{4}\", value)"));
     }
 
+    /**
+     * A branch that says nothing about the strings at a position leaves every string standing
+     * there, and a choice between that and a run is every string.
+     *
+     * <p>The one place the two operations part. Held together, a reading that says nothing about a
+     * position changes nothing and the other side stands; held as a choice, it is every string and
+     * absorbs whatever the other side admits. Read as the one branch that spoke, the choice would
+     * stop the values where only one of its branches stops them — a line the model does not draw.
+     */
+    @Test
+    void aBranchSayingNothingAboutTheStringsAbsorbsTheRunOfTheOther() {
+        String source = """
+                module example.rooms
+
+                data Code = { s: String, b: Bool }
+                    invariant one = String.startsWith("JP", s) || b
+                """;
+        assertEquals(Set.of(CoverageObligation.ADMITTED_VALUES), raisedIn(source, "Code"),
+                "the choice leaves every string at `s`, so nothing stops them anywhere");
+    }
+
+    /**
+     * One clause can state where the values stop on one number and leave the next standing.
+     *
+     * <p>Both branches of the choice state a run at {@code a}, so the choice does; and at {@code b}
+     * the rule is one this reads no further into, so whether it states a line there is a question
+     * nothing settled. A classification that said one number would have to choose between them, and
+     * one that said "a bound" of the whole clause would lose the second question.
+     */
+    @Test
+    void oneClauseCanBoundOneNumberAndLeaveTheNextStanding() {
+        String deep = "(".repeat(201) + "x" + ")".repeat(201);
+        String source = """
+                module example.rooms
+
+                data Code = { a: String, b: String }
+                    invariant one =
+                        (String.startsWith("A", a) && String.matches("%s", b))
+                            || (String.startsWith("A", a) && String.matches("%s", b))
+                """.formatted(deep, deep);
+        assertEquals(Set.of(CoverageObligation.ADMITTED_VALUES, CoverageObligation.BOUNDARY),
+                raisedIn(source, "Code"),
+                "a line on one number and a question about the next");
+        assertEquals(Set.of(RuleKey.of("b")), undeterminedIn(source, "Code"),
+                "and whether it stops them at `b` is a question with no answer, which is what"
+                        + " would be lost if the clause were classified by the number it did stop"
+                        + " them on");
+    }
+
+    /** The names whose line the one clause of {@code named} leaves undecided. */
+    private static Set<RuleKey> undeterminedIn(String source, String named) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        assertNotNull(symbols);
+        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
+        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
+        assertNotNull(data);
+        Set<RuleKey> out = new LinkedHashSet<>();
+        FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
+                .required().values().forEach(required ->
+                        required.undetermined().forEach(each -> out.add(each.at())));
+        return out;
+    }
+
+    /**
+     * A reading that ran out of what it may build says so in its own words.
+     *
+     * <p>The pattern is one this reads and the machine for what it admits is one it makes; what runs
+     * out is the further machine that says where those strings begin and end. Written down as a
+     * pattern too large, an author would be sent to a pattern this read perfectly — so it is its
+     * own reason, and which limit refused it is kept.
+     */
+    @Test
+    void whereTheRunRanOutTheReasonIsTheRunsOwn() {
+        FieldDomains domains = read("invariant top = String.matches(\"[0-9]{300}\", value)",
+                "Code", "String");
+        java.util.List<souther.compiler.inputs.BlockReason.RuleWithoutLineReason> why =
+                domains.noLineAt(RuleKey.THE_VALUE).stream()
+                        .map(FieldDomains.NoLine::why).toList();
+        assertEquals(1, why.size(), () -> "one rule, one reason: " + why);
+        souther.compiler.inputs.BlockReason.OrderedExtentTooCostly stopped = assertInstanceOf(
+                souther.compiler.inputs.BlockReason.OrderedExtentTooCostly.class, why.get(0));
+        assertEquals(souther.compiler.regex.Meter.Stopped.ONE_MACHINE, stopped.stopped(),
+                "the machine the run wanted is larger than a machine may be");
+    }
+
+    /** The rules of one declaration of {@code over}, read as the compilation reads them. */
+    private static FieldDomains read(String clause, String named, String over) {
+        String source = """
+                module example.rooms
+
+                data %s = %s
+                    %s
+                """.formatted(named, over, clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        assertNotNull(symbols);
+        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
+        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
+        assertNotNull(data, "no `" + named + "` declared");
+        return FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+
+    /** What the one clause of {@code named} raises, over every place it writes. */
+    private static Set<CoverageObligation> raisedIn(String source, String named) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        assertNotNull(symbols);
+        TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
+        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
+        assertNotNull(data, "no `" + named + "` declared");
+        FieldDomains domains = FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        Set<CoverageObligation> out = new LinkedHashSet<>();
+        domains.required().values().forEach(required ->
+                required.obligations().forEach(owed -> out.add(owed.obligation())));
+        return out;
+    }
+
     /** The same of a declaration over strings, since a run is a statement about those. */
     private static Set<CoverageObligation> onAString(String clause) {
         String source = """

--- a/souther-compiler/src/test/java/souther/compiler/check/TheAlgebraOfWhatARuleAdmitsHoldsWhereverItIsBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheAlgebraOfWhatARuleAdmitsHoldsWhereverItIsBracketedTest.java
@@ -1,0 +1,169 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * What a clause admits at a position does not turn on how its connectives were bracketed.
+ *
+ * <p>Three kinds of answer meet here — the strings a rule admits, every string where a reading
+ * writes about the position without restricting it, and a rule this could not work out — and the
+ * laws over them are the ones the plans already keep. Every string absorbs a choice and is the
+ * identity of a conjunction; nothing at all absorbs a conjunction. Those hold whether or not the
+ * other side was worked out, so a reading that stopped may not take an answer the law already gives.
+ *
+ * <p><b>Which is why this is a law and not a table of cases.</b> The same rules written with the
+ * brackets moved are the same rules: {@code a || (b || c)} and {@code (a || b) || c} are one clause,
+ * and a reading that answered them differently would make where a position's values stop turn on
+ * something no author means. Written as cases, the first level was right and the composition of its
+ * answer was not.
+ */
+class TheAlgebraOfWhatARuleAdmitsHoldsWhereverItIsBracketedTest {
+
+    private static final StringRestriction PREFIX = new StringRestriction.Admitting(
+            AdmittedPlan.of(ValueSet.oneOf(java.util.Set.of(Value.text("JP")))));
+    private static final StringRestriction EVERY = StringRestriction.EVERY_STRING;
+    private static final StringRestriction NONE =
+            new StringRestriction.Admitting(AdmittedPlan.NONE);
+    private static final StringRestriction UNKNOWN =
+            new StringRestriction.NotKnown(new BlockReason.PatternTooDeeplyNested());
+    private static final StringRestriction UNREAD =
+            new StringRestriction.NotKnown(new BlockReason.UnreadValueRule());
+
+    /** The answers a clause can come to at one position, which is what the laws are over. The last
+     *  is a reading that writes nothing about the position, which is one of them. */
+    private static final List<StringRestriction> EVERY_ANSWER =
+            java.util.Arrays.asList(PREFIX, EVERY, NONE, UNKNOWN, null);
+
+    /** Every string absorbs a choice, whatever the other side is and whether it was read. */
+    @Test
+    void everyStringAbsorbsAChoice() {
+        for (StringRestriction each : EVERY_ANSWER) {
+            assertAdmitsEveryString(join(EVERY, each), "every || " + each);
+            assertAdmitsEveryString(join(each, EVERY), each + " || every");
+            assertAdmitsEveryString(join(null, each), "nothing said || " + each);
+            assertAdmitsEveryString(join(each, null), each + " || nothing said");
+        }
+    }
+
+    /** And is the identity of a conjunction, on the same terms. */
+    @Test
+    void everyStringIsTheIdentityOfAConjunction() {
+        for (StringRestriction each : EVERY_ANSWER) {
+            assertEquals(said(each), meet(EVERY, each), "every && " + each);
+            assertEquals(said(each), meet(each, EVERY), each + " && every");
+            assertEquals(said(each), meet(null, each), "nothing said && " + each);
+        }
+    }
+
+    /** Nothing at all absorbs a conjunction, read or not. */
+    @Test
+    void nothingAtAllAbsorbsAConjunction() {
+        for (StringRestriction each : EVERY_ANSWER) {
+            assertEquals(NONE, meet(NONE, each), "none && " + each);
+            assertEquals(NONE, meet(each, NONE), each + " && none");
+        }
+    }
+
+    /**
+     * Moving the brackets of a choice does not move the answer.
+     *
+     * <p>The one this is here for. {@code unknown || (nothing said || prefix)} has an inner answer
+     * of every string, so the whole is every string; bracketed the other way the inner answer is
+     * the unknown one. Answered by a case for the absence rather than by the law, the two came out
+     * different — and which of them an author got was where they put the brackets.
+     */
+    @Test
+    void movingTheBracketsOfAChoiceDoesNotMoveTheAnswer() {
+        for (StringRestriction one : EVERY_ANSWER) {
+            for (StringRestriction two : EVERY_ANSWER) {
+                for (StringRestriction three : EVERY_ANSWER) {
+                    StringRestriction left = join(join(one, two), three);
+                    StringRestriction right = join(one, join(two, three));
+                    assertEquals(admitsEveryString(left), admitsEveryString(right),
+                            one + " || " + two + " || " + three);
+                    assertEquals(left instanceof StringRestriction.NotKnown,
+                            right instanceof StringRestriction.NotKnown,
+                            one + " || " + two + " || " + three);
+                }
+            }
+        }
+    }
+
+    /** And of a conjunction. */
+    @Test
+    void movingTheBracketsOfAConjunctionDoesNotMoveTheAnswer() {
+        for (StringRestriction one : EVERY_ANSWER) {
+            for (StringRestriction two : EVERY_ANSWER) {
+                for (StringRestriction three : EVERY_ANSWER) {
+                    StringRestriction left = meet(meet(one, two), three);
+                    StringRestriction right = meet(one, meet(two, three));
+                    assertEquals(left instanceof StringRestriction.NotKnown,
+                            right instanceof StringRestriction.NotKnown,
+                            one + " && " + two + " && " + three);
+                }
+            }
+        }
+    }
+
+    /**
+     * Two readings that stopped keep both reasons, and in the order the clause writes them.
+     *
+     * <p>Two branches of one choice can be stopped by two different things, and those go out under
+     * two different words. Keeping one, which of them a reader is shown would turn on which branch
+     * the author wrote first.
+     */
+    @Test
+    void twoReadingsThatStoppedKeepBothReasons() {
+        StringRestriction.NotKnown both = assertInstanceOf(StringRestriction.NotKnown.class,
+                join(UNKNOWN, UNREAD));
+        assertEquals(List.of(new BlockReason.PatternTooDeeplyNested(),
+                        new BlockReason.UnreadValueRule()), both.why());
+
+        StringRestriction.NotKnown other = assertInstanceOf(StringRestriction.NotKnown.class,
+                join(UNREAD, UNKNOWN));
+        assertEquals(List.of(new BlockReason.UnreadValueRule(),
+                new BlockReason.PatternTooDeeplyNested()), other.why());
+    }
+
+    /** The same reason twice is one reason: one rule stopped by one thing in two branches is not
+     *  two things to say. */
+    @Test
+    void theSameReasonTwiceIsOneReason() {
+        StringRestriction.NotKnown both = assertInstanceOf(StringRestriction.NotKnown.class,
+                join(UNKNOWN, UNKNOWN));
+        assertEquals(List.of(new BlockReason.PatternTooDeeplyNested()), both.why());
+    }
+
+    private static StringRestriction join(StringRestriction one, StringRestriction other) {
+        return StringRestriction.over(one, other, false);
+    }
+
+    private static StringRestriction meet(StringRestriction one, StringRestriction other) {
+        return StringRestriction.over(one, other, true);
+    }
+
+    /** What a reading that says nothing leaves, which is what it is compared against. */
+    private static StringRestriction said(StringRestriction each) {
+        return each == null ? EVERY : each;
+    }
+
+    private static boolean admitsEveryString(StringRestriction said) {
+        return said instanceof StringRestriction.Admitting it
+                && it.plan() instanceof AdmittedPlan.Everything;
+    }
+
+    private static void assertAdmitsEveryString(StringRestriction said, String what) {
+        org.junit.jupiter.api.Assertions.assertTrue(admitsEveryString(said),
+                () -> what + " came to " + said);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/EveryAnswerAboutAPositionSaysWhatItDoesAboutTheValueAboveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/EveryAnswerAboutAPositionSaysWhatItDoesAboutTheValueAboveTest.java
@@ -103,6 +103,13 @@ class EveryAnswerAboutAPositionSaysWhatItDoesAboutTheValueAboveTest {
                         + "reading is opened at, which is the one place the reading of the clauses "
                         + "as they are written cannot see them",
                 "NoRuleIsPlacedWhereNothingAccountsForItTest.everyRuleThatPlacedAnEndIsInTheAccount"));
+        table.put("statedAtTheValue", new Decided(Above.NOT_ASKED,
+                "the same answer as `placed` and for the same reason, and the other half of what "
+                        + "`movedAtTheValue` is the first half of: an end of the value above is "
+                        + "placed under that value and accounted for there. What is asked here is "
+                        + "the ends this value's own conjuncts state on its own coordinates, which "
+                        + "is where a rule stating no comparison puts one",
+                "ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest"));
         table.put("bounds", new Decided(Above.NOT_ASKED,
                 "what a reading holds of its own value, which is what the answers above are taken "
                         + "from — the value above is asked through them and not through this",

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
@@ -87,6 +87,12 @@ class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
         // Its own word and not the one above — that one reached the values and this did not.
         table.put("PatternTooDeeplyNested",
                 "PATTERN_TOO_DEEPLY_NESTED/MAY_CHANGE");
+        // And the third figure, which is the further work of asking where the strings a rule was
+        // read to actually stop. One word with `PatternTooCostly` because out there both are the
+        // values coming out wider than the rules leave them; its own row because what was too much
+        // is a machine nobody wrote, and an author sent after their pattern would find one this
+        // read perfectly.
+        table.put("OrderedExtentTooCostly", "EXACT_VALUES_TOO_COSTLY/MAY_CHANGE");
         // One word with `ComparisonBetweenPositions` below, and on purpose: they are the two
         // readings of `a < b`, opposite sentences about this compiler, and a document promises
         // its reader which kind of thing stopped a derivation rather than which reader stopped.
@@ -359,6 +365,8 @@ class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
                 new BlockReason.UnreadValueRule(),
                 new BlockReason.PatternTooCostly(),
                 new BlockReason.PatternTooDeeplyNested(),
+                new BlockReason.OrderedExtentTooCostly(
+                        souther.compiler.regex.Meter.Stopped.ONE_MACHINE),
                 new BlockReason.ExactValuesTooCostly(),
                 new BlockReason.ValueRuleRelatingTwoPositions(),
                 new BlockReason.CompetingCoordinates(),

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TheLeastStringAboveOneIsWhereTheOrderPutsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TheLeastStringAboveOneIsWhereTheOrderPutsItTest.java
@@ -1,0 +1,59 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What is just above a string is held to {@link String#compareTo}, like everything else about the
+ * order.
+ *
+ * <p>The claim is two things and both are checked against the comparison itself: the answer is above
+ * the string, and no string is between the two. A reading that answered with the string and one more
+ * of the wrong unit would satisfy the first and not the second, and a run holding a single value
+ * would be told apart from one holding more by an answer that is merely somewhere above.
+ */
+class TheLeastStringAboveOneIsWhereTheOrderPutsItTest {
+
+    /** Strings crossing the boundaries the order is written in units over. */
+    private static final List<String> STRINGS = List.of(
+            "", " ", "a", "ab", "JP", "JQ", "퟿", "\uD800", "𐀀", "􏿿",
+            "\uD800￿", "\uDC00", "\uDFFF", "", "￿", "￿￿");
+
+    /** It is above, and nothing among the strings there are is between. */
+    @Test
+    void nothingIsBetweenAStringAndTheOneJustAboveIt() {
+        for (String each : STRINGS) {
+            String above = Text.of(each).justAbove().at();
+            assertTrue(each.compareTo(above) < 0,
+                    shown(above) + " is above " + shown(each));
+            for (String other : between(each)) {
+                assertTrue(other.compareTo(each) <= 0 || other.compareTo(above) >= 0,
+                        shown(other) + " is between " + shown(each) + " and " + shown(above));
+            }
+        }
+    }
+
+    /** The strings closest to {@code than}: itself with one more unit, and its prefixes with one. */
+    private static List<String> between(String than) {
+        List<String> out = new java.util.ArrayList<>();
+        for (int at = 0; at <= than.length(); at++) {
+            for (char unit : new char[] {0, 1, ' ', 'a', '\uD800', '\uDC00', '￿'}) {
+                out.add(than.substring(0, at) + unit);
+                out.add(than.substring(0, at) + unit + than.substring(at));
+            }
+        }
+        out.addAll(STRINGS);
+        return out;
+    }
+
+    private static String shown(String value) {
+        StringBuilder out = new StringBuilder("\"");
+        for (int at = 0; at < value.length(); at++) {
+            out.append(String.format("\\u%04X", (int) value.charAt(at)));
+        }
+        return out.append('"').toString();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule whose strings are one stretch of the order they are measured on bounds the position, and
+ * is owed the row at the place they begin.
+ *
+ * <p>{@code String.startsWith("JP", value)} admits exactly the strings from {@code "JP"} up to but
+ * not including {@code "JQ"}, and a string is measured on the order the runtime compares them on. So
+ * the position stops in two places, and a rule stating that in a comparison and one stating it as a
+ * predicate leave it in the same two — the second was read as a rule holding the position to what it
+ * admits and drawing no line, which is true of the format beside it and not of this.
+ *
+ * <p>What a rule states about the strings and where the strings stop are two questions here. The
+ * first is settled by the reading that turns clauses into sets and is settled whether or not this
+ * compiler could work out the text written in the rule; the second is asked only of a language it
+ * has. So a format whose strings are not one stretch, and a rule this could read no language out of,
+ * come back with no edge for reasons that are not the same reason.
+ */
+class ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest {
+
+    private static final String MODEL = """
+            module runs
+
+            data Pre    = String invariant String.startsWith("JP", value)
+            data Cmp    = String invariant value >= "JP" && value < "JQ"
+            data Same   = String invariant String.matches("JP[\\\\s\\\\S]*", value)
+            data Format = String invariant String.matches("[0-9]{4}", value)
+            data One    = String invariant String.matches("C", value)
+
+            data Ok = { size: Int }
+
+            behavior onPre : (v: Pre) -> Ok
+                constructs Ok
+            let onPre (v) = Ok { size = String.length(v.value) }
+
+            behavior onCmp : (v: Cmp) -> Ok
+                constructs Ok
+            let onCmp (v) = Ok { size = String.length(v.value) }
+
+            behavior onSame : (v: Same) -> Ok
+                constructs Ok
+            let onSame (v) = Ok { size = String.length(v.value) }
+
+            behavior onFormat : (v: Format) -> Ok
+                constructs Ok
+            let onFormat (v) = Ok { size = String.length(v.value) }
+
+            behavior onOne : (v: One) -> Ok
+                constructs Ok
+            let onOne (v) = Ok { size = String.length(v.value) }
+            """;
+
+    /**
+     * The prefix and the comparison leave the position in the same places, and are owed the same
+     * rows.
+     *
+     * <p>Compared as what the two are owed rather than as what a measure holds. A line is where a
+     * row can be written against, and how many of those a measure keeps is this compiler's
+     * arrangement; what has to agree is what an author is asked for.
+     */
+    @Test
+    void aPrefixAndTheComparisonThatSaysItAreOwedTheSameRows() {
+        String report = report(MODEL);
+
+        assertEquals(owed(report, "onCmp"), owed(report, "onPre"),
+                "the same strings leave the position in the same places:\n" + report);
+    }
+
+    /** And so is the pattern that accepts the same strings, whichever call states it. */
+    @Test
+    void andSoIsAPatternAcceptingTheSameStrings() {
+        String report = report(MODEL);
+
+        assertEquals(owed(report, "onCmp"), owed(report, "onSame"),
+                "what a rule leaves is the strings it admits and not the call it is written as:\n"
+                        + report);
+    }
+
+    /** The row is at the place the strings begin, and there is none at the place they stop: no
+     *  string is at the second, and the order names none just below it. */
+    @Test
+    void theRowIsWhereTheStringsBeginAndNotWhereTheyStop() {
+        String report = report(MODEL);
+
+        assertTrue(report.contains(
+                "undecided whether a row is at the ON point value = JP (invariant Pre #1)"), report);
+        assertTrue(report.contains(
+                "no ON point is owed at v = JQ (invariant Pre #1): this order names no value there"),
+                report);
+    }
+
+    /**
+     * A format whose strings are not one stretch holds the position to what it admits and draws no
+     * line.
+     *
+     * <p>{@code [0-9]{4}} leaves out {@code "0000a"}, which is between two of the strings it
+     * admits — so there are no two places to put an edge at, and what the rule does is what every
+     * rule of this kind did before.
+     */
+    @Test
+    void aFormatWhoseStringsAreNotOneStretchDrawsNoLine() {
+        String report = report(MODEL);
+
+        assertTrue(report.contains("no line: invariant Format #1 — it restricts this position to"
+                + " the values it admits"), report);
+        assertFalse(report.contains("(invariant Format #1):"),
+                "and no edge is owed for it:\n" + report);
+    }
+
+    /**
+     * And a rule admitting one string names a value rather than bounding a range.
+     *
+     * <p>One string is a stretch of the order like any other — it begins somewhere and ends at the
+     * next string above it — and there is nothing between the two for a row to be owed at. What such
+     * a rule leaves is what it admits, which is what a report says of it.
+     */
+    @Test
+    void aRuleAdmittingOneStringNamesAValueRatherThanBoundingARange() {
+        String report = report(MODEL);
+
+        assertTrue(report.contains("no line: invariant One #1 — it restricts this position to"
+                + " the values it admits"), report);
+        assertFalse(report.contains("(invariant One #1):"), report);
+    }
+
+    /** What {@code behavior} is asked for, as the report writes it against the behavior's own
+     *  positions. */
+    private static String owed(String report, String behavior) {
+        StringBuilder out = new StringBuilder();
+        for (String line : report.lines().toList()) {
+            if (line.contains("read as " + behavior + "/")) {
+                out.append(line.substring(line.indexOf("read as ") + behavior.length() + 9))
+                        .append('\n');
+            }
+        }
+        return out.toString();
+    }
+
+    private static String report(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
@@ -135,6 +135,68 @@ class ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest {
     }
 
     /**
+     * A rule nobody could read in a branch nobody can take hides no run of the branch that stands.
+     *
+     * <p>What a rule about the strings leaves is what its own branch of every choice in it leaves,
+     * and so is whether the strings were worked out. The left branch asks for a string below the
+     * least one there is, so nobody can take it, and what it could not read goes with it — read as
+     * a fact about the clause, the branch that stands would have no run at a position its own rule
+     * runs between two places.
+     */
+    @Test
+    void aRuleNobodyCouldReadInADeadBranchHidesNoRunOfTheOneThatStands() {
+        String report = report("""
+                module branches
+
+                data Code = String
+                    invariant (value < "" && String.matches("%s", value))
+                        || String.startsWith("JP", value)
+
+                data Ok = { size: Int }
+
+                behavior onCode : (v: Code) -> Ok
+                    constructs Ok
+                let onCode (v) = Ok { size = String.length(v.value) }
+                """.formatted(NESTED_PAST_WHAT_IS_READ));
+
+        assertTrue(report.contains(
+                "undecided whether a row is at the ON point value = JP (invariant Code #1)"),
+                "the branch that stands runs from JP:\n" + report);
+    }
+
+    /**
+     * A rule this reads no further into leaves the question of where the values stop standing, and
+     * not answered.
+     *
+     * <p>What such a rule admits is not every string; it is not known. Read off what the reading
+     * left, the rule would look like one that admits every string and states no bound — which is a
+     * fact about the model, where what is true is that nobody worked out whether it states one.
+     */
+    @Test
+    void aRuleThisReadsNoFurtherIntoLeavesTheBoundaryStanding() {
+        String report = report("""
+                module unread
+
+                data Code = String invariant String.matches("%s", value)
+
+                data Ok = { size: Int }
+
+                behavior onCode : (v: Code) -> Ok
+                    constructs Ok
+                let onCode (v) = Ok { size = String.length(v.value) }
+                """.formatted(NESTED_PAST_WHAT_IS_READ));
+
+        assertTrue(report.contains("not accounted for: invariant Code #1 — whether the values stop"
+                        + " on v: written more deeply nested than this compiler reads"),
+                "the question stands and says what stopped it:\n" + report);
+    }
+
+    /** A pattern written more deeply than the subset reads, which is a rule this reads no further
+     *  into and no error. */
+    private static final String NESTED_PAST_WHAT_IS_READ =
+            "(".repeat(201) + "a" + ")".repeat(201);
+
+    /**
      * A reading that ran out of what it may build says so, and is not read as a rule that draws no
      * line.
      *
@@ -192,38 +254,6 @@ class ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest {
         assertEquals(1, report.lines()
                         .filter(each -> each.contains("point value = m")).count(),
                 "one line, owed once:\n" + report);
-    }
-
-    /**
-     * A rule whose text this could not work out draws no line, and is not read as one admitting
-     * every string.
-     *
-     * <p>What the reading left where it worked nothing out is every value — which is what a
-     * position nothing was read about holds, and the run of every string begins where the strings
-     * begin. Read off what was left, such a rule would arrive here as one that admits every string,
-     * and what it draws would be settled by a set nobody established.
-     *
-     * <p>The pattern is written out of a name this module holds, so what stops the reading is the
-     * text and not the pattern: the call is a rule about {@code value} either way, and only the
-     * strings are missing.
-     */
-    @Test
-    void aRuleWhoseTextWasNotWorkedOutDrawsNoLine() {
-        String report = report("""
-                module unread
-
-                data Code = String invariant String.matches(pattern(), value)
-
-                data Ok = { size: Int }
-
-                behavior pattern : () -> String
-                behavior onCode : (v: Code) -> Ok
-                    constructs Ok
-                let onCode (v) = Ok { size = String.length(v.value) }
-                """);
-
-        assertFalse(report.contains("point v = "), "no edge is owed for it:\n" + report);
-        assertFalse(report.contains("point value = "), report);
     }
 
     /** What {@code behavior} is asked for, as the report writes it against the behavior's own

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest.java
@@ -134,6 +134,98 @@ class ARunOfTheStringsIsABoundAndIsOwedItsEdgeTest {
         assertFalse(report.contains("(invariant One #1):"), report);
     }
 
+    /**
+     * A reading that ran out of what it may build says so, and is not read as a rule that draws no
+     * line.
+     *
+     * <p>The two read alike at the position and are opposite claims. One is about the strings a rule
+     * admits — every one of them was worked out and they are not one stretch of the order — and the
+     * other is about this compiler, which established nothing. An author shown the first would be
+     * told their rule holds the position to what it admits and stops it nowhere, of a rule whose
+     * geometry nobody read.
+     *
+     * <p>The pattern is one this compiler reads and the machine for what it admits is one it makes;
+     * what runs out is the further machine the run needs, which is the product of that one with the
+     * strings above where it begins.
+     */
+    @Test
+    void areadingThatRanOutSaysSoRatherThanThatTheRuleDrawsNoLine() {
+        String report = report("""
+                module costly
+
+                data Long = String invariant String.matches("[0-9]{300}", value)
+
+                data Ok = { size: Int }
+
+                behavior onLong : (v: Long) -> Ok
+                    constructs Ok
+                let onLong (v) = Ok { size = String.length(v.value) }
+                """);
+
+        assertTrue(report.contains("invariant Long #1"), "the rule is named:\n" + report);
+        assertFalse(report.contains("it restricts this position to the values it admits"),
+                "a limit of this compiler is not a rule read to the end without a line:\n" + report);
+    }
+
+    /**
+     * An end two readings both saw is one line owed to one conjunct.
+     *
+     * <p>A newtype's own comparisons are read off the clauses as they are written and again as the
+     * ends its conjuncts state, since the second is where a rule stating no comparison puts one. So
+     * the same end arrives twice, and what tells whether that costs anything is the rule it is owed
+     * to: two names at one place would be two rows for one line an author wrote once.
+     */
+    @Test
+    void anEndTwoReadingsBothSawIsOwedToOneRule() {
+        String report = report("""
+                module twice
+
+                data Held = String invariant value >= "m"
+
+                data Ok = { size: Int }
+
+                behavior onHeld : (v: Held) -> Ok
+                    constructs Ok
+                let onHeld (v) = Ok { size = String.length(v.value) }
+                """);
+
+        assertEquals(1, report.lines()
+                        .filter(each -> each.contains("point value = m")).count(),
+                "one line, owed once:\n" + report);
+    }
+
+    /**
+     * A rule whose text this could not work out draws no line, and is not read as one admitting
+     * every string.
+     *
+     * <p>What the reading left where it worked nothing out is every value — which is what a
+     * position nothing was read about holds, and the run of every string begins where the strings
+     * begin. Read off what was left, such a rule would arrive here as one that admits every string,
+     * and what it draws would be settled by a set nobody established.
+     *
+     * <p>The pattern is written out of a name this module holds, so what stops the reading is the
+     * text and not the pattern: the call is a rule about {@code value} either way, and only the
+     * strings are missing.
+     */
+    @Test
+    void aRuleWhoseTextWasNotWorkedOutDrawsNoLine() {
+        String report = report("""
+                module unread
+
+                data Code = String invariant String.matches(pattern(), value)
+
+                data Ok = { size: Int }
+
+                behavior pattern : () -> String
+                behavior onCode : (v: Code) -> Ok
+                    constructs Ok
+                let onCode (v) = Ok { size = String.length(v.value) }
+                """);
+
+        assertFalse(report.contains("point v = "), "no edge is owed for it:\n" + report);
+        assertFalse(report.contains("point value = "), report);
+    }
+
     /** What {@code behavior} is asked for, as the report writes it against the behavior's own
      *  positions. */
     private static String owed(String report, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
@@ -116,6 +116,46 @@ class TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest {
         }
     }
 
+    /**
+     * The least string a language holds is a string it holds.
+     *
+     * <p>The law the walk is held to, beside the one about the order. A machine steps over what a
+     * matcher reads, so a high surrogate and a low one standing next to each other are the pair and
+     * not two symbols — and a walk that took them as two answers with a sequence of symbols no
+     * string is written as. Asked whether it holds that, the language says no, and the two answers
+     * are about the same string.
+     *
+     * <p>Over languages built by taking one away from another, which is where such a sequence turns
+     * up: the strings above a pair that a prefix of it does not admit begin with the same two units
+     * as the prefix does, and only the reading of those units tells them apart.
+     */
+    @Test
+    void theLeastStringALanguageHoldsIsOneItHolds() {
+        for (String pattern : List.of("JP[\\s\\S]*", "a*b", "𐀀[\\s\\S]*",
+                "[\\s\\S]*", "\uD800[\\s\\S]*", "(JP|US)[\\s\\S]*")) {
+            for (Language each : List.of(of(pattern), leftOver(of(pattern)))) {
+                String least = each.least();
+                if (least != null) {
+                    assertTrue(each.has(least),
+                            shown(least) + " is answered as the least of a language that does not"
+                                    + " hold it, from " + pattern);
+                }
+            }
+        }
+    }
+
+    /** What a language leaves out from its least string upwards, which is where the two readings of
+     *  a pair's units part. */
+    private static Language leftOver(Language language) {
+        Meter meter = allowing();
+        String least = language.least();
+        if (least == null) {
+            return language;
+        }
+        Language above = Language.before(least, meter).not(meter);
+        return above.and(language.not(meter), meter);
+    }
+
     /** A language with nothing in it has no least string, which is not a string it holds. */
     @Test
     void aLanguageHoldingNothingHasNoLeast() {

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
@@ -1,0 +1,224 @@
+package souther.compiler.regex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The order these machines are built and walked on is {@link String#compareTo} and nothing else.
+ *
+ * <p>Held to the comparison itself rather than to a table of written answers, because what this is
+ * here to catch is a second definition of the order. The symbols a machine steps over are what a
+ * matcher reads — a code point where a string holds a well-formed pair — and the runtime compares
+ * UTF-16 code units, so the two disagree wherever a pair is involved. A reading that ordered the
+ * symbols instead passes every test written over letters and digits.
+ *
+ * <p>Every string here is written in units, because units are what the question is about.
+ * {@code \uD800￿} against {@code 𐀀} is the one that catches the near miss: the two
+ * begin with the same unit and spend a different number of them on their first symbol, so no
+ * relabelling of the alphabet puts them in the runtime's order — a repair that sorted the symbols by
+ * unit rather than by code point would still get it wrong.
+ */
+class TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest {
+
+    /** What a language is allowed while one of these is answered. */
+    private static Meter allowing() {
+        return new Meter(20000, 200000);
+    }
+
+    /**
+     * Strings crossing every boundary the two orders differ at: the basic plane either side of the
+     * surrogates, halves of a pair standing alone, and pairs.
+     */
+    private static final List<String> STRINGS = List.of(
+            "", " ", "a", "ab", "b", "JP", "JPa", "JQ", "J",
+            "퟿", "\uD800", "𐀀", "𐏿",
+            "\uD800￿", "\uD800\uD800", "􏿿", "\uDC00", "\uDFFF",
+            "", " ", "￿", "￿￿",
+            "𐀀𐀀", "𐀁", "𐐀");
+
+    /**
+     * The machine for what comes before a string accepts exactly the strings that do.
+     *
+     * <p>Over every pair of the corpus, both ways round, so that what is checked is the comparison
+     * and not one side of it.
+     */
+    @Test
+    void whatComesBeforeAStringIsWhatTheRuntimeSaysComesBeforeIt() {
+        for (String than : STRINGS) {
+            Language before = Language.before(than, allowing());
+            assertNotNull(before, "the machine for what comes before " + shown(than));
+            for (String value : STRINGS) {
+                assertEquals(value.compareTo(than) < 0, before.has(value),
+                        shown(value) + " against " + shown(than));
+            }
+        }
+    }
+
+    /**
+     * And the strings around one it does not hold, so that the edge is where the comparison puts it
+     * and not one unit either side.
+     *
+     * <p>Every prefix of every string of the corpus, each with one more unit and each with one more
+     * unit and the rest. A prefix is below and a string that goes on is above, which is where an
+     * off-by-one in the unit walk shows.
+     */
+    @Test
+    void theEdgeIsWhereTheComparisonPutsIt() {
+        for (String than : STRINGS) {
+            Language before = Language.before(than, allowing());
+            assertNotNull(before, shown(than));
+            for (String value : around(than)) {
+                assertEquals(value.compareTo(than) < 0, before.has(value),
+                        shown(value) + " against " + shown(than));
+            }
+        }
+    }
+
+    /** The units a prefix is extended by, which are the ones the two orders part over. */
+    private static final char[] UNITS =
+            {' ', 'a', '퟿', '\uD800', '\uDBFF', '\uDC00', '\uDFFF', '', '￿'};
+
+    /** A string's prefixes, each on its own and each with one more unit before the rest. */
+    private static List<String> around(String than) {
+        List<String> out = new ArrayList<>();
+        for (int at = 0; at <= than.length(); at++) {
+            String prefix = than.substring(0, at);
+            out.add(prefix);
+            for (char unit : UNITS) {
+                out.add(prefix + unit);
+                out.add(prefix + unit + than.substring(at));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The least string a language holds is the one the comparison puts first.
+     *
+     * <p>Read against the corpus rather than against a written answer: such a language is the words
+     * themselves, so what it has to answer is whichever of them comes first.
+     */
+    @Test
+    void theLeastStringIsTheOneTheComparisonPutsFirst() {
+        for (int held = 1; held <= STRINGS.size(); held++) {
+            List<String> words = STRINGS.subList(0, held);
+            assertEquals(words.stream().sorted().findFirst().orElseThrow(), wordsOf(words).least(),
+                    "the least of " + words.stream().map(
+                            TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest::shown).toList());
+        }
+    }
+
+    /** A language with nothing in it has no least string, which is not a string it holds. */
+    @Test
+    void aLanguageHoldingNothingHasNoLeast() {
+        Language nothing = wordsOf(List.of("a")).and(wordsOf(List.of("b")), allowing());
+        assertNotNull(nothing);
+        assertTrue(nothing.isEmpty());
+        assertNull(nothing.least());
+    }
+
+    /**
+     * A language whose strings descend without stopping has no least, and says so rather than
+     * answering with one it reached.
+     *
+     * <p>{@code a*b} holds {@code b}, and {@code ab} below it, and {@code aab} below that: every
+     * string of it has one below it, and what is below all of them is not a string. Answered with
+     * the shortest, a reading would put a line at {@code b} and call it where the values stop.
+     */
+    @Test
+    void aLanguageDescendingWithoutStoppingHasNoLeast() {
+        Language descending = of("a*b");
+        assertTrue(descending.has("b"));
+        assertTrue(descending.has("aaab"));
+        assertNull(descending.least());
+    }
+
+    /** A prefix has one: every string it holds begins with it, so it is the least of them. */
+    @Test
+    void aPrefixIsTheLeastOfWhatItAdmits() {
+        assertEquals("JP", of("JP[\\s\\S]*").least());
+    }
+
+    /**
+     * The one that tells the two orders apart.
+     *
+     * <p>The runtime puts the pair first and the symbols put the lone surrogate first, because the
+     * pair's first symbol is above every unit. A reading over symbols answers with the wrong one of
+     * them whichever way its alphabet is sorted, since the two agree on their first unit and part on
+     * how many units that first symbol was.
+     */
+    @Test
+    void aPairAndALoneSurrogateAreOrderedAsTheRuntimeOrdersThem() {
+        String pair = "𐀀";
+        String lone = "\uD800￿";
+        assertTrue(pair.compareTo(lone) < 0, "the runtime puts the pair first");
+        assertTrue(pair.codePointAt(0) > lone.codePointAt(0),
+                "and the symbols put it second, which is what this is about");
+
+        assertEquals(pair, wordsOf(List.of(pair, lone)).least());
+
+        Language before = Language.before(lone, allowing());
+        assertNotNull(before);
+        assertTrue(before.has(pair), "the pair comes before the lone surrogate");
+        assertFalse(before.has(lone));
+    }
+
+    /**
+     * The same across the surrogates: a pair is below every string beginning past them.
+     *
+     * <p>Beside the one above and not a second spelling of it. There, the two strings begin with the
+     * same unit, and a walk that took the units to try from the steps as they are written finds that
+     * unit anyway — the lone surrogate's own step supplies it, and the pair is reached by accident.
+     * Here nothing supplies it: the first units are a high surrogate and one past the surrogates,
+     * and a walk that did not take a pair's step apart into the units it spends never offers the
+     * first of them. So this is the one place where reading a pair as a unit at a time is what
+     * answers, and it is why the walk is written that way.
+     */
+    @Test
+    void aPairIsBelowTheFirstStringPastTheSurrogates() {
+        String pair = "𐀀";
+        String past = "";
+        assertTrue(pair.compareTo(past) < 0);
+        assertTrue(pair.codePointAt(0) > past.codePointAt(0));
+
+        assertEquals(pair, wordsOf(List.of(pair, past)).least());
+        assertTrue(Language.before(past, allowing()).has(pair));
+    }
+
+    /** The language holding exactly {@code words}. */
+    private static Language wordsOf(List<String> words) {
+        Meter meter = allowing();
+        Automaton made = Automaton.ofWords(words, meter);
+        assertNotNull(made, "a machine for " + words.size() + " words");
+        Automaton canonical = made.canonical(meter);
+        assertNotNull(canonical);
+        return new Language(canonical);
+    }
+
+    /** The language of one written pattern, which is what a rule states. */
+    private static Language of(String pattern) {
+        PatternRead read = PatternParser.read(pattern);
+        assertTrue(read instanceof PatternRead.Read, pattern + " is read");
+        Language made = PatternPlan.of(((PatternRead.Read) read).syntax())
+                .compile(PatternPlan.Budget.OF_ADMITTED_VALUES);
+        assertNotNull(made, pattern + " compiles");
+        return made;
+    }
+
+    /** A string with its units written out, so that a failure names what it was about. */
+    private static String shown(String value) {
+        StringBuilder out = new StringBuilder("\"");
+        for (int at = 0; at < value.length(); at++) {
+            out.append(String.format("\\u%04X", (int) value.charAt(at)));
+        }
+        return out.append('"').toString();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/regex/TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest.java
@@ -144,6 +144,100 @@ class TheRuntimesOrderIsWhatTheseMachinesAnswerAboutTest {
         }
     }
 
+    /**
+     * What a language does not hold is what every string it does not hold is.
+     *
+     * <p>The complement is over the strings and not over the sequences a machine steps between:
+     * there are sequences of symbols no string is read as, and a machine's complement holds them
+     * like anything else. Read against every string of the corpus, so a complement that kept them
+     * would still answer this — what such a complement gets wrong is the next question asked of it,
+     * which is the one below.
+     */
+    @Test
+    void whatALanguageDoesNotHoldIsEveryStringItDoesNotHold() {
+        for (String pattern : List.of("JP[\\s\\S]*", "a*b", "𐀀[\\s\\S]*", "\uD800[\\s\\S]*")) {
+            Language one = of(pattern);
+            Language rest = one.not(allowing());
+            assertNotNull(rest, pattern);
+            for (String value : STRINGS) {
+                assertEquals(!one.has(value), rest.has(value),
+                        shown(value) + " against what " + pattern + " does not hold");
+            }
+        }
+    }
+
+    /**
+     * Two languages holding the same strings are one language.
+     *
+     * <p>The law a machine can pass every membership question and still break. Here are two
+     * machines that stop on exactly the same strings and differ over a sequence of symbols no
+     * string is read as — a high surrogate standing alone with a low one after it, which a matcher
+     * reads as the pair. Held apart, the two are one set said two ways: a reader comparing them is
+     * told the model states two things, and one asking whether either holds nothing is told it holds
+     * something no string is.
+     */
+    @Test
+    void twoLanguagesHoldingTheSameStringsAreOne() {
+        // The pair as one symbol, which is what a string of it is read as.
+        Language pair = languageOf(new int[] {0x10000});
+        // And the same, with a high surrogate and a low one in turn beside it — two symbols no
+        // string is read as, so the two machines stop on exactly the same strings.
+        Language andTheSequence = languageOf(new int[] {0x10000}, new int[] {0xD800, 0xDC00});
+
+        for (String value : STRINGS) {
+            assertEquals(pair.has(value), andTheSequence.has(value), shown(value));
+        }
+        assertEquals(pair, andTheSequence,
+                "two machines stopping on the same strings are one language");
+    }
+
+    /** And a machine stopping on nothing but such a sequence is a language holding nothing. */
+    @Test
+    void aMachineStoppingOnNoStringHoldsNothing() {
+        Language none = languageOf(new int[] {0xD800, 0xDC00});
+        assertTrue(none.isEmpty(),
+                "a high surrogate beside a low one is the pair, so no string is read as the two");
+        assertNull(none.least());
+    }
+
+    /** The language of exactly these sequences of symbols, put through the way in that every
+     *  language takes. */
+    private static Language languageOf(int[]... sequences) {
+        Meter meter = allowing();
+        java.util.List<java.util.List<Automaton.Step>> steps = new ArrayList<>();
+        steps.add(new ArrayList<>());
+        java.util.BitSet accepting = new java.util.BitSet();
+        for (int[] each : sequences) {
+            int at = Automaton.START;
+            for (int symbol : each) {
+                steps.add(new ArrayList<>());
+                int made = steps.size() - 1;
+                steps.get(at).add(new Automaton.Step(CodePoints.of(symbol), made));
+                at = made;
+            }
+            accepting.set(at);
+        }
+        Language made = Language.canonical(Automaton.madeOf(steps, accepting), meter);
+        assertNotNull(made);
+        return made;
+    }
+
+    /**
+     * And a language holding every string says so, however it was arrived at.
+     *
+     * <p>Not the one state every symbol stops at: the sequences no string is read as are in no
+     * language here, so the machine for every string turns those away and stops on the rest.
+     */
+    @Test
+    void aLanguageHoldingEveryStringSaysSo() {
+        assertTrue(of("[\\s\\S]*").isEverything());
+        assertTrue(Language.EVERY_STRING.isEverything());
+        Language something = of("JP[\\s\\S]*");
+        assertTrue(something.or(something.not(allowing()), allowing()).isEverything(),
+                "a language and what it leaves out are every string there is");
+        assertFalse(of("a*b").isEverything());
+    }
+
     /** What a language leaves out from its least string upwards, which is where the two readings of
      *  a pair's units part. */
     private static Language leftOver(Language language) {

--- a/souther-compiler/src/test/java/souther/compiler/values/WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest.java
@@ -1,0 +1,208 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Text;
+import souther.compiler.regex.Language;
+import souther.compiler.regex.Meter;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a rule about a string leaves the values it is about, read off the strings it admits.
+ *
+ * <p>Off the language and not off how the rule was written. {@code String.startsWith("JP", value)}
+ * admits the strings from {@code "JP"} up to but not including {@code "JQ"}, and so does a pattern
+ * accepting the same strings — so the two leave the position between the same two places, and a
+ * reading keyed on which library operation was named would answer for one and not the other.
+ *
+ * <p>The three answers are about three different things, and the tests below are arranged by which:
+ * a run the rule names, a language established to name none, and an allowance that ran out. Nothing
+ * here folds the last two together — a rule an author can rewrite and a limit they cannot see are
+ * the two a report has to tell apart.
+ */
+class WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest {
+
+    /**
+     * A prefix is a run: everything it admits begins with the written text, so it begins at that
+     * text and ends where the next string past every one of them begins.
+     */
+    @Test
+    void aPrefixNamesTheRunFromItsTextToTheNextStringPastIt() {
+        assertEquals(new TextExtent.One(Text.of("JP"), Text.of("JQ")), extentOf("JP[\\s\\S]*"));
+    }
+
+    /**
+     * And the same run however the rule reaching it was spelled.
+     *
+     * <p>The two patterns accept the same strings and are one language, so what they leave the
+     * position between is one answer. Read off the spelling, {@code startsWith} would have an edge
+     * and the class written out by hand would not.
+     */
+    @Test
+    void thesSameStringsLeaveThePositionBetweenTheSamePlaces() {
+        assertEquals(extentOf("JP[\\s\\S]*"), extentOf("J(P)[\\s\\S]*"));
+        assertEquals(extentOf("JP[\\s\\S]*"), extentOf("JP[\\s\\S]{0,}"));
+    }
+
+    /** A rule naming one string is the run holding that string and nothing else. */
+    @Test
+    void oneStringIsTheRunFromItToTheNextThingAbove() {
+        TextExtent one = extentOf("JP");
+        TextExtent.One run = assertInstanceOf(TextExtent.One.class, one);
+        assertEquals(Text.of("JP"), run.first());
+        assertNotNull(run.after());
+        assertTrue(run.after().at().startsWith("JP"),
+                "what comes after every string beginning with JP and equal to it is JP and a"
+                        + " smallest unit: " + run.after());
+    }
+
+    /**
+     * A rule admitting everything from a string upwards has a beginning and no end.
+     *
+     * <p>There is no string above every one it admits, so there is nowhere an upper edge could be
+     * written — which is a run of the order all the same, and not a run this could not work out.
+     *
+     * <p>The language is built out of what comes before a string because no pattern says it: every
+     * string above {@code "J"} includes the ones written with a pair, and a class over the symbols
+     * cannot name those and the basic plane in one range. What is under test here is the reading of
+     * the run and not the machine it is handed.
+     */
+    @Test
+    void aRuleAdmittingEverythingAboveAStringHasNoEnd() {
+        Meter meter = PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter();
+        Language from = Language.everyString(meter)
+                .and(Language.before("J", meter).not(meter), meter);
+        assertNotNull(from);
+        assertTrue(from.has("J"));
+        assertTrue(from.has("𐀀"), "a string written with a pair is above J");
+        assertEquals(new TextExtent.One(Text.of("J"), null), TextExtents.of(from));
+    }
+
+    /** And everything there is, which begins at the string of nothing and has no end either. */
+    @Test
+    void everyStringThereIsBeginsAtTheStringOfNothing() {
+        assertEquals(new TextExtent.One(Text.of(""), null), extentOf("[\\s\\S]*"));
+    }
+
+    /**
+     * Two prefixes are two runs, and what that comes to is that no one run is named.
+     *
+     * <p>The answer is not that the strings are not convex. What follows is that there is no single
+     * pair of places to put an edge at, which is what this says — and a reading that answered with
+     * the reason would be saying something about the shape of the language rather than about where
+     * the values stop.
+     */
+    @Test
+    void twoPrefixesNameNoOneRun() {
+        assertEquals(new TextExtent.NoNamedRun(), extentOf("(JP|US)[\\s\\S]*"));
+    }
+
+    /**
+     * And a language whose strings descend without stopping names none either, for the other of the
+     * two reasons.
+     *
+     * <p>{@code a*b} holds a string below every string it holds. There is no least, so there is no
+     * place a lower edge could be written — and answering with the shortest would put a line where
+     * the values do not stop.
+     */
+    @Test
+    void aLanguageDescendingWithoutStoppingNamesNoRun() {
+        assertEquals(new TextExtent.NoNamedRun(), extentOf("a*b"));
+    }
+
+    /**
+     * A run whose ends are a pair and a lone surrogate is read on the runtime's order.
+     *
+     * <p>The prefix is the one pair, so what it admits runs from that pair up to the pair after it.
+     * On the order the symbols of a machine are in, the string after would be somewhere else
+     * entirely — every pair is above every unit there, and the two disagree about which of two
+     * strings beginning with the same unit comes first.
+     */
+    @Test
+    void aRunAcrossThePairsIsReadOnTheRuntimesOrder() {
+        assertEquals(new TextExtent.One(Text.of("𐀀"), Text.of("𐀁")),
+                extentOf("𐀀[\\s\\S]*"));
+    }
+
+    /**
+     * And a lone surrogate beside a pair is read as the string it is.
+     *
+     * <p>A high surrogate and a low one standing next to each other are the pair, which is what a
+     * matcher reads and what a walk over a string takes in. Read as two symbols, the run of the pair
+     * would end at the pair itself — the walk would answer with a sequence of symbols no string is
+     * written as, and the language would be said to hold a string it does not.
+     */
+    @Test
+    void aHighSurrogateBesideALowOneIsThePairAndNotTwoSymbols() {
+        Language pair = languageOf("𐀀[\\s\\S]*");
+        String least = pair.least();
+        assertEquals("𐀀", least);
+        assertTrue(pair.has(least), "the least string it holds is one it holds");
+    }
+
+    /**
+     * An allowance that runs out is said as itself, and never as a language that names no run.
+     *
+     * <p>The two read alike and are opposite claims: one is about the strings a rule admits and the
+     * other about what this compiler was allowed to build. A reader shown the first would tell an
+     * author their rule draws no line, of a rule that draws one.
+     */
+    @Test
+    void anAllowanceThatRanOutIsSaidAsItself() {
+        Language prefix = languageOf("JP[\\s\\S]*");
+        assertInstanceOf(TextExtent.NotBuilt.class,
+                TextExtents.of(prefix, new Meter(2, 2)),
+                "a rule that names a run under an allowance that holds nothing");
+    }
+
+    /** And which limit refused it, since the two are not one fact. */
+    @Test
+    void andWhichLimitRefusedIt() {
+        Language prefix = languageOf("JP[\\s\\S]*");
+        TextExtent.NotBuilt one = assertInstanceOf(TextExtent.NotBuilt.class,
+                TextExtents.of(prefix, new Meter(2, 1000)));
+        assertEquals(Meter.Stopped.ONE_MACHINE, one.stopped());
+
+        TextExtent.NotBuilt all = assertInstanceOf(TextExtent.NotBuilt.class,
+                TextExtents.of(prefix, new Meter(100_000, 3)));
+        assertEquals(Meter.Stopped.THE_ANSWER, all.stopped());
+    }
+
+    /** A run has a string at its lower end and none just below its upper: the shape is the one
+     *  thing the type will hold. */
+    @Test
+    void aRunHasNoOtherShape() {
+        assertNull(new TextExtent.One(Text.of("JP"), null).after());
+        assertThrows(() -> new TextExtent.One(null, Text.of("JQ")));
+        assertThrows(() -> new TextExtent.One(Text.of("JQ"), Text.of("JP")));
+        assertThrows(() -> new TextExtent.One(Text.of("JP"), Text.of("JP")));
+    }
+
+    private static void assertThrows(Runnable what) {
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+                what::run);
+    }
+
+    /** What the rule written as {@code pattern} leaves the position between. */
+    private static TextExtent extentOf(String pattern) {
+        return TextExtents.of(languageOf(pattern));
+    }
+
+    /** The strings {@code pattern} accepts. */
+    private static Language languageOf(String pattern) {
+        PatternRead read = PatternParser.read(pattern);
+        assertInstanceOf(PatternRead.Read.class, read, pattern + " is read");
+        Language made = PatternPlan.of(((PatternRead.Read) read).syntax())
+                .compile(PatternPlan.Budget.OF_ADMITTED_VALUES);
+        assertNotNull(made, pattern + " compiles");
+        return made;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest.java
@@ -78,8 +78,7 @@ class WhereAStringRuleStopsIsReadOffTheLanguageItAdmitsTest {
     @Test
     void aRuleAdmittingEverythingAboveAStringHasNoEnd() {
         Meter meter = PatternPlan.Budget.OF_AN_ORDERED_EXTENT.meter();
-        Language from = Language.everyString(meter)
-                .and(Language.before("J", meter).not(meter), meter);
+        Language from = Language.before("J", meter).not(meter);
         assertNotNull(from);
         assertTrue(from.has("J"));
         assertTrue(from.has("𐀀"), "a string written with a pair is above J");


### PR DESCRIPTION
Closes #1301.

`String.startsWith("JP", value)` admits exactly the strings from `"JP"` up to but not including
`"JQ"`, and a string is measured on the order the runtime compares them on. So the position stops in
two places — and a rule stating that in a comparison and one stating it as a predicate left it in
different ones. The second was read as a rule holding the position to what it admits and drawing no
line, which is true of a format and not of this.

Whether a rule places an end was decided by the shape of the clause: the reading of ends looks at
comparisons, and a predicate over strings is not one. An end is a property of the values a rule
admits and not of the syntax that stated it, so it is read off the strings — the reading that owns
those is the one that has them, and what a predicate states is recognised once and handed on.

Which means the same run however it is spelled. A prefix, the pattern accepting the same strings,
and the comparison that says it now leave the position between the same two places and are owed the
same rows.

## What is asked of what

Two answers of one recognition, and neither read off the other. Which of a position's numbers such a
rule is written about is settled by the call, so it is written down whether or not the text in the
rule could be worked out — a format written out of a constant a module cannot reach is a rule about
the string as plainly as one written out. Where the strings stop is asked only of a language this
has, and under an allowance of its own: what a report costs may not be paid out of what the
position's own answer is allowed.

Per conjunct, because that is what an end is owed to. Two conjuncts stating the same run name the
line together and a looser one beside a tighter states nothing about where the values stop, which is
what the ends of a comparison already come to. So these go where a comparison's own end goes, and a
run is what the conjunct admits rather than something worked out from what the rules leave together.

## The order a language is asked about

A machine here steps over what a matcher reads: a code point where a string holds a well-formed
pair, a unit where it holds half of one. The runtime compares UTF-16 code units. Those are not the
same order and no relabelling of the symbols makes them one — two strings can begin with the same
unit and spend a different number of units on their first symbol, so which of them comes first is
not a fact about their first symbols at all. Both questions a run needs are therefore asked a unit
at a time, and the laws over them are written against `String.compareTo` rather than against an
expected answer.

The same asymmetry is why a language holding nothing but sequences no string is read as said it held
something, why two machines holding the same strings compared unequal, and why the least of a
language came back a string that language then said it did not hold. Those sequences are taken out
where a language is made rather than by each caller before asking, so every question asked of one is
a question about strings.

## What does not change

A language that is not one run — two prefixes, a format leaving out a string between two it admits —
leaves the position exactly where it was. A run holding one string is the rule naming a value rather
than bounding a range, and a value it names is a distinction of the position rather than an edge on
it. Measured over the example corpus, no position gains a cut on a string's own order.

## Found on the way, and not closed here

- #1312 — a pattern written out of a constant is read only in the module that declares the type.
- #1316 — string admission and the order's bounds are not met when deciding whether an invariant
  admits anything.
- #1317 — a type whose own rules are written about both of its numbers is measured at one and says
  nothing about the other. Older than this change, which only enlarges the set of models that reach
  it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
