### PR TITLE
A reason says what it is a fact about, and a debt says what left it unmeasured

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/observe/MeasureReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/MeasureReason.java
@@ -23,4 +23,40 @@ public interface MeasureReason {
 
     /** The constant's own word, which is what the JSON form lowercases. */
     String name();
+
+    /**
+     * What this reason is a fact about.
+     *
+     * <p>The reason's own answer, asked at its declaration. Three readers put this question and
+     * none of them can work it out from what it holds: a surface decides from it whether a line of
+     * its own is printed, a fold over the readings of one line decides from it whether the reasons
+     * two readings gave are two facts or one fact said twice, and whoever adds a reason has to say
+     * which it is. Answered at each of those instead, one fact about a constant is spelled in as
+     * many tables as there are readers, and a constant added later reaches the ones whose author
+     * remembered it.
+     *
+     * <p><b>Not read off anything else the reason answers, and nothing else read off this.</b>
+     * Whether a row could be hiding behind a reason is a different question with a different
+     * answer — a reading of the arms that came back unreadable is a fact about the behavior and may
+     * be hiding a row — and a reader wanting that one asks the measure that has it.
+     */
+    About about();
+
+    /** What a reason is a fact about, which is a property of the reason and of nothing around it. */
+    enum About {
+
+        /**
+         * The run, and not the behavior the measure is of.
+         *
+         * <p>What a build asked for is an input to the whole run, so every measure of every
+         * behavior says the same one — a surface printing a line per measure would say one fact as
+         * many times as the module has behaviors, and readings of one line that say this say one
+         * fact rather than several.
+         */
+        THE_RUN,
+
+        /** The behavior the measure is of, so the measure says it and two behaviors can say
+         *  different ones. */
+        THE_BEHAVIOR
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
@@ -389,4 +389,17 @@ public final class PublicationOrders {
                     ItemAssessment.WritabilityEvidence.Ground.THE_RULES_PROVE_IT,
                     ItemAssessment.WritabilityEvidence.Ground.A_ROW_IS_AT_IT,
                     ItemAssessment.WritabilityEvidence.Ground.A_VALUE_WAS_BUILT));
+
+    /**
+     * Why nothing was read against a point, over every reading of the line it is on.
+     *
+     * <p>What the run asked for before what one behavior turned out to have. A reader told that
+     * this build measured nothing has been told why every line of it says so, and what a single
+     * behavior has no rows for is the narrower fact under it.
+     */
+    public static final CanonicalSelection.Order<ItemAssessment.Coverage.NotAsked> UNASKED_REASONS =
+            CanonicalSelection.Order.overValues(List.of(
+                    ItemAssessment.Coverage.NotAsked.NOT_ASKED,
+                    ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED,
+                    ItemAssessment.Coverage.NotAsked.NO_ROWS));
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -25,6 +25,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
 import souther.compiler.partition.Axis;
@@ -495,13 +496,23 @@ public final class Adequacy {
              *  cover and no row could make one. Held rather than read back from the two empty case
              *  sets below it: a reader that counted them would be answering a different question —
              *  how many cases there are — and getting this one right by coincidence. */
-            NOT_A_SUM
+            NOT_A_SUM;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         /** The same, for a measurement nobody asked for. */
         public enum NoRows implements NotMeasuredReason {
             /** No row names this behavior, so nothing was established about it either way. */
-            NO_ROWS
+            NO_ROWS;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         public static SignatureEvidence notASum(OutputCaseEvidence output,
@@ -2145,7 +2156,17 @@ public final class Adequacy {
             NOT_ASKED,
             /** No row names this behavior. The measurement is opted into by writing one, and
              *  reaching the behavior through somebody else's row is not opting in. */
-            NO_ROWS
+            NO_ROWS;
+
+            /** What the build asked for is one value for the run; which behaviors a row names is
+             *  not. */
+            @Override
+            public MeasureReason.About about() {
+                return switch (this) {
+                    case NOT_ASKED -> MeasureReason.About.THE_RUN;
+                    case NO_ROWS -> MeasureReason.About.THE_BEHAVIOR;
+                };
+            }
         }
 
         /**
@@ -2178,13 +2199,23 @@ public final class Adequacy {
              * writes and a branch no test can reach, so the two are the one answer the obligations
              * give.
              */
-            NO_ARM_OBLIGATIONS
+            NO_ARM_OBLIGATIONS;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         /** The rows ran without instrumentation, so what they went through went with it. The one
          *  reason here that is a measurement started and not finished. */
         public enum Unreadable implements FailureReason {
-            UNREADABLE
+            UNREADABLE;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         /**
@@ -2200,7 +2231,14 @@ public final class Adequacy {
          * were one answer while the measure read the elaborated bodies for both (issue #996).
          */
         public enum Unelaborated implements FailureReason {
-            BODIES_NOT_ELABORATED
+            BODIES_NOT_ELABORATED;
+
+            /** The module the behavior is in, which another behavior of the same run need not be
+             *  in. */
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         public static BranchEvidence noArms(NoArms reason) {
@@ -2524,12 +2562,22 @@ public final class Adequacy {
          *  the ways a reading that was made came out. */
         public enum NotAsked implements NotMeasuredReason {
             /** This build does not read rows, so nothing was seen and nothing is owed about it. */
-            ROWS_NOT_ASKED
+            ROWS_NOT_ASKED;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_RUN;
+            }
         }
 
         /** Nothing came back at all, so a measure over what remains is over none of them. */
         public enum Unavailable implements FailureReason {
-            ROWS_UNAVAILABLE
+            ROWS_UNAVAILABLE;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryDerivation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryDerivation.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.partition.MeasureClosure;
 
 import java.util.List;
@@ -42,12 +43,22 @@ public final class BoundaryDerivation {
         public String name() {
             return WORD;
         }
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** This behavior has no positions for a line to be drawn on — a {@code >->} composition, which
      *  is measured at its stages. */
     public enum NoSubject implements NotApplicableReason {
-        NO_SUBJECT
+        NO_SUBJECT;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /**
@@ -59,7 +70,12 @@ public final class BoundaryDerivation {
      * at all; the closure tells them apart, and this is what is left of the first.
      */
     public enum TheReadingDidNotRunOut implements FailureReason {
-        THE_READING_DID_NOT_RUN_OUT
+        THE_READING_DID_NOT_RUN_OUT;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** What a behavior measured at its stages rather than at itself comes to. */

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Sig;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.observe.MeasureReason;
 
 import java.util.Map;
 import java.util.Objects;
@@ -76,6 +77,13 @@ public sealed interface BoundaryForMeasurement {
          * refuses the reading of.
          */
         BEHAVIOR_INPUT_NOT_READ;
+
+        /** Both are read off one behavior's own declaration and its own input, so two behaviors of
+         *  one run can say different ones. */
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
 
         /**
          * What a measure short of this went without, as the fact that made it so.

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -754,9 +754,8 @@ final class Coverages {
         // clause's are about the values — one refuses everything outside its bound, the other states
         // a relation — so for both of those writing the value is the whole of what there is to reach.
         boolean guard = border.origin().comparisonAt().isPresent();
-        Measurement<ItemAssessment.Coverage> absent = guard
-                ? whyNoGuardLine(observed, level)
-                : whyNoInvariantLine(observed, level);
+        Measurement<ItemAssessment.Coverage> absent =
+                whyNothingWasReadAgainstTheLine(guard, observed, level);
 
         // The rows as the values they hold and what running them recorded, which is the whole of
         // what a point is met by. Read once for the border: what a row is stays the same however
@@ -1246,6 +1245,21 @@ final class Coverages {
         ItemAssessment.Coverage seen = new ItemAssessment.Coverage.NoHit();
         return by.isEmpty() ? new Measurement.Complete<>(seen)
                 : new Measurement.Partial<>(seen, WeakeningSet.ofAll(by));
+    }
+
+    /**
+     * Why nothing was read against a line at all, or null where the rows are what answer it.
+     *
+     * <p>The gates, behind one name. Which of them a line goes through is settled by the level the
+     * build asked for and by whether a fork or an invariant drew it, and that is one decision with
+     * one owner — a caller writing the choice out again, and a check enumerating what a reading can
+     * come to, would be two more statements of it, free to say what this stopped saying.
+     */
+    static Measurement<ItemAssessment.Coverage> whyNothingWasReadAgainstTheLine(
+            boolean drawnByAFork,
+            souther.compiler.query.Adequacy.RowReading observed,
+            souther.compiler.query.Adequacy.Level level) {
+        return drawnByAFork ? whyNoGuardLine(observed, level) : whyNoInvariantLine(observed, level);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/InputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/InputCaseEvidence.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
@@ -56,13 +57,23 @@ public record InputCaseEvidence(int at, Set<TypeSymbol> declared, Set<TypeSymbol
 
     /** No row names this behavior. */
     public enum NoRows implements NotMeasuredReason {
-        NO_ROWS
+        NO_ROWS;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** Why one input's cases have no numbers. */
     public enum NotASum implements NotApplicableReason {
         /** The position is one data rather than a sum, so there is no case to cover. */
-        NOT_A_SUM
+        NOT_A_SUM;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     public InputCaseEvidence {

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -360,11 +360,10 @@ public sealed interface ItemAssessment {
                 return MeasureReason.About.THE_BEHAVIOR;
             }
 
-            /** Whether a row at the point could be sitting behind this, as {@link NotAsked} answers
-             *  it. The rows ran, so one of them may have reached the comparison unrecorded. */
-            public boolean mayHideARow() {
-                return true;
-            }
+            // Whether a row could be sitting behind one of these is not asked, the way it is of
+            // NotAsked. A measurement that failed says what it went without and cannot say nothing,
+            // so every one of these leaves the point undecided whatever the reason — which is the
+            // state's answer and not a reason's.
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.NotOwedReason;
@@ -311,6 +312,27 @@ public sealed interface ItemAssessment {
             NO_ROWS;
 
             /**
+             * What each of these is a fact about.
+             *
+             * <p>Which of them a line says is settled by the level the build asked for and by
+             * whether a fork or an invariant drew the line, and the first of those is one value for
+             * the whole run. So the two settings say the same thing at every reading of every line
+             * they reach, and only the third is something one behavior can say and the next one
+             * not.
+             *
+             * <p><b>Not what {@link #mayHideARow()} answers, and the two are not read off each
+             * other.</b> They agree over these three constants and part over {@link CouldNotAsk},
+             * which is a fact about the behavior that may well be hiding a row.
+             */
+            @Override
+            public MeasureReason.About about() {
+                return switch (this) {
+                    case NOT_ASKED, ARMS_NOT_ASKED -> MeasureReason.About.THE_RUN;
+                    case NO_ROWS -> MeasureReason.About.THE_BEHAVIOR;
+                };
+            }
+
+            /**
              * Whether a row at the point could be sitting behind this and not have been seen.
              *
              * <p>Asked of the reason and not of the state around it. Three of these are one
@@ -330,6 +352,13 @@ public sealed interface ItemAssessment {
             /** The rows ran without instrumentation, so no row can be shown to have reached the
              *  comparison. Never a reason for an invariant's line. */
             ARMS_UNREADABLE;
+
+            /** This behavior's rows, which ran and were not recorded. Another behavior of the same
+             *  run can have been read to the end, so this is nothing the run says. */
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
 
             /** Whether a row at the point could be sitting behind this, as {@link NotAsked} answers
              *  it. The rows ran, so one of them may have reached the comparison unrecorded. */

--- a/souther-compiler/src/main/java/souther/compiler/query/NoFeasibleInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/NoFeasibleInput.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import souther.compiler.inputs.EmptyInput;
+import souther.compiler.observe.MeasureReason;
 
 /**
  * There is nothing for a measure of a behavior's input to be about, because the rules reaching that
@@ -40,6 +41,11 @@ public record NoFeasibleInput(EmptyInput proof) implements NotApplicableReason {
     @Override
     public String name() {
         return WORD;
+    }
+
+    @Override
+    public MeasureReason.About about() {
+        return MeasureReason.About.THE_BEHAVIOR;
     }
 
     public NoFeasibleInput {

--- a/souther-compiler/src/main/java/souther/compiler/query/NothingWasAsked.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/NothingWasAsked.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.MeasureReason;
 
 /**
  * The build asked for no measurement at all, so this measure was not made.
@@ -15,5 +16,12 @@ package souther.compiler.query;
  * (issue #955).
  */
 public enum NothingWasAsked implements NotMeasuredReason {
-    NOT_ASKED
+    NOT_ASKED;
+
+    /** The run's, which is the whole of what this reason is: what a build asked for is an input to
+     *  the run, and every measure of every behavior says the same one. */
+    @Override
+    public MeasureReason.About about() {
+        return MeasureReason.About.THE_RUN;
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationAssessment.java
@@ -51,8 +51,11 @@ public record ObligationAssessment(Criterion criterion, ObligationCoverage cover
     public boolean worthSearching() {
         return switch (coverage) {
             case ObligationCoverage.Missed _ -> true;
-            case ObligationCoverage.NotMeasured it ->
-                    it.why() == ItemAssessment.Coverage.NotAsked.NO_ROWS;
+            // Asked of the reasons rather than of one constant. A point nothing was read against is
+            // work to hand to an author where nothing that was not read could be hiding a row
+            // there — which is what "no row names this behavior" means and what a reason added
+            // beside it would have to say for itself.
+            case ObligationCoverage.NotMeasured it -> !it.why().mayHideARow();
             case ObligationCoverage.Witnessed _, ObligationCoverage.Undecided _ -> false;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
@@ -2,8 +2,10 @@ package souther.compiler.query;
 
 import souther.compiler.observe.MeasureReason;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Whether a row is at one point of an authored line, over every reading of that line.
@@ -43,8 +45,15 @@ public sealed interface ObligationCoverage {
         }
     }
 
-    /** Nothing was read against this point, and this is why. */
-    record NotMeasured(NotMeasuredReason why) implements ObligationCoverage {
+    /**
+     * Nothing was read against this point, and this is every reason the readings gave.
+     *
+     * <p>All of them, for the reason {@link Undecided} holds all of what left it undecided. One
+     * debt is read once per behavior carrying the type and each reading says for itself why it
+     * asked nothing, so these are independent facts about one point — and a debt holding one of
+     * them said whichever reading the walk reached last.
+     */
+    record NotMeasured(UnaskedReasons why) implements ObligationCoverage {
 
         public NotMeasured {
             Objects.requireNonNull(why, "an obligation nobody measured says why");
@@ -85,9 +94,16 @@ public sealed interface ObligationCoverage {
         return this instanceof Undecided it ? it.by() : WeakeningSet.none();
     }
 
-    /** Why there is no answer, or null where there is one. */
-    default MeasureReason why() {
-        return this instanceof NotMeasured it ? it.why() : null;
+    /**
+     * The one reason a surface that publishes one writes, or none where there is an answer.
+     *
+     * <p>The projection and not the fact. What a reader gets here is what a boundary item of the
+     * report has room for, and {@link UnaskedReasons#asOne()} refuses an account that does not fit
+     * rather than picking from it. A reader wanting the facts asks {@link NotMeasured#why()}, which
+     * is the arm that has them.
+     */
+    default Optional<MeasureReason> theReasonAsOne() {
+        return this instanceof NotMeasured it ? Optional.of(it.why().asOne()) : Optional.empty();
     }
 
     /**
@@ -108,6 +124,10 @@ public sealed interface ObligationCoverage {
      * And a reading with no rows to look at is neither: it hides nothing, so it cannot take back a
      * miss another reading established, and where every reading is one there was nothing anywhere to
      * look at.
+     *
+     * <p><b>What is ranked is the states and never the reasons inside one.</b> Two readings that
+     * asked nothing gave two facts about one point, and this keeps both — the reasons a debt has
+     * are a set for the reason what left it undecided is one.
      */
     static ObligationCoverage acrossTheReadings(
             List<Measurement<ItemAssessment.Coverage>> readings) {
@@ -116,7 +136,7 @@ public sealed interface ObligationCoverage {
                     "a debt is what its readings came to, and this is none of them");
         }
         WeakeningSet unread = WeakeningSet.none();
-        NotMeasuredReason unasked = null;
+        List<ItemAssessment.Coverage.NotAsked> unasked = new ArrayList<>();
         boolean missed = false;
         for (Measurement<ItemAssessment.Coverage> reading : readings) {
             // Found is found. Said before anything else is looked at, so that no accounting of what
@@ -133,14 +153,12 @@ public sealed interface ObligationCoverage {
                         unread = unread.union(stopped.by());
                     }
                 }
-                // The three reasons a question was not put are not one answer here. One that may be
-                // hiding a row is kept as itself rather than turned into a weakening: nothing was
-                // read, so there is no reading for a weakening to be about.
-                case Measurement.NotMeasured<ItemAssessment.Coverage> none -> {
-                    if (((ItemAssessment.Coverage.NotAsked) none.why()).mayHideARow()) {
-                        unasked = none.why();
-                    }
-                }
+                // The reasons a question was not put are kept as themselves rather than turned into
+                // weakenings: nothing was read, so there is no reading for a weakening to be about.
+                // Every one of them, whatever it is a fact about — which of these outranks a miss
+                // is decided below, over the reasons together.
+                case Measurement.NotMeasured<ItemAssessment.Coverage> none ->
+                        unasked.add((ItemAssessment.Coverage.NotAsked) none.why());
                 // Read to the end and no row is at the point, which is what a miss is.
                 case Measurement.Complete<ItemAssessment.Coverage> _ -> missed = true;
             }
@@ -148,16 +166,19 @@ public sealed interface ObligationCoverage {
         if (!unread.isEmpty()) {
             return new Undecided(unread);
         }
+        UnaskedReasons why = unasked.isEmpty() ? null : UnaskedReasons.ofAll(unasked);
         // Above a miss another reading established, because a reading that looked at nothing leaves
-        // the rows it would have looked at unaccounted for. Both of the reasons that reach here are
-        // settings of the build rather than facts about one behavior, so this is reached where every
-        // reading says it and not where one of them does.
-        if (unasked != null) {
-            return new NotMeasured(unasked);
+        // the rows it would have looked at unaccounted for. Asked of the reasons together: one that
+        // could be hiding a row leaves the point unanswered whatever the readings beside it said,
+        // and the reasons that hide nothing are held all the same, because each of them is still
+        // why one reading read nothing.
+        if (why != null && why.mayHideARow()) {
+            return new NotMeasured(why);
         }
-        // Every reading had nothing to look at, so neither has the debt.
-        return missed ? new Missed()
-                : new NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS);
+        // Nothing among them hides a row, so a miss another reading established stands. Where there
+        // was no such reading, every reading had nothing to look at and neither has the debt — said
+        // in the reasons they gave rather than in one minted here.
+        return missed ? new Missed() : new NotMeasured(why);
     }
 
     /**
@@ -191,7 +212,11 @@ public sealed interface ObligationCoverage {
             case Undecided it -> new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(),
                     it.weakening());
             case Missed _ -> new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit());
-            case NotMeasured it -> new Measurement.NotMeasured<>(it.why());
+            // A reading says the one reason it asked nothing for. Two searches of one reading are
+            // of one line of one behavior under one level, so what left them unasked is one
+            // reason — and where it is not, this is a state a reading's measurement has no room
+            // for rather than one to pick from.
+            case NotMeasured it -> new Measurement.NotMeasured<>(it.why().asOne());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
@@ -148,11 +148,13 @@ public sealed interface ObligationCoverage {
                 // A reading of this line that did not run out. Whatever it could not read may be
                 // holding the row.
                 case Measurement.Partial<ItemAssessment.Coverage> in -> unread = unread.union(in.by());
-                case Measurement.FailedToMeasure<ItemAssessment.Coverage> stopped -> {
-                    if (((ItemAssessment.Coverage.CouldNotAsk) stopped.why()).mayHideARow()) {
+                // And one that was started and could not be finished, which is the same thing said
+                // by a state with no value: it did not run out, and what it went without may be
+                // holding the row. Asked of the state and not of the reason — a measurement that
+                // failed carries what it went without and cannot carry nothing, so there is no
+                // failure here that leaves the point where it found it.
+                case Measurement.FailedToMeasure<ItemAssessment.Coverage> stopped ->
                         unread = unread.union(stopped.by());
-                    }
-                }
                 // The reasons a question was not put are kept as themselves rather than turned into
                 // weakenings: nothing was read, so there is no reading for a weakening to be about.
                 // Every one of them, whatever it is a fact about — which of these outranks a miss
@@ -166,19 +168,25 @@ public sealed interface ObligationCoverage {
         if (!unread.isEmpty()) {
             return new Undecided(unread);
         }
-        UnaskedReasons why = unasked.isEmpty() ? null : UnaskedReasons.ofAll(unasked);
         // Above a miss another reading established, because a reading that looked at nothing leaves
-        // the rows it would have looked at unaccounted for. Asked of the reasons together: one that
-        // could be hiding a row leaves the point unanswered whatever the readings beside it said,
-        // and the reasons that hide nothing are held all the same, because each of them is still
-        // why one reading read nothing.
-        if (why != null && why.mayHideARow()) {
-            return new NotMeasured(why);
+        // the rows it would have looked at unaccounted for. All of them and not one, and every one
+        // of them is one that could be hiding a row: what a debt says is what put it in the state
+        // it is in, the way an undecided one says what left it undecided. A reading with nothing to
+        // look at did not put it here — it hides nothing, so it neither takes back a miss nor joins
+        // the reasons that outranked one.
+        List<ItemAssessment.Coverage.NotAsked> mayHideARow = new ArrayList<>();
+        for (ItemAssessment.Coverage.NotAsked each : unasked) {
+            if (each.mayHideARow()) {
+                mayHideARow.add(each);
+            }
+        }
+        if (!mayHideARow.isEmpty()) {
+            return new NotMeasured(UnaskedReasons.ofAll(mayHideARow));
         }
         // Nothing among them hides a row, so a miss another reading established stands. Where there
         // was no such reading, every reading had nothing to look at and neither has the debt — said
         // in the reasons they gave rather than in one minted here.
-        return missed ? new Missed() : new NotMeasured(why);
+        return missed ? new Missed() : new NotMeasured(UnaskedReasons.ofAll(unasked));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationCoverage.java
@@ -46,12 +46,17 @@ public sealed interface ObligationCoverage {
     }
 
     /**
-     * Nothing was read against this point, and this is every reason the readings gave.
+     * Nothing was read against this point, and these are the reasons that leave it unmeasured.
      *
-     * <p>All of them, for the reason {@link Undecided} holds all of what left it undecided. One
-     * debt is read once per behavior carrying the type and each reading says for itself why it
-     * asked nothing, so these are independent facts about one point — and a debt holding one of
-     * them said whichever reading the walk reached last.
+     * <p>Every one of them and not one, for the reason {@link Undecided} holds everything that
+     * left it undecided. One debt is read once per behavior carrying the type, and where more than
+     * one of those readings accounts for this state they are independent facts about one point — so
+     * a debt holding one of them said whichever reading the walk reached last.
+     *
+     * <p><b>What accounts for the state, and not everything the readings said.</b> A reading that
+     * had nothing to look at does not put a point here: it hides nothing, so it neither takes back
+     * a miss nor is one of the reasons that outranked one. Which is the same thing {@code Undecided}
+     * does — a reading that ran to the end went without nothing, and nothing of it is in there.
      */
     record NotMeasured(UnaskedReasons why) implements ObligationCoverage {
 
@@ -125,9 +130,11 @@ public sealed interface ObligationCoverage {
      * miss another reading established, and where every reading is one there was nothing anywhere to
      * look at.
      *
-     * <p><b>What is ranked is the states and never the reasons inside one.</b> Two readings that
-     * asked nothing gave two facts about one point, and this keeps both — the reasons a debt has
-     * are a set for the reason what left it undecided is one.
+     * <p><b>The ranking chooses a state, and the state keeps every reason that accounts for it.</b>
+     * Which of the four this is turns on what the readings came to and, in the one state a reason
+     * decides, on what those reasons are. Once it is chosen, the readings that put it there can be
+     * several and none of them outranks another — so they are held as a set, the way everything
+     * that left a point undecided is.
      */
     static ObligationCoverage acrossTheReadings(
             List<Measurement<ItemAssessment.Coverage>> readings) {

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
@@ -149,8 +149,13 @@ public sealed interface ObligationDisposition {
              * measurement over rows. The obligation is the model's either way — what the rows were
              * not read against is not something the model stopped owing (issue #1249) — so the
              * question is open and says which of the two left it so.
+             *
+             * <p>Every reason the readings gave, as the coverage holds them. A count and a build's
+             * refusal read this beside the document, and asking for one reason here would put the
+             * refusal of an account too wide for a sentence in front of all three — where what is
+             * too wide is the sentence, which is written somewhere else.
              */
-            record NothingWasRead(NotMeasuredReason why) implements WhetherARowIsThere {
+            record NothingWasRead(UnaskedReasons why) implements WhetherARowIsThere {
 
                 public NothingWasRead {
                     Objects.requireNonNull(why, "a point nobody read against says why nobody did");
@@ -282,13 +287,8 @@ public sealed interface ObligationDisposition {
             // whether a row is owed here is the model's answer, and no row naming the behavior is a
             // setting of this build (issue #1249). What is known about a row being writable there
             // is said beside that rather than instead of it.
-            // The reason as a surface that says one says it. What the point is open on is written
-            // into a sentence and into one opening, and both have room for one reason — so the
-            // account asks for one here rather than each of them choosing from what the readings
-            // gave.
             case ObligationCoverage.NotMeasured it -> Undecided.about(alsoWritability(
-                    new Uncertainty.WhetherARowIsThere.NothingWasRead(it.why().asOne()),
-                    knowledge));
+                    new Uncertainty.WhetherARowIsThere.NothingWasRead(it.why()), knowledge));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
@@ -150,10 +150,10 @@ public sealed interface ObligationDisposition {
              * not read against is not something the model stopped owing (issue #1249) — so the
              * question is open and says which of the two left it so.
              *
-             * <p>Every reason the readings gave, as the coverage holds them. A count and a build's
-             * refusal read this beside the document, and asking for one reason here would put the
-             * refusal of an account too wide for a sentence in front of all three — where what is
-             * too wide is the sentence, which is written somewhere else.
+             * <p>Every reason that leaves the point unmeasured, as the coverage holds them. A count
+             * and a build's refusal read this beside the document, and asking for one reason here
+             * would put the refusal of an account too wide for a sentence in front of all three —
+             * where what is too wide is the sentence, which is written somewhere else.
              */
             record NothingWasRead(UnaskedReasons why) implements WhetherARowIsThere {
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ObligationDisposition.java
@@ -282,8 +282,13 @@ public sealed interface ObligationDisposition {
             // whether a row is owed here is the model's answer, and no row naming the behavior is a
             // setting of this build (issue #1249). What is known about a row being writable there
             // is said beside that rather than instead of it.
+            // The reason as a surface that says one says it. What the point is open on is written
+            // into a sentence and into one opening, and both have room for one reason — so the
+            // account asks for one here rather than each of them choosing from what the readings
+            // gave.
             case ObligationCoverage.NotMeasured it -> Undecided.about(alsoWritability(
-                    new Uncertainty.WhetherARowIsThere.NothingWasRead(it.why()), knowledge));
+                    new Uncertainty.WhetherARowIsThere.NothingWasRead(it.why().asOne()),
+                    knowledge));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/OutputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OutputCaseEvidence.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
@@ -59,14 +60,24 @@ public record OutputCaseEvidence(Set<TypeSymbol> declared, Measure<Cases> cases)
 
     /** No row names this behavior, so nothing was established about its cases either way. */
     public enum NoRows implements NotMeasuredReason {
-        NO_ROWS
+        NO_ROWS;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** Why a behavior's output cases have no numbers. */
     public enum NotASum implements NotApplicableReason {
         /** The output is one data rather than a sum, so there is no case to cover and no row can
          *  fail to cover it. */
-        NOT_A_SUM
+        NOT_A_SUM;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     public OutputCaseEvidence {

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionDerivation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionDerivation.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.partition.ClosureGap;
 import souther.compiler.partition.MeasureClosure;
 
@@ -57,12 +58,22 @@ public final class PartitionDerivation {
         public String name() {
             return WORD;
         }
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** This behavior has no positions for the measure to be about — a {@code >->} composition,
      *  which is measured at its stages. */
     public enum NoSubject implements NotApplicableReason {
-        NO_SUBJECT
+        NO_SUBJECT;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /**
@@ -74,7 +85,12 @@ public final class PartitionDerivation {
      * and, since #953, said beside the gaps that make it true rather than on its own.
      */
     public enum TheReadingDidNotRunOut implements FailureReason {
-        THE_READING_DID_NOT_RUN_OUT
+        THE_READING_DID_NOT_RUN_OUT;
+
+        @Override
+        public MeasureReason.About about() {
+            return MeasureReason.About.THE_BEHAVIOR;
+        }
     }
 
     /** What a behavior measured at its stages rather than at itself comes to. */

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -9,6 +9,7 @@ import souther.compiler.inputs.FilingCoordinate;
 import souther.compiler.inputs.InputQuestion;
 import souther.compiler.inputs.StandingQuestion;
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.partition.ReportedReason;
 import souther.compiler.partition.UndividedPosition;
 
@@ -512,7 +513,12 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         /** Why the combinations have no numbers. */
         public enum NoRows implements NotMeasuredReason {
             /** No row names this behavior, so nothing sits anywhere. */
-            NO_ROWS
+            NO_ROWS;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         public static final PairSpace NONE =
@@ -665,7 +671,12 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         public enum NoRows implements NotMeasuredReason {
             /** No row names this behavior. An absence of evidence is not a set of gaps, so the
              *  classes nothing sits in are not classes nothing reaches. */
-            NO_ROWS
+            NO_ROWS;
+
+            @Override
+            public MeasureReason.About about() {
+                return MeasureReason.About.THE_BEHAVIOR;
+            }
         }
 
         /** Which classes there are is a fact about the model, and no row has to exist for it to be

--- a/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
@@ -9,13 +9,18 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Why nothing was read against one authored line, over every reading of that line.
+ * Why one authored line is unmeasured, over the readings of it that account for that.
  *
  * <p>What {@link WeakeningSet} is to a reading that stopped short, one grain up: a debt is read at
- * every position of every behavior carrying the type, each of those readings says for itself why it
- * asked nothing, and what the debt says is all of them. Held as one reason, what a debt said was
- * whichever reading came later in the walk, and which reading comes later is the order the lines
- * were gathered in.
+ * every position of every behavior carrying the type, and where several of those readings are why
+ * nothing was read against the point, what the debt says is all of them. Held as one reason, what a
+ * debt said was whichever reading came later in the walk, and which reading comes later is the
+ * order the lines were gathered in.
+ *
+ * <p>The readings that account for it, and not every reading that said something. Which readings
+ * those are is {@link ObligationCoverage#acrossTheReadings}'s answer and no part of this: a
+ * reading with nothing to look at leaves a point where it found it, and one that is here is one
+ * this holds.
  *
  * <p><b>The cardinality comes from what the reasons are facts about.</b> A reason about the run is
  * an input to the whole run, so every reading of every line that reaches it says the same one and
@@ -95,11 +100,12 @@ public final class UnaskedReasons {
     /**
      * The one reason, for somewhere that has room for one.
      *
-     * <p>Two places do: a boundary item of the report says a single {@code reason}, which is what
-     * the document promises its reader, and a reading's own {@link Measurement.NotMeasured} says
-     * the one reason that reading asked nothing for. So the projection is written here rather than
-     * left to a caller taking whichever came first — an account holding more than one reason is not
-     * something either of them can say, and this says so instead of choosing.
+     * <p>A boundary item of the report says a single {@code reason}, the opening under a verdict
+     * names one, the sentence beside a point reads as one, and a reading's own
+     * {@link Measurement.NotMeasured} holds the one reason that reading asked nothing for. So the
+     * projection is written here rather than left to each of them taking whichever came first — an
+     * account holding more than one reason is not something any of them can say, and this says so
+     * instead of choosing.
      *
      * <p><b>The refusal is the contract and not a reading of what reaches it.</b> Nothing here
      * rests on the readings this compiler makes today coming to one. The day one comes to two, this

--- a/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
@@ -70,16 +70,6 @@ public final class UnaskedReasons {
         return new UnaskedReasons(held);
     }
 
-    /** Both, as one. A reason given by two readings arrives once. */
-    public UnaskedReasons union(UnaskedReasons other) {
-        if (other == null || other.reasons.equals(reasons)) {
-            return this;
-        }
-        List<ItemAssessment.Coverage.NotAsked> both = new ArrayList<>(reasons.written());
-        both.addAll(other.reasons.written());
-        return ofAll(both);
-    }
-
     /** The reasons, each once, in the order a document says them. */
     public CanonicalSelection<ItemAssessment.Coverage.NotAsked> reasons() {
         return reasons;

--- a/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/UnaskedReasons.java
@@ -1,0 +1,140 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.MeasureReason;
+import souther.compiler.publish.CanonicalSelection;
+import souther.compiler.publish.PublicationOrders;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Why nothing was read against one authored line, over every reading of that line.
+ *
+ * <p>What {@link WeakeningSet} is to a reading that stopped short, one grain up: a debt is read at
+ * every position of every behavior carrying the type, each of those readings says for itself why it
+ * asked nothing, and what the debt says is all of them. Held as one reason, what a debt said was
+ * whichever reading came later in the walk, and which reading comes later is the order the lines
+ * were gathered in.
+ *
+ * <p><b>The cardinality comes from what the reasons are facts about.</b> A reason about the run is
+ * an input to the whole run, so every reading of every line that reaches it says the same one and
+ * two different ones at one line is a state no run is in — refused here, where the value is made,
+ * rather than by whoever folds. A reason about the behavior is something one behavior says and the
+ * next need not, so there is no limit on those.
+ *
+ * <p>Nothing else is refused. That a reason about the run never arrives beside one about the
+ * behavior is true of the readings this compiler makes today, and it is true because of the order
+ * the gates in {@code Coverages} are asked in — a fact about a producer, which is not this type's
+ * to state.
+ *
+ * <p>Held in the order they are published in ({@link PublicationOrders#UNASKED_REASONS}), which is
+ * a decision about what a reader is shown and no ranking of the reasons. Which of them outranks a
+ * miss is asked of what each is — {@link #mayHideARow()} — and never of where it sits here.
+ *
+ * <p>A value, because these travel inside {@code Db} answers, which is what {@link WeakeningSet}
+ * says of itself for the same reason.
+ */
+public final class UnaskedReasons {
+
+    /** The reasons, each once, in the order a document says them and never in the order the
+     *  readings were walked in. */
+    private final CanonicalSelection<ItemAssessment.Coverage.NotAsked> reasons;
+
+    private UnaskedReasons(CanonicalSelection<ItemAssessment.Coverage.NotAsked> reasons) {
+        this.reasons = reasons;
+    }
+
+    /** What one reading gave. */
+    public static UnaskedReasons of(ItemAssessment.Coverage.NotAsked one) {
+        return ofAll(List.of(one));
+    }
+
+    public static UnaskedReasons ofAll(Collection<ItemAssessment.Coverage.NotAsked> given) {
+        if (given.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "a point nobody read against says why nobody did, and this says nothing");
+        }
+        CanonicalSelection<ItemAssessment.Coverage.NotAsked> held =
+                PublicationOrders.UNASKED_REASONS.keep(given);
+        List<ItemAssessment.Coverage.NotAsked> ofTheRun = new ArrayList<>();
+        for (ItemAssessment.Coverage.NotAsked each : held.written()) {
+            if (each.about() == MeasureReason.About.THE_RUN) {
+                ofTheRun.add(each);
+            }
+        }
+        if (ofTheRun.size() > 1) {
+            throw new IllegalArgumentException("one line, and two things the run asked for: "
+                    + ofTheRun);
+        }
+        return new UnaskedReasons(held);
+    }
+
+    /** Both, as one. A reason given by two readings arrives once. */
+    public UnaskedReasons union(UnaskedReasons other) {
+        if (other == null || other.reasons.equals(reasons)) {
+            return this;
+        }
+        List<ItemAssessment.Coverage.NotAsked> both = new ArrayList<>(reasons.written());
+        both.addAll(other.reasons.written());
+        return ofAll(both);
+    }
+
+    /** The reasons, each once, in the order a document says them. */
+    public CanonicalSelection<ItemAssessment.Coverage.NotAsked> reasons() {
+        return reasons;
+    }
+
+    /**
+     * Whether a row at the point could be sitting behind any of these and not have been seen.
+     *
+     * <p>Any of them, because each is a reason nothing was read and one that could be hiding a row
+     * is enough to leave the point unanswered. Not read off what the reasons are facts about: the
+     * two questions agree over these three constants and part elsewhere, and a reader that derived
+     * one from the other would be right by coincidence.
+     */
+    public boolean mayHideARow() {
+        for (ItemAssessment.Coverage.NotAsked each : reasons.written()) {
+            if (each.mayHideARow()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The one reason, for somewhere that has room for one.
+     *
+     * <p>Two places do: a boundary item of the report says a single {@code reason}, which is what
+     * the document promises its reader, and a reading's own {@link Measurement.NotMeasured} says
+     * the one reason that reading asked nothing for. So the projection is written here rather than
+     * left to a caller taking whichever came first — an account holding more than one reason is not
+     * something either of them can say, and this says so instead of choosing.
+     *
+     * <p><b>The refusal is the contract and not a reading of what reaches it.</b> Nothing here
+     * rests on the readings this compiler makes today coming to one. The day one comes to two, this
+     * is where it is said that there is no room for the second, and what to do about that is
+     * decided then rather than lost.
+     */
+    public ItemAssessment.Coverage.NotAsked asOne() {
+        if (reasons.size() != 1) {
+            throw new IllegalStateException("a surface that says one reason cannot say " + reasons);
+        }
+        return reasons.written().get(0);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof UnaskedReasons it && reasons.equals(it.reasons);
+    }
+
+    @Override
+    public int hashCode() {
+        return reasons.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return reasons.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -61,6 +61,7 @@ import souther.compiler.query.ObligationCoverage;
 import souther.compiler.query.ObligationDisposition;
 import souther.compiler.query.ObligationSummary;
 import souther.compiler.query.ReadingReasons;
+import souther.compiler.query.UnaskedReasons;
 import souther.compiler.query.EstablishmentGap;
 import souther.compiler.query.WritabilityKnowledge;
 import souther.compiler.publish.CanonicalSelection;
@@ -829,8 +830,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (ObligationDisposition.Uncertainty each : undecided.because().written()) {
             switch (each) {
                 case ObligationDisposition.Uncertainty.WhetherARowIsThere.ReadingsStopped _ -> { }
+                // One opening, which says one reason. What the readings gave is a set, and asking
+                // for it as one is where an opening with no room for the second says so.
                 case ObligationDisposition.Uncertainty.WhetherARowIsThere.NothingWasRead it ->
-                        out.add(new AdequacyOpening.NotMeasured(it.why()));
+                        out.add(new AdequacyOpening.NotMeasured(it.why().asOne()));
                 case ObligationDisposition.Uncertainty.WhetherARowCanBeWritten.Stopped it ->
                         it.by().by().written().forEach(gap ->
                                 out.add(new AdequacyOpening.ShowingStopped(gap)));
@@ -1907,9 +1910,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // that reached past it for the evidence would be one more reader working the
                 // answer out on its own terms.
                 case ObligationDisposition.Uncertainty.WhetherARowIsThere.NothingWasRead(
-                        MeasureReason why) ->
+                        UnaskedReasons why) ->
                         "undecided whether a row is at the " + point + " — "
-                                + ReasonProse.of(why).clause();
+                                + ReasonProse.of(why.asOne()).clause();
                 // Named for what happened, which is not one thing. A reading that did not come
                 // back is of a row this compiler composed; a composing that stopped never had one
                 // — and an opening written for the first says a row was built at a point where

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -2019,10 +2019,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * short of whatever the reason is about.
      */
     private static void sayWhy(StringBuilder out, String measure, MeasureReason reason) {
-        ReasonProse why = ReasonProse.of(reason);
-        if (why.scope() == ReasonProse.Scope.BEHAVIOR) {
+        if (reason.about() == MeasureReason.About.THE_BEHAVIOR) {
             out.append(String.format("    %s%s%n",
-                    DisplayColumns.padRight(measure, 12), why.sentence()));
+                    DisplayColumns.padRight(measure, 12), ReasonProse.of(reason).sentence()));
         }
     }
 
@@ -2276,8 +2275,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     /** What an obligation's coverage was left short by, where a reason says. A coverage that came
      *  to an answer has none, and the note beside the item is what this fills in. */
     private static String whyNoBoundaryItem(ObligationCoverage coverage) {
-        MeasureReason why = coverage.why();
-        return why == null ? "" : ReasonProse.of(why).clause();
+        return coverage.theReasonAsOne().map(why -> ReasonProse.of(why).clause()).orElse("");
     }
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
@@ -3566,9 +3564,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         }
         ObligationCoverage coverage = owed.coverage();
         of.put("status", wire(ReportMeasurement.statusOf(coverage)));
-        if (coverage.why() != null) {
-            of.put("reason", word(coverage.why()));
-        }
+        // One word, which is what a boundary item promises. What the readings gave is a set, and
+        // asking for it as one is where an account with no room in the document says so.
+        coverage.theReasonAsOne().ifPresent(why -> of.put("reason", word(why)));
         weakening(of, coverage.weakening());
         if (coverage.hasAnswer()) {
             of.put("hit", coverage.hasRowWitness());

--- a/souther-compiler/src/main/java/souther/compiler/report/ReasonProse.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/ReasonProse.java
@@ -43,27 +43,17 @@ import souther.compiler.query.PartitionEvidence;
  * itself: a type reaching it without passing through one of the three has no sentence, and there is
  * nothing below to ask for one.
  *
+ * <p><b>Words, and nothing about where they are said.</b> Whether a reason is a fact about the run
+ * or about the behavior decides whether a surface gives it a line of its own, and it is the
+ * reason's answer ({@link MeasureReason#about()}) rather than a second column here. Held beside the
+ * words, one fact about a constant was written down in as many tables as there are readers, and the
+ * fold over the readings of one line — which needs the same fact to tell two readings saying one
+ * thing from two readings saying two — had no table to read and worked from a different question.
+ *
  * @param introduction how the sentence opens, which the family settles
- * @param said         what this state says, and what it is a fact about
+ * @param said         what this state says
  */
-record ReasonProse(Introduction introduction, Clause said) {
-
-    /** What a reason is a fact about. */
-    enum Scope {
-
-        /**
-         * The run, and not the behavior the measure is of.
-         *
-         * <p>What a build asked for is an input to the whole run, so a line saying it under each
-         * behavior says one fact as many times as the module has behaviors. A surface printing a
-         * whole line per measure leaves the line out; one writing a clause into a line that is
-         * there for another reason says it, because there the reason is what that line is short of.
-         */
-        RUN,
-
-        /** This behavior, so the measure it is of says it. */
-        BEHAVIOR
-    }
+record ReasonProse(Introduction introduction, String said) {
 
     /** How a sentence opens, which is the whole of what the family says to a reader. */
     enum Introduction {
@@ -77,19 +67,6 @@ record ReasonProse(Introduction introduction, Clause said) {
             this.word = word;
         }
     }
-
-    /**
-     * What one state says, without the opening.
-     *
-     * <p>Both halves at once. What a state says and what it is a fact about are decided as one
-     * thing, so a state added here cannot be given a sentence and left without a place to say it.
-     * Asked as a second question about the reason — a table of clauses here and a reader deciding
-     * placement elsewhere — the two are two books, and a state reaches the second missing from it.
-     *
-     * @param words what a person is told
-     * @param scope what it is a fact about
-     */
-    record Clause(String words, Scope scope) {}
 
     /**
      * What the report says about this reason, and what it is about.
@@ -127,98 +104,93 @@ record ReasonProse(Introduction introduction, Clause said) {
      * whose whole subject is one measure.
      */
     String clause() {
-        return said.words();
+        return said;
     }
 
-    /** What this reason is a fact about, which decides whether a line of its own is printed. */
-    Scope scope() {
-        return said.scope();
-    }
-
-    private static Clause nothingToBeAbout(NotApplicableReason reason) {
+    private static String nothingToBeAbout(NotApplicableReason reason) {
         return switch (reason) {
             case Adequacy.BranchEvidence.NoArms it -> switch (it) {
-                case NO_BODY -> behavior("this behavior has no body");
-                case NO_ARM_OBLIGATIONS -> behavior("this body owes no arm");
+                case NO_BODY -> "this behavior has no body";
+                case NO_ARM_OBLIGATIONS -> "this body owes no arm";
             };
             case Adequacy.SignatureEvidence.NotASum it -> switch (it) {
-                case NOT_A_SUM -> behavior("this behavior's output is not a sum");
+                case NOT_A_SUM -> "this behavior's output is not a sum";
             };
             // Said of the rules and not of their absence, here and at the partition below. A
             // behavior whose only rule about a pair of positions relates them has rules — printed a
             // line above, by name — and they divide no position and draw no line; a sentence saying
             // the model has none would read as contradicting the rule beside it.
             case BoundaryDerivation.NoRuleDrawsALine _ ->
-                    behavior("the rules of this behavior draw no line");
+                    "the rules of this behavior draw no line";
             case BoundaryDerivation.NoSubject it -> switch (it) {
-                case NO_SUBJECT -> behavior("this behavior is measured at its stages");
+                case NO_SUBJECT -> "this behavior is measured at its stages";
             };
             case InputCaseEvidence.NotASum it -> switch (it) {
-                case NOT_A_SUM -> behavior("this position is one data rather than a sum");
+                case NOT_A_SUM -> "this position is one data rather than a sum";
             };
             case NoFeasibleInput _ ->
-                    behavior("the rules reaching this behavior's input leave it no value");
+                    "the rules reaching this behavior's input leave it no value";
             case OutputCaseEvidence.NotASum it -> switch (it) {
-                case NOT_A_SUM -> behavior("what this behavior answers with is not a sum");
+                case NOT_A_SUM -> "what this behavior answers with is not a sum";
             };
             case PartitionDerivation.NoSubject it -> switch (it) {
-                case NO_SUBJECT -> behavior("this behavior is measured at its stages");
+                case NO_SUBJECT -> "this behavior is measured at its stages";
             };
             case PartitionDerivation.NothingIsDivided _ ->
-                    behavior("the rules of this behavior divide no position");
+                    "the rules of this behavior divide no position";
         };
     }
 
-    private static Clause neverMade(NotMeasuredReason reason) {
+    private static String neverMade(NotMeasuredReason reason) {
         return switch (reason) {
             case Adequacy.BranchEvidence.NotAsked it -> switch (it) {
-                case NOT_ASKED -> run("the build did not ask for the arms");
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NOT_ASKED -> "the build did not ask for the arms";
+                case NO_ROWS -> "no row names this behavior";
             };
             case Adequacy.RowReading.NotAsked it -> switch (it) {
-                case ROWS_NOT_ASKED -> run("this build does not read rows");
+                case ROWS_NOT_ASKED -> "this build does not read rows";
             };
             case Adequacy.SignatureEvidence.NoRows it -> switch (it) {
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NO_ROWS -> "no row names this behavior";
             };
             case InputCaseEvidence.NoRows it -> switch (it) {
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NO_ROWS -> "no row names this behavior";
             };
             case ItemAssessment.Coverage.NotAsked it -> switch (it) {
-                case NOT_ASKED -> run("nothing was asked for");
-                case ARMS_NOT_ASKED -> run("the arms were not asked for");
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NOT_ASKED -> "nothing was asked for";
+                case ARMS_NOT_ASKED -> "the arms were not asked for";
+                case NO_ROWS -> "no row names this behavior";
             };
             case NothingWasAsked it -> switch (it) {
-                case NOT_ASKED -> run("nothing was asked for");
+                case NOT_ASKED -> "nothing was asked for";
             };
             case OutputCaseEvidence.NoRows it -> switch (it) {
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NO_ROWS -> "no row names this behavior";
             };
             case PartitionEvidence.AxisCoverage.NoRows it -> switch (it) {
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NO_ROWS -> "no row names this behavior";
             };
             case PartitionEvidence.PairSpace.NoRows it -> switch (it) {
-                case NO_ROWS -> behavior("no row names this behavior");
+                case NO_ROWS -> "no row names this behavior";
             };
         };
     }
 
-    private static Clause couldNotBeFinished(FailureReason reason) {
+    private static String couldNotBeFinished(FailureReason reason) {
         return switch (reason) {
             // The model says this behavior writes a body. What it owes is unknown rather than
             // nothing, which is the difference the line saying this exists to show.
             case Adequacy.BranchEvidence.Unelaborated it -> switch (it) {
-                case BODIES_NOT_ELABORATED -> behavior("this module's bodies were not elaborated");
+                case BODIES_NOT_ELABORATED -> "this module's bodies were not elaborated";
             };
             case Adequacy.BranchEvidence.Unreadable it -> switch (it) {
-                case UNREADABLE -> behavior("the arms could not be read");
+                case UNREADABLE -> "the arms could not be read";
             };
             case Adequacy.RowReading.Unavailable it -> switch (it) {
-                case ROWS_UNAVAILABLE -> behavior("nothing came back from the rows");
+                case ROWS_UNAVAILABLE -> "nothing came back from the rows";
             };
             case BoundaryDerivation.TheReadingDidNotRunOut it -> switch (it) {
-                case THE_READING_DID_NOT_RUN_OUT -> behavior("no line was derived at any position");
+                case THE_READING_DID_NOT_RUN_OUT -> "no line was derived at any position";
             };
             // The two halves of one boundary, and an author acts on them in different places. A
             // behavior whose boundary was not derived has a name in its own declaration that
@@ -227,26 +199,16 @@ record ReasonProse(Introduction introduction, Clause said) {
             // resolved to nothing is reported where it was written, on the line the author edits.
             case BoundaryForMeasurement.NotDerived it -> switch (it) {
                 case BEHAVIOR_BOUNDARY_NOT_DERIVED ->
-                        behavior("this behavior's signature could not be read");
-                case BEHAVIOR_INPUT_NOT_READ -> behavior("what this behavior takes was not read");
+                        "this behavior's signature could not be read";
+                case BEHAVIOR_INPUT_NOT_READ -> "what this behavior takes was not read";
             };
             case ItemAssessment.Coverage.CouldNotAsk it -> switch (it) {
-                case ARMS_UNREADABLE -> behavior("the arms could not be measured");
+                case ARMS_UNREADABLE -> "the arms could not be measured";
             };
             case PartitionDerivation.TheReadingDidNotRunOut it -> switch (it) {
                 case THE_READING_DID_NOT_RUN_OUT ->
-                        behavior("no partition axis was derived at any position");
+                        "no partition axis was derived at any position";
             };
         };
-    }
-
-    /** A fact about the behavior the measure is of, so the measure says it. */
-    private static Clause behavior(String words) {
-        return new Clause(words, Scope.BEHAVIOR);
-    }
-
-    /** A fact about the run, so a line per behavior would say it once per behavior. */
-    private static Clause run(String words) {
-        return new Clause(words, Scope.RUN);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -22,6 +22,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.EstablishmentGap;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.query.ReadingReasons;
+import souther.compiler.query.UnaskedReasons;
 import souther.compiler.query.WritabilityKnowledge;
 import souther.compiler.partition.ReadingGap;
 import souther.compiler.check.BehaviorImplementation;
@@ -489,7 +490,8 @@ class EverySchemaWordIsAccountedForTest {
                                 ReadingReasons.of(List.of(ReadingGap.NO_VALUE))))),
                 ObligationDisposition.Undecided.about(List.of(
                         new ObligationDisposition.Uncertainty.WhetherARowIsThere.NothingWasRead(
-                                ItemAssessment.Coverage.NotAsked.NO_ROWS))),
+                                UnaskedReasons.of(
+                                        ItemAssessment.Coverage.NotAsked.NO_ROWS)))),
                 ObligationDisposition.Undecided.about(List.of(
                         new ObligationDisposition.Uncertainty.WhetherARowCanBeWritten.Stopped(
                                 WritabilityKnowledge.Prevented.by(EstablishmentGap.Observation.of(

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -126,7 +126,8 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
                         new ObligationDisposition.Uncertainty
                                 .WhetherARowCanBeWritten.NothingShowedIt())),
                 ObligationDisposition.of(
-                        new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS),
+                        new ObligationCoverage.NotMeasured(
+                        UnaskedReasons.of(ItemAssessment.Coverage.NotAsked.NO_ROWS)),
                         new WritabilityKnowledge.NoEvidence()),
                 "nothing was read and nothing promises a row, both are open about it, and each"
                         + " says which of the two left it so");
@@ -203,7 +204,8 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
                 new ObligationCoverage.Undecided(WeakeningSet.of(
                         new Weakening.BorderValueUnreadable(null,
                                 ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED)))),
-                new ObligationCoverage.NotMeasured(ItemAssessment.Coverage.NotAsked.NO_ROWS));
+                new ObligationCoverage.NotMeasured(
+                        UnaskedReasons.of(ItemAssessment.Coverage.NotAsked.NO_ROWS)));
     }
 
     private static List<WritabilityKnowledge> everyKnowledge() {

--- a/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest.java
@@ -122,7 +122,7 @@ class ALimitOfThisCompilerDoesNotTakeAnObligationOutOfTheCountTest {
     void aPointNothingWasReadAgainstIsUndecidedAboutBoth() {
         assertEquals(ObligationDisposition.Undecided.about(List.of(
                         new ObligationDisposition.Uncertainty.WhetherARowIsThere.NothingWasRead(
-                                ItemAssessment.Coverage.NotAsked.NO_ROWS),
+                                UnaskedReasons.of(ItemAssessment.Coverage.NotAsked.NO_ROWS)),
                         new ObligationDisposition.Uncertainty
                                 .WhetherARowCanBeWritten.NothingShowedIt())),
                 ObligationDisposition.of(

--- a/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
@@ -3,12 +3,15 @@ package souther.compiler.query;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.MeasureReason;
 import souther.compiler.partition.ReadingGap;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -24,40 +27,128 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * comes to when the debt reads them apart is what it comes to when the debt reads them folded. Held
  * as a table, every case anybody thought of would pass and the one nobody thought of is the one the
  * fold gets wrong.
+ *
+ * <p><b>Over the measurements a reading can be in, which is not every measurement that can be
+ * written.</b> Which reason a reading gives for asking nothing is settled by the level the build
+ * asked for and by whether a fork or an invariant drew the line, and a run has one level and a line
+ * is of one kind. So the pairs are taken inside one of those and not across them: a pair drawn from
+ * the whole product is a pair of readings from two runs, and a law over it asks the fold to answer
+ * for a state nothing produces.
  */
 class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
 
-    /** Every measurement a reading of a point can be in, one of each. */
-    private static List<Measurement<ItemAssessment.Coverage>> everyShape() {
-        return List.of(
+    /** What drew the line, which decides which reasons a reading of it can give. */
+    private enum LineKind { A_FORK, AN_INVARIANT }
+
+    /** One run's level and one line's kind, which is what fixes the reasons below. */
+    private record Reading(Adequacy.Level level, LineKind kind) {}
+
+    private static List<Reading> everyReading() {
+        List<Reading> out = new ArrayList<>();
+        for (Adequacy.Level level : Adequacy.Level.values()) {
+            for (LineKind kind : LineKind.values()) {
+                out.add(new Reading(level, kind));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Every measurement a reading of one line can be in, under one level.
+     *
+     * <p>Written from the gates the reading goes through: a build that reads no rows says so before
+     * anything is looked at, a build that runs no instrumented rows says it of a line a fork drew,
+     * and what is left is what the rows came to. An invariant's line is never waiting on the arms,
+     * which is why the two kinds have different sets.
+     */
+    private static List<Measurement<ItemAssessment.Coverage>> everyShape(Reading of) {
+        if (!of.level().readsRows()) {
+            return List.of(new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED));
+        }
+        if (of.kind() == LineKind.A_FORK && !of.level().runsInstrumentedRows()) {
+            return List.of(
+                    new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED));
+        }
+        List<Measurement<ItemAssessment.Coverage>> out = new ArrayList<>(List.of(
                 new Measurement.Complete<>(new ItemAssessment.Coverage.Hit()),
                 new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit()),
                 new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), truncated()),
                 new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), truncated()),
                 new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), unreadable()),
-                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS),
-                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED),
-                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED),
-                new Measurement.FailedToMeasure<>(ItemAssessment.Coverage.CouldNotAsk.ARMS_UNREADABLE,
-                        unreadable()));
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS)));
+        if (of.kind() == LineKind.A_FORK) {
+            // The rows ran and what they went through was not recorded, which takes a run that
+            // instruments them. An invariant's line has no arms to be waiting on.
+            out.add(new Measurement.FailedToMeasure<>(
+                    ItemAssessment.Coverage.CouldNotAsk.ARMS_UNREADABLE, unreadable()));
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The population holds the states the laws below are about.
+     *
+     * <p>A negative control on the two of them. Every law here is over a set this file builds, and
+     * a set that had lost the reasons a question was not put would pass all of them while saying
+     * nothing — which is the shape the population had when it was one hand-written list.
+     */
+    @Test
+    void everyReasonAQuestionIsNotPutForIsSomewhereInThePopulation() {
+        List<ItemAssessment.Coverage.NotAsked> found = new ArrayList<>();
+        for (Reading reading : everyReading()) {
+            for (Measurement<ItemAssessment.Coverage> shape : everyShape(reading)) {
+                if (shape instanceof Measurement.NotMeasured<ItemAssessment.Coverage> none) {
+                    ItemAssessment.Coverage.NotAsked why =
+                            (ItemAssessment.Coverage.NotAsked) none.why();
+                    if (!found.contains(why)) {
+                        found.add(why);
+                    }
+                }
+            }
+        }
+
+        assertEquals(List.of(ItemAssessment.Coverage.NotAsked.values()).size(), found.size(),
+                "every reason a reading gives for asking nothing is given by some reading: "
+                        + found);
+    }
+
+    /** And no reading gives two of the reasons that are the run's, which is what lets the pairs
+     *  below be taken inside one reading rather than across two runs. */
+    @Test
+    void noOneReadingCanGiveTwoOfTheRunsReasons() {
+        for (Reading reading : everyReading()) {
+            List<ItemAssessment.Coverage.NotAsked> ofTheRun = new ArrayList<>();
+            for (Measurement<ItemAssessment.Coverage> shape : everyShape(reading)) {
+                if (shape instanceof Measurement.NotMeasured<ItemAssessment.Coverage> none
+                        && ((ItemAssessment.Coverage.NotAsked) none.why()).about()
+                                == MeasureReason.About.THE_RUN) {
+                    ofTheRun.add((ItemAssessment.Coverage.NotAsked) none.why());
+                }
+            }
+            assertTrue(ofTheRun.size() <= 1,
+                    reading + " gives more than one of the run's reasons: " + ofTheRun);
+        }
     }
 
     /**
      * The fold and the debt agree, at every pair there is.
      *
-     * <p>Every pair and not a chosen few, because the shapes are few enough to walk. What this
-     * refuses is the fold deciding anything: it may only say the debt's answer back.
+     * <p>Every pair of one reading and not a chosen few. What this refuses is the fold deciding
+     * anything: it may only say the debt's answer back.
      */
     @Test
     void whatTheDebtSaysIsTheSameWhicheverWayThePairReachesIt() {
         List<String> apart = new ArrayList<>();
-        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
-            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
-                ObligationCoverage read = ObligationCoverage.acrossTheReadings(List.of(a, b));
-                ObligationCoverage folded = ObligationCoverage.acrossTheReadings(
-                        List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
-                if (!read.equals(folded)) {
-                    apart.add(a + " with " + b + ": read " + read + ", folded " + folded);
+        for (Reading reading : everyReading()) {
+            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
+                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
+                    ObligationCoverage read = ObligationCoverage.acrossTheReadings(List.of(a, b));
+                    ObligationCoverage folded = ObligationCoverage.acrossTheReadings(
+                            List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                    if (!read.equals(folded)) {
+                        apart.add(reading + ": " + a + " with " + b + ": read " + read
+                                + ", folded " + folded);
+                    }
                 }
             }
         }
@@ -66,29 +157,21 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
                 "a fold of two searches of one reading says what the debt says of the two");
     }
 
-    /**
-     * And it is the same either way round, so nothing turns on which search was walked first.
-     *
-     * <p>Over the pairs a run can produce. Two readings saying the build asked for nothing and that
-     * it asked for no arms is not one of them — the first is said by every line of a run that
-     * measured nothing, so a reading beside it saying anything else is two runs — and the debt's own
-     * fold keeps whichever of those it saw last. That the fold here says the same is this test's
-     * subject; that the debt does it at all is not, and it is written down where it belongs.
-     */
+    /** And it is the same either way round, so nothing turns on which search was walked first. */
     @Test
     void thePairIsTheSameWhicheverOfThemCameFirst() {
         List<String> apart = new ArrayList<>();
-        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
-            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
-                if (bothSayNobodyAsked(a, b)) {
-                    continue;
-                }
-                ObligationCoverage one = ObligationCoverage.acrossTheReadings(
-                        List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
-                ObligationCoverage other = ObligationCoverage.acrossTheReadings(
-                        List.of(ObligationCoverage.acrossOneReadingsSearches(b, a)));
-                if (!one.equals(other)) {
-                    apart.add(a + " with " + b + ": " + one + " one way, " + other + " the other");
+        for (Reading reading : everyReading()) {
+            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
+                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
+                    ObligationCoverage one = ObligationCoverage.acrossTheReadings(
+                            List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                    ObligationCoverage other = ObligationCoverage.acrossTheReadings(
+                            List.of(ObligationCoverage.acrossOneReadingsSearches(b, a)));
+                    if (!one.equals(other)) {
+                        apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
+                                + other + " the other");
+                    }
                 }
             }
         }
@@ -108,22 +191,69 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     @Test
     void thePairIsTheSameValueWhicheverOfThemCameFirst() {
         List<String> apart = new ArrayList<>();
-        for (Measurement<ItemAssessment.Coverage> a : everyShape()) {
-            for (Measurement<ItemAssessment.Coverage> b : everyShape()) {
-                if (bothSayNobodyAsked(a, b)) {
-                    continue;
-                }
-                Measurement<ItemAssessment.Coverage> one =
-                        ObligationCoverage.acrossOneReadingsSearches(a, b);
-                Measurement<ItemAssessment.Coverage> other =
-                        ObligationCoverage.acrossOneReadingsSearches(b, a);
-                if (!one.equals(other)) {
-                    apart.add(a + " with " + b + ": " + one + " one way, " + other + " the other");
+        for (Reading reading : everyReading()) {
+            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
+                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
+                    Measurement<ItemAssessment.Coverage> one =
+                            ObligationCoverage.acrossOneReadingsSearches(a, b);
+                    Measurement<ItemAssessment.Coverage> other =
+                            ObligationCoverage.acrossOneReadingsSearches(b, a);
+                    if (!one.equals(other)) {
+                        apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
+                                + other + " the other");
+                    }
                 }
             }
         }
 
         assertEquals(List.of(), apart, "the searches of one reading are a set of facts about it");
+    }
+
+    /**
+     * What a debt comes to over the readings a run can give it fits the one reason a document says.
+     *
+     * <p>Beside the laws above rather than inside them. What a debt holds is every reason its
+     * readings gave, which is what the fold is for; what a boundary item of the report has room for
+     * is one. The two are separate contracts, and a producer that came to two reasons at one point
+     * would leave the first green and this one red — which is where it is decided whether the
+     * document gains room or the producer was wrong.
+     *
+     * <p>Over the readings of one line, which is what a debt is gathered from: a line is read once
+     * per behavior carrying the type, every one of those readings is of the same run, and each is
+     * whatever that behavior's rows came to.
+     */
+    @Test
+    void whatTheReadingsOfOneRunComeToIsOneReasonADocumentCanSay() {
+        for (Reading reading : everyReading()) {
+            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
+                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
+                    ObligationCoverage debt = ObligationCoverage.acrossTheReadings(List.of(a, b));
+                    if (debt instanceof ObligationCoverage.NotMeasured it) {
+                        assertEquals(1, it.why().reasons().size(),
+                                reading + ": " + a + " with " + b + " comes to " + it.why()
+                                        + ", which a boundary item has no room for");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Two readings of one line saying two of the run's reasons is refused, and not answered.
+     *
+     * <p>The state the debt used to decide by walk order. It takes two runs to produce and no
+     * reading here can be in it, so what closes it is the value refusing to be built rather than a
+     * case in the fold — and a reader of a debt has no such state to consider.
+     */
+    @Test
+    void aLineCannotHoldTwoOfWhatTheRunAsked() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ObligationCoverage.acrossTheReadings(List.of(
+                        new Measurement.NotMeasured<>(
+                                ItemAssessment.Coverage.NotAsked.NOT_ASKED),
+                        new Measurement.NotMeasured<>(
+                                ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED))),
+                "a build is at one level and a line is of one kind");
     }
 
     /**
@@ -154,15 +284,28 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
                 "and the debt reads it as a row at the point, which is what it is");
     }
 
-    /** Two readings each saying a question was not put, for two different reasons — which no run
-     *  produces, and which the debt's own fold answers by the one it saw last. */
-    private static boolean bothSayNobodyAsked(Measurement<ItemAssessment.Coverage> a,
-                                              Measurement<ItemAssessment.Coverage> b) {
-        return a instanceof Measurement.NotMeasured<ItemAssessment.Coverage> one
-                && b instanceof Measurement.NotMeasured<ItemAssessment.Coverage> two
-                && one.why() != two.why()
-                && ((ItemAssessment.Coverage.NotAsked) one.why()).mayHideARow()
-                && ((ItemAssessment.Coverage.NotAsked) two.why()).mayHideARow();
+    /**
+     * A reading with nothing to look at is held beside one the run never asked, and does not take
+     * it back.
+     *
+     * <p>The fold's own rule and not a claim about what a run reaches. The pair takes a build that
+     * read no rows beside a behavior that has none, which the gates settle before the rows are
+     * looked at — so what this pins is that the fold keeps both facts rather than that anything
+     * hands it both.
+     */
+    @Test
+    void aReadingWithNoRowsIsHeldBesideOneNobodyAsked() {
+        ObligationCoverage debt = ObligationCoverage.acrossTheReadings(List.of(
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED),
+                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS)));
+
+        assertEquals(new ObligationCoverage.NotMeasured(UnaskedReasons.ofAll(List.of(
+                        ItemAssessment.Coverage.NotAsked.NOT_ASKED,
+                        ItemAssessment.Coverage.NotAsked.NO_ROWS))),
+                debt,
+                "both readings said why they read nothing, and the debt says both");
+        assertFalse(debt.settled(), "and the point is still open, because one of them may hide a"
+                + " row");
     }
 
     private static WeakeningSet truncated() {

--- a/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/FoldingOneReadingsSearchesDoesNotMoveTheDebtTest.java
@@ -54,33 +54,76 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     }
 
     /**
-     * Every measurement a reading of one line can be in, under one level.
+     * What the readings of one behavior's rows can come back as.
      *
-     * <p>Written from the gates the reading goes through: a build that reads no rows says so before
-     * anything is looked at, a build that runs no instrumented rows says it of a line a fork drew,
-     * and what is left is what the rows came to. An invariant's line is never waiting on the arms,
-     * which is why the two kinds have different sets.
+     * <p>The half of the input the gates read. Nothing here decides what a reading comes to — that
+     * is asked of the gates below — and these are what a behavior hands them: rows nobody wrote,
+     * rows nothing came back from, rows read without the instrumentation that records what they
+     * went through, and rows this run read.
      */
-    private static List<Measurement<ItemAssessment.Coverage>> everyShape(Reading of) {
-        if (!of.level().readsRows()) {
-            return List.of(new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED));
+    private static List<Adequacy.RowReading> everyReadingOfTheRows() {
+        return List.of(
+                Adequacy.RowReading.NONE,
+                readingThatMet(Incompleteness.Code.OBSERVATION_ABSENT),
+                readingThatMet(Incompleteness.Code.INSTRUMENTATION_ABSENT),
+                readingThatMet(Incompleteness.Code.VALUE_UNREADABLE),
+                Adequacy.RowReading.NOT_ASKED);
+    }
+
+    private static Adequacy.RowReading readingThatMet(Incompleteness.Code code) {
+        return Adequacy.RowReading.of(List.of(),
+                List.of(Incompleteness.of(code, Incompleteness.Scope.BEHAVIOR, "b")));
+    }
+
+    /**
+     * What two searches of one reading can each come to.
+     *
+     * <p>One reading is one line of one behavior in one run, so the gates are asked once and both
+     * searches get that answer. Where the gates leave the rows to answer, the two searches can
+     * differ — they composed over different regions — and what they differ in is the value and what
+     * each went without.
+     *
+     * <p><b>The reasons come from the gates and not from a table here.</b> Which reason a reading
+     * gives is settled by {@link Coverages#whyNothingWasReadAgainstTheLine}, and a population that
+     * wrote the gates out again would be a second statement of them — green over a producer that
+     * had stopped agreeing with it, which is the shape this file's own subject is about one layer
+     * down.
+     */
+    private static List<Measurement<ItemAssessment.Coverage>> everySearchOfOneReading(
+            Reading of, Adequacy.RowReading rows) {
+        Measurement<ItemAssessment.Coverage> nothingWasRead =
+                Coverages.whyNothingWasReadAgainstTheLine(
+                        of.kind() == LineKind.A_FORK, rows, of.level());
+        if (nothingWasRead != null) {
+            return List.of(nothingWasRead);
         }
-        if (of.kind() == LineKind.A_FORK && !of.level().runsInstrumentedRows()) {
-            return List.of(
-                    new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.ARMS_NOT_ASKED));
-        }
-        List<Measurement<ItemAssessment.Coverage>> out = new ArrayList<>(List.of(
+        // Nothing back from the gates is them leaving the rows to answer, which is the gates' own
+        // way of saying it and not something read off the level here. What a search then comes to
+        // is a row at the point or none, read to the end or as far as it got.
+        return List.of(
                 new Measurement.Complete<>(new ItemAssessment.Coverage.Hit()),
                 new Measurement.Complete<>(new ItemAssessment.Coverage.NoHit()),
                 new Measurement.Partial<>(new ItemAssessment.Coverage.Hit(), truncated()),
                 new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), truncated()),
-                new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), unreadable()),
-                new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS)));
-        if (of.kind() == LineKind.A_FORK) {
-            // The rows ran and what they went through was not recorded, which takes a run that
-            // instruments them. An invariant's line has no arms to be waiting on.
-            out.add(new Measurement.FailedToMeasure<>(
-                    ItemAssessment.Coverage.CouldNotAsk.ARMS_UNREADABLE, unreadable()));
+                new Measurement.Partial<>(new ItemAssessment.Coverage.NoHit(), unreadable()));
+    }
+
+    /**
+     * What the readings of one line in one run can each come to.
+     *
+     * <p>Beside the one above and not the same set. A line is read once per behavior carrying the
+     * type, and two behaviors of one run hand the gates different readings of their rows — so what
+     * two readings of one line can be is wider than what two searches of one reading can be, and a
+     * law about one of them run over the other asks its subject to answer for pairs it never sees.
+     */
+    private static List<Measurement<ItemAssessment.Coverage>> everyReadingOfOneLine(Reading of) {
+        List<Measurement<ItemAssessment.Coverage>> out = new ArrayList<>();
+        for (Adequacy.RowReading rows : everyReadingOfTheRows()) {
+            for (Measurement<ItemAssessment.Coverage> each : everySearchOfOneReading(of, rows)) {
+                if (!out.contains(each)) {
+                    out.add(each);
+                }
+            }
         }
         return List.copyOf(out);
     }
@@ -96,7 +139,7 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     void everyReasonAQuestionIsNotPutForIsSomewhereInThePopulation() {
         List<ItemAssessment.Coverage.NotAsked> found = new ArrayList<>();
         for (Reading reading : everyReading()) {
-            for (Measurement<ItemAssessment.Coverage> shape : everyShape(reading)) {
+            for (Measurement<ItemAssessment.Coverage> shape : everyReadingOfOneLine(reading)) {
                 if (shape instanceof Measurement.NotMeasured<ItemAssessment.Coverage> none) {
                     ItemAssessment.Coverage.NotAsked why =
                             (ItemAssessment.Coverage.NotAsked) none.why();
@@ -118,7 +161,7 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     void noOneReadingCanGiveTwoOfTheRunsReasons() {
         for (Reading reading : everyReading()) {
             List<ItemAssessment.Coverage.NotAsked> ofTheRun = new ArrayList<>();
-            for (Measurement<ItemAssessment.Coverage> shape : everyShape(reading)) {
+            for (Measurement<ItemAssessment.Coverage> shape : everyReadingOfOneLine(reading)) {
                 if (shape instanceof Measurement.NotMeasured<ItemAssessment.Coverage> none
                         && ((ItemAssessment.Coverage.NotAsked) none.why()).about()
                                 == MeasureReason.About.THE_RUN) {
@@ -140,14 +183,19 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     void whatTheDebtSaysIsTheSameWhicheverWayThePairReachesIt() {
         List<String> apart = new ArrayList<>();
         for (Reading reading : everyReading()) {
-            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
-                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
-                    ObligationCoverage read = ObligationCoverage.acrossTheReadings(List.of(a, b));
-                    ObligationCoverage folded = ObligationCoverage.acrossTheReadings(
-                            List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
-                    if (!read.equals(folded)) {
-                        apart.add(reading + ": " + a + " with " + b + ": read " + read
-                                + ", folded " + folded);
+            for (Adequacy.RowReading rows : everyReadingOfTheRows()) {
+                for (Measurement<ItemAssessment.Coverage> a
+                        : everySearchOfOneReading(reading, rows)) {
+                    for (Measurement<ItemAssessment.Coverage> b
+                            : everySearchOfOneReading(reading, rows)) {
+                        ObligationCoverage read =
+                                ObligationCoverage.acrossTheReadings(List.of(a, b));
+                        ObligationCoverage folded = ObligationCoverage.acrossTheReadings(
+                                List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                        if (!read.equals(folded)) {
+                            apart.add(reading + ": " + a + " with " + b + ": read " + read
+                                    + ", folded " + folded);
+                        }
                     }
                 }
             }
@@ -162,15 +210,19 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     void thePairIsTheSameWhicheverOfThemCameFirst() {
         List<String> apart = new ArrayList<>();
         for (Reading reading : everyReading()) {
-            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
-                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
-                    ObligationCoverage one = ObligationCoverage.acrossTheReadings(
-                            List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
-                    ObligationCoverage other = ObligationCoverage.acrossTheReadings(
-                            List.of(ObligationCoverage.acrossOneReadingsSearches(b, a)));
-                    if (!one.equals(other)) {
-                        apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
-                                + other + " the other");
+            for (Adequacy.RowReading rows : everyReadingOfTheRows()) {
+                for (Measurement<ItemAssessment.Coverage> a
+                        : everySearchOfOneReading(reading, rows)) {
+                    for (Measurement<ItemAssessment.Coverage> b
+                            : everySearchOfOneReading(reading, rows)) {
+                        ObligationCoverage one = ObligationCoverage.acrossTheReadings(
+                                List.of(ObligationCoverage.acrossOneReadingsSearches(a, b)));
+                        ObligationCoverage other = ObligationCoverage.acrossTheReadings(
+                                List.of(ObligationCoverage.acrossOneReadingsSearches(b, a)));
+                        if (!one.equals(other)) {
+                            apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
+                                    + other + " the other");
+                        }
                     }
                 }
             }
@@ -192,15 +244,19 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     void thePairIsTheSameValueWhicheverOfThemCameFirst() {
         List<String> apart = new ArrayList<>();
         for (Reading reading : everyReading()) {
-            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
-                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
-                    Measurement<ItemAssessment.Coverage> one =
-                            ObligationCoverage.acrossOneReadingsSearches(a, b);
-                    Measurement<ItemAssessment.Coverage> other =
-                            ObligationCoverage.acrossOneReadingsSearches(b, a);
-                    if (!one.equals(other)) {
-                        apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
-                                + other + " the other");
+            for (Adequacy.RowReading rows : everyReadingOfTheRows()) {
+                for (Measurement<ItemAssessment.Coverage> a
+                        : everySearchOfOneReading(reading, rows)) {
+                    for (Measurement<ItemAssessment.Coverage> b
+                            : everySearchOfOneReading(reading, rows)) {
+                        Measurement<ItemAssessment.Coverage> one =
+                                ObligationCoverage.acrossOneReadingsSearches(a, b);
+                        Measurement<ItemAssessment.Coverage> other =
+                                ObligationCoverage.acrossOneReadingsSearches(b, a);
+                        if (!one.equals(other)) {
+                            apart.add(reading + ": " + a + " with " + b + ": " + one + " one way, "
+                                    + other + " the other");
+                        }
                     }
                 }
             }
@@ -225,8 +281,8 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     @Test
     void whatTheReadingsOfOneRunComeToIsOneReasonADocumentCanSay() {
         for (Reading reading : everyReading()) {
-            for (Measurement<ItemAssessment.Coverage> a : everyShape(reading)) {
-                for (Measurement<ItemAssessment.Coverage> b : everyShape(reading)) {
+            for (Measurement<ItemAssessment.Coverage> a : everyReadingOfOneLine(reading)) {
+                for (Measurement<ItemAssessment.Coverage> b : everyReadingOfOneLine(reading)) {
                     ObligationCoverage debt = ObligationCoverage.acrossTheReadings(List.of(a, b));
                     if (debt instanceof ObligationCoverage.NotMeasured it) {
                         assertEquals(1, it.why().reasons().size(),
@@ -285,27 +341,50 @@ class FoldingOneReadingsSearchesDoesNotMoveTheDebtTest {
     }
 
     /**
-     * A reading with nothing to look at is held beside one the run never asked, and does not take
-     * it back.
+     * What a debt says is what put it in the state it is in, and a reading with nothing to look at
+     * did not.
      *
-     * <p>The fold's own rule and not a claim about what a run reaches. The pair takes a build that
-     * read no rows beside a behavior that has none, which the gates settle before the rows are
-     * looked at — so what this pins is that the fold keeps both facts rather than that anything
-     * hands it both.
+     * <p>The fold ranks the states, and inside the one state a reason decides — nothing was read —
+     * the reasons that outrank a miss are the ones that could be hiding a row. So those are what
+     * the debt says, the way an undecided one says what left it undecided rather than everything
+     * every reading went without. A reading with no rows hides nothing: it neither takes the state
+     * back nor joins the reasons that reached it.
      */
     @Test
-    void aReadingWithNoRowsIsHeldBesideOneNobodyAsked() {
+    void aReadingWithNoRowsIsNotOneOfTheReasonsThePointIsOpen() {
         ObligationCoverage debt = ObligationCoverage.acrossTheReadings(List.of(
                 new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NOT_ASKED),
                 new Measurement.NotMeasured<>(ItemAssessment.Coverage.NotAsked.NO_ROWS)));
 
-        assertEquals(new ObligationCoverage.NotMeasured(UnaskedReasons.ofAll(List.of(
-                        ItemAssessment.Coverage.NotAsked.NOT_ASKED,
-                        ItemAssessment.Coverage.NotAsked.NO_ROWS))),
+        assertEquals(new ObligationCoverage.NotMeasured(
+                        UnaskedReasons.of(ItemAssessment.Coverage.NotAsked.NOT_ASKED)),
                 debt,
-                "both readings said why they read nothing, and the debt says both");
-        assertFalse(debt.settled(), "and the point is still open, because one of them may hide a"
-                + " row");
+                "the rows nobody looked at are why the point is open, and the behavior with none"
+                        + " is not");
+        assertFalse(debt.settled(), "and the point is open, because those rows may be at it");
+    }
+
+    /**
+     * A surface that says one reason refuses an account of two, and does not pick from it.
+     *
+     * <p>The negative control on the projection, and it is needed because nothing produces two
+     * today: a law over what the producers make would pass just as well against a projection that
+     * quietly took the first. What is refused is exactly the defect this issue is about, one layer
+     * along — an answer chosen from a set by whatever order it happened to be in.
+     *
+     * <p>Built here rather than folded to, because the carrier admits the pair and the fold does
+     * not make one. What the carrier admits is a question about the reasons; what the fold makes is
+     * a question about the readings, and this is about neither.
+     */
+    @Test
+    void aSurfaceThatSaysOneReasonRefusesTwoRatherThanChoosing() {
+        UnaskedReasons two = UnaskedReasons.ofAll(List.of(
+                ItemAssessment.Coverage.NotAsked.NOT_ASKED,
+                ItemAssessment.Coverage.NotAsked.NO_ROWS));
+
+        assertEquals(2, two.reasons().size(), "the carrier holds both, which is what it is for");
+        assertThrows(IllegalStateException.class, two::asOne,
+                "and a surface with room for one says so rather than taking whichever is first");
     }
 
     private static WeakeningSet truncated() {

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatTheReadingsOfOneDebtComeToTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatTheReadingsOfOneDebtComeToTogetherTest.java
@@ -83,7 +83,8 @@ class WhatTheReadingsOfOneDebtComeToTogetherTest {
      */
     @Test
     void aBuildThatLookedAtNothingDoesUnsettleAMissBesideIt() {
-        assertEquals(new ObligationCoverage.NotMeasured(Coverage.NotAsked.NOT_ASKED),
+        assertEquals(new ObligationCoverage.NotMeasured(
+                        UnaskedReasons.of(Coverage.NotAsked.NOT_ASKED)),
                 ObligationCoverage.acrossTheReadings(List.of(notAsked(), missed())),
                 "the rows of the reading that was never made may be at the point");
     }
@@ -91,7 +92,8 @@ class WhatTheReadingsOfOneDebtComeToTogetherTest {
     /** Where every reading had nothing to look at, neither has the debt. */
     @Test
     void aDebtNoRowAnywhereCouldHaveAnsweredIsNotAMiss() {
-        assertEquals(new ObligationCoverage.NotMeasured(Coverage.NotAsked.NO_ROWS),
+        assertEquals(new ObligationCoverage.NotMeasured(
+                        UnaskedReasons.of(Coverage.NotAsked.NO_ROWS)),
                 ObligationCoverage.acrossTheReadings(List.of(noRows(), noRows())));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryWayTheVerdictStaysOpenNamesSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryWayTheVerdictStaysOpenNamesSomethingTest.java
@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.CompositionBudget;
 import souther.compiler.query.EstablishmentGap;
-import souther.compiler.query.NothingWasAsked;
+import souther.compiler.query.ItemAssessment;
 import souther.compiler.query.ObligationCoverage;
 import souther.compiler.query.ObligationDisposition;
 import souther.compiler.query.ReadingReasons;
+import souther.compiler.query.UnaskedReasons;
 import souther.compiler.query.WeakeningSet;
 import souther.compiler.query.WritabilityKnowledge;
 
@@ -143,7 +144,7 @@ class EveryWayTheVerdictStaysOpenNamesSomethingTest {
                         ReadingReasons.of(List.of())));
         out.put("NothingWasRead",
                 new ObligationDisposition.Uncertainty.WhetherARowIsThere.NothingWasRead(
-                        NothingWasAsked.NOT_ASKED));
+                        UnaskedReasons.of(ItemAssessment.Coverage.NotAsked.NOT_ASKED)));
         out.put("Stopped[observation of a value a limit shortened]",
                 stopped(EstablishmentGap.Observation.of(
                         Set.of(Incompleteness.Code.VALUE_TRUNCATED))));


### PR DESCRIPTION
Closes #1245.

What a debt said about a question nobody put was whichever reading the walk reached last, and which
reading comes last is the order the lines were gathered in.

The fact that tells two readings saying one thing from two readings saying two already existed, in
the renderer: a table there sorted each constant into a fact about the run and a fact about the
behavior, to decide whether a measure got a line of its own. The fold could not see it, so it worked
from `mayHideARow` — a different question with a different answer, under which two settings of the
build look like candidates to choose between. A scalar field leaves nothing to do but choose.

So every reason answers what it is a fact about, at its own declaration, and the renderer keeps the
words alone. Neither question is read off the other: the arms coming back unreadable is a fact about
the behavior that may well be hiding a row.

## What a debt holds

The reasons that account for the state it is in, held as a set. The fold ranks the states, and only
in the one state a reason decides does it ask a reason anything — so a reading with nothing to look
at, which hides nothing, neither takes back a miss another reading established nor joins the reasons
that outranked one. That is what the arm beside it already does: an undecided point holds what left
it undecided, and a reading that ran to the end put nothing in there.

A state that says for itself how it ranks is not asked either. A measurement that failed carries
what it went without and cannot carry nothing, so every one of those leaves the point undecided
whatever its reason.

The cardinality comes from the natures rather than from a list of constants — a reason about the run
is an input to the whole run, so two different ones at one line is a state no run is in, and it is
refused where the value is made. Nothing else is refused: that a reason about the run never arrives
beside one about the behavior is true of the order a producer asks its gates in, which is not the
carrier's to state.

## What a document says

One reason, as before, and it asks for one rather than picking from what it was handed. The account
carries what the coverage carries, so an account too wide for a sentence stops the sentence and not
the count that reads the same value. The wire is where it was.

## The population the laws run over

Two of them, because there are two questions. Two searches of one reading are of one line of one
behavior under one level, so the gates answer once and both get that answer; two readings of one
line are of two behaviors, and their rows went differently. One population for both asked the round
trip through a reading's own measurement to carry what only a debt can hold.

Both come from the gates rather than from a table written beside them, which is the ownership this
change is about one layer down. A reason reaching the readings that no surface can say leaves the
fold's laws green and the one about what a document can say red — and a projection that quietly took
the first of a set is refused by a control that builds one, since nothing produces one today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)