### PR TITLE
Ask a name whether it denotes, not the projection that flattened it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,21 @@
                                      the same. Nothing else here catches one; the way to ask again
                                      is to turn the check back on for a run and read what it says,
                                      which is how the comparisons above were read. -->
-                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:ReferenceEquality:OFF -Xep:RemoveUnusedImports:ERROR ${nullaway.args}</arg>
+                                <!-- BadInstanceof is off. It reports an `instanceof` whose operand
+                                     already has the type asked for, which it reads as a null check
+                                     wearing a type test, and it was right about a whole family of
+                                     them: a name was asked `name.answered() instanceof Denoting`,
+                                     which projects the two forms of a name down to the answered one
+                                     or null and then narrows that back. Those now ask the name.
+
+                                     What is left is a call whose result is bound and null-checked
+                                     in one condition. Inside an expression there is no other
+                                     spelling — a declaration is a statement, and the condition is
+                                     not — so the check would be asking for the question to be
+                                     asked somewhere it cannot be. That those methods answer an
+                                     absence with null is a thing to fix in the methods, not at the
+                                     conditions reading them, and it is not what this reports. -->
+                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:BadInstanceof:OFF -Xep:ReferenceEquality:OFF -Xep:RemoveUnusedImports:ERROR ${nullaway.args}</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -923,11 +923,12 @@ public interface Ast {
                     region);
         }
 
