### PR TITLE
Fill a container to a total through the cases of what it holds

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -83,14 +83,11 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/check/ReadingPolicy;)"
                             + "Lsouther/compiler/partition/TermRealizations$Realization;",
                     "records the three a total can be short of, where each decides not to go on"),
-            Map.entry("souther.compiler.partition.ContainersAddingUp#waysDown("
-                            + "Lsouther/compiler/types/Type;"
-                            + "Lsouther/compiler/inputs/TermPath;"
-                            + "Lsouther/compiler/inputs/TermPath;"
-                            + "Lsouther/compiler/check/RuleReadingSource;)"
-                            + "Lsouther/compiler/partition/ContainersAddingUp$Ways;",
-                    "stops enumerating the ways down to the number and hands over that figure and"
-                            + " whatever the planning gave up at"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$Asking#next()"
+                            + "Lsouther/compiler/partition/ConstructionPlan$Result;",
+                    "stops asking about ways down to the number, which is the one place they are"
+                            + " asked about, and hands the figure over with whatever the planning"
+                            + " gave up at"),
             Map.entry("souther.compiler.partition.LevelRealizer#<clinit>()V",
                     "the places a pair is tried at, the steps, the progression — and the re-reads,"
                             + " which travel nowhere because reaching that one gives nothing up:"

--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -83,6 +83,14 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/check/ReadingPolicy;)"
                             + "Lsouther/compiler/partition/TermRealizations$Realization;",
                     "records the three a total can be short of, where each decides not to go on"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp#waysDown("
+                            + "Lsouther/compiler/types/Type;"
+                            + "Lsouther/compiler/inputs/TermPath;"
+                            + "Lsouther/compiler/inputs/TermPath;"
+                            + "Lsouther/compiler/check/RuleReadingSource;)"
+                            + "Lsouther/compiler/partition/ContainersAddingUp$Ways;",
+                    "stops enumerating the ways down to the number and hands over that figure and"
+                            + " whatever the planning gave up at"),
             Map.entry("souther.compiler.partition.LevelRealizer#<clinit>()V",
                     "the places a pair is tried at, the steps, the progression — and the re-reads,"
                             + " which travel nowhere because reaching that one gives nothing up:"

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -63,6 +63,12 @@ public enum CompositionBudget {
      *  buys is another row reading like the last. */
     SHAPES_OF_A_TOTAL_OFFERED(() -> 4),
 
+    /** How many ways down to the number a total is read from are tried. Its own figure and not
+     *  {@link #SHAPES_OF_A_TOTAL_OFFERED}: a way that plans is not a container that was offered, and
+     *  charging one to the other leaves a case never tried because an earlier one planned and built
+     *  nothing. What multiplies here is the cases of every sum the way down crosses. */
+    WAYS_DOWN_TO_A_TOTAL_TRIED(() -> 8),
+
     /** How many ways the difference between a starting point and a total is spread over the
      *  elements. Read off the walk that has them, so a third way of spreading is this budget
      *  raised. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -3,6 +3,8 @@ package souther.compiler.partition;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
+import souther.compiler.inputs.Case;
+import souther.compiler.inputs.Distinctions;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.Requirements;
 import souther.compiler.check.ConstructionDescent;
@@ -240,15 +242,17 @@ final class ConstructionPlan {
     /**
      * A plan, or why there is none.
      *
-     * <p>The two ways of having none are whose fact it is. A caller asking for a class under one
-     * case of a sum beside a class under another has asked for a row no value is, which the model
+     * <p>The ways of having none are whose fact each is. A caller asking for a class under one case
+     * of a sum beside a class under another has asked for a row no value is, which the model
      * settles and this reports; nothing here fell short. A caller asking for a position deeper than
      * this plans has asked for something ordinary that this compiler declined to work out, and what
-     * would change it is somebody raising a figure.
+     * would change it is somebody raising a figure. A caller asking for something under a position
+     * that holds nothing until a narrowing says what stands there has not said which, and what
+     * would change that is the caller stating one.
      *
      * <p>Told apart because a reader acts on them differently, and reported rather than answered
-     * because neither is a plan. Handed back as one, the second would arrive in the words of the
-     * first — a limit of this compiler's said as a thing the model settles.
+     * because none of them is a plan. Handed back as one, a limit of this compiler's would arrive
+     * in the words of a thing the model settles.
      */
     sealed interface Result {
 
@@ -283,6 +287,33 @@ final class ConstructionPlan {
                     throw new IllegalArgumentException(
                             "a demand out of this compiler's reach says which figure put it there");
                 }
+            }
+        }
+
+        /**
+         * What the caller asked for stands under a position that holds nothing until a narrowing
+         * says what stands there, and nothing said which.
+         *
+         * <p>A sum is the one of these a model writes. Its cases are what put positions under it,
+         * so a path reaching a field of every case names a position of the sum and no case of it —
+         * which is how a rule about the shared part is read (spec §sum-data) and is not enough to
+         * write a value with. Reading and writing part here, and the reading is right: what has to
+         * be added is which case the value is, and the caller is the one with a reason to prefer
+         * one.
+         *
+         * <p>Handed back rather than chosen here. Which case a value is is a fact about the value
+         * and not about the plan, and a plan that took the first would answer a question nobody
+         * asked it — the narrowing the caller then states is what makes the position, and every
+         * path under it, the one the value is written at.
+         *
+         * @param narrowings what the position stands at, in the order the declarations write them.
+         *                   Empty where the position divides no way at all, which is a demand under
+         *                   a position nothing puts anything under
+         */
+        record Unnarrowed(TermPath at, List<Refinement> narrowings) implements Result {
+
+            public Unnarrowed {
+                narrowings = List.copyOf(narrowings);
             }
         }
     }
@@ -334,6 +365,8 @@ final class ConstructionPlan {
         return switch (node(declared, at, symbols, 0, decided, required, least)) {
             case NodeResult.Made(Node root) -> new Result.Planned(new ConstructionPlan(root));
             case NodeResult.Beyond(Set<CompositionBudget> by) -> new Result.Beyond(by);
+            case NodeResult.Unnarrowed(TermPath where, List<Refinement> narrowings) ->
+                    new Result.Unnarrowed(where, narrowings);
         };
     }
 
