### PR TITLE
Publish the form a data was declared in, not the shape it was left with

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/core/ValueShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/ValueShape.java
@@ -20,6 +20,12 @@ import java.util.Optional;
  * a clause means is the elaboration, and a reader elaborating one of its own would be the second
  * place that decided it — which is what {@code Core} was made to end.
  *
+ * <p>What a value is made of, and nothing about how one is written. Whether the declaration was
+ * written with its fields out or as {@code data X = Y} is not here, and nothing here derives it:
+ * the two are made alike, and which one a declaration is decides how a value of it crosses (spec
+ * §newtype). That is a fact about the declaration and is held where a declaration is published
+ * ({@code program.CheckedData}). A value is laid out from the same shape either way.
+ *
  * <p>The shape of the data a value is being built as, and not of the declaration a clause was
  * written on. An include carries a clause into the data that includes it (spec §invariant), and it
  * is checked there, over the fields that data has; the binding it reads is the one the declaration

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
@@ -11,18 +11,28 @@ import java.util.NoSuchElementException;
  * What one of a module's declared data is made of, as an output outside this compiler reads it.
  *
  * <p>A {@link Type.Ref} names a data and says nothing of what is in it. So a reader holding a value
- * of a declared type could say neither where in it a field lies nor which case it turned out to be,
- * and both are decisions the language made. This is where they are read back.
+ * of a declared type could say neither where in it a field lies, nor which case it turned out to
+ * be, nor which of the language's forms it was declared in, and all three are decisions the
+ * language made. This is where they are read back.
  *