-        /** The type the source wrote on this binding, or null when it wrote none. An annotation is an
-         * ordinary type (a function type belongs only in a helper's parameter), so this is the one
-         * place that narrows {@code declaredType}, and a carrier from inlining never reads as one. */
+        /** The type the source wrote on this binding, or null when it wrote none. What the source
+         * wrote and what a later pass put there are both held in {@code declaredType}, and
+         * {@code annotated} is what tells them apart: a carrier from inlining is not an annotation
+         * and is not answered here. */
         public RetType annotation() {
-            return annotated && declaredType instanceof RetType rt ? rt : null;
+            return annotated ? declaredType : null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -1359,11 +1359,12 @@ public interface Hir {
             return binder.name();
         }
 
-        /** The type the source wrote on this binding, or null when it wrote none. An annotation is an
-         * ordinary type (a function type belongs only in a helper's parameter), so this is the one
-         * place that narrows {@code declaredType}, and a carrier from inlining never reads as one. */
+        /** The type the source wrote on this binding, or null when it wrote none. What the source
+         * wrote and what a later pass put there are both held in {@code declaredType}, and
+         * {@code annotated} is what tells them apart: a carrier from inlining is not an annotation
+         * and is not answered here. */
         public RetType annotation() {
-            return annotated && declaredType instanceof RetType rt ? rt : null;
+            return annotated ? declaredType : null;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
@@ -92,7 +92,7 @@ final class CardinalityTransfer {
     private static List<TypeSymbol> namedCases(Hir.SumData sum) {
         List<TypeSymbol> named = new ArrayList<>();
         for (Hir.Name each : sum.cases()) {
-            if (!(each.answered() instanceof Hir.Name.Denoting denoting)) {
+            if (!(each instanceof Hir.Name.Denoting denoting)) {
                 return null;
             }
             named.add(denoting.type());

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -70,7 +70,7 @@ public final class DataChecker {
 
     private static void collectConstChecks(Hir.Expr e, Symbols symbols, List<ConstCheck> out) {
         if (e instanceof Hir.NewData nd
-                && nd.typeName().answered() instanceof Hir.Name.Denoting built
+                && nd.typeName() instanceof Hir.Name.Denoting built
                 && built.type() instanceof TypeSymbol.AtModule constructed
                 && symbols.declaredNode(constructed) instanceof Hir.Data nt
                 && nt.newtype() && isInvariantBearing(constructed, symbols)) {
@@ -203,7 +203,7 @@ public final class DataChecker {
                 // it compares against a limit rather than setting one.
                 // A construction naming nothing builds no type to record; it is reported where the
                 // name is written, and the fields written under it are still walked.
-                if (nd.typeName().answered() instanceof Hir.Name.Denoting built) {
+                if (nd.typeName() instanceof Hir.Name.Denoting built) {
                     Map<TypeSymbol, String> side =
                             built.type() instanceof TypeSymbol.AtModule made && nd.wasCarried(made)
                                     ? out.carried() : out.originated();
@@ -346,7 +346,7 @@ public final class DataChecker {
         for (Hir.Name caseName : s.cases()) {
             // A case naming nothing is no step of a cycle, and it is reported on the declaration
             // that writes it — which may be another module's, and not one this check was handed.
-            if (!(caseName.answered() instanceof Hir.Name.Denoting names)) {
+            if (!(caseName instanceof Hir.Name.Denoting names)) {
                 continue;
             }
             if (target.equals(names.type())) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -240,7 +240,7 @@ public final class Elaborator {
             case Hir.Apply call -> CallElaborator.elaborateCall(call, env, ctx, expected);
             case Hir.Binary bin -> BinaryElaborator.elaborateBinary(bin, env, ctx);
             case Hir.NewData nd -> {
-                if (!(nd.typeName().answered() instanceof Hir.Name.Denoting built)) {
+                if (!(nd.typeName() instanceof Hir.Name.Denoting built)) {
                     // reported where the name is written; this definition has no meaning to work out
                     throw new Unanswerable(nd.pos());
                 }
@@ -258,7 +258,7 @@ public final class Elaborator {
                 // fields, so it is refused the way the name would be anywhere else a value goes.
                 List<Core.Read> spreads = new ArrayList<>();
                 for (Hir.Var s : nd.spreads()) {
-                    if (!(s.answered() instanceof Hir.Var.Denoting named
+                    if (!(s instanceof Hir.Var.Denoting named
                             && named.denotes() instanceof ValueName.Local local)) {
                         throw notAValue(s, env);
                     }
@@ -660,7 +660,7 @@ public final class Elaborator {
         // question about it: what the binding opens has no type, so the body under it would be
         // checked against a shape nothing states. Abandoned as a name standing anywhere else in a
         // body is, rather than passed on as an absent type for the reading below to take for one.
-        if (!(li.opens().answered() instanceof Hir.Name.Denoting opens)) {
+        if (!(li.opens() instanceof Hir.Name.Denoting opens)) {
             throw new Unanswerable(li.opens().pos());
         }
         TypeSymbol layer = opens.type();
@@ -976,7 +976,7 @@ public final class Elaborator {
      * where it is applied and not here. Where it is not, it is left to the body that applies it.
      */
     private static boolean reads(Hir.Expr e, Scope env) {
-        if (e instanceof Hir.Apply call && call.answered() instanceof Hir.Var.Denoting callee
+        if (e instanceof Hir.Apply call && call.function() instanceof Hir.Var.Denoting callee
                 && callee.denotes() instanceof ValueName.Helper
                 && env.of(callee.denotes(), callee.reaches()) == null) {
             return false;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -620,7 +620,7 @@ public final class HelperInliner {
      * declaration: a binding holding a lambda is applied by the expression and reaches nothing.
      */
     private static ReachName.Declaration calledHelper(Stdlib stdlib, Hir.Apply call) {
-        if (!(call.answered() instanceof Hir.Var.Denoting callee)) {
+        if (!(call.function() instanceof Hir.Var.Denoting callee)) {
             return null;
         }
         Stdlib.Rewrite rewrite = rewriteTaken(stdlib, call);
@@ -724,7 +724,7 @@ public final class HelperInliner {
      * boundary is read in is what answers for it.
      */
     private Hir.RetType arrivesAs(Hir.Expr arg) {
-        if (!(arg instanceof Hir.Var v) || !(v.answered() instanceof Hir.Var.Denoting named)) {
+        if (!(arg instanceof Hir.Var.Denoting named)) {
             return null;
         }
         Hir.FnDef is = expands(named);
@@ -1603,7 +1603,7 @@ public final class HelperInliner {
      * {@code ()}, and there is no block taking no parameter to expand it to.
      */
     private OptionalInt declarationArity(Hir.Var name) {
-        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+        if (!(name instanceof Hir.Var.Denoting v)) {
             return OptionalInt.empty();   // it stands for no declaration to take anything
         }
         int arity = switch (v.denotes()) {
@@ -1652,7 +1652,7 @@ public final class HelperInliner {
             int k = next();
             return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
-        if (!(v.answered() instanceof Hir.Var.Denoting named)
+        if (!(v instanceof Hir.Var.Denoting named)
                 || !(named.denotes() instanceof ValueName.Helper)) {
             return v;
         }
@@ -1809,8 +1809,7 @@ public final class HelperInliner {
         Integer idx = table.library().theWalk().equals(call.answered().denotes())
                 ? BLOCK_ARG_OF_THE_WALK : null;
         if (idx == null || idx >= call.args().size()
-                || !(call.args().get(idx) instanceof Hir.Var v)
-                || !(v.answered() instanceof Hir.Var.Denoting named)) {
+                || !(call.args().get(idx) instanceof Hir.Var.Denoting named)) {
             return call;
         }
         Hir.FnDef helper = expands(named);
@@ -1818,7 +1817,7 @@ public final class HelperInliner {
             return call;   // a bare name that stands for no body is left for the type checker to report
         }
         int k = next();
-        Hir.Block block = etaExpand(v, helper.params().size(), i -> "$b" + k + "_" + i);
+        Hir.Block block = etaExpand(named, helper.params().size(), i -> "$b" + k + "_" + i);
         List<Hir.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
         return call.withArgs(args);
@@ -2218,7 +2217,7 @@ public final class HelperInliner {
      * comes out as far as its spelling is long.
      */
     private Hir.Var renameVar(Hir.Var name, Renaming renaming) {
-        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+        if (!(name instanceof Hir.Var.Denoting v)) {
             return name;   // it names nothing, so there is nothing to rename it to
         }
         Substituted stands = renaming.substituted(v.denotes());
@@ -2251,7 +2250,7 @@ public final class HelperInliner {
      * no exception.
      */
     private Hir.FnDef valueSpread(Hir.Var name) {
-        if (!(name.answered() instanceof Hir.Var.Denoting spread)
+        if (!(name instanceof Hir.Var.Denoting spread)
                 || !(spread.denotes() instanceof ValueName.Helper)) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -194,7 +194,7 @@ public final class HelperNames {
 
     /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
     private static Hir.Var qualified(Hir.Var name, Predicate<ValueName.Helper> which) {
-        return name.answered() instanceof Hir.Var.Denoting named
+        return name instanceof Hir.Var.Denoting named
                 && foreign(named.denotes(), which)
                 ? Hir.Var.respelled(qualifiedName(named.denotes()), ofModule(named.denotes()),
                         name.pos(), name.region())

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -585,7 +585,7 @@ final class HelperParams {
             }
             // the value the attempt built is in force over the success arm, at the type it was built as
             Scope built = ic.construct() instanceof Hir.NewData nd
-                    && nd.typeName().answered() instanceof Hir.Name.Denoting names
+                    && nd.typeName() instanceof Hir.Name.Denoting names
                     ? env.with(ic.binder(), Type.ref(names.type())) : env;
             List<Reading> arms = new ArrayList<>();
             arms.add(new Reading(ic.then(), built));
@@ -1033,7 +1033,7 @@ final class HelperParams {
 
         /** Each field of a construction, asked for the type that field holds. */
         private void visitInits(Hir.NewData nd, Scope env, BindingId target) {
-            Hir.Data data = nd.typeName().answered() instanceof Hir.Name.Denoting names
+            Hir.Data data = nd.typeName() instanceof Hir.Name.Denoting names
                     && symbols.declaredNode(names.type()) instanceof Hir.Data d
                     ? d : null;
             for (Hir.FieldInit init : nd.inits()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -248,7 +248,7 @@ public final class MatchElaborator {
      * for.
      */
     private static TypeSymbol names(Hir.Name arm) {
-        if (!(arm.answered() instanceof Hir.Name.Denoting named)) {
+        if (!(arm instanceof Hir.Name.Denoting named)) {
             throw new Unanswerable(arm.pos());
         }
         return named.type();

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -151,7 +151,7 @@ final class PartialReachability {
      * not be written where a value goes. A value takes none and is read rather than handed over.
      */
     boolean isPartialFunctionNamed(Hir.Var v) {
-        if (!(v.answered() instanceof Hir.Var.Denoting named)) {
+        if (!(v instanceof Hir.Var.Denoting named)) {
             return false;   // it names no helper, partial or otherwise
         }
         Hir.FnDef declared = declarationOf(named, inliner);

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -1769,7 +1769,7 @@ public final class Resolve {
      * synthesized by an earlier pass rather than written, so there is nothing to point at, and a
      * name nothing answered is an absence rather than a declaration to record. */
     private Hir.Name answered(Hir.Name n) {
-        if (!(n.answered() instanceof Hir.Name.Denoting names)) {
+        if (!(n instanceof Hir.Name.Denoting names)) {
             failed++;
         } else if (n.pos() != null) {
             denotations.add(new TypeUse(n.name(), names.type()));

--- a/souther-compiler/src/main/java/souther/compiler/check/ResolvedFieldTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ResolvedFieldTypes.java
@@ -63,7 +63,7 @@ public final class ResolvedFieldTypes implements FieldTypes {
         Map<String, Hir.TypeRef> out = new LinkedHashMap<>();
         if (symbols.declaredNode(typeName) instanceof Hir.Data d) {
             for (Hir.Name inc : d.includes()) {
-                if (inc.answered() instanceof Hir.Name.Denoting named) {
+                if (inc instanceof Hir.Name.Denoting named) {
                     out.putAll(written(named.type(), symbols));
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/RowFixtures.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RowFixtures.java
@@ -196,7 +196,7 @@ public final class RowFixtures {
     /** Whether an expression is a bare name standing for a declared type — the form an expectation
      *  takes when it asserts the arm and nothing under it. */
     static boolean assertsAnArm(Hir.Expr e) {
-        return e instanceof Hir.Var v && v.answered() instanceof Hir.Var.Denoting d
+        return e instanceof Hir.Var.Denoting d
                 && d.denotes() instanceof souther.compiler.types.ValueName.OfType;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -143,7 +143,7 @@ public final class SpecChecker {
                 continue;
             }
             for (Hir.Var required : spec.dependsOn()) {
-                if (!(required.answered() instanceof Hir.Var.Denoting named)) {
+                if (!(required instanceof Hir.Var.Denoting named)) {
                     continue;
                 }
                 ValueName.Behavior reached = behaviorReached(required);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -323,7 +323,7 @@ public final class TypeCardinality {
             case Hir.UnitData _ -> { }
             // A case naming nothing names no declaration for this to have read.
  	    case Hir.SumData sum -> sum.cases().forEach(each -> {
-                if (each.answered() instanceof Hir.Name.Denoting names) {
+                if (each instanceof Hir.Name.Denoting names) {
                     named.add(names.type());
                 }
             });

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -366,7 +366,7 @@ public final class TypeChecker {
                 for (Hir.Var req : spec.dependsOn()) {
                     // A name nothing answered is no name for another to be a duplicate of, and it
                     // was reported where it is written.
-                    if (req.answered() instanceof Hir.Var.Denoting named) {
+                    if (req instanceof Hir.Var.Denoting named) {
                         // The bare name, and deliberately not the declaration. Two dependencies are
                         // two behaviors whatever modules declared them, and the clause is still
                         // refused when they go by one spelling: what it decides is the implementing

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -390,7 +390,7 @@ public final class TypeOps {
     static List<TypeSymbol> caseNames(Hir.SumData sum) {
         List<TypeSymbol> names = new ArrayList<>();
         for (Hir.Name c : sum.cases()) {
-            if (c.answered() instanceof Hir.Name.Denoting named) {
+            if (c instanceof Hir.Name.Denoting named) {
                 names.add(named.type());
             }
         }
@@ -1036,7 +1036,7 @@ public final class TypeOps {
         // through spreads, holds no such field at all.
         Map<String, String> suppliedBy = new LinkedHashMap<>();
         for (Hir.Name inc : data.includes()) {
-            if (!(inc.answered() instanceof Hir.Name.Denoting names)) {
+            if (!(inc instanceof Hir.Name.Denoting names)) {
                 // Nothing declares it, which was reported where it is written. It brings in no
                 // fields, and complaining here that it is not a product data would be a second
                 // report about the one mistake.
@@ -1097,7 +1097,7 @@ public final class TypeOps {
      * not a product. Only {@link #fieldTypes} turns those into a diagnostic, and every declared data
      * goes through it; the readers asked about one field or one invariant answer for what they see. */
     private static Hir.Data spreadTarget(Hir.Name inc, Symbols symbols) {
-        return inc.answered() instanceof Hir.Name.Denoting named
+        return inc instanceof Hir.Name.Denoting named
                 && symbols.declaredNode(named.type()) instanceof Hir.Data d
                 ? d : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -784,7 +784,7 @@ public final class FixtureReader {
     /** The case a bare name stands for: the type it denotes where it denotes one — a unit case, or a
      * case written bare — and otherwise the case the value or binding it names constructs. */
     private TypeSymbol namedCase(Hir.Var name, Set<String> followed, List<TypeSymbol> worn) {
-        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+        if (!(name instanceof Hir.Var.Denoting v)) {
             // it names nothing, so it stands for no case; reported where it is written
             return null;
         }
@@ -1402,7 +1402,7 @@ public final class FixtureReader {
     }
 
     private Stated statedByName(Hir.Var name) {
-        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+        if (!(name instanceof Hir.Var.Denoting v)) {
             // it names nothing, and the reading that follows says so where it is written
             return ELSEWHERE;
         }
@@ -1486,7 +1486,7 @@ public final class FixtureReader {
      * again here: a binding in force is the value it holds, whatever else bears its spelling.
      */
     private Object named(Hir.Var name, Position at, Admission admission) {
-        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+        if (!(name instanceof Hir.Var.Denoting v)) {
             throw new FixtureException("`" + name.name() + "` is not a value a fixture can name");
         }
         return switch (v.denotes()) {
@@ -1717,7 +1717,7 @@ public final class FixtureReader {
         // `...base` copies the fields of a value, and the fields written after it replace what it
         // brought.
         for (Hir.Var spreadName : nd.spreads()) {
-            if (!(spreadName.answered() instanceof Hir.Var.Denoting ref)) {
+            if (!(spreadName instanceof Hir.Var.Denoting ref)) {
                 throw new FixtureException("`" + spreadName.name()
                         + "` is not a value a fixture can spread");
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3322,11 +3322,10 @@ public final class Adequacy {
                                                   List<Hir.Expr> inputs) {
             Map<String, Generator.Baseline.Named> at = new LinkedHashMap<>();
             for (int p = 0; p < inputs.size() && p < spec.params().size(); p++) {
-                if (inputs.get(p) instanceof Hir.Var written
-                        && written.answered() instanceof Hir.Var.Denoting denoting
+                if (inputs.get(p) instanceof Hir.Var.Denoting denoting
                         && denoting.denotes() instanceof souther.compiler.types.ValueName.Helper helper) {
                     at.put(spec.params().get(p).name(),
-                            new Generator.Baseline.Named(helper.module(), written.name()));
+                            new Generator.Baseline.Named(helper.module(), denoting.name()));
                 }
             }
             return new Generator.Baseline(at);

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1879,7 +1879,7 @@ public final class Bodies {
         Set<String> names = new HashSet<>();
         for (Hir.Var req : spec.value().dependsOn()) {
             // Reported where it is written; it names no parameter for a body to be held to.
-            if (req.answered() instanceof Hir.Var.Denoting named) {
+            if (req instanceof Hir.Var.Denoting named) {
                 names.add(named.denotes().name());
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
@@ -100,7 +100,7 @@ class OneModuleIsExpandedAgainstOneTableTest {
     private static void namedSpreads(Hir.Expr e, HelperTable table, Set<String> out) {
         if (e instanceof Hir.NewData nd) {
             for (Hir.Var spread : nd.spreads()) {
-                if (spread.answered() instanceof Hir.Var.Denoting named
+                if (spread instanceof Hir.Var.Denoting named
                         && named.reachesADeclaration() != null
                         && table.reaches(named.reachesADeclaration())) {
                     out.add(named.reaches());


### PR DESCRIPTION
`Hir.Var` and `Hir.Name` are each two forms — a name that denotes a declaration, and one nothing declares — and `answered()` projects them onto the answered form or null. Its own note says a reader arrives at what a name names through that projection *or* through narrowing to the two forms.

A family of readers was doing both at once: `name.answered() instanceof Denoting`. That takes the projection and narrows it back to the form it came from, so the question is asked twice, and by the second asking a test of a form has become a test for null — which is what Error Prone's `BadInstanceof` reports of every one of them. The name answers it on its own, because the form is what it is.

Two of the readers held an applied expression rather than a name. There the projection is the callee read through the application, so they ask the function, which is the thing that either is a name that denotes or is not.

`answered()` stays. Reading what an answered name says — what it denotes, what it reaches, the type it names — goes through it, and those readers are not doing this.

What the check reports and this does not change is a call whose result is bound and null-checked in one condition. Inside an expression there is no other spelling, since a declaration is a statement and a condition is not; that those methods answer an absence with null is a thing to fix in the methods. So the check goes off with that written beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)