@@ -352,6 +385,10 @@ final class ConstructionPlan {
 
         /** Nothing was, because what the caller asked for is under a figure this reached. */
         record Beyond(Set<CompositionBudget> by) implements NodeResult {}
+
+        /** Nothing was, because what the caller asked for is under a position nothing stands at
+         *  until a narrowing says what does. */
+        record Unnarrowed(TermPath at, List<Refinement> narrowings) implements NodeResult {}
     }
 
     /**
@@ -493,6 +530,15 @@ final class ConstructionPlan {
         // however deep it is, and answering the figure first would file the model's own answer as
         // something this compiler declined to do.
         if (composed == null || composed.fields().isEmpty()) {
+            // A whole value is chosen here, so anything the caller asked for below it has nowhere
+            // to be written. Said rather than dropped, for the reason a demand under the figure is:
+            // a plan handed back all the same is one the composing satisfies while leaving the
+            // caller's value out of what it built. What the two answers differ in is what would
+            // change them — a figure is raised, and this is a narrowing the caller has yet to
+            // state.
+            if (anythingIsAskedUnder(here, decided, required)) {
+                return new NodeResult.Unnarrowed(here, narrowingsAt(view, symbols));
+            }
             return new NodeResult.Made(
                     new Slot(here, building, settled.outer(), new Leaf.Open()));
         }
@@ -509,6 +555,11 @@ final class ConstructionPlan {
                 // are two figures a reader could raise, and taking whichever the walk met first
                 // would make the answer turn on the order the fields are declared in.
                 case NodeResult.Beyond(Set<CompositionBudget> by) -> beyond.addAll(by);
+                // One position, and the first of them. A narrowing is stated at a position rather
+                // than gathered up, and the caller states one and asks again — so what it is owed
+                // is somewhere to begin, and the field a second one is under may not even be
+                // reached under the narrowing it settles on here.
+                case NodeResult.Unnarrowed unnarrowed -> { return unnarrowed; }
             }
         }
         if (!beyond.isEmpty()) {
@@ -532,6 +583,30 @@ final class ConstructionPlan {
         Set<CompositionBudget> by = Set.of(figure);
         return anythingIsAskedUnder(here, decided, required) ? new NodeResult.Beyond(by)
                 : new NodeResult.Made(new Slot(here, building, outer, new Leaf.Beneath(by)));
+    }
+
+    /**
+     * The narrowings a position stands at, in the order its declarations write them.
+     *
+     * <p>Asked of {@link Distinctions}, which is where what a position's type divides into is
+     * answered. A second reading here would be this deciding what a case is beside the reading that
+     * decides what a class is, and the two would be free to differ about a case that is itself a
+     * sum.
+     *
+     * <p>Those that narrow, which is not every distinction. A {@code Bool} divides into two values
+     * and puts no position under either, so nothing there is a narrowing to state and the list is
+     * empty — which says, correctly, that stating something here is not what would make the demand
+     * reachable.
+     */
+    private static List<Refinement> narrowingsAt(TypeView view, Symbols symbols) {
+        List<Refinement> out = new ArrayList<>();
+        for (Case one : Distinctions.ofType(view, symbols)) {
+            Refinement narrowing = Refinement.of(one);
+            if (narrowing != null) {
+                out.add(narrowing);
+            }
+        }
+        return List.copyOf(out);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -537,7 +537,7 @@ final class ConstructionPlan {
             // change them — a figure is raised, and this is a narrowing the caller has yet to
             // state.
             if (anythingIsAskedUnder(here, decided, required)) {
-                return new NodeResult.Unnarrowed(here, narrowingsAt(view, symbols));
+                return new NodeResult.Unnarrowed(here, narrowingsAt(settled, symbols, required));
             }
             return new NodeResult.Made(
                     new Slot(here, building, settled.outer(), new Leaf.Open()));
@@ -586,23 +586,32 @@ final class ConstructionPlan {
     }
 
     /**
-     * The narrowings a position stands at, in the order its declarations write them.
+     * The narrowings that would put a position under {@code settled}, in the order its declarations
+     * write them.
      *
-     * <p>Asked of {@link Distinctions}, which is where what a position's type divides into is
+     * <p>What a position divides into is asked of {@link Distinctions}, which is where that is
      * answered. A second reading here would be this deciding what a case is beside the reading that
      * decides what a class is, and the two would be free to differ about a case that is itself a
      * sum.
      *
-     * <p>Those that narrow, which is not every distinction. A {@code Bool} divides into two values
-     * and puts no position under either, so nothing there is a narrowing to state and the list is
-     * empty — which says, correctly, that stating something here is not what would make the demand
-     * reachable.
+     * <p><b>Those that leave something to be built, which is not every narrowing.</b> The absence of
+     * an optional settles the value rather than narrowing to something with positions under it, so
+     * stating it is not a way to reach what the caller asked for — it is the answer that there is
+     * nothing there at all, and a caller that stated it would be asking for a value under a position
+     * holding none. Asked by applying it, so this and {@link #applying} cannot come to differ about
+     * which narrowings those are.
+     *
+     * <p>Empty where nothing here would put a position under this at all. A {@code Bool} divides
+     * into two values and holds nothing under either, which says, correctly, that stating something
+     * here is not what would make the demand reachable.
      */
-    private static List<Refinement> narrowingsAt(TypeView view, Symbols symbols) {
+    private static List<Refinement> narrowingsAt(Settled settled, Symbols symbols,
+                                                 Requirements required) {
         List<Refinement> out = new ArrayList<>();
-        for (Case one : Distinctions.ofType(view, symbols)) {
+        for (Case one : Distinctions.ofType(TypeView.of(settled.building(), symbols), symbols)) {
             Refinement narrowing = Refinement.of(one);
-            if (narrowing != null) {
+            if (narrowing != null
+                    && applying(settled, narrowing, symbols, required).exact() == null) {
                 out.add(narrowing);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -127,7 +127,10 @@ final class ContainersAddingUp {
         // were one fact and a reader was told a search stopped without being told what would let it
         // go further — and worked out afterwards from the ends, they cannot all be seen at once.
         java.util.Set<CompositionBudget> left = java.util.EnumSet.noneOf(CompositionBudget.class);
-        if (cap < howMany.most()) {
+        // Where there is a way down to fill a container along. A figure over how many elements one
+        // is worth carrying stopped nothing where nothing was ever filled, and a reader told to
+        // raise it would be raising a figure that took nothing away.
+        if (cap < howMany.most() && !ways.filled().isEmpty()) {
             left.add(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER);
         }
         // What the planning gave up at, which is this compiler's the same way the figures below are.
@@ -143,7 +146,7 @@ final class ContainersAddingUp {
             // More than one element is more than one decomposition, whether or not this made a
             // second: what is offered is two shapes of the many, and the many are what a rule taking
             // a value out of the middle of a run tells apart.
-            if (many > 1) {
+            if (many > 1 && !ways.filled().isEmpty()) {
                 left.add(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED);
             }
             for (Spread how : Spread.values()) {
@@ -174,9 +177,12 @@ final class ContainersAddingUp {
         }
         // Nothing was composed, so what the budgets stopped is the composing itself and not the rest
         // of an offer. Where none of them ran out, this is a total nothing here writes a container
-        // for, which is a different thing to tell anybody.
+        // for — and what a reader is then owed is which of the ways to one were walked, since a
+        // figure having stopped the walk is exactly what says the ways were not all tried.
         return left.isEmpty()
-                ? none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                ? new TermRealizations.Realization.None(
+                        Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                        ways.said(occurrences(target)))
                 : new TermRealizations.Realization.Stopped(left);
     }
 
@@ -347,9 +353,11 @@ final class ContainersAddingUp {
         }
         List<FixtureTemplate> values = new ArrayList<>();
         for (BigDecimal each : split) {
-            FixtureTemplate one = ValuesCarryingANumber.carrying(filling.plan().root(), filling.fixed(),
-                    FixtureTemplate.on(elements, Count.of(each),
-                            ruleSource.symbols().scope()::reach),
+            FixtureTemplate one = PlanComposer.compose(filling.plan().root(),
+                    new ValuesCarryingANumber(filling.fixed(),
+                            FixtureTemplate.on(elements, Count.of(each),
+                                    ruleSource.symbols().scope()::reach),
+                            ruleSource, policy),
                     ruleSource, policy);
             if (one == null) {
                 return null;
@@ -375,11 +383,38 @@ final class ContainersAddingUp {
      * @param filled  one per way that planned, in the order they were reached
      * @param cutBy   the figures the planning stopped at, which are this compiler's
      */
-    private record Ways(List<Filling> filled, java.util.Set<CompositionBudget> cutBy) {
+    private record Ways(List<Filling> filled, java.util.Set<CompositionBudget> cutBy,
+                        List<TermPath> nothingStandsAt) {
 
         Ways {
             filled = List.copyOf(filled);
             cutBy = java.util.Set.copyOf(cutBy);
+            nothingStandsAt = List.copyOf(nothingStandsAt);
+        }
+
+        /**
+         * What this walk found, said where a reader is told nothing was composed.
+         *
+         * <p>Two answers and never one sentence for both. A way that was tried and built nothing
+         * says the ways are exhausted; a position nothing stands under says there was never a way
+         * to try. Told the same thing, a reader would be working out which of them it was from what
+         * the sentence left out.
+         */
+        String said(TermPath demand) {
+            if (filled.isEmpty()) {
+                return nothingStandsAt.isEmpty()
+                        ? "nothing here reaches `" + demand + "`"
+                        : "nothing standing at " + spelling(nothingStandsAt)
+                                + " gives a way down to `" + demand + "`";
+            }
+            return spelling(filled.stream().map(Filling::fixed).toList())
+                    + (filled.size() == 1 ? " was a way down to `" : " were ways down to `")
+                    + demand + "`, and none of them composed a value";
+        }
+
+        private static String spelling(List<TermPath> paths) {
+            return paths.stream().map(each -> "`" + each + "`")
+                    .collect(java.util.stream.Collectors.joining(", "));
         }
     }
 
@@ -404,6 +439,7 @@ final class ContainersAddingUp {
                                  RuleReadingSource ruleSource) {
         List<Filling> found = new ArrayList<>();
         java.util.Set<CompositionBudget> cutBy = java.util.EnumSet.noneOf(CompositionBudget.class);
+        List<TermPath> nothingStandsAt = new ArrayList<>();
         java.util.Deque<TermPath> asking = new java.util.ArrayDeque<>(List.of(demand));
         while (!asking.isEmpty()) {
             TermPath fixed = asking.removeFirst();
@@ -419,12 +455,26 @@ final class ContainersAddingUp {
             switch (ConstructionPlan.of(element, at, ruleSource.symbols(), java.util.Set.of(fixed),
                     Requirements.NONE,
                     (_, building) -> Partitions.leastHeld(building, ruleSource))) {
-                case ConstructionPlan.Result.Planned(ConstructionPlan plan) ->
+                // A way whose number stands inside a container of its own holds as many occurrences
+                // of it as that container's rules ask for, and the split above is one number per
+                // element of the outer one. So a value built along it comes to a multiple of the
+                // total it was built for, and nothing composes one until what is decomposed is the
+                // occurrences rather than the elements.
+                case ConstructionPlan.Result.Planned(ConstructionPlan plan) -> {
+                    if (!crossesAContainer(plan, fixed)) {
                         found.add(new Filling(plan, fixed));
+                    }
+                }
                 // A narrowing to state, and the walk states each of them. Asked again rather than
                 // planned around: a second narrowing may stand under the first, and which one that
                 // is depends on the case this settled on.
                 case ConstructionPlan.Result.Unnarrowed(TermPath where, List<Refinement> narrowings) -> {
+                    // A position nothing stands under is not a way that was tried and refused.
+                    // Kept as itself so that a reader is told there was never a way down rather
+                    // than that the ways came to nothing.
+                    if (narrowings.isEmpty()) {
+                        nothingStandsAt.add(where);
+                    }
                     for (Refinement narrowing : narrowings) {
                         asking.addLast(narrowed(fixed, where, narrowing));
                     }
@@ -439,7 +489,19 @@ final class ContainersAddingUp {
                                 + conflict.other().spelled() + ", though one narrowing was stated");
             }
         }
-        return new Ways(found, cutBy);
+        return new Ways(found, cutBy, nothingStandsAt);
+    }
+
+    /**
+     * Whether the way down to {@code fixed} passes through a container of its own.
+     *
+     * <p>Asked of the plan, which is what says where a container is built rather than chosen whole.
+     * Read off the path's steps instead, a step into a sequence the plan settled another way would
+     * be counted as one this builds around.
+     */
+    private static boolean crossesAContainer(ConstructionPlan plan, TermPath fixed) {
+        return plan.held().stream().anyMatch(each -> fixed.isAtOrUnder(each.at())
+                && !fixed.equals(each.at()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -64,6 +64,9 @@ final class ContainersAddingUp {
     private static final int HOW_MANY_SHAPES_ARE_OFFERED =
             CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED.maximum();
 
+    private static final int MOST_WAYS_DOWN_TRIED =
+            CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED.maximum();
+
     /**
      * How many ways a difference is spread over the elements, which is how many this walk has.
      *
@@ -369,7 +372,7 @@ final class ContainersAddingUp {
     /**
      * The ways down, and what the planning gave up at.
      *
-     * @param filled  one per way, in the order the declarations write the narrowings
+     * @param filled  one per way that planned, in the order they were reached
      * @param cutBy   the figures the planning stopped at, which are this compiler's
      */
     private record Ways(List<Filling> filled, java.util.Set<CompositionBudget> cutBy) {
@@ -389,8 +392,13 @@ final class ContainersAddingUp {
      * stands at, and this states one of them and asks again — so which cases there are, and which
      * of them a field is under, are read where a position's divisions are read and nowhere here.
      *
-     * <p>Bounded by how many shapes are offered at all. What is dropped is ways nothing would have
-     * been offered from, and the figure travels so that a reader is told the rest were never made.
+     * <p>Bounded by its own figure, and the figure travels so that a reader is told the rest were
+     * never tried.
+     *
+     * <p>The narrowings of one position in the order the declarations write them, and a second
+     * position's under whichever of the first's it was reached by. Nothing here orders the ways of
+     * two positions against each other: what a caller does with them is try each, and the figure
+     * above is what says how many.
      */
     private static Ways waysDown(Type element, TermPath at, TermPath demand,
                                  RuleReadingSource ruleSource) {
@@ -399,8 +407,13 @@ final class ContainersAddingUp {
         java.util.Deque<TermPath> asking = new java.util.ArrayDeque<>(List.of(demand));
         while (!asking.isEmpty()) {
             TermPath fixed = asking.removeFirst();
-            if (found.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
-                cutBy.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
+            // What this walk stops at, and not what the offering does. A way that plans is not a
+            // container that was offered -- the values are composed afterwards and a case may be
+            // refused there -- so spending the offer's figure here would leave a case never tried
+            // because an earlier one planned and then built nothing, which is the declaration order
+            // deciding what is offered.
+            if (found.size() == MOST_WAYS_DOWN_TRIED) {
+                cutBy.add(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED);
                 break;
             }
             switch (ConstructionPlan.of(element, at, ruleSource.symbols(), java.util.Set.of(fixed),

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -10,6 +10,8 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.BoundaryDomain;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.SearchRegion;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.inputs.TermPath;
@@ -110,7 +112,11 @@ final class ContainersAddingUp {
             // is said as a container this composed none of rather than as a total nothing reaches.
             return none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        List<TermPath.Step> under = stepsInsideAnElement(target);
+        // How a value of the element is built with the number written where the total reads it,
+        // asked of the plan and once per way down. A sum puts nothing under it until a case is
+        // named, so what comes back is one way per case and the walk offers each of them.
+        Ways ways = waysDown(holding.element(), target.writeRoot().element(), occurrences(target),
+                ruleSource);
         List<FixtureTemplate> built = new ArrayList<>();
         int cap = Math.min(howMany.most(), MOST_ELEMENTS_A_ROW_CARRIES);
         // What this walk did not do, recorded as it decides not to do it, and as which budget of
@@ -121,6 +127,10 @@ final class ContainersAddingUp {
         if (cap < howMany.most()) {
             left.add(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER);
         }
+        // What the planning gave up at, which is this compiler's the same way the figures below are.
+        // A way down that was never planned is a value never composed, and a reader told only that
+        // nothing was composed would look for the rule that refuses it.
+        left.addAll(ways.cutBy());
         // Asked where a container is added and nowhere else. What the budget counts is containers,
         // and a walk that asked at the top of the counts was asking about containers in a place that
         // steps by counts — so a count offering two of them stepped past the figure by one, and how
@@ -135,16 +145,25 @@ final class ContainersAddingUp {
             }
             for (Spread how : Spread.values()) {
                 List<BigDecimal> split = splitting(total.at(), many, ends, how, elements);
-                FixtureTemplate one = split == null ? null
-                        : filled(split, holding, container, under, elements, ruleSource, policy);
-                if (one == null || built.contains(one)) {
+                if (split == null) {
                     continue;
                 }
-                if (built.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
-                    left.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
-                    break offering;
+                // Every way down at this count, and the whole container by one of them. Which case
+                // an element is is a fact about the value, so a container whose elements are of
+                // several would be offering a shape nothing asked for; what the walk owes is to
+                // offer each case and to say the rest were never made.
+                for (Filling filling : ways.filled()) {
+                    FixtureTemplate one =
+                            filled(split, holding, container, filling, elements, ruleSource, policy);
+                    if (one == null || built.contains(one)) {
+                        continue;
+                    }
+                    if (built.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
+                        left.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
+                        break offering;
+                    }
+                    built.add(one);
                 }
-                built.add(one);
             }
         }
         if (!built.isEmpty()) {
@@ -202,19 +221,6 @@ final class ContainersAddingUp {
             case RealizationTarget.AtOnePosition one -> one.term().position().element();
             case RealizationTarget.OverARun over -> over.term().source().subjectPath();
         };
-    }
-
-    /**
-     * The way down from one element to the number, which is the occurrences' path with the container
-     * and the step into it taken off.
-     *
-     * <p>Steps and not a path. What is named is a way down from a value whose own location the
-     * element composer does not know, and a {@link TermPath} is rooted at a parameter — so a
-     * relative path written as one would be a second spelling of a location.
-     */
-    private static List<TermPath.Step> stepsInsideAnElement(RealizationTarget target) {
-        List<TermPath.Step> steps = occurrences(target).steps();
-        return List.copyOf(steps.subList(target.writeRoot().steps().size() + 1, steps.size()));
     }
 
     /**
@@ -331,14 +337,14 @@ final class ContainersAddingUp {
      * rather than composed as a list, so that the day one arrives it arrives here.
      */
     private static FixtureTemplate filled(List<BigDecimal> split, Shape.Sequence holding,
-                                          Type container, List<TermPath.Step> under,
+                                          Type container, Filling filling,
                                           Carrier elements, RuleReadingSource ruleSource, ReadingPolicy policy) {
         if (holding.kind() != Shape.Sequence.Kind.LIST) {
             return null;
         }
         List<FixtureTemplate> values = new ArrayList<>();
         for (BigDecimal each : split) {
-            FixtureTemplate one = Partitions.carrying(holding.element(), under,
+            FixtureTemplate one = ValuesCarryingANumber.carrying(filling.plan().root(), filling.fixed(),
                     FixtureTemplate.on(elements, Count.of(each),
                             ruleSource.symbols().scope()::reach),
                     ruleSource, policy);
@@ -348,6 +354,100 @@ final class ContainersAddingUp {
             values.add(one);
         }
         return Witnesses.wrapped(container, FixtureTemplate.collection(values), ruleSource);
+    }
+
+    /**
+     * One way of building an element with the number in it: the plan, and the position the number
+     * is written at under it.
+     *
+     * <p>Both, because the second is what the first was planned against. A narrowing is written into
+     * the path — {@code items[*].kind@Card.amount} — so a plan and a path from another way down are
+     * a plan with nowhere to put the value.
+     */
+    private record Filling(ConstructionPlan plan, TermPath fixed) {}
+
+    /**
+     * The ways down, and what the planning gave up at.
+     *
+     * @param filled  one per way, in the order the declarations write the narrowings
+     * @param cutBy   the figures the planning stopped at, which are this compiler's
+     */
+    private record Ways(List<Filling> filled, java.util.Set<CompositionBudget> cutBy) {
+
+        Ways {
+            filled = List.copyOf(filled);
+            cutBy = java.util.Set.copyOf(cutBy);
+        }
+    }
+
+    /**
+     * Every way an element of {@code element} holds the number at {@code demand}.
+     *
+     * <p>One where the way down is a record's fields all the way, and one per case where it crosses
+     * a position that holds nothing until a narrowing says what stands there. The plan is what says
+     * which of those it is: a demand under such a position comes back as the position and what it
+     * stands at, and this states one of them and asks again — so which cases there are, and which
+     * of them a field is under, are read where a position's divisions are read and nowhere here.
+     *
+     * <p>Bounded by how many shapes are offered at all. What is dropped is ways nothing would have
+     * been offered from, and the figure travels so that a reader is told the rest were never made.
+     */
+    private static Ways waysDown(Type element, TermPath at, TermPath demand,
+                                 RuleReadingSource ruleSource) {
+        List<Filling> found = new ArrayList<>();
+        java.util.Set<CompositionBudget> cutBy = java.util.EnumSet.noneOf(CompositionBudget.class);
+        java.util.Deque<TermPath> asking = new java.util.ArrayDeque<>(List.of(demand));
+        while (!asking.isEmpty()) {
+            TermPath fixed = asking.removeFirst();
+            if (found.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
+                cutBy.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
+                break;
+            }
+            switch (ConstructionPlan.of(element, at, ruleSource.symbols(), java.util.Set.of(fixed),
+                    Requirements.NONE,
+                    (_, building) -> Partitions.leastHeld(building, ruleSource))) {
+                case ConstructionPlan.Result.Planned(ConstructionPlan plan) ->
+                        found.add(new Filling(plan, fixed));
+                // A narrowing to state, and the walk states each of them. Asked again rather than
+                // planned around: a second narrowing may stand under the first, and which one that
+                // is depends on the case this settled on.
+                case ConstructionPlan.Result.Unnarrowed(TermPath where, List<Refinement> narrowings) -> {
+                    for (Refinement narrowing : narrowings) {
+                        asking.addLast(narrowed(fixed, where, narrowing));
+                    }
+                }
+                case ConstructionPlan.Result.Beyond(java.util.Set<CompositionBudget> by) ->
+                        cutBy.addAll(by);
+                // Two narrowings at one position, which nothing here writes: every one of them was
+                // stated by this walk, one at a time, at a position the plan named.
+                case ConstructionPlan.Result.Conflict conflict ->
+                        throw new IllegalStateException("`" + conflict.at() + "` would have to be"
+                                + " both " + conflict.one().spelled() + " and "
+                                + conflict.other().spelled() + ", though one narrowing was stated");
+            }
+        }
+        return new Ways(found, cutBy);
+    }
+
+    /**
+     * {@code demand} with {@code narrowing} written in at {@code where}.
+     *
+     * <p>Written into the path rather than carried beside it, because a path states the
+     * requirements for the position it names to exist ({@link TermPath#requirements}) and the plan
+     * names every position below a narrowing under the narrowed spelling. Kept beside it, the value
+     * would be fixed at a position the plan has none of.
+     */
+    private static TermPath narrowed(TermPath demand, TermPath where, Refinement narrowing) {
+        TermPath out = where.refine(narrowing);
+        for (TermPath.Step step
+                : demand.steps().subList(where.steps().size(), demand.steps().size())) {
+            out = switch (step) {
+                case TermPath.Step.Field(String name) -> out.then(name);
+                case TermPath.Step.Element _ -> out.element();
+                case TermPath.Step.Refine(Refinement already) -> out.refine(already);
+            };
+        }
+        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -441,17 +441,24 @@ final class ContainersAddingUp {
         java.util.Set<CompositionBudget> cutBy = java.util.EnumSet.noneOf(CompositionBudget.class);
         List<TermPath> nothingStandsAt = new ArrayList<>();
         java.util.Deque<TermPath> asking = new java.util.ArrayDeque<>(List.of(demand));
+        int tried = 0;
         while (!asking.isEmpty()) {
             TermPath fixed = asking.removeFirst();
-            // What this walk stops at, and not what the offering does. A way that plans is not a
-            // container that was offered -- the values are composed afterwards and a case may be
-            // refused there -- so spending the offer's figure here would leave a case never tried
-            // because an earlier one planned and then built nothing, which is the declaration order
-            // deciding what is offered.
-            if (found.size() == MOST_WAYS_DOWN_TRIED) {
+            // What this walk did, and not what it kept. Every position that has to be narrowed
+            // multiplies what is left to ask about, and a walk none of whose branches plans keeps
+            // none of them -- so a figure counting what was kept bounds nothing at all and the
+            // cases of every sum on the way are walked through in full.
+            //
+            // And this walk's figure rather than the offering's. A way that plans is not a
+            // container that was offered, since the values are composed afterwards and a case may
+            // be refused there; spending the offer's figure here would leave a case never tried
+            // because an earlier one planned and then built nothing, which is the declaration
+            // order deciding what is offered.
+            if (tried == MOST_WAYS_DOWN_TRIED) {
                 cutBy.add(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED);
                 break;
             }
+            tried++;
             switch (ConstructionPlan.of(element, at, ruleSource.symbols(), java.util.Set.of(fixed),
                     Requirements.NONE,
                     (_, building) -> Partitions.leastHeld(building, ruleSource))) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -395,21 +395,21 @@ final class ContainersAddingUp {
         /**
          * What this walk found, said where a reader is told nothing was composed.
          *
-         * <p>Two answers and never one sentence for both. A way that was tried and built nothing
-         * says the ways are exhausted; a position nothing stands under says there was never a way
-         * to try. Told the same thing, a reader would be working out which of them it was from what
-         * the sentence left out.
+         * <p>One sentence per thing that happened, and never one for two of them. A way that was
+         * walked and built nothing says the ways are exhausted; a position nothing stands under
+         * says there was never a way to try. Told the same thing, a reader would be working out
+         * which of them it was from what the sentence left out.
          */
         String said(TermPath demand) {
-            if (filled.isEmpty()) {
-                return nothingStandsAt.isEmpty()
-                        ? "nothing here reaches `" + demand + "`"
-                        : "nothing standing at " + spelling(nothingStandsAt)
-                                + " gives a way down to `" + demand + "`";
+            if (!filled.isEmpty()) {
+                return spelling(filled.stream().map(Filling::fixed).toList())
+                        + (filled.size() == 1 ? " was a way down to `" : " were ways down to `")
+                        + demand + "`, and none of them composed a value";
             }
-            return spelling(filled.stream().map(Filling::fixed).toList())
-                    + (filled.size() == 1 ? " was a way down to `" : " were ways down to `")
-                    + demand + "`, and none of them composed a value";
+            return nothingStandsAt.isEmpty()
+                    ? "nothing here reaches `" + demand + "`"
+                    : "nothing standing at " + spelling(nothingStandsAt)
+                            + " gives a way down to `" + demand + "`";
         }
 
         private static String spelling(List<TermPath> paths) {
@@ -430,6 +430,15 @@ final class ContainersAddingUp {
      * <p>Bounded by its own figure, and the figure travels so that a reader is told the rest were
      * never tried.
      *
+     * <p><b>One occurrence of the number per element, and nothing here has to check it.</b> The
+     * split this fills a container from is one number per element, so a way down that passed
+     * through a container of its own would build a value coming to a multiple of the total. No such
+     * way is asked about: a run is read from a path standing inside one sequence
+     * ({@link souther.compiler.inputs.RunSource}), and a total of what a location holds is read at
+     * the element itself — so a position under the element with a sequence on the way to it is not
+     * a number this is ever asked to write for. Guarded here as well, the guard would be one
+     * nothing can reach and nothing could show wrong.
+     *
      * <p>The narrowings of one position in the order the declarations write them, and a second
      * position's under whichever of the first's it was reached by. Nothing here orders the ways of
      * two positions against each other: what a caller does with them is try each, and the figure
@@ -438,40 +447,20 @@ final class ContainersAddingUp {
     private static Ways waysDown(Type element, TermPath at, TermPath demand,
                                  RuleReadingSource ruleSource) {
         List<Filling> found = new ArrayList<>();
-        java.util.Set<CompositionBudget> cutBy = java.util.EnumSet.noneOf(CompositionBudget.class);
         List<TermPath> nothingStandsAt = new ArrayList<>();
-        java.util.Deque<TermPath> asking = new java.util.ArrayDeque<>(List.of(demand));
-        int tried = 0;
-        while (!asking.isEmpty()) {
-            TermPath fixed = asking.removeFirst();
-            // What this walk did, and not what it kept. Every position that has to be narrowed
-            // multiplies what is left to ask about, and a walk none of whose branches plans keeps
-            // none of them -- so a figure counting what was kept bounds nothing at all and the
-            // cases of every sum on the way are walked through in full.
-            //
-            // And this walk's figure rather than the offering's. A way that plans is not a
-            // container that was offered, since the values are composed afterwards and a case may
-            // be refused there; spending the offer's figure here would leave a case never tried
-            // because an earlier one planned and then built nothing, which is the declaration
-            // order deciding what is offered.
-            if (tried == MOST_WAYS_DOWN_TRIED) {
-                cutBy.add(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED);
-                break;
-            }
-            tried++;
-            switch (ConstructionPlan.of(element, at, ruleSource.symbols(), java.util.Set.of(fixed),
-                    Requirements.NONE,
-                    (_, building) -> Partitions.leastHeld(building, ruleSource))) {
+        Asking asking = new Asking(element, at, ruleSource);
+        asking.add(demand);
+        for (ConstructionPlan.Result answer = asking.next(); answer != null;
+                answer = asking.next()) {
+            TermPath fixed = asking.asked();
+            switch (answer) {
                 // A way whose number stands inside a container of its own holds as many occurrences
                 // of it as that container's rules ask for, and the split above is one number per
                 // element of the outer one. So a value built along it comes to a multiple of the
                 // total it was built for, and nothing composes one until what is decomposed is the
                 // occurrences rather than the elements.
-                case ConstructionPlan.Result.Planned(ConstructionPlan plan) -> {
-                    if (!crossesAContainer(plan, fixed)) {
+                case ConstructionPlan.Result.Planned(ConstructionPlan plan) ->
                         found.add(new Filling(plan, fixed));
-                    }
-                }
                 // A narrowing to state, and the walk states each of them. Asked again rather than
                 // planned around: a second narrowing may stand under the first, and which one that
                 // is depends on the case this settled on.
@@ -483,11 +472,11 @@ final class ContainersAddingUp {
                         nothingStandsAt.add(where);
                     }
                     for (Refinement narrowing : narrowings) {
-                        asking.addLast(narrowed(fixed, where, narrowing));
+                        asking.add(narrowed(fixed, where, narrowing));
                     }
                 }
                 case ConstructionPlan.Result.Beyond(java.util.Set<CompositionBudget> by) ->
-                        cutBy.addAll(by);
+                        asking.gaveUpAt(by);
                 // Two narrowings at one position, which nothing here writes: every one of them was
                 // stated by this walk, one at a time, at a position the plan named.
                 case ConstructionPlan.Result.Conflict conflict ->
@@ -496,19 +485,79 @@ final class ContainersAddingUp {
                                 + conflict.other().spelled() + ", though one narrowing was stated");
             }
         }
-        return new Ways(found, cutBy, nothingStandsAt);
+        return new Ways(found, asking.stoppedBy(), nothingStandsAt);
     }
 
     /**
-     * Whether the way down to {@code fixed} passes through a container of its own.
+     * The ways this walk has left to ask the plan about, and the figure that says how many it may.
      *
-     * <p>Asked of the plan, which is what says where a container is built rather than chosen whole.
-     * Read off the path's steps instead, a step into a sequence the plan settled another way would
-     * be counted as one this builds around.
+     * <p><b>The asking and the counting are one thing.</b> What multiplies here is the cases of
+     * every position that has to be narrowed, and what bounds the walk is therefore how many times
+     * it asks — not how many answers it keeps, which is nothing at all where no branch plans. Held
+     * apart, the figure was written against whichever count was nearest the top of the loop, and a
+     * walk that kept none of what it asked about ran through the whole cross product saying nothing
+     * had stopped it.
+     *
+     * <p>So a caller cannot ask without being counted: there is one way in, and a second place that
+     * reached the plan another way would be a second walk rather than an unbounded one.
      */
-    private static boolean crossesAContainer(ConstructionPlan plan, TermPath fixed) {
-        return plan.held().stream().anyMatch(each -> fixed.isAtOrUnder(each.at())
-                && !fixed.equals(each.at()));
+    private static final class Asking {
+
+        private final Type element;
+        private final TermPath at;
+        private final RuleReadingSource ruleSource;
+        private final java.util.Deque<TermPath> left = new java.util.ArrayDeque<>();
+        private final java.util.Set<CompositionBudget> stoppedBy =
+                java.util.EnumSet.noneOf(CompositionBudget.class);
+        private TermPath asked;
+        private int asks;
+
+        Asking(Type element, TermPath at, RuleReadingSource ruleSource) {
+            this.element = element;
+            this.at = at;
+            this.ruleSource = ruleSource;
+        }
+
+        /** One more way to ask about, which is what stating a narrowing leaves. */
+        void add(TermPath way) {
+            left.addLast(way);
+        }
+
+        /**
+         * What the plan says about the next way, or null where there is no next one to ask about.
+         *
+         * <p>Null for two reasons and the figures tell them apart: nothing is left to ask, or this
+         * has asked as often as it may — which {@link #stoppedBy()} says and a reader is owed.
+         */
+        ConstructionPlan.Result next() {
+            if (left.isEmpty()) {
+                return null;
+            }
+            if (asks == MOST_WAYS_DOWN_TRIED) {
+                stoppedBy.add(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED);
+                return null;
+            }
+            asks++;
+            asked = left.removeFirst();
+            return ConstructionPlan.of(element, at, ruleSource.symbols(),
+                    java.util.Set.of(asked), Requirements.NONE,
+                    (_, building) -> Partitions.leastHeld(building, ruleSource));
+        }
+
+        /** The way the last answer is about. */
+        TermPath asked() {
+            return asked;
+        }
+
+        /** What the planning of one way gave up at, which is this compiler's as the figure here is. */
+        void gaveUpAt(java.util.Set<CompositionBudget> by) {
+            stoppedBy.addAll(by);
+        }
+
+        /** Every figure reached, whether by the planning or by this walk. */
+        java.util.Set<CompositionBudget> stoppedBy() {
+            return stoppedBy;
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -4532,8 +4532,8 @@ public final class Generator {
      * <p>Null where a name the position wears is one this module cannot write, which is a value
      * that cannot be written rather than one written without the name.
      */
-    private static FixtureTemplate worn(List<TypeOps.Layer> worn, FixtureTemplate value,
-                                        RuleReadingSource ruleSource) {
+    static FixtureTemplate worn(List<TypeOps.Layer> worn, FixtureTemplate value,
+                                RuleReadingSource ruleSource) {
         if (value == null || worn.isEmpty()) {
             return value;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -453,6 +453,7 @@ public final class Generator {
                              PLACES_A_PAIR_IS_TRIED_AT -> NOTHING_COMPOSES_ONE;
                         case PAIRINGS_BUILT_AT_ONCE, ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
                              SHAPES_OF_A_TOTAL_OFFERED, DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
+                             WAYS_DOWN_TO_A_TOTAL_TRIED,
                              STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES,
                              VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
                              LEVELS_A_SIDE_IS_ASKED_AT -> SEARCH_LIMIT;
@@ -3658,18 +3659,21 @@ public final class Generator {
             case ConstructionPlan.Result.Beyond(Set<CompositionBudget> by) -> {
                 return new Outcome.Unplanned(by);
             }
-            // A class that puts a value under a case states the case (`PartitionClasses`), and a
-            // path that reaches one carries it (`TermPath.requirements`), so a search arriving here
-            // without one is this compiler asking for a position it has not said how to reach.
-            // Refused in the words the other arrangement of two accounts is refused in, rather than
-            // answered as a row nothing composes — a model has nothing to do with it.
-            case ConstructionPlan.Result.Unnarrowed(TermPath where, List<Refinement> narrowings) ->
-                    throw new IllegalStateException("a value is asked for under `" + where
-                            + "`, which stands at " + narrowings.stream().map(Refinement::spelled)
-                                    .collect(java.util.stream.Collectors.joining(" or "))
-                            + " and holds nothing until one of them is stated; the class or the"
-                            + " path that asked for it is keeping the narrowing it needs somewhere"
-                            + " this cannot read");
+            // Something is asked for under a position that holds nothing until a narrowing says
+            // what stands there, and this search has not said which. There is no plan, so nothing
+            // was searched and nothing was refused: what a reader is owed is that no value was
+            // composed and where the way down stopped. Said as a row nothing composes rather than
+            // as a failure of this compiler, because a model reaches it — a class may state a
+            // narrowing below a position nothing narrows.
+            case ConstructionPlan.Result.Unnarrowed(TermPath where, List<Refinement> narrowings) -> {
+                return new Outcome.Unresolved(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                        narrowings.isEmpty()
+                                ? "`" + where + "` holds nothing that could be built under it"
+                                : "`" + where + "` stands at "
+                                        + narrowings.stream().map(Refinement::spelled)
+                                                .collect(java.util.stream.Collectors.joining(" or "))
+                                        + ", and nothing said which of them the value under it is");
+            }
         }
         Choices choices = choicesOf(subject, p, plan, decided, settled);
         if (choices.missingAt() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -13,6 +13,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.reading.PathAccess;
+import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
@@ -3657,6 +3658,18 @@ public final class Generator {
             case ConstructionPlan.Result.Beyond(Set<CompositionBudget> by) -> {
                 return new Outcome.Unplanned(by);
             }
+            // A class that puts a value under a case states the case (`PartitionClasses`), and a
+            // path that reaches one carries it (`TermPath.requirements`), so a search arriving here
+            // without one is this compiler asking for a position it has not said how to reach.
+            // Refused in the words the other arrangement of two accounts is refused in, rather than
+            // answered as a row nothing composes — a model has nothing to do with it.
+            case ConstructionPlan.Result.Unnarrowed(TermPath where, List<Refinement> narrowings) ->
+                    throw new IllegalStateException("a value is asked for under `" + where
+                            + "`, which stands at " + narrowings.stream().map(Refinement::spelled)
+                                    .collect(java.util.stream.Collectors.joining(" or "))
+                            + " and holds nothing until one of them is stated; the class or the"
+                            + " path that asked for it is keeping the narrowing it needs somewhere"
+                            + " this cannot read");
         }
         Choices choices = choicesOf(subject, p, plan, decided, settled);
         if (choices.missingAt() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2501,7 +2501,8 @@ public final class Generator {
                 // sentences and only the first names something anybody could raise.
                 return edge.stoppedBy().isEmpty()
                         ? new BoundaryAttempt.Unresolved(
-                                new UnresolvedCombination(List.of(label), edge.reason()),
+                                new UnresolvedCombination(List.of(label), edge.reason(),
+                                        edge.detail()),
                                 where.unrepresented())
                         : BoundaryAttempt.Stopped.at(label, edge.stoppedBy(),
                                 where.unrepresented());
@@ -4516,114 +4517,37 @@ public final class Generator {
     private static FixtureTemplate compose(ConstructionPlan.Node node,
                                            Map<TermPath, FixtureTemplate> chosen, RuleReadingSource ruleSource,
                                            ReadingPolicy policy) {
-        return switch (node) {
-            // Under the names the position wore before a narrowing reached it, and under none where
-            // none did: what is chosen at a slot is a value of the narrowed type, already written
-            // under whatever names that type wears, and a `data DecisionN = Decision` narrowed to
-            // one of its cases is written `DecisionN(...)` all the same.
-            case ConstructionPlan.Slot slot -> worn(slot.worn(), chosen.get(slot.at()), ruleSource);
-            case ConstructionPlan.Built built -> composed(built, chosen, ruleSource, policy);
-            case ConstructionPlan.Held held -> held(held, chosen, ruleSource, policy);
-            // The requirement settled this one, so nothing was chosen for it and there is nothing to
-            // look up. Under every name the position wears, since the value arrives bare.
-            case ConstructionPlan.Exact exact -> worn(exact.worn(), exact.exact(), ruleSource);
-        };
+        return PlanComposer.compose(node, new FromTheAssignment(chosen), ruleSource, policy);
     }
 
     /**
-     * {@code value} under {@code worn}, or {@code value} where nothing is worn over it.
+     * The values of a plan as the search's assignment settled them.
      *
-     * <p>Null where a name the position wears is one this module cannot write, which is a value
-     * that cannot be written rather than one written without the name.
+     * <p>Every position of the plan is one the search chose at, so every field of a record is
+     * composed from what stands under it and nothing here reads a rule. What is left where a
+     * position has nothing is nothing: a row missing a value the plan asks for is not a row.
      */
-    static FixtureTemplate worn(List<TypeOps.Layer> worn, FixtureTemplate value,
-                                RuleReadingSource ruleSource) {
-        if (value == null || worn.isEmpty()) {
-            return value;
+    private record FromTheAssignment(Map<TermPath, FixtureTemplate> chosen)
+            implements PlanComposer.Values {
+
+        @Override
+        public FixtureTemplate at(ConstructionPlan.Slot slot) {
+            return chosen.get(slot.at());
         }
-        List<TypeReachName.Written> names = written(worn, ruleSource);
-        return names == null ? null : RepresentativeSource.under(names, value);
-    }
 
-    /**
-     * The names a position wears as this module writes them, or null where one of them is a name it
-     * cannot write.
-     *
-     * <p>Null takes the whole value with it: the name goes on the value as it is written, and a
-     * value composed without one is of a type the parameter does not declare. Asked in one place
-     * because every value this composes needs the same answer, and three copies of the loop are
-     * three chances to differ about what a name this module cannot reach comes to.
-     */
-    private static List<TypeReachName.Written> written(List<TypeOps.Layer> worn, RuleReadingSource ruleSource) {
-        List<TypeReachName.Written> names = new ArrayList<>();
-        for (TypeOps.Layer layer : worn) {
-            if (!(ruleSource.symbols().scope().reach(layer.named()) instanceof TypeReachName.Written name)) {
-                return null;
+        @Override
+        public Map<String, FixtureTemplate> under(ConstructionPlan.Built built,
+                                                  PlanComposer.Under under) {
+            Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
+            for (Map.Entry<String, ConstructionPlan.Node> each : built.under().entrySet()) {
+                FixtureTemplate value = under.of(each.getValue());
+                if (value == null) {
+                    return null;
+                }
+                fields.put(each.getKey(), value);
             }
-            names.add(name);
+            return fields;
         }
-        return names;
-    }
-
-    /**
-     * The list of one this plan builds around what stands at its element.
-     *
-     * <p>Under the names the position is written with, as a record is: a row at a
-     * {@code data Basket = List<Item>} carries {@code Basket([...])}, and a list composed without
-     * them is of a type the parameter does not declare.
-     */
-    private static FixtureTemplate held(ConstructionPlan.Held plan,
-                                        Map<TermPath, FixtureTemplate> chosen, RuleReadingSource ruleSource,
-                                        ReadingPolicy policy) {
-        FixtureTemplate element = compose(plan.under(), chosen, ruleSource, policy);
-        if (element == null) {
-            return null;
-        }
-        // The one placed in the class, and enough beside it for the collection to be one the rules
-        // admit. What may stand beside it is the carrier's business — a list may hold the same
-        // value again and a set may not — so the collection is asked for whole rather than padded
-        // here.
-        if (!(souther.compiler.check.TypeView.of(plan.type(), ruleSource.symbols()).shape()
-                instanceof souther.compiler.check.Shape.Sequence carrier)) {
-            return null;
-        }
-        FixtureTemplate collection =
-                Witnesses.holdingAlso(carrier, element, plan.least(), ruleSource, policy);
-        if (collection == null) {
-            return null;
-        }
-        // A name this module cannot write leaves no value to write.
-        List<TypeReachName.Written> worn = written(plan.worn(), ruleSource);
-        return worn == null ? null : RepresentativeSource.under(worn, collection);
-    }
-
-    /** One record of the plan, out of what the assignment put at the positions under it. */
-    private static FixtureTemplate composed(ConstructionPlan.Built built,
-                                            Map<TermPath, FixtureTemplate> chosen, RuleReadingSource ruleSource,
-                                            ReadingPolicy policy) {
-        Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
-        for (Map.Entry<String, ConstructionPlan.Node> under : built.under().entrySet()) {
-            FixtureTemplate value = compose(under.getValue(), chosen, ruleSource, policy);
-            if (value == null) {
-                return null;
-            }
-            fields.put(under.getKey(), value);
-        }
-        // Under the names the position is written with, which the descent that found the fields took
-        // off to find them. A row at a `data SlotN = Slot` carries `SlotN(Slot { ... })`, and a value
-        // composed without them is of a type the parameter does not declare.
-        // A name this module cannot write leaves no value to write.
-        List<TypeReachName.Written> worn = written(built.worn(), ruleSource);
-        if (worn == null
-                || !(ruleSource.symbols().scope().reach(built.of())
-                        instanceof TypeReachName.Written written)) {
-            return null;
-        }
-        // Under every name the position wears, which where a refinement narrowed it are the names
-        // it wore before the narrowing and the ones the narrowed value wears after it. One list and
-        // one putting-back-on: read as two, the outer names had to be recovered from the class that
-        // asked for the narrowing rather than from the position they belong to.
-        return RepresentativeSource.under(worn, FixtureTemplate.record(written, fields));
     }
 
     /**
@@ -4659,6 +4583,17 @@ public final class Generator {
                 case TermRealizations.Realization.Stopped stopped -> stopped.by();
                 case TermRealizations.Realization.None _ -> java.util.Set.of();
             };
+        }
+
+        /**
+         * What this edge found, beside the word, or null where it has nothing to add.
+         *
+         * <p>Carried from the walk that composed nothing rather than worked out here. Two walks
+         * come back with one word and what they met differs, and a reader left with the word alone
+         * would be telling them apart by what the sentence does not say.
+         */
+        String detail() {
+            return came instanceof TermRealizations.Realization.None none ? none.detail() : null;
         }
 
         /** What to report where no value was offered here at all. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1386,9 +1386,33 @@ public final class Partitions {
         if (expanding.contains(record) || !(ruleSource.symbols().declaredNode(record) instanceof Hir.Data data)) {
             return List.of();
         }
+        Map<String, FixtureTemplate> chosen =
+                fieldsOf(record, ruleSource, policy, expanding, given);
+        return chosen == null || !(ruleSource.symbols().scope().reach(record)
+                instanceof TypeReachName.Written written)
+                        ? List.of() : List.of(FixtureTemplate.record(written, chosen));
+    }
+
+    /**
+     * What stands at each field of {@code record}, or null where one of them has nothing to stand
+     * for it.
+     *
+     * <p>Beside {@link #composed} and under it: this is the choosing, and writing the record is what
+     * a caller then does with it. Asked on its own by the composing of a plan, which has the record
+     * to write and needs what goes in it — a caller that took a written record apart again to get at
+     * the fields would be reading one answer back out of another.
+     */
+    static Map<String, FixtureTemplate> fieldsOf(TypeSymbol.AtModule record,
+                                                 RuleReadingSource ruleSource, ReadingPolicy policy,
+                                                 java.util.Set<TypeSymbol> expanding,
+                                                 Map<String, FixtureTemplate> given) {
+        if (expanding.contains(record)
+                || !(ruleSource.symbols().declaredNode(record) instanceof Hir.Data data)) {
+            return null;
+        }
         Map<String, Type> fields = TypeOps.fieldTypes(data, ruleSource.symbols());
         if (fields.isEmpty()) {
-            return List.of();   // a unit has no fields to compose, and is named rather than built
+            return null;   // a unit has no fields to compose, and is named rather than built
         }
         java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
@@ -1396,7 +1420,7 @@ public final class Partitions {
         FieldDomains left = FieldDomains.of(record, data, ruleSource, policy, settled);
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {
-            return List.of();
+            return null;
         }
         for (Map.Entry<String, Type> field : fields.entrySet()) {
             FixtureTemplate at = given.get(field.getKey());
@@ -1406,7 +1430,7 @@ public final class Partitions {
                 List<FixtureTemplate> stands = representativesHolding(field.getValue(), ruleSource,
                         policy, left.at(named).bounds(), left.heldAt(named), inside);
                 if (stands.isEmpty()) {
-                    return List.of();
+                    return null;
                 }
                 at = stands.get(0);
             }
@@ -1419,8 +1443,7 @@ public final class Partitions {
                 left = FieldDomains.of(record, data, ruleSource, policy, settled);
             }
         }
-        return ruleSource.symbols().scope().reach(record) instanceof TypeReachName.Written written
-                ? List.of(FixtureTemplate.record(written, chosen)) : List.of();
+        return chosen;
     }
 
     /** How many of whatever counts a value the rules on it require it to hold, read where the rules

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1379,10 +1379,10 @@ public final class Partitions {
      * @param given what stands at some of the fields, by name. A name no field has is nothing this
      *              can build, and is the caller asking for a value of another type
      */
-    private static List<FixtureTemplate> composed(TypeSymbol.AtModule record, RuleReadingSource ruleSource,
-                                                  ReadingPolicy policy,
-                                                  java.util.Set<TypeSymbol> expanding,
-                                                  Map<String, FixtureTemplate> given) {
+    static List<FixtureTemplate> composed(TypeSymbol.AtModule record, RuleReadingSource ruleSource,
+                                          ReadingPolicy policy,
+                                          java.util.Set<TypeSymbol> expanding,
+                                          Map<String, FixtureTemplate> given) {
         if (expanding.contains(record) || !(ruleSource.symbols().declaredNode(record) instanceof Hir.Data data)) {
             return List.of();
         }
@@ -1421,55 +1421,6 @@ public final class Partitions {
         }
         return ruleSource.symbols().scope().reach(record) instanceof TypeReachName.Written written
                 ? List.of(FixtureTemplate.record(written, chosen)) : List.of();
-    }
-
-    /**
-     * A value of {@code type} whose position at {@code under} holds {@code value}, or null where
-     * nothing here builds one.
-     *
-     * <p>What a caller wanting a particular number somewhere inside a value asks for. The value at
-     * the position is the caller's and everything beside it is chosen the way any value of the type
-     * is — against the rules of the record it sits in, read again once the caller's value is in
-     * them, so what is offered is a value the model may well admit rather than a shape that carries
-     * the number and breaks a rule about the field next to it.
-     *
-     * <p><b>Steps under the value and not a path.</b> A {@link TermPath} is rooted at a parameter and
-     * says where a location of a row is; what is named here is a way down from a value whose own
-     * location this does not know. Written as a path, one vocabulary would spell two things.
-     *
-     * <p>Fields, and nothing else. A step into a sequence asks for a value inside a container and how
-     * many of them there are, which is a question about the container and not about this value; a
-     * step into a case of a sum asks for a value narrowed to that case, which is composed where the
-     * narrowings are read. Both come back null, which says nothing composes one and leaves what does
-     * to whoever writes it.
-     */
-    static FixtureTemplate carrying(Type type, List<TermPath.Step> under, FixtureTemplate value,
-                                    RuleReadingSource ruleSource, ReadingPolicy policy) {
-        if (value == null) {
-            return null;
-        }
-        // The value itself, under every name the position wears. A newtype around a number is the
-        // number as it is written there, and putting the names on is the one reader that does it.
-        if (under.isEmpty()) {
-            return Witnesses.wrapped(type, value, ruleSource);
-        }
-        if (!(under.getFirst() instanceof TermPath.Step.Field(String name))) {
-            return null;
-        }
-        if (!(TypeOps.base(type, ruleSource.symbols()) instanceof Type.Ref(TypeSymbol.AtModule named))
-                || !(ruleSource.symbols().declaredNode(named) instanceof Hir.Data data)
-                || data.newtype()) {
-            return null;
-        }
-        Type at = TypeOps.fieldTypes(data, ruleSource.symbols()).get(name);
-        FixtureTemplate inner = at == null ? null
-                : carrying(at, under.subList(1, under.size()), value, ruleSource, policy);
-        if (inner == null) {
-            return null;
-        }
-        List<FixtureTemplate> whole =
-                composed(named, ruleSource, policy, java.util.Set.of(), Map.of(name, inner));
-        return whole.isEmpty() ? null : Witnesses.wrapped(type, whole.getFirst(), ruleSource);
     }
 
     /** How many of whatever counts a value the rules on it require it to hold, read where the rules

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -1,0 +1,175 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.Shape;
+import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
+import souther.compiler.types.TypeReachName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The value a construction plan builds.
+ *
+ * <p>What a plan means as a value is decided here and nowhere else: which positions are under a
+ * position, what a container holds, what a narrowing settled, and which names a value still has to
+ * wear. Two readers had this walk each — the search, composing what its assignment chose, and the
+ * walk that puts a number inside a value — and what they differed in was never the plan.
+ *
+ * <p><b>What differs is where a record's fields come from.</b> A search has values for all of them
+ * and hands them over; a walk with one position fixed has that one and chooses the rest against the
+ * record's own rules. That is two questions about values and one answer about the plan, so it is the
+ * one thing a caller brings ({@link Values}).
+ */
+final class PlanComposer {
+
+    /**
+     * Where the values in a plan's positions come from.
+     *
+     * <p>Both halves are about values and neither is about the plan. A caller that answered
+     * anything else here — which positions are under this one, what a container holds — would be
+     * reading the plan a second time.
+     */
+    interface Values {
+
+        /** What stands at a position the plan chooses a whole value at, or null where nothing does. */
+        FixtureTemplate at(ConstructionPlan.Slot slot);
+
+        /**
+         * What stands at each field of a record the plan composes, or null where one of them has
+         * nothing to stand for it.
+         *
+         * @param under composes a position of the plan, which is how a caller reaches the fields it
+         *              does have a value under. Handed over rather than left to the caller so that
+         *              what is below a field is still read the one way
+         */
+        Map<String, FixtureTemplate> under(ConstructionPlan.Built built, Under under);
+    }
+
+    /** Composing one position of the plan, which is what a caller is given to reach below a field. */
+    interface Under {
+
+        /** The value at {@code node}, or null where nothing here builds one. */
+        FixtureTemplate of(ConstructionPlan.Node node);
+    }
+
+    /**
+     * The value at one position of the plan, or null where nothing builds one.
+     *
+     * <p>Null travels up: a field with nothing at it is a record with nothing at it, because what
+     * would be written instead is a value of a type the position does not declare.
+     */
+    static FixtureTemplate compose(ConstructionPlan.Node node, Values values,
+                                   RuleReadingSource ruleSource, ReadingPolicy policy) {
+        return switch (node) {
+            // Under the names the position wore before a narrowing reached it, and under none where
+            // none did: what stands at a slot is a value of the narrowed type, already written
+            // under whatever names that type wears, and a `data DecisionN = Decision` narrowed to
+            // one of its cases is written `DecisionN(...)` all the same.
+            case ConstructionPlan.Slot slot -> worn(slot.worn(), values.at(slot), ruleSource);
+            case ConstructionPlan.Built built -> composed(built, values, ruleSource, policy);
+            case ConstructionPlan.Held held -> held(held, values, ruleSource, policy);
+            // The requirement settled this one, so nothing was chosen for it and there is nothing to
+            // look up. Under every name the position wears, since the value arrives bare.
+            case ConstructionPlan.Exact exact -> worn(exact.worn(), exact.exact(), ruleSource);
+        };
+    }
+
+    /**
+     * {@code value} under {@code worn}, or {@code value} where nothing is worn over it.
+     *
+     * <p>Null where a name the position wears is one this module cannot write, which is a value
+     * that cannot be written rather than one written without the name.
+     */
+    static FixtureTemplate worn(List<TypeOps.Layer> worn, FixtureTemplate value,
+                                RuleReadingSource ruleSource) {
+        if (value == null || worn.isEmpty()) {
+            return value;
+        }
+        List<TypeReachName.Written> names = written(worn, ruleSource);
+        return names == null ? null : RepresentativeSource.under(names, value);
+    }
+
+    /**
+     * The names a position wears as this module writes them, or null where one of them is a name it
+     * cannot write.
+     *
+     * <p>Null takes the whole value with it: the name goes on the value as it is written, and a
+     * value composed without one is of a type the parameter does not declare. Asked in one place
+     * because every value this composes needs the same answer, and three copies of the loop are
+     * three chances to differ about what a name this module cannot reach comes to.
+     */
+    private static List<TypeReachName.Written> written(List<TypeOps.Layer> worn,
+                                                       RuleReadingSource ruleSource) {
+        List<TypeReachName.Written> names = new ArrayList<>();
+        for (TypeOps.Layer layer : worn) {
+            if (!(ruleSource.symbols().scope().reach(layer.named())
+                    instanceof TypeReachName.Written name)) {
+                return null;
+            }
+            names.add(name);
+        }
+        return names;
+    }
+
+    /**
+     * The list of one this plan builds around what stands at its element.
+     *
+     * <p>Under the names the position is written with, as a record is: a row at a
+     * {@code data Basket = List<Item>} carries {@code Basket([...])}, and a list composed without
+     * them is of a type the parameter does not declare.
+     */
+    private static FixtureTemplate held(ConstructionPlan.Held plan, Values values,
+                                        RuleReadingSource ruleSource, ReadingPolicy policy) {
+        FixtureTemplate element = compose(plan.under(), values, ruleSource, policy);
+        if (element == null) {
+            return null;
+        }
+        // The one placed in the class, and enough beside it for the collection to be one the rules
+        // admit. What may stand beside it is the carrier's business — a list may hold the same
+        // value again and a set may not — so the collection is asked for whole rather than padded
+        // here.
+        if (!(TypeView.of(plan.type(), ruleSource.symbols()).shape()
+                instanceof Shape.Sequence carrier)) {
+            return null;
+        }
+        FixtureTemplate collection =
+                Witnesses.holdingAlso(carrier, element, plan.least(), ruleSource, policy);
+        if (collection == null) {
+            return null;
+        }
+        // A name this module cannot write leaves no value to write.
+        List<TypeReachName.Written> worn = written(plan.worn(), ruleSource);
+        return worn == null ? null : RepresentativeSource.under(worn, collection);
+    }
+
+    /** One record of the plan, out of whatever the caller has at the positions under it. */
+    private static FixtureTemplate composed(ConstructionPlan.Built built, Values values,
+                                            RuleReadingSource ruleSource, ReadingPolicy policy) {
+        Map<String, FixtureTemplate> fields =
+                values.under(built, node -> compose(node, values, ruleSource, policy));
+        if (fields == null) {
+            return null;
+        }
+        // Under the names the position is written with, which the descent that found the fields took
+        // off to find them. A row at a `data SlotN = Slot` carries `SlotN(Slot { ... })`, and a value
+        // composed without them is of a type the parameter does not declare.
+        // A name this module cannot write leaves no value to write.
+        List<TypeReachName.Written> worn = written(built.worn(), ruleSource);
+        if (worn == null
+                || !(ruleSource.symbols().scope().reach(built.of())
+                        instanceof TypeReachName.Written written)) {
+            return null;
+        }
+        // Under every name the position wears, which where a refinement narrowed it are the names
+        // it wore before the narrowing and the ones the narrowed value wears after it. One list and
+        // one putting-back-on: read as two, the outer names had to be recovered from the class that
+        // asked for the narrowing rather than from the position they belong to.
+        return RepresentativeSource.under(worn, FixtureTemplate.record(written, fields));
+    }
+
+    private PlanComposer() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -89,8 +89,26 @@ final class TermRealizations {
             }
         }
 
-        /** Nothing here writes a value answering it, and no budget of this compiler's is why. */
-        record None(Generator.UnresolvedCombination.Reason why) implements Realization {}
+        /**
+         * Nothing here writes a value answering it, and no budget of this compiler's is why.
+         *
+         * <p>The word is how a reader downstream treats it and {@code detail} is what happened in
+         * this attempt, which is the arrangement {@link Generator.UnresolvedCombination} has. A
+         * word read for the shape of the question outlives whatever made it true, so what a reader
+         * is owed beyond it is evidence rather than another word.
+         *
+         * @param detail what this walk found, or null where it has nothing to add to the word. Two
+         *               of these that came about differently do not carry the same sentence: a
+         *               reader told the same thing twice is the reader working the difference out
+         *               from an absence
+         */
+        record None(Generator.UnresolvedCombination.Reason why, String detail)
+                implements Realization {
+
+            None(Generator.UnresolvedCombination.Reason why) {
+                this(why, null);
+            }
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -1,0 +1,112 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.Shape;
+import souther.compiler.check.TypeView;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Values built with a number written somewhere inside them.
+ *
+ * <p>What a walk filling a container to a total asks for: each element is a whole value of its own
+ * type with the number at the path the total reads, and everything beside it is chosen the way any
+ * value of that type is.
+ *
+ * <p><b>The way down is the plan's and none of this reader's.</b> Which positions are under a
+ * position, which case a value is narrowed to, what a container holds and which names a value still
+ * has to wear are {@link ConstructionPlan}'s answers. Walked here from the declarations instead,
+ * this was a second reading of them: it agreed wherever a field is a field of a plain record and
+ * lost the value at every sum, newtype and container, and each of those came back as one silence.
+ *
+ * <p>So what is left here is the filling. A record is composed by the reader that has its rules, a
+ * container is asked what may stand beside the element the value is in, and the names a position
+ * wears go on where the plan says they do.
+ */
+final class ValuesCarryingANumber {
+
+    /**
+     * The value the plan builds at {@code node}, holding {@code value} at {@code fixed}, or null
+     * where nothing here builds one.
+     *
+     * <p>The value at the position is the caller's and everything beside it is chosen against the
+     * rules of the record it sits in, read again once the caller's value is in them — so what is
+     * offered is a value the model may well admit rather than a shape that carries the number and
+     * breaks a rule about the field next to it.
+     */
+    static FixtureTemplate carrying(ConstructionPlan.Node node, TermPath fixed, FixtureTemplate value,
+                                    RuleReadingSource ruleSource, ReadingPolicy policy) {
+        if (value == null || !fixed.isAtOrUnder(node.at())) {
+            return null;
+        }
+        return switch (node) {
+            // The value itself, under every name the position wears. Both halves: what the caller
+            // hands over is a number and not a value of the position, so the names its own type
+            // wears go on here — the plan's `worn` is what a value that already wears those is
+            // still missing, which is what a value chosen at a slot by the search is.
+            case ConstructionPlan.Slot slot -> slot.at().equals(fixed)
+                    ? Generator.worn(slot.worn(),
+                            Witnesses.wrapped(slot.type(), value, ruleSource), ruleSource)
+                    : null;
+            // A narrowing settled the value here, so there is no position under it for anything to
+            // be written at. Nothing reaches this — the plan refuses a demand under a position it
+            // settles — and it is answered rather than assumed away.
+            case ConstructionPlan.Exact _ -> null;
+            case ConstructionPlan.Built built -> {
+                Map.Entry<String, ConstructionPlan.Node> down = fieldTowards(built, fixed);
+                FixtureTemplate inner = down == null ? null
+                        : carrying(down.getValue(), fixed, value, ruleSource, policy);
+                // A record this module composes is one a module declares. A constructor this cannot
+                // name is a value nothing here writes, which is what the empty answer below says.
+                if (inner == null || !(built.of() instanceof TypeSymbol.AtModule record)) {
+                    yield null;
+                }
+                // The rest of the record is chosen against what its own rules leave each field,
+                // which is the reading `Partitions.composed` makes of them. Chosen from the types
+                // alone, a record whose rule relates two fields would be handed a value it refuses.
+                List<FixtureTemplate> whole = Partitions.composed(record, ruleSource, policy,
+                        java.util.Set.of(), Map.of(down.getKey(), inner));
+                yield whole.isEmpty() ? null
+                        : Generator.worn(built.worn(), whole.getFirst(), ruleSource);
+            }
+            // A container with the value somewhere inside one of its elements. What may stand
+            // beside that element is the carrier's business and is asked of the one reader that has
+            // it, the same way a row built around an element asks.
+            case ConstructionPlan.Held held -> {
+                FixtureTemplate element = carrying(held.under(), fixed, value, ruleSource, policy);
+                if (element == null || !(TypeView.of(held.type(), ruleSource.symbols()).shape()
+                        instanceof Shape.Sequence carrier)) {
+                    yield null;
+                }
+                FixtureTemplate collection = Witnesses.holdingAlso(carrier, element, held.least(),
+                        ruleSource, policy);
+                yield collection == null ? null
+                        : Generator.worn(held.worn(), collection, ruleSource);
+            }
+        };
+    }
+
+    /**
+     * The field of {@code built} the fixed position is at or under, or null where none is.
+     *
+     * <p>Asked of the plan's own positions rather than of the path's steps. The two agree wherever
+     * a field step is a field of a record, and part where a narrowing takes no level: the plan's
+     * position for a case is written at the same remove as the sum it narrows, so a walk counting
+     * steps would be one out from there down.
+     */
+    private static Map.Entry<String, ConstructionPlan.Node> fieldTowards(ConstructionPlan.Built built,
+                                                                        TermPath fixed) {
+        for (Map.Entry<String, ConstructionPlan.Node> each : built.under().entrySet()) {
+            if (fixed.isAtOrUnder(each.getValue().at())) {
+                return each;
+            }
+        }
+        return null;
+    }
+
+    private ValuesCarryingANumber() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -2,8 +2,6 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.Shape;
-import souther.compiler.check.TypeView;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.TypeSymbol;
 
@@ -23,9 +21,13 @@ import java.util.Map;
  * this was a second reading of them: it agreed wherever a field is a field of a plain record and
  * lost the value at every sum, newtype and container, and each of those came back as one silence.
  *
- * <p>So what is left here is the filling. A record is composed by the reader that has its rules, a
- * container is asked what may stand beside the element the value is in, and the names a position
- * wears go on where the plan says they do.
+ * <p>So what is left here is the filling. A record is composed by the reader that has its rules, and
+ * the names a position wears go on where the plan says they do.
+ *
+ * <p><b>One occurrence of the number per element.</b> The walk that asks for this splits a total
+ * over the elements of one container, so a container between an element and the number is a value
+ * whose occurrences are not the ones that were split. Nothing is composed there rather than a value
+ * coming to a multiple of what was asked for.
  */
 final class ValuesCarryingANumber {
 
@@ -73,20 +75,13 @@ final class ValuesCarryingANumber {
                 yield whole.isEmpty() ? null
                         : Generator.worn(built.worn(), whole.getFirst(), ruleSource);
             }
-            // A container with the value somewhere inside one of its elements. What may stand
-            // beside that element is the carrier's business and is asked of the one reader that has
-            // it, the same way a row built around an element asks.
-            case ConstructionPlan.Held held -> {
-                FixtureTemplate element = carrying(held.under(), fixed, value, ruleSource, policy);
-                if (element == null || !(TypeView.of(held.type(), ruleSource.symbols()).shape()
-                        instanceof Shape.Sequence carrier)) {
-                    yield null;
-                }
-                FixtureTemplate collection = Witnesses.holdingAlso(carrier, element, held.least(),
-                        ruleSource, policy);
-                yield collection == null ? null
-                        : Generator.worn(held.worn(), collection, ruleSource);
-            }
+            // A container between the element and the number, which is more occurrences of the
+            // number than the walk that split the total counted. The split is one number per
+            // element of the outer container, and a container here holds as many as its own rules
+            // ask for -- so a value built here would come to a multiple of the total it was built
+            // for. Nothing composes one until what is decomposed is the occurrences rather than the
+            // elements, and that is a question for the walk that decomposes.
+            case ConstructionPlan.Held _ -> null;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -5,96 +5,65 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.TypeSymbol;
 
-import java.util.List;
 import java.util.Map;
 
 /**
- * Values built with a number written somewhere inside them.
+ * The values of a plan where one position inside it holds a number the caller has.
  *
- * <p>What a walk filling a container to a total asks for: each element is a whole value of its own
+ * <p>What a walk filling a container to a total needs: each element is a whole value of its own
  * type with the number at the path the total reads, and everything beside it is chosen the way any
  * value of that type is.
  *
- * <p><b>The way down is the plan's and none of this reader's.</b> Which positions are under a
- * position, which case a value is narrowed to, what a container holds and which names a value still
- * has to wear are {@link ConstructionPlan}'s answers. Walked here from the declarations instead,
- * this was a second reading of them: it agreed wherever a field is a field of a plain record and
- * lost the value at every sum, newtype and container, and each of those came back as one silence.
+ * <p>A source of values and not a second reading of the plan. Which positions are under a position,
+ * which case a value is narrowed to, what a container holds and which names a value still has to
+ * wear are {@link ConstructionPlan}'s answers, read by {@link PlanComposer} for every caller —
+ * walked here from the declarations instead, this agreed wherever the way down was records and lost
+ * the value at every sum, newtype and container.
  *
- * <p>So what is left here is the filling. A record is composed by the reader that has its rules, and
- * the names a position wears go on where the plan says they do.
+ * <p>So what is left here is one question: where a record's fields come from. The one the caller's
+ * number is under comes from below, and the rest are chosen against the record's own rules, read
+ * again once the number is in them — so what is offered is a value the model may well admit rather
+ * than a shape that carries the number and breaks a rule about the field next to it.
  *
- * <p><b>One occurrence of the number per element.</b> The walk that asks for this splits a total
- * over the elements of one container, so a container between an element and the number is a value
- * whose occurrences are not the ones that were split. Nothing is composed there rather than a value
- * coming to a multiple of what was asked for.
+ * @param fixed the position the number is written at, which is the one the plan was made against
+ * @param value the number, as the position's own carrier writes it
  */
-final class ValuesCarryingANumber {
+record ValuesCarryingANumber(TermPath fixed, FixtureTemplate value, RuleReadingSource ruleSource,
+                             ReadingPolicy policy) implements PlanComposer.Values {
 
-    /**
-     * The value the plan builds at {@code node}, holding {@code value} at {@code fixed}, or null
-     * where nothing here builds one.
-     *
-     * <p>The value at the position is the caller's and everything beside it is chosen against the
-     * rules of the record it sits in, read again once the caller's value is in them — so what is
-     * offered is a value the model may well admit rather than a shape that carries the number and
-     * breaks a rule about the field next to it.
-     */
-    static FixtureTemplate carrying(ConstructionPlan.Node node, TermPath fixed, FixtureTemplate value,
-                                    RuleReadingSource ruleSource, ReadingPolicy policy) {
-        if (value == null || !fixed.isAtOrUnder(node.at())) {
+    @Override
+    public FixtureTemplate at(ConstructionPlan.Slot slot) {
+        // The value itself, under every name the position wears. What the caller hands over is a
+        // number and not a value of the position, so the names its own type wears go on here — the
+        // plan's `worn` is what a value already wearing those is still missing, which is what a
+        // value chosen at a slot by a search is.
+        return slot.at().equals(fixed)
+                ? Witnesses.wrapped(slot.type(), value, ruleSource) : null;
+    }
+
+    @Override
+    public Map<String, FixtureTemplate> under(ConstructionPlan.Built built,
+                                              PlanComposer.Under under) {
+        Map.Entry<String, ConstructionPlan.Node> down = fieldTowards(built);
+        FixtureTemplate inner = down == null ? null : under.of(down.getValue());
+        // A record this module composes is one a module declares. A constructor this cannot name is
+        // a value nothing here writes, which is what the empty answer says.
+        if (inner == null || !(built.of() instanceof TypeSymbol.AtModule record)) {
             return null;
         }
-        return switch (node) {
-            // The value itself, under every name the position wears. Both halves: what the caller
-            // hands over is a number and not a value of the position, so the names its own type
-            // wears go on here — the plan's `worn` is what a value that already wears those is
-            // still missing, which is what a value chosen at a slot by the search is.
-            case ConstructionPlan.Slot slot -> slot.at().equals(fixed)
-                    ? Generator.worn(slot.worn(),
-                            Witnesses.wrapped(slot.type(), value, ruleSource), ruleSource)
-                    : null;
-            // A narrowing settled the value here, so there is no position under it for anything to
-            // be written at. Nothing reaches this — the plan refuses a demand under a position it
-            // settles — and it is answered rather than assumed away.
-            case ConstructionPlan.Exact _ -> null;
-            case ConstructionPlan.Built built -> {
-                Map.Entry<String, ConstructionPlan.Node> down = fieldTowards(built, fixed);
-                FixtureTemplate inner = down == null ? null
-                        : carrying(down.getValue(), fixed, value, ruleSource, policy);
-                // A record this module composes is one a module declares. A constructor this cannot
-                // name is a value nothing here writes, which is what the empty answer below says.
-                if (inner == null || !(built.of() instanceof TypeSymbol.AtModule record)) {
-                    yield null;
-                }
-                // The rest of the record is chosen against what its own rules leave each field,
-                // which is the reading `Partitions.composed` makes of them. Chosen from the types
-                // alone, a record whose rule relates two fields would be handed a value it refuses.
-                List<FixtureTemplate> whole = Partitions.composed(record, ruleSource, policy,
-                        java.util.Set.of(), Map.of(down.getKey(), inner));
-                yield whole.isEmpty() ? null
-                        : Generator.worn(built.worn(), whole.getFirst(), ruleSource);
-            }
-            // A container between the element and the number, which is more occurrences of the
-            // number than the walk that split the total counted. The split is one number per
-            // element of the outer container, and a container here holds as many as its own rules
-            // ask for -- so a value built here would come to a multiple of the total it was built
-            // for. Nothing composes one until what is decomposed is the occurrences rather than the
-            // elements, and that is a question for the walk that decomposes.
-            case ConstructionPlan.Held _ -> null;
-        };
+        return Partitions.fieldsOf(record, ruleSource, policy, java.util.Set.of(),
+                Map.of(down.getKey(), inner));
     }
 
     /**
-     * The field of {@code built} the fixed position is at or under, or null where none is.
+     * The field of {@code built} the number's position is at or under, or null where none is.
      *
      * <p>Asked of the plan's own positions rather than of the path's steps. The two agree wherever
      * a field step is a field of a record, and part where a narrowing takes no level: the plan's
      * position for a case is written at the same remove as the sum it narrows, so a walk counting
      * steps would be one out from there down.
      */
-    private static Map.Entry<String, ConstructionPlan.Node> fieldTowards(ConstructionPlan.Built built,
-                                                                        TermPath fixed) {
+    private Map.Entry<String, ConstructionPlan.Node> fieldTowards(ConstructionPlan.Built built) {
         for (Map.Entry<String, ConstructionPlan.Node> each : built.under().entrySet()) {
             if (fixed.isAtOrUnder(each.getValue().at())) {
                 return each;
@@ -102,6 +71,4 @@ final class ValuesCarryingANumber {
         }
         return null;
     }
-
-    private ValuesCarryingANumber() {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
@@ -233,6 +233,7 @@ public final class PublicationOrders {
                     CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
                     CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
                     CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
+                    CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED,
                     CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
                     CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT,
                     CompositionBudget.VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT,

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -2176,6 +2176,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 case SHAPES_OF_A_TOTAL_OFFERED -> "how many containers are offered for one total";
                 case DECOMPOSITIONS_OF_A_TOTAL_OFFERED ->
                         "how many ways a total is decomposed";
+                case WAYS_DOWN_TO_A_TOTAL_TRIED ->
+                        "how many ways down to what a total adds up are tried";
                 case PLACES_A_PAIR_IS_TRIED_AT -> "how many places a pair is tried at";
                 case STEPS_A_SEARCH_MAY_TAKE -> "how many steps a search takes";
                 case ASSIGNMENTS_A_SEARCH_COMPOSES -> "how many assignments a search composes";

--- a/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
@@ -1,0 +1,133 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.RunSource;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A container is filled to a total through the cases of what it holds.
+ *
+ * <p>Where every case of a sum spreads the same declaration, a field of it is read through the sum:
+ * the total {@code List.sum(ns[*].method.amount)} names a position of the sum and no case of it,
+ * which is what makes the rule readable and is not enough to write a value with. A value of that
+ * position is a value of one of the cases, and which one is a fact about the value — so the walk
+ * offers one shape per case rather than choosing.
+ *
+ * <p>The way down is the plan's. Walked from the declarations instead, a field of a plain record at
+ * a time, the sum was a shape it had no answer for: every count and every spread came back with
+ * nothing built, and the point the total was about was reported in the words of a figure this
+ * compiler had stopped at.
+ */
+class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
+
+    /**
+     * Entries whose method is a sum of two cases, the amount spread through both.
+     *
+     * <p>Each case carries a field of its own, so that composing one is composing a record and not
+     * merely naming a case — which is the shape a model writes and the one this could not fill.
+     */
+    private static final String SHARED = """
+            module g
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Common = { amount: Amount }
+
+            data Card = { ...Common, issuer: Issuer }
+            data Cash = { ...Common, note: Note }
+
+            data Issuer = String
+                invariant String.length(value) >= 1
+
+            data Note = String
+                invariant String.length(value) >= 1
+
+            data Method = Card | Cash
+
+            data Entry = { method: Method }
+
+            data Page = { count: Int }
+
+            behavior readArticles : (ns: List<Entry>) -> Page
+            """;
+
+    private static final RuleReadingSource RULES = RuleReadings.ofSource(SHARED);
+
+    private static final Symbols SYMBOLS = RULES.symbols();
+
+    private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
+
+    /** What the behavior takes: a list of entries, which is the container the total is over. */
+    private static final Type ENTRIES = new Type.ListOf(named("Entry"));
+
+    /**
+     * A total two counts reach, so that both a container of one and a container of two are among
+     * what is offered.
+     */
+    private static final Count SIX = Count.of(6);
+
+    /**
+     * Every case is offered, and each container is a whole value of it.
+     *
+     * <p>The texts and not a count of them. What a case brings with it is the rest of its own
+     * record, and a walk that reached the amount without composing the case around it would offer
+     * as many containers as this and none the decoder accepts.
+     */
+    @Test
+    void aContainerIsOfferedForEachCaseOfWhatItHolds() {
+        assertEquals(List.of(
+                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") } }]",
+                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") } }]",
+                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") } }"
+                                + ", Entry { method = Card { amount = Amount(0)"
+                                + ", issuer = Issuer(\"x\") } }]",
+                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") } }"
+                                + ", Entry { method = Cash { amount = Amount(0)"
+                                + ", note = Note(\"x\") } }]"),
+                offered().stream().map(FixtureTemplate::text).toList(),
+                "one container per case at each count, with the case's own field beside the"
+                        + " amount");
+    }
+
+    /** The containers this offered. */
+    private static List<FixtureTemplate> offered() {
+        NumericTerm.TakenOver total = NumericTerm.TakenOver.of(
+                ValueName.Stdlib.operation("List", "sum"),
+                new RunSource.ProjectedOccurrences(
+                        TermPath.of("ns").element().then("method").then("amount")),
+                named("Amount"), SYMBOLS);
+        assertNotNull(total, "adding up the amounts of a run is a number of it");
+        TermOrders orders = TermOrdersFixtures.at(total, named("Amount"), SYMBOLS);
+        assertNotNull(orders.answered(), "and the order it answers on is the amounts'");
+
+        TermRealizations.Realization made = TermRealizations.at(ENTRIES, orders, SIX,
+                NothingTheRulesSay.REGION, RULES, POLICY);
+        return assertInstanceOf(TermRealizations.Realization.Built.class, made,
+                "a list of entries whose amounts come to six is a container this composes")
+                .values();
+    }
+
+    private static Type named(String data) {
+        return Type.ref(TypeSymbols.declared(new TypeKey("g", data)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
@@ -130,6 +130,74 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
                 "and the ways it did try composed containers");
     }
 
+    /**
+     * The figure counts what this walk did, so a walk that keeps nothing is stopped by it too.
+     *
+     * <p>Every position that has to be narrowed multiplies what is left to ask about. Where the
+     * branches plan, a figure over what was kept stops the walk soon enough that nothing shows;
+     * where none of them does — here the number stands deeper than a value is built — nothing is
+     * kept, and a figure over what was kept would let the cases of every sum on the way be walked
+     * in full while saying the walk was never stopped.
+     */
+    @Test
+    void theFigureCountsTheWaysTriedAndNotTheOnesKept() {
+        TermRealizations.Realization came = realizing(DEEP_UNDER_SUMS, DEEPLY);
+
+        assertEquals(java.util.Set.of(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED,
+                        CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS),
+                assertInstanceOf(TermRealizations.Realization.Stopped.class, came,
+                        "no way down was kept, so there is no container and no reason of the"
+                                + " model's").by(),
+                "and both figures are said: the ways this tried, and what each of them was planned"
+                        + " no further than");
+    }
+
+    /** The amount under two sums and then below more levels than a value is built through. */
+    private static final List<String> DEEPLY = List.of("first", "second", "down", "down", "down",
+            "down", "down", "down", "down", "amount");
+
+    /**
+     * Two sums on the way down, with the number below the depth a plan descends.
+     *
+     * <p>So every combination of their cases is a way to ask about and none of them plans, which is
+     * the walk a figure over what was kept does not bound.
+     */
+    private static final String DEEP_UNDER_SUMS = """
+            module g
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Common = { amount: Amount }
+
+            data L8 = { ...Common, tag: Int }
+            data L7 = { down: L8 }
+            data L6 = { down: L7 }
+            data L5 = { down: L6 }
+            data L4 = { down: L5 }
+            data L3 = { down: L4 }
+            data L2 = { down: L3 }
+            data L1 = { down: L2 }
+
+            data A1 = { down: L1 }
+            data A2 = { down: L1 }
+            data A3 = { down: L1 }
+            data A4 = { down: L1 }
+            data Second = A1 | A2 | A3 | A4
+
+            data B1 = { second: Second }
+            data B2 = { second: Second }
+            data B3 = { second: Second }
+            data B4 = { second: Second }
+            data First = B1 | B2 | B3 | B4
+
+            data Entry = { first: First, settled: Bool }
+
+            data Page = { count: Int }
+
+            behavior readArticles : (ns: List<Entry>) -> Page
+            """;
+
     /** The same sum with more cases than the ways down are tried. */
     private static final String MANY_CASES = SHARED.replace(
             "data Method = Card | Cash",

--- a/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
@@ -20,8 +20,10 @@ import souther.compiler.types.ValueName;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A container is filled to a total through the cases of what it holds.
@@ -71,14 +73,7 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
             behavior readArticles : (ns: List<Entry>) -> Page
             """;
 
-    private static final RuleReadingSource RULES = RuleReadings.ofSource(SHARED);
-
-    private static final Symbols SYMBOLS = RULES.symbols();
-
     private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
-
-    /** What the behavior takes: a list of entries, which is the container the total is over. */
-    private static final Type ENTRIES = new Type.ListOf(named("Entry"));
 
     /**
      * A total two counts reach, so that both a container of one and a container of two are among
@@ -109,22 +104,71 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
                         + " amount");
     }
 
-    /** The containers this offered. */
+    /**
+     * The ways down are stopped by a figure of their own, and it is not the one that counts the
+     * containers offered.
+     *
+     * <p>A way that plans is not a container that was offered: the values are composed afterwards,
+     * and a case may be refused there. Charged to one figure, a case that planned and built nothing
+     * would spend an offer, so which cases are tried at all would be decided by the order they are
+     * declared in — which is what the offers were meant not to turn on.
+     */
+    @Test
+    void theWaysDownAreStoppedByTheirOwnFigure() {
+        TermRealizations.Realization.Built made = assertInstanceOf(
+                TermRealizations.Realization.Built.class, realizing(MANY_CASES),
+                "the cases that were tried compose containers");
+
+        assertTrue(made.heldBack().contains(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED),
+                () -> "more cases than this tries, and it says which figure stopped it: "
+                        + made.heldBack());
+        assertFalse(made.values().isEmpty(),
+                "and the ways it did try composed containers");
+    }
+
+    /** The same sum with more cases than the ways down are tried. */
+    private static final String MANY_CASES = SHARED.replace(
+            "data Method = Card | Cash",
+            """
+            data Cash2 = { ...Common, note: Note }
+            data Cash3 = { ...Common, note: Note }
+            data Cash4 = { ...Common, note: Note }
+            data Cash5 = { ...Common, note: Note }
+            data Cash6 = { ...Common, note: Note }
+            data Cash7 = { ...Common, note: Note }
+            data Cash8 = { ...Common, note: Note }
+            data Cash9 = { ...Common, note: Note }
+
+            data Method = Card | Cash | Cash2 | Cash3 | Cash4 | Cash5 | Cash6 | Cash7 | Cash8
+                        | Cash9""");
+
+    /** The containers this offered for the model every test here is about. */
     private static List<FixtureTemplate> offered() {
+        return offeredBy(SHARED);
+    }
+
+    /** The containers this offered for {@code source}, whose behavior takes the entries. */
+    private static List<FixtureTemplate> offeredBy(String source) {
+        return assertInstanceOf(TermRealizations.Realization.Built.class, realizing(source),
+                "a list of entries whose amounts come to six is a container this composes")
+                .values();
+    }
+
+    /** What this walk came to for {@code source}. */
+    private static TermRealizations.Realization realizing(String source) {
+        RuleReadingSource rules = RuleReadings.ofSource(source);
+        Symbols symbols = rules.symbols();
+        Type entries = new Type.ListOf(named("Entry"));
         NumericTerm.TakenOver total = NumericTerm.TakenOver.of(
                 ValueName.Stdlib.operation("List", "sum"),
                 new RunSource.ProjectedOccurrences(
                         TermPath.of("ns").element().then("method").then("amount")),
-                named("Amount"), SYMBOLS);
+                named("Amount"), symbols);
         assertNotNull(total, "adding up the amounts of a run is a number of it");
-        TermOrders orders = TermOrdersFixtures.at(total, named("Amount"), SYMBOLS);
+        TermOrders orders = TermOrdersFixtures.at(total, named("Amount"), symbols);
         assertNotNull(orders.answered(), "and the order it answers on is the amounts'");
 
-        TermRealizations.Realization made = TermRealizations.at(ENTRIES, orders, SIX,
-                NothingTheRulesSay.REGION, RULES, POLICY);
-        return assertInstanceOf(TermRealizations.Realization.Built.class, made,
-                "a list of entries whose amounts come to six is a container this composes")
-                .values();
+        return TermRealizations.at(entries, orders, SIX, NothingTheRulesSay.REGION, rules, POLICY);
     }
 
     private static Type named(String data) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest.java
@@ -66,7 +66,7 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
 
             data Method = Card | Cash
 
-            data Entry = { method: Method }
+            data Entry = { method: Method, settled: Bool }
 
             data Page = { count: Int }
 
@@ -91,14 +91,18 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
     @Test
     void aContainerIsOfferedForEachCaseOfWhatItHolds() {
         assertEquals(List.of(
-                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") } }]",
-                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") } }]",
-                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") } }"
-                                + ", Entry { method = Card { amount = Amount(0)"
-                                + ", issuer = Issuer(\"x\") } }]",
-                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") } }"
-                                + ", Entry { method = Cash { amount = Amount(0)"
-                                + ", note = Note(\"x\") } }]"),
+                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") }"
+                                + ", settled = true }]",
+                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") }"
+                                + ", settled = true }]",
+                        "[Entry { method = Card { amount = Amount(6), issuer = Issuer(\"x\") }"
+                                + ", settled = true }, Entry { method = Card"
+                                + " { amount = Amount(0), issuer = Issuer(\"x\") }"
+                                + ", settled = true }]",
+                        "[Entry { method = Cash { amount = Amount(6), note = Note(\"x\") }"
+                                + ", settled = true }, Entry { method = Cash"
+                                + " { amount = Amount(0), note = Note(\"x\") }"
+                                + ", settled = true }]"),
                 offered().stream().map(FixtureTemplate::text).toList(),
                 "one container per case at each count, with the case's own field beside the"
                         + " amount");
@@ -142,6 +146,83 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
             data Method = Card | Cash | Cash2 | Cash3 | Cash4 | Cash5 | Cash6 | Cash7 | Cash8
                         | Cash9""");
 
+    /**
+     * Every way down was tried and none composed a value, which is not the answer a demand nothing
+     * reaches gets.
+     *
+     * <p>The evidence and not the word. What a reader downstream does with a total nothing composed
+     * is one classification; what happened in this attempt is another, and a walk that said the same
+     * thing about both would leave the difference to be worked out from what the sentence left out.
+     */
+    @Test
+    void everyWayTriedAndNoneComposedSaysSo() {
+        TermRealizations.Realization.None came = assertInstanceOf(
+                TermRealizations.Realization.None.class,
+                realizing(NO_CASE_COMPOSES, AMOUNT, namedIn(NO_CASE_COMPOSES, "Entries")),
+                "the ways down are there and neither of them builds a value");
+
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, came.why());
+        assertEquals("`ns[*].method@Card.amount`, `ns[*].method@Cash.amount` were ways down to"
+                        + " `ns[*].method.amount`, and none of them composed a value",
+                came.detail(),
+                "and the ways that were walked are named, so a reader is not left to tell this"
+                        + " from a demand nothing reaches");
+    }
+
+    /**
+     * A demand under a position nothing stands under says that instead.
+     *
+     * <p>The other corner. Both come back with the one word a reader downstream acts on, and what
+     * tells them apart is what each says it found.
+     */
+    @Test
+    void aDemandNothingStandsUnderSaysThatInstead() {
+        TermRealizations.Realization.None came = assertInstanceOf(
+                TermRealizations.Realization.None.class, realizing(SHARED, UNDER_A_TRUTH),
+                "a truth value holds no position, so there is no way down to ask for");
+
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, came.why());
+        assertEquals("nothing standing at `ns[*].settled` gives a way down to"
+                        + " `ns[*].settled.amount`",
+                came.detail(),
+                "and what it says is that there was never a way, which is not that the ways came"
+                        + " to nothing");
+    }
+
+    /** The amount, read through the sum every case spreads it in. */
+    private static final List<String> AMOUNT = List.of("method", "amount");
+
+    /** A way down that goes under a truth value, which divides into two values and holds no
+     *  position under either. */
+    private static final List<String> UNDER_A_TRUTH = List.of("settled", "amount");
+
+    /**
+     * The same sum with both cases holding a string longer than one is worth writing out, so the
+     * way down to the amount is there and neither case composes a value.
+     */
+    private static final String NO_CASE_COMPOSES = """
+            module g
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Common = { amount: Amount }
+
+            data Card = { ...Common, inner: Method }
+            data Cash = { ...Common, inner: Method }
+
+            data Method = Card | Cash
+
+            data Entries = List<Entry>
+                invariant List.length(value) <= 1
+
+            data Entry = { method: Method, settled: Bool }
+
+            data Page = { count: Int }
+
+            behavior readArticles : (ns: List<Entry>) -> Page
+            """;
+
     /** The containers this offered for the model every test here is about. */
     private static List<FixtureTemplate> offered() {
         return offeredBy(SHARED);
@@ -154,15 +235,29 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
                 .values();
     }
 
-    /** What this walk came to for {@code source}. */
+    /** What this walk came to for {@code source}, with the amount read the way it is written. */
     private static TermRealizations.Realization realizing(String source) {
+        return realizing(source, AMOUNT);
+    }
+
+    /** The same, for a total read at {@code steps} below each element. */
+    private static TermRealizations.Realization realizing(String source, List<String> steps) {
+        return realizing(source, steps, new Type.ListOf(named("Entry")));
+    }
+
+    /** The same, over a container of {@code held}. */
+    private static TermRealizations.Realization realizing(String source, List<String> steps,
+                                                          Type held) {
         RuleReadingSource rules = RuleReadings.ofSource(source);
         Symbols symbols = rules.symbols();
-        Type entries = new Type.ListOf(named("Entry"));
+        Type entries = held;
+        TermPath read = TermPath.of("ns").element();
+        for (String step : steps) {
+            read = read.then(step);
+        }
         NumericTerm.TakenOver total = NumericTerm.TakenOver.of(
                 ValueName.Stdlib.operation("List", "sum"),
-                new RunSource.ProjectedOccurrences(
-                        TermPath.of("ns").element().then("method").then("amount")),
+                new RunSource.ProjectedOccurrences(read),
                 named("Amount"), symbols);
         assertNotNull(total, "adding up the amounts of a run is a number of it");
         TermOrders orders = TermOrdersFixtures.at(total, named("Amount"), symbols);
@@ -173,5 +268,11 @@ class AContainerAddingUpIsFilledThroughTheCasesOfWhatItHoldsTest {
 
     private static Type named(String data) {
         return Type.ref(TypeSymbols.declared(new TypeKey("g", data)));
+    }
+
+    /** The same, said of a model whose declarations are the ones being read. */
+    private static Type namedIn(String source, String data) {
+        assertTrue(source.contains("data " + data), "the model declares `" + data + "`");
+        return named(data);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
@@ -1,0 +1,176 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.Requirements;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.ResolvedCase;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value asked for under a sum is a value asked for under one of its cases, and the plan says
+ * which cases there are rather than choosing one.
+ *
+ * <p>Where every case spreads the same declaration, a field of it is read through the sum: the path
+ * names a position of the sum and no case of it (spec §sum-data), which is enough to read a rule at
+ * and not enough to write a value with. So the reading and the writing part here, and what the
+ * writing needs is the one thing the reading did not have to say.
+ *
+ * <p><b>What a plan must not do with such a demand is drop it.</b> A sum composes nothing out of
+ * anything, so a whole value is chosen there and a path fixed below it has nowhere to be written —
+ * the arrangement {@code ConstructionPlan.Result.Beyond} refuses at the depth figure, met at a
+ * position instead of at a depth. Handed back as an ordinary plan, the composing satisfies it and
+ * the caller's value is quietly missing from what was built.
+ */
+class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
+
+    /**
+     * A list of items whose method is a sum of two cases, both spreading the same amount.
+     *
+     * <p>The shape a total over a sequence meets: the amount is one field, readable through the
+     * sum, and each case has a field of its own so that neither is the whole of what a value there
+     * is.
+     */
+    private static final String SHARED = """
+            module g
+
+            data Common = { amount: Int }
+            data Card = { ...Common, issuer: Int }
+            data Cash = { ...Common, note: Int }
+            data Method = Card | Cash
+            data Item = { method: Method }
+
+            data Query = { item: Item }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+            """;
+
+    /** The amount, reached through the sum and under no case. */
+    private static TermPath through() {
+        return TermPath.of("query").then("item").then("method").then("amount");
+    }
+
+    /** The sum itself, which is where a narrowing is owed. */
+    private static TermPath sum() {
+        return TermPath.of("query").then("item").then("method");
+    }
+
+    /**
+     * The demand comes back with the position and what stands there, in the order the sum declares
+     * its cases.
+     *
+     * <p>The order is part of the answer. What the caller does with these is offer one value per
+     * case, and a reader comparing two runs of this compiler is comparing lists — an order read off
+     * a hash would make the same model answer differently on two days.
+     */
+    @Test
+    void aDemandUnderASumNamesThePositionAndWhatStandsThere() {
+        ConstructionPlan.Result result = planning(Set.of(through()));
+
+        ConstructionPlan.Result.Unnarrowed owed = assertInstanceOf(
+                ConstructionPlan.Result.Unnarrowed.class, result,
+                "nothing said which case the value is, so there is no plan and this says what is"
+                        + " missing");
+        assertEquals(sum(), owed.at(), "the position a narrowing is owed at is the sum itself");
+        assertEquals(List.of("Card", "Cash"),
+                owed.narrowings().stream().map(Refinement::spelled).toList(),
+                "and what stands there is its cases, in the order they are declared");
+    }
+
+    /**
+     * With the case written in, the same demand plans, and the value is written at it.
+     *
+     * <p>The other half of the first. Without this, a plan that refused every demand under a sum
+     * would pass — and what the caller is owed is not a refusal but somewhere to put the value once
+     * it has said which case it is building.
+     */
+    @Test
+    void theSameDemandUnderACasePlansAndTakesTheValueThere() {
+        TermPath under = sum().refine(caseOf("Card")).then("amount");
+
+        ConstructionPlan plan = assertInstanceOf(ConstructionPlan.Result.Planned.class,
+                planning(Set.of(under)), "the case is stated, so the position is one the plan has")
+                .plan();
+
+        ConstructionPlan.Slot at = plan.slots().stream()
+                .filter(each -> each.at().equals(under)).findFirst().orElseThrow();
+        assertInstanceOf(ConstructionPlan.Leaf.Fixed.class, at.leaf(),
+                "and the plan says the caller's value goes there");
+    }
+
+    /**
+     * A whole value asked for at the sum is not a demand under it, and nothing is owed.
+     *
+     * <p>The control. Read as "anything to do with a sum", the answer above would arrive wherever a
+     * caller fixes a value at a position that happens to be one — which is every class of a sum
+     * standing at a position, and none of them is missing anything.
+     */
+    @Test
+    void aValueFixedAtTheSumItselfPlansWithNothingOwed() {
+        ConstructionPlan plan = assertInstanceOf(ConstructionPlan.Result.Planned.class,
+                planning(Set.of(sum())),
+                "a value at the sum is a value at a position, whatever the position divides into")
+                .plan();
+
+        assertTrue(plan.slots().stream().anyMatch(each -> each.at().equals(sum())),
+                () -> "and it is chosen at the sum: " + plan.slots().stream()
+                        .map(ConstructionPlan.Slot::at).toList());
+    }
+
+    /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
+     *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
+    private static Refinement caseOf(String leaf) {
+        TypeSymbol named = TypeSymbols.declared(new TypeKey("g", leaf));
+        return Refinement.of(ResolvedCase.of(CaseSelector.direct(named), List.of(named)));
+    }
+
+    private static ConstructionPlan.Result planning(Set<TermPath> decided) {
+        return ConstructionPlan.of(typeOf(SHARED), TermPath.of("query"), symbolsOf(SHARED),
+                decided, Requirements.NONE, (_, _) -> 0);
+    }
+
+    private static Type typeOf(String source) {
+        return readOf(source).sig().inputTypes().get(0);
+    }
+
+    private static Symbols symbolsOf(String source) {
+        return readOf(source).symbols();
+    }
+
+    private record Read(Sig sig, Symbols symbols) {}
+
+    private static Read readOf(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("readArticles")).findFirst().orElseThrow();
+        return new Read(sigs.get(spec.name()), Scopes.derived(compilation.db(), module).value());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
@@ -122,6 +122,39 @@ class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
     }
 
     /**
+     * What is offered is the narrowings that leave something to be built, and an absence is not one
+     * of them.
+     *
+     * <p>{@code None} settles the value rather than narrowing to something with positions under it,
+     * so a caller that stated it would be asking for a value under a position holding none — which
+     * the plan refuses outright. Offered as a way down, the one answer a caller could act on came
+     * back beside one that ends the walk.
+     */
+    @Test
+    void anAbsenceIsNotOfferedAsAWayDown() {
+        TermPath under = TermPath.of("query").then("held").then("amount");
+
+        ConstructionPlan.Result.Unnarrowed owed = assertInstanceOf(
+                ConstructionPlan.Result.Unnarrowed.class, planningOf(OPTIONAL, Set.of(under)),
+                "an optional holds nothing until something says the value is there");
+        assertEquals(List.of("Some"),
+                owed.narrowings().stream().map(Refinement::spelled).toList(),
+                "and what is offered is the presence, which is what puts a position under it");
+    }
+
+    /** A record whose field is an optional of a record, which is where an absence is a distinction
+     *  of the position and no way down to what the record holds. */
+    private static final String OPTIONAL = """
+            module g
+
+            data Inner = { amount: Int }
+            data Query = { held: Inner? }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+            """;
+
+    /**
      * A whole value asked for at the sum is not a demand under it, and nothing is owed.
      *
      * <p>The control. Read as "anything to do with a sum", the answer above would arrive wherever a
@@ -148,7 +181,11 @@ class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
     }
 
     private static ConstructionPlan.Result planning(Set<TermPath> decided) {
-        return ConstructionPlan.of(typeOf(SHARED), TermPath.of("query"), symbolsOf(SHARED),
+        return planningOf(SHARED, decided);
+    }
+
+    private static ConstructionPlan.Result planningOf(String source, Set<TermPath> decided) {
+        return ConstructionPlan.of(typeOf(source), TermPath.of("query"), symbolsOf(source),
                 decided, Requirements.NONE, (_, _) -> 0);
     }
 


### PR DESCRIPTION
Closes #1308.

## What was wrong

The way down from an element to the number a total reads was walked from the declarations, a field of a plain record at a time. It agreed wherever the way down was records and had no answer for a sum, a newtype, or a container inside one — and each of those came back as one silence, so a point on such a total was reported in the words of a figure this compiler had stopped at while nothing had been composed at all.

Under it is a fact about the model rather than about the walk. Where every case of a sum spreads the same declaration, a field of it is read through the sum: the term names a position of the sum and no case of it, which is what makes the rule readable and is not enough to write a value with. Reading and writing part there, and what the writing needs is the one thing the reading never had to say.

## What is here

A demand under a position that composes nothing is no longer dropped. The plan answers with the position and what stands there, in the order the declarations write it, and the caller states one of them and asks again. That is the arrangement a demand under the depth figure is already refused for, met at a position instead of at a depth: handed back as an ordinary plan, the composing satisfies it and what is built is missing the value the caller asked for.

Which case a value is is a fact about the value, so the plan hands the narrowings over rather than taking one. The walk that fills a container states each of them, and a container is offered per case of what it holds — one case for the whole container, since a container whose elements are of several is a shape nothing asked for. What is not offered is said, and what the planning gave up at travels beside it.

The composer now reads the plan and fills what it says: a record is composed by the reader that has its rules, a container is asked what may stand beside the element the value is in, and the names a position wears go on where the plan says they do. It is its own file because a file that holds a plan does not read the input's positions — a coordinate of the plan is not a position of the input, and the two are one type. The inventory of budget readers gains the walk that enumerates the ways down, which reaches a figure and hands it over.

## Checking

The plan's answer is fixed at the plan, and the containers are fixed where they are built. Both claims were mutated to see them go red: emptying the case enumeration puts the realization back to the word it came back with before, and taking the plan's refusal out drops the value again in both tests.

Two checks the repository already had fired while this was written, and both were right: the one that says a file holding a plan does not consult the input reading, and the sheet that says every figure this compiler stops at is read where something says what it does with it.

## What this does not close

A total read through a sum's shared field is still not seen reaching the term when the model is run, so a point on it stays undecided even where the author's own example stands exactly on it. That is the reading rather than the composing, it holds whether or not anything was composed, and it is written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
