### PR TITLE
Read what a position is once in the partitioning stage, and refuse a second reading

### DIFF
--- a/souther-bench/src/test/java/souther/bench/Compiled.java
+++ b/souther-bench/src/test/java/souther/bench/Compiled.java
@@ -195,8 +195,21 @@ final class Compiled {
 
     /** Everything every compiled class of every module does. */
     static List<Site> sites() throws IOException {
+        return sitesIn(Reactor.classes());
+    }
+
+    /**
+     * The same of the classes named, beside {@link #invocationsIn} and for the same reason.
+     *
+     * <p>Which classes are read and what is read of them are two things, and a rule that fixed both
+     * could only ever be asked about the repository as it stands. A check of what this reading
+     * <em>does</em> — that a call two methods away is still a call, that a switch over a sum names
+     * its cases — has to be able to hand it code written to be read, and a copy of the walk written
+     * for that would be a check of the copy.
+     */
+    static List<Site> sitesIn(List<Path> classes) throws IOException {
         List<Site> found = new ArrayList<>();
-        for (Path each : Reactor.classes()) {
+        for (Path each : classes) {
             ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
             String from = named(model.thisClass().asInternalName());
             for (var method : model.methods()) {

--- a/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
+++ b/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
@@ -1,0 +1,376 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The partitioning stage reads what a position is; it never works it out again underneath.
+ *
+ * <p>What a value is made of has one answer, and the stage had it four ways over: from the reading
+ * of a position, from the declaration through its field types, from a collection constructor taken
+ * apart by hand, and from a walk reaching through the names a value is written under. Four readings
+ * of one fact agree wherever they happen to stop at the same depth and part everywhere else — at a
+ * sum, at a name over a name, inside a container — and each parting was a defect somebody found
+ * separately.
+ *
+ * <p><b>So this is about reachability and not about a vocabulary.</b> A rule naming the ways
+ * anybody had written it down so far would be passed by the next one written another way, and that
+ * is the failure this exists after rather than a hypothetical: the walk it removed reached the
+ * declaration through an accessor no earlier rule watched. What is checked is that no path from the
+ * stage arrives at raw structure at all, however many methods it goes through and whatever those
+ * methods return. A helper handing back a {@code boolean} hides nothing here, because what is
+ * followed is the call and not the answer.
+ *
+ * <p><b>What counts as raw structure is the types' own statement.</b> {@link
+ * souther.compiler.types.Type.Leaf} says it holds no type inside it and {@link
+ * souther.compiler.types.Type.Compound} says it is built out of others, so taking a compound apart
+ * is reading structure and reading the name off a {@code Ref} is not — a {@code Ref} has no
+ * structure to read, which is what makes it a leaf. {@link souther.compiler.ast.Hir.Def} permits
+ * the declarations, so reaching one of those is reading what a module wrote. Both sets come from
+ * the sealed hierarchies rather than from a list here, and a constructor added to either joins them
+ * without anybody remembering to.
+ *
+ * <p><b>The stage stops at an authority, and the authorities are the point.</b> Each is a place
+ * that owns a question, reads whatever raw material that question needs, and hands back an answer.
+ * The table below is not a list of methods allowed to reach past the boundary — it is why the stage
+ * does not need to look past it. A method reaching raw structure that no authority answers for is a
+ * second reading of something already decided, whatever it is called.
+ */
+class PartitionReadsAPositionRatherThanReinterpretingItTest {
+
+    /** The stage this is about: where a row for a coverage item is composed. */
+    private static final String STAGE = "souther.compiler.partition.";
+
+    /** What a declaration is, as {@code Hir.Def} permits them. */
+    private static final String DECLARATION = "souther.compiler.ast.Hir$Def";
+
+    /** What is built out of types, as {@code Type} divides itself. */
+    private static final String COMPOUND = "souther.compiler.types.Type$Compound";
+
+    /** Whether a walk stops at an authority or carries on through it. */
+    enum Traversal {
+
+        /**
+         * The answer is complete before anything of the caller's runs, so what the authority reads
+         * to make it is its own business and the walk stops here.
+         */
+        OPAQUE,
+
+        /**
+         * The owner of the question, walked through all the same. What it answers with is composed
+         * by something the caller handed it, so a reading the caller wrote is reached from here —
+         * and stopping at this boundary would put a caller's own walk on the far side of it.
+         */
+        TRANSPARENT
+    }
+
+    /**
+     * A place that owns a question, and what a walk does when it arrives.
+     *
+     * @param question what it answers, in the words the answer is about. A place that cannot be
+     *                 given one that some other authority does not already answer is not an
+     *                 authority: it is a second reading under another name
+     * @param owns     the class, or the one method of it, that answers. A class holding several
+     *                 unrelated questions is named by the method, because that is the size of the
+     *                 owner and not because the rest of the class is being excused
+     */
+    record Authority(String question, String owns, Traversal traversal) {
+
+        /** Whether this answers for {@code at}, named with or without what it takes and returns. */
+        boolean answersFor(String at) {
+            String named = at.contains("(") ? at.substring(0, at.indexOf('(')) : at;
+            String owner = named.substring(0, named.indexOf('#'));
+            return owns.contains("#")
+                    ? named.equals(owns)
+                    : owner.equals(owns) || owner.startsWith(owns + "$");
+        }
+    }
+
+    /**
+     * Why the stage does not have to look past each of these.
+     *
+     * <p>A place earns an entry by answering four things. It has a question of its own, rather than
+     * giving another authority's answer a second name. What it hands back is that answer, never the
+     * raw material — a type as the subject of a question is fine, a child type or a declaration
+     * handed out is not. It finishes before anything of the caller's runs. And it is the lowest
+     * owner: a facade or a switch that hands the decision on is walked through to whatever makes
+     * it.
+     */
+    private static final List<Authority> AUTHORITIES = List.of(
+            // What a position is, and how it is written. The one this stage exists on top of.
+            new Authority("what a position is, with the names it is written under off",
+                    "souther.compiler.check.TypeView", Traversal.OPAQUE),
+            new Authority("what the rules written on a record leave its fields able to hold",
+                    "souther.compiler.check.FieldDomains", Traversal.OPAQUE),
+            new Authority("which conjuncts are written on each of the names a value wears",
+                    "souther.compiler.check.DeclaredClauses", Traversal.OPAQUE),
+            new Authority("which ends a declaration writes on the values of a type",
+                    "souther.compiler.check.DeclaredBounds", Traversal.OPAQUE),
+            new Authority("which binding each field of a declaration introduces inside its own"
+                            + " invariant",
+                    "souther.compiler.check.TypeOps#fieldBindings", Traversal.OPAQUE),
+            new Authority("what carries the values of a type, and in what order",
+                    "souther.compiler.check.Carrier", Traversal.OPAQUE),
+            new Authority("whether reading a field reaches another location",
+                    "souther.compiler.check.Location", Traversal.OPAQUE),
+            new Authority("what there is to count about a value",
+                    "souther.compiler.check.NumericMeasures", Traversal.OPAQUE),
+            new Authority("which distinctions the type at a position states",
+                    "souther.compiler.inputs.Distinctions", Traversal.OPAQUE),
+            new Authority("what reaches each position of a behavior's inputs, read once",
+                    "souther.compiler.inputs.InputDomain", Traversal.OPAQUE),
+            new Authority("what a name in the tree denotes where the reader stands",
+                    "souther.compiler.inputs.InputReads", Traversal.OPAQUE),
+            new Authority("which number of an input an expression names",
+                    "souther.compiler.inputs.InputNumber", Traversal.OPAQUE),
+            new Authority("which number a comparison draws which line on",
+                    "souther.compiler.inputs.ComparedNumber", Traversal.OPAQUE),
+            new Authority("whether an operation and a position make one term of a number taken of"
+                            + " a value",
+                    "souther.compiler.inputs.NumericTerm$TakenOf", Traversal.OPAQUE),
+            new Authority("how a type is written where an author reads it",
+                    "souther.compiler.types.Type#show", Traversal.OPAQUE),
+
+            // Owners all the same, walked through. Neither can stand as a boundary: what one
+            // answers with is composed by a reading the caller wrote, and the other hands its
+            // decision to whichever term it is about — so a stop at either would leave the walk
+            // this checks on the far side of it.
+            new Authority("what affine form an expression composes",
+                    "souther.compiler.check.AffineForms", Traversal.TRANSPARENT),
+            new Authority("what a term about a number comes to at another position",
+                    "souther.compiler.inputs.NumericTerm", Traversal.TRANSPARENT));
+
+    /**
+     * No path from the stage reaches raw structure without an authority answering for it.
+     *
+     * <p>Both what a method's own code does and what it calls, to any depth. A place that reads
+     * structure and hands back a word about it is on the path like any other: what makes the
+     * difference is whether some authority owns the question, not what the answer is made of.
+     */
+    @Test
+    void nothingInTheStageReadsStructureThatNoAuthorityAnswersFor() throws IOException {
+        Structure world = Structure.read();
+
+        assertFalse(world.observers().isEmpty(),
+                "no reading of raw structure was found anywhere, so this asserts nothing about the"
+                        + " stage: the walk or the sinks are wrong rather than the compiler clean");
+        assertFalse(world.stageMethods().isEmpty(),
+                "the stage has no compiled methods, so nothing was checked");
+
+        assertEquals(List.of(), world.bypasses(),
+                "a path from the partitioning stage to raw structure that no authority answers"
+                        + " for. Either the question it is asking has an owner and it should ask"
+                        + " there, or it is a second reading of something a reading already"
+                        + " decided");
+    }
+
+    /**
+     * Every authority is one the stage actually reaches.
+     *
+     * <p>The other way round, and the half that keeps this from becoming a list. An entry nothing
+     * arrives at is a rule about a boundary that is not there — either the reader that needed it
+     * has gone, and the entry with it, or the walk stopped reaching it and what this checks has
+     * quietly narrowed.
+     */
+    @Test
+    void everyAuthorityIsOneTheStageArrivesAt() throws IOException {
+        Structure world = Structure.read();
+        List<String> unreached = new ArrayList<>();
+        for (Authority each : AUTHORITIES) {
+            if (world.reached().stream().noneMatch(each::answersFor)) {
+                unreached.add(each.owns());
+            }
+        }
+        assertEquals(List.of(), unreached,
+                "an authority nothing in the stage arrives at, which is a rule about a boundary"
+                        + " that is not there");
+    }
+
+    /**
+     * What the compiled classes hold, and what follows from it.
+     *
+     * @param observers  the methods whose own code reads raw structure
+     * @param stageMethods every compiled method of the stage
+     * @param reached    what the stage calls, one step out
+     * @param bypasses   the stage's methods that reach raw structure with no authority between,
+     *                   each with the path that gets there
+     */
+    record Structure(Set<String> observers, Set<String> stageMethods, Set<String> reached,
+                     List<String> bypasses) {
+
+        static Structure read() throws IOException {
+            Map<String, ClassModel> models = new LinkedHashMap<>();
+            for (Path each : Reactor.classes()) {
+                ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+                models.put(model.thisClass().asInternalName().replace('/', '.'), model);
+            }
+            Set<String> declarations = descendantsOf(models, DECLARATION);
+            Map<String, Set<String>> apart = componentsHoldingTypes(models,
+                    descendantsOf(models, COMPOUND));
+
+            Set<String> observers = new LinkedHashSet<>();
+            Set<String> stage = new LinkedHashSet<>();
+            Set<String> reached = new LinkedHashSet<>();
+            Map<String, Set<String>> callersOf = new LinkedHashMap<>();
+            Map<String, String> why = new LinkedHashMap<>();
+            for (Compiled.Site site : Compiled.sites()) {
+                if (site.from().startsWith(STAGE)) {
+                    stage.add(site.at());
+                    reached.add(site.owner() + "#" + site.member());
+                }
+                callersOf.computeIfAbsent(site.owner() + "#" + site.member(),
+                        k -> new LinkedHashSet<>()).add(site.at());
+                String read = observation(site, declarations, apart);
+                if (read != null) {
+                    observers.add(site.at());
+                    why.putIfAbsent(site.at(), read);
+                }
+            }
+
+            // Backwards from every reading of raw structure, stopping where an authority answers.
+            // A method inside one is not carrying the reading outwards — it is making the answer.
+            Map<String, String> through = new LinkedHashMap<>();
+            Deque<String> queue = new ArrayDeque<>();
+            for (String at : observers) {
+                if (!answeredBy(at, Traversal.OPAQUE) && through.putIfAbsent(at, why.get(at)) == null) {
+                    queue.add(at);
+                }
+            }
+            while (!queue.isEmpty()) {
+                String at = queue.poll();
+                for (String caller : callersOf.getOrDefault(at.substring(0, at.indexOf('(')),
+                        Set.of())) {
+                    if (answeredBy(caller, Traversal.OPAQUE)
+                            || through.putIfAbsent(caller, at) != null) {
+                        continue;
+                    }
+                    queue.add(caller);
+                }
+            }
+
+            List<String> bypasses = new ArrayList<>();
+            for (String at : stage) {
+                if (through.containsKey(at)) {
+                    bypasses.add(at.substring(STAGE.length()) + "  ->  " + pathFrom(at, through));
+                }
+            }
+            bypasses.sort(null);
+            return new Structure(observers, stage, reached, bypasses);
+        }
+
+        /** How the reading is arrived at from here, for a reader who has to go and look. */
+        private static String pathFrom(String at, Map<String, String> through) {
+            List<String> path = new ArrayList<>();
+            String walk = at;
+            Set<String> seen = new LinkedHashSet<>();
+            while (walk != null && seen.add(walk) && path.size() < 8) {
+                String next = through.get(walk);
+                if (next == null || !next.contains("#")) {
+                    path.add(next == null ? "?" : next);
+                    break;
+                }
+                path.add(next.substring(0, next.indexOf('(')));
+                walk = next;
+            }
+            return String.join(" -> ", path);
+        }
+
+        private static boolean answeredBy(String at, Traversal how) {
+            return AUTHORITIES.stream()
+                    .anyMatch(each -> each.traversal() == how && each.answersFor(at));
+        }
+    }
+
+    /** What this site reads of raw structure, or null where it reads none. */
+    private static String observation(Compiled.Site site, Set<String> declarations,
+                                      Map<String, Set<String>> apart) {
+        if (declarations.contains(site.owner())) {
+            return "reaches a declaration: " + site.owner() + "#" + site.member();
+        }
+        if (site.owner().equals("souther.compiler.check.Symbols")
+                && site.member().equals("declaredNode")) {
+            return "asks what a name declares";
+        }
+        if (!apart.containsKey(site.owner())) {
+            return null;
+        }
+        return switch (site.how()) {
+            case ASKS, NAMES -> "asks which compound a type is: " + site.owner();
+            case CALLS, REFERS -> apart.get(site.owner()).contains(site.member())
+                    ? "takes a compound apart: " + site.owner() + "#" + site.member() : null;
+            // Making one is not reading one, and a field of a compound holds no type to read.
+            case MAKES, READS -> null;
+        };
+    }
+
+    /** Every class of this repository that is a {@code root}, root included. */
+    private static Set<String> descendantsOf(Map<String, ClassModel> models, String root) {
+        Set<String> found = new LinkedHashSet<>(Set.of(root));
+        boolean grew = true;
+        while (grew) {
+            grew = false;
+            for (var entry : models.entrySet()) {
+                if (found.contains(entry.getKey())) {
+                    continue;
+                }
+                List<String> above = new ArrayList<>();
+                entry.getValue().superclass()
+                        .ifPresent(each -> above.add(each.asInternalName().replace('/', '.')));
+                entry.getValue().interfaces()
+                        .forEach(each -> above.add(each.asInternalName().replace('/', '.')));
+                if (above.stream().anyMatch(found::contains)) {
+                    found.add(entry.getKey());
+                    grew = true;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * For each compound, the components of it that are made of types.
+     *
+     * <p>Off the generic signature where there is one: a list of types erases to a list, and a rule
+     * written over descriptors alone would not see what a tuple or a function holds.
+     */
+    private static Map<String, Set<String>> componentsHoldingTypes(Map<String, ClassModel> models,
+                                                                   Set<String> compounds) {
+        Map<String, Set<String>> found = new LinkedHashMap<>();
+        for (String each : compounds) {
+            ClassModel model = models.get(each);
+            if (model == null) {
+                continue;
+            }
+            Set<String> holding = new LinkedHashSet<>();
+            model.findAttribute(Attributes.record()).ifPresent(record -> {
+                for (var component : record.components()) {
+                    String written = component.findAttribute(Attributes.signature())
+                            .map(signature -> signature.signature().stringValue())
+                            .orElse(component.descriptor().stringValue());
+                    if (written.contains("Lsouther/compiler/types/Type;")) {
+                        holding.add(component.name().stringValue());
+                    }
+                }
+            });
+            found.put(each, holding);
+        }
+        return found;
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
+++ b/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
@@ -28,6 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * methods return. A helper handing back a {@code boolean} hides nothing here, because what is
  * followed is the call and not the answer.
  *
+ * <p>Over the calls as written, which is the shape of what this claims. A method reached only
+ * through an interface has no edge here, so a seam of that kind is held by what is on the far side
+ * of it being in the stage rather than by this. Every reading the stage has today is reached
+ * through a class a call names.
+ *
  * <p><b>What counts as raw structure is the types' own statement.</b> {@link
  * souther.compiler.types.Type.Leaf} says it holds no type inside it and {@link
  * souther.compiler.types.Type.Compound} says it is built out of others, so taking a compound apart
@@ -65,21 +70,17 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
                     "souther.compiler.check.TypeView", Traversal.OPAQUE),
             new Authority("what the rules written on a record leave its fields able to hold",
                     "souther.compiler.check.FieldDomains", Traversal.OPAQUE),
+            new Authority("which ends a declaration writes on the values of a type, and how much"
+                            + " they say it holds",
+                    "souther.compiler.check.DeclaredBounds", Traversal.OPAQUE),
             new Authority("which conjuncts are written on each of the names a value wears",
                     "souther.compiler.check.DeclaredClauses", Traversal.OPAQUE),
-            new Authority("which ends a declaration writes on the values of a type",
-                    "souther.compiler.check.DeclaredBounds", Traversal.OPAQUE),
-            new Authority("which binding each field of a declaration introduces inside its own"
-                            + " invariant",
-                    "souther.compiler.check.TypeOps#fieldBindings", Traversal.OPAQUE),
             new Authority("what carries the values of a type, and in what order",
                     "souther.compiler.check.Carrier", Traversal.OPAQUE),
             new Authority("whether reading a field reaches another location",
                     "souther.compiler.check.Location", Traversal.OPAQUE),
             new Authority("what there is to count about a value",
                     "souther.compiler.check.NumericMeasures", Traversal.OPAQUE),
-            new Authority("which distinctions the type at a position states",
-                    "souther.compiler.inputs.Distinctions", Traversal.OPAQUE),
             new Authority("what reaches each position of a behavior's inputs, read once",
                     "souther.compiler.inputs.InputDomain", Traversal.OPAQUE),
             new Authority("what a name in the tree denotes where the reader stands",
@@ -91,6 +92,15 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
             new Authority("whether an operation and a position make one term of a number taken of"
                             + " a value",
                     "souther.compiler.inputs.NumericTerm$TakenOf", Traversal.OPAQUE),
+
+            // Named by the operation, because the class holds more than one question. A second
+            // operation beside these, about something else, would be answering under a name that
+            // was never about it — which is what naming the class would let it do.
+            new Authority("which distinctions the type at a position states",
+                    "souther.compiler.inputs.Distinctions#ofType", Traversal.OPAQUE),
+            new Authority("which binding each field of a declaration introduces inside its own"
+                            + " invariant",
+                    "souther.compiler.check.TypeOps#fieldBindings", Traversal.OPAQUE),
             new Authority("how a type is written where an author reads it",
                     "souther.compiler.types.Type#show", Traversal.OPAQUE),
 
@@ -103,7 +113,7 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
             new Authority("what a term about a number comes to at another position",
                     "souther.compiler.inputs.NumericTerm", Traversal.TRANSPARENT));
 
-    private static PositionReadings.Over thisCompiler() throws IOException {
+    static PositionReadings.Over thisCompiler() throws IOException {
         return new PositionReadings.Over(Reactor.classes(), "souther.compiler.partition.",
                 "souther.compiler.ast.Hir$Def", "souther.compiler.check.Symbols#declaredNode",
                 "souther.compiler.types.Type$Compound", "Lsouther/compiler/types/Type;",
@@ -137,18 +147,52 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
     }
 
     /**
-     * Every authority is one the stage actually reaches.
+     * The table names exactly the operations that have to be answered for.
      *
-     * <p>The other way round, and the half that keeps this from becoming a list. An entry nothing
-     * arrives at is a rule about a boundary that is not there — either the reader that needed it
-     * has gone, and the entry with it, or the walk stopped reaching it and what this checks has
-     * quietly narrowed.
+     * <p>Both ways round, and derived rather than judged. What needs an answer is worked out by
+     * running the same walk with nothing answering: every operation the stage calls that would
+     * arrive at raw structure on its own. An operation missing from the table has nobody saying
+     * what question it answers; an entry that answers for nothing is a rule about a boundary that
+     * is not there.
+     *
+     * <p>Which is also what keeps a boundary the size of its question. Named by its class, an
+     * authority answers for whatever else that class comes to hold — a second operation beside it,
+     * about something else, reaching the declarations under a question that was never about them.
+     * Named by the operation, that second one arrives here instead.
      */
     @Test
-    void everyAuthorityIsOneTheStageArrivesAt() throws IOException {
+    void theTableNamesTheOperationsThatHaveToBeAnsweredFor() throws IOException {
         PositionReadings.Over over = thisCompiler();
-        assertEquals(List.of(), PositionReadings.unreached(over, PositionReadings.of(over)),
-                "an authority nothing in the stage arrives at, which is a rule about a boundary"
+        PositionReadings.Reading read = PositionReadings.of(over);
+
+        List<String> unanswered = read.answering().stream()
+                .filter(each -> AUTHORITIES.stream().noneMatch(one -> one.answersFor(each)))
+                .sorted().toList();
+        List<String> answersForNothing = AUTHORITIES.stream()
+                .filter(one -> read.answering().stream().noneMatch(one::answersFor))
+                .map(Authority::owns).sorted().toList();
+
+        assertEquals(List.of(), unanswered,
+                "an operation the stage calls that reaches raw structure and nothing says what"
+                        + " question it answers");
+        assertEquals(List.of(), answersForNothing,
+                "an entry answering for nothing the stage calls, which is a rule about a boundary"
                         + " that is not there");
+    }
+
+    /**
+     * A case of what is built out of types is one this can read the components of.
+     *
+     * <p>Which components hold a type is read off the record attribute, so a case that is not a
+     * record holds nothing this can see, and a walk taking it apart would read as taking nothing
+     * apart. The claim that a case added to the sum joins the rule without anybody remembering to
+     * holds exactly as far as this does.
+     */
+    @Test
+    void everythingBuiltOutOfTypesIsOneThisCanReadTheComponentsOf() throws IOException {
+        assertEquals(List.of(), PositionReadings.of(thisCompiler()).madeOfNonRecords(),
+                "a case of what is built out of types that is not a record: what it holds is not"
+                        + " where this reads what a compound holds, so taking it apart would read"
+                        + " as reading nothing");
     }
 }

--- a/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
+++ b/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
@@ -127,7 +127,8 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
                         + " stage: the walk or the sums it derives from are wrong rather than the"
                         + " compiler clean");
         assertFalse(read.inTheStage().isEmpty(),
-                "the stage has no compiled methods, so nothing was checked");
+                "nothing compiled in the stage calls anything, so there is no way out of it for"
+                        + " this to have followed and nothing below was checked");
 
         assertEquals(List.of(), read.bypasses(),
                 "a path from the partitioning stage to raw structure that no authority answers"

--- a/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
+++ b/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
@@ -2,20 +2,11 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
+import souther.bench.PositionReadings.Authority;
+import souther.bench.PositionReadings.Traversal;
+
 import java.io.IOException;
-import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.ClassModel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,8 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * of a position, from the declaration through its field types, from a collection constructor taken
  * apart by hand, and from a walk reaching through the names a value is written under. Four readings
  * of one fact agree wherever they happen to stop at the same depth and part everywhere else — at a
- * sum, at a name over a name, inside a container — and each parting was a defect somebody found
- * separately.
+ * sum, at a name over a name, inside a container — and each parting was a defect found separately.
  *
  * <p><b>So this is about reachability and not about a vocabulary.</b> A rule naming the ways
  * anybody had written it down so far would be passed by the next one written another way, and that
@@ -43,65 +33,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * souther.compiler.types.Type.Compound} says it is built out of others, so taking a compound apart
  * is reading structure and reading the name off a {@code Ref} is not — a {@code Ref} has no
  * structure to read, which is what makes it a leaf. {@link souther.compiler.ast.Hir.Def} permits
- * the declarations, so reaching one of those is reading what a module wrote. Both sets come from
- * the sealed hierarchies rather than from a list here, and a constructor added to either joins them
+ * the declarations, so reaching one of those is reading what a module wrote. Both sets are derived
+ * from the sealed hierarchies rather than listed here, and a constructor added to either joins them
  * without anybody remembering to.
  *
- * <p><b>The stage stops at an authority, and the authorities are the point.</b> Each is a place
- * that owns a question, reads whatever raw material that question needs, and hands back an answer.
- * The table below is not a list of methods allowed to reach past the boundary — it is why the stage
- * does not need to look past it. A method reaching raw structure that no authority answers for is a
- * second reading of something already decided, whatever it is called.
+ * <p><b>The table is of authorities, and that is the point.</b> Each is a place that owns a
+ * question, reads whatever raw material that question needs, and hands back an answer. It is not a
+ * list of methods allowed past the boundary — it is why the stage does not need to look past it. A
+ * method reaching raw structure that no authority answers for is a second reading of something
+ * already decided, whatever it is called.
+ *
+ * <p>What the walk itself does is held by {@link ThisReadingSeesAReadingOfRawStructureTest}, which
+ * hands it code written to be read. Green here says the compiler is clean; green there says this
+ * would have gone red had it not been.
  */
 class PartitionReadsAPositionRatherThanReinterpretingItTest {
-
-    /** The stage this is about: where a row for a coverage item is composed. */
-    private static final String STAGE = "souther.compiler.partition.";
-
-    /** What a declaration is, as {@code Hir.Def} permits them. */
-    private static final String DECLARATION = "souther.compiler.ast.Hir$Def";
-
-    /** What is built out of types, as {@code Type} divides itself. */
-    private static final String COMPOUND = "souther.compiler.types.Type$Compound";
-
-    /** Whether a walk stops at an authority or carries on through it. */
-    enum Traversal {
-
-        /**
-         * The answer is complete before anything of the caller's runs, so what the authority reads
-         * to make it is its own business and the walk stops here.
-         */
-        OPAQUE,
-
-        /**
-         * The owner of the question, walked through all the same. What it answers with is composed
-         * by something the caller handed it, so a reading the caller wrote is reached from here —
-         * and stopping at this boundary would put a caller's own walk on the far side of it.
-         */
-        TRANSPARENT
-    }
-
-    /**
-     * A place that owns a question, and what a walk does when it arrives.
-     *
-     * @param question what it answers, in the words the answer is about. A place that cannot be
-     *                 given one that some other authority does not already answer is not an
-     *                 authority: it is a second reading under another name
-     * @param owns     the class, or the one method of it, that answers. A class holding several
-     *                 unrelated questions is named by the method, because that is the size of the
-     *                 owner and not because the rest of the class is being excused
-     */
-    record Authority(String question, String owns, Traversal traversal) {
-
-        /** Whether this answers for {@code at}, named with or without what it takes and returns. */
-        boolean answersFor(String at) {
-            String named = at.contains("(") ? at.substring(0, at.indexOf('(')) : at;
-            String owner = named.substring(0, named.indexOf('#'));
-            return owns.contains("#")
-                    ? named.equals(owns)
-                    : owner.equals(owns) || owner.startsWith(owns + "$");
-        }
-    }
 
     /**
      * Why the stage does not have to look past each of these.
@@ -114,7 +60,7 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
      * it.
      */
     private static final List<Authority> AUTHORITIES = List.of(
-            // What a position is, and how it is written. The one this stage exists on top of.
+            // What a position is, and how it is written. The one this stage stands on.
             new Authority("what a position is, with the names it is written under off",
                     "souther.compiler.check.TypeView", Traversal.OPAQUE),
             new Authority("what the rules written on a record leave its fields able to hold",
@@ -157,6 +103,13 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
             new Authority("what a term about a number comes to at another position",
                     "souther.compiler.inputs.NumericTerm", Traversal.TRANSPARENT));
 
+    private static PositionReadings.Over thisCompiler() throws IOException {
+        return new PositionReadings.Over(Reactor.classes(), "souther.compiler.partition.",
+                "souther.compiler.ast.Hir$Def", "souther.compiler.check.Symbols#declaredNode",
+                "souther.compiler.types.Type$Compound", "Lsouther/compiler/types/Type;",
+                AUTHORITIES);
+    }
+
     /**
      * No path from the stage reaches raw structure without an authority answering for it.
      *
@@ -166,15 +119,17 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
      */
     @Test
     void nothingInTheStageReadsStructureThatNoAuthorityAnswersFor() throws IOException {
-        Structure world = Structure.read();
+        PositionReadings.Over over = thisCompiler();
+        PositionReadings.Reading read = PositionReadings.of(over);
 
-        assertFalse(world.observers().isEmpty(),
+        assertFalse(read.observers().isEmpty(),
                 "no reading of raw structure was found anywhere, so this asserts nothing about the"
-                        + " stage: the walk or the sinks are wrong rather than the compiler clean");
-        assertFalse(world.stageMethods().isEmpty(),
+                        + " stage: the walk or the sums it derives from are wrong rather than the"
+                        + " compiler clean");
+        assertFalse(read.inTheStage().isEmpty(),
                 "the stage has no compiled methods, so nothing was checked");
 
-        assertEquals(List.of(), world.bypasses(),
+        assertEquals(List.of(), read.bypasses(),
                 "a path from the partitioning stage to raw structure that no authority answers"
                         + " for. Either the question it is asking has an owner and it should ask"
                         + " there, or it is a second reading of something a reading already"
@@ -191,186 +146,9 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
      */
     @Test
     void everyAuthorityIsOneTheStageArrivesAt() throws IOException {
-        Structure world = Structure.read();
-        List<String> unreached = new ArrayList<>();
-        for (Authority each : AUTHORITIES) {
-            if (world.reached().stream().noneMatch(each::answersFor)) {
-                unreached.add(each.owns());
-            }
-        }
-        assertEquals(List.of(), unreached,
+        PositionReadings.Over over = thisCompiler();
+        assertEquals(List.of(), PositionReadings.unreached(over, PositionReadings.of(over)),
                 "an authority nothing in the stage arrives at, which is a rule about a boundary"
                         + " that is not there");
-    }
-
-    /**
-     * What the compiled classes hold, and what follows from it.
-     *
-     * @param observers  the methods whose own code reads raw structure
-     * @param stageMethods every compiled method of the stage
-     * @param reached    what the stage calls, one step out
-     * @param bypasses   the stage's methods that reach raw structure with no authority between,
-     *                   each with the path that gets there
-     */
-    record Structure(Set<String> observers, Set<String> stageMethods, Set<String> reached,
-                     List<String> bypasses) {
-
-        static Structure read() throws IOException {
-            Map<String, ClassModel> models = new LinkedHashMap<>();
-            for (Path each : Reactor.classes()) {
-                ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
-                models.put(model.thisClass().asInternalName().replace('/', '.'), model);
-            }
-            Set<String> declarations = descendantsOf(models, DECLARATION);
-            Map<String, Set<String>> apart = componentsHoldingTypes(models,
-                    descendantsOf(models, COMPOUND));
-
-            Set<String> observers = new LinkedHashSet<>();
-            Set<String> stage = new LinkedHashSet<>();
-            Set<String> reached = new LinkedHashSet<>();
-            Map<String, Set<String>> callersOf = new LinkedHashMap<>();
-            Map<String, String> why = new LinkedHashMap<>();
-            for (Compiled.Site site : Compiled.sites()) {
-                if (site.from().startsWith(STAGE)) {
-                    stage.add(site.at());
-                    reached.add(site.owner() + "#" + site.member());
-                }
-                callersOf.computeIfAbsent(site.owner() + "#" + site.member(),
-                        k -> new LinkedHashSet<>()).add(site.at());
-                String read = observation(site, declarations, apart);
-                if (read != null) {
-                    observers.add(site.at());
-                    why.putIfAbsent(site.at(), read);
-                }
-            }
-
-            // Backwards from every reading of raw structure, stopping where an authority answers.
-            // A method inside one is not carrying the reading outwards — it is making the answer.
-            Map<String, String> through = new LinkedHashMap<>();
-            Deque<String> queue = new ArrayDeque<>();
-            for (String at : observers) {
-                if (!answeredBy(at, Traversal.OPAQUE) && through.putIfAbsent(at, why.get(at)) == null) {
-                    queue.add(at);
-                }
-            }
-            while (!queue.isEmpty()) {
-                String at = queue.poll();
-                for (String caller : callersOf.getOrDefault(at.substring(0, at.indexOf('(')),
-                        Set.of())) {
-                    if (answeredBy(caller, Traversal.OPAQUE)
-                            || through.putIfAbsent(caller, at) != null) {
-                        continue;
-                    }
-                    queue.add(caller);
-                }
-            }
-
-            List<String> bypasses = new ArrayList<>();
-            for (String at : stage) {
-                if (through.containsKey(at)) {
-                    bypasses.add(at.substring(STAGE.length()) + "  ->  " + pathFrom(at, through));
-                }
-            }
-            bypasses.sort(null);
-            return new Structure(observers, stage, reached, bypasses);
-        }
-
-        /** How the reading is arrived at from here, for a reader who has to go and look. */
-        private static String pathFrom(String at, Map<String, String> through) {
-            List<String> path = new ArrayList<>();
-            String walk = at;
-            Set<String> seen = new LinkedHashSet<>();
-            while (walk != null && seen.add(walk) && path.size() < 8) {
-                String next = through.get(walk);
-                if (next == null || !next.contains("#")) {
-                    path.add(next == null ? "?" : next);
-                    break;
-                }
-                path.add(next.substring(0, next.indexOf('(')));
-                walk = next;
-            }
-            return String.join(" -> ", path);
-        }
-
-        private static boolean answeredBy(String at, Traversal how) {
-            return AUTHORITIES.stream()
-                    .anyMatch(each -> each.traversal() == how && each.answersFor(at));
-        }
-    }
-
-    /** What this site reads of raw structure, or null where it reads none. */
-    private static String observation(Compiled.Site site, Set<String> declarations,
-                                      Map<String, Set<String>> apart) {
-        if (declarations.contains(site.owner())) {
-            return "reaches a declaration: " + site.owner() + "#" + site.member();
-        }
-        if (site.owner().equals("souther.compiler.check.Symbols")
-                && site.member().equals("declaredNode")) {
-            return "asks what a name declares";
-        }
-        if (!apart.containsKey(site.owner())) {
-            return null;
-        }
-        return switch (site.how()) {
-            case ASKS, NAMES -> "asks which compound a type is: " + site.owner();
-            case CALLS, REFERS -> apart.get(site.owner()).contains(site.member())
-                    ? "takes a compound apart: " + site.owner() + "#" + site.member() : null;
-            // Making one is not reading one, and a field of a compound holds no type to read.
-            case MAKES, READS -> null;
-        };
-    }
-
-    /** Every class of this repository that is a {@code root}, root included. */
-    private static Set<String> descendantsOf(Map<String, ClassModel> models, String root) {
-        Set<String> found = new LinkedHashSet<>(Set.of(root));
-        boolean grew = true;
-        while (grew) {
-            grew = false;
-            for (var entry : models.entrySet()) {
-                if (found.contains(entry.getKey())) {
-                    continue;
-                }
-                List<String> above = new ArrayList<>();
-                entry.getValue().superclass()
-                        .ifPresent(each -> above.add(each.asInternalName().replace('/', '.')));
-                entry.getValue().interfaces()
-                        .forEach(each -> above.add(each.asInternalName().replace('/', '.')));
-                if (above.stream().anyMatch(found::contains)) {
-                    found.add(entry.getKey());
-                    grew = true;
-                }
-            }
-        }
-        return found;
-    }
-
-    /**
-     * For each compound, the components of it that are made of types.
-     *
-     * <p>Off the generic signature where there is one: a list of types erases to a list, and a rule
-     * written over descriptors alone would not see what a tuple or a function holds.
-     */
-    private static Map<String, Set<String>> componentsHoldingTypes(Map<String, ClassModel> models,
-                                                                   Set<String> compounds) {
-        Map<String, Set<String>> found = new LinkedHashMap<>();
-        for (String each : compounds) {
-            ClassModel model = models.get(each);
-            if (model == null) {
-                continue;
-            }
-            Set<String> holding = new LinkedHashSet<>();
-            model.findAttribute(Attributes.record()).ifPresent(record -> {
-                for (var component : record.components()) {
-                    String written = component.findAttribute(Attributes.signature())
-                            .map(signature -> signature.signature().stringValue())
-                            .orElse(component.descriptor().stringValue());
-                    if (written.contains("Lsouther/compiler/types/Type;")) {
-                        holding.add(component.name().stringValue());
-                    }
-                }
-            });
-            found.put(each, holding);
-        }
-        return found;
     }
 }

--- a/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
+++ b/souther-bench/src/test/java/souther/bench/PartitionReadsAPositionRatherThanReinterpretingItTest.java
@@ -70,9 +70,6 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
                     "souther.compiler.check.TypeView", Traversal.OPAQUE),
             new Authority("what the rules written on a record leave its fields able to hold",
                     "souther.compiler.check.FieldDomains", Traversal.OPAQUE),
-            new Authority("which ends a declaration writes on the values of a type, and how much"
-                            + " they say it holds",
-                    "souther.compiler.check.DeclaredBounds", Traversal.OPAQUE),
             new Authority("which conjuncts are written on each of the names a value wears",
                     "souther.compiler.check.DeclaredClauses", Traversal.OPAQUE),
             new Authority("what carries the values of a type, and in what order",
@@ -83,12 +80,8 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
                     "souther.compiler.check.NumericMeasures", Traversal.OPAQUE),
             new Authority("what reaches each position of a behavior's inputs, read once",
                     "souther.compiler.inputs.InputDomain", Traversal.OPAQUE),
-            new Authority("what a name in the tree denotes where the reader stands",
-                    "souther.compiler.inputs.InputReads", Traversal.OPAQUE),
             new Authority("which number of an input an expression names",
                     "souther.compiler.inputs.InputNumber", Traversal.OPAQUE),
-            new Authority("which number a comparison draws which line on",
-                    "souther.compiler.inputs.ComparedNumber", Traversal.OPAQUE),
             new Authority("whether an operation and a position make one term of a number taken of"
                             + " a value",
                     "souther.compiler.inputs.NumericTerm$TakenOf", Traversal.OPAQUE),
@@ -104,12 +97,9 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
             new Authority("how a type is written where an author reads it",
                     "souther.compiler.types.Type#show", Traversal.OPAQUE),
 
-            // Owners all the same, walked through. Neither can stand as a boundary: what one
-            // answers with is composed by a reading the caller wrote, and the other hands its
-            // decision to whichever term it is about — so a stop at either would leave the walk
-            // this checks on the far side of it.
-            new Authority("what affine form an expression composes",
-                    "souther.compiler.check.AffineForms", Traversal.TRANSPARENT),
+            // An owner all the same, walked through. It cannot stand as a boundary: it hands its
+            // decision to whichever term it is about, so a stop here would leave the place that
+            // makes it on the far side of the check.
             new Authority("what a term about a number comes to at another position",
                     "souther.compiler.inputs.NumericTerm", Traversal.TRANSPARENT));
 
@@ -147,37 +137,28 @@ class PartitionReadsAPositionRatherThanReinterpretingItTest {
     }
 
     /**
-     * The table names exactly the operations that have to be answered for.
+     * Every authority the table names is standing on a way from the stage to a reading.
      *
-     * <p>Both ways round, and derived rather than judged. What needs an answer is worked out by
-     * running the same walk with nothing answering: every operation the stage calls that would
-     * arrive at raw structure on its own. An operation missing from the table has nobody saying
-     * what question it answers; an entry that answers for nothing is a rule about a boundary that
-     * is not there.
+     * <p>The other half of the rule above, and the one that keeps the table honest. That one says
+     * no way arrives at raw structure with nothing answering; this one says each place the table
+     * credits with answering is somewhere a way actually goes. An entry standing nowhere is a rule
+     * about a boundary that is not there — the reader that needed it has gone, and the entry with
+     * it.
      *
-     * <p>Which is also what keeps a boundary the size of its question. Named by its class, an
-     * authority answers for whatever else that class comes to hold — a second operation beside it,
-     * about something else, reaching the declarations under a question that was never about them.
-     * Named by the operation, that second one arrives here instead.
+     * <p>Where an authority stands is what the table decides, and no walk can decide it: an
+     * ordinary helper on the same way is on the way and not an answer to it, and the two are the
+     * same shape from here. So what is checked is that a named place is met, never that a met place
+     * is named — which is what would make calling a helper an authority the way to go green.
      */
     @Test
-    void theTableNamesTheOperationsThatHaveToBeAnsweredFor() throws IOException {
-        PositionReadings.Over over = thisCompiler();
-        PositionReadings.Reading read = PositionReadings.of(over);
-
-        List<String> unanswered = read.answering().stream()
-                .filter(each -> AUTHORITIES.stream().noneMatch(one -> one.answersFor(each)))
-                .sorted().toList();
-        List<String> answersForNothing = AUTHORITIES.stream()
-                .filter(one -> read.answering().stream().noneMatch(one::answersFor))
-                .map(Authority::owns).sorted().toList();
-
-        assertEquals(List.of(), unanswered,
-                "an operation the stage calls that reaches raw structure and nothing says what"
-                        + " question it answers");
-        assertEquals(List.of(), answersForNothing,
-                "an entry answering for nothing the stage calls, which is a rule about a boundary"
-                        + " that is not there");
+    void everyAuthorityIsStandingSomewhereOnTheWay() throws IOException {
+        PositionReadings.Reading read = PositionReadings.of(thisCompiler());
+        assertEquals(List.of(), AUTHORITIES.stream()
+                        .map(Authority::owns)
+                        .filter(each -> !read.encountered().contains(each))
+                        .sorted().toList(),
+                "an authority the walk never met, which is a rule about a boundary that nothing"
+                        + " arrives at");
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -141,10 +141,11 @@ final class PositionReadings {
 
         // Backwards from every reading of raw structure, stopping where an authority answers. A
         // method inside one is not carrying the reading outwards — it is making the answer.
-        Map<String, String> through = new LinkedHashMap<>();
+        Map<String, Step> through = new LinkedHashMap<>();
         Deque<String> queue = new ArrayDeque<>();
         for (String at : observers) {
-            if (!stops(over, at) && through.putIfAbsent(at, why.get(at)) == null) {
+            if (!stops(over, at)
+                    && through.putIfAbsent(at, new Step.Reading(why.get(at))) == null) {
                 queue.add(at);
             }
         }
@@ -152,7 +153,8 @@ final class PositionReadings {
             String at = queue.poll();
             for (String caller
                     : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
-                if (stops(over, caller) || through.putIfAbsent(caller, at) != null) {
+                if (stops(over, caller)
+                        || through.putIfAbsent(caller, new Step.Through(at)) != null) {
                     continue;
                 }
                 queue.add(caller);
@@ -188,21 +190,40 @@ final class PositionReadings {
                 .anyMatch(each -> each.traversal() == Traversal.OPAQUE && each.answersFor(at));
     }
 
+    /**
+     * The next step out of a method towards the reading it arrives at.
+     *
+     * <p>Two things a step can be, said as two and not told apart by how they are spelled. A method
+     * carries the reading up from what it calls; a sentence is where the reading is, and is the end
+     * of the path. Held as one string, the end of a path and a step of it are told apart by
+     * sniffing for a bracket — which is a reading of a value that could have said which it was.
+     */
+    private sealed interface Step {
+
+        /** The method this one reaches it through. */
+        record Through(String at) implements Step {}
+
+        /** What is read here, which is where the path stops. */
+        record Reading(String said) implements Step {}
+    }
+
     /** How the reading is arrived at from here, for a reader who has to go and look. */
-    private static String pathFrom(String at, Map<String, String> through) {
+    private static String pathFrom(String at, Map<String, Step> through) {
         List<String> path = new ArrayList<>();
         String walk = at;
         Set<String> seen = new LinkedHashSet<>();
         while (walk != null && seen.add(walk) && path.size() < 8) {
-            String next = through.get(walk);
-            // The end of a path is why it is one, which is a sentence rather than a method — and a
-            // sentence naming the member it is about has a `#` in it like any other.
-            if (next == null || !next.contains("(")) {
-                path.add(next == null ? "?" : next);
-                break;
+            switch (through.get(walk)) {
+                case Step.Through(String next) -> {
+                    path.add(next.substring(0, next.indexOf('(')));
+                    walk = next;
+                }
+                case Step.Reading(String said) -> {
+                    path.add(said);
+                    walk = null;
+                }
+                case null -> walk = null;
             }
-            path.add(next.substring(0, next.indexOf('(')));
-            walk = next;
         }
         return String.join(" -> ", path);
     }

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -27,6 +27,13 @@ import java.util.Set;
  * what is built out of types are stated by the sums the caller names, so the walk derives both from
  * the class files rather than knowing either — and a caller can therefore hand it a sum of its own
  * and see what the walk makes of it.
+ *
+ * <p><b>What a call is, here, is the receiver it names.</b> A method reached only through an
+ * interface, or through an override of the method a call names, has no edge: what is read is the
+ * class written into the call and not what stands there when it runs. So the reachability this
+ * answers is over the calls as written. Where a seam is an interface, what is on the far side of it
+ * is held by being in the stage — or by nothing, which is where this stops being an argument and
+ * the reader has to look.
  */
 final class PositionReadings {
 
@@ -43,8 +50,14 @@ final class PositionReadings {
 
         /**
          * The owner of the question, walked through all the same. What it answers with is composed
-         * by something the caller handed it, so a reading the caller wrote is reached from here —
-         * and stopping at this boundary would put a caller's own walk on the far side of it.
+         * by something the caller handed it, so stopping here would put whatever the caller wrote
+         * beyond this — and what the caller wrote is the thing being checked.
+         *
+         * <p>What carrying on buys is the calls this place makes itself. It does not follow the
+         * caller's own reading into the callback: that arrives by an interface, and what is
+         * followed here is the receiver a call names rather than what stands there when it runs.
+         * A reading written in the stage is checked because it is in the stage, not because this
+         * reached it.
          */
         TRANSPARENT
     }
@@ -93,10 +106,17 @@ final class PositionReadings {
      * @param observers the methods whose own code reads raw structure
      * @param inTheStage every compiled method of the stage
      * @param reached   what the stage calls, one step out
+     * @param answering the operations the stage calls that would reach raw structure if nothing
+     *                  answered for them, which is what an authority has to be named for. Derived,
+     *                  so that an operation beside one already answered for cannot arrive under its
+     *                  name — a class answers for what it was named for and nothing else
+     * @param madeOfNonRecords the cases of the compound sum whose components this cannot read,
+     *                  because they are not records. What holds another type would be invisible
      * @param bypassing the stage's methods that reach raw structure with no authority between
      * @param bypasses  the same, each with the path that gets there, for a reader to go and look
      */
     record Reading(Set<String> observers, Set<String> inTheStage, Set<String> reached,
+                   Set<String> answering, List<String> madeOfNonRecords,
                    List<String> bypassing, List<String> bypasses) {
 
         /** Which methods those are, by name alone, which is what a claim about them is written in. */
@@ -171,17 +191,73 @@ final class PositionReadings {
         }
         bypassing.sort(null);
         bypasses.sort(null);
-        return new Reading(observers, stage, reached, bypassing, bypasses);
+        return new Reading(observers, stage, reached, answering(over, observers, callersOf, reached),
+                madeOfNonRecords(models, descendantsOf(models, over.compound())),
+                bypassing, bypasses);
     }
 
-    /** The authorities of {@code over} nothing in the stage arrives at. */
-    static List<String> unreached(Over over, Reading reading) {
-        List<String> out = new ArrayList<>();
-        for (Authority each : over.authorities()) {
-            if (reading.reached().stream().noneMatch(each::answersFor)) {
-                out.add(each.owns());
+    /**
+     * The operations the stage calls that reach raw structure when nothing answers for them.
+     *
+     * <p>Derived rather than judged, which is what keeps a boundary the size of its question. Named
+     * by a class, an authority answers for whatever else that class comes to hold; named by the
+     * operation the stage calls, it answers for that one, and an operation beside it arrives here
+     * instead of under a question that was never about it.
+     *
+     * <p>The walk that finds these is the same one, with nothing answering: what is left is every
+     * way the stage would arrive at raw structure, and the first step of each is an operation
+     * somebody has to be able to point at.
+     */
+    private static Set<String> answering(Over over, Set<String> observers,
+                                         Map<String, Set<String>> callersOf, Set<String> reached) {
+        Set<String> reaches = new LinkedHashSet<>(observers);
+        Deque<String> queue = new ArrayDeque<>(reaches);
+        while (!queue.isEmpty()) {
+            String at = queue.poll();
+            for (String caller
+                    : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
+                if (reaches.add(caller)) {
+                    queue.add(caller);
+                }
             }
         }
+        Set<String> named = new LinkedHashSet<>();
+        for (String at : reaches) {
+            named.add(at.substring(0, at.indexOf('(')));
+        }
+        Set<String> out = new LinkedHashSet<>();
+        for (String each : reached) {
+            // What the stage calls of its own is the population, not an answer to it: a method
+            // held to the rule cannot be what excuses another from it.
+            if (named.contains(each) && !each.startsWith(over.stage())) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The cases of the compound sum this cannot read the components of.
+     *
+     * <p>What is built out of types is derived from the sum, and which of a case's components hold
+     * one is read off the record attribute. A case that is not a record has no such attribute, so
+     * what it holds would be invisible and a walk taking it apart would read as taking nothing
+     * apart. The claim that a case added to the sum joins the rule holds exactly as far as this is
+     * empty, so it is answered rather than assumed.
+     */
+    private static List<String> madeOfNonRecords(Map<String, ClassModel> models,
+                                                 Set<String> compounds) {
+        List<String> out = new ArrayList<>();
+        for (String each : compounds) {
+            ClassModel model = models.get(each);
+            if (model == null || (model.flags().flagsMask() & 0x0600) != 0) {
+                continue;   // not built here, or an interface or abstract class holding no value
+            }
+            if (model.findAttribute(Attributes.record()).isEmpty()) {
+                out.add(each);
+            }
+        }
+        out.sort(null);
         return out;
     }
 

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -106,17 +106,17 @@ final class PositionReadings {
      * @param observers the methods whose own code reads raw structure
      * @param inTheStage every compiled method of the stage
      * @param reached   what the stage calls, one step out
-     * @param answering the operations the stage calls that would reach raw structure if nothing
-     *                  answered for them, which is what an authority has to be named for. Derived,
-     *                  so that an operation beside one already answered for cannot arrive under its
-     *                  name — a class answers for what it was named for and nothing else
+     * @param encountered the authorities the walk met on a way from the stage to a reading. Where
+     *                  an authority stands is what the table decides and reachability cannot: a
+     *                  helper on the same way is on the way and not an answer to it. What is
+     *                  checked is that each one the table names is standing somewhere
      * @param madeOfNonRecords the cases of the compound sum whose components this cannot read,
      *                  because they are not records. What holds another type would be invisible
      * @param bypassing the stage's methods that reach raw structure with no authority between
      * @param bypasses  the same, each with the path that gets there, for a reader to go and look
      */
     record Reading(Set<String> observers, Set<String> inTheStage, Set<String> reached,
-                   Set<String> answering, List<String> madeOfNonRecords,
+                   Set<String> encountered, List<String> madeOfNonRecords,
                    List<String> bypassing, List<String> bypasses) {
 
         /** Which methods those are, by name alone, which is what a claim about them is written in. */
@@ -162,9 +162,10 @@ final class PositionReadings {
         // Backwards from every reading of raw structure, stopping where an authority answers. A
         // method inside one is not carrying the reading outwards — it is making the answer.
         Map<String, Step> through = new LinkedHashMap<>();
+        Set<String> encountered = new LinkedHashSet<>();
         Deque<String> queue = new ArrayDeque<>();
         for (String at : observers) {
-            if (!stops(over, at)
+            if (!standing(over, at, encountered)
                     && through.putIfAbsent(at, new Step.Reading(why.get(at))) == null) {
                 queue.add(at);
             }
@@ -173,7 +174,7 @@ final class PositionReadings {
             String at = queue.poll();
             for (String caller
                     : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
-                if (stops(over, caller)
+                if (standing(over, caller, encountered)
                         || through.putIfAbsent(caller, new Step.Through(at)) != null) {
                     continue;
                 }
@@ -191,49 +192,9 @@ final class PositionReadings {
         }
         bypassing.sort(null);
         bypasses.sort(null);
-        return new Reading(observers, stage, reached, answering(over, observers, callersOf, reached),
+        return new Reading(observers, stage, reached, encountered,
                 madeOfNonRecords(models, descendantsOf(models, over.compound())),
                 bypassing, bypasses);
-    }
-
-    /**
-     * The operations the stage calls that reach raw structure when nothing answers for them.
-     *
-     * <p>Derived rather than judged, which is what keeps a boundary the size of its question. Named
-     * by a class, an authority answers for whatever else that class comes to hold; named by the
-     * operation the stage calls, it answers for that one, and an operation beside it arrives here
-     * instead of under a question that was never about it.
-     *
-     * <p>The walk that finds these is the same one, with nothing answering: what is left is every
-     * way the stage would arrive at raw structure, and the first step of each is an operation
-     * somebody has to be able to point at.
-     */
-    private static Set<String> answering(Over over, Set<String> observers,
-                                         Map<String, Set<String>> callersOf, Set<String> reached) {
-        Set<String> reaches = new LinkedHashSet<>(observers);
-        Deque<String> queue = new ArrayDeque<>(reaches);
-        while (!queue.isEmpty()) {
-            String at = queue.poll();
-            for (String caller
-                    : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
-                if (reaches.add(caller)) {
-                    queue.add(caller);
-                }
-            }
-        }
-        Set<String> named = new LinkedHashSet<>();
-        for (String at : reaches) {
-            named.add(at.substring(0, at.indexOf('(')));
-        }
-        Set<String> out = new LinkedHashSet<>();
-        for (String each : reached) {
-            // What the stage calls of its own is the population, not an answer to it: a method
-            // held to the rule cannot be what excuses another from it.
-            if (named.contains(each) && !each.startsWith(over.stage())) {
-                out.add(each);
-            }
-        }
-        return out;
     }
 
     /**
@@ -261,9 +222,27 @@ final class PositionReadings {
         return out;
     }
 
-    private static boolean stops(Over over, String at) {
-        return over.authorities().stream()
-                .anyMatch(each -> each.traversal() == Traversal.OPAQUE && each.answersFor(at));
+    /**
+     * Whether the walk stops here, noting any authority it met on the way.
+     *
+     * <p>Met on a way from the stage to a reading is what makes an authority one that is standing
+     * somewhere, and it is the walk that knows. Worked out from what the stage calls instead, an
+     * ordinary helper on the same way is indistinguishable from the place that answers — and the
+     * way to make such a check green is to call the helper an authority, which is what a table of
+     * owners must not reward.
+     *
+     * <p>One that carries on is met all the same. It owns the question and says so; what it does
+     * not do is finish before the caller's own code runs, which is why the walk goes past it.
+     */
+    private static boolean standing(Over over, String at, Set<String> encountered) {
+        boolean stops = false;
+        for (Authority each : over.authorities()) {
+            if (each.answersFor(at)) {
+                encountered.add(each.owns());
+                stops |= each.traversal() == Traversal.OPAQUE;
+            }
+        }
+        return stops;
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -1,0 +1,284 @@
+package souther.bench;
+
+import java.io.IOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where a stage's calls arrive at raw structure, and what answers for them on the way.
+ *
+ * <p>What it reads and which classes it reads are two things. The rule about this compiler names
+ * the partitioning stage and the compiler's own sums; a check of the reading itself hands it code
+ * written to be read, and neither is a copy of the other. A second walk written for the second
+ * purpose would be a check of the copy.
+ *
+ * <p>Everything about the vocabulary is an argument for the same reason. What a declaration is and
+ * what is built out of types are stated by the sums the caller names, so the walk derives both from
+ * the class files rather than knowing either — and a caller can therefore hand it a sum of its own
+ * and see what the walk makes of it.
+ */
+final class PositionReadings {
+
+    private PositionReadings() {}
+
+    /** Whether a walk stops at an authority or carries on through it. */
+    enum Traversal {
+
+        /**
+         * The answer is complete before anything of the caller's runs, so what the authority reads
+         * to make it is its own business and the walk stops here.
+         */
+        OPAQUE,
+
+        /**
+         * The owner of the question, walked through all the same. What it answers with is composed
+         * by something the caller handed it, so a reading the caller wrote is reached from here —
+         * and stopping at this boundary would put a caller's own walk on the far side of it.
+         */
+        TRANSPARENT
+    }
+
+    /**
+     * A place that owns a question, and what a walk does when it arrives.
+     *
+     * @param question what it answers, in the words the answer is about. A place that cannot be
+     *                 given one that some other authority does not already answer is not an
+     *                 authority: it is a second reading under another name
+     * @param owns     the class, or the one method of it, that answers. A class holding several
+     *                 unrelated questions is named by the method, because that is the size of the
+     *                 owner and not because the rest of the class is being excused
+     */
+    record Authority(String question, String owns, Traversal traversal) {
+
+        /** Whether this answers for {@code at}, named with or without what it takes and returns. */
+        boolean answersFor(String at) {
+            String named = at.contains("(") ? at.substring(0, at.indexOf('(')) : at;
+            String owner = named.substring(0, named.indexOf('#'));
+            return owns.contains("#")
+                    ? named.equals(owns)
+                    : owner.equals(owns) || owner.startsWith(owns + "$");
+        }
+    }
+
+    /**
+     * What the walk is over.
+     *
+     * @param classes     the compiled classes to read
+     * @param stage       the package whose methods are held to the rule, by name prefix
+     * @param declaration the sum whose cases are what a module wrote
+     * @param lookup      the one method that answers what a name declares, or null where the
+     *                    vocabulary has none
+     * @param compound    the sum whose cases are built out of types
+     * @param held        the descriptor of what a compound's components hold, so that a component
+     *                    made of them is told from one that is not
+     * @param authorities what answers for a reading, and what a walk does at each
+     */
+    record Over(List<Path> classes, String stage, String declaration, String lookup,
+                String compound, String held, List<Authority> authorities) {}
+
+    /**
+     * What the classes hold and what follows from it.
+     *
+     * @param observers the methods whose own code reads raw structure
+     * @param inTheStage every compiled method of the stage
+     * @param reached   what the stage calls, one step out
+     * @param bypassing the stage's methods that reach raw structure with no authority between
+     * @param bypasses  the same, each with the path that gets there, for a reader to go and look
+     */
+    record Reading(Set<String> observers, Set<String> inTheStage, Set<String> reached,
+                   List<String> bypassing, List<String> bypasses) {
+
+        /** Which methods those are, by name alone, which is what a claim about them is written in. */
+        List<String> named() {
+            List<String> out = new ArrayList<>();
+            for (String each : bypassing) {
+                out.add(each.substring(each.indexOf('#') + 1, each.indexOf('(')));
+            }
+            out.sort(null);
+            return out;
+        }
+    }
+
+    static Reading of(Over over) throws IOException {
+        Map<String, ClassModel> models = new LinkedHashMap<>();
+        for (Path each : over.classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            models.put(model.thisClass().asInternalName().replace('/', '.'), model);
+        }
+        Set<String> declarations = descendantsOf(models, over.declaration());
+        Map<String, Set<String>> apart =
+                componentsHolding(models, descendantsOf(models, over.compound()), over.held());
+
+        Set<String> observers = new LinkedHashSet<>();
+        Set<String> stage = new LinkedHashSet<>();
+        Set<String> reached = new LinkedHashSet<>();
+        Map<String, Set<String>> callersOf = new LinkedHashMap<>();
+        Map<String, String> why = new LinkedHashMap<>();
+        for (Compiled.Site site : Compiled.sitesIn(over.classes())) {
+            if (site.from().startsWith(over.stage())) {
+                stage.add(site.at());
+                reached.add(site.owner() + "#" + site.member());
+            }
+            callersOf.computeIfAbsent(site.owner() + "#" + site.member(),
+                    k -> new LinkedHashSet<>()).add(site.at());
+            String read = observation(site, declarations, apart, over.lookup());
+            if (read != null) {
+                observers.add(site.at());
+                why.putIfAbsent(site.at(), read);
+            }
+        }
+
+        // Backwards from every reading of raw structure, stopping where an authority answers. A
+        // method inside one is not carrying the reading outwards — it is making the answer.
+        Map<String, String> through = new LinkedHashMap<>();
+        Deque<String> queue = new ArrayDeque<>();
+        for (String at : observers) {
+            if (!stops(over, at) && through.putIfAbsent(at, why.get(at)) == null) {
+                queue.add(at);
+            }
+        }
+        while (!queue.isEmpty()) {
+            String at = queue.poll();
+            for (String caller
+                    : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
+                if (stops(over, caller) || through.putIfAbsent(caller, at) != null) {
+                    continue;
+                }
+                queue.add(caller);
+            }
+        }
+
+        List<String> bypassing = new ArrayList<>();
+        List<String> bypasses = new ArrayList<>();
+        for (String at : stage) {
+            if (through.containsKey(at)) {
+                bypassing.add(at);
+                bypasses.add(at.substring(over.stage().length()) + "  ->  " + pathFrom(at, through));
+            }
+        }
+        bypassing.sort(null);
+        bypasses.sort(null);
+        return new Reading(observers, stage, reached, bypassing, bypasses);
+    }
+
+    /** The authorities of {@code over} nothing in the stage arrives at. */
+    static List<String> unreached(Over over, Reading reading) {
+        List<String> out = new ArrayList<>();
+        for (Authority each : over.authorities()) {
+            if (reading.reached().stream().noneMatch(each::answersFor)) {
+                out.add(each.owns());
+            }
+        }
+        return out;
+    }
+
+    private static boolean stops(Over over, String at) {
+        return over.authorities().stream()
+                .anyMatch(each -> each.traversal() == Traversal.OPAQUE && each.answersFor(at));
+    }
+
+    /** How the reading is arrived at from here, for a reader who has to go and look. */
+    private static String pathFrom(String at, Map<String, String> through) {
+        List<String> path = new ArrayList<>();
+        String walk = at;
+        Set<String> seen = new LinkedHashSet<>();
+        while (walk != null && seen.add(walk) && path.size() < 8) {
+            String next = through.get(walk);
+            // The end of a path is why it is one, which is a sentence rather than a method — and a
+            // sentence naming the member it is about has a `#` in it like any other.
+            if (next == null || !next.contains("(")) {
+                path.add(next == null ? "?" : next);
+                break;
+            }
+            path.add(next.substring(0, next.indexOf('(')));
+            walk = next;
+        }
+        return String.join(" -> ", path);
+    }
+
+    /** What this site reads of raw structure, or null where it reads none. */
+    private static String observation(Compiled.Site site, Set<String> declarations,
+                                      Map<String, Set<String>> apart, String lookup) {
+        if (declarations.contains(site.owner())) {
+            return "reaches a declaration: " + site.owner() + "#" + site.member();
+        }
+        if (lookup != null && (site.owner() + "#" + site.member()).equals(lookup)) {
+            return "asks what a name declares";
+        }
+        if (!apart.containsKey(site.owner())) {
+            return null;
+        }
+        return switch (site.how()) {
+            case ASKS, NAMES -> "asks which compound a type is: " + site.owner();
+            case CALLS, REFERS -> apart.get(site.owner()).contains(site.member())
+                    ? "takes a compound apart: " + site.owner() + "#" + site.member() : null;
+            // Making one is not reading one, and a field of a compound holds no type to read.
+            case MAKES, READS -> null;
+        };
+    }
+
+    /** Every class among {@code models} that is a {@code root}, root included. */
+    private static Set<String> descendantsOf(Map<String, ClassModel> models, String root) {
+        Set<String> found = new LinkedHashSet<>(Set.of(root));
+        boolean grew = true;
+        while (grew) {
+            grew = false;
+            for (var entry : models.entrySet()) {
+                if (found.contains(entry.getKey())) {
+                    continue;
+                }
+                List<String> above = new ArrayList<>();
+                entry.getValue().superclass()
+                        .ifPresent(each -> above.add(each.asInternalName().replace('/', '.')));
+                entry.getValue().interfaces()
+                        .forEach(each -> above.add(each.asInternalName().replace('/', '.')));
+                if (above.stream().anyMatch(found::contains)) {
+                    found.add(entry.getKey());
+                    grew = true;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * For each compound, the components of it that hold {@code held}.
+     *
+     * <p>Off the generic signature where there is one: a list of them erases to a list, and a rule
+     * written over descriptors alone would not see what a tuple or a function holds.
+     */
+    private static Map<String, Set<String>> componentsHolding(Map<String, ClassModel> models,
+                                                              Set<String> compounds, String held) {
+        Map<String, Set<String>> found = new LinkedHashMap<>();
+        for (String each : compounds) {
+            ClassModel model = models.get(each);
+            if (model == null) {
+                continue;
+            }
+            Set<String> holding = new LinkedHashSet<>();
+            model.findAttribute(Attributes.record()).ifPresent(record -> {
+                for (var component : record.components()) {
+                    String written = component.findAttribute(Attributes.signature())
+                            .map(signature -> signature.signature().stringValue())
+                            .orElse(component.descriptor().stringValue());
+                    if (written.contains(held)) {
+                        holding.add(component.name().stringValue());
+                    }
+                }
+            });
+            found.put(each, holding);
+        }
+        return found;
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/PositionReadings.java
+++ b/souther-bench/src/test/java/souther/bench/PositionReadings.java
@@ -104,18 +104,21 @@ final class PositionReadings {
      * What the classes hold and what follows from it.
      *
      * @param observers the methods whose own code reads raw structure
-     * @param inTheStage every compiled method of the stage
-     * @param reached   what the stage calls, one step out
-     * @param encountered the authorities the walk met on a way from the stage to a reading. Where
-     *                  an authority stands is what the table decides and reachability cannot: a
-     *                  helper on the same way is on the way and not an answer to it. What is
-     *                  checked is that each one the table names is standing somewhere
+     * @param inTheStage the stage's compiled methods that call something, which is every one a way
+     *                  out of the stage could start at. One that calls nothing reaches nothing
+     * @param encountered the authorities standing on a way from the stage to a reading: met by the
+     *                  walk back from a reading, and reachable forwards from the stage. Two
+     *                  questions and both of them, because either alone is about a wider set than
+     *                  the sentence — a place on a way to a reading somewhere is not on a way from
+     *                  here, and a place the stage can reach is not thereby on the way to anything.
+     *                  Where an authority stands is the table's to say and reachability's to
+     *                  confirm: a helper on the same way is on the way and not an answer to it
      * @param madeOfNonRecords the cases of the compound sum whose components this cannot read,
      *                  because they are not records. What holds another type would be invisible
      * @param bypassing the stage's methods that reach raw structure with no authority between
      * @param bypasses  the same, each with the path that gets there, for a reader to go and look
      */
-    record Reading(Set<String> observers, Set<String> inTheStage, Set<String> reached,
+    record Reading(Set<String> observers, Set<String> inTheStage,
                    Set<String> encountered, List<String> madeOfNonRecords,
                    List<String> bypassing, List<String> bypasses) {
 
@@ -142,20 +145,41 @@ final class PositionReadings {
 
         Set<String> observers = new LinkedHashSet<>();
         Set<String> stage = new LinkedHashSet<>();
-        Set<String> reached = new LinkedHashSet<>();
         Map<String, Set<String>> callersOf = new LinkedHashMap<>();
+        Map<String, Set<String>> callsOf = new LinkedHashMap<>();
+        Map<String, Set<String>> named = new LinkedHashMap<>();
         Map<String, String> why = new LinkedHashMap<>();
         for (Compiled.Site site : Compiled.sitesIn(over.classes())) {
             if (site.from().startsWith(over.stage())) {
                 stage.add(site.at());
-                reached.add(site.owner() + "#" + site.member());
             }
+            named.computeIfAbsent(site.at().substring(0, site.at().indexOf('(')),
+                    k -> new LinkedHashSet<>()).add(site.at());
             callersOf.computeIfAbsent(site.owner() + "#" + site.member(),
                     k -> new LinkedHashSet<>()).add(site.at());
+            callsOf.computeIfAbsent(site.at(), k -> new LinkedHashSet<>())
+                    .add(site.owner() + "#" + site.member());
             String read = observation(site, declarations, apart, over.lookup());
             if (read != null) {
                 observers.add(site.at());
                 why.putIfAbsent(site.at(), read);
+            }
+        }
+
+        // Which methods the stage can arrive at, forwards, whatever answers on the way. Asked
+        // apart from the walk below and answered before it: stopping the walk where an authority
+        // answers is one question, and whether the stage can arrive at a place at all is another.
+        // Read off the walk alone, a place on a way to a reading in some other part of this
+        // compiler would count as standing on a way from here.
+        Set<String> fromTheStage = new LinkedHashSet<>(stage);
+        Deque<String> forwards = new ArrayDeque<>(stage);
+        while (!forwards.isEmpty()) {
+            for (String call : callsOf.getOrDefault(forwards.poll(), Set.of())) {
+                for (String at : named.getOrDefault(call, Set.of())) {
+                    if (fromTheStage.add(at)) {
+                        forwards.add(at);
+                    }
+                }
             }
         }
 
@@ -165,7 +189,7 @@ final class PositionReadings {
         Set<String> encountered = new LinkedHashSet<>();
         Deque<String> queue = new ArrayDeque<>();
         for (String at : observers) {
-            if (!standing(over, at, encountered)
+            if (!standing(over, at, encountered, fromTheStage)
                     && through.putIfAbsent(at, new Step.Reading(why.get(at))) == null) {
                 queue.add(at);
             }
@@ -174,7 +198,7 @@ final class PositionReadings {
             String at = queue.poll();
             for (String caller
                     : callersOf.getOrDefault(at.substring(0, at.indexOf('(')), Set.of())) {
-                if (standing(over, caller, encountered)
+                if (standing(over, caller, encountered, fromTheStage)
                         || through.putIfAbsent(caller, new Step.Through(at)) != null) {
                     continue;
                 }
@@ -192,7 +216,7 @@ final class PositionReadings {
         }
         bypassing.sort(null);
         bypasses.sort(null);
-        return new Reading(observers, stage, reached, encountered,
+        return new Reading(observers, stage, encountered,
                 madeOfNonRecords(models, descendantsOf(models, over.compound())),
                 bypassing, bypasses);
     }
@@ -233,12 +257,21 @@ final class PositionReadings {
      *
      * <p>One that carries on is met all the same. It owns the question and says so; what it does
      * not do is finish before the caller's own code runs, which is why the walk goes past it.
+     *
+     * <p><b>Stopping and standing are two answers.</b> The walk stops wherever an authority is,
+     * because taint that goes no further can reach no method of the stage either way; what is
+     * recorded as standing is only what the stage can arrive at. Recorded on meeting alone, a place
+     * answering for some other part of this compiler would be credited with standing on a way from
+     * here — which is a wider set than the sentence names.
      */
-    private static boolean standing(Over over, String at, Set<String> encountered) {
+    private static boolean standing(Over over, String at, Set<String> encountered,
+                                    Set<String> fromTheStage) {
         boolean stops = false;
         for (Authority each : over.authorities()) {
             if (each.answersFor(at)) {
-                encountered.add(each.owns());
+                if (fromTheStage.contains(at)) {
+                    encountered.add(each.owns());
+                }
                 stops |= each.traversal() == Traversal.OPAQUE;
             }
         }

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -1,0 +1,171 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import souther.bench.PositionReadings.Authority;
+import souther.bench.PositionReadings.Traversal;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the walk over a stage's readings sees, asked of code written to be read.
+ *
+ * <p>The rule beside this one says the compiler has no path from its partitioning stage to raw
+ * structure. That is a fact about the compiler as it stands, and it stays green if the walk stops
+ * seeing something: break the collection of one instruction and, with no such path written today,
+ * nothing goes red. What the rule protects would be gone and nothing would say so.
+ *
+ * <p>So the walk is asked here about a model that holds one of everything. Each fixture is a claim
+ * a reader can check by reading it — this reaches a declaration, this takes a compound apart, this
+ * one only reads a name — and the walk's answer is held against it. A mutation run once against
+ * the compiler proves the walk saw a defect that day; this says it still would.
+ *
+ * <p>The model is written in sums of its own. What the walk is handed is which sum says what a
+ * module wrote and which is built out of others, so a model with its own asks whether those sets
+ * are derived from the classes it was given rather than known. Written in the compiler's types, a
+ * fixture would be checking a spelling.
+ */
+class ThisReadingSeesAReadingOfRawStructureTest {
+
+    /** The stage of the model, whose readers are the ones held to the rule. */
+    private static final String STAGE = "souther.bench.readings.Stage";
+
+    private static final List<Authority> AUTHORITIES = List.of(
+            new Authority("how a name is written where a reader meets one",
+                    "souther.bench.readings.Opaque", Traversal.OPAQUE),
+            new Authority("what a name comes to on the way",
+                    "souther.bench.readings.Transparent", Traversal.TRANSPARENT));
+
+    private static PositionReadings.Over model() throws IOException {
+        return new PositionReadings.Over(written(), STAGE,
+                "souther.bench.readings.Written$Declared", "souther.bench.readings.Written$Names#declaredNode",
+                "souther.bench.readings.Written$Position$Built",
+                "Lsouther/bench/readings/Written$Position;", AUTHORITIES);
+    }
+
+    /** The compiled model, which is what this is a reading of. */
+    private static List<Path> written() throws IOException {
+        Path built = Path.of("target/test-classes/souther/bench/readings");
+        assertTrue(Files.isDirectory(built),
+                "the model was not compiled, so this would assert nothing: " + built.toAbsolutePath());
+        try (Stream<Path> walk = Files.walk(built)) {
+            List<Path> out = new ArrayList<>(
+                    walk.filter(each -> each.toString().endsWith(".class")).toList());
+            assertFalse(out.isEmpty(), "the model compiled to no classes");
+            return out;
+        }
+    }
+
+    private static List<String> bypassing() throws IOException {
+        return PositionReadings.of(model()).named();
+    }
+
+    /**
+     * Every reader that reaches raw structure is seen, and only those.
+     *
+     * <p>Both halves at once, and named rather than counted. A walk that saw one shape and not
+     * another would pass a check that only asked how many there were, and which shapes it sees is
+     * the whole of what this is about.
+     */
+    @Test
+    void everyReaderThatReachesRawStructureIsSeenAndNoOtherIs() throws IOException {
+        assertEquals(List.of(
+                        // Its own code reaches a declaration, and its own code takes a compound
+                        // apart. The two plainest readings there are.
+                        // Asking which compound a position is and taking nothing out of it, which
+                        // is the reading a walk over components alone would not see.
+                        "asksWhichCompoundItIs",
+                        "readsADeclaration",
+                        // Past an owner the walk is told to go through, which is what keeps a
+                        // caller's own reading from hiding behind one.
+                        "readsPastATransparentBoundary",
+                        // Two calls away, behind something that answers with a word. What is
+                        // followed is the call: a walk over what came back would see neither.
+                        "readsThroughAHelper",
+                        "takesACompoundApart",
+                        "takesOneApartThroughAHelper"),
+                bypassing(),
+                "the readers the walk sees, against the ones written to be seen. A reader missing"
+                        + " from this is a shape the walk has stopped seeing, and one that is here"
+                        + " and should not be reads no structure at all");
+    }
+
+    /**
+     * What the walk does not call a reading, said as itself.
+     *
+     * <p>The same list read the other way. These are the four ways of touching the model that are
+     * not readings of it, and a walk calling any of them one would refuse code that is doing
+     * nothing wrong — which is how a rule stops being read.
+     */
+    @Test
+    void touchingTheModelWithoutReadingItIsNotOne() throws IOException {
+        List<String> seen = bypassing();
+        for (String each : List.of("asksAnAuthority", "readsANameOffALeaf", "makesACompound",
+                "readsAComponentHoldingNoPosition")) {
+            assertFalse(seen.contains(each), () -> each + " reads no structure, and the walk says"
+                    + " it does. What it does instead is written on it: " + seen);
+        }
+    }
+
+    /** An authority the stage arrives at is not reported as a boundary that is not there. */
+    @Test
+    void anAuthorityTheStageArrivesAtIsNotStale() throws IOException {
+        PositionReadings.Over over = model();
+        assertEquals(List.of(), PositionReadings.unreached(over, PositionReadings.of(over)),
+                "both authorities are called by the stage of the model");
+    }
+
+    /**
+     * And one nothing arrives at is, which is what a boundary that has gone looks like.
+     *
+     * <p>Named as a method of an authority that is there, because that is the way an entry goes
+     * stale: the place stays and the operation the table pointed at is renamed or removed under it.
+     */
+    @Test
+    void anAuthorityNothingArrivesAtIsStale() throws IOException {
+        PositionReadings.Over over = model();
+        List<Authority> withOneMore = new ArrayList<>(AUTHORITIES);
+        withOneMore.add(new Authority("a question nothing in the model asks any more",
+                "souther.bench.readings.Opaque#spellingAsItWasCalled", Traversal.OPAQUE));
+        PositionReadings.Over stale = new PositionReadings.Over(over.classes(), over.stage(),
+                over.declaration(), over.lookup(), over.compound(), over.held(), withOneMore);
+
+        assertEquals(List.of("souther.bench.readings.Opaque#spellingAsItWasCalled"),
+                PositionReadings.unreached(stale, PositionReadings.of(stale)),
+                "nothing of that name is there to be called, so naming it is a rule about a"
+                        + " boundary that is not");
+    }
+
+    /**
+     * An opaque boundary stops the walk, and what it reads to answer is its own business.
+     *
+     * <p>Asked by taking the boundary away: the reader that asks it is not a bypass while the
+     * authority is named and is one when it is not. Without this the table could hold entries that
+     * change nothing, and an authority that stopped stopping anything would look like a clean
+     * compiler.
+     */
+    @Test
+    void anOpaqueBoundaryIsWhatStopsTheWalk() throws IOException {
+        assertFalse(bypassing().contains("asksAnAuthority"),
+                "the authority answers, so its caller reaches nothing raw");
+
+        PositionReadings.Over over = model();
+        PositionReadings.Over without = new PositionReadings.Over(over.classes(), over.stage(),
+                over.declaration(), over.lookup(), over.compound(), over.held(),
+                AUTHORITIES.stream()
+                        .filter(each -> each.traversal() != Traversal.OPAQUE).toList());
+        List<String> reaching = PositionReadings.of(without).named();
+        assertTrue(reaching.contains("asksAnAuthority"),
+                "with nothing answering for it, the same reader reaches the declaration behind it:"
+                        + " " + reaching);
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -156,27 +156,60 @@ class ThisReadingSeesAReadingOfRawStructureTest {
     }
 
     /**
-     * What has to be answered for is the operations the stage calls that reach structure.
+     * Both boundaries are met on a way from the stage, and a helper on one is not mistaken for a
+     * boundary.
      *
-     * <p>Derived, so that an operation beside one already answered for cannot arrive under its
-     * name. Both boundaries of the model are here and the helpers are not: a helper is on the way
-     * to a reading rather than an answer to it, and the stage calls it directly.
+     * <p>The distinction the walk cannot make and must not be asked to. `Helpers` sits between the
+     * stage and a reading exactly as an authority does, and is not one — it is written as a helper
+     * and the model says so. What is met is recorded; what answers is the table's to say.
      */
     @Test
-    void whatHasToBeAnsweredForIsWhatTheStageCallsThatReachesStructure() throws IOException {
-        assertEquals(List.of(
-                        "souther.bench.readings.Helpers#holdsALeaf",
-                        "souther.bench.readings.Helpers#isARecord",
-                        "souther.bench.readings.Opaque#somethingElse",
-                        "souther.bench.readings.Opaque#spelling",
-                        "souther.bench.readings.Transparent#answering",
-                        // An accessor of a declaration is a reading of one, so calling it is
-                        // arriving at raw structure like any other way of doing so. The lookup
-                        // beside it is not here: it is answered by whatever implements it, and
-                        // what a call names is an interface with no code of its own.
-                        "souther.bench.readings.Written$Declared$Record#holdsAnything"),
-                PositionReadings.of(model()).answering().stream().sorted().toList(),
-                "every operation the stage calls that would arrive at raw structure on its own");
+    void everyBoundaryOfTheModelIsMetAndAHelperIsNotOne() throws IOException {
+        PositionReadings.Reading read = PositionReadings.of(model());
+
+        assertEquals(List.of("souther.bench.readings.Opaque",
+                        "souther.bench.readings.Transparent"),
+                read.encountered().stream().sorted().toList(),
+                "the places the walk met that the table names, which is both of them and nothing"
+                        + " else: a helper is met too and is not named, so it is not here");
+    }
+
+    /**
+     * A helper between the stage and an authority changes nothing.
+     *
+     * <p>The way a rule about owners turns into a list of whatever is on the way. Put something
+     * ordinary between the two and a check that asked every step to name its question would call
+     * the helper unanswered and the authority unmet — and the way to green would be to call the
+     * helper an owner. What is on the way is walked through; what answers is met at the end of it.
+     */
+    @Test
+    void aHelperBetweenTheStageAndAnAuthorityChangesNothing() throws IOException {
+        PositionReadings.Reading read = PositionReadings.of(model());
+
+        assertFalse(read.named().contains("asksAnAuthorityThroughAHelper"),
+                "the authority answers however many steps away it is: " + read.named());
+        assertTrue(read.encountered().contains("souther.bench.readings.Opaque"),
+                "and is met on that way, so nothing calls it a boundary that is not there");
+    }
+
+    /**
+     * An authority the walk never meets is not among those it met.
+     *
+     * <p>Which is what a boundary that has gone looks like, and what the rule beside this one reads
+     * to say so. Named by an operation nothing is written under, this stands nowhere.
+     */
+    @Test
+    void anAuthorityStandingNowhereIsNotMet() throws IOException {
+        PositionReadings.Over over = model();
+        List<Authority> withOneMore = new ArrayList<>(over.authorities());
+        withOneMore.add(new Authority("a question nothing in the model asks any more",
+                "souther.bench.readings.Opaque#spellingAsItWasCalled", Traversal.OPAQUE));
+        PositionReadings.Over stale = new PositionReadings.Over(over.classes(), over.stage(),
+                over.declaration(), over.lookup(), over.compound(), over.held(), withOneMore);
+
+        assertFalse(PositionReadings.of(stale).encountered()
+                        .contains("souther.bench.readings.Opaque#spellingAsItWasCalled"),
+                "nothing of that name is there to be met");
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -200,16 +201,39 @@ class ThisReadingSeesAReadingOfRawStructureTest {
      */
     @Test
     void anAuthorityStandingNowhereIsNotMet() throws IOException {
-        PositionReadings.Over over = model();
-        List<Authority> withOneMore = new ArrayList<>(over.authorities());
-        withOneMore.add(new Authority("a question nothing in the model asks any more",
-                "souther.bench.readings.Opaque#spellingAsItWasCalled", Traversal.OPAQUE));
-        PositionReadings.Over stale = new PositionReadings.Over(over.classes(), over.stage(),
-                over.declaration(), over.lookup(), over.compound(), over.held(), withOneMore);
-
-        assertFalse(PositionReadings.of(stale).encountered()
+        assertFalse(alsoNaming("souther.bench.readings.Opaque#spellingAsItWasCalled")
                         .contains("souther.bench.readings.Opaque#spellingAsItWasCalled"),
                 "nothing of that name is there to be met");
+    }
+
+    /**
+     * Nor is one that answers on a way the stage is not on.
+     *
+     * <p>The harder half, and the one a name that is not there cannot ask about. This authority is
+     * written, reached, and reads the declarations — everything a walk backwards from a reading
+     * meets on the way. What it is not is anywhere the stage arrives, and the sentence beside the
+     * rule says from the stage. Met and standing are two answers, and only the second is the one
+     * being made.
+     */
+    @Test
+    void anAuthorityOnAWayTheStageIsNotOnIsNotStanding() throws IOException {
+        assertFalse(alsoNaming("souther.bench.readings.Elsewhere").contains(
+                        "souther.bench.readings.Elsewhere"),
+                "it answers for a reader of its own, and the stage reaches neither");
+        assertTrue(alsoNaming("souther.bench.readings.Elsewhere")
+                        .contains("souther.bench.readings.Opaque"),
+                "while the one the stage does arrive at is still standing");
+    }
+
+    /** What the walk records as standing, with one more entry named. */
+    private static Set<String> alsoNaming(String owns) throws IOException {
+        PositionReadings.Over over = model();
+        List<Authority> withOneMore = new ArrayList<>(over.authorities());
+        withOneMore.add(new Authority("a question nothing on a way from the stage asks", owns,
+                Traversal.OPAQUE));
+        return PositionReadings.of(new PositionReadings.Over(over.classes(), over.stage(),
+                over.declaration(), over.lookup(), over.compound(), over.held(), withOneMore))
+                .encountered();
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -52,11 +52,17 @@ class ThisReadingSeesAReadingOfRawStructureTest {
                 "Lsouther/bench/readings/Written$Position;", AUTHORITIES);
     }
 
-    /** The compiled model, which is what this is a reading of. */
+    /**
+     * The compiled model, which is what this is a reading of.
+     *
+     * <p>Found from the repository, the way everything else here finds what a build produced. Read
+     * from wherever this happens to have been started instead, the model would be missing whenever
+     * that was somewhere else — and a walk over no classes finds no reading and says nothing.
+     */
     private static List<Path> written() throws IOException {
-        Path built = Path.of("target/test-classes/souther/bench/readings");
+        Path built = Reactor.root().resolve("souther-bench/target/test-classes/souther/bench/readings");
         assertTrue(Files.isDirectory(built),
-                "the model was not compiled, so this would assert nothing: " + built.toAbsolutePath());
+                "the model was not compiled, so this would assert nothing: " + built);
         try (Stream<Path> walk = Files.walk(built)) {
             List<Path> out = new ArrayList<>(
                     walk.filter(each -> each.toString().endsWith(".class")).toList());

--- a/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
+++ b/souther-bench/src/test/java/souther/bench/ThisReadingSeesAReadingOfRawStructureTest.java
@@ -98,11 +98,44 @@ class ThisReadingSeesAReadingOfRawStructureTest {
                         // followed is the call: a walk over what came back would see neither.
                         "readsThroughAHelper",
                         "takesACompoundApart",
+                        // What a component holds is written only in the generic signature, so a
+                        // reading over descriptors alone would see this one hold nothing.
+                        "takesApartOneHoldingMany",
                         "takesOneApartThroughAHelper"),
                 bypassing(),
                 "the readers the walk sees, against the ones written to be seen. A reader missing"
                         + " from this is a shape the walk has stopped seeing, and one that is here"
                         + " and should not be reads no structure at all");
+    }
+
+    /**
+     * A boundary named by its class stands in front of the operation beside it; named by the
+     * operation, it does not.
+     *
+     * <p>Which is the whole of what sizing a boundary decides. The model's authority holds two
+     * questions, and the second reaches the declarations for reasons of its own. Named by the
+     * class, a reader asking that second question is answered for by an entry about the first —
+     * and the walk stops at a boundary that was never about what it is standing in front of.
+     */
+    @Test
+    void namingTheOperationCatchesTheQuestionBesideItAndNamingTheClassDoesNot() throws IOException {
+        assertFalse(bypassing().contains("asksTheQuestionBesideIt"),
+                "named by its class, the entry about one question answers for the other too");
+
+        PositionReadings.Over over = model();
+        PositionReadings.Over named = new PositionReadings.Over(over.classes(), over.stage(),
+                over.declaration(), over.lookup(), over.compound(), over.held(),
+                over.authorities().stream()
+                        .map(each -> each.owns().equals("souther.bench.readings.Opaque")
+                                ? new Authority(each.question(),
+                                        "souther.bench.readings.Opaque#spelling", each.traversal())
+                                : each)
+                        .toList());
+
+        assertTrue(PositionReadings.of(named).named().contains("asksTheQuestionBesideIt"),
+                "named by the operation it answers for, the question beside it arrives here");
+        assertFalse(PositionReadings.of(named).named().contains("asksAnAuthority"),
+                "and the reader of the question that is answered for still is");
     }
 
     /**
@@ -122,33 +155,44 @@ class ThisReadingSeesAReadingOfRawStructureTest {
         }
     }
 
-    /** An authority the stage arrives at is not reported as a boundary that is not there. */
+    /**
+     * What has to be answered for is the operations the stage calls that reach structure.
+     *
+     * <p>Derived, so that an operation beside one already answered for cannot arrive under its
+     * name. Both boundaries of the model are here and the helpers are not: a helper is on the way
+     * to a reading rather than an answer to it, and the stage calls it directly.
+     */
     @Test
-    void anAuthorityTheStageArrivesAtIsNotStale() throws IOException {
-        PositionReadings.Over over = model();
-        assertEquals(List.of(), PositionReadings.unreached(over, PositionReadings.of(over)),
-                "both authorities are called by the stage of the model");
+    void whatHasToBeAnsweredForIsWhatTheStageCallsThatReachesStructure() throws IOException {
+        assertEquals(List.of(
+                        "souther.bench.readings.Helpers#holdsALeaf",
+                        "souther.bench.readings.Helpers#isARecord",
+                        "souther.bench.readings.Opaque#somethingElse",
+                        "souther.bench.readings.Opaque#spelling",
+                        "souther.bench.readings.Transparent#answering",
+                        // An accessor of a declaration is a reading of one, so calling it is
+                        // arriving at raw structure like any other way of doing so. The lookup
+                        // beside it is not here: it is answered by whatever implements it, and
+                        // what a call names is an interface with no code of its own.
+                        "souther.bench.readings.Written$Declared$Record#holdsAnything"),
+                PositionReadings.of(model()).answering().stream().sorted().toList(),
+                "every operation the stage calls that would arrive at raw structure on its own");
     }
 
     /**
-     * And one nothing arrives at is, which is what a boundary that has gone looks like.
+     * A case of what is built out of types that is not a record is refused.
      *
-     * <p>Named as a method of an authority that is there, because that is the way an entry goes
-     * stale: the place stays and the operation the table pointed at is renamed or removed under it.
+     * <p>Which components hold a type is read off the record attribute, so a case without one holds
+     * nothing this can see. The claim that a case added to the sum joins the rule holds exactly as
+     * far as this refuses, which is why the refusal is asked of a model that has one.
      */
     @Test
-    void anAuthorityNothingArrivesAtIsStale() throws IOException {
-        PositionReadings.Over over = model();
-        List<Authority> withOneMore = new ArrayList<>(AUTHORITIES);
-        withOneMore.add(new Authority("a question nothing in the model asks any more",
-                "souther.bench.readings.Opaque#spellingAsItWasCalled", Traversal.OPAQUE));
-        PositionReadings.Over stale = new PositionReadings.Over(over.classes(), over.stage(),
-                over.declaration(), over.lookup(), over.compound(), over.held(), withOneMore);
-
-        assertEquals(List.of("souther.bench.readings.Opaque#spellingAsItWasCalled"),
-                PositionReadings.unreached(stale, PositionReadings.of(stale)),
-                "nothing of that name is there to be called, so naming it is a rule about a"
-                        + " boundary that is not");
+    void aCaseBuiltOutOfTypesThatIsNotARecordIsRefused() throws IOException {
+        assertEquals(List.of("souther.bench.readings.Written$Position$Built$Awkward"),
+                PositionReadings.of(model()).madeOfNonRecords(),
+                "the arm of the model written as a class rather than a record: what it holds is"
+                        + " not where this reads what a compound holds, so it is named rather than"
+                        + " read past");
     }
 
     /**

--- a/souther-bench/src/test/java/souther/bench/readings/Elsewhere.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Elsewhere.java
@@ -1,0 +1,29 @@
+package souther.bench.readings;
+
+/**
+ * A place that answers, on a way to a reading that does not start at the stage.
+ *
+ * <p>Written and reached, so that a walk over the classes finds it and finds what it reads. What it
+ * is not is anywhere the stage can arrive: nothing here is called from there, directly or through
+ * anything else.
+ *
+ * <p>Here because a walk backwards from a reading meets whatever is on the way to that reading,
+ * wherever the way begins. Recorded on being met, this would count as standing on a way from the
+ * stage — and an entry naming it would look like a boundary doing its job while the stage went past
+ * somewhere else entirely.
+ */
+public final class Elsewhere {
+
+    private Elsewhere() {}
+
+    /** Answers the same kind of question the model's own authority does, for a caller of its own. */
+    public static String spelling(Written.Names names, String name) {
+        return names.declaredNode(name) instanceof Written.Declared.Record record
+                ? record.name() : name;
+    }
+
+    /** The caller, which is not the stage and is reached from nothing that is. */
+    public static String asked(Written.Names names, String name) {
+        return spelling(names, name);
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/readings/Helpers.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Helpers.java
@@ -21,4 +21,16 @@ public final class Helpers {
         return position instanceof Written.Position.Built.OfOne one
                 && one.element() instanceof Written.Position.Leaf;
     }
+
+    /**
+     * On the way to an authority rather than to a reading, which is the other thing a helper is.
+     *
+     * <p>Here because the two are the same shape from a walk: something between the stage and what
+     * is at the end. What is at the end of this one answers, so nothing here has a question of its
+     * own to be given — and a check that asked every place on a way to name its question would be
+     * made green by inventing one.
+     */
+    public static String spellingOf(Written.Names names, String name) {
+        return Opaque.spelling(names, name);
+    }
 }

--- a/souther-bench/src/test/java/souther/bench/readings/Helpers.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Helpers.java
@@ -1,0 +1,24 @@
+package souther.bench.readings;
+
+/**
+ * Places outside the stage that read raw structure and answer with a word.
+ *
+ * <p>Neither owns a question: each is the reading of something the model already says, given
+ * another name and a smaller return type. They are here because that is exactly what a walk over
+ * return types cannot see — what is followed has to be the call.
+ */
+public final class Helpers {
+
+    private Helpers() {}
+
+    /** Whether the name declares a record, which is what reaching the declaration answers. */
+    public static boolean isARecord(Written.Names names, String name) {
+        return names.declaredNode(name) instanceof Written.Declared.Record;
+    }
+
+    /** Whether the compound holds a leaf, which is what taking it apart answers. */
+    public static boolean holdsALeaf(Written.Position position) {
+        return position instanceof Written.Position.Built.OfOne one
+                && one.element() instanceof Written.Position.Leaf;
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/readings/Opaque.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Opaque.java
@@ -15,4 +15,15 @@ public final class Opaque {
         return names.declaredNode(name) instanceof Written.Declared.Record record
                 ? record.name() : name;
     }
+
+    /**
+     * A second question, beside the first and about something else.
+     *
+     * <p>Here because a class is not always the size of a question. Named by the class, the answer
+     * to the first question stands in front of this one too, and a reader arriving here reaches the
+     * declarations under a name that was never about them. Named by the operation, it does not.
+     */
+    public static boolean somethingElse(Written.Names names, String name) {
+        return names.declaredNode(name) instanceof Written.Declared.OneValue;
+    }
 }

--- a/souther-bench/src/test/java/souther/bench/readings/Opaque.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Opaque.java
@@ -1,0 +1,18 @@
+package souther.bench.readings;
+
+/**
+ * An authority: it owns a question, reads whatever the answer needs, and hands back the answer.
+ *
+ * <p>Nothing of the caller's runs before it is finished and nothing raw comes back, so a walk that
+ * arrives here has no reason to go on — which is the whole of what a boundary is.
+ */
+public final class Opaque {
+
+    private Opaque() {}
+
+    /** How a name is written where a reader meets one. */
+    public static String spelling(Written.Names names, String name) {
+        return names.declaredNode(name) instanceof Written.Declared.Record record
+                ? record.name() : name;
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/readings/Stage.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Stage.java
@@ -1,0 +1,71 @@
+package souther.bench.readings;
+
+/**
+ * A stage written to be read: every shape the walk has to tell apart, and one of nothing at all.
+ *
+ * <p>Each method here is a claim about the walk rather than about this compiler. What they have in
+ * common is that a reader looking at the source can see which answer is right, so a walk that gives
+ * another has been caught by something that does not depend on the compiler standing still.
+ */
+public final class Stage {
+
+    private Stage() {}
+
+    /** Reaches a declaration itself, which is the plainest reading there is. */
+    public static boolean readsADeclaration(Written.Names names, String name) {
+        return names.declaredNode(name) instanceof Written.Declared.Record record
+                && record.holdsAnything();
+    }
+
+    /** Takes a compound apart, which is the other. */
+    public static Written.Position takesACompoundApart(Written.Position position) {
+        return position instanceof Written.Position.Built.OfOne one ? one.element() : null;
+    }
+
+    /**
+     * Asks which compound it is and takes nothing out, which is a reading all the same.
+     *
+     * <p>Beside the one above and not the same shape. That one asks and then reads a component, so
+     * a walk seeing only the component would still see it; this one asks and stops, which is what
+     * telling a list from a map is — and a reader with the answer has divided the position without
+     * anything having handed it a division.
+     */
+    public static boolean asksWhichCompoundItIs(Written.Position position) {
+        return position instanceof Written.Position.Built.OfTwo;
+    }
+
+    /** Reaches a declaration two calls away, behind something that answers with a word. */
+    public static boolean readsThroughAHelper(Written.Names names, String name) {
+        return Helpers.isARecord(names, name);
+    }
+
+    /** Takes a compound apart from behind a helper that hands back no type of anybody's. */
+    public static boolean takesOneApartThroughAHelper(Written.Position position) {
+        return Helpers.holdsALeaf(position);
+    }
+
+    /** Reaches a reading past a boundary the walk is told to go through. */
+    public static boolean readsPastATransparentBoundary(Written.Names names, String name) {
+        return Transparent.answering(names, name);
+    }
+
+    /** Asks an authority, which answers and hands nothing raw back. */
+    public static String asksAnAuthority(Written.Names names, String name) {
+        return Opaque.spelling(names, name);
+    }
+
+    /** Reads the name off a leaf, which is a name and not a structure. */
+    public static String readsANameOffALeaf(Written.Position position) {
+        return position instanceof Written.Position.Leaf leaf ? leaf.name() : null;
+    }
+
+    /** Makes a compound, which is not reading one. */
+    public static Written.Position makesACompound(Written.Position element) {
+        return new Written.Position.Built.OfOne(element);
+    }
+
+    /** Reads a component of a compound that holds no position, which reads no structure. */
+    public static String readsAComponentHoldingNoPosition(Written.Position.Built.OfTwo pair) {
+        return pair.label();
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/readings/Stage.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Stage.java
@@ -67,6 +67,11 @@ public final class Stage {
         return Opaque.spelling(names, name);
     }
 
+    /** Asks an authority with a helper in between, which answers all the same. */
+    public static String asksAnAuthorityThroughAHelper(Written.Names names, String name) {
+        return Helpers.spellingOf(names, name);
+    }
+
     /** Asks the operation beside it, which answers something else and reaches the declarations. */
     public static boolean asksTheQuestionBesideIt(Written.Names names, String name) {
         return Opaque.somethingElse(names, name);

--- a/souther-bench/src/test/java/souther/bench/readings/Stage.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Stage.java
@@ -23,6 +23,19 @@ public final class Stage {
     }
 
     /**
+     * Takes apart a compound whose component holds many, which no descriptor says.
+     *
+     * <p>Beside the one above because the two are read differently: what that one holds is written
+     * in the descriptor of its component, and what this one holds is written only in the generic
+     * signature. A reading of components that looked at descriptors alone would see this one hold
+     * nothing, and taking it apart would read as taking nothing apart.
+     */
+    public static Written.Position takesApartOneHoldingMany(Written.Position position) {
+        return position instanceof Written.Position.Built.OfMany many
+                ? many.elements().getFirst() : null;
+    }
+
+    /**
      * Asks which compound it is and takes nothing out, which is a reading all the same.
      *
      * <p>Beside the one above and not the same shape. That one asks and then reads a component, so
@@ -52,6 +65,11 @@ public final class Stage {
     /** Asks an authority, which answers and hands nothing raw back. */
     public static String asksAnAuthority(Written.Names names, String name) {
         return Opaque.spelling(names, name);
+    }
+
+    /** Asks the operation beside it, which answers something else and reaches the declarations. */
+    public static boolean asksTheQuestionBesideIt(Written.Names names, String name) {
+        return Opaque.somethingElse(names, name);
     }
 
     /** Reads the name off a leaf, which is a name and not a structure. */

--- a/souther-bench/src/test/java/souther/bench/readings/Transparent.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Transparent.java
@@ -1,0 +1,20 @@
+package souther.bench.readings;
+
+/**
+ * An owner of a question that is walked through all the same.
+ *
+ * <p>It reads raw structure to answer, like the authority beside it. What it does not do is finish
+ * on its own: a caller reaches through it, so a boundary here would put whatever the caller wrote
+ * on the far side of the check. Written with the reading inside for the fixture's sake — what makes
+ * a place transparent is that a caller's code is reached from it, and the walk cannot see which
+ * side wrote what.
+ */
+public final class Transparent {
+
+    private Transparent() {}
+
+    /** What the name comes to, read on the way. */
+    public static boolean answering(Written.Names names, String name) {
+        return Helpers.isARecord(names, name);
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/readings/Written.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Written.java
@@ -1,5 +1,7 @@
 package souther.bench.readings;
 
+import java.util.List;
+
 /**
  * A model written to be read by the walk that holds this compiler's stages apart, and by nothing
  * else.
@@ -36,11 +38,41 @@ public final class Written {
         record Leaf(String name) implements Position {}
 
         /** Built out of others, which is what taking one apart reads. */
-        sealed interface Built extends Position permits Built.OfOne, Built.OfTwo {
+        sealed interface Built extends Position
+                permits Built.OfOne, Built.OfTwo, Built.OfMany, Built.Awkward {
 
             record OfOne(Position element) implements Built {}
 
             record OfTwo(Position key, Position value, String label) implements Built {}
+
+            /**
+             * One holding many, which a descriptor cannot say.
+             *
+             * <p>A list of them erases to a list, so what this holds is written only in the generic
+             * signature — and a reading of components that looked at descriptors alone would say
+             * this one holds nothing at all.
+             */
+            record OfMany(List<Position> elements) implements Built {}
+
+            /**
+             * One written as a class, whose components are nowhere to be read.
+             *
+             * <p>Here to be refused rather than read. What a case holds is taken off the record
+             * attribute, so a case without one is a case this cannot see inside — and the claim
+             * that a case added to the sum joins the rule is worth exactly what refusing this is.
+             */
+            final class Awkward implements Built {
+
+                private final Position held;
+
+                Awkward(Position held) {
+                    this.held = held;
+                }
+
+                Position held() {
+                    return held;
+                }
+            }
         }
     }
 

--- a/souther-bench/src/test/java/souther/bench/readings/Written.java
+++ b/souther-bench/src/test/java/souther/bench/readings/Written.java
@@ -1,0 +1,52 @@
+package souther.bench.readings;
+
+/**
+ * A model written to be read by the walk that holds this compiler's stages apart, and by nothing
+ * else.
+ *
+ * <p>Its own sums, not the compiler's. What the walk is given is which sum says what a module
+ * wrote and which says what is built out of others, so a model with sums of its own asks it the
+ * question it is really for: whether it derives those sets from the class files it was handed. A
+ * fixture written in the compiler's own types would be a check of the compiler's spelling.
+ */
+public final class Written {
+
+    private Written() {}
+
+    /** What a module wrote, which is the thing a reader is not to reach for. */
+    public sealed interface Declared permits Declared.Record, Declared.OneValue {
+
+        /** A declaration with fields. */
+        record Record(String name) implements Declared {
+
+            /** Something to read off it, which is what reaching one is for. */
+            public boolean holdsAnything() {
+                return !name.isEmpty();
+            }
+        }
+
+        /** A declaration of one value. */
+        record OneValue(String name) implements Declared {}
+    }
+
+    /** A position's type: either something with nothing inside it, or something built of others. */
+    public sealed interface Position permits Position.Leaf, Position.Built {
+
+        /** Nothing inside it. A name read off one is a name and not a structure. */
+        record Leaf(String name) implements Position {}
+
+        /** Built out of others, which is what taking one apart reads. */
+        sealed interface Built extends Position permits Built.OfOne, Built.OfTwo {
+
+            record OfOne(Position element) implements Built {}
+
+            record OfTwo(Position key, Position value, String label) implements Built {}
+        }
+    }
+
+    /** Where a name is looked up, which is the one way to a declaration from a name alone. */
+    public interface Names {
+
+        Declared declaredNode(String name);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -612,16 +612,17 @@ public final class AffineForms {
                     answered(e, at, reading, following, stopped);
             case Core.Call _ when formSaidOf(e) != null ->
                     answered(e, at, reading, following, stopped);
-            // A newtype's construction is the value it wraps. What makes it one is the declaration
-            // and never the shape, which is what `isSingleValueNewtype` is asked — a data of one
-            // field that is not a newtype wraps its value rather than being it, and its
-            // construction is a value of its own.
+            // A newtype's construction is the value it wraps. Whether the name is one is asked of
+            // the reading of the position, which says the names a value is written under: a
+            // newtype puts one there and a data of one field does not — that one wraps its value
+            // rather than being it, and its construction is a value of its own. Asked of the
+            // declarations again instead, this would be a second answer to how far a name reaches.
             // A carrier takes the same names off to find a value written down, and answers above
             // for `Yen(100)` before this is reached. The two agree where they overlap and are not
             // one rule: that one asks what a written value counts as and stops where nothing is
             // written, and this one asks what the arithmetic under the name comes to.
             case Core.Construct nd when !nd.values().isEmpty()
-                    && TypeOps.isSingleValueNewtype(Type.ref(nd.typeName()), reading.symbols()) ->
+                    && TypeView.of(Type.ref(nd.typeName()), reading.symbols()).isWrapped() ->
                     formOf(nd.values().get(0).value(), at, reading, following, stopped);
             // One arm, holding two proofs that this projection is the value it reads. The
             // structural one is asked first and is asked as whether it produced a successor rather

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -89,7 +89,7 @@ final class Clauses {
      * them answer alike.
      */
     Map<String, BindingId> bindingsOf(TypeSymbol.AtModule named, Hir.Data data) {
-        return bindings.computeIfAbsent(named, name -> TypeOps.fieldBindings(name, data, symbols));
+        return bindings.computeIfAbsent(named, name -> TypeOps.fieldBindings(name, symbols));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -649,7 +649,7 @@ public final class DataChecker {
     static Scope fieldScope(TypeSymbol.AtModule declared, Hir.Data data, Symbols symbols) {
         Map<String, Type> types = TypeOps.fieldTypes(data, symbols);
         Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
-        TypeOps.fieldBindings(declared, data, symbols).forEach((name, binding) ->
+        TypeOps.fieldBindings(declared, symbols).forEach((name, binding) ->
                 bindings.put(binding, new Scope.Binding(name, types.get(name))));
         return Scope.of(bindings);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
@@ -66,7 +66,7 @@ public final class DeclaredClauses {
      * @param conjuncts every conjunct of every rule written on it, in the order the author wrote
      *                  them; empty where the name carries none
      */
-    public record OnAName(TypeOps.Layer worn, List<Conjunct> conjuncts) {
+    public record OnAName(TypeSymbol worn, List<Conjunct> conjuncts) {
 
         public OnAName {
             conjuncts = List.copyOf(conjuncts);
@@ -75,17 +75,17 @@ public final class DeclaredClauses {
 
     /** Every conjunct of every rule written on the names {@code worn}, one entry per name, in the
      *  order the names were read off the position. */
-    public static List<OnAName> of(List<TypeOps.Layer> worn, RuleReadingSource source) {
+    public static List<OnAName> of(List<TypeSymbol> worn, RuleReadingSource source) {
         List<OnAName> out = new ArrayList<>();
-        for (TypeOps.Layer layer : worn) {
-            out.add(new OnAName(layer, writtenOn(layer, source)));
+        for (TypeSymbol wears : worn) {
+            out.add(new OnAName(wears, writtenOn(wears, source)));
         }
         return List.copyOf(out);
     }
 
     /** Every conjunct written on every one of them, which is what a reader that has no use for
      *  where a rule was written asks for. */
-    public static List<Conjunct> allOf(List<TypeOps.Layer> worn, RuleReadingSource source) {
+    public static List<Conjunct> allOf(List<TypeSymbol> worn, RuleReadingSource source) {
         List<Conjunct> out = new ArrayList<>();
         for (OnAName each : of(worn, source)) {
             out.addAll(each.conjuncts());
@@ -93,10 +93,12 @@ public final class DeclaredClauses {
         return List.copyOf(out);
     }
 
-    private static List<Conjunct> writtenOn(TypeOps.Layer layer, RuleReadingSource source) {
-        // A layer wraps a declaration a module wrote, which is what having a `Hir.Data` for it
-        // says; the pattern is where the layer's name says so.
-        if (!(layer.named() instanceof TypeSymbol.AtModule named)) {
+    private static List<Conjunct> writtenOn(TypeSymbol wears, RuleReadingSource source) {
+        // The declaration the name was written by, read here. A name a module wrote is one this
+        // finds a data for; a caller handed the body instead would be holding a declaration for a
+        // question that is this one's, and could read the position's structure back out of it.
+        if (!(wears instanceof TypeSymbol.AtModule named)
+                || !(source.symbols().declaredNode(named) instanceof Hir.Data data)) {
             return List.of();
         }
         List<Conjunct> out = new ArrayList<>();
@@ -104,7 +106,7 @@ public final class DeclaredClauses {
         // (ADR-0090). Read flat, every clause a spread brought in was named after the type that
         // spread it, and two clauses of one declaration were one rule.
         for (TypeOps.Declared declared : TypeOps.declaredForAnalysis(
-                named, layer.data(), source.symbols(), source.invariants())) {
+                named, data, source.symbols(), source.invariants())) {
             RuleRef.Invariant rule = new RuleRef.Invariant(Clause.Ref.of(declared));
             int conjunct = -1;
             for (Hir.Expr each : ClauseHelpers.conjunctsOf(declared.clause().expr())) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ExecutableInvariants.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExecutableInvariants.java
@@ -42,7 +42,7 @@ public final class ExecutableInvariants {
     public static ValueShape of(Hir.Data data, Symbols symbols, Map<String, Type> helpers) {
         Map<String, Type> types = TypeOps.fieldTypes(data, symbols);
         Map<String, BindingId> bindings =
-                TypeOps.fieldBindings(data.declares(), data, symbols);
+                TypeOps.fieldBindings(data.declares(), symbols);
         List<ValueShape.Field> fields = new ArrayList<>();
         // In the order a value lays its fields out, which is what `fieldTypes` answers. The bindings
         // are a walk of their own and answer in an order of nothing's deciding, so what is read off

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -296,10 +296,32 @@ public final class FieldDomains {
         return READINGS.get();
     }
 
-    /** What {@code data}, declared as {@code named}, leaves its fields able to hold. */
-    public static FieldDomains of(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    /**
+     * What the record declared as {@code named} leaves its fields able to hold.
+     *
+     * <p>The declaration is read here rather than handed in. What is written about a record's
+     * fields is this reading's question, so the body it is written on is this reading's to fetch —
+     * a caller made to fetch one has a declaration in its hands for a question that was never its
+     * own, and can read the record's structure back out of it.
+     */
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy) {
-        return of(named, data, source, policy, Map.of());
+        return of(named, source, policy, Map.of());
+    }
+
+    /**
+     * The record {@code named} is declared as.
+     *
+     * <p>A name that is not one is a caller asking for the field rules of something that has no
+     * fields, which is a question about the caller rather than about the model: what a name stands
+     * for is decided before anything asks what is written about its fields.
+     */
+    private static Hir.Data declaring(TypeSymbol.AtModule named, RuleReadingSource source) {
+        if (source.symbols().declaredNode(named.key()) instanceof Hir.Data data) {
+            return data;
+        }
+        throw new IllegalArgumentException(
+                "the field rules of a name that declares no record: " + named);
     }
 
     /**
@@ -310,9 +332,9 @@ public final class FieldDomains {
      * not read off {@code endsAt}'s own range — which still runs from 1 — but off what is left of it
      * once the other end is fixed, which is 1440 and nothing else.
      */
-    public static FieldDomains of(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy, Map<RuleKey, Count> settled) {
-        return of(named, data, source, policy, atValues(settled),
+        return of(named, declaring(named, source), source, policy, atValues(settled),
                 InvariantChecker.Reach.EVERYTHING);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -309,20 +309,6 @@ public final class FieldDomains {
         return of(named, source, policy, Map.of());
     }
 
-    /**
-     * The record {@code named} is declared as.
-     *
-     * <p>A name that is not one is a caller asking for the field rules of something that has no
-     * fields, which is a question about the caller rather than about the model: what a name stands
-     * for is decided before anything asks what is written about its fields.
-     */
-    private static Hir.Data declaring(TypeSymbol.AtModule named, RuleReadingSource source) {
-        if (source.symbols().declaredNode(named.key()) instanceof Hir.Data data) {
-            return data;
-        }
-        throw new IllegalArgumentException(
-                "the field rules of a name that declares no record: " + named);
-    }
 
     /**
      * The same, with some fields already settled at a value.
@@ -334,8 +320,14 @@ public final class FieldDomains {
      */
     public static FieldDomains of(TypeSymbol.AtModule named, RuleReadingSource source,
                                   ReadingPolicy policy, Map<RuleKey, Count> settled) {
-        return of(named, declaring(named, source), source, policy, atValues(settled),
-                InvariantChecker.Reach.EVERYTHING);
+        // A name declaring no record leaves nothing about fields it has not got, which is what
+        // nothing written comes to here. The same answer the other readers of a declaration give
+        // when handed such a name, because it is the same fact about the name rather than three
+        // opinions about the caller.
+        return source.symbols().declaredNode(named.key()) instanceof Hir.Data data
+                ? of(named, data, source, policy, atValues(settled),
+                        InvariantChecker.Reach.EVERYTHING)
+                : NONE;
     }
 
     /** Settlings written as names, read as what stands at each. What a caller naming a place means

--- a/souther-compiler/src/main/java/souther/compiler/check/Rules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Rules.java
@@ -154,7 +154,7 @@ public sealed interface Rules {
             // the identity to get one, so the test below never decides anything. It is how the
             // name says which kind it is rather than a reader assuming it.
             case Hir.Data data -> named instanceof TypeSymbol.AtModule at
-                    ? new Read(FieldDomains.of(at, data, source, policy))
+                    ? new Read(FieldDomains.of(at, source, policy))
                     : Declared.notAModules(named, data);
             // A sum names which cases a value can be and carries no clause of its own; a unit data
             // has one value and may write no rule about it (spec §unit-data). Both are declarations

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -942,18 +942,25 @@ public final class TypeOps {
      * that declares it, in the order that declaration writes them. An include brings a field in
      * without renumbering it, so the two passes agree however either of them reaches it.
      *
-     * <p>{@code declared} is which declaration this is, and is asked of the caller because
-     * {@code data} cannot say: a declaration carries the name it was written under and not the module
-     * that wrote it. Worked out here from that name it would be worked out against whoever is
-     * reading, and a reader of another module's declaration would bind its fields under its own name
-     * — a different binding for the same field, and the clauses carried in with the declaration
-     * resolve against nothing. A caller reading its own declaration passes {@link Symbols#own}; a
-     * caller reading one it reached passes the name it reached it by.
+     * <p>{@code declared} is which declaration this is, and is the caller's to name: a declaration
+     * carries the name it was written under and not the module that wrote it, so worked out here it
+     * would be worked out against whoever is reading, and a reader of another module's declaration
+     * would bind its fields under its own name — a different binding for the same field, and the
+     * clauses carried in with the declaration resolve against nothing. A caller reading its own
+     * declaration passes {@link Symbols#own}; a caller reading one it reached passes the name it
+     * reached it by.
+     *
+     * <p>The body under that name is read here. Naming which declaration this is and holding the
+     * declaration are two things, and only the first is the caller's: a caller made to fetch the
+     * body holds one for a question that was never its own, and can read the record's structure out
+     * of it. A name declaring no record binds no field.
      */
     public static Map<String, BindingId> fieldBindings(TypeSymbol.AtModule declared,
-                                                       Hir.Data data, Symbols symbols) {
+                                                       Symbols symbols) {
         Map<String, BindingId> bindings = new LinkedHashMap<>();
-        walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings);
+        if (symbols.declaredNode(declared.key()) instanceof Hir.Data data) {
+            walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings);
+        }
         return bindings;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
@@ -34,12 +34,19 @@ import java.util.List;
  * to find out whether a name is a newtype is the defect this exists to remove, not a shortcut around
  * it.
  *
+ * <p><b>Names, and not the declarations they are written by.</b> What a value wears is which names
+ * it is written under; the bodies those names are declared with are what a reader of the rules
+ * asks for, and it asks the walk over the declarations
+ * ({@link TypeOps#newtypeChain}) rather than this. Handed a declaration here, a consumer holding an
+ * interpreted position could read structure back out of it and settle for itself what this had
+ * already decided — which is the reading this exists to be the only one of.
+ *
  * @param declared the type the signature wrote
  * @param wrappers the newtype names worn over {@link #shape}, outermost first; empty for a type
  *                 written under no name of its own
  * @param shape    what the value is, with those names off
  */
-public record TypeView(Type declared, List<TypeOps.Layer> wrappers, Shape shape) {
+public record TypeView(Type declared, List<TypeSymbol> wrappers, Shape shape) {
 
     public TypeView {
         wrappers = List.copyOf(wrappers);
@@ -54,7 +61,8 @@ public record TypeView(Type declared, List<TypeOps.Layer> wrappers, Shape shape)
      */
     public static TypeView of(Type type, Symbols symbols) {
         TypeOps.NewtypeSpine spine = TypeOps.newtypeSpine(type, symbols);
-        return new TypeView(type, spine.layers(), shapeOf(spine.terminal(), symbols));
+        return new TypeView(type, spine.layers().stream().map(TypeOps.Layer::named).toList(),
+                shapeOf(spine.terminal(), symbols));
     }
 
     /** Whether any name is worn over the shape — which is a fact about how the value is written,

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
@@ -109,7 +109,10 @@ sealed interface ValueReading {
     static ValueReading of(Type type, Symbols symbols) {
         TypeView view = TypeView.of(type, symbols);
         if (view.isWrapped()) {
-            TypeOps.Layer worn = view.wrappers().getFirst();
+            // What is readable under the name is written on the name's own declaration, so the
+            // declaration is asked of the walk over them. The reading above says which names are
+            // worn and stops there: a position's interpretation is not a way back to a body.
+            TypeOps.Layer worn = TypeOps.newtypeChain(type, symbols).getFirst();
             return new UnderAName(worn.named(), owning(worn.named(), symbols),
                     TypeOps.fieldTypes(worn.data(), symbols));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
@@ -108,13 +108,16 @@ sealed interface ValueReading {
     /** What the model writes where a value of {@code type} stands. */
     static ValueReading of(Type type, Symbols symbols) {
         TypeView view = TypeView.of(type, symbols);
-        if (view.isWrapped()) {
-            // What is readable under the name is written on the name's own declaration, so the
-            // declaration is asked of the walk over them. The reading above says which names are
-            // worn and stops there: a position's interpretation is not a way back to a body.
-            TypeOps.Layer worn = TypeOps.newtypeChain(type, symbols).getFirst();
-            return new UnderAName(worn.named(), owning(worn.named(), symbols),
-                    TypeOps.fieldTypes(worn.data(), symbols));
+        if (view.isWrapped() && symbols.declaredNode(view.wrappers().getFirst())
+                instanceof Hir.Data worn) {
+            // The outermost name is the reading's, and what is readable under it is written on that
+            // name's own declaration — so the name comes from the reading and the body is fetched
+            // here, where reading a declaration is the question. Walked again for the body instead,
+            // this would decide how far a newtype reaches a second time in a method that has
+            // already been told.
+            TypeSymbol name = view.wrappers().getFirst();
+            return new UnderAName(name, owning(name, symbols),
+                    TypeOps.fieldTypes(worn, symbols));
         }
         // What a field access may write here is one question with one owner, asked once for every
         // shape. What is left for the switch is which declarations state something of every value

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1720,8 +1720,7 @@ public final class ExampleVerifier {
      */
     private TypeSymbol caseWritten(FixtureReader fixtures, Hir.Expr fixture, Type position) {
         try {
-            return fixtures.caseUnder(TypeView.of(position, symbols).wrappers().stream()
-                    .map(TypeOps.Layer::named).toList(), fixture);
+            return fixtures.caseUnder(TypeView.of(position, symbols).wrappers(), fixture);
         } catch (RuntimeException e) {
             if (overspending(e) != null) {
                 throw e;   // the row's budget is gone; it is not a form that could not be read

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -4,7 +4,6 @@ import souther.compiler.check.ReadableFields;
 import souther.compiler.check.Shape;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.TermPath;
@@ -304,8 +303,7 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                 return true;
             }
             TypeView view = TypeView.of(type, symbols);
-            ObservedValue here = Classifier.inside(
-                    view.wrappers().stream().map(TypeOps.Layer::named).toList(), value);
+            ObservedValue here = Classifier.inside(view.wrappers(), value);
             if (here.unread() != null) {
                 out.add(new Standing(here, type, reached, at));
                 return true;

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Case;
 import souther.compiler.inputs.Distinctions;
@@ -93,7 +92,7 @@ final class ConstructionPlan {
          * {@code DecisionN(Special(5))}. A value composed without them is of a type the parameter
          * does not declare.
          */
-        List<TypeOps.Layer> worn();
+        List<TypeSymbol> worn();
     }
 
     /**
@@ -104,7 +103,7 @@ final class ConstructionPlan {
      * @param leaf why the search chooses a whole value here rather than composing one out of
      *             positions under it
      */
-    record Slot(TermPath at, Type type, List<TypeOps.Layer> worn, Leaf leaf) implements Node {
+    record Slot(TermPath at, Type type, List<TypeSymbol> worn, Leaf leaf) implements Node {
 
         Slot {
             worn = List.copyOf(worn);
@@ -180,7 +179,7 @@ final class ConstructionPlan {
      *              element's type: a class at an element asks for a list holding a value in it, and
      *              a list that met that and broke the rule about how many it holds is not a row
      */
-    record Held(TermPath at, Type type, List<TypeOps.Layer> worn, Node under, int least)
+    record Held(TermPath at, Type type, List<TypeSymbol> worn, Node under, int least)
             implements Node {
 
         Held {
@@ -202,7 +201,7 @@ final class ConstructionPlan {
      *              putting them back on is one thing done once
      * @param under the positions of its fields, in the order the declaration writes them
      */
-    record Built(TermPath at, Type type, TypeSymbol of, List<TypeOps.Layer> worn,
+    record Built(TermPath at, Type type, TypeSymbol of, List<TypeSymbol> worn,
                  Map<String, Node> under) implements Node {
 
         Built {
@@ -229,7 +228,7 @@ final class ConstructionPlan {
      * @param worn  {@link Node#worn}: every name the position wears, since the value arrives bare.
      *              A {@code data MaybeTagN = Tag?} carries {@code MaybeTagN(None)}
      */
-    record Exact(TermPath at, FixtureTemplate exact, List<TypeOps.Layer> worn) implements Node {
+    record Exact(TermPath at, FixtureTemplate exact, List<TypeSymbol> worn) implements Node {
 
         Exact {
             if (exact == null) {
@@ -487,7 +486,7 @@ final class ConstructionPlan {
         // after them — which is what a value composed here bare needs. Both are what the position
         // declares, kept: a value written under the narrowed type's names alone is of a type the
         // parameter does not declare.
-        List<TypeOps.Layer> worn = settled.outer().isEmpty() ? view.wrappers()
+        List<TypeSymbol> worn = settled.outer().isEmpty() ? view.wrappers()
                 : outside(settled.outer(), view.wrappers());
         // A sequence with something to be placed inside it. Built out of its element rather than
         // chosen whole, since what is being asked for is a list holding a value in a class and no
@@ -578,7 +577,7 @@ final class ConstructionPlan {
      * written at, and a plan handed back would compose a row the caller's value is missing from.
      */
     private static NodeResult givenUpAt(CompositionBudget figure, TermPath here, Type building,
-                                        List<TypeOps.Layer> outer, Set<TermPath> decided,
+                                        List<TypeSymbol> outer, Set<TermPath> decided,
                                         Requirements required) {
         Set<CompositionBudget> by = Set.of(figure);
         return anythingIsAskedUnder(here, decided, required) ? new NodeResult.Beyond(by)
@@ -638,7 +637,7 @@ final class ConstructionPlan {
      *                 arriving under the narrowed type is still missing
      */
     private record Settled(TermPath at, Type building, FixtureTemplate exact,
-                           List<TypeOps.Layer> outer) {
+                           List<TypeSymbol> outer) {
 
         Settled {
             if ((building == null) == (exact == null)) {
@@ -687,7 +686,7 @@ final class ConstructionPlan {
      */
     private static Settled applying(Settled settled, Refinement refinement, Symbols symbols,
                                     Requirements required) {
-        List<TypeOps.Layer> outer = outside(settled.outer(),
+        List<TypeSymbol> outer = outside(settled.outer(),
                 TypeView.of(settled.building(), symbols).wrappers());
         TermPath here = settled.at().refine(refinement);
         if (refinement instanceof Refinement.Presence presence && !presence.present()) {
@@ -737,9 +736,8 @@ final class ConstructionPlan {
     }
 
     /** {@code outer} and then {@code inner}, which is the order names are put back on a value. */
-    private static List<TypeOps.Layer> outside(List<TypeOps.Layer> outer,
-                                               List<TypeOps.Layer> inner) {
-        List<TypeOps.Layer> out = new ArrayList<>(outer);
+    private static List<TypeSymbol> outside(List<TypeSymbol> outer, List<TypeSymbol> inner) {
+        List<TypeSymbol> out = new ArrayList<>(outer);
         out.addAll(inner);
         return List.copyOf(out);
     }
@@ -776,7 +774,7 @@ final class ConstructionPlan {
      */
     private static Under under(Node inside) {
         Under below = switch (inside) {
-            case Slot(TermPath _, Type _, List<TypeOps.Layer> _, Leaf leaf) -> switch (leaf) {
+            case Slot(TermPath _, Type _, List<TypeSymbol> _, Leaf leaf) -> switch (leaf) {
                 case Leaf.Fixed _ -> new Under(true, Set.of());
                 case Leaf.Open _ -> new Under(false, Set.of());
                 // Nothing was asked below one of these, and that is settled where the position is

--- a/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DeclaredThresholds.java
@@ -1,6 +1,5 @@
 package souther.compiler.partition;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.check.Comparison;
 import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Location;
@@ -171,11 +170,8 @@ public final class DeclaredThresholds {
         // further down than the position it is at.
         for (souther.compiler.types.TypeSymbol.AtModule declaration
                 : List.of(clause.rule().clause().id().declaredOn(), clause.readUnder())) {
-            if (!(symbols.declaredNode(declaration) instanceof Hir.Data data)) {
-                continue;
-            }
             Type of = Type.ref(declaration);
-            TypeOps.fieldBindings(declaration, data, symbols).forEach((field, binding) ->
+            TypeOps.fieldBindings(declaration, symbols).forEach((field, binding) ->
                     roots.putIfAbsent(binding, Location.isStep(of, field, symbols)
                             ? clause.at().then(field) : clause.at()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -9,8 +9,10 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.FieldDomains;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.reading.PathAccess;
 import souther.compiler.inputs.Refinement;
@@ -4286,10 +4288,13 @@ public final class Generator {
      */
     private static FieldDomains rulesOf(Type type, RuleReadingSource source, ReadingPolicy policy,
                                         Map<RuleKey, Count> settled) {
-        return type instanceof Type.Ref(TypeSymbol.AtModule named)
-                && source.symbols().declaredNode(named) instanceof Hir.Data data
-                && !data.newtype()
-                ? FieldDomains.of(named, data, source, policy, settled) : FieldDomains.NONE;
+        // Whether the position is a record, and which record, are one answer and it is the
+        // reading's. The rules are then read on the declaration the fields came off — a position
+        // written under a name takes its fields from what that name wraps, and reading the rules on
+        // the name instead would be asking a declaration that has no such field.
+        return TypeView.of(type, source.symbols()).shape()
+                        instanceof Shape.Product(TypeSymbol.AtModule declared, Map<String, Type> _)
+                ? FieldDomains.of(declared, source, policy, settled) : FieldDomains.NONE;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2249,11 +2249,14 @@ public final class Generator {
      * spread would drop the included ones with it.
      */
     private static List<String> fieldsOf(MeasuredInput subject, TypeSymbol built) {
-        // Read where a position's reading is made. A walk from the declaration to its fields is
-        // that reading taken a second time, and the two part at every name one of them reaches
-        // through and the other stops at.
-        return TypeView.of(Type.ref(built), subject.symbols()).shape()
-                        instanceof Shape.Product(TypeSymbol _, Map<String, Type> fields)
+        // A value written under a name is not written field by field: what the row writes is the
+        // name round a value, and the fields belong to what the name wraps. So the position has to
+        // wear no name as well as be a record — read where a position's reading is made, which
+        // answers both, rather than walked from the declaration a second time.
+        TypeView view = TypeView.of(Type.ref(built), subject.symbols());
+        return !view.isWrapped()
+                        && view.shape() instanceof Shape.Product(TypeSymbol _,
+                                Map<String, Type> fields)
                 ? List.copyOf(fields.keySet()) : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -11,7 +11,6 @@ import souther.compiler.check.RuleKey;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.reading.PathAccess;
@@ -2250,10 +2249,12 @@ public final class Generator {
      * spread would drop the included ones with it.
      */
     private static List<String> fieldsOf(MeasuredInput subject, TypeSymbol built) {
-        return subject.symbols().declaredNode(built) instanceof Hir.Data data
-                && !data.newtype()
-                ? List.copyOf(TypeOps.fieldTypes(data, subject.symbols()).keySet())
-                : null;
+        // Read where a position's reading is made. A walk from the declaration to its fields is
+        // that reading taken a second time, and the two part at every name one of them reaches
+        // through and the other stops at.
+        return TypeView.of(Type.ref(built), subject.symbols()).shape()
+                        instanceof Shape.Product(TypeSymbol _, Map<String, Type> fields)
+                ? List.copyOf(fields.keySet()) : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Case;
 import souther.compiler.inputs.Distinctions;
@@ -56,7 +55,7 @@ final class PartitionClasses {
         if (cases.isEmpty()) {
             return List.of();
         }
-        List<TypeSymbol> worn = view.wrappers().stream().map(TypeOps.Layer::named).toList();
+        List<TypeSymbol> worn = view.wrappers();
         // The same names twice over, because two different questions are asked of them. Whether an
         // observed value is under this class is asked of the declarations, and what a row writes it
         // under is asked of the module doing the writing — one of these is an identity and the other

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -225,13 +225,12 @@ final class PartitionClasses {
         // A case of a primitive-headed union is a primitive or one of the language's own, which
         // no module declares and nothing composes field by field: naming it builds it, the same as
         // a unit data. So the two are told apart here, where the declaration is asked for.
-        TypeView held = leaf instanceof TypeSymbol.AtModule at
-                ? TypeView.of(Type.ref(at), ruleSource.symbols()) : null;
-        if (!(leaf instanceof TypeSymbol.AtModule declared) || held == null
-                || !(held.isWrapped() || held.shape() instanceof Shape.Product)) {
-            return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
-                    RepresentativeSource.under(writes,
-                            RepresentativeSource.of(FixtureTemplate.unitCase(names))));
+        if (!(leaf instanceof TypeSymbol.AtModule declared)) {
+            return namingItBuildsIt(leaf, is, writes, names);
+        }
+        TypeView held = TypeView.of(Type.ref(declared), ruleSource.symbols());
+        if (!held.isWrapped() && !(held.shape() instanceof Shape.Product)) {
+            return namingItBuildsIt(leaf, is, writes, names);
         }
         if (held.isWrapped()) {
             // Values of the case, which is a position of its own: it is read like any other, and
@@ -252,6 +251,22 @@ final class PartitionClasses {
         // { id = 1 })`.
         return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
                 RepresentativeSource.under(writes, new RepresentativeSource.Composed(declared)));
+    }
+
+    /**
+     * The class of a case whose value is written by naming it.
+     *
+     * <p>What a unit data is, and what a case of a primitive-headed union is: neither is composed
+     * field by field, because there are no fields to compose. Written once because the two arrive
+     * at it by different questions — one has no declaration of this module's at all, and the other
+     * has one that makes no record — and what they come to is the same class.
+     */
+    private static PartitionClass namingItBuildsIt(TypeSymbol leaf, Recognition is,
+                                                   List<TypeReachName.Written> writes,
+                                                   TypeReachName.Written names) {
+        return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
+                RepresentativeSource.under(writes,
+                        RepresentativeSource.of(FixtureTemplate.unitCase(names))));
     }
 
     private PartitionClasses() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -1,8 +1,8 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.ReadingPolicy;
-import souther.compiler.ast.Hir;
 import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.Shape;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Case;
 import souther.compiler.inputs.Distinctions;
@@ -225,13 +225,15 @@ final class PartitionClasses {
         // A case of a primitive-headed union is a primitive or one of the language's own, which
         // no module declares and nothing composes field by field: naming it builds it, the same as
         // a unit data. So the two are told apart here, where the declaration is asked for.
-        if (!(leaf instanceof TypeSymbol.AtModule declared)
-                || !(ruleSource.symbols().declaredNode(declared) instanceof Hir.Data data)) {
+        TypeView held = leaf instanceof TypeSymbol.AtModule at
+                ? TypeView.of(Type.ref(at), ruleSource.symbols()) : null;
+        if (!(leaf instanceof TypeSymbol.AtModule declared) || held == null
+                || !(held.isWrapped() || held.shape() instanceof Shape.Product)) {
             return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
                     RepresentativeSource.under(writes,
                             RepresentativeSource.of(FixtureTemplate.unitCase(names))));
         }
-        if (data.newtype()) {
+        if (held.isWrapped()) {
             // Values of the case, which is a position of its own: it is read like any other, and
             // what comes back already wears the case's own name. Under the position's names as well,
             // since a case of a `data DecisionN = Decision` is written inside that name too.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.DefaultBoundOperationFacts;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleKey;
 import souther.compiler.check.DeclaredBounds;
@@ -11,7 +10,6 @@ import souther.compiler.check.StringPredicates;
 import souther.compiler.check.DeclaredClauses;
 import souther.compiler.inputs.Distinctions;
 import souther.compiler.check.Shape;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.NarrowedBounds;
@@ -1537,7 +1535,7 @@ public final class Partitions {
                                           ReadingPolicy policy,
                                           java.util.Set<TypeSymbol> expanding,
                                           Map<String, FixtureTemplate> given) {
-        if (expanding.contains(record) || !(ruleSource.symbols().declaredNode(record) instanceof Hir.Data data)) {
+        if (expanding.contains(record)) {
             return List.of();
         }
         Map<String, FixtureTemplate> chosen =
@@ -1560,11 +1558,14 @@ public final class Partitions {
                                                  RuleReadingSource ruleSource, ReadingPolicy policy,
                                                  java.util.Set<TypeSymbol> expanding,
                                                  Map<String, FixtureTemplate> given) {
+        // What the record is made of, read where a position's reading is made. A walk from the
+        // declaration to its fields is that same reading taken a second time, and the two part
+        // wherever one of them reaches through a name the other stops at.
         if (expanding.contains(record)
-                || !(ruleSource.symbols().declaredNode(record) instanceof Hir.Data data)) {
+                || !(TypeView.of(Type.ref(record), ruleSource.symbols()).shape()
+                        instanceof Shape.Product(TypeSymbol _, Map<String, Type> fields))) {
             return null;
         }
-        Map<String, Type> fields = TypeOps.fieldTypes(data, ruleSource.symbols());
         if (fields.isEmpty()) {
             return null;   // a unit has no fields to compose, and is named rather than built
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1561,9 +1561,15 @@ public final class Partitions {
         // What the record is made of, read where a position's reading is made. A walk from the
         // declaration to its fields is that same reading taken a second time, and the two part
         // wherever one of them reaches through a name the other stops at.
-        if (expanding.contains(record)
-                || !(TypeView.of(Type.ref(record), ruleSource.symbols()).shape()
-                        instanceof Shape.Product(TypeSymbol _, Map<String, Type> fields))) {
+        //
+        // And the name has to be the record's own, because the rules below are read on the name
+        // the caller gave. Read through a name to another declaration's fields, the fields would
+        // be one declaration's and the rules another's, and every field would be chosen against
+        // rules that name nothing it has.
+        TypeView view = TypeView.of(Type.ref(record), ruleSource.symbols());
+        if (expanding.contains(record) || view.isWrapped()
+                || !(view.shape() instanceof Shape.Product(TypeSymbol _,
+                        Map<String, Type> fields))) {
             return null;
         }
         if (fields.isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1272,8 +1272,8 @@ public final class Partitions {
         // itself and there is nothing to hand back. Which is the answer and not a limit: no value of
         // such a type exists.
         java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
-        for (TypeOps.Layer layer : view.wrappers()) {
-            if (!inside.add(layer.named())) {
+        for (TypeSymbol wears : view.wrappers()) {
+            if (!inside.add(wears)) {
                 return List.of();
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1571,7 +1571,7 @@ public final class Partitions {
         java.util.Set<TypeSymbol> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
         Map<RuleKey, Count> settled = new LinkedHashMap<>();
-        FieldDomains left = FieldDomains.of(record, data, ruleSource, policy, settled);
+        FieldDomains left = FieldDomains.of(record, ruleSource, policy, settled);
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         if (!fields.keySet().containsAll(given.keySet())) {
             return null;
@@ -1594,7 +1594,7 @@ public final class Partitions {
             // which leaves `b` its whole range and takes the bottom of it.
             if (Counts.writtenIn(at.value()) instanceof Count count) {
                 settled.put(RuleKey.of(field.getKey()), count);
-                left = FieldDomains.of(record, data, ruleSource, policy, settled);
+                left = FieldDomains.of(record, ruleSource, policy, settled);
             }
         }
         return chosen;

--- a/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WornNames.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.RuleReadingSource;
-import souther.compiler.check.TypeOps;
 import souther.compiler.types.TypeReachName;
 import souther.compiler.types.TypeSymbol;
 
@@ -42,12 +41,12 @@ sealed interface WornNames {
 
     /** How {@code worn} is written here, outermost first, or the first of them that has no
      *  spelling. */
-    static WornNames of(List<TypeOps.Layer> worn, RuleReadingSource ruleSource) {
+    static WornNames of(List<TypeSymbol> worn, RuleReadingSource ruleSource) {
         List<TypeReachName.Written> names = new ArrayList<>();
-        for (TypeOps.Layer layer : worn) {
-            if (!(ruleSource.symbols().scope().reach(layer.named())
+        for (TypeSymbol wears : worn) {
+            if (!(ruleSource.symbols().scope().reach(wears)
                     instanceof TypeReachName.Written written)) {
-                return new Unwritable(layer.named());
+                return new Unwritable(wears);
             }
             names.add(written);
         }
@@ -67,7 +66,7 @@ sealed interface WornNames {
      * {@link RepresentativeSource#under}'s, so a value never wears a name that was spelled anywhere
      * but here.
      */
-    static FixtureTemplate under(List<TypeOps.Layer> worn, FixtureTemplate value,
+    static FixtureTemplate under(List<TypeSymbol> worn, FixtureTemplate value,
                                  RuleReadingSource ruleSource) {
         if (value == null || worn.isEmpty()) {
             return value;

--- a/souther-compiler/src/test/java/souther/compiler/check/ABranchDeadOnlyByItsPatternsLeavesNothingBehindTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABranchDeadOnlyByItsPatternsLeavesNothingBehindTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -56,7 +55,6 @@ class ABranchDeadOnlyByItsPatternsLeavesNothingBehindTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "Pair"));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -72,7 +71,6 @@ class ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), declared));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -236,7 +235,6 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(symbols.module(), name));
         return FieldDomains.of(at,
-                (Hir.Data) symbols.declaredNode(at.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.query.Scopes;
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -39,9 +38,8 @@ class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` in " + module);
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` in " + module);
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES, settled);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.query.Scopes;
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -36,9 +35,8 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` in " + module);
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` in " + module);
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 
@@ -317,8 +315,8 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         Symbols symbols = Scopes.derived(compilation.db(), "example.report").value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("example.report", "Forecast"));
-        FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declaredNode(named.key()),
-                RuleReadings.of(compilation, "example.report"),
+        FieldDomains domains = FieldDomains.of(named,
+                RuleReadings.of(compilation,"example.report"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
         assertTrue(domains.projection().isCertified(),
@@ -416,8 +414,8 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         compilation.answerEverything();
         Symbols symbols = Scopes.derived(compilation.db(), "example.pair").value();
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("example.pair", "Pair"));
-        FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declaredNode(named.key()),
-                RuleReadings.of(compilation, "example.pair"),
+        FieldDomains domains = FieldDomains.of(named,
+                RuleReadings.of(compilation,"example.pair"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
         assertBounds(at(domains, "a"), 0, 9);
@@ -519,8 +517,8 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         compilation.answerEverything();
         Symbols symbols = Scopes.derived(compilation.db(), "example.report").value();
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("example.report", "Pair"));
-        FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declaredNode(named.key()),
-                RuleReadings.of(compilation, "example.report"),
+        FieldDomains domains = FieldDomains.of(named,
+                RuleReadings.of(compilation,"example.report"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
         assertBounds(at(domains, "a"), 0, 9);

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
@@ -44,9 +43,8 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model under test compiles");
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
@@ -53,9 +52,8 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Length"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `Length` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `Length` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 
@@ -310,9 +308,8 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
-        assertNotNull(data, "no `" + named + "` declared");
-        return FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(at.key()), "no `" + named + "` declared");
+        return FieldDomains.of(at, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 
@@ -332,9 +329,8 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule at = TypeSymbols.declared(new TypeKey(module, named));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(at.key());
-        assertNotNull(data, "no `" + named + "` declared");
-        return FieldDomains.of(at, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(at.key()), "no `" + named + "` declared");
+        return FieldDomains.of(at, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 
@@ -352,9 +348,8 @@ class AQuestionExistsBecauseTheModelStatesItAndNotBecauseAReadingSucceededTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Code"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `Code` declared");
-        FieldDomains domains = FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `Code` declared");
+        FieldDomains domains = FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         assertEquals(1, domains.required().size(),
                 () -> "one clause, one rule: " + domains.required().keySet());

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -52,9 +51,8 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES).accounting();
     }
 
@@ -136,8 +134,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
         String module = compilation.modules().get(0);
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         TypeSymbol.AtModule holder = TypeSymbols.declared(new TypeKey(module, "Holder"));
-        return FieldDomains.of(holder,
-                        (Hir.Data) symbols.declaredNode(holder.key()), RuleReadings.of(compilation, module),
+        return FieldDomains.of(holder, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
                 .at(RuleKey.of("len")).bounds().min().at().toString();
     }
@@ -359,8 +356,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
         String module = compilation.modules().get(0);
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Length"));
-        FieldDomains read = FieldDomains.of(named,
-                (Hir.Data) symbols.declaredNode(named.key()), RuleReadings.of(compilation, module),
+        FieldDomains read = FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
         assertFalse(read.projection().isCertified(), "the bounds hold no hole");

--- a/souther-compiler/src/test/java/souther/compiler/check/AReasonBelongsToTheConjunctItCameFromTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReasonBelongsToTheConjunctItCameFromTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -45,9 +44,7 @@ class AReasonBelongsToTheConjunctItCameFromTest {
         String module = compilation.modules().get(0);
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Pair"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES).accounting().values().stream()
                 .flatMap(each -> each.answers().entrySet().stream())
                 .filter(e -> e.getKey().obligation() == CoverageObligation.BOUNDARY)

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsFiledAtWhatItsQuantityIsAboutTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
@@ -129,7 +128,6 @@ class ARuleIsFiledAtWhatItsQuantityIsAboutTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleNoAlternativeNeededIsStillOneNobodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleNoAlternativeNeededIsStillOneNobodyReadTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -42,8 +41,7 @@ class ARuleNoAlternativeNeededIsStillOneNobodyReadTest {
                 .toList(), "the model this reads has to be one somebody could write");
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
-        return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()), RuleReadings.of(compilation, "demo"),
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AStoppedReadingSaysWhatStoppedItAtEachPlaceTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
@@ -87,7 +86,6 @@ class AStoppedReadingSaysWhatStoppedItAtEachPlaceTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueNothingSatisfiesHasNoRangeToBeExactAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueNothingSatisfiesHasNoRangeToBeExactAboutTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -65,9 +64,8 @@ class AValueNothingSatisfiesHasNoRangeToBeExactAboutTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Length"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `Length` declared");
-        FieldDomains domains = FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `Length` declared");
+        FieldDomains domains = FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         return domains.projection().causes().stream()
                 .map(cause -> cause.getClass().getSimpleName())

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEmptinessCheckStatesWhatItMeansAboutTheLengthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEmptinessCheckStatesWhatItMeansAboutTheLengthTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
@@ -46,10 +45,9 @@ class AnEmptinessCheckStatesWhatItMeansAboutTheLengthTest {
         String module = compilation.modules().get(0);
         RuleReadingSource rules = RuleReadings.of(compilation, module);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Name"));
-        Hir.Data data = (Hir.Data) rules.symbols().declaredNode(named.key());
-        assertNotNull(data, "no `Name` declared");
+        assertNotNull(rules.symbols().declaredNode(named.key()), "no `Name` declared");
         String[] taken = measure.split("\\.");
-        return FieldDomains.of(named, data, rules, ReadAs.THE_COMPILATION_DOES)
+        return FieldDomains.of(named, rules, ReadAs.THE_COMPILATION_DOES)
                 .leftAt(RuleKey.THE_VALUE, new NumberAt.OfWhatNumber.OfWhatAnOperationAnswers(
                         ValueName.Stdlib.operation(taken[0], taken[1])));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -174,7 +173,6 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
@@ -6,6 +6,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
 import java.util.List;
@@ -109,9 +110,9 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     @Test
     void theNamesWornAreKeptOutermostFirst() {
         assertEquals(List.of("StageNN", "StageN"),
-                view("StageNN").wrappers().stream().map(l -> l.named().name()).toList());
+                view("StageNN").wrappers().stream().map(TypeSymbol::name).toList());
         assertEquals(List.of("StageN"),
-                view("StageN").wrappers().stream().map(l -> l.named().name()).toList());
+                view("StageN").wrappers().stream().map(TypeSymbol::name).toList());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
@@ -42,7 +42,7 @@ class UnsupportedInformationNeverShrinksTheModelSetTest {
         compilation.answerEverything();
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return FieldDomains.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)),
-                data(compilation, name), RuleReadings.of(compilation, "demo"),
+                RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -4,7 +4,6 @@ import souther.compiler.query.ReadAs;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Scopes;
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -75,7 +74,6 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return new Read(FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"), policy), symbols);
     }
 
@@ -100,7 +98,6 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -78,7 +77,6 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "Code"));
         return FieldDomains.of(name,
-                (Hir.Data) symbols.declaredNode(name.key()),
                 RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
                 .admits(RuleKey.THE_VALUE);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesDependsOnTheValueItAppliesToTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesDependsOnTheValueItAppliesToTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
@@ -87,10 +86,9 @@ class WhatARuleRaisesDependsOnTheValueItAppliesToTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` declared");
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` declared");
         java.util.Collection<Required> raised = FieldDomains
-                .of(named, data, RuleReadings.of(compilation, module),
+                .of(named, RuleReadings.of(compilation, module),
                         ReadAs.THE_COMPILATION_DOES).required().values();
         assertEquals(1, raised.size(), type + " is held to one rule here");
         return raised.iterator().next();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesDoesNotMoveWithWhatAReaderCanDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesDoesNotMoveWithWhatAReaderCanDoTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
@@ -93,8 +92,7 @@ class WhatARuleRaisesDoesNotMoveWithWhatAReaderCanDoTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "P"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `P` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module), policy);
+        assertNotNull(symbols.declaredNode(named.key()), "no `P` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module), policy);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedAtEachPlaceItNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedAtEachPlaceItNamesTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
@@ -134,10 +133,9 @@ class WhatARuleRaisesIsAskedAtEachPlaceItNamesTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, "Span"));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `Span` declared");
+        assertNotNull(symbols.declaredNode(named.key()), "no `Span` declared");
         Collection<Required> every = FieldDomains
-                .of(named, data, RuleReadings.of(compilation, module),
+                .of(named, RuleReadings.of(compilation, module),
                         ReadAs.THE_COMPILATION_DOES).required().values();
         assertEquals(1, every.size(), "one clause, so one answer about what it raises");
         return every.iterator().next();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -39,9 +38,8 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES).required();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.query.Compilation;
@@ -53,9 +52,8 @@ class WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest {
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
-        Hir.Data data = (Hir.Data) symbols.declaredNode(named.key());
-        assertNotNull(data, "no `" + type + "` declared");
-        return FieldDomains.of(named, data, RuleReadings.of(compilation, module),
+        assertNotNull(symbols.declaredNode(named.key()), "no `" + type + "` declared");
+        return FieldDomains.of(named, RuleReadings.of(compilation, module),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest.java
@@ -61,7 +61,7 @@ class WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest {
 
     private FieldDomains reading() {
         Hir.Data data = (Hir.Data) symbols.declaredNode(named("Held"));
-        return FieldDomains.of(named("Held"), data, rules,
+        return FieldDomains.of(named("Held"), rules,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoHoldsAnEndIsWorkedOutWhenItIsAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoHoldsAnEndIsWorkedOutWhenItIsAskedForTest.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
@@ -115,7 +114,6 @@ class WhoHoldsAnEndIsWorkedOutWhenItIsAskedForTest {
         Symbols symbols = Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
         TypeSymbol.AtModule held = TypeSymbols.declared(new TypeKey("demo", "Held"));
         return FieldDomains.of(held,
-                (Hir.Data) symbols.declaredNode(held.key()),
                 RuleReadings.of(compilation, compilation.modules().get(0)),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsFixedIsAskedTogetherHoweverItArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsFixedIsAskedTogetherHoweverItArrivedTest.java
@@ -365,13 +365,13 @@ class WhatIsFixedIsAskedTogetherHoweverItArrivedTest {
                 new souther.compiler.types.TypeKey(read.rules().symbols().module(), "P"));
         Hir.Data data = (Hir.Data) read.rules().symbols().declaredNode(name.key());
         souther.compiler.check.FieldDomains whole = souther.compiler.check.FieldDomains.of(
-                name, data, read.rules(), ReadAs.THE_COMPILATION_DOES);
+                name, read.rules(), ReadAs.THE_COMPILATION_DOES);
 
         for (int at = 0; at <= 5; at++) {
             Map<souther.compiler.check.RuleKey, Count> settled =
                     Map.of(souther.compiler.check.RuleKey.of("x"), count(at));
             souther.compiler.check.FieldDomains readIn = souther.compiler.check.FieldDomains.of(
-                    name, data, read.rules(), ReadAs.THE_COMPILATION_DOES, settled);
+                    name, read.rules(), ReadAs.THE_COMPILATION_DOES, settled);
             souther.compiler.check.FieldDomains.Carried<String> taken = whole.given(Map.of(
                     souther.compiler.check.NumberAt
                             .valueOf(souther.compiler.check.RuleKey.of("x")), count(at)))

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
@@ -34,7 +34,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
             TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, type));
             Hir.Data data = (Hir.Data) rules.symbols().declaredNode(named.key());
             assertNotNull(data, "no `" + type + "`");
-            return FieldDomains.of(named, data, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+            return FieldDomains.of(named, rules, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         }
 
         Type ref(String type) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -78,7 +78,7 @@ class ANameGoesBackOnTheWayItCameOffTest {
     void theNamesAreReadOffOutermostFirst() {
         assertEquals(List.of("DecisionNN", "DecisionN"),
                 TypeView.of(Type.ref(named("DecisionNN")), rules.symbols()).wrappers().stream()
-                        .map(layer -> layer.named().name()).toList());
+                        .map(TypeSymbol::name).toList());
     }
 
     // --- and put back on -------------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
@@ -7,13 +7,13 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
-import souther.compiler.check.TypeOps;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeSymbol;
 
 import java.util.List;
 import java.util.Map;
@@ -131,13 +131,13 @@ class ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest {
     }
 
     private static List<String> names(ConstructionPlan.Node node) {
-        List<TypeOps.Layer> worn = switch (node) {
+        List<TypeSymbol> worn = switch (node) {
             case ConstructionPlan.Slot slot -> slot.worn();
             case ConstructionPlan.Exact exact -> exact.worn();
             case null -> throw new AssertionError("the plan builds nothing at that position");
             default -> throw new AssertionError("not a position a value is put at: " + node);
         };
-        return worn.stream().map(each -> each.named().name()).toList();
+        return worn.stream().map(TypeSymbol::name).toList();
     }
 
     private record Read(String parameter, Sig sig, RuleReadingSource rules, InputDomain domain) {}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AWrappedRecordTakesItsFieldsFromWhatItWrapsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AWrappedRecordTakesItsFieldsFromWhatItWrapsTest.java
@@ -1,0 +1,192 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Shape;
+import souther.compiler.check.TypeView;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.GeneratedRows;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name written over a record takes its fields from the record and its rules from both.
+ *
+ * <p>Two declarations meet at such a position and they answer different questions. What the value
+ * is made of is the record's answer, and the reading names that record — a walk stopping at the
+ * outer name would find a position with no fields at all. What the value must satisfy is written on
+ * either declaration and both reach it, so a reader taking only one of them offers a value the
+ * other refuses.
+ *
+ * <p>Which is why the two are pinned against written-out rows rather than against each other. The
+ * field structure and the rules are read by different parts of this compiler, and they agree here
+ * only because each asks the declaration its own question is about. A reader that took the fields
+ * from one declaration and the rules from the other would pass every test that compared the two
+ * readings with one another.
+ */
+class AWrappedRecordTakesItsFieldsFromWhatItWrapsTest {
+
+    /** A rule on the record, and the position written as a name over it. */
+    private static final String WRAPPED = """
+            module demo
+
+            data Ok
+
+            data Inner = { x: Int }
+                invariant small = x >= 11 && x <= 13
+
+            data Outer = Inner
+            data Twice = Outer
+
+            behavior run : (o: Outer) -> Ok
+            let run (o) = Ok
+            """;
+
+    /** The same rule, with the position written as the record itself. */
+    private static final String PLAIN = """
+            module demo
+
+            data Ok
+
+            data Inner = { x: Int }
+                invariant small = x >= 11 && x <= 13
+
+            behavior run : (o: Inner) -> Ok
+            let run (o) = Ok
+            """;
+
+    /** A rule on the name as well, which leaves less than the record's own does. */
+    private static final String BOTH = """
+            module demo
+
+            data Ok
+
+            data Inner = { x: Int }
+                invariant small = x >= 11 && x <= 13
+
+            data Outer = Inner
+                invariant tighter = value.x >= 12
+
+            behavior run : (o: Outer) -> Ok
+            let run (o) = Ok
+            """;
+
+    /** Two names each written as the other, so the walk over them reaches no record at all. */
+    private static final String IN_TERMS_OF_ITSELF = """
+            module demo
+
+            data Ok
+
+            data A = B
+            data B = A
+
+            behavior run : (a: A) -> Ok
+            let run (a) = Ok
+            """;
+
+    private static TypeView view(String source, String name) {
+        RuleReadingSource rules = RuleReadings.ofSource(source);
+        return TypeView.of(Type.ref(TypeSymbols.declared(
+                new TypeKey(rules.symbols().module(), name))), rules.symbols());
+    }
+
+    private static String rowsOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return GeneratedRows.of(compilation, "demo", "run", true,
+                SourceNameResolver.identity()).text();
+    }
+
+    /**
+     * The fields, and which declaration they were read off.
+     *
+     * <p>The name in the shape is the record's and not the position's. What is made of those fields
+     * is the record, so a reader going back to the declaration for what is written about one of them
+     * has to go back to that record — going back to the name the position was written as would be
+     * asking a declaration that has no such field.
+     */
+    @Test
+    void theFieldsAndTheirDeclarationComeFromTheRecordTheNameWraps() {
+        Shape.Product under = assertInstanceOf(Shape.Product.class, view(WRAPPED, "Outer").shape());
+        assertEquals("Inner", under.name().name());
+        assertEquals(Set.of("x"), under.fields().keySet());
+
+        Shape.Product twice = assertInstanceOf(Shape.Product.class, view(WRAPPED, "Twice").shape());
+        assertEquals("Inner", twice.name().name());
+    }
+
+    /** And the names, which are what the value is written under rather than what it is made of. */
+    @Test
+    void theNamesAreWhatThePositionIsWrittenAs() {
+        assertEquals(List.of("Outer"), worn(WRAPPED, "Outer"));
+        assertEquals(List.of("Twice", "Outer"), worn(WRAPPED, "Twice"));
+        assertTrue(view(WRAPPED, "Inner").wrappers().isEmpty());
+    }
+
+    private static List<String> worn(String source, String name) {
+        return view(source, name).wrappers().stream().map(each -> each.named().name()).toList();
+    }
+
+    /**
+     * A row at the wrapped position stands where the record's rule leaves it, and is written under
+     * the name.
+     *
+     * <p>Against the unwrapped model rather than against a figure written here. What the rule leaves
+     * is the record's answer either way, and a name round the position changes how the row is
+     * written and nothing else.
+     */
+    @Test
+    void aRowUnderTheNameStandsWhereTheRecordsRuleLeavesIt() {
+        String wrapped = rowsOf(WRAPPED);
+        assertTrue(wrapped.contains("(Outer(Inner { x = 11 }))"), wrapped);
+        assertTrue(wrapped.contains("(Outer(Inner { x = 13 }))"), wrapped);
+
+        String plain = rowsOf(PLAIN);
+        assertTrue(plain.contains("(Inner { x = 11 })"), plain);
+        assertTrue(plain.contains("(Inner { x = 13 })"), plain);
+    }
+
+    /**
+     * A rule written on the name is read too, and narrows what the record left.
+     *
+     * <p>The case that tells the two declarations apart. Both are read here — the floor moves to the
+     * name's and the ceiling stays the record's — so a reader that dropped either would be offering
+     * a value the other declaration refuses. Written at a figure the record's own rule does not
+     * reach, because a bound the two agree on would pass whichever of them was read.
+     */
+    @Test
+    void aRuleOnTheNameNarrowsWhatTheRecordLeft() {
+        String rows = rowsOf(BOTH);
+        assertTrue(rows.contains("(Outer(Inner { x = 12 }))"), rows);
+        assertTrue(rows.contains("(Outer(Inner { x = 13 }))"), rows);
+        assertTrue(!rows.contains("x = 11"), rows);
+    }
+
+    /**
+     * A name written in terms of itself ends the walk over the names rather than repeating it.
+     *
+     * <p>Both names come off — each is written as the other, so both are worn — and what is left
+     * underneath is a name that stands for no shape. The answer is that the position could not be
+     * interpreted, which is a reading, and the walk that produced it terminated.
+     */
+    @Test
+    void aNameWrittenInTermsOfItselfEndsTheWalk() {
+        TypeView cycle = view(IN_TERMS_OF_ITSELF, "A");
+        assertEquals(List.of("A", "B"), worn(IN_TERMS_OF_ITSELF, "A"));
+        assertInstanceOf(Shape.Unresolved.class, cycle.shape());
+        rowsOf(IN_TERMS_OF_ITSELF);   // reaches an answer rather than walking the names forever
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AWrappedRecordTakesItsFieldsFromWhatItWrapsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AWrappedRecordTakesItsFieldsFromWhatItWrapsTest.java
@@ -12,6 +12,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.report.GeneratedRows;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
 import java.util.List;
@@ -137,7 +138,7 @@ class AWrappedRecordTakesItsFieldsFromWhatItWrapsTest {
     }
 
     private static List<String> worn(String source, String name) {
-        return view(source, name).wrappers().stream().map(each -> each.named().name()).toList();
+        return view(source, name).wrappers().stream().map(TypeSymbol::name).toList();
     }
 
     /**


### PR DESCRIPTION
Closes #1313.

## What was wrong

What a value is made of had more than one answer in the partitioning stage. The reading of a position said it; beside that, readers walked from a declaration through its field types, took a collection constructor apart by hand, and reached through the names a value is written under. Readings of one fact agree wherever they happen to stop at the same depth and part everywhere else — at a sum, at a name over a name, inside a container — and each parting had been found and fixed on its own.

#1322 removed the walks over the names. This removes the walk from a declaration to its fields, moves the last of the raw material out of what a reading hands over, and then refuses the shape from coming back.

## What changed

The reading of a position hands on the names a value wears, not the declarations they are written by. A consumer holding an interpreted position could read the structure back out of one and settle for itself what the reading had already decided. The plan carries the names for the same reason: what it holds is what to put back on the value. The readers of the rules written on those names fetch their own bodies — each had been handed one because the walk that produced the names had it, which made every caller of theirs a place a declaration passed through on its way to a question about something else.

The same for the rules written about a record's fields, and for the binding each field introduces inside its own invariant: what is written about a declaration is that reading's question, so the body it is written on is that reading's to fetch. Callers name which declaration they mean and hold none. That took the declaration out of the hands of a great many tests, which is most of the diff.

Which makes each caller name what it was really asking. One wanted the kind of declaration and keeps that question where declarations are read; the other wanted to know whether a position is a record, and asks the reading — then reads the rules on the record the fields came off, because a position written under a name takes its fields from what the name wraps.

Nothing in the stage now reaches a declaration or takes a type apart.

## What keeps it that way

An architecture check, written as reachability rather than as a vocabulary. A rule naming the ways anybody had written it down would be passed by the next one written another way, which is not hypothetical: the walk removed here reached the declaration through an accessor no earlier rule watched. What is checked is that no path from the stage arrives at raw structure at all, however many methods it goes through and whatever those methods hand back — so a helper answering with a word hides nothing, because what is followed is the call.

Over the calls as written, which is the shape of what it claims. A method reached only through an interface has no edge, so a seam of that kind is held by what is on the far side of it being in the stage rather than by this; every reading the stage has today is reached through a class a call names. Walking through an owner, likewise, follows the calls that owner makes and not a reading its caller handed it.

What raw structure is comes from the types themselves. A leaf says it holds no type inside it and a compound says it is built out of others, so taking a compound apart is reading structure and reading a name off a reference is not. The declarations are what their own sum permits. A constructor added to either joins the rule without anybody remembering to.

The table is of authorities, not of methods let through. Each entry says what question is answered there and why the stage need not look past it. A place earns one by owning a question no other authority already answers, by handing back that answer rather than the material, by finishing before any of the caller's own code runs, and by being where the decision is made rather than a facade in front of it. Two owners fail the third and are walked through: what one answers with is composed by a reading its caller wrote, so stopping there would put that caller's walk beyond the check.

The other half is that every entry is standing somewhere: the walk records the authorities it meets on a way from the stage to a reading, and an entry it never met is a rule about a boundary that is not there. Which of the places on such a way is the one that answers is the table's to say and no walk's — an ordinary helper sits between the stage and a reading exactly as an owner does — so a named place must be met, and a met place is never required to be named. Asked the other way round, the way to make this green would be to call a helper an owner, which is the shape a table of owners must not reward.

There are no exemptions, and no method is excused.

## What the check found

Walking through one of those transparent owners found the last of the old readings, which no one had gone looking for: an affine form asked the declarations whether a name was a newtype. That is the question reading a position answers, and the type that answers it names asking the declarations again as the defect it exists to remove. Its comment justified the walk on the grounds that a shape cannot tell a newtype from a record of one field — true, and the names a value wears can, which is the other half of the same reading.

## Verifying the check

Run against the compiler with four mutations, each restored afterwards: a declaration reached from the stage, a compound taken apart there, and both again from behind a helper that answers with a word. All four were caught and the two indirect ones were reported with the path through the helper. A boundary naming something nothing arrives at was caught as stale.

Those prove the walk saw a defect on the day it was run. What says it still would is a model written to be read, holding one of every shape the walk has to tell apart, and the ways of touching a model that are not readings of it. Breaking the collection of one instruction leaves the compiler-facing check green and turns that one red, which is the failure this pair exists for. Adding the shape that asks which compound a position is and takes nothing out of it is what found the gap: every other fixture reads a component afterwards, so a walk that had stopped seeing the asking would have been green through all of them.

The model is written in sums of its own, so what is checked is that the walk derives what a declaration is and what is built out of types from the classes it was handed rather than knowing them.

## Behaviour

A characterization of what a name over a record takes from which declaration goes first, and holds through. The fields and the rules are read by different parts of this compiler and agree here only because each asks the declaration its own question is about — so they are pinned against written-out rows rather than against one another, which a reader taking the fields from one declaration and the rules from the other would pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
