### PR TITLE
Answer the two checks that found something written as though it said something

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,15 @@
                                      asked somewhere it cannot be. That those methods answer an
                                      absence with null is a thing to fix in the methods, not at the
                                      conditions reading them, and it is not what this reports. -->
-                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:BadInstanceof:OFF -Xep:ReferenceEquality:OFF -Xep:RemoveUnusedImports:ERROR ${nullaway.args}</arg>
+                                <!-- ObjectToString and DuplicateBranches are errors. Each found a
+                                     place written as though it said something and saying nothing:
+                                     an exception message that named an end and printed its identity
+                                     hash, an assertion whose left side asked a `toString` nothing
+                                     wrote and so could not hold, and a condition whose two branches
+                                     were the same number. What they report is cheap to answer and
+                                     silent to miss, which is the pairing that earns a build
+                                     failure rather than a line in a log. -->
+                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:BadInstanceof:OFF -Xep:ReferenceEquality:OFF -Xep:RemoveUnusedImports:ERROR -Xep:ObjectToString:ERROR -Xep:DuplicateBranches:ERROR ${nullaway.args}</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>

--- a/souther-compiler/src/main/java/souther/compiler/partition/DomainEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/DomainEnd.java
@@ -96,6 +96,14 @@ public final class DomainEnd {
         return attribution;
     }
 
+    /** Which end this is and where it leaves off, which is what a message naming one has to say.
+     *  The attribution is not here: it is what a reading answered, and a message about the end
+     *  reaching somewhere it should not is not about who took it in. */
+    @Override
+    public String toString() {
+        return side + " at " + bound;
+    }
+
     /** Where {@code end} is, or null where there is no end that way. */
     public static Bound boundOf(DomainEnd end) {
         return end == null ? null : end.bound();

--- a/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
@@ -135,7 +135,7 @@ class AConstructionMeansWhatItsFormMeansTest {
         Diagnostic d = only(rows);
         assertEquals(code, d.code(), d.said().toString());
         for (String name : names) {
-            assertTrue(d.toString().contains(name) || d.said().toString().contains(name),
+            assertTrue(d.said().toString().contains(name),
                     "`" + name + "` is said: " + d.said());
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatTheDifferenceBoundsSayIsWhatThePointsSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatTheDifferenceBoundsSayIsWhatThePointsSayTest.java
@@ -174,7 +174,7 @@ class WhatTheDifferenceBoundsSayIsWhatThePointsSayTest {
     private static List<Written> aSystem(Random dice) {
         List<Written> out = new ArrayList<>();
         for (String position : POSITIONS) {
-            out.add(new Written(Map.of(position, Rational.of(-LOW == 0 ? 1 : 1)),
+            out.add(new Written(Map.of(position, Rational.ONE),
                     Rational.of(-LOW), Rel.GE));
             out.add(new Written(Map.of(position, Rational.ONE), Rational.of(-HIGH), Rel.LE));
         }


### PR DESCRIPTION
Error Prone's `ObjectToString` and `DuplicateBranches` each found a place written as though it said something and saying nothing. Both are now errors, because what they report is cheap to answer and silent to miss.

An `IllegalStateException` in `QuantityArrangement` names the end the rules leave, and `DomainEnd` is final and writes no `toString` — so the state that exception is raised to report arrives as an identity hash. The class now says which end it is and where it leaves off, which is what a message naming one has to say. Its attribution is not in there: that is what a reading answered, and a message about the end reaching somewhere it should not is not about who took it in.

An assertion in `AConstructionMeansWhatItsFormMeansTest` asked `Diagnostic.toString` first and the message second. `Diagnostic` writes no `toString` either, so the first could only ever compare the name against an identity hash, and what held the test up was the second alone. It now asks only that, so what the test covers and what it says it covers are the same.

A generated row in `WhatTheDifferenceBoundsSayIsWhatThePointsSayTest` wrote its coefficient as a conditional whose branches were the same number, showing a reader a sign of `LOW` deciding something it does not. The row beside it writes that coefficient plainly, and now so does this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)