- * <p>The shape a value has, and not the declaration as it was written. An include is already
- * flattened into {@link Product#fields()}, and a case that is itself a sum is already descended
+ * <p>What the checker settled and a reader cannot recover from a name: the form a data was declared
+ * in, the shape a value of it has, and the cases it can be.
+ *
+ * <p>The shape and not the declaration as it was written. An include is already flattened into
+ * {@link WithFields#fields()}, and a case that is itself a sum is already descended
  * into {@link Sum#cases()}. Either one worked out again by a reader would be a second answer to a
  * question the language settled once, and two readers that each descended would differ at the
  * shape neither of them is written against: the one where the descent reaches a case twice.
  *
- * <p>Three arms and not fields-or-cases. The language declares in three forms, and a unit written as
- * a product with no fields is a declaration a reader cannot tell from one that happens to have
- * none — while {@link souther.compiler.core.Core.UnitValue} names exactly the first.
+ * <p>Four arms, one to a form the language declares in, and not fields-or-cases. Which form a
+ * declaration was written in is the one thing here its shape does not answer, and a reader given
+ * the shape alone would be left to guess it from the name of a member. {@code data X = Y} and
+ * {@code data X = { value: Y }} are made of one field of the same type and hold the same clauses.
+ * At a position declaring the first, a value is written as {@code Y} is written; at one declaring
+ * the second, as an object. Which of the two a declaration is, is decided by the syntax it was
+ * written in rather than by the shape it came out as (spec §newtype). A {@link Unit} is its own arm
+ * for the same reason: a product that happens to have no fields is a declaration a reader could not
+ * tell it from, while {@link souther.compiler.core.Core.UnitValue} names exactly the first.
  *
  * <p>What was declared, by a module of this compilation or by the language in the reserved
  * namespace. The two are one kind of thing here, and which of them declared a given one is
@@ -34,10 +44,10 @@ import java.util.NoSuchElementException;
  * one, among them what {@code Core.UnitValue} can carry, is answered for by the sealed identity
  * itself; it is not a declaration this snapshot is missing.
  *
- * <p>{@link Product} is a class and answers no {@code equals}. What a value of a product is made
- * of is {@link ValueShape}, which the check answers and this hands over whole — the fields, the
- * binding each is read through, and what must hold of a value built from them. {@link Sum} and
- * {@link Unit} hold everything they will hold, so they are records.
+ * <p>{@link Product} and {@link Newtype} are classes and answer no {@code equals}. What a value of
+ * either is made of is {@link ValueShape}, which the check answers and this hands over whole — the
+ * fields, the binding each is read through, and what must hold of a value built from them.
+ * {@link Sum} and {@link Unit} hold everything they will hold, so they are records.
  */
 public sealed interface CheckedData {
 
@@ -45,29 +55,24 @@ public sealed interface CheckedData {
     TypeSymbol.AtModule name();
 
     /**
-     * A data a value is built out of, field by field.
+     * A data a value is built out of, field by field: a {@link Product} and a {@link Newtype}.
      *
-     * <p>A {@code newtype} is one of these: a single field called {@code value} holding what it
-     * wraps (spec §newtype). Only its external representation differs, which is
-     * {@code check.Boundary}'s answer and no part of what a value is made of, so nothing here marks
-     * it out.
+     * <p>The second question asked of a declaration here, and the one the arms do not answer. Which
+     * form it was written in decides how a value of it crosses; what a value is built out of, and
+     * where in it a field lies, is this — and a newtype answers it exactly as the one-field product
+     * it is made like, because construction, access and the clauses that must hold are the same for
+     * the two (spec §newtype).
+     *
+     * <p>Two questions and two ways of being total. A reader laying a value out asks here and is
+     * answered for every declaration without naming a form; a reader writing a value's external
+     * form asks the arm and has to say what it writes for each. Carried on one hierarchy, the
+     * second reader would be asking about layout, which answers alike for the two — and answering
+     * alike is what this is for.
      */
-    final class Product implements CheckedData {
+    sealed interface WithFields permits Product, Newtype {
 
-        private final ValueShape shape;
-
-        Product(ValueShape shape) {
-            if (shape == null) {
-                throw new IllegalArgumentException(
-                        "a product is what a value of it is made of and what must hold of one");
-            }
-            this.shape = shape;
-        }
-
-        @Override
-        public TypeSymbol.AtModule name() {
-            return shape.name();
-        }
+        /** Which declaration this is. */
+        TypeSymbol.AtModule name();
 
         /**
          * Every field a value of this holds, in the order they are laid out. What an included data
@@ -85,9 +90,7 @@ public sealed interface CheckedData {
          * the clause is running what the checker decided, and one working the bindings out from the
          * declarations would be deciding it a second time.
          */
-        public List<ValueShape.Field> fields() {
-            return shape.fields();
-        }
+        List<ValueShape.Field> fields();
 
         /**
          * What must hold of a value of this, in the order a failure is decided in.
@@ -99,9 +102,7 @@ public sealed interface CheckedData {
          *
          * <p>Empty where nothing is stated, which is a data any value of its fields is one of.
          */
-        public List<ValueShape.Invariant> invariants() {
-            return shape.invariants();
-        }
+        List<ValueShape.Invariant> invariants();
 
         /**
          * Where the field called {@code field} lies among {@link #fields()}.
@@ -110,6 +111,108 @@ public sealed interface CheckedData {
          *     field of it is a mistake at the reader, and answering with a position that is not one
          *     would put the mistake in whatever it emitted
          */
+        int positionOf(String field);
+    }
+
+    /** A data declared with its fields written out, {@code data X = { ... }} (spec §product-data).
+     *  At a boundary position that declares this type, a value of one crosses as an object whatever
+     *  it holds — a single member included (spec §newtype). */
+    final class Product implements CheckedData, WithFields {
+
+        private final ValueShape shape;
+
+        Product(ValueShape shape) {
+            if (shape == null) {
+                throw new IllegalArgumentException(
+                        "a product is what a value of it is made of and what must hold of one");
+            }
+            this.shape = shape;
+        }
+
+        @Override
+        public TypeSymbol.AtModule name() {
+            return shape.name();
+        }
+
+        @Override
+        public List<ValueShape.Field> fields() {
+            return shape.fields();
+        }
+
+        @Override
+        public List<ValueShape.Invariant> invariants() {
+            return shape.invariants();
+        }
+
+        @Override
+        public int positionOf(String field) {
+            return shape.positionOf(field);
+        }
+
+        @Override
+        public String toString() {
+            return shape.name().toString();
+        }
+    }
+
+    /**
+     * A data declared over another, {@code data X = Y} (spec §newtype).
+     *
+     * <p>One value under another name. At a boundary position that declares this type, a value of
+     * it is written as a value of {@link #wrapped()} is written — bare, and not as an object
+     * holding it under a key — and that is the whole of the difference from a product declared with
+     * a single member, which is why everything else about it is asked through {@link WithFields}.
+     *
+     * <p>The position it stands at is the other half of a representation, and it is not this
+     * (ADR-0094). A sum that admits this as a case writes what admitting it adds: a bare scalar has
+     * nowhere to carry the discriminator, so the payload stands under a {@code value} key there
+     * (ADR-0014, spec §sum-discrimination). What is here is what this declaration is, and a reader
+     * writing a value asks it together with the position the value is being written at.
+     */
+    final class Newtype implements CheckedData, WithFields {
+
+        private final ValueShape shape;
+
+        Newtype(ValueShape shape) {
+            if (shape == null) {
+                throw new IllegalArgumentException(
+                        "a newtype is what a value of it is made of and what must hold of one");
+            }
+            if (shape.fields().size() != 1) {
+                throw new IllegalArgumentException("a newtype is one value under another name, and `"
+                        + shape.name() + "` is made of " + shape.fields());
+            }
+            this.shape = shape;
+        }
+
+        @Override
+        public TypeSymbol.AtModule name() {
+            return shape.name();
+        }
+
+        /**
+         * The type this is a name for — the {@code Y} of {@code data X = Y}.
+         *
+         * <p>The type and not the field that holds it. The field is the one the desugaring wrote to
+         * hold the value, under a name that pass chose; handed the field, a reader would be reading
+         * a name this compiler picked as though the declaration had written it — and reading a
+         * member's name for what a value is written as is the reading this arm is here to spare it.
+         */
+        public Type wrapped() {
+            return shape.fields().getFirst().type();
+        }
+
+        @Override
+        public List<ValueShape.Field> fields() {
+            return shape.fields();
+        }
+
+        @Override
+        public List<ValueShape.Invariant> invariants() {
+            return shape.invariants();
+        }
+
+        @Override
         public int positionOf(String field) {
             return shape.positionOf(field);
         }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -249,7 +249,7 @@ public final class CheckedProgram {
      * <p>What this is total over is the identities this compile resolved, and not every value the
      * Java type admits. An identity is minted where a declaration world says one is at an address,
      * so an address nothing declares is a mistake at the reader — refused here, for the reason
-     * {@link CheckedData.Product#positionOf} refuses a name that is no field.
+     * {@link CheckedData.WithFields#positionOf} refuses a name that is no field.
      *
      * @throws IllegalArgumentException where nothing this compile read declares {@code name}
      */

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -517,7 +517,7 @@ final class CheckedProgramAssembler {
     /**
      * What the module declares.
      *
-     * <p>Each of the three forms is materialised from the answer this compiler already has for it,
+     * <p>Each of the four forms is materialised from the answer this compiler already has for it,
      * and neither walk is written again here. A product's fields are
      * {@link TypeOps#fieldTypes}, which flattens what an include brought in; a sum's cases are
      * {@link AtomSpace#subjectAtoms}, which descends a case that is itself a sum and reaches one
@@ -534,7 +534,7 @@ final class CheckedProgramAssembler {
      * on its own and one a sum's case list declares reach {@code defs} by different routes, so
      * where either stands among them is how the front end put them there rather than something the
      * language decided. The two orders that are decided are inside a declaration —
-     * {@link CheckedData.Product#fields} and {@link CheckedData.Sum#cases} — and those are the
+     * {@link CheckedData.WithFields#fields} and {@link CheckedData.Sum#cases} — and those are the
      * ones said out loud.
      */
     private static List<CheckedData> dataOf(Hir.Module declarations, Symbols symbols,
@@ -547,7 +547,7 @@ final class CheckedProgramAssembler {
     }
 
     /**
-     * One declaration, in whichever of the three forms it was written.
+     * One declaration, in whichever of the four forms it was written.
      *
      * <p>One reading for both worlds. A module's declaration and the language's are the same kind
      * of thing — they resolve and type alike and a value of either lays out alike — and this is
@@ -556,7 +556,7 @@ final class CheckedProgramAssembler {
     private static CheckedData declaredAs(Hir.Def def, Symbols symbols,
                                           Map<TypeSymbol.AtModule, ValueShape> shapes) {
         return switch (def) {
-            case Hir.Data product -> productOf(product, shapes);
+            case Hir.Data data -> checkedDataOf(data, shapes);
             case Hir.SumData sum -> new CheckedData.Sum(sum.declares(),
                     AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols));
             case Hir.UnitData unit -> new CheckedData.Unit(unit.declares());
@@ -564,24 +564,30 @@ final class CheckedProgramAssembler {
     }
 
     /**
-     * One product, as the check answered what a value of it is made of.
+     * One data built field by field, as the check answered what a value of it is made of and as the
+     * author wrote it.
      *
      * <p>Handed over and not rebuilt. The fields, the binding each is read through and the clauses
      * that must hold of a value are one answer of the checker's, and the JVM emits a construction
      * from that same answer — so what an output outside this compiler reads and what the bytecode
      * refuses a value by cannot come apart.
+     *
+     * <p>Which of the two arms it is, is what the author wrote. A newtype and a one-field product
+     * reach here with the same shape, and the shape is what the language says does not decide
+     * between them (spec §newtype), so it is read off the declaration — the same answer a derived
+     * codec is generated from.
      */
-    private static CheckedData productOf(Hir.Data product,
-                                         Map<TypeSymbol.AtModule, ValueShape> shapes) {
-        ValueShape shape = shapes.get(product.declares());
+    private static CheckedData checkedDataOf(Hir.Data data,
+                                             Map<TypeSymbol.AtModule, ValueShape> shapes) {
+        ValueShape shape = shapes.get(data.declares());
         if (shape == null) {
             // The module was taken as checked, and a declaration of it has no answer for what a
             // value of it is. Handing over a product with no clauses would be saying that anything
             // its fields admit is one of it, which is the opposite of what the author wrote.
-            throw new IllegalStateException("`" + product.declares() + "` was taken as checked and"
+            throw new IllegalStateException("`" + data.declares() + "` was taken as checked and"
                     + " the check said nothing about what a value of it is");
         }
-        return new CheckedData.Product(shape);
+        return data.newtype() ? new CheckedData.Newtype(shape) : new CheckedData.Product(shape);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/Declared.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/Declared.java
@@ -15,7 +15,7 @@ package souther.compiler.program;
  * <p>Nothing for a name nothing declares. An identity comes from a declaration world having said
  * one is at an address, so a reader that assembled one from two strings is asking about something
  * that is not a declaration — {@link CheckedProgram#declaration} refuses rather than answering, for
- * the reason {@link CheckedData.Product#positionOf} does. A case for it would be an output handling
+ * the reason {@link CheckedData.WithFields#positionOf} does. A case for it would be an output handling
  * a mistake of its own as one of the states a checked program is in.
  */
 public record Declared(CheckedData data, DeclaredBy declaredBy) {

--- a/souther-compiler/src/main/java/souther/compiler/program/DeclaredFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/DeclaredFields.java
@@ -40,7 +40,10 @@ final class DeclaredFields implements Declarations {
         Map<TypeSymbol, Composed> byOwner = new LinkedHashMap<>();
         for (CheckedData each : declarations) {
             byOwner.put(each.name(), switch (each) {
-                case CheckedData.Product product -> new Composed.OfFields(fieldsOf(product));
+                // What a value is made of, which is the question a newtype answers as the one-field
+                // product it is made like. How one is written is the other question, and a
+                // comparison of two values does not ask it.
+                case CheckedData.WithFields built -> new Composed.OfFields(fieldsOf(built));
                 // A sum is its cases and a unit carries nothing, so neither is a place a field
                 // stands under.
                 case CheckedData.Sum _, CheckedData.Unit _ -> Composed.NOTHING;
@@ -49,9 +52,9 @@ final class DeclaredFields implements Declarations {
         return new DeclaredFields(byOwner);
     }
 
-    private static Map<String, Type> fieldsOf(CheckedData.Product product) {
+    private static Map<String, Type> fieldsOf(CheckedData.WithFields built) {
         Map<String, Type> fields = new LinkedHashMap<>();
-        for (ValueShape.Field field : product.fields()) {
+        for (ValueShape.Field field : built.fields()) {
             fields.put(field.name(), field.type());
         }
         return fields;

--- a/souther-compiler/src/test/java/souther/compiler/program/ANewtypeIsMadeOfTheOneValueItIsANameForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/ANewtypeIsMadeOfTheOneValueItIsANameForTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.program;
+
+import souther.compiler.core.ValueShape;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeSymbol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@link CheckedData.Newtype} is refused a shape that is not one value.
+ *
+ * <p>What {@link CheckedData.Newtype#wrapped()} rests on. It answers with the type of the one field
+ * the shape holds, and a shape holding another number of them would have it answer with whichever
+ * field happened to be laid out first — an answer about a type the declaration is not a name for,
+ * and one nothing downstream could tell from the right one.
+ *
+ * <p>Held against a shape the checker made rather than one assembled here, so what is refused is a
+ * shape of the kind this arm is handed. Nothing in the front end writes a newtype of more than one
+ * field today — the desugaring writes exactly the one — which is why the warrant is stated where the
+ * value is made and asked for here: a later producer reaches this constructor, and this is the
+ * refusal it meets.
+ */
+class ANewtypeIsMadeOfTheOneValueItIsANameForTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Amount = Int
+
+            data Common = { id: Int, tag: String }
+            """;
+
+    /** The shapes the check settled for {@code demo}, by the declaration each is of. */
+    private static Map<TypeSymbol.AtModule, ValueShape> shapes() {
+        Compilation compilation = Compilation.ofSources(List.of(MODULE), ModulePath.EMPTY);
+        Map<TypeSymbol.AtModule, ValueShape> shapes =
+                compilation.db().ask(new Shapes.ValueShapes("demo")).value();
+        assertNotNull(shapes, "the check answered what a value of each declaration is made of");
+        return shapes;
+    }
+
+    private static ValueShape shapeOf(String name) {
+        for (Map.Entry<TypeSymbol.AtModule, ValueShape> each : shapes().entrySet()) {
+            if (each.getKey().name().equals(name)) {
+                return each.getValue();
+            }
+        }
+        throw new AssertionError(name + " is not a declaration of this module");
+    }
+
+    @Test
+    void aShapeOfMoreThanOneFieldIsNotOneValueUnderAnotherName() {
+        ValueShape common = shapeOf("Common");
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new CheckedData.Newtype(common));
+
+        assertTrue(refused.getMessage().contains("Common"), refused::getMessage);
+    }
+
+    /** And the shape a newtype is declared with is taken, so the refusal is about the shape and not
+     *  about the arm. */
+    @Test
+    void andTheOneItIsDeclaredWithIsTaken() {
+        CheckedData.Newtype amount = new CheckedData.Newtype(shapeOf("Amount"));
+
+        assertEquals(shapeOf("Amount").fields().getFirst().type(), amount.wrapped());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/program/BothReadersOfAValueTakeTheSameCheckedShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/BothReadersOfAValueTakeTheSameCheckedShapeTest.java
@@ -161,10 +161,10 @@ class BothReadersOfAValueTakeTheSameCheckedShapeTest {
         CheckedProgram program = CheckedProgram.of(List.of(MODULE));
         int named = 0;
         for (CheckedData each : declarationsOf(program)) {
-            if (!(each instanceof CheckedData.Product product)) {
+            if (!(each instanceof CheckedData.WithFields built)) {
                 continue;
             }
-            for (souther.compiler.core.ValueShape.Field field : product.fields()) {
+            for (souther.compiler.core.ValueShape.Field field : built.fields()) {
                 for (TypeSymbol reached : declarationsIn(field.type())) {
                     if (reached instanceof TypeSymbol.AtModule at) {
                         named++;

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest.java
@@ -51,12 +51,19 @@ class WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest {
      * newtype, whose applications are rewritten below the declarations; a data carrying an
      * invariant, which is settled and rewritten between the two trees; an include; a sum of sums;
      * and units a case list declares rather than a line of its own.
+     *
+     * <p>{@code Wrapper} is the newtype's twin and is here so that the form is compared both ways.
+     * A snapshot deciding the form by the shape it was left with — one field, called {@code value} —
+     * answers as the declaration does for {@code Amount} and would go unremarked if nothing was
+     * declared that the shape says the same thing about and the language does not.
      */
     private static final String MODULE = """
             module demo
 
             data Amount = Int
                 invariant value >= 0
+
+            data Wrapper = { value: Int }
 
             data Common = { id: Int, tag: String }
             data Wide   = { ...Common, extra: Int }
@@ -89,6 +96,11 @@ class WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest {
      * from. A product's fields and a sum's cases are read here the way every reader below the check
      * reads them, so a snapshot built over a tree that had drifted answers differently at the first
      * declaration the drift touched.
+     *
+     * <p>And which form it was written in, which the fields do not say. A newtype and a product of
+     * one member are made of the same field of the same type, and the arm is where they part; read
+     * off {@code Hir.Data.newtype()}, which is what the derived codec is generated from, so the
+     * form an output writes a value by and the form the JVM's codec writes it by are one answer.
      */
     @Test
     void andIsMadeOfWhatTheCheckerWouldSayItIsMadeOf() {
@@ -98,12 +110,15 @@ class WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest {
             CheckedData published = read.snapshot().get(declared.getKey());
             assertNotNull(published, () -> "not in the snapshot: " + declared.getKey());
             switch (declared.getValue()) {
-                case Hir.Data data -> assertEquals(
-                        new ArrayList<>(TypeOps.fieldTypes(data, read.symbols()).keySet()),
-                        assertInstanceOf(CheckedData.Product.class, published,
-                                declared.getKey()::toString)
-                                .fields().stream().map(ValueShape.Field::name).toList(),
-                        () -> "the fields of " + declared.getKey());
+                case Hir.Data data -> {
+                    CheckedData.WithFields built = assertInstanceOf(CheckedData.WithFields.class,
+                            published, declared.getKey()::toString);
+                    assertEquals(new ArrayList<>(TypeOps.fieldTypes(data, read.symbols()).keySet()),
+                            built.fields().stream().map(ValueShape.Field::name).toList(),
+                            () -> "the fields of " + declared.getKey());
+                    assertEquals(data.newtype(), built instanceof CheckedData.Newtype,
+                            () -> "which form " + declared.getKey() + " was declared in");
+                }
                 case Hir.SumData sum -> assertEquals(
                         souther.compiler.check.AtomSpace.subjectAtoms(
                                 souther.compiler.types.Type.ref(sum.declares()), read.symbols()),
@@ -116,17 +131,17 @@ class WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest {
         }
     }
 
-    /** The three declarations a module can write, so that neither side is compared over a set that
+    /** The four declarations a module can write, so that neither side is compared over a set that
      *  happens to hold only one of them. */
     @Test
-    void andAllThreeShapesAreAmongThem() {
+    void andAllFourShapesAreAmongThem() {
         Set<Class<?>> shapes = new LinkedHashSet<>();
         for (CheckedData published : read().snapshot().values()) {
             shapes.add(published.getClass());
         }
 
-        assertEquals(Set.of(CheckedData.Product.class, CheckedData.Sum.class,
-                CheckedData.Unit.class), shapes);
+        assertEquals(Set.of(CheckedData.Product.class, CheckedData.Newtype.class,
+                CheckedData.Sum.class, CheckedData.Unit.class), shapes);
     }
 
     /** The declaration world the checker resolves against, the snapshot taken of the same compile,

--- a/souther-program-api-test/src/test/java/souther/program/api/ANewtypeAndAProductOfOneMemberCrossAsDifferentDeclarationsTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/ANewtypeAndAProductOfOneMemberCrossAsDifferentDeclarationsTest.java
@@ -1,0 +1,130 @@
+package souther.program.api;
+
+import souther.compiler.core.ValueShape;
+import souther.compiler.program.CheckedData;
+import souther.compiler.program.CheckedModule;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A data declared over another and a product declared with one member called {@code value} are told
+ * apart by a reader of a checked program.
+ *
+ * <p>The two are made of the same thing: one field, of the same type, holding the same clauses. They
+ * are written differently — {@code data X = Y} crosses as {@code Y} crosses and the braced one
+ * crosses as an object — and the language says which by the syntax the declaration was written in
+ * rather than by the shape it came out as (spec §newtype). So a reader handed the shape has nothing
+ * to tell them by, and writing either as the other is silent: a build that reads the program and
+ * writes the value agrees with itself either way, and what a document from one side means to the
+ * other is where it shows.
+ *
+ * <p>Both directions, because either alone is kept by a reader that answers one way for everything.
+ * And over a primitive and over a named data, because a derived codec writes a newtype over a
+ * primitive as a bare scalar and one over anything else as that thing writes itself — two branches
+ * of one rule, which a reader derives from the one fact this holds it is given.
+ */
+class ANewtypeAndAProductOfOneMemberCrossAsDifferentDeclarationsTest {
+
+    /** Two pairs, each written the two ways: over a primitive and over a data of the module. */
+    private static final String MODULE = """
+            module demo
+
+            data Inner = { n: Int }
+
+            data OverText  = String
+                invariant said = String.length(value) > 0
+
+            data HoldsText = { value: String }
+                invariant said = String.length(value) > 0
+
+            data OverInner  = Inner
+            data HoldsInner = { value: Inner }
+            """;
+
+    private static CheckedModule demo() {
+        CheckedModule module = CheckedProgram.of(List.of(MODULE)).module("demo");
+        assertNotNull(module, "the compile checked this module");
+        return module;
+    }
+
+    private static CheckedData declared(CheckedModule module, String name) {
+        for (CheckedData each : module.data()) {
+            if (each.name().name().equals(name)) {
+                return each;
+            }
+        }
+        throw new AssertionError(name + " is not among this module's data");
+    }
+
+    private static List<String> fieldNames(CheckedData.WithFields built) {
+        return built.fields().stream().map(ValueShape.Field::name).toList();
+    }
+
+    private static List<Type> fieldTypes(CheckedData.WithFields built) {
+        return built.fields().stream().map(ValueShape.Field::type).toList();
+    }
+
+    /** What is declared over another is a {@link CheckedData.Newtype}, and says what it is over. */
+    @Test
+    void aDataDeclaredOverAnotherIsANewtypeOverThatType() {
+        CheckedModule demo = demo();
+
+        assertEquals(Type.STRING,
+                assertInstanceOf(CheckedData.Newtype.class, declared(demo, "OverText")).wrapped());
+        assertEquals(Type.ref(declared(demo, "Inner").name()),
+                assertInstanceOf(CheckedData.Newtype.class, declared(demo, "OverInner")).wrapped());
+    }
+
+    /** And a product declared with one member is a {@link CheckedData.Product}, whatever the member
+     *  is called. */
+    @Test
+    void aProductOfOneMemberCalledValueIsAProduct() {
+        CheckedModule demo = demo();
+
+        assertInstanceOf(CheckedData.Product.class, declared(demo, "HoldsText"));
+        assertInstanceOf(CheckedData.Product.class, declared(demo, "HoldsInner"));
+    }
+
+    /**
+     * And what they are made of does not separate them.
+     *
+     * <p>The half that says why the arm is the answer. A reader told to look at the fields is told
+     * the same thing about both, member for member and type for type, so an answer worked out from
+     * the shape — or from the name of the member, which is the same shape read one field in — is an
+     * answer about neither.
+     */
+    @Test
+    void andWhatTheyAreMadeOfIsTheSame() {
+        CheckedModule demo = demo();
+
+        for (List<String> pair : List.of(List.of("OverText", "HoldsText"),
+                List.of("OverInner", "HoldsInner"))) {
+            CheckedData.WithFields over = assertInstanceOf(CheckedData.WithFields.class,
+                    declared(demo, pair.get(0)));
+            CheckedData.WithFields holds = assertInstanceOf(CheckedData.WithFields.class,
+                    declared(demo, pair.get(1)));
+
+            assertEquals(fieldNames(holds), fieldNames(over), () -> "the members of " + pair);
+            assertEquals(fieldTypes(holds), fieldTypes(over), () -> "what stands in them: " + pair);
+            assertEquals(clauseNames(holds), clauseNames(over),
+                    () -> "what must hold of one: " + pair);
+        }
+
+        assertEquals(List.of("said"),
+                clauseNames(assertInstanceOf(CheckedData.WithFields.class,
+                        declared(demo, "OverText"))),
+                "one pair states a clause, so the comparison above is over something");
+    }
+
+    private static List<String> clauseNames(CheckedData.WithFields built) {
+        return built.invariants().stream().map(each -> each.name().orElse("")).toList();
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -133,8 +133,8 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         return data.stream().map(each -> each.name().name()).toList();
     }
 
-    private static List<String> fieldNames(CheckedData.Product product) {
-        return product.fields().stream().map(ValueShape.Field::name).toList();
+    private static List<String> fieldNames(CheckedData.WithFields built) {
+        return built.fields().stream().map(ValueShape.Field::name).toList();
     }
 
     /**
@@ -175,16 +175,18 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
     }
 
     /**
-     * A newtype is the one-field product it is.
+     * A newtype is its own arm, made of the one field it wraps.
      *
-     * <p>Held to deliberately. What differs about a newtype is how it is written outside the
-     * program, which is no part of what a value is made of, so a reader laying one out has nothing
-     * to tell it from any other single-field product.
+     * <p>Both halves at once. A reader laying a value out is answered as it is for any other data
+     * built field by field — the field is there, with the type it wraps — and a reader writing a
+     * value is told which form was declared, which is the thing the fields do not say.
      */
     @Test
-    void aNewtypeIsAProductOfTheOneFieldItWraps() {
-        CheckedData.Product amount = product(demo(), "Amount");
+    void aNewtypeIsItsOwnArmMadeOfTheOneFieldItWraps() {
+        CheckedData.Newtype amount =
+                assertInstanceOf(CheckedData.Newtype.class, declared(demo(), "Amount"));
 
+        assertEquals(Type.INT, amount.wrapped());
         assertEquals(List.of("value"), fieldNames(amount));
         assertEquals(Type.INT, amount.fields().get(0).type());
     }
@@ -273,9 +275,13 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      * Every construction fills the declared fields, in the order they are laid out.
      *
      * <p>A property of the checked program and not how a reader places a field — that is
-     * {@link CheckedData.Product#positionOf}, which reads the name a construction wrote. Held here
-     * because a store and a load that came to disagree would disagree silently, and this is the one
-     * place both readings are visible at once.
+     * {@link CheckedData.WithFields#positionOf}, which reads the name a construction wrote. Held
+     * here because a store and a load that came to disagree would disagree silently, and this is
+     * the one place both readings are visible at once.
+     *
+     * <p>Over both forms a construction can build. {@code Amount(n)} builds a newtype and writes
+     * the one field it wraps, so a reading that asked only about products would leave a
+     * construction this module writes unaccounted for.
      */
     @Test
     void everyConstructionFillsTheDeclaredFieldsInTheOrderTheyAreLaidOut() {
@@ -290,7 +296,7 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         assertEquals(2, constructions.size(), () -> "the constructions this module writes: "
                 + constructions.stream().map(each -> each.typeName().name()).toList());
         for (Core.Construct construction : constructions) {
-            CheckedData.Product built = assertInstanceOf(CheckedData.Product.class,
+            CheckedData.WithFields built = assertInstanceOf(CheckedData.WithFields.class,
                     layout(program, construction.typeName()), construction.typeName()::toString);
             assertEquals(fieldNames(built),
                     construction.values().stream().map(Core.FieldValue::field).toList(),
@@ -303,8 +309,10 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      *
      * <p>The other half of the same reading, and the half a construction cannot stand in for: a
      * module may read a field of a product it never builds, and that read is what a backend has to
-     * place. Two shapes can be read from — a product, and a sum every case of which carries the
-     * field — and the second is answered by the leaves the sum already descended to.
+     * place. What can be read from is a data built field by field — either form of one, since
+     * {@code x.value} reads a newtype the way {@code w.extra} reads a product — and a sum every
+     * case of which carries the field, which is answered by the leaves the sum already descended
+     * to.
      */
     @Test
     void everyFieldReadNamesAFieldOfWhatItReadsFrom() {
@@ -319,7 +327,7 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         assertEquals(2, reads.size(), () -> "the field reads this module writes: "
                 + reads.stream().map(Core.FieldAccess::field).toList());
         int offSums = 0;
-        int offProducts = 0;
+        int offFields = 0;
         List<Core.FieldAccess> unaccounted = new ArrayList<>();
         for (Core.FieldAccess read : reads) {
             if (!(read.target().type() instanceof Type.Ref(TypeSymbol.AtModule named))) {
@@ -328,9 +336,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             }
             switch (layout(program, named)) {
                 // Answering at all is the assertion: a name that is no field of it is refused.
-                case CheckedData.Product product -> {
-                    offProducts++;
-                    product.positionOf(read.field());
+                case CheckedData.WithFields built -> {
+                    offFields++;
+                    built.positionOf(read.field());
                 }
                 case CheckedData.Sum sum -> {
                     offSums++;
@@ -338,7 +346,8 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
                             sum.cases().stream().map(TypeSymbol::name).toList(),
                             () -> "the cases " + named + " is read across");
                     for (TypeSymbol leaf : sum.cases()) {
-                        CheckedData.Product carrying = assertInstanceOf(CheckedData.Product.class,
+                        CheckedData.WithFields carrying = assertInstanceOf(
+                                CheckedData.WithFields.class,
                                 layout(program, assertInstanceOf(TypeSymbol.AtModule.class, leaf)),
                                 leaf::toString);
                         carrying.positionOf(read.field());
@@ -349,7 +358,8 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             }
         }
         assertEquals(1, offSums, "the read off a sum is the one this module writes");
-        assertEquals(1, offProducts, "the read off a product is the one this module writes");
+        assertEquals(1, offFields,
+                "the read off a data built field by field is the one this module writes");
         // Every read is accounted for, so a read of a shape this does not know how to place cannot
         // pass by being skipped. The two arms above are what the language admits reading a field
         // off; a read that arrived at neither would be the finding, and going quiet about it is

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatMustHoldOfAValueTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatMustHoldOfAValueTest.java
@@ -77,10 +77,17 @@ class AnOutputReadsWhatMustHoldOfAValueTest {
         return CheckedProgram.of(List.of(DECLARING, INCLUDING));
     }
 
-    private static CheckedData.Product product(CheckedModule module, String name) {
+    /**
+     * What must hold of a value of {@code name}, whichever of the two forms it was declared in.
+     *
+     * <p>A newtype is held to its clauses as a product is — {@code Amount} states one here — so the
+     * question is asked of what answers it. Asked as {@code Product}, the data this module states
+     * the clause on would not have been reached at all.
+     */
+    private static CheckedData.WithFields built(CheckedModule module, String name) {
         for (CheckedData each : module.data()) {
             if (each.name().name().equals(name)) {
-                return assertInstanceOf(CheckedData.Product.class, each, name);
+                return assertInstanceOf(CheckedData.WithFields.class, each, name);
             }
         }
         throw new AssertionError(name + " is not among this module's data");
@@ -96,8 +103,8 @@ class AnOutputReadsWhatMustHoldOfAValueTest {
     }
 
     @Test
-    void aProductSaysWhatMustHoldOfAValueOfIt() {
-        CheckedData.Product amount = product(program().module("up"), "Amount");
+    void aDataSaysWhatMustHoldOfAValueOfIt() {
+        CheckedData.WithFields amount = built(program().module("up"), "Amount");
 
         assertEquals(1, amount.invariants().size(), "one clause is declared of it");
         assertEquals("positive", amount.invariants().get(0).name().orElse(null),
@@ -109,7 +116,7 @@ class AnOutputReadsWhatMustHoldOfAValueTest {
     /** A data nothing is stated of says so by stating nothing, which is not a data with no fields. */
     @Test
     void aProductWithNoClauseStatesNothing() {
-        CheckedData.Product common = product(program().module("up"), "Common");
+        CheckedData.WithFields common = built(program().module("up"), "Common");
 
         assertEquals(List.of("identified"),
                 common.invariants().stream().map(each -> each.name().orElse("")).toList());
@@ -119,24 +126,28 @@ class AnOutputReadsWhatMustHoldOfAValueTest {
      * A clause reads its fields through the bindings the same answer names.
      *
      * <p>The half that makes a clause runnable. An output puts each field's value under the binding
-     * {@link CheckedData.Product#fields()} gives it and emits the condition; a binding the condition
-     * reads and the fields do not name is a value nothing put anywhere, and the check would run over
-     * whatever happened to be in that slot.
+     * {@link CheckedData.WithFields#fields()} gives it and emits the condition; a binding the
+     * condition reads and the fields do not name is a value nothing put anywhere, and the check
+     * would run over whatever happened to be in that slot.
+     *
+     * <p>Over every data a clause can be stated of, which is both forms built field by field. A
+     * walk that took only the products would pass over the newtype this module states a clause on
+     * and hold nothing about it.
      */
     @Test
     void everyBindingAClauseReadsIsAFieldOfWhatItIsAbout() {
         for (CheckedModule module : program().modules()) {
             for (CheckedData declared : module.data()) {
-                if (!(declared instanceof CheckedData.Product product)) {
+                if (!(declared instanceof CheckedData.WithFields built)) {
                     continue;
                 }
                 Set<BindingId> bound = new LinkedHashSet<>();
-                for (ValueShape.Field field : product.fields()) {
+                for (ValueShape.Field field : built.fields()) {
                     bound.add(field.binding());
                 }
-                for (ValueShape.Invariant clause : product.invariants()) {
+                for (ValueShape.Invariant clause : built.invariants()) {
                     assertTrue(bound.containsAll(read(clause.condition())),
-                            () -> "`" + product.name() + "` states " + clause.name()
+                            () -> "`" + built.name() + "` states " + clause.name()
                                     + " over " + read(clause.condition())
                                     + ", and holds " + bound);
                 }
@@ -155,7 +166,7 @@ class AnOutputReadsWhatMustHoldOfAValueTest {
      */
     @Test
     void aClauseAnIncludeBroughtInIsStatedOfTheDataBeingBuilt() {
-        CheckedData.Product wide = product(program().module("down"), "Wide");
+        CheckedData.WithFields wide = built(program().module("down"), "Wide");
 
         assertEquals(List.of("identified", "wide"),
                 wide.invariants().stream().map(each -> each.name().orElse("")).toList(),

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
@@ -302,8 +302,8 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     private static ValueShape.Field fieldOf(CheckedModule module, String data, String field) {
         for (CheckedData declared : module.data()) {
             if (declared.name().name().equals(data)) {
-                for (ValueShape.Field each : assertInstanceOf(CheckedData.Product.class, declared)
-                        .fields()) {
+                for (ValueShape.Field each
+                        : assertInstanceOf(CheckedData.WithFields.class, declared).fields()) {
                     if (each.name().equals(field)) {
                         return each;
                     }
@@ -328,8 +328,8 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
             for (CheckedData declared : module.data()) {
                 named.add(declared.name());
                 switch (declared) {
-                    case CheckedData.Product product -> {
-                        for (ValueShape.Field field : product.fields()) {
+                    case CheckedData.WithFields built -> {
+                        for (ValueShape.Field field : built.fields()) {
                             namesIn(field.type(), named);
                         }
                     }


### PR DESCRIPTION
Closes #1328.

`data X = Y` and `data X = { value: Y }` reached `CheckedProgram` as one thing: a product of one field, called `value`, of the same type, holding the same clauses. They are written differently — the first crosses as `Y` crosses, the second as an object — and the language settles which by the syntax the declaration was written in rather than by the shape it came out as (spec §newtype). A reader given the shape had nothing to tell them by, and writing either as the other went unreported, because a build that reads the program and writes the value agrees with itself either way.

The answer was never missing, only dropped. The desugaring writes the implicit member and `Hir.Data.newtype()` keeps what the author wrote, which is what the derived codec is generated from; the assembler read the shape and handed that on alone.

So `CheckedData` gains the arm the language has and it did not. `Newtype` says what it is a name for as a type, not as the member the desugaring made to hold it — a reader that had to read the member's name would be reading a name this compiler chose. `Product` keeps the object form, whatever it holds. Nothing about a representation is stored: what is published is the declaration, and how a value of it is written is derived from that, as ADR-0004 has it.

What a value is made of is the other question, and both forms answer it, so the fields, the clauses and where a field lies moved to `WithFields`. A reader laying a value out asks that and is total over the language without naming a form; a reader writing a value's external form asks the arm and has to say what it writes for each. Two axes rather than one hierarchy, and javac counts the readers of either — which is what turned up the places a newtype was being read as a product, among them the walk that holds every binding a clause reads and the closure over what a field's type names.

`ValueShape` says that the form is not in it and is not derived from it, so the flag does not come back to where the shape is built.

Held by a pair declared both ways, over a primitive and over a data of the module, asserting that what they are made of is the same and the arm is not; and inside the compiler by the published arm agreeing with `Hir.Data.newtype()` over the whole declaration world, whose fixture now declares the newtype's braced twin so the agreement is compared both ways. A snapshot that always answered product, and one that read the single-field shape for the form, each fail on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
