### PR TITLE
A rule on a name over a name is read at the value it wraps

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -68,11 +68,17 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
             Map.entry("souther.compiler.partition.Witnesses#<clinit>()V",
                     "how many elements and characters a proposal holds, and how many pairings"),
             Map.entry("souther.compiler.partition.Witnesses#sized("
-                            + "Lsouther/compiler/types/Type;I"
+                            + "Lsouther/compiler/check/Shape;I"
                             + "Lsouther/compiler/check/RuleReadingSource;"
                             + "Lsouther/compiler/check/ReadingPolicy;Ljava/util/Set;)"
                             + "Lsouther/compiler/partition/Witnesses$Built;",
                     "stops at the elements and the characters, and says which"),
+            Map.entry("souther.compiler.partition.Witnesses#ofMapping("
+                            + "Lsouther/compiler/check/Shape$Mapping;I"
+                            + "Lsouther/compiler/check/RuleReadingSource;"
+                            + "Lsouther/compiler/check/ReadingPolicy;Ljava/util/Set;)"
+                            + "Lsouther/compiler/partition/Witnesses$Built;",
+                    "stops at the pairings a map is built from at once, and says which"),
             Map.entry("souther.compiler.partition.ContainersAddingUp#<clinit>()V",
                     "how many elements a total is spread over, and how many shapes are offered"),
             Map.entry("souther.compiler.partition.ContainersAddingUp#to("

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -138,16 +138,19 @@ public final class DeclaredBounds {
 
     /** What a numeric newtype's own rules leave its value between, for a caller that is asking about
      * the value and not about anything taken of it. */
-    public static Bounds of(Type type, RuleReadingSource source) {
-        return of(type, source, Carrier.ofValue(type, source.symbols()), null);
+    public static Bounds of(TypeView view, RuleReadingSource source) {
+        return of(view, source, Carrier.ofValue(view.declared(), source.symbols()), null);
     }
 
     /**
+     * @param view    the position as it was read: the rules of every name it wears are the rules of
+     *                its value, and which names those are is that reading's answer rather than one
+     *                worked out again here
      * @param carrier what the clauses' values are read on, or null where nothing here reads them
      * @param measure the operation the number is taken by, or null where the number is the value
      *                itself
      */
-    public static Bounds of(Type type, RuleReadingSource source, Carrier carrier,
+    public static Bounds of(TypeView view, RuleReadingSource source, Carrier carrier,
                             ValueName measure) {
         if (carrier == null) {
             return null;
@@ -156,7 +159,7 @@ public final class DeclaredBounds {
         End max = null;
         // The ends of the clauses, which is one projection of them and not the reading of them.
         // Every layer that put an end where it is is kept, because each is a rule a row is owed.
-        for (DeclaredClauses.Conjunct each : DeclaredClauses.of(type, source)) {
+        for (DeclaredClauses.Conjunct each : DeclaredClauses.allOf(view.wrappers(), source)) {
             // An end and nothing else. A rule this reads no end from narrows nothing here, and a
             // rule stepping past the last value of the order states an end no value is at — which
             // is a declaration with no value, answered where counts are and not by a bound written
@@ -301,7 +304,8 @@ public final class DeclaredBounds {
     public static CountRange countsHeld(Type type, RuleReadingSource source,
                                         FieldDomains.Held held) {
         ValueName.Stdlib counts = NumericMeasures.takenOf(type, source.symbols());
-        Bounds sized = counts == null ? null : of(type, source, Carrier.WHOLE, counts);
+        Bounds sized = counts == null ? null
+                : of(TypeView.of(type, source.symbols()), source, Carrier.WHOLE, counts);
         Endpoint least = sized == null || sized.min() == null ? null : sized.min().at();
         Endpoint most = sized == null || sized.max() == null ? null : sized.max().at();
         return new CountRange(

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import souther.compiler.numeric.CountDomain;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Place;
-import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -244,9 +243,14 @@ public final class DeclaredBounds {
      * <p>What is being counted follows from the type. A string's rule reaches this as readily as a
      * list's, and comes back a floor on characters; a caller reading every floor above zero as a
      * collection that cannot be empty would be answering a question this did not.
+     *
+     * <p>Of the position as it was read, like every other question about the rules on it. How many a
+     * value holds is what the rules of every name it wears say, so this needs the same reading
+     * {@link #of} does — and a caller that had already read the position and handed a type over here
+     * would have it read a second time, which is one more answer to which names it wears.
      */
-    public static int leastCountOf(Type type, RuleReadingSource source) {
-        return countsHeld(type, source, null).least();
+    public static int leastCountOf(TypeView view, RuleReadingSource source) {
+        return countsHeld(view, source, null).least();
     }
 
     /**
@@ -261,20 +265,20 @@ public final class DeclaredBounds {
      * settled once. A second reading here could put a record's {@code > 3} at three while the type's
      * came to four, and the two would disagree about one rule written twice.
      */
-    public static int leastCountOf(Type type, RuleReadingSource source, FieldDomains.Held held) {
-        return countsHeld(type, source, held).least();
+    public static int leastCountOf(TypeView view, RuleReadingSource source, FieldDomains.Held held) {
+        return countsHeld(view, source, held).least();
     }
 
     /**
-     * How many of whatever counts a value of {@code type} the rules on it allow it to hold, or every
+     * How many of whatever counts a value of the position the rules on it allow it to hold, or every
      * number where they cap it in no way.
      *
      * <p>The dual of {@link #leastCountOf} and asked for the same reason: a rule capping a value at
      * none is written on the type as readily as on the record holding one, and a reader finding only
      * the second offered a value at a position the first leaves no room for.
      */
-    public static int mostCountOf(Type type, RuleReadingSource source) {
-        return countsHeld(type, source, null).most();
+    public static int mostCountOf(TypeView view, RuleReadingSource source) {
+        return countsHeld(view, source, null).most();
     }
 
     /**
@@ -283,12 +287,12 @@ public final class DeclaredBounds {
      * <p>The lower of the two, because both are rules the construction has to satisfy -- which is
      * {@link #leastCountOf}'s argument at the other end.
      */
-    public static int mostCountOf(Type type, RuleReadingSource source, FieldDomains.Held held) {
-        return countsHeld(type, source, held).most();
+    public static int mostCountOf(TypeView view, RuleReadingSource source, FieldDomains.Held held) {
+        return countsHeld(view, source, held).most();
     }
 
     /**
-     * How many a value of {@code type} may hold, both ends of one reading of the rules.
+     * How many a value of the position may hold, both ends of one reading of the rules.
      *
      * <p>Both together, because a caller choosing how many to build needs the pair and neither end
      * alone is safe to stand in for it. A reader holding only the floor builds the fewest a rule
@@ -301,11 +305,10 @@ public final class DeclaredBounds {
      * to walk. That is the model's answer, and a caller that walked an inverted range would step
      * over it silently.
      */
-    public static CountRange countsHeld(Type type, RuleReadingSource source,
+    public static CountRange countsHeld(TypeView view, RuleReadingSource source,
                                         FieldDomains.Held held) {
-        ValueName.Stdlib counts = NumericMeasures.takenOf(type, source.symbols());
-        Bounds sized = counts == null ? null
-                : of(TypeView.of(type, source.symbols()), source, Carrier.WHOLE, counts);
+        ValueName.Stdlib counts = NumericMeasures.takenOf(view.declared(), source.symbols());
+        Bounds sized = counts == null ? null : of(view, source, Carrier.WHOLE, counts);
         Endpoint least = sized == null || sized.min() == null ? null : sized.min().at();
         Endpoint most = sized == null || sized.max() == null ? null : sized.max().at();
         return new CountRange(

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
-import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
@@ -13,8 +12,17 @@ import java.util.List;
  * <p>Every name the value wears, not the outermost one. A rule written on the type a newtype wraps
  * bounds the value as much as one written on the newtype does, and the two are read together:
  * {@code Inner: value >= 0} under {@code Outer: value <= 10} is a range of {@code [0, 10]}, and
- * neither layer alone says so. How far that reaches is asked of {@link TypeOps} rather than walked
- * again here.
+ * neither layer alone says so.
+ *
+ * <p>The names are handed in, never worked out here. Which names a position wears is what reading
+ * its type comes to ({@link TypeView#wrappers}), and a second walk to the same place is a second
+ * answer to how far a newtype reaches — they would part the day either of them changed. So this is
+ * a projection of that reading and takes it as its subject.
+ *
+ * <p>Grouped by the name each rule is written on, because a caller that has to put the rules in an
+ * order has only this to take it from. Which rules govern a value does not turn on the order — every
+ * name's do — so nothing here reads one into them, and a caller enumerating them says for itself
+ * which end it starts at.
  *
  * <p>Walked once, because the number a conjunct carries is part of an identity. A line is named by
  * the clause and the conjunct it came out of ({@link DeclaredBounds.Drawn}), counted over every
@@ -51,29 +59,60 @@ public final class DeclaredClauses {
         }
     }
 
-    /** Every conjunct of every rule written on {@code type} and on the types it wraps. */
-    public static List<Conjunct> of(Type type, RuleReadingSource source) {
-        List<Conjunct> out = new ArrayList<>();
-        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, source.symbols())) {
-            // A layer wraps a declaration a module wrote, which is what having a `Hir.Data` for it
-            // says; the pattern is where the layer's name says so.
-            if (!(layer.named() instanceof TypeSymbol.AtModule named)) {
-                continue;
-            }
-            // The clauses with the declaration each was written on, which is what names the line
-            // (ADR-0090). Read flat, every clause a spread brought in was named after the type that
-            // spread it, and two clauses of one declaration were one rule.
-            for (TypeOps.Declared declared : TypeOps.declaredForAnalysis(
-                    named, layer.data(), source.symbols(), source.invariants())) {
-                RuleRef.Invariant rule = new RuleRef.Invariant(Clause.Ref.of(declared));
-                int conjunct = -1;
-                for (Hir.Expr each : ClauseHelpers.conjunctsOf(declared.clause().expr())) {
-                    conjunct++;
-                    out.add(new Conjunct(rule, conjunct, each));
-                }
-            }
+    /**
+     * The conjuncts written on one of the names a value wears.
+     *
+     * @param worn      the name, as the reading of the position read it off
+     * @param conjuncts every conjunct of every rule written on it, in the order the author wrote
+     *                  them; empty where the name carries none
+     */
+    public record OnAName(TypeOps.Layer worn, List<Conjunct> conjuncts) {
+
+        public OnAName {
+            conjuncts = List.copyOf(conjuncts);
+        }
+    }
+
+    /** Every conjunct of every rule written on the names {@code worn}, one entry per name, in the
+     *  order the names were read off the position. */
+    public static List<OnAName> of(List<TypeOps.Layer> worn, RuleReadingSource source) {
+        List<OnAName> out = new ArrayList<>();
+        for (TypeOps.Layer layer : worn) {
+            out.add(new OnAName(layer, writtenOn(layer, source)));
         }
         return List.copyOf(out);
+    }
+
+    /** Every conjunct written on every one of them, which is what a reader that has no use for
+     *  where a rule was written asks for. */
+    public static List<Conjunct> allOf(List<TypeOps.Layer> worn, RuleReadingSource source) {
+        List<Conjunct> out = new ArrayList<>();
+        for (OnAName each : of(worn, source)) {
+            out.addAll(each.conjuncts());
+        }
+        return List.copyOf(out);
+    }
+
+    private static List<Conjunct> writtenOn(TypeOps.Layer layer, RuleReadingSource source) {
+        // A layer wraps a declaration a module wrote, which is what having a `Hir.Data` for it
+        // says; the pattern is where the layer's name says so.
+        if (!(layer.named() instanceof TypeSymbol.AtModule named)) {
+            return List.of();
+        }
+        List<Conjunct> out = new ArrayList<>();
+        // The clauses with the declaration each was written on, which is what names the line
+        // (ADR-0090). Read flat, every clause a spread brought in was named after the type that
+        // spread it, and two clauses of one declaration were one rule.
+        for (TypeOps.Declared declared : TypeOps.declaredForAnalysis(
+                named, layer.data(), source.symbols(), source.invariants())) {
+            RuleRef.Invariant rule = new RuleRef.Invariant(Clause.Ref.of(declared));
+            int conjunct = -1;
+            for (Hir.Expr each : ClauseHelpers.conjunctsOf(declared.clause().expr())) {
+                conjunct++;
+                out.add(new Conjunct(rule, conjunct, each));
+            }
+        }
+        return out;
     }
 
     private DeclaredClauses() {}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1318,9 +1318,9 @@ public final class InputDomain {
         // carrier first, every rule anybody ever wrote about the length of a string would have
         // become a rule about the string.
         DeclaredBounds.Bounds ofType = taken == null ? null
-                : DeclaredBounds.of(type, source, Carrier.WHOLE, taken);
+                : DeclaredBounds.of(view, source, Carrier.WHOLE, taken);
         DeclaredBounds.Bounds valueOfType = carried == null ? null
-                : DeclaredBounds.of(type, source, carried, null);
+                : DeclaredBounds.of(view, source, carried, null);
         // Rules about both coordinates and nothing here to choose between. Said before they are
         // dropped and from the list that still holds them, because this is the one place that knows
         // which rules they were — recovered afterwards from a position with no axis, the finding

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -98,15 +98,17 @@ final class ContainersAddingUp {
         if (!(answer instanceof Count total) || elements == null) {
             return none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        if (!(TypeView.of(container, ruleSource.symbols()).shape()
-                instanceof Shape.Sequence holding)) {
+        // The position, read once. What it holds, how many of them its rules leave it holding, and
+        // the names the container is written under are three questions of one reading, and asking
+        // the type again for any of them is another answer to which names it wears.
+        TypeView view = TypeView.of(container, ruleSource.symbols());
+        if (!(view.shape() instanceof Shape.Sequence holding)) {
             // A total is taken of a container, and what is declared at the root is not one. Which is
             // a term nobody should have been able to build; said here rather than by composing a
             // value of whatever shape is there.
             return none(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        DeclaredBounds.CountRange howMany =
-                howMany(container, target.writeRoot(), within, ruleSource);
+        DeclaredBounds.CountRange howMany = howMany(view, target.writeRoot(), within, ruleSource);
         NumericDomain.Bounds runs =
                 within.runsBetween(new NumericTerm.ValueOf(occurrences(target)));
         Ends ends = Ends.of(runs == null ? NumericDomain.Bounds.OPEN : runs, elements);
@@ -160,7 +162,7 @@ final class ContainersAddingUp {
                 // offer each case and to say the rest were never made.
                 for (Filling filling : ways.filled()) {
                     FixtureTemplate one =
-                            filled(split, holding, container, filling, elements, ruleSource, policy);
+                            filled(split, holding, view, filling, elements, ruleSource, policy);
                     if (one == null || built.contains(one)) {
                         continue;
                     }
@@ -199,15 +201,15 @@ final class ContainersAddingUp {
      * answers it as narrowed by whatever the row had to pass to get here. Read here instead, this
      * would be a second reading of the rules, free to part from the one the search was run against.
      */
-    private static DeclaredBounds.CountRange howMany(Type container, TermPath root,
+    private static DeclaredBounds.CountRange howMany(TypeView container, TermPath root,
                                                      SearchRegion within,
                                                      RuleReadingSource ruleSource) {
         Symbols symbols = ruleSource.symbols();
         DeclaredBounds.CountRange declared =
                 DeclaredBounds.countsHeld(container, ruleSource, null);
-        ValueName.Stdlib counts = NumericMeasures.takenOf(container, symbols);
+        ValueName.Stdlib counts = NumericMeasures.takenOf(container.declared(), symbols);
         NumericTerm.FromOnePosition term = counts == null ? null
-                : NumericTerm.TakenOf.of(counts, root, container, symbols);
+                : NumericTerm.TakenOf.of(counts, root, container.declared(), symbols);
         NumericDomain.Bounds runs = term == null ? null : within.runsBetween(term);
         if (runs == null) {
             return declared;
@@ -346,7 +348,7 @@ final class ContainersAddingUp {
      * rather than composed as a list, so that the day one arrives it arrives here.
      */
     private static FixtureTemplate filled(List<BigDecimal> split, Shape.Sequence holding,
-                                          Type container, Filling filling,
+                                          TypeView container, Filling filling,
                                           Carrier elements, RuleReadingSource ruleSource, ReadingPolicy policy) {
         if (holding.kind() != Shape.Sequence.Kind.LIST) {
             return null;
@@ -364,8 +366,7 @@ final class ContainersAddingUp {
             }
             values.add(one);
         }
-        return WornNames.under(TypeView.of(container, ruleSource.symbols()).wrappers(),
-                FixtureTemplate.collection(values), ruleSource);
+        return WornNames.under(container.wrappers(), FixtureTemplate.collection(values), ruleSource);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -364,7 +364,8 @@ final class ContainersAddingUp {
             }
             values.add(one);
         }
-        return Witnesses.wrapped(container, FixtureTemplate.collection(values), ruleSource);
+        return WornNames.under(TypeView.of(container, ruleSource.symbols()).wrappers(),
+                FixtureTemplate.collection(values), ruleSource);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -165,10 +165,10 @@ public record FixtureTemplate(String text, Hir.Expr value) {
      * order stops is a second thing to keep true. What such a point leaves is a point nothing
      * composes a value at, which is what the callers already read a null as.
      *
-     * <p>Bare. How many names the value wears at the position it is going to is a different question
-     * with its own answer ({@link Witnesses#wrapped}), which walks every layer; answered here as
-     * well, it was answered one layer deep, and a value of a newtype over a newtype came back
-     * missing the name in the middle.
+     * <p>Bare. Which names the value wears at the position it is going to is a different question
+     * with its own answer ({@link WornNames#under}), taken from the reading of that position;
+     * answered here as well, it was answered one layer deep, and a value of a newtype over a newtype
+     * came back missing the name in the middle.
      */
     public static FixtureTemplate on(Carrier carrier, Place at, TypeReachName.Naming naming) {
         if (!carrier.extent().admits(at)) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -4,6 +4,7 @@ import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Quantities;
 import souther.compiler.inputs.TermOrders;
@@ -273,7 +274,8 @@ final class Intervals {
         // how to build for rather than one that falls to whichever branch it was not named in.
         switch (of) {
             case NumericTerm.ValueOf _ -> {
-                FixtureTemplate standing = Witnesses.wrapped(type,
+                FixtureTemplate standing = WornNames.under(
+                        TypeView.of(type, ruleSource.symbols()).wrappers(),
                         FixtureTemplate.on(carrier, inside, ruleSource.symbols().scope()::reach),
                         ruleSource);
                 return standing == null ? List.of() : List.of(standing);
@@ -284,11 +286,12 @@ final class Intervals {
         if (size < 0) {
             return List.of();
         }
+        TypeView view = TypeView.of(type, ruleSource.symbols());
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each
                 : Witnesses.ofSize(TypeOps.base(type, ruleSource.symbols()), size, ruleSource,
                         policy, Set.of()).values()) {
-            out.add(Witnesses.wrapped(type, each, ruleSource));
+            out.add(WornNames.under(view.wrappers(), each, ruleSource));
         }
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Quantities;
@@ -289,8 +288,7 @@ final class Intervals {
         TypeView view = TypeView.of(type, ruleSource.symbols());
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each
-                : Witnesses.ofSize(TypeOps.base(type, ruleSource.symbols()), size, ruleSource,
-                        policy, Set.of()).values()) {
+                : Witnesses.ofSize(view.shape(), size, ruleSource, policy, Set.of()).values()) {
             out.add(WornNames.under(view.wrappers(), each, ruleSource));
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -271,13 +271,18 @@ final class Intervals {
         // Exhaustive, with no `default`. What a value reading as this number looks like is a
         // different construction per kind of number, so a kind added is one this has to be told
         // how to build for rather than one that falls to whichever branch it was not named in.
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        // A name this module cannot write leaves no value to write, whichever number the value is
+        // asked to read as. Asked of the position, once, before anything is built for it.
+        if (!(WornNames.of(view.wrappers(), ruleSource) instanceof WornNames.Spelled worn)) {
+            return List.of();
+        }
         switch (of) {
             case NumericTerm.ValueOf _ -> {
-                FixtureTemplate standing = WornNames.under(
-                        TypeView.of(type, ruleSource.symbols()).wrappers(),
-                        FixtureTemplate.on(carrier, inside, ruleSource.symbols().scope()::reach),
-                        ruleSource);
-                return standing == null ? List.of() : List.of(standing);
+                FixtureTemplate standing =
+                        FixtureTemplate.on(carrier, inside, ruleSource.symbols().scope()::reach);
+                return standing == null ? List.of()
+                        : List.of(RepresentativeSource.under(worn.names(), standing));
             }
             case NumericTerm.TakenOf _ -> { }
         }
@@ -285,11 +290,10 @@ final class Intervals {
         if (size < 0) {
             return List.of();
         }
-        TypeView view = TypeView.of(type, ruleSource.symbols());
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each
                 : Witnesses.ofSize(view.shape(), size, ruleSource, policy, Set.of()).values()) {
-            out.add(WornNames.under(view.wrappers(), each, ruleSource));
+            out.add(RepresentativeSource.under(worn.names(), each));
         }
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -42,8 +42,11 @@ final class LocalInspection {
         // Said to be classes of this position's own measure as they are built. What a class means is
         // the same wherever it stands; which number's values it divides is this reading's answer,
         // and a reader working it back out of the meaning would be answering it again.
+        // Nothing is being built here: a position is being inspected, so no value's own name is
+        // already open.
         List<PartitionClass> classes =
-                PartitionClasses.of(position.obligationCases(), position.view(), ruleSource, policy)
+                PartitionClasses.of(position.obligationCases(), position.view(), ruleSource, policy,
+                                java.util.Set.of())
                         .stream().map(each -> each.ofTheNumber(position.term())).toList();
         DeclaredBounds.Bounds axis = position.nothingExists() ? null
                 : axisBounds(position.ownEnds(), position.rangeLeft());

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -213,14 +213,16 @@ final class PartitionClasses {
                             RepresentativeSource.of(FixtureTemplate.unitCase(names))));
         }
         if (data.newtype()) {
-            List<FixtureTemplate> inner =
-                    Partitions.insideTheNewtype(declared, ruleSource, policy);
-            return inner.isEmpty()
+            // Values of the case, which is a position of its own: it is read like any other, and
+            // what comes back already wears the case's own name. Under the position's names as well,
+            // since a case of a `data DecisionN = Decision` is written inside that name too.
+            List<FixtureTemplate> values = Partitions.representativesOf(
+                    Type.ref(declared), ruleSource, policy, null, java.util.Set.of());
+            return values.isEmpty()
                     ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
-                            "nothing here composed a value of what `" + leaf.name() + "` wraps")
+                            "nothing here composed a value of `" + leaf.name() + "`")
                     : PartitionClass.of(idOfCase(leaf), leaf.name(), is,
-                            RepresentativeSource.under(writes, RepresentativeSource.under(
-                                    List.of(names), RepresentativeSource.of(inner))));
+                            RepresentativeSource.under(writes, RepresentativeSource.of(values)));
         }
         // A record case is written field by field, which is the generator's composition. So the class
         // names the constructor and the generator does the composing — the same walk every other

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -53,18 +53,17 @@ final class PartitionClasses {
         // observed value is under this class is asked of the declarations, and what a row writes it
         // under is asked of the module doing the writing — one of these is an identity and the other
         // is a reference, and a module reaching a name through an alias answers them differently.
-        List<TypeReachName.Written> writes = new ArrayList<>();
-        for (TypeSymbol each : worn) {
-            if (!(ruleSource.symbols().scope().reach(each) instanceof TypeReachName.Written written)) {
-                return unwritable(cases, view, ruleSource, policy, worn, each);
+        return switch (WornNames.of(view.wrappers(), ruleSource)) {
+            case WornNames.Unwritable unwritable ->
+                    unwritable(cases, view, ruleSource, policy, worn, unwritable);
+            case WornNames.Spelled spelled -> {
+                List<PartitionClass> out = new ArrayList<>();
+                for (Case one : cases) {
+                    out.add(classOf(one, view, worn, policy, spelled.names(), ruleSource));
+                }
+                yield List.copyOf(out);
             }
-            writes.add(written);
-        }
-        List<PartitionClass> out = new ArrayList<>();
-        for (Case one : cases) {
-            out.add(classOf(one, view, worn, policy, writes, ruleSource));
-        }
-        return List.copyOf(out);
+        };
     }
 
     /**
@@ -77,8 +76,8 @@ final class PartitionClasses {
      */
     private static List<PartitionClass> unwritable(List<Case> cases, TypeView view, RuleReadingSource ruleSource,
                                                    ReadingPolicy policy,
-                                                   List<TypeSymbol> worn, TypeSymbol unnamed) {
-        String why = notExposed(unnamed);
+                                                   List<TypeSymbol> worn, WornNames.Unwritable unnamed) {
+        String why = unnamed.why();
         List<PartitionClass> out = new ArrayList<>();
         // The classes of the same position with no names to write them under. What each is and what
         // reads a value into it are the position's either way; only the recipes are dropped, and
@@ -90,17 +89,6 @@ final class PartitionClasses {
                     .holding(each.denotes()).selecting(each.selects()));
         }
         return List.copyOf(out);
-    }
-
-    /** Why nothing here can write a value of {@code unnamed}: no spelling reaches it. */
-    private static String notExposed(TypeSymbol unnamed) {
-        return unnamed instanceof TypeSymbol.AtModule at
-                ? "`" + at.module() + "` does not expose `" + at.name()
-                        + "`, so nothing here can name it"
-                // What the language declares is kept by nobody: a declaration of this module
-                // spells it, so the language's has no name left here.
-                : "`" + unnamed.name() + "` is declared here, so what the language declares under"
-                        + " that name has no name here";
     }
 
     /** What a case's class is called, in one place: a reading that decides which cases the position
@@ -212,7 +200,8 @@ final class PartitionClasses {
         // author here can write down. Said as that, rather than offered under a spelling that
         // resolves to nothing wherever the row is pasted (issue #696).
         if (!(ruleSource.symbols().scope().reach(leaf) instanceof TypeReachName.Written names)) {
-            return PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is, notExposed(leaf));
+            return PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
+                    WornNames.noSpellingFor(leaf));
         }
         // A case of a primitive-headed union is a primitive or one of the language's own, which
         // no module declares and nothing composes field by field: naming it builds it, the same as

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -31,9 +31,11 @@ final class PartitionClasses {
     /** The classes a type states, before any rule is crossed with them. What a witness varies over
      *  and what a generator offers for a bare position, which are asked of a type and not of a
      *  position of one. */
-    static List<PartitionClass> of(Type type, RuleReadingSource ruleSource, ReadingPolicy policy) {
+    static List<PartitionClass> of(Type type, RuleReadingSource ruleSource, ReadingPolicy policy,
+                                   java.util.Set<TypeSymbol> expanding) {
         TypeView view = TypeView.of(type, ruleSource.symbols());
-        return of(Distinctions.ofType(view, ruleSource.symbols()), view, ruleSource, policy);
+        return of(Distinctions.ofType(view, ruleSource.symbols()), view, ruleSource, policy,
+                expanding);
     }
 
     /**
@@ -42,9 +44,15 @@ final class PartitionClasses {
      * <p>A name the position wears that nothing here writes takes every class with it: the classes
      * are still the position's and a row already sitting in one still covers it, so what is absent
      * is the offer of a new row rather than the class.
+     *
+     * @param expanding the names whose own value is already being built. A class carries what stands
+     *                  for it, and what stands for it is built from the position under it — so the
+     *                  walk that reaches a class is the walk that reaches that position, and a class
+     *                  built without what is already being built starts the descent again with
+     *                  nothing to stop it
      */
     static List<PartitionClass> of(List<Case> cases, TypeView view, RuleReadingSource ruleSource,
-                                   ReadingPolicy policy) {
+                                   ReadingPolicy policy, java.util.Set<TypeSymbol> expanding) {
         if (cases.isEmpty()) {
             return List.of();
         }
@@ -55,11 +63,11 @@ final class PartitionClasses {
         // is a reference, and a module reaching a name through an alias answers them differently.
         return switch (WornNames.of(view.wrappers(), ruleSource)) {
             case WornNames.Unwritable unwritable ->
-                    unwritable(cases, view, ruleSource, policy, worn, unwritable);
+                    unwritable(cases, view, ruleSource, policy, worn, unwritable, expanding);
             case WornNames.Spelled spelled -> {
                 List<PartitionClass> out = new ArrayList<>();
                 for (Case one : cases) {
-                    out.add(classOf(one, view, worn, policy, spelled.names(), ruleSource));
+                    out.add(classOf(one, view, worn, policy, spelled.names(), ruleSource, expanding));
                 }
                 yield List.copyOf(out);
             }
@@ -76,14 +84,16 @@ final class PartitionClasses {
      */
     private static List<PartitionClass> unwritable(List<Case> cases, TypeView view, RuleReadingSource ruleSource,
                                                    ReadingPolicy policy,
-                                                   List<TypeSymbol> worn, WornNames.Unwritable unnamed) {
+                                                   List<TypeSymbol> worn, WornNames.Unwritable unnamed,
+                                                   java.util.Set<TypeSymbol> expanding) {
         String why = unnamed.why();
         List<PartitionClass> out = new ArrayList<>();
         // The classes of the same position with no names to write them under. What each is and what
         // reads a value into it are the position's either way; only the recipes are dropped, and
         // they are what there is no writing them.
         for (PartitionClass each : of(cases,
-                new TypeView(view.declared(), List.of(), view.shape()), ruleSource, policy)) {
+                new TypeView(view.declared(), List.of(), view.shape()), ruleSource, policy,
+                expanding)) {
             out.add(PartitionClass.ungeneratable(each.id(), each.label(),
                     Recognition.Under.of(worn, each.recognises()), why)
                     .holding(each.denotes()).selecting(each.selects()));
@@ -112,11 +122,14 @@ final class PartitionClasses {
      */
     private static PartitionClass classOf(Case one, TypeView view, List<TypeSymbol> worn,
                                           ReadingPolicy policy,
-                                          List<TypeReachName.Written> writes, RuleReadingSource ruleSource) {
+                                          List<TypeReachName.Written> writes, RuleReadingSource ruleSource,
+                                          java.util.Set<TypeSymbol> expanding) {
         PartitionClass built = switch (one) {
             case Case.Truth truth -> eitherWay(truth.value(), worn, writes);
-            case Case.Presence presence -> heldOrNot(presence.present(), view, worn, policy, writes, ruleSource);
-            case Case.SumCase sum -> caseClass(sum, view.declared(), worn, policy, writes, ruleSource);
+            case Case.Presence presence ->
+                    heldOrNot(presence.present(), view, worn, policy, writes, ruleSource, expanding);
+            case Case.SumCase sum ->
+                    caseClass(sum, view.declared(), worn, policy, writes, ruleSource, expanding);
             case Case.Named named -> ValueClasses.classAt(named.value(), view, worn, ruleSource);
         };
         Refinement narrowing = Refinement.of(one);
@@ -140,7 +153,8 @@ final class PartitionClasses {
     /** Whether an optional holds anything, which is the one division its type makes. */
     private static PartitionClass heldOrNot(boolean present, TypeView view, List<TypeSymbol> worn,
                                             ReadingPolicy policy,
-                                            List<TypeReachName.Written> writes, RuleReadingSource ruleSource) {
+                                            List<TypeReachName.Written> writes, RuleReadingSource ruleSource,
+                                            java.util.Set<TypeSymbol> expanding) {
         if (!present) {
             return PartitionClass.of("None", "None",
                     Recognition.Under.of(worn, new Recognition.Held(false)),
@@ -156,7 +170,10 @@ final class PartitionClasses {
                             + " from it disagree about its shape");
         }
         Type element = optional.element();
-        List<FixtureTemplate> some = Partitions.representativesOf(element, ruleSource, policy);
+        // Under what is already being built: what stands for `Some` is what stands at the element,
+        // and the walk that got here is the walk that is building it.
+        List<FixtureTemplate> some =
+                Partitions.representativesOf(element, ruleSource, policy, null, expanding);
         Recognition is = Recognition.Under.of(worn, new Recognition.Held(true));
         return some.isEmpty()
                 ? PartitionClass.ungeneratable("Some", "Some", is,
@@ -167,8 +184,10 @@ final class PartitionClasses {
 
     private static PartitionClass caseClass(Case.SumCase one, Type of, List<TypeSymbol> worn,
                                             ReadingPolicy policy,
-                                            List<TypeReachName.Written> writes, RuleReadingSource ruleSource) {
-        return holdingWhatItIs(one, writableCase(one.leaf(), of, worn, policy, writes, ruleSource));
+                                            List<TypeReachName.Written> writes, RuleReadingSource ruleSource,
+                                            java.util.Set<TypeSymbol> expanding) {
+        return holdingWhatItIs(one,
+                writableCase(one.leaf(), of, worn, policy, writes, ruleSource, expanding));
     }
 
     /**
@@ -189,7 +208,8 @@ final class PartitionClasses {
     private static PartitionClass writableCase(TypeSymbol leaf, Type of, List<TypeSymbol> worn,
                                                ReadingPolicy policy,
                                                List<TypeReachName.Written> writes,
-                                               RuleReadingSource ruleSource) {
+                                               RuleReadingSource ruleSource,
+                                               java.util.Set<TypeSymbol> expanding) {
         // Where the case sits on the position's order, decided here where the case, the position's
         // type and the declarations are all in hand. A line a body draws on an ordered enumeration
         // is at one of these places, and the class holding it is asked with the place.
@@ -217,7 +237,7 @@ final class PartitionClasses {
             // what comes back already wears the case's own name. Under the position's names as well,
             // since a case of a `data DecisionN = Decision` is written inside that name too.
             List<FixtureTemplate> values = Partitions.representativesOf(
-                    Type.ref(declared), ruleSource, policy, null, java.util.Set.of());
+                    Type.ref(declared), ruleSource, policy, null, expanding);
             return values.isEmpty()
                     ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
                             "nothing here composed a value of `" + leaf.name() + "`")

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1836,12 +1836,13 @@ public final class Partitions {
      */
     static List<FixtureTemplate> inReserve(Type type, RuleReadingSource ruleSource, ReadingPolicy policy,
                                            NumericDomain.Bounds within) {
-        if (!(type instanceof Type.Ref ref) || !(ruleSource.symbols().declaredNode(ref.name()) instanceof Hir.Data data)
-                || !data.newtype()) {
+        // A far edge is a rule's, and a rule is written on a name. A position wearing none carries
+        // no rule of its own, so there is no edge here to hold anything back at.
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        if (!view.isWrapped()) {
             return List.of();
         }
-        DeclaredBounds.Bounds own =
-                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource);
+        DeclaredBounds.Bounds own = DeclaredBounds.of(view, ruleSource);
         NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         // The far end has to be a value the position holds. Where the range stops short of it there
         // is nothing there to hold back, and a dense order has no value beside it to hold back
@@ -1851,10 +1852,15 @@ public final class Partitions {
                 || bounds.max().at().sameAs(bounds.min().at())) {
             return List.of();
         }
-        FixtureTemplate held = standing(type, own.carrier(), bounds.max().at(), ruleSource);
+        FixtureTemplate held = WornNames.under(view.wrappers(),
+                FixtureTemplate.on(own.carrier(), bounds.max().at(),
+                        ruleSource.symbols().scope()::reach), ruleSource);
+        if (held == null) {
+            return List.of();   // a name this module cannot write leaves no value to hold back
+        }
         // Nothing already on offer: a range whose far edge is the number the base type stands for
         // would otherwise hold the same value twice, once in each tier.
-        return representativesOf(type, ruleSource, policy, within).stream()
+        return representativesOf(view, ruleSource, policy, within, java.util.Set.of()).stream()
                 .map(FixtureTemplate::text).anyMatch(held.text()::equals)
                 ? List.of() : List.of(held);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -944,12 +944,14 @@ public final class Partitions {
                 values.add(each.value());
             }
         }
+        // The position, read once: every class below writes its value under the same names.
+        TypeView view = TypeView.of(type, ruleSource.symbols());
         List<PartitionClass> classes = new ArrayList<>();
         for (Place value : values) {
             String written = carrier.written(value);
             classes.add(classAt(term + "/= " + written, "= " + written,
                     holding(orders, new Recognition.CountIs.At(value)),
-                    standing(type, carrier, value, ruleSource)));
+                    standing(view, carrier, value, ruleSource)));
         }
         Place other = carrier.somethingOtherThan(values, within);
         String label = "/= " + String.join(", ",
@@ -961,7 +963,7 @@ public final class Partitions {
                         "nothing here composed a value of this position other than the ones"
                                 + " singled out")
                 : classAt(term + "/" + label, label, away,
-                        standing(type, carrier, other, ruleSource)));
+                        standing(view, carrier, other, ruleSource)));
         // Classes of the number the values were singled out of, said where that is known.
         return classes.stream().map(each -> each.ofTheNumber(term)).toList();
     }
@@ -976,10 +978,11 @@ public final class Partitions {
                 : PartitionClass.of(id, label, is, RepresentativeSource.of(standing));
     }
 
-    /** A count written at a position, wearing every name that position declares. */
-    private static FixtureTemplate standing(Type type, Carrier carrier, Place at,
+    /** A count written at a position, wearing every name that position declares — which the reading
+     *  of the position says, and nothing here asks again. */
+    private static FixtureTemplate standing(TypeView view, Carrier carrier, Place at,
             RuleReadingSource ruleSource) {
-        return WornNames.under(TypeView.of(type, ruleSource.symbols()).wrappers(),
+        return WornNames.under(view.wrappers(),
                 FixtureTemplate.on(carrier, at, ruleSource.symbols().scope()::reach), ruleSource);
     }
 
@@ -1274,12 +1277,18 @@ public final class Partitions {
                 return List.of();
             }
         }
+        // A name this module cannot write leaves no value to write. Asked of the position and not of
+        // each value: whether the names can be spelled is a fact about where the value is going, and
+        // a value at a position wearing one of them is no value here whatever it is.
+        if (!(WornNames.of(view.wrappers(), ruleSource) instanceof WornNames.Spelled spelled)) {
+            return List.of();
+        }
         // What the rules ask for, and then what the position is where nothing was written about it.
         List<FixtureTemplate> bare = new ArrayList<>();
         bare.addAll(whereTheRulesLeaveTheValue(view, ruleSource, within));
         bare.addAll(whatAFormatAsksFor(view, ruleSource));
         // What the rules say the value holds, before the value that would hold nothing.
-        bare.addAll(Witnesses.holding(view.shape(), leastHeld(view.declared(), ruleSource),
+        bare.addAll(Witnesses.holding(view.shape(), leastHeld(view, ruleSource),
                 ruleSource, policy, inside));
         List<FixtureTemplate> ofTheShape =
                 whatTheShapeStandsFor(view.shape(), ruleSource, policy, within, inside);
@@ -1287,19 +1296,14 @@ public final class Partitions {
 
         List<FixtureTemplate> candidates = new ArrayList<>();
         for (FixtureTemplate each : bare) {
-            // A name this module cannot write leaves no value to write, and no candidate.
-            FixtureTemplate written = WornNames.under(view.wrappers(), each, ruleSource);
-            if (written != null) {
-                candidates.add(written);
-            }
+            candidates.add(RepresentativeSource.under(spelled.names(), each));
         }
         // Where the shape stands for no value of its own, what stands at the position is one of the
-        // kinds its type divides into, and the classes are what name them. Asked only there: what a
-        // class says about the value a position holds is what stands at the position under it, and
-        // asking that of a shape that has a value of its own is the value asking for itself — an
-        // optional's `Some` is its element, met again while the element is being built.
+        // kinds its type divides into, and the classes are what name them. Asked only there, because
+        // a class of a position says what stands at the position under it: asked of a shape that has
+        // a value of its own, the answer is that value again, arrived at by building it.
         if (ofTheShape.isEmpty()) {
-            candidates.addAll(dividedInto(view, ruleSource, policy, expanding));
+            candidates.addAll(dividedInto(view, ruleSource, policy, inside));
         }
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();
         for (FixtureTemplate each : candidates) {
@@ -1324,7 +1328,8 @@ public final class Partitions {
                                                      ReadingPolicy policy,
                                                      java.util.Set<TypeSymbol> expanding) {
         for (PartitionClass each : PartitionClasses.of(
-                Distinctions.ofType(view, ruleSource.symbols()), view, ruleSource, policy)) {
+                Distinctions.ofType(view, ruleSource.symbols()), view, ruleSource, policy,
+                expanding)) {
             List<FixtureTemplate> stands =
                     standingFor(each.representatives(), ruleSource, policy, expanding);
             if (!stands.isEmpty()) {
@@ -1597,20 +1602,31 @@ public final class Partitions {
     }
 
     /** How many of whatever counts a value the rules on it require it to hold, read where the rules
-     * are: {@link DeclaredBounds#leastCountOf}. */
+     * are: {@link DeclaredBounds#leastCountOf}. Of the position as it was read, since how many a
+     * value holds is what the rules of every name it wears say. */
+    static int leastHeld(TypeView view, RuleReadingSource ruleSource) {
+        return DeclaredBounds.leastCountOf(view, ruleSource);
+    }
+
+    /** The same, of a position nothing here has read yet. */
     static int leastHeld(Type type, RuleReadingSource ruleSource) {
-        return DeclaredBounds.leastCountOf(type, ruleSource);
+        return leastHeld(TypeView.of(type, ruleSource.symbols()), ruleSource);
     }
 
     /** The same, where the record the position sits in has a rule about it too. */
-    static int leastHeld(Type type, RuleReadingSource ruleSource, FieldDomains.Held held) {
-        return DeclaredBounds.leastCountOf(type, ruleSource, held);
+    static int leastHeld(TypeView view, RuleReadingSource ruleSource, FieldDomains.Held held) {
+        return DeclaredBounds.leastCountOf(view, ruleSource, held);
     }
 
-    /** How many the rules on a value of {@code type} allow it to hold, where the record the position
-     *  sits in has a rule about it too: {@link DeclaredBounds#mostCountOf}. */
+    /** The same, of a position nothing here has read yet. */
+    static int leastHeld(Type type, RuleReadingSource ruleSource, FieldDomains.Held held) {
+        return leastHeld(TypeView.of(type, ruleSource.symbols()), ruleSource, held);
+    }
+
+    /** How many the rules on a value of the position allow it to hold, where the record it sits in
+     *  has a rule about it too: {@link DeclaredBounds#mostCountOf}. */
     static int mostHeld(Type type, RuleReadingSource ruleSource, FieldDomains.Held held) {
-        return DeclaredBounds.mostCountOf(type, ruleSource, held);
+        return DeclaredBounds.mostCountOf(TypeView.of(type, ruleSource.symbols()), ruleSource, held);
     }
 
     /**
@@ -1633,8 +1649,9 @@ public final class Partitions {
     static java.util.Set<CompositionBudget> notBuilt(Type type, RuleReadingSource ruleSource,
                                                      ReadingPolicy policy,
                                                      FieldDomains.Held held) {
-        return Witnesses.heldBackFor(TypeView.of(type, ruleSource.symbols()).shape(),
-                leastHeld(type, ruleSource, held), ruleSource, policy);
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        return Witnesses.heldBackFor(view.shape(), leastHeld(view, ruleSource, held),
+                ruleSource, policy);
     }
 
     /**
@@ -1649,13 +1666,13 @@ public final class Partitions {
      * <p>Only a whole number steps. Between two decimals there is no next value, so a dense carrier
      * names the one number inside its range and no more.
      */
-    static Place numberInside(Type type, RuleReadingSource ruleSource, int index) {
-        Type base = TypeOps.numericBase(type, ruleSource.symbols());
+    static Place numberInside(TypeView view, RuleReadingSource ruleSource, int index) {
+        Type base = TypeOps.numericBase(view.declared(), ruleSource.symbols());
         if (base == null) {
             return null;
         }
-        NumericDomain.Bounds range = TypeBounds.admissible(
-                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource), null);
+        NumericDomain.Bounds range =
+                TypeBounds.admissible(DeclaredBounds.of(view, ruleSource), null);
         Place from = inside(range, base == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE);
         if (from == null || base != Type.INT) {
             return from != null && index == 0 ? from : null;
@@ -1669,8 +1686,10 @@ public final class Partitions {
      *
      * <p>Both, and the floor first. Each is what one rule was read to produce and which of them the
      * whole of the rules admits is the decoder's answer, so neither withdraws the other — the same
-     * reading {@link #insideTheNewtype} makes of a newtype carrying a floor, made here of a position
-     * whose floor is its record's. What the order decides is not which is right: the search over a
+     * reading {@link #representativesOf(TypeView, RuleReadingSource, ReadingPolicy,
+     * NumericDomain.Bounds, java.util.Set)} makes of a position whose own rules give it a floor,
+     * made here of one whose floor is its record's. What the order decides is not which is right:
+     * the search over a
      * row's positions is bounded, so a position offering the value that holds nothing first spends
      * an assignment on a value the rule refuses, and rows at positions the rule has nothing to do
      * with are what runs out.
@@ -1679,12 +1698,23 @@ public final class Partitions {
                                                         ReadingPolicy policy,
                                                         NumericDomain.Bounds within,
                                                         FieldDomains.Held held) {
-        return representativesHolding(type, ruleSource, policy, within, held, java.util.Set.of());
+        return representativesHolding(TypeView.of(type, ruleSource.symbols()), ruleSource, policy,
+                within, held, java.util.Set.of());
+    }
+
+    /** The same, of a position nothing here has read yet. */
+    static List<FixtureTemplate> representativesHolding(Type type, RuleReadingSource ruleSource,
+                                                        ReadingPolicy policy,
+                                                        NumericDomain.Bounds within,
+                                                        FieldDomains.Held held,
+                                                        java.util.Set<TypeSymbol> expanding) {
+        return representativesHolding(TypeView.of(type, ruleSource.symbols()), ruleSource, policy,
+                within, held, expanding);
     }
 
     /** The same, with the names this is already inside the value of, for the same reason
      *  {@link #representativesOf} carries them. */
-    static List<FixtureTemplate> representativesHolding(Type type, RuleReadingSource ruleSource,
+    static List<FixtureTemplate> representativesHolding(TypeView view, RuleReadingSource ruleSource,
                                                         ReadingPolicy policy,
                                                         NumericDomain.Bounds within,
                                                         FieldDomains.Held held,
@@ -1693,16 +1723,16 @@ public final class Partitions {
         // Under every name the position wears, because a floor read off the record says how much the
         // value holds and not what it is written as: a field of a newtype over a list takes a list
         // inside that newtype's own name.
-        TypeView view = TypeView.of(type, ruleSource.symbols());
-        for (FixtureTemplate bare : Witnesses.holding(view.shape(),
-                leastHeld(type, ruleSource, held), ruleSource, policy, expanding)) {
-            // A name this module cannot write leaves no value to write, and no candidate.
-            FixtureTemplate written = WornNames.under(view.wrappers(), bare, ruleSource);
-            if (written != null) {
-                candidates.add(written);
+        //
+        // A name this module cannot write leaves no value to write, which is asked once of the
+        // position rather than of each value built for it.
+        if (WornNames.of(view.wrappers(), ruleSource) instanceof WornNames.Spelled spelled) {
+            for (FixtureTemplate bare : Witnesses.holding(view.shape(),
+                    leastHeld(view, ruleSource, held), ruleSource, policy, expanding)) {
+                candidates.add(RepresentativeSource.under(spelled.names(), bare));
             }
         }
-        candidates.addAll(representativesOf(type, ruleSource, policy, within, expanding));
+        candidates.addAll(representativesOf(view, ruleSource, policy, within, expanding));
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();
         for (FixtureTemplate each : candidates) {
             once.putIfAbsent(each.text(), each);
@@ -1728,12 +1758,15 @@ public final class Partitions {
                                                             ReadingPolicy policy,
                                                             NumericDomain.Bounds within,
                                                             FieldDomains.Held held) {
-        List<FixtureTemplate> base =
-                new ArrayList<>(representativesHolding(type, ruleSource, policy, within, held));
+        // The position, read once and handed to everything below: what it ordinarily offers, what it
+        // holds back, where its rules leave a number, and the names any of those go under.
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        List<FixtureTemplate> base = new ArrayList<>(representativesHolding(
+                view, ruleSource, policy, within, held, java.util.Set.of()));
         // What a position holds back for the product search's second pass is on offer here from the
         // start. This pass runs only where both of those have already failed, and a position keeping
         // a value from the last search there is a value nothing will ever be tried at.
-        for (FixtureTemplate kept : inReserve(type, ruleSource, policy, within)) {
+        for (FixtureTemplate kept : inReserve(view, ruleSource, policy, within)) {
             if (base.stream().noneMatch(each -> each.text().equals(kept.text()))) {
                 base.add(kept);
             }
@@ -1742,15 +1775,17 @@ public final class Partitions {
         if (numeric == null) {
             return List.copyOf(base);
         }
-        NumericDomain.Bounds range = TypeBounds.admissible(
-                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource), within);
+        NumericDomain.Bounds range =
+                TypeBounds.admissible(DeclaredBounds.of(view, ruleSource), within);
         Carrier carrier = numeric == Type.INT ? Carrier.WHOLE : Carrier.DENSE;
         Place step = displaced(range, carrier);
         if (step == null) {
             return List.copyOf(base);
         }
-        FixtureTemplate value = standing(type, carrier, step, ruleSource);
-        if (base.stream().anyMatch(each -> each.text().equals(value.text()))) {
+        FixtureTemplate value = standing(view, carrier, step, ruleSource);
+        // Nothing to offer beside the first, either because the order has no value there or because
+        // a name the position wears is one this module cannot write.
+        if (value == null || base.stream().anyMatch(each -> each.text().equals(value.text()))) {
             return List.copyOf(base);
         }
         base.add(value);
@@ -1836,9 +1871,14 @@ public final class Partitions {
      */
     static List<FixtureTemplate> inReserve(Type type, RuleReadingSource ruleSource, ReadingPolicy policy,
                                            NumericDomain.Bounds within) {
+        return inReserve(TypeView.of(type, ruleSource.symbols()), ruleSource, policy, within);
+    }
+
+    /** The same, of a position that has already been read. */
+    static List<FixtureTemplate> inReserve(TypeView view, RuleReadingSource ruleSource,
+                                           ReadingPolicy policy, NumericDomain.Bounds within) {
         // A far edge is a rule's, and a rule is written on a name. A position wearing none carries
         // no rule of its own, so there is no edge here to hold anything back at.
-        TypeView view = TypeView.of(type, ruleSource.symbols());
         if (!view.isWrapped()) {
             return List.of();
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -7,8 +7,10 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.DeclaredBounds;
-import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.StringPredicates;
+import souther.compiler.check.DeclaredClauses;
+import souther.compiler.inputs.Distinctions;
+import souther.compiler.check.Shape;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.check.FieldDomains;
@@ -1239,87 +1241,234 @@ public final class Partitions {
     static List<FixtureTemplate> representativesOf(Type type, RuleReadingSource ruleSource, ReadingPolicy policy,
                                                    NumericDomain.Bounds within,
                                                    java.util.Set<TypeSymbol> expanding) {
-        if (type == null) {
-            return List.of();
+        return type == null ? List.of()
+                : representativesOf(TypeView.of(type, ruleSource.symbols()), ruleSource, policy,
+                        within, expanding);
+    }
+
+    /**
+     * The same, of a position that has already been read.
+     *
+     * <p>One reading, three answers taken from it. What the position is, with every name off, is what
+     * the values are made of; the rules of every name it wears are the rules its value is under; and
+     * the names themselves are what the value is written with. Held as one walk, how far to look to
+     * know what a rule is about and how far to descend to write the value were the same number — and
+     * one name is right for the second and wrong for the first, so a rule on a name that wraps a name
+     * was never reached.
+     *
+     * <p>Rules first, then what the shape stands for. Each rule is a reason to offer another value
+     * and never to withdraw one already offered: which of them the whole of the rules admits is the
+     * decoder's answer, so a position carrying a format and a floor gets a value from each and the
+     * order they were declared in does not decide whether one builds.
+     */
+    static List<FixtureTemplate> representativesOf(TypeView view, RuleReadingSource ruleSource,
+                                                   ReadingPolicy policy,
+                                                   NumericDomain.Bounds within,
+                                                   java.util.Set<TypeSymbol> expanding) {
+        // Already inside the value of one of the names this wears, so the type is written in terms of
+        // itself and there is nothing to hand back. Which is the answer and not a limit: no value of
+        // such a type exists.
+        java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
+        for (TypeOps.Layer layer : view.wrappers()) {
+            if (!inside.add(layer.named())) {
+                return List.of();
+            }
         }
-        if (type == Type.INT || type == Type.DECIMAL) {
-            Carrier carrier = type == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE;
-            Place at = inside(within, carrier);
-            FixtureTemplate standing = at == null ? null
-                    : FixtureTemplate.on(carrier, at, ruleSource.symbols().scope()::reach);
-            return standing == null ? List.of() : List.of(standing);
+        // What the rules ask for, and then what the position is where nothing was written about it.
+        List<FixtureTemplate> bare = new ArrayList<>();
+        bare.addAll(whereTheRulesLeaveTheValue(view, ruleSource, within));
+        bare.addAll(whatAFormatAsksFor(view, ruleSource));
+        // What the rules say the value holds, before the value that would hold nothing.
+        bare.addAll(Witnesses.holding(view.shape(), leastHeld(view.declared(), ruleSource),
+                ruleSource, policy, inside));
+        List<FixtureTemplate> ofTheShape =
+                whatTheShapeStandsFor(view.shape(), ruleSource, policy, within, inside);
+        bare.addAll(ofTheShape);
+
+        List<FixtureTemplate> candidates = new ArrayList<>();
+        for (FixtureTemplate each : bare) {
+            // A name this module cannot write leaves no value to write, and no candidate.
+            FixtureTemplate written = WornNames.under(view.wrappers(), each, ruleSource);
+            if (written != null) {
+                candidates.add(written);
+            }
         }
-        if (type == Type.STRING) {
-            return List.of(FixtureTemplate.string("x"));
+        // Where the shape stands for no value of its own, what stands at the position is one of the
+        // kinds its type divides into, and the classes are what name them. Asked only there: what a
+        // class says about the value a position holds is what stands at the position under it, and
+        // asking that of a shape that has a value of its own is the value asking for itself — an
+        // optional's `Some` is its element, met again while the element is being built.
+        if (ofTheShape.isEmpty()) {
+            candidates.addAll(dividedInto(view, ruleSource, policy, expanding));
         }
-        if (type == Type.BOOL) {
-            return List.of(FixtureTemplate.bool(true));
+        Map<String, FixtureTemplate> once = new LinkedHashMap<>();
+        for (FixtureTemplate each : candidates) {
+            once.putIfAbsent(each.text(), each);
         }
-        // A date is built from its ISO 8601 form, which is how a row writes one. One fixed day rather
-        // than today's: a generated row is compared with the last one to see what changed, and a value
-        // that read the clock would change every time nothing had.
-        if (type == Type.DATE) {
-            return List.of(FixtureTemplate.date("2000-01-01"));
-        }
-        if (type == Type.TIME) {
-            return List.of(FixtureTemplate.time("00:00:00"));
-        }
-        if (type == Type.DATETIME) {
-            return List.of(FixtureTemplate.dateTime("2000-01-01T00:00:00"));
-        }
-        if (type == Type.INSTANT) {
-            return List.of(FixtureTemplate.instant("2000-01-01T00:00:00Z"));
-        }
-        // The empty one, for every collection nothing has said otherwise about. A row whose collection
-        // is not what it is about should say so by carrying nothing, and where no rule counts what the
-        // position holds there is nothing else to go on. What a rule does say is read a layer out, at
-        // the newtype the rule is written on.
-        if (type instanceof Type.ListOf || type instanceof Type.SetOf || type instanceof Type.MapOf) {
-            return List.of(FixtureTemplate.emptyCollection());
-        }
-        // Absence, which every optional holds. Answered here rather than through the classes below
-        // because what the classes say about `Some` is what stands for the element, and asking that
-        // while the element is being built is the element asking for itself.
-        if (type instanceof Type.OptionOf) {
-            return List.of(FixtureTemplate.none());
-        }
-        List<PartitionClass> classes = PartitionClasses.of(type, ruleSource, policy);
-        for (PartitionClass each : classes) {
-            List<FixtureTemplate> stands = standingFor(each.representatives(), ruleSource, policy, expanding);
+        return List.copyOf(once.values());
+    }
+
+    /**
+     * What a position divides into, or nothing where its type states no division.
+     *
+     * <p>The first class anything can be produced for and not all of them: what is wanted here is a
+     * value of the position, and the classes are how a position that has more than one kind of value
+     * says which kinds there are. Their recipes carry the names the position wears already
+     * ({@link RepresentativeSource}), so nothing is put on them here.
+     *
+     * <p>Where there were classes and none produced a value, that is the answer. Each said nothing
+     * can be produced for it and why, and arriving at a value another way is this deciding the
+     * classes were wrong about themselves — the answer they carry is the one an author is shown.
+     */
+    private static List<FixtureTemplate> dividedInto(TypeView view, RuleReadingSource ruleSource,
+                                                     ReadingPolicy policy,
+                                                     java.util.Set<TypeSymbol> expanding) {
+        for (PartitionClass each : PartitionClasses.of(
+                Distinctions.ofType(view, ruleSource.symbols()), view, ruleSource, policy)) {
+            List<FixtureTemplate> stands =
+                    standingFor(each.representatives(), ruleSource, policy, expanding);
             if (!stands.isEmpty()) {
                 return stands;
             }
         }
-        // Where there were classes, they have answered. Each said nothing can be produced for it and
-        // why, and reading that and then arriving at a value another way is this deciding the classes
-        // were wrong about themselves — the answer they carry is the one an author is shown.
-        if (!classes.isEmpty()) {
+        return List.of();
+    }
+
+    /**
+     * The value at the edge the rules leave, or nothing where they leave no edge.
+     *
+     * <p>Read of the position and not of one of its names: a value wearing two names is bounded by
+     * the rules written on either, and both are what its reading came to. Nothing where no rule and
+     * no narrowing said anything — the value the position stands for is what answers there, and a
+     * number named here as well would be the same number said twice.
+     */
+    private static List<FixtureTemplate> whereTheRulesLeaveTheValue(TypeView view,
+                                                                    RuleReadingSource ruleSource,
+                                                                    NumericDomain.Bounds within) {
+        DeclaredBounds.Bounds own = DeclaredBounds.of(view, ruleSource);
+        if (own == null) {
+            return List.of();   // nothing here reads a number of this position at all
+        }
+        NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
+        Place held = bounds == null || bounds.saysNothing() ? null : inside(bounds, own.carrier());
+        FixtureTemplate at = held == null ? null
+                : FixtureTemplate.on(own.carrier(), held, ruleSource.symbols().scope()::reach);
+        return at == null ? List.of() : List.of(at);
+    }
+
+    /**
+     * A value each rule about the characters of a string admits, innermost name first.
+     *
+     * <p>Read in the representation the analysis reads, which is where a library predicate is still
+     * the operation it was written as. In the settled form it is the body it expands to, and the
+     * reading below has no word for that.
+     *
+     * <p>Innermost first, which is an order over the proposals and not over the rules: every name's
+     * rules govern the value, whichever end they are read from. What the order decides is which
+     * proposal a bounded search reaches before it stops, and the value a name wraps is the one its
+     * own rules were written closest to.
+     */
+    private static List<FixtureTemplate> whatAFormatAsksFor(TypeView view,
+                                                            RuleReadingSource ruleSource) {
+        if (!(view.shape() instanceof Shape.Scalar scalar) || scalar.prim() != Type.Prim.STRING) {
             return List.of();
         }
-        // A unit data is one value, and naming it writes it. Read through the classes above it has
-        // none — nothing tells its one value from another — so what stands for it is said here, in
-        // the same words a class of a sum says it in. Left out, a position holding one was a
-        // position nothing could write a value at, which is what a case of a sum narrows to.
-        if (type instanceof Type.Ref unit
-                && ruleSource.symbols().declaredNode(unit.name()) instanceof Hir.UnitData) {
-            return ruleSource.symbols().scope().reach(unit.name()) instanceof TypeReachName.Written written
-                    ? List.of(FixtureTemplate.unitCase(written)) : List.of();
-        }
-        // A newtype the model only bounds has no classes — everything outside the bound is refused at
-        // construction — but it does have values, and the edge of the bound is one that builds.
-        if (type instanceof Type.Ref(TypeSymbol.AtModule named)
-                && ruleSource.symbols().declaredNode(named) instanceof Hir.Data data) {
-            if (!data.newtype()) {
-                return composed(named, ruleSource, policy, expanding);
+        List<DeclaredClauses.OnAName> written = DeclaredClauses.of(view.wrappers(), ruleSource);
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (int name = written.size() - 1; name >= 0; name--) {
+            for (DeclaredClauses.Conjunct each : written.get(name).conjuncts()) {
+                // Asked of what the predicate means and not of what the decoder is told. The two are
+                // different questions: a constraint is what a generated class declares to the
+                // runtime, which is a format and nothing else, and this is which strings the rule
+                // admits — asked through the constraint, every predicate the decoder has no word for
+                // proposed no value, and a position an author had written a rule for was offered
+                // `"x"` and refused.
+                //
+                // Told which strings only where the reading came to them. Why it did not is the
+                // reading's to keep and nothing here has a use for it: a rule this could not read
+                // proposes no value, the same as one whose strings nobody can paste.
+                StringPredicates.Reading admits =
+                        StringPredicates.statedByWritten(each.expr(), ruleSource.symbols());
+                String text = admits instanceof StringPredicates.Reading.Accepting it
+                        ? writtenFor(it.accepts()) : null;
+                if (text != null) {
+                    out.add(FixtureTemplate.string(text));
+                }
             }
-            // A newtype nothing here names has no value anything here can write: the name goes on
-            // the value as it is written, and there is none to put on.
-            return ruleSource.symbols().scope().reach(named) instanceof TypeReachName.Written written
-                    ? insideTheNewtype(named, ruleSource, policy, within, expanding).stream()
-                            .map(t -> FixtureTemplate.newtype(written, t)).toList()
-                    : List.of();
         }
-        return List.of();
+        return out;
+    }
+
+    /**
+     * The value a shape stands for where nothing has been written about the position.
+     *
+     * <p>Exhaustive, with no {@code default}: what stands at a position is a question about each
+     * kind of position, and a shape added later is one this has to be told about rather than one
+     * that falls to whichever arm it was not named in.
+     */
+    private static List<FixtureTemplate> whatTheShapeStandsFor(Shape shape,
+                                                               RuleReadingSource ruleSource,
+                                                               ReadingPolicy policy,
+                                                               NumericDomain.Bounds within,
+                                                               java.util.Set<TypeSymbol> inside) {
+        return switch (shape) {
+            case Shape.Scalar scalar -> standsForA(scalar.prim(), within, ruleSource);
+            // The empty one, for every collection nothing has said otherwise about. A row whose
+            // collection is not what it is about should say so by carrying nothing, and where no rule
+            // counts what the position holds there is nothing else to go on.
+            case Shape.Sequence _, Shape.Mapping _ -> List.of(FixtureTemplate.emptyCollection());
+            // Absence, which every optional holds. Answered here rather than through the classes
+            // because what a class says about `Some` is what stands for the element, and asking that
+            // while the element is being built is the element asking for itself.
+            case Shape.Optional _ -> List.of(FixtureTemplate.none());
+            // A unit data is one value, and naming it writes it. Nothing tells its one value from
+            // another, so no class of the position names it and it is said here.
+            case Shape.Unit unit ->
+                    ruleSource.symbols().scope().reach(unit.name())
+                            instanceof TypeReachName.Written written
+                            ? List.of(FixtureTemplate.unitCase(written)) : List.of();
+            // A record is written field by field, against the rules relating them.
+            case Shape.Product product -> product.name() instanceof TypeSymbol.AtModule named
+                    ? composed(named, ruleSource, policy, inside) : List.of();
+            // What a sum or a union stands for is which of its cases it is, which is what the
+            // position divides into rather than a value to name here.
+            case Shape.Sum _, Shape.Cases _ -> List.of();
+            // And the shapes that carry no value of their own, or that this compiler could not read.
+            case Shape.Unresolved _, Shape.Tuple _, Shape.Function _, Shape.Uninhabited _,
+                 Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ -> List.of();
+        };
+    }
+
+    /** The value a primitive stands for, which for a number is one the position is left able to
+     *  hold and for everything else is one fixed value. */
+    private static List<FixtureTemplate> standsForA(Type.Prim prim, NumericDomain.Bounds within,
+                                                    RuleReadingSource ruleSource) {
+        return switch (prim) {
+            case INT, DECIMAL -> numberStandingFor(prim, within, ruleSource);
+            case STRING -> List.of(FixtureTemplate.string("x"));
+            case BOOL -> List.of(FixtureTemplate.bool(true));
+            // A date is built from its ISO 8601 form, which is how a row writes one. One fixed day
+            // rather than today's: a generated row is compared with the last one to see what changed,
+            // and a value that read the clock would change every time nothing had.
+            case DATE -> List.of(FixtureTemplate.date("2000-01-01"));
+            case TIME -> List.of(FixtureTemplate.time("00:00:00"));
+            case DATETIME -> List.of(FixtureTemplate.dateTime("2000-01-01T00:00:00"));
+            case INSTANT -> List.of(FixtureTemplate.instant("2000-01-01T00:00:00Z"));
+            // Bytes nobody wrote. What a row would carry is a value of somebody's making, and there
+            // is none here to make it out of.
+            case RAW -> List.of();
+        };
+    }
+
+    /** A number the position is left able to hold, or none where what is left of it holds none. */
+    private static List<FixtureTemplate> numberStandingFor(Type.Prim prim,
+                                                           NumericDomain.Bounds within,
+                                                           RuleReadingSource ruleSource) {
+        Carrier carrier = prim == Type.Prim.DECIMAL ? Carrier.DENSE : Carrier.WHOLE;
+        Place at = inside(within, carrier);
+        FixtureTemplate standing = at == null ? null
+                : FixtureTemplate.on(carrier, at, ruleSource.symbols().scope()::reach);
+        return standing == null ? List.of() : List.of(standing);
     }
 
     /**
@@ -1484,7 +1633,7 @@ public final class Partitions {
     static java.util.Set<CompositionBudget> notBuilt(Type type, RuleReadingSource ruleSource,
                                                      ReadingPolicy policy,
                                                      FieldDomains.Held held) {
-        return Witnesses.heldBackFor(TypeOps.base(type, ruleSource.symbols()),
+        return Witnesses.heldBackFor(TypeView.of(type, ruleSource.symbols()).shape(),
                 leastHeld(type, ruleSource, held), ruleSource, policy);
     }
 
@@ -1545,7 +1694,7 @@ public final class Partitions {
         // value holds and not what it is written as: a field of a newtype over a list takes a list
         // inside that newtype's own name.
         TypeView view = TypeView.of(type, ruleSource.symbols());
-        for (FixtureTemplate bare : Witnesses.holding(TypeOps.base(type, ruleSource.symbols()),
+        for (FixtureTemplate bare : Witnesses.holding(view.shape(),
                 leastHeld(type, ruleSource, held), ruleSource, policy, expanding)) {
             // A name this module cannot write leaves no value to write, and no candidate.
             FixtureTemplate written = WornNames.under(view.wrappers(), bare, ruleSource);
@@ -1633,93 +1782,6 @@ public final class Partitions {
     /** Whether a range holds a count, with no range holding everything. */
     private static boolean holdsCount(NumericDomain.Bounds range, Place at) {
         return range == null || range.admits(at);
-    }
-
-    /**
-     * What a newtype wraps: every value for it this can think of, in the order to try them.
-     *
-     * <p>Candidates, not an answer. Whether a newtype accepts a value is decided by its own
-     * constructor, and this only proposes — so a rule it reads is a reason to offer another value
-     * rather than to withdraw the ones already there. A format rule that cannot be read leaves the
-     * position with what it had before this could read any of them, and a newtype carrying two rules
-     * gets a value from each, which is why the order they are declared in does not decide whether one
-     * builds.
-     *
-     * <p>Both the bound on a number and the format of a string, in one place, because a newtype is
-     * asked for a value from two: a field of a record, and a case of a sum. Reading the rules in only
-     * one of them is how a value that holds everywhere came to be written in one place and not the
-     * other.
-     */
-    static List<FixtureTemplate> insideTheNewtype(TypeSymbol newtype, RuleReadingSource ruleSource,
-                                                  ReadingPolicy policy) {
-        return insideTheNewtype(newtype, ruleSource, policy, null, java.util.Set.of());
-    }
-
-    static List<FixtureTemplate> insideTheNewtype(TypeSymbol newtype, RuleReadingSource ruleSource,
-                                                          ReadingPolicy policy,
-                                                          NumericDomain.Bounds within,
-                                                          java.util.Set<TypeSymbol> expanding) {
-        // Already inside this one's own value, so the type is written in terms of itself and there is
-        // nothing to hand back. Which is the answer and not a limit: no value of such a type exists.
-        if (expanding.contains(newtype)) {
-            return List.of();
-        }
-        java.util.Set<TypeSymbol> inside = new java.util.LinkedHashSet<>(expanding);
-        inside.add(newtype);
-        Type base = TypeOps.newtypeInner(newtype, ruleSource.symbols());
-        List<FixtureTemplate> candidates = new ArrayList<>();
-
-        DeclaredBounds.Bounds own =
-                DeclaredBounds.of(TypeView.of(new Type.Ref(newtype), ruleSource.symbols()), ruleSource);
-        NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
-        Place held = bounds == null || bounds.saysNothing() ? null : inside(bounds, own.carrier());
-        FixtureTemplate at = held == null ? null
-                : FixtureTemplate.on(own.carrier(), held, ruleSource.symbols().scope()::reach);
-        if (at != null) {
-            candidates.add(at);
-        }
-        if (base == Type.STRING
-                && ruleSource.symbols().declaredNode(newtype) instanceof Hir.Data data) {
-            // Read in the representation the analysis reads, which is where a library predicate is
-            // still the operation it was written as. In the settled form it is the body it expands
-            // to, and the reading below has no word for that.
-            for (Hir.InvariantClause clause : TypeOps.analysisInvariants(
-                    newtype instanceof TypeSymbol.AtModule declared ? declared : null, data,
-                    ruleSource.symbols(), ruleSource.invariants())) {
-                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
-                    // Asked of what the predicate means and not of what the decoder is told. The
-                    // two are different questions: a constraint is what a generated class declares
-                    // to the runtime, which is a format and nothing else, and this is which strings
-                    // the rule admits — asked through the constraint, every predicate the decoder
-                    // has no word for proposed no value, and a position an author had written a
-                    // rule for was offered `"x"` and refused.
-                    //
-                    // Told which strings only where the reading came to them. Why it did not is
-                    // the reading's to keep and nothing here has a use for it: a rule this could
-                    // not read proposes no value, the same as one whose strings nobody can paste.
-                    StringPredicates.Reading admits =
-                            StringPredicates.statedByWritten(each, ruleSource.symbols());
-                    String written = admits instanceof StringPredicates.Reading.Accepting it
-                            ? writtenFor(it.accepts()) : null;
-                    if (written != null) {
-                        candidates.add(FixtureTemplate.string(written));
-                    }
-                }
-            }
-        }
-        // What the rules say the value holds, before the value that would hold nothing. A format and a
-        // minimum are two proposals and not a choice between them: each is what one rule asks for, and
-        // which of them the whole of the rules admits is the decoder's answer rather than an order
-        // settled here.
-        candidates.addAll(Witnesses.holding(base, leastHeld(new Type.Ref(newtype), ruleSource),
-                ruleSource, policy, inside));
-        candidates.addAll(representativesOf(base, ruleSource, policy, null, inside));
-
-        Map<String, FixtureTemplate> once = new LinkedHashMap<>();
-        for (FixtureTemplate each : candidates) {
-            once.putIfAbsent(each.text(), each);
-        }
-        return List.copyOf(once.values());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -10,6 +10,7 @@ import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.StringPredicates;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.NarrowedBounds;
 import souther.compiler.inputs.InputDomain;
@@ -1504,7 +1505,8 @@ public final class Partitions {
         if (base == null) {
             return null;
         }
-        NumericDomain.Bounds range = TypeBounds.admissible(DeclaredBounds.of(type, ruleSource), null);
+        NumericDomain.Bounds range = TypeBounds.admissible(
+                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource), null);
         Place from = inside(range, base == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE);
         if (from == null || base != Type.INT) {
             return from != null && index == 0 ? from : null;
@@ -1586,7 +1588,8 @@ public final class Partitions {
         if (numeric == null) {
             return List.copyOf(base);
         }
-        NumericDomain.Bounds range = TypeBounds.admissible(DeclaredBounds.of(type, ruleSource), within);
+        NumericDomain.Bounds range = TypeBounds.admissible(
+                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource), within);
         Carrier carrier = numeric == Type.INT ? Carrier.WHOLE : Carrier.DENSE;
         Place step = displaced(range, carrier);
         if (step == null) {
@@ -1661,7 +1664,8 @@ public final class Partitions {
         Type base = TypeOps.newtypeInner(newtype, ruleSource.symbols());
         List<FixtureTemplate> candidates = new ArrayList<>();
 
-        DeclaredBounds.Bounds own = DeclaredBounds.of(new Type.Ref(newtype), ruleSource);
+        DeclaredBounds.Bounds own =
+                DeclaredBounds.of(TypeView.of(new Type.Ref(newtype), ruleSource.symbols()), ruleSource);
         NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         Place held = bounds == null || bounds.saysNothing() ? null : inside(bounds, own.carrier());
         FixtureTemplate at = held == null ? null
@@ -1769,7 +1773,8 @@ public final class Partitions {
                 || !data.newtype()) {
             return List.of();
         }
-        DeclaredBounds.Bounds own = DeclaredBounds.of(type, ruleSource);
+        DeclaredBounds.Bounds own =
+                DeclaredBounds.of(TypeView.of(type, ruleSource.symbols()), ruleSource);
         NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         // The far end has to be a value the position holds. Where the range stops short of it there
         // is nothing there to hold back, and a dense order has no value beside it to hold back

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1417,7 +1417,7 @@ public final class Partitions {
                                                                NumericDomain.Bounds within,
                                                                java.util.Set<TypeSymbol> inside) {
         return switch (shape) {
-            case Shape.Scalar scalar -> standsForA(scalar.prim(), within, ruleSource);
+            case Shape.Scalar scalar -> standsForA(scalar, within, ruleSource);
             // The empty one, for every collection nothing has said otherwise about. A row whose
             // collection is not what it is about should say so by carrying nothing, and where no rule
             // counts what the position holds there is nothing else to go on.
@@ -1446,10 +1446,10 @@ public final class Partitions {
 
     /** The value a primitive stands for, which for a number is one the position is left able to
      *  hold and for everything else is one fixed value. */
-    private static List<FixtureTemplate> standsForA(Type.Prim prim, NumericDomain.Bounds within,
+    private static List<FixtureTemplate> standsForA(Shape.Scalar scalar, NumericDomain.Bounds within,
                                                     RuleReadingSource ruleSource) {
-        return switch (prim) {
-            case INT, DECIMAL -> numberStandingFor(prim, within, ruleSource);
+        return switch (scalar.prim()) {
+            case INT, DECIMAL -> numberStandingFor(numbersOf(scalar), within, ruleSource);
             case STRING -> List.of(FixtureTemplate.string("x"));
             case BOOL -> List.of(FixtureTemplate.bool(true));
             // A date is built from its ISO 8601 form, which is how a row writes one. One fixed day
@@ -1466,10 +1466,9 @@ public final class Partitions {
     }
 
     /** A number the position is left able to hold, or none where what is left of it holds none. */
-    private static List<FixtureTemplate> numberStandingFor(Type.Prim prim,
+    private static List<FixtureTemplate> numberStandingFor(Carrier carrier,
                                                            NumericDomain.Bounds within,
                                                            RuleReadingSource ruleSource) {
-        Carrier carrier = prim == Type.Prim.DECIMAL ? Carrier.DENSE : Carrier.WHOLE;
         Place at = inside(within, carrier);
         FixtureTemplate standing = at == null ? null
                 : FixtureTemplate.on(carrier, at, ruleSource.symbols().scope()::reach);
@@ -1667,18 +1666,44 @@ public final class Partitions {
      * names the one number inside its range and no more.
      */
     static Place numberInside(TypeView view, RuleReadingSource ruleSource, int index) {
-        Type base = TypeOps.numericBase(view.declared(), ruleSource.symbols());
-        if (base == null) {
+        Carrier carrier = numbersOf(view.shape());
+        if (carrier == null) {
             return null;
         }
         NumericDomain.Bounds range =
                 TypeBounds.admissible(DeclaredBounds.of(view, ruleSource), null);
-        Place from = inside(range, base == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE);
-        if (from == null || base != Type.INT) {
+        Place from = inside(range, carrier);
+        if (from == null || carrier != Carrier.WHOLE) {
             return from != null && index == 0 ? from : null;
         }
         Count stepped = Count.number(from).plus(index);
         return holdsCount(range, stepped) ? stepped : null;
+    }
+
+    /**
+     * The order a position's own numbers are counted on, or null where its values are not numbers.
+     *
+     * <p>Of the shape, which is what the position is with every name off — so this is a projection
+     * of the reading and not a second look at what the names wrap. Asked of the type instead, it
+     * walked the names again to find the number under them, which is the reading's answer and was
+     * already in hand.
+     *
+     * <p>Exhaustive over the primitives, with no {@code default}: whether a primitive's values are
+     * counted is a question about each of them, and one added later is one this has to be told about
+     * rather than one that falls to the arm it was not named in.
+     */
+    private static Carrier numbersOf(Shape shape) {
+        if (!(shape instanceof Shape.Scalar scalar)) {
+            return null;
+        }
+        return switch (scalar.prim()) {
+            case INT -> Carrier.WHOLE;
+            case DECIMAL -> Carrier.DENSE;
+            // Ordered, some of them, and none of them counted in numbers of its own: a date is a
+            // count of days and a string a count of characters, which is what a rule about them
+            // counts rather than what the value is.
+            case STRING, BOOL, DATE, TIME, DATETIME, INSTANT, RAW -> null;
+        };
     }
 
     /**
@@ -1771,13 +1796,12 @@ public final class Partitions {
                 base.add(kept);
             }
         }
-        Type numeric = TypeOps.numericBase(type, ruleSource.symbols());
-        if (numeric == null) {
+        Carrier carrier = numbersOf(view.shape());
+        if (carrier == null) {
             return List.copyOf(base);
         }
         NumericDomain.Bounds range =
                 TypeBounds.admissible(DeclaredBounds.of(view, ruleSource), within);
-        Carrier carrier = numeric == Type.INT ? Carrier.WHOLE : Carrier.DENSE;
         Place step = displaced(range, carrier);
         if (step == null) {
             return List.copyOf(base);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -977,7 +977,7 @@ public final class Partitions {
     /** A count written at a position, wearing every name that position declares. */
     private static FixtureTemplate standing(Type type, Carrier carrier, Place at,
             RuleReadingSource ruleSource) {
-        return Witnesses.wrapped(type,
+        return WornNames.under(TypeView.of(type, ruleSource.symbols()).wrappers(),
                 FixtureTemplate.on(carrier, at, ruleSource.symbols().scope()::reach), ruleSource);
     }
 
@@ -1544,9 +1544,14 @@ public final class Partitions {
         // Under every name the position wears, because a floor read off the record says how much the
         // value holds and not what it is written as: a field of a newtype over a list takes a list
         // inside that newtype's own name.
+        TypeView view = TypeView.of(type, ruleSource.symbols());
         for (FixtureTemplate bare : Witnesses.holding(TypeOps.base(type, ruleSource.symbols()),
                 leastHeld(type, ruleSource, held), ruleSource, policy, expanding)) {
-            candidates.add(Witnesses.wrapped(type, bare, ruleSource));
+            // A name this module cannot write leaves no value to write, and no candidate.
+            FixtureTemplate written = WornNames.under(view.wrappers(), bare, ruleSource);
+            if (written != null) {
+                candidates.add(written);
+            }
         }
         candidates.addAll(representativesOf(type, ruleSource, policy, within, expanding));
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -3,11 +3,9 @@ package souther.compiler.partition;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.Shape;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.types.TypeReachName;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,28 +66,15 @@ final class PlanComposer {
             // none did: what stands at a slot is a value of the narrowed type, already written
             // under whatever names that type wears, and a `data DecisionN = Decision` narrowed to
             // one of its cases is written `DecisionN(...)` all the same.
-            case ConstructionPlan.Slot slot -> worn(slot.worn(), values.at(slot), ruleSource);
+            case ConstructionPlan.Slot slot ->
+                    WornNames.under(slot.worn(), values.at(slot), ruleSource);
             case ConstructionPlan.Built built -> composed(built, values, ruleSource, policy);
             case ConstructionPlan.Held held -> held(held, values, ruleSource, policy);
             // The requirement settled this one, so nothing was chosen for it and there is nothing to
             // look up. Under every name the position wears, since the value arrives bare.
-            case ConstructionPlan.Exact exact -> worn(exact.worn(), exact.exact(), ruleSource);
+            case ConstructionPlan.Exact exact ->
+                    WornNames.under(exact.worn(), exact.exact(), ruleSource);
         };
-    }
-
-    /**
-     * {@code value} under {@code worn}, or {@code value} where nothing is worn over it.
-     *
-     * <p>Null where a name the position wears is one this module cannot write, which is a value
-     * that cannot be written rather than one written without the name.
-     */
-    static FixtureTemplate worn(List<TypeOps.Layer> worn, FixtureTemplate value,
-                                RuleReadingSource ruleSource) {
-        if (value == null || worn.isEmpty()) {
-            return value;
-        }
-        return WornNames.of(worn, ruleSource) instanceof WornNames.Spelled spelled
-                ? RepresentativeSource.under(spelled.names(), value) : null;
     }
 
     /**
@@ -119,7 +104,7 @@ final class PlanComposer {
             return null;
         }
         // A name this module cannot write leaves no value to write.
-        return worn(plan.worn(), collection, ruleSource);
+        return WornNames.under(plan.worn(), collection, ruleSource);
     }
 
     /** One record of the plan, out of whatever the caller has at the positions under it. */
@@ -142,7 +127,7 @@ final class PlanComposer {
         // it wore before the narrowing and the ones the narrowed value wears after it. One list and
         // one putting-back-on: read as two, the outer names had to be recovered from the class that
         // asked for the narrowing rather than from the position they belong to.
-        return worn(built.worn(), FixtureTemplate.record(written, fields), ruleSource);
+        return WornNames.under(built.worn(), FixtureTemplate.record(written, fields), ruleSource);
     }
 
     private PlanComposer() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -7,7 +7,6 @@ import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.types.TypeReachName;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -89,30 +88,8 @@ final class PlanComposer {
         if (value == null || worn.isEmpty()) {
             return value;
         }
-        List<TypeReachName.Written> names = written(worn, ruleSource);
-        return names == null ? null : RepresentativeSource.under(names, value);
-    }
-
-    /**
-     * The names a position wears as this module writes them, or null where one of them is a name it
-     * cannot write.
-     *
-     * <p>Null takes the whole value with it: the name goes on the value as it is written, and a
-     * value composed without one is of a type the parameter does not declare. Asked in one place
-     * because every value this composes needs the same answer, and three copies of the loop are
-     * three chances to differ about what a name this module cannot reach comes to.
-     */
-    private static List<TypeReachName.Written> written(List<TypeOps.Layer> worn,
-                                                       RuleReadingSource ruleSource) {
-        List<TypeReachName.Written> names = new ArrayList<>();
-        for (TypeOps.Layer layer : worn) {
-            if (!(ruleSource.symbols().scope().reach(layer.named())
-                    instanceof TypeReachName.Written name)) {
-                return null;
-            }
-            names.add(name);
-        }
-        return names;
+        return WornNames.of(worn, ruleSource) instanceof WornNames.Spelled spelled
+                ? RepresentativeSource.under(spelled.names(), value) : null;
     }
 
     /**
@@ -142,8 +119,7 @@ final class PlanComposer {
             return null;
         }
         // A name this module cannot write leaves no value to write.
-        List<TypeReachName.Written> worn = written(plan.worn(), ruleSource);
-        return worn == null ? null : RepresentativeSource.under(worn, collection);
+        return worn(plan.worn(), collection, ruleSource);
     }
 
     /** One record of the plan, out of whatever the caller has at the positions under it. */
@@ -158,17 +134,15 @@ final class PlanComposer {
         // off to find them. A row at a `data SlotN = Slot` carries `SlotN(Slot { ... })`, and a value
         // composed without them is of a type the parameter does not declare.
         // A name this module cannot write leaves no value to write.
-        List<TypeReachName.Written> worn = written(built.worn(), ruleSource);
-        if (worn == null
-                || !(ruleSource.symbols().scope().reach(built.of())
-                        instanceof TypeReachName.Written written)) {
+        if (!(ruleSource.symbols().scope().reach(built.of())
+                instanceof TypeReachName.Written written)) {
             return null;
         }
         // Under every name the position wears, which where a refinement narrowed it are the names
         // it wore before the narrowing and the ones the narrowed value wears after it. One list and
         // one putting-back-on: read as two, the outer names had to be recovered from the class that
         // asked for the narrowing rather than from the position they belong to.
-        return RepresentativeSource.under(worn, FixtureTemplate.record(written, fields));
+        return worn(built.worn(), FixtureTemplate.record(written, fields), ruleSource);
     }
 
     private PlanComposer() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermOrders;
@@ -252,8 +251,8 @@ final class TermRealizations {
             return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        Type holder = TypeOps.base(sourceType, ruleSource.symbols());
-        Witnesses.Sized built = Witnesses.ofSize(holder, many, ruleSource, policy, Set.of());
+        TypeView holder = TypeView.of(sourceType, ruleSource.symbols());
+        Witnesses.Sized built = Witnesses.ofSize(holder.shape(), many, ruleSource, policy, Set.of());
         if (built.values().isEmpty()) {
             // Read off the build that was already done. `Witnesses` keeps what it made and why it
             // stopped as two halves of one answer for exactly this, and asking it again would be
@@ -264,10 +263,9 @@ final class TermRealizations {
                             Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
                     : new Realization.Stopped(built.heldBack());
         }
-        List<TypeOps.Layer> worn = TypeView.of(sourceType, ruleSource.symbols()).wrappers();
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : built.values()) {
-            FixtureTemplate standing = WornNames.under(worn, each, ruleSource);
+            FixtureTemplate standing = WornNames.under(holder.wrappers(), each, ruleSource);
             // A name this module cannot write leaves no value to write, which is a position nothing
             // composes one for rather than a value written without the name.
             if (standing == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -252,6 +252,13 @@ final class TermRealizations {
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         TypeView holder = TypeView.of(sourceType, ruleSource.symbols());
+        // A name this module cannot write leaves no value to write, which is a position nothing
+        // composes one for rather than a value written without the name. Asked of the position
+        // before anything is built for it, since it is the same answer for every value.
+        if (!(WornNames.of(holder.wrappers(), ruleSource) instanceof WornNames.Spelled worn)) {
+            return new Realization.None(
+                    Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+        }
         Witnesses.Sized built = Witnesses.ofSize(holder.shape(), many, ruleSource, policy, Set.of());
         if (built.values().isEmpty()) {
             // Read off the build that was already done. `Witnesses` keeps what it made and why it
@@ -265,14 +272,7 @@ final class TermRealizations {
         }
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : built.values()) {
-            FixtureTemplate standing = WornNames.under(holder.wrappers(), each, ruleSource);
-            // A name this module cannot write leaves no value to write, which is a position nothing
-            // composes one for rather than a value written without the name.
-            if (standing == null) {
-                return new Realization.None(
-                        Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
-            }
-            out.add(standing);
+            out.add(RepresentativeSource.under(worn.names(), each));
         }
         return new Realization.Built(out, built.heldBack());
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -4,6 +4,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.numeric.Count;
@@ -263,9 +264,17 @@ final class TermRealizations {
                             Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
                     : new Realization.Stopped(built.heldBack());
         }
+        List<TypeOps.Layer> worn = TypeView.of(sourceType, ruleSource.symbols()).wrappers();
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : built.values()) {
-            out.add(Witnesses.wrapped(sourceType, each, ruleSource));
+            FixtureTemplate standing = WornNames.under(worn, each, ruleSource);
+            // A name this module cannot write leaves no value to write, which is a position nothing
+            // composes one for rather than a value written without the name.
+            if (standing == null) {
+                return new Realization.None(
+                        Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+            }
+            out.add(standing);
         }
         return new Realization.Built(out, built.heldBack());
     }
@@ -296,7 +305,8 @@ final class TermRealizations {
         }
         Place seconds = Count.of(count.at()
                 .multiply(java.math.BigDecimal.valueOf(part.seconds())));
-        FixtureTemplate standing = Witnesses.wrapped(sourceType,
+        FixtureTemplate standing = WornNames.under(
+                TypeView.of(sourceType, ruleSource.symbols()).wrappers(),
                 FixtureTemplate.on(observed, seconds, ruleSource.symbols().scope()::reach), ruleSource);
         return standing == null
                 ? new Realization.None(
@@ -336,8 +346,10 @@ final class TermRealizations {
             return new Realization.None(
                     Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        FixtureTemplate standing = Witnesses.wrapped(sourceType,
-                FixtureTemplate.on(observed, Dates.dayOf(on), ruleSource.symbols().scope()::reach), ruleSource);
+        FixtureTemplate standing = WornNames.under(
+                TypeView.of(sourceType, ruleSource.symbols()).wrappers(),
+                FixtureTemplate.on(observed, Dates.dayOf(on), ruleSource.symbols().scope()::reach),
+                ruleSource);
         return standing == null
                 ? new Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
@@ -401,7 +413,8 @@ final class TermRealizations {
 
     /** One value, wearing every name the position declares, or the reason there is none. */
     private static Realization oneValue(FixtureTemplate bare, Type sourceType, RuleReadingSource ruleSource) {
-        FixtureTemplate standing = Witnesses.wrapped(sourceType, bare, ruleSource);
+        FixtureTemplate standing = WornNames.under(
+                TypeView.of(sourceType, ruleSource.symbols()).wrappers(), bare, ruleSource);
         return standing == null
                 ? new Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValueClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValueClasses.java
@@ -1,8 +1,8 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
@@ -35,7 +35,7 @@ final class ValueClasses {
      */
     static PartitionClass classAt(Value value, TypeView view, List<TypeSymbol> worn,
                                   RuleReadingSource ruleSource) {
-        FixtureTemplate bare = written(value, view.declared(), ruleSource.symbols());
+        FixtureTemplate bare = written(value, view.shape());
         if (bare == null) {
             throw new IllegalStateException(
                     "the reading of `" + Type.show(view.declared()) + "` states a distinction at a"
@@ -97,17 +97,18 @@ final class ValueClasses {
     /**
      * The value as a row writes it, or null where this does not write values of that kind.
      *
-     * <p>Which of {@code Int} and {@code Decimal} a number is written as is the position's own type
-     * to say. The two are never compared with each other (E1319), so a position is written about in
-     * one of them and never in both.
+     * <p>Which of {@code Int} and {@code Decimal} a number is written as is what the position is
+     * with its names off, which the reading of it already says. The two are never compared with each
+     * other (E1319), so a position is written about in one of them and never in both.
      */
-    private static FixtureTemplate written(Value value, Type type, Symbols symbols) {
+    private static FixtureTemplate written(Value value, Shape shape) {
         return switch (value) {
             case Value.Text text -> FixtureTemplate.string(text.value());
             case Value.Truth truth -> FixtureTemplate.bool(truth.value());
-            case Value.Number number -> TypeOps.numericBase(type, symbols) == Type.DECIMAL
-                    ? FixtureTemplate.decimal(number.value())
-                    : whole(number.value());
+            case Value.Number number ->
+                    shape instanceof Shape.Scalar scalar && scalar.prim() == Type.Prim.DECIMAL
+                            ? FixtureTemplate.decimal(number.value())
+                            : whole(number.value());
             case Value.Case _ -> null;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValueClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValueClasses.java
@@ -45,7 +45,7 @@ final class ValueClasses {
         Recognition is = Recognition.Under.of(worn,
                 new Recognition.AtAValue(value,
                         placeOf(value, view.declared(), ruleSource.symbols())));
-        FixtureTemplate stands = Witnesses.wrapped(view.declared(), bare, ruleSource);
+        FixtureTemplate stands = WornNames.under(view.wrappers(), bare, ruleSource);
         return (stands == null
                 // A name the position wears that nothing here writes. The class is the position's
                 // either way and a row already sitting in it still covers it; what is absent is the

--- a/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ValuesCarryingANumber.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.TypeView;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.TypeSymbol;
 
@@ -38,7 +39,9 @@ record ValuesCarryingANumber(TermPath fixed, FixtureTemplate value, RuleReadingS
         // plan's `worn` is what a value already wearing those is still missing, which is what a
         // value chosen at a slot by a search is.
         return slot.at().equals(fixed)
-                ? Witnesses.wrapped(slot.type(), value, ruleSource) : null;
+                ? WornNames.under(TypeView.of(slot.type(), ruleSource.symbols()).wrappers(),
+                        value, ruleSource)
+                : null;
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -1,14 +1,13 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.ReadingPolicy;
-import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.numeric.Place;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.TypeOps;
+import souther.compiler.check.Shape;
+import souther.compiler.check.TypeView;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
-import souther.compiler.types.TypeReachName;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -441,37 +440,20 @@ final class Witnesses {
      * not to offer — which is what the values a type divides into are for, above.
      */
     private static FixtureTemplate varied(Type type, int index, RuleReadingSource ruleSource) {
-        Type carrier = TypeOps.base(type, ruleSource.symbols());
-        if (carrier == Type.STRING) {
-            return wrapped(type, FixtureTemplate.string(
-                    "x".repeat(Math.max(1, Partitions.leastHeld(type, ruleSource)) + index)), ruleSource);
+        TypeView view = TypeView.of(type, ruleSource.symbols());
+        if (view.shape() instanceof Shape.Scalar scalar && scalar.prim() == Type.Prim.STRING) {
+            return WornNames.under(view.wrappers(), FixtureTemplate.string(
+                    "x".repeat(Math.max(1, Partitions.leastHeld(type, ruleSource)) + index)),
+                    ruleSource);
         }
         Place at = Partitions.numberInside(type, ruleSource, index);
         if (at == null) {
             return null;
         }
-        return wrapped(type, FixtureTemplate.on(
-                carrier == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE, at, ruleSource.symbols().scope()::reach), ruleSource);
-    }
-
-    /**
-     * The value under every name the position wears, which is how it is written where the position
-     * declares a newtype rather than what the newtype carries.
-     *
-     * <p>Null where {@code bare} is, and where a name the position wears is one this module cannot
-     * write: a value goes under the names as it is written, so a name there is nothing here reaches
-     * leaves no way of writing the value at all.
-     */
-    static FixtureTemplate wrapped(Type type, FixtureTemplate bare, RuleReadingSource ruleSource) {
-        if (bare == null || !(type instanceof Type.Ref ref)
-                || !(ruleSource.symbols().declaredNode(ref.name()) instanceof Hir.Data data) || !data.newtype()) {
-            return bare;
-        }
-        TypeSymbol name = ref.name();
-        FixtureTemplate inner =
-                wrapped(TypeOps.newtypeInner(name, ruleSource.symbols()), bare, ruleSource);
-        return inner != null && ruleSource.symbols().scope().reach(name) instanceof TypeReachName.Written written
-                ? FixtureTemplate.newtype(written, inner) : null;
+        Carrier carrier = view.shape() instanceof Shape.Scalar scalar
+                && scalar.prim() == Type.Prim.DECIMAL ? Carrier.DENSE : Carrier.WHOLE;
+        return WornNames.under(view.wrappers(), FixtureTemplate.on(
+                carrier, at, ruleSource.symbols().scope()::reach), ruleSource);
     }
 
     private Witnesses() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -97,13 +97,21 @@ final class Witnesses {
      * proposal for a floor and are not the count asked for here, and offering them would put a row of
      * two under a line drawn at three.
      */
-    static Sized ofSize(Type carrier, int size, RuleReadingSource ruleSource, ReadingPolicy policy,
+    static Sized ofSize(Shape carrier, int size, RuleReadingSource ruleSource, ReadingPolicy policy,
                         Set<TypeSymbol> expanding) {
         if (size == 0) {
-            return Sized.all(carrier == Type.STRING ? List.of(FixtureTemplate.string(""))
-                    : carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
-                            || carrier instanceof Type.MapOf
-                                    ? List.of(FixtureTemplate.collection(List.of())) : List.of());
+            // The same shapes {@link #sized} builds for, and for the same reason they are written
+            // out: what a value of none looks like is a question about each shape.
+            return Sized.all(switch (carrier) {
+                case Shape.Scalar scalar when scalar.prim() == Type.Prim.STRING ->
+                        List.of(FixtureTemplate.string(""));
+                case Shape.Sequence _, Shape.Mapping _ ->
+                        List.of(FixtureTemplate.collection(List.of()));
+                case Shape.Scalar _, Shape.Product _, Shape.Sum _, Shape.Unit _, Shape.Optional _,
+                     Shape.Unresolved _, Shape.Cases _, Shape.Tuple _, Shape.Function _,
+                     Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _,
+                     Shape.Undecided _ -> List.<FixtureTemplate>of();
+            });
         }
         Built built = sized(carrier, size, ruleSource, policy, expanding);
         return new Sized(built.exactly(size), built.heldBack());
@@ -121,7 +129,7 @@ final class Witnesses {
      * ({@link Sized#heldBack()}) and travels as itself; what is here is the word a search comes back
      * with, for readers that have only ever wanted that.
      */
-    static Generator.UnresolvedCombination.Reason reasonForSize(Type carrier, int size,
+    static Generator.UnresolvedCombination.Reason reasonForSize(Shape carrier, int size,
                                                                 ReadingPolicy policy,
                                                                 RuleReadingSource ruleSource) {
         Sized made = ofSize(carrier, size, ruleSource, policy, Set.of());
@@ -153,7 +161,7 @@ final class Witnesses {
      * too few values for comes back as nothing at all. The two read one build and neither is written
      * in terms of the other, so a cheaper value for a floor cannot move a line.
      */
-    static List<FixtureTemplate> holding(Type carrier, int least, RuleReadingSource ruleSource,
+    static List<FixtureTemplate> holding(Shape carrier, int least, RuleReadingSource ruleSource,
                                          ReadingPolicy policy,
                                          Set<TypeSymbol> expanding) {
         return least <= 0 ? List.of() : sized(carrier, least, ruleSource, policy, expanding).all();
@@ -171,7 +179,7 @@ final class Witnesses {
      * floor nothing was built for is a position offering what it ordinarily offers, and naming a
      * reason there would put "nothing composes one" under every position that has no floor at all.
      */
-    static Set<CompositionBudget> heldBackFor(Type carrier, int least, RuleReadingSource ruleSource,
+    static Set<CompositionBudget> heldBackFor(Shape carrier, int least, RuleReadingSource ruleSource,
                                               ReadingPolicy policy) {
         return least <= 0 ? Set.of()
                 : sized(carrier, least, ruleSource, policy, Set.of()).heldBack();
@@ -214,50 +222,68 @@ final class Witnesses {
         }
     }
 
-    private static Built sized(Type carrier, int least, RuleReadingSource ruleSource, ReadingPolicy policy,
+    private static Built sized(Shape carrier, int least, RuleReadingSource ruleSource, ReadingPolicy policy,
                                Set<TypeSymbol> expanding) {
-        if (carrier == null || least <= 0) {
+        if (least <= 0) {
             return Built.NONE;
         }
-        // A string is counted by its characters, and one character is as good as another where the
-        // rule is about how many there are. What a format asks for instead is a proposal of its own,
-        // put beside this one by the caller.
-        if (carrier == Type.STRING) {
-            return least > MOST_CHARACTERS
-                    ? Built.stoppedBy(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS)
-                    : Built.of(List.of(new Made(FixtureTemplate.string("x".repeat(least)), least)));
-        }
-        if (!(carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
-                || carrier instanceof Type.MapOf)) {
-            return Built.NONE;
-        }
-        if (least > MOST_ELEMENTS) {
-            return Built.stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS);
-        }
-        // A list may hold the same element as many times as it needs to.
-        if (carrier instanceof Type.ListOf list) {
-            List<Made> out = new ArrayList<>();
-            for (FixtureTemplate each : proposalsFor(list.element(), ruleSource, policy, expanding)) {
-                List<FixtureTemplate> elements = new ArrayList<>();
+        // Exhaustive over what a position can be, with no `default`. Whether a value of a shape
+        // counts anything is a question about each of them, and a chain of tests answers "no" for a
+        // shape added later without being asked.
+        return switch (carrier) {
+            // A string is counted by its characters, and one character is as good as another where
+            // the rule is about how many there are. What a format asks for instead is a proposal of
+            // its own, put beside this one by the caller.
+            case Shape.Scalar scalar when scalar.prim() == Type.Prim.STRING ->
+                    least > MOST_CHARACTERS
+                            ? Built.stoppedBy(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS)
+                            : Built.of(List.of(
+                                    new Made(FixtureTemplate.string("x".repeat(least)), least)));
+            case Shape.Sequence sequence -> least > MOST_ELEMENTS
+                    ? Built.stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS)
+                    : ofSequence(sequence, least, ruleSource, policy, expanding);
+            case Shape.Mapping mapping -> least > MOST_ELEMENTS
+                    ? Built.stoppedBy(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS)
+                    : ofMapping(mapping, least, ruleSource, policy, expanding);
+            // Nothing else has a count this builds to. A number is one value however many the rules
+            // ask for, a record holds its fields and not a number of them, and the shapes that are
+            // not value shapes have no value to count.
+            case Shape.Scalar _, Shape.Product _, Shape.Sum _, Shape.Unit _, Shape.Optional _,
+                 Shape.Unresolved _, Shape.Cases _, Shape.Tuple _, Shape.Function _,
+                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _,
+                 Shape.Undecided _ -> Built.NONE;
+        };
+    }
+
+    /**
+     * A list of that many, or a set of that many no two of which are equal.
+     *
+     * <p>A list may hold the same element as many times as it needs to. A set of three is three
+     * elements no two of which are equal, which the element's own values have to supply.
+     */
+    private static Built ofSequence(Shape.Sequence carrier, int least, RuleReadingSource ruleSource,
+                                    ReadingPolicy policy, Set<TypeSymbol> expanding) {
+        List<Made> out = new ArrayList<>();
+        for (FixtureTemplate seed
+                : proposalsFor(carrier.element(), ruleSource, policy, expanding)) {
+            List<FixtureTemplate> elements = new ArrayList<>();
+            if (carrier.kind() == Shape.Sequence.Kind.LIST) {
                 for (int i = 0; i < least; i++) {
-                    elements.add(each);
+                    elements.add(seed);
                 }
-                out.add(new Made(FixtureTemplate.collection(elements), elements.size()));
+            } else {
+                elements.addAll(
+                        distinctFrom(seed, carrier.element(), least, policy, ruleSource, expanding));
             }
-            return Built.of(out);
+            out.add(new Made(FixtureTemplate.collection(elements), elements.size()));
         }
-        // A set of three is three elements no two of which are equal, and a map of three is three
-        // entries no two of which share a key. The values under a map's keys are free to repeat.
-        if (carrier instanceof Type.SetOf set) {
-            List<Made> out = new ArrayList<>();
-            for (FixtureTemplate seed : proposalsFor(set.element(), ruleSource, policy, expanding)) {
-                List<FixtureTemplate> elements =
-                        distinctFrom(seed, set.element(), least, policy, ruleSource, expanding);
-                out.add(new Made(FixtureTemplate.collection(elements), elements.size()));
-            }
-            return Built.of(out);
-        }
-        Type.MapOf map = (Type.MapOf) carrier;
+        return Built.of(out);
+    }
+
+    /** A map of that many entries, no two of which share a key. The values under the keys are free
+     *  to repeat. */
+    private static Built ofMapping(Shape.Mapping map, int least, RuleReadingSource ruleSource,
+                                   ReadingPolicy policy, Set<TypeSymbol> expanding) {
         List<FixtureTemplate> keys = proposalsFor(map.key(), ruleSource, policy, expanding);
         List<FixtureTemplate> values = proposalsFor(map.value(), ruleSource, policy, expanding);
         if (keys.isEmpty() || values.isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -450,7 +450,7 @@ final class Witnesses {
                                                      ReadingPolicy policy,
                                                      Set<TypeSymbol> expanding) {
         List<FixtureTemplate> out = new ArrayList<>();
-        for (PartitionClass each : PartitionClasses.of(type, ruleSource, policy)) {
+        for (PartitionClass each : PartitionClasses.of(type, ruleSource, policy, expanding)) {
             out.addAll(Partitions.standingFor(each.representatives(), ruleSource, policy, expanding));
         }
         return out;
@@ -469,10 +469,10 @@ final class Witnesses {
         TypeView view = TypeView.of(type, ruleSource.symbols());
         if (view.shape() instanceof Shape.Scalar scalar && scalar.prim() == Type.Prim.STRING) {
             return WornNames.under(view.wrappers(), FixtureTemplate.string(
-                    "x".repeat(Math.max(1, Partitions.leastHeld(type, ruleSource)) + index)),
+                    "x".repeat(Math.max(1, Partitions.leastHeld(view, ruleSource)) + index)),
                     ruleSource);
         }
-        Place at = Partitions.numberInside(type, ruleSource, index);
+        Place at = Partitions.numberInside(view, ruleSource, index);
         if (at == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
@@ -1,0 +1,67 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.TypeOps;
+import souther.compiler.types.TypeReachName;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * How this module writes the names a position wears, or the one of them it cannot write.
+ *
+ * <p>Asked before anything is written under them, and answered for all of them at once. The name
+ * goes on the value as the value is written, so a name this module cannot reach is not a value
+ * written without that name — it is no value here at all, and every name has to be in hand before
+ * the first one goes on. A reading that put them on as it resolved them would leave a value wearing
+ * some of its names when the next one turned out to have no spelling.
+ *
+ * <p>Which one it was, and not that there was one. A reader told only that the names could not be
+ * written has to find out for itself which name and why, and each of them finds a different way of
+ * saying it — so the name that stopped this is carried, and the sentence about it is written here
+ * where the question was asked.
+ */
+sealed interface WornNames {
+
+    /** Every name the position wears, spelled as this module reaches it, outermost first. */
+    record Spelled(List<TypeReachName.Written> names) implements WornNames {
+
+        public Spelled {
+            names = List.copyOf(names);
+        }
+    }
+
+    /** A name nothing here can write, which takes the whole value with it. */
+    record Unwritable(TypeSymbol name) implements WornNames {
+
+        String why() {
+            return noSpellingFor(name);
+        }
+    }
+
+    /** How {@code worn} is written here, outermost first, or the first of them that has no
+     *  spelling. */
+    static WornNames of(List<TypeOps.Layer> worn, RuleReadingSource ruleSource) {
+        List<TypeReachName.Written> names = new ArrayList<>();
+        for (TypeOps.Layer layer : worn) {
+            if (!(ruleSource.symbols().scope().reach(layer.named())
+                    instanceof TypeReachName.Written written)) {
+                return new Unwritable(layer.named());
+            }
+            names.add(written);
+        }
+        return new Spelled(names);
+    }
+
+    /** Why nothing here can write a value of {@code name}: no spelling reaches it. */
+    static String noSpellingFor(TypeSymbol name) {
+        return name instanceof TypeSymbol.AtModule at
+                ? "`" + at.module() + "` does not expose `" + at.name()
+                        + "`, so nothing here can name it"
+                // What the language declares is kept by nobody: a declaration of this module
+                // spells it, so the language's has no name left here.
+                : "`" + name.name() + "` is declared here, so what the language declares under"
+                        + " that name has no name here";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
@@ -54,6 +54,28 @@ sealed interface WornNames {
         return new Spelled(names);
     }
 
+    /**
+     * {@code value} under {@code worn}, or null where one of those names cannot be written here.
+     *
+     * <p>Null takes the whole value with it: the name goes on the value as it is written, and a
+     * value written without one is of a type the position does not declare. What comes back is
+     * {@code value} itself where the position wears no name, so that nothing is written round
+     * nothing.
+     *
+     * <p>The names are the reading's. Nothing here works out which names a value wears — that is
+     * what reading the position came to — and the putting-back-on is
+     * {@link RepresentativeSource#under}'s, so a value never wears a name that was spelled anywhere
+     * but here.
+     */
+    static FixtureTemplate under(List<TypeOps.Layer> worn, FixtureTemplate value,
+                                 RuleReadingSource ruleSource) {
+        if (value == null || worn.isEmpty()) {
+            return value;
+        }
+        return of(worn, ruleSource) instanceof Spelled spelled
+                ? RepresentativeSource.under(spelled.names(), value) : null;
+    }
+
     /** Why nothing here can write a value of {@code name}: no spelling reaches it. */
     static String noSpellingFor(TypeSymbol name) {
         return name instanceof TypeSymbol.AtModule at

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABudgetIsNamedByThePlaceItStopsTest.java
@@ -6,7 +6,9 @@ import souther.compiler.DefaultStdlib;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.inputs.TermPath;
@@ -48,6 +50,11 @@ class ABudgetIsNamedByThePlaceItStopsTest {
     private static final RuleReadingSource RULES = RuleReadings.ofNoClauseFiled(SYMBOLS);
     private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
 
+    /** What a position of this type is, which is what the builder is asked about. */
+    private static Shape shape(Type type) {
+        return TypeView.of(type, SYMBOLS).shape();
+    }
+
     /**
      * A collection at the figure is built, and one past it is a composing this stopped.
      *
@@ -59,10 +66,10 @@ class ABudgetIsNamedByThePlaceItStopsTest {
         int most = CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS.maximum();
 
         assertEquals(Set.of(),
-                Witnesses.heldBackFor(Type.list(Type.INT), most, RULES, POLICY),
+                Witnesses.heldBackFor(shape(Type.list(Type.INT)), most, RULES, POLICY),
                 "a collection of exactly as many as a row carries is one this builds");
         assertEquals(Set.of(CompositionBudget.ELEMENTS_A_PROPOSAL_HOLDS),
-                Witnesses.heldBackFor(Type.list(Type.INT), most + 1, RULES, POLICY),
+                Witnesses.heldBackFor(shape(Type.list(Type.INT)), most + 1, RULES, POLICY),
                 "and one past it is this compiler declining, said as the figure it declined at");
     }
 
@@ -71,10 +78,10 @@ class ABudgetIsNamedByThePlaceItStopsTest {
     void aProposalHoldsAsManyCharactersAsItsOwnFigure() {
         int most = CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS.maximum();
 
-        assertEquals(Set.of(), Witnesses.heldBackFor(Type.STRING, most, RULES, POLICY),
+        assertEquals(Set.of(), Witnesses.heldBackFor(shape(Type.STRING), most, RULES, POLICY),
                 "a string of exactly as many characters as one is worth building");
         assertEquals(Set.of(CompositionBudget.CHARACTERS_A_PROPOSAL_HOLDS),
-                Witnesses.heldBackFor(Type.STRING, most + 1, RULES, POLICY),
+                Witnesses.heldBackFor(shape(Type.STRING), most + 1, RULES, POLICY),
                 "and one past it names the string's figure and not the collection's");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
+import souther.compiler.check.TypeView;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -85,7 +86,8 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
     @Test
     void aCollectionRequiredToHoldOneOfASumOfRecordsIsBuilt() {
         List<FixtureTemplate> held =
-                Witnesses.holding(new Type.ListOf(sum()), 1, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of());
+                Witnesses.holding(TypeView.of(new Type.ListOf(sum()), rules.symbols()).shape(),
+                        1, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of());
 
         assertFalse(held.isEmpty(), "a list of one is built from a case of the sum");
     }
@@ -95,7 +97,8 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
     @Test
     void aSetOfTwoIsBuiltFromTwoCasesOfASumOfRecords() {
         List<FixtureTemplate> held =
-                Witnesses.holding(new Type.SetOf(sum()), 2, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of());
+                Witnesses.holding(TypeView.of(new Type.SetOf(sum()), rules.symbols()).shape(),
+                        2, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of());
 
         assertFalse(held.isEmpty(), "the two cases are two distinct values");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -72,7 +72,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
      */
     @Test
     void theSomeOfAnOptionalSumOfRecordsStandsForAComposedCase() {
-        PartitionClass some = PartitionClasses.of(new Type.OptionOf(sum()), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES).stream()
+        PartitionClass some = PartitionClasses.of(new Type.OptionOf(sum()), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).stream()
                 .filter(each -> each.id().equals("Some")).findFirst().orElseThrow();
 
         List<FixtureTemplate> stands =
@@ -118,7 +118,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
      *  value for. */
     @Test
     void everyCaseOfTheSumStandsForSomething() {
-        for (PartitionClass each : PartitionClasses.of(sum(), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES)) {
+        for (PartitionClass each : PartitionClasses.of(sum(), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of())) {
             assertFalse(Partitions.representativesOf(named(each.id()), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES).isEmpty(),
                     () -> "a record case stands for a value: " + each.id());
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
@@ -55,7 +55,7 @@ class ADeclaredCaseIsNotYetAClassThePositionHoldsTest {
     @Test
     void theTypeDeclaresEveryCaseWhateverItsRulesSay() {
         assertEquals(List.of("Prospecting", "Qualified", "Won"),
-                PartitionClasses.of(Type.ref(TypeSymbols.declared(new TypeKey(rules.symbols().module(), "StageI"))), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES).stream()
+                PartitionClasses.of(Type.ref(TypeSymbols.declared(new TypeKey(rules.symbols().module(), "StageI"))), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, java.util.Set.of()).stream()
                         .map(PartitionClass::id).toList());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -67,7 +67,7 @@ class ANameGoesBackOnTheWayItCameOffTest {
     }
 
     private PartitionClass classOf(String type, String id) {
-        return PartitionClasses.of(Type.ref(named(type)), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES).stream()
+        return PartitionClasses.of(Type.ref(named(type)), rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, java.util.Set.of()).stream()
                 .filter(each -> each.id().equals(id)).findFirst().orElseThrow();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionIsProposedForAlikeWhetherOrNotItWearsANameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionIsProposedForAlikeWhetherOrNotItWearsANameTest.java
@@ -17,15 +17,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * A position and the same position under a name are proposed for alike.
  *
- * <p>Two routes reach one answer. A position whose type is written as a primitive is answered from
- * what the primitive is; a position wearing a name is asked what it divides into first, and a
- * {@code Bool} divides into two and an {@code Option} into present and absent. So the value a row
- * carries at {@code Bool} is chosen by one reading and the value it carries at {@code data F = Bool}
- * by another, and nothing says the two agree.
+ * <p>One route. The position is read, and the value is chosen from the shape that reading came to —
+ * so what a name does is decide how the value is spelled and nothing else. A {@code Bool} divides
+ * into two and an {@code Option} into present and absent whether or not a name is worn over it, and
+ * which of those the position stands for is settled before any name goes back on.
  *
- * <p>Held because they have to. A name is how a value is written and never what it is, so a name put
- * on a position cannot change which value stands for it. What is pinned here is that the two routes
- * arrive at the same value today, which is what makes joining them a change that keeps the answers
+ * <p>Written down before the routes were joined, when there were two. A position whose type was
+ * written as a primitive was answered from what the primitive is, and one wearing a name was asked
+ * what it divides into first — so the two chose the value by different readings and nothing said
+ * they agreed. They did, and pinning that is what made joining them a change that keeps the answers
  * rather than one that quietly picks a different row.
  */
 class APositionIsProposedForAlikeWhetherOrNotItWearsANameTest {

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionIsProposedForAlikeWhetherOrNotItWearsANameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionIsProposedForAlikeWhetherOrNotItWearsANameTest.java
@@ -1,0 +1,63 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A position and the same position under a name are proposed for alike.
+ *
+ * <p>Two routes reach one answer. A position whose type is written as a primitive is answered from
+ * what the primitive is; a position wearing a name is asked what it divides into first, and a
+ * {@code Bool} divides into two and an {@code Option} into present and absent. So the value a row
+ * carries at {@code Bool} is chosen by one reading and the value it carries at {@code data F = Bool}
+ * by another, and nothing says the two agree.
+ *
+ * <p>Held because they have to. A name is how a value is written and never what it is, so a name put
+ * on a position cannot change which value stands for it. What is pinned here is that the two routes
+ * arrive at the same value today, which is what makes joining them a change that keeps the answers
+ * rather than one that quietly picks a different row.
+ */
+class APositionIsProposedForAlikeWhetherOrNotItWearsANameTest {
+
+    private static final RuleReadingSource RULES = RuleReadings.ofSource("""
+            module demo
+
+            data F = Bool
+
+            data O = Option<String>
+            """);
+
+    private static List<String> proposedFor(Type type) {
+        return Partitions.representativesOf(type, RULES, ReadAs.THE_COMPILATION_DOES, null, Set.of())
+                .stream().map(FixtureTemplate::text).toList();
+    }
+
+    private static Type named(String type) {
+        return Type.ref(TypeSymbols.declared(new TypeKey(RULES.symbols().module(), type)));
+    }
+
+    /** A flag, which the type divides into two: the same one of them either way. */
+    @Test
+    void aFlagIsProposedForAlikeUnderANameAndWithoutOne() {
+        assertEquals(List.of("true"), proposedFor(Type.BOOL));
+        assertEquals(List.of("F(true)"), proposedFor(named("F")));
+    }
+
+    /** An option, which divides into absent and present: the same one of them either way. */
+    @Test
+    void anOptionIsProposedForAlikeUnderANameAndWithoutOne() {
+        assertEquals(List.of("None"), proposedFor(Type.option(Type.STRING)));
+        assertEquals(List.of("O(None)"), proposedFor(named("O")));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.DefaultStdlib;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
 import souther.compiler.types.Type;
 
 import java.util.List;
@@ -30,10 +32,15 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     private static final RuleReadingSource NONE =
             RuleReadings.ofNoClauseFiled(Symbols.none(DefaultStdlib.get()));
 
+    /** What a position of this type is, which is what the builder is asked about. */
+    private static Shape shape(Type type) {
+        return TypeView.of(type, NONE.symbols()).shape();
+    }
+
     @Test
     void aStringOfTheSizeAskedForIsBuilt() {
         assertEquals(List.of("\"xxx\""),
-                Witnesses.ofSize(Type.STRING, 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
+                Witnesses.ofSize(shape(Type.STRING), 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -45,10 +52,10 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aSizeOfZeroIsTheEmptyValue() {
         assertEquals(List.of("\"\""),
-                Witnesses.ofSize(Type.STRING, 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
+                Witnesses.ofSize(shape(Type.STRING), 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
         assertEquals(List.of("[]"),
-                Witnesses.ofSize(new Type.ListOf(Type.INT), 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
+                Witnesses.ofSize(shape(new Type.ListOf(Type.INT)), 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -61,24 +68,24 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
      */
     @Test
     void aFloorOfNoneAsksForNothingWhereASizeOfZeroAsksForTheEmptyValue() {
-        assertEquals(List.of(), Witnesses.holding(Type.STRING, 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()));
-        assertTrue(!Witnesses.ofSize(Type.STRING, 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().isEmpty());
+        assertEquals(List.of(), Witnesses.holding(shape(Type.STRING), 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()));
+        assertTrue(!Witnesses.ofSize(shape(Type.STRING), 0, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().isEmpty());
     }
 
     /** A count past what a row is worth carrying is one nothing composes, and says which it is. */
     @Test
     void aSizeNoRowWouldCarrySaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(Type.STRING, 100_000, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values());
+        assertEquals(List.of(), Witnesses.ofSize(shape(Type.STRING), 100_000, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                Witnesses.reasonForSize(Type.STRING, 100_000, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, NONE));
+                Witnesses.reasonForSize(shape(Type.STRING), 100_000, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, NONE));
     }
 
     /** A carrier nothing counts has no size to build at, and says which silence that is. */
     @Test
     void aCarrierNothingCountsSaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(Type.INT, 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values());
+        assertEquals(List.of(), Witnesses.ofSize(shape(Type.INT), 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                Witnesses.reasonForSize(Type.INT, 3, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, NONE));
+                Witnesses.reasonForSize(shape(Type.INT), 3, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, NONE));
     }
 
     /**
@@ -92,7 +99,7 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
      */
     @Test
     void aSetIsNothingWhereTheTypeHasFewerValuesThanTheCountAsksFor() {
-        Type set = new Type.SetOf(Type.BOOL);
+        Shape set = shape(new Type.SetOf(Type.BOOL));
 
         assertEquals(List.of("[true, false]"), Witnesses.ofSize(set, 2, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().stream()
                 .map(FixtureTemplate::text).toList());
@@ -105,14 +112,14 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aFloorIsStillOfferedTheValueTheTypeCanReach() {
         assertEquals(List.of("[true, false]"),
-                Witnesses.holding(new Type.SetOf(Type.BOOL), 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).stream()
+                Witnesses.holding(shape(new Type.SetOf(Type.BOOL)), 3, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).stream()
                         .map(FixtureTemplate::text).toList());
     }
 
     /** A map counts its entries, and a key that cannot be told from the others is not one more. */
     @Test
     void aMapIsNothingWhereItsKeysRunOutBeforeTheCount() {
-        Type map = new Type.MapOf(Type.BOOL, Type.INT);
+        Shape map = shape(new Type.MapOf(Type.BOOL, Type.INT));
 
         assertTrue(!Witnesses.ofSize(map, 2, NONE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES, Set.of()).values().isEmpty(),
                 "two keys are two the type has");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
@@ -19,17 +19,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Which of the names a value wears has its rules read when a value is proposed for it.
  *
- * <p>A value written under a name is written under every name the position wears, and each of those
- * names may carry rules of its own. What proposes a value from a rule about the characters of a
- * string reaches one name deep: it asks what the outermost name wraps, and reads that name's own
- * predicates only where what it wraps is the string itself. A name over a name therefore proposes
- * nothing of its own — the value comes out wearing both names, but only the innermost one's rules
- * were read for it.
+ * <p>All of them. A value written under a name is written under every name the position wears, and
+ * the rules of every one of those names are rules its value is under — so each of them proposes a
+ * value, and the value comes out wearing all the names whichever of them asked for it.
  *
  * <p>Held here because it is the difference between two readings of one position. The names a value
  * wears and what is left under all of them are one answer; walking to what a single name wraps is
- * another, and the two part exactly where a name wraps a name. What this pins is which of them
- * decides today, so that a change to either is a change somebody chose.
+ * another, and the two part exactly where a name wraps a name. Read the second way, a rule was
+ * about whatever the walk had reached when it stopped, which was one name deep — so a name over a
+ * name proposed nothing of its own, and the position was offered the value it would have had with
+ * no rule written on it at all.
+ *
+ * <p>Innermost first, which is an order over the proposals and not over the rules. Every name's
+ * rules govern the value whichever end they are read from; what the order decides is which proposal
+ * a bounded search reaches before it stops.
  */
 class WhichNamesRulesAreReadWhenAValueIsProposedTest {
 
@@ -68,14 +71,14 @@ class WhichNamesRulesAreReadWhenAValueIsProposedTest {
     }
 
     /**
-     * A rule on a name that wraps a name proposes nothing.
+     * A rule on a name that wraps a name proposes the value it asks for.
      *
-     * <p>The walk that reads such a rule asks what the name wraps and finds another name rather than
-     * the string, so the predicates written on it are not reached. What comes out is the value the
-     * type would have offered with no rule written on it at all, under both names.
+     * <p>What the rule is about is the value under every name, and how the value is written is every
+     * name the position wears. Read as one question, the second answer decided the first: the rule
+     * was about whatever a single name wrapped, which here is another name and not the string.
      */
     @Test
-    void aRuleOnANameOverANameProposesNothing() {
+    void aRuleOnANameOverANameProposesTheValueItAsksFor() {
         List<String> proposed = proposedFor("""
                 data B = String
 
@@ -83,25 +86,21 @@ class WhichNamesRulesAreReadWhenAValueIsProposedTest {
                     invariant tagged = startsWith("X", value)
                 """, "A");
 
-        assertEquals(List.of("A(B(\"x\"))"), proposed);
-        assertTrue(proposed.stream().noneMatch(each -> each.contains("X")),
-                "the outer name's rule reached no proposal: " + proposed);
+        assertEquals(List.of("A(B(\"X\"))", "A(B(\"x\"))"), proposed);
+        assertTrue(proposed.stream().anyMatch(each -> each.contains("X")),
+                "the rule on the outer name proposed what it asks for: " + proposed);
     }
 
-    /** Both names carrying a rule: the inner one's is proposed and the outer one's is not. */
+    /** Both names carrying a rule: each proposes what it asks for, innermost first. */
     @Test
-    void whereBothNamesCarryARuleOnlyTheInnerOneProposes() {
-        List<String> proposed = proposedFor("""
+    void whereBothNamesCarryARuleEachProposesInnermostFirst() {
+        assertEquals(List.of("A(B(\"X\"))", "A(B(\"Z\"))", "A(B(\"x\"))"), proposedFor("""
                 data B = String
                     invariant tagged = startsWith("X", value)
 
                 data A = B
                     invariant ended = endsWith("Z", value)
-                """, "A");
-
-        assertEquals(List.of("A(B(\"X\"))", "A(B(\"x\"))"), proposed);
-        assertTrue(proposed.stream().noneMatch(each -> each.endsWith("Z\"))")),
-                "the outer name's rule reached no proposal: " + proposed);
+                """, "A"));
     }
 
     /** And the names go back on in the order they were read off, however many there are. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichNamesRulesAreReadWhenAValueIsProposedTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which of the names a value wears has its rules read when a value is proposed for it.
+ *
+ * <p>A value written under a name is written under every name the position wears, and each of those
+ * names may carry rules of its own. What proposes a value from a rule about the characters of a
+ * string reaches one name deep: it asks what the outermost name wraps, and reads that name's own
+ * predicates only where what it wraps is the string itself. A name over a name therefore proposes
+ * nothing of its own — the value comes out wearing both names, but only the innermost one's rules
+ * were read for it.
+ *
+ * <p>Held here because it is the difference between two readings of one position. The names a value
+ * wears and what is left under all of them are one answer; walking to what a single name wraps is
+ * another, and the two part exactly where a name wraps a name. What this pins is which of them
+ * decides today, so that a change to either is a change somebody chose.
+ */
+class WhichNamesRulesAreReadWhenAValueIsProposedTest {
+
+    private static List<String> proposedFor(String declarations, String type) {
+        RuleReadingSource rules = RuleReadings.ofSource("""
+                module demo
+
+                import String ( startsWith, endsWith )
+
+                """ + declarations);
+        TypeSymbol at = TypeSymbols.declared(new TypeKey(rules.symbols().module(), type));
+        return Partitions.representativesOf(Type.ref(at), rules, ReadAs.THE_COMPILATION_DOES,
+                        null, Set.of())
+                .stream().map(FixtureTemplate::text).toList();
+    }
+
+    /** A rule on the name the string is directly under is read, and proposes what it asks for. */
+    @Test
+    void aRuleOnTheNameOverTheStringProposesAValue() {
+        assertEquals(List.of("A(\"X\")", "A(\"x\")"), proposedFor("""
+                data A = String
+                    invariant tagged = startsWith("X", value)
+                """, "A"));
+    }
+
+    /** The same rule under a second name: the value comes out under both, and the proposal is the
+     *  inner name's. */
+    @Test
+    void aRuleOnTheInnerNameIsReadThroughTheOuterOne() {
+        assertEquals(List.of("A(B(\"X\"))", "A(B(\"x\"))"), proposedFor("""
+                data B = String
+                    invariant tagged = startsWith("X", value)
+
+                data A = B
+                """, "A"));
+    }
+
+    /**
+     * A rule on a name that wraps a name proposes nothing.
+     *
+     * <p>The walk that reads such a rule asks what the name wraps and finds another name rather than
+     * the string, so the predicates written on it are not reached. What comes out is the value the
+     * type would have offered with no rule written on it at all, under both names.
+     */
+    @Test
+    void aRuleOnANameOverANameProposesNothing() {
+        List<String> proposed = proposedFor("""
+                data B = String
+
+                data A = B
+                    invariant tagged = startsWith("X", value)
+                """, "A");
+
+        assertEquals(List.of("A(B(\"x\"))"), proposed);
+        assertTrue(proposed.stream().noneMatch(each -> each.contains("X")),
+                "the outer name's rule reached no proposal: " + proposed);
+    }
+
+    /** Both names carrying a rule: the inner one's is proposed and the outer one's is not. */
+    @Test
+    void whereBothNamesCarryARuleOnlyTheInnerOneProposes() {
+        List<String> proposed = proposedFor("""
+                data B = String
+                    invariant tagged = startsWith("X", value)
+
+                data A = B
+                    invariant ended = endsWith("Z", value)
+                """, "A");
+
+        assertEquals(List.of("A(B(\"X\"))", "A(B(\"x\"))"), proposed);
+        assertTrue(proposed.stream().noneMatch(each -> each.endsWith("Z\"))")),
+                "the outer name's rule reached no proposal: " + proposed);
+    }
+
+    /** And the names go back on in the order they were read off, however many there are. */
+    @Test
+    void theValueComesOutUnderEveryNameThePositionWears() {
+        assertEquals(List.of("A(B(\"x\"))"), proposedFor("""
+                data B = String
+
+                data A = B
+                """, "A"));
+    }
+}


### PR DESCRIPTION
Closes #1322.

A rule written on a name that wraps a name proposed nothing. `data B = String`
with `data A = B` carrying `startsWith("X", value)` offered the position the
value it would have had with no rule written on it at all, under both names —
while the same rule written directly over the string proposed what it asks for.
Which of a value's names had its rules read depended on how many names stood
between that one and the string.

## What the defect was

One walk was answering two questions at one depth. How far to look to know what
a rule is about goes through every name to the value; how far to descend to
write the value goes one name at a time, so that each name goes back on. Because
both were the recursion's depth, neither could be right for the other, and the
depth that was right for writing the value stopped the rule reading one name in.

Reading the rules against what is left under all the names reaches the rule and
writes the value wrong: the proposal comes out wearing the outer name and not
the one between. Both were observed by mutating the walk.

## What this does

A position is read once. What it is with every name off, and which names it
wears, are that reading's two answers, and everything else is a projection of
them:

* the rules its value is under are the rules of every name it wears, read off
  the names the reading found rather than by walking to them again;
* how many of anything those rules leave it holding is asked of the same
  reading, and so is the order its numbers are counted on;
* the values are made from the shape under those names, by a builder that has no
  way to tell a name from what it wraps;
* the names go back on from the same reading, all of them, in one place.

So a value's rules reach it however many names it is written under, and the
value comes out wearing all of them.

The proposals a name's rules make are enumerated innermost first. That is an
order over the proposals and not over the rules — every name's rules govern the
value whichever end they are read from — and what it decides is which proposal a
bounded search reaches before it stops.

## Reading it

The first commits are meant to leave every answer as it was, and the existing
suite is what says so; the fix is one change on top of them; the rest answer
review.

1. pin that a name on a position does not change which value stands for it;
2. ask in one place how this module writes the names a position wears;
3. read a position's rules off the names its reading found;
4. put a name back on from the reading, never from the type;
5. read a position once and propose from that reading — **the fix**;
6. ask the reading whether a position wears a name;
7. take every question about a position from its reading, and carry the
   recursion guard through the classes;
8. say what the reading of a position is, where a test still described two;
9. take the order a position's numbers are on from its shape.

## What is left over

The reader that asked what a single name wraps is gone from the partitioning
stage, along with every other walk from a type to what it is made of. That stage
now reaches into a declaration for the names a position wears and for the fields
of a record being composed, and for nothing else. Putting a name on a value has
one caller.

`Carrier`, `Ordering` and the reader of what an operation counts still ask the
declarations their own questions, which is what they are for; #1313 takes the
inventory of those entrances over the boundary this leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
