### PR TITLE
Model a search budget's refusal and an enumerator's incompleteness as two facts

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -84,25 +84,20 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/check/ReadingPolicy;Ljava/util/Set;)"
                             + "Lsouther/compiler/partition/Witnesses$Built;",
                     "stops at the pairings a map is built from at once, and says which"),
-            // A total's three, one consumer each. The figure is asked for twice per consumer and
-            // for two questions: whether there is room for the piece in front of it, and — where
-            // the walk finds there was not — which figure to say so under. Held apart, a consumer
-            // could report having run out of one figure while making room by another.
+            // A total's two, one consumer each. The figure is asked for twice per consumer and for
+            // two questions: whether there is room for the piece in front of it, and — where the
+            // walk finds there was not — which figure to say so under. Held apart, a consumer could
+            // report having run out of one figure while making room by another.
+            //
+            // Two and not three, because the ways a difference is spread are not held to a figure.
+            // What is written of them is that this compiler writes some of them, which is no number
+            // to raise and travels as a CompositionRepertoire rather than from here.
             Map.entry("souther.compiler.partition.ContainersAddingUp$HowManyElements#take("
                             + "Ljava/lang/Integer;)Lsouther/compiler/partition/Taking$Taken;",
                     "has no room for a count of more elements than a row carries"),
             Map.entry("souther.compiler.partition.ContainersAddingUp$HowManyElements#figure()"
                             + "Lsouther/compiler/partition/CompositionBudget;",
                     "says which figure that was, which is what the walk hands over"),
-            Map.entry("souther.compiler.partition.ContainersAddingUp$HowItIsSpread#take("
-                            + "Lsouther/compiler/partition/ContainersAddingUp$Spread;)"
-                            + "Lsouther/compiler/partition/Taking$Taken;",
-                    "has no room for a shape past as many as one total is spread in"),
-            Map.entry("souther.compiler.partition.ContainersAddingUp$HowItIsSpread#figure()"
-                            + "Lsouther/compiler/partition/CompositionBudget;",
-                    "says which figure that was — and it is the one the walk hands over where it"
-                            + " ran out of the shapes there are to try, which are not all the ways"
-                            + " a difference is spread"),
             Map.entry("souther.compiler.partition.ContainersAddingUp$WhatIsOffered#take("
                             + "Lsouther/compiler/partition/FixtureTemplate;)"
                             + "Lsouther/compiler/partition/Taking$Taken;",

--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -48,6 +48,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * figure over; that the place reaches it only where there was more to do is not something either
  * sheet can read. What says that is the threshold tests, one either side of a figure and on it, and
  * they exist for the walks that can be put there.
+ *
+ * <p>Which is why a place that reaches a figure and a place that decides a walk was stopped are
+ * worth keeping apart. A consumer here says it has no room for the piece in front of it and says
+ * under which figure; that the walk was holding a piece at all is the walk's, and a walk that
+ * records a figure without one is the reading these sheets cannot see going wrong.
  */
 class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
 
@@ -79,16 +84,32 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/check/ReadingPolicy;Ljava/util/Set;)"
                             + "Lsouther/compiler/partition/Witnesses$Built;",
                     "stops at the pairings a map is built from at once, and says which"),
-            Map.entry("souther.compiler.partition.ContainersAddingUp#<clinit>()V",
-                    "how many elements a total is spread over, and how many shapes are offered"),
-            Map.entry("souther.compiler.partition.ContainersAddingUp#to("
-                            + "Lsouther/compiler/numeric/Place;Lsouther/compiler/types/Type;"
-                            + "Lsouther/compiler/inputs/TermOrders;"
-                            + "Lsouther/compiler/inputs/SearchRegion;"
-                            + "Lsouther/compiler/check/RuleReadingSource;"
-                            + "Lsouther/compiler/check/ReadingPolicy;)"
-                            + "Lsouther/compiler/partition/TermRealizations$Realization;",
-                    "records the three a total can be short of, where each decides not to go on"),
+            // A total's three, one consumer each. The figure is asked for twice per consumer and
+            // for two questions: whether there is room for the piece in front of it, and — where
+            // the walk finds there was not — which figure to say so under. Held apart, a consumer
+            // could report having run out of one figure while making room by another.
+            Map.entry("souther.compiler.partition.ContainersAddingUp$HowManyElements#take("
+                            + "Ljava/lang/Integer;)Lsouther/compiler/partition/Taking$Taken;",
+                    "has no room for a count of more elements than a row carries"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$HowManyElements#figure()"
+                            + "Lsouther/compiler/partition/CompositionBudget;",
+                    "says which figure that was, which is what the walk hands over"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$HowItIsSpread#take("
+                            + "Lsouther/compiler/partition/ContainersAddingUp$Spread;)"
+                            + "Lsouther/compiler/partition/Taking$Taken;",
+                    "has no room for a shape past as many as one total is spread in"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$HowItIsSpread#figure()"
+                            + "Lsouther/compiler/partition/CompositionBudget;",
+                    "says which figure that was — and it is the one the walk hands over where it"
+                            + " ran out of the shapes there are to try, which are not all the ways"
+                            + " a difference is spread"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$WhatIsOffered#take("
+                            + "Lsouther/compiler/partition/FixtureTemplate;)"
+                            + "Lsouther/compiler/partition/Taking$Taken;",
+                    "has no room for a container past as many as are offered"),
+            Map.entry("souther.compiler.partition.ContainersAddingUp$WhatIsOffered#figure()"
+                            + "Lsouther/compiler/partition/CompositionBudget;",
+                    "says which figure that was, which is what the walk hands over"),
             Map.entry("souther.compiler.partition.ContainersAddingUp$Asking#next()"
                             + "Lsouther/compiler/partition/ConstructionPlan$Result;",
                     "stops asking about ways down to the number, which is the one place they are"

--- a/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest.java
@@ -31,9 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * a rule about spelling would be passed by the next figure spelled differently, which is the failure
  * that made this necessary.
  *
- * <p>What it still does not see is a figure derived from something other than a number: how many
- * ways a total is decomposed is the size of a walk, and no constant holds it. That one is caught by
- * the other sheet, which sees the enum being read where the walk stops. Neither is enough alone.
+ * <p>What it still does not see is a figure derived from something other than a number, which is
+ * anything worked out rather than written down. Every figure there is is written down as one of
+ * this compiler's budgets, so what such a number would be is a bound somebody put beside a walk
+ * without registering it — and that one is caught by the other sheet, which sees the enum being
+ * read where the walk stops. Neither is enough alone.
  */
 class EveryFigureTheComposingStageStopsAtIsABudgetOrIsSaidNotToBeTest {
 

--- a/souther-cli/src/test/java/souther/cli/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-cli/src/test/java/souther/cli/APairIsChosenOnePositionAtATimeTest.java
@@ -128,7 +128,7 @@ class APairIsChosenOnePositionAtATimeTest {
         }
         String rows = out.toString(StandardCharsets.UTF_8);
 
-        assertTrue(rows.contains("the search stopped before reaching it"),
+        assertTrue(rows.contains("the search left something untried"),
                 () -> "it ran out of assignments to compose:\n" + rows);
         assertFalse(rows.contains("every value tried was refused"),
                 () -> "and it did not try them all:\n" + rows);
@@ -174,7 +174,7 @@ class APairIsChosenOnePositionAtATimeTest {
 
         assertTrue(rows.contains("every value tried was refused"),
                 () -> "256 assignments, all composed and all refused:\n" + rows);
-        assertFalse(rows.contains("the search stopped before reaching it"),
+        assertFalse(rows.contains("the search left something untried"),
                 () -> "and none of them was left untried:\n" + rows);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -32,12 +32,12 @@ package souther.compiler.partition;
  * leaves the point unestablished, and one that had produced something leaves an offer that is some
  * of what there was — so the same member appears on both sides and is neither of them.
  *
- * <p><b>Every figure is written down here, and none is the size of the walk it bounds.</b> What a
- * walk has to offer and how many of them it may take are two decisions somebody makes separately:
- * writing a third way of doing something is work, and letting the walk go on to it is a number. Set
- * to the size of the walk, a figure is reached on every run and on none — it says what this compiler
- * is made of rather than what one search declined — and a reader handed it is told to raise
- * something that stopped nothing.
+ * <p><b>Every figure is written down here, and none is the size of the walk it bounds.</b> A figure
+ * set to how many pieces a walk has is reached on every run and on none: it says what this compiler
+ * is made of rather than what one search declined, and a reader handed it is told to raise something
+ * that stopped nothing. What such a number was saying belongs to
+ * {@link CompositionRepertoire}, which is a population this compiler offers some of and is not a
+ * number anybody raises.
  */
 public enum CompositionBudget {
 
@@ -69,18 +69,6 @@ public enum CompositionBudget {
      *  charging one to the other leaves a case never tried because an earlier one planned and built
      *  nothing. What multiplies here is the cases of every sum the way down crosses. */
     WAYS_DOWN_TO_A_TOTAL_TRIED(8),
-
-    /**
-     * How many ways the difference between a starting point and a total is spread over the elements
-     * this walks to.
-     *
-     * <p>Written down, and not the number of them there are to walk to. The shapes a decomposition
-     * takes are what somebody implemented and this is how far along them a search goes, and a third
-     * shape written is a value that gets offered only when somebody also decides it is worth the
-     * walk. Read off the shapes instead, the two would be one edit — and this would be a figure
-     * every total reached, naming what this compiler has rather than what one search left.
-     */
-    DECOMPOSITIONS_OF_A_TOTAL_OFFERED(2),
 
     /** How many places along a line a pair is tried at. What a range cannot say is that one of its
      *  values is missing, so what stepping past this walks over is holes, and there are as many of

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionBudget.java
@@ -1,7 +1,5 @@
 package souther.compiler.partition;
 
-import java.util.function.IntSupplier;
-
 /**
  * A figure this compiler holds a piece of its own work to.
  *
@@ -34,64 +32,74 @@ import java.util.function.IntSupplier;
  * leaves the point unestablished, and one that had produced something leaves an offer that is some
  * of what there was — so the same member appears on both sides and is neither of them.
  *
- * <p>The figures are read through {@link #maximum()} and are not all written down. One of them is
- * how many shapes a decomposition is offered in, which is how many the walk has — read off the walk,
- * so that a shape added there is a budget raised here and not a number that stayed behind.
+ * <p><b>Every figure is written down here, and none is the size of the walk it bounds.</b> What a
+ * walk has to offer and how many of them it may take are two decisions somebody makes separately:
+ * writing a third way of doing something is work, and letting the walk go on to it is a number. Set
+ * to the size of the walk, a figure is reached on every run and on none — it says what this compiler
+ * is made of rather than what one search declined — and a reader handed it is told to raise
+ * something that stopped nothing.
  */
 public enum CompositionBudget {
 
     /** How many elements a proposed collection is worth building. A row is offered for somebody to
      *  read and complete, and a minimum past this asks for one nobody would. */
-    ELEMENTS_A_PROPOSAL_HOLDS(() -> 64),
+    ELEMENTS_A_PROPOSAL_HOLDS(64),
 
     /** How many characters a proposed string is worth building. Its own figure, because a string of
      *  sixty-five is one literal where a collection of sixty-five is sixty-five values each built in
      *  turn — holding the two to one number bounds a string by something about collections. */
-    CHARACTERS_A_PROPOSAL_HOLDS(() -> 4096),
+    CHARACTERS_A_PROPOSAL_HOLDS(4096),
 
     /** How many pairings of what a map's key and value propose are built at once. Every pair is
      *  built before any of them is tried, so this bounds what is allocated rather than what is
      *  walked. */
-    PAIRINGS_BUILT_AT_ONCE(() -> 64),
+    PAIRINGS_BUILT_AT_ONCE(64),
 
     /** How many elements a container built to reach a total is worth carrying. Its own figure and
      *  not {@link #ELEMENTS_A_PROPOSAL_HOLDS}, though they agree: held as one, a change made for one
      *  of them would move the other for no reason anybody could state. */
-    ELEMENTS_A_TOTAL_IS_SPREAD_OVER(() -> 64),
+    ELEMENTS_A_TOTAL_IS_SPREAD_OVER(64),
 
     /** How many containers are offered for one total. They are alike to the total, so what a fifth
      *  buys is another row reading like the last. */
-    SHAPES_OF_A_TOTAL_OFFERED(() -> 4),
+    SHAPES_OF_A_TOTAL_OFFERED(4),
 
     /** How many ways down to the number a total is read from are tried. Its own figure and not
      *  {@link #SHAPES_OF_A_TOTAL_OFFERED}: a way that plans is not a container that was offered, and
      *  charging one to the other leaves a case never tried because an earlier one planned and built
      *  nothing. What multiplies here is the cases of every sum the way down crosses. */
-    WAYS_DOWN_TO_A_TOTAL_TRIED(() -> 8),
+    WAYS_DOWN_TO_A_TOTAL_TRIED(8),
 
-    /** How many ways the difference between a starting point and a total is spread over the
-     *  elements. Read off the walk that has them, so a third way of spreading is this budget
-     *  raised. */
-    DECOMPOSITIONS_OF_A_TOTAL_OFFERED(ContainersAddingUp::decompositionsOffered),
+    /**
+     * How many ways the difference between a starting point and a total is spread over the elements
+     * this walks to.
+     *
+     * <p>Written down, and not the number of them there are to walk to. The shapes a decomposition
+     * takes are what somebody implemented and this is how far along them a search goes, and a third
+     * shape written is a value that gets offered only when somebody also decides it is worth the
+     * walk. Read off the shapes instead, the two would be one edit — and this would be a figure
+     * every total reached, naming what this compiler has rather than what one search left.
+     */
+    DECOMPOSITIONS_OF_A_TOTAL_OFFERED(2),
 
     /** How many places along a line a pair is tried at. What a range cannot say is that one of its
      *  values is missing, so what stepping past this walks over is holes, and there are as many of
      *  those as the rules state. */
-    PLACES_A_PAIR_IS_TRIED_AT(() -> 64),
+    PLACES_A_PAIR_IS_TRIED_AT(64),
 
     /** How many steps a walk over the positions of a form may take. A run without an end is not
      *  walked to the end at any length. */
-    STEPS_A_SEARCH_MAY_TAKE(() -> 200_000),
+    STEPS_A_SEARCH_MAY_TAKE(200_000),
 
     /** How many assignments of one parameter's positions a search composes. A bound on the search
      *  and not on any one position. */
-    ASSIGNMENTS_A_SEARCH_COMPOSES(() -> 256),
+    ASSIGNMENTS_A_SEARCH_COMPOSES(256),
 
     /** How many values of a progression nothing bounds are tried. */
-    VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED(() -> 16),
+    VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED(16),
 
     /** How many levels past the one a side starts from are asked for. */
-    LEVELS_A_SIDE_IS_ASKED_AT(() -> 8),
+    LEVELS_A_SIDE_IS_ASKED_AT(8),
 
     /**
      * How often a walk re-reads the rules with the positions it has fixed.
@@ -107,12 +115,12 @@ public enum CompositionBudget {
      * nothing. The others are named beside their carriers; this is named beside the reason it has
      * none.
      */
-    TIMES_THE_RULES_ARE_ASKED_AGAIN(() -> 2_000),
+    TIMES_THE_RULES_ARE_ASKED_AGAIN(2_000),
 
     /** How many values of one position on the way to a border are tried. Its outcome is not a
      *  composing that stopped: the row is composed, and what was not composed against is one
      *  condition on the way ({@link ReachabilityGap}). */
-    VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT(() -> 8),
+    VALUES_A_POSITION_ON_THE_WAY_IS_TRIED_AT(8),
 
     /**
      * How deep a construction plan descends.
@@ -131,16 +139,16 @@ public enum CompositionBudget {
      * all: a row composed against such a plan is one the caller's own value is missing from, and
      * the plan says so instead of handing one back.
      */
-    DEPTH_A_CONSTRUCTION_PLAN_DESCENDS(() -> 8);
+    DEPTH_A_CONSTRUCTION_PLAN_DESCENDS(8);
 
-    private final IntSupplier maximum;
+    private final int maximum;
 
-    CompositionBudget(IntSupplier maximum) {
+    CompositionBudget(int maximum) {
         this.maximum = maximum;
     }
 
     /** The figure itself. What is done on reaching it is the member's to say. */
     public int maximum() {
-        return maximum.getAsInt();
+        return maximum;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/CompositionRepertoire.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CompositionRepertoire.java
@@ -1,0 +1,35 @@
+package souther.compiler.partition;
+
+/**
+ * A population this compiler offers some of rather than all of.
+ *
+ * <p><b>Apart from {@link CompositionBudget}, and the difference is what a reader can do.</b> A
+ * figure is a number somebody wrote down: raise it and the search goes on to what it was holding.
+ * One of these is a set of values this compiler has no way of producing the rest of — raising
+ * anything reaches none of them, and what would is somebody writing the rest. Held in one
+ * vocabulary, the two are a set a reader unions and then acts on by raising a number that changes
+ * nothing.
+ *
+ * <p>So neither is the other's default. A walk under a figure that ran out of pieces reached no
+ * figure at all, and a walk that went everywhere it knows how to go refused nothing — and both
+ * leave an offer that is not the whole of what there is, which is the one thing they have in
+ * common and the reason both have to travel.
+ *
+ * <p><b>Said only where it cannot be shown otherwise.</b> A walk that produced everything of its
+ * kind says so, and every other walk is one of these: an offer claiming to be everything is a claim
+ * about a population, and the walk that would have to have enumerated it is the only thing that
+ * could establish one. So this is what a walk says by default, and completeness is what it has to
+ * prove.
+ */
+public enum CompositionRepertoire {
+
+    /**
+     * The ways a difference is spread over the elements of a container adding up to a total.
+     *
+     * <p>Two are written — the whole of it on as few elements as will carry it, and as near an
+     * equal share each as the order allows — and the arrangements of more than one element are
+     * many. Which of them a rule tells apart is the rule's own business, so no reading of the two
+     * says anything about the rest.
+     */
+    WAYS_A_TOTAL_IS_SPREAD
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -25,8 +25,18 @@ import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Containers filled so that the occurrences of a path inside them come to a number.
@@ -56,26 +66,6 @@ import java.util.List;
  * number.
  */
 final class ContainersAddingUp {
-
-    /** What this stops at, named where every budget of this compiler's is named. */
-    private static final int MOST_ELEMENTS_A_ROW_CARRIES =
-            CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER.maximum();
-
-    private static final int HOW_MANY_SHAPES_ARE_OFFERED =
-            CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED.maximum();
-
-    private static final int MOST_WAYS_DOWN_TRIED =
-            CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED.maximum();
-
-    /**
-     * How many ways a difference is spread over the elements, which is how many this walk has.
-     *
-     * <p>Read off {@link Spread} rather than written down beside it. A third way of spreading is a
-     * budget raised, and a figure of its own here would be a second declaration that stayed at two.
-     */
-    static int decompositionsOffered() {
-        return Spread.values().length;
-    }
 
     /**
      * Containers whose occurrences of {@code target}'s path come to {@code answer}, or why there are
@@ -122,70 +112,352 @@ final class ContainersAddingUp {
         // named, so what comes back is one way per case and the walk offers each of them.
         Ways ways = waysDown(holding.element(), target.writeRoot().element(), occurrences(target),
                 ruleSource);
-        List<FixtureTemplate> built = new ArrayList<>();
-        int cap = Math.min(howMany.most(), MOST_ELEMENTS_A_ROW_CARRIES);
-        // What this walk did not do, recorded as it decides not to do it, and as which budget of
-        // this compiler's decided it. Held as one flag, the three ways of leaving something unmade
-        // were one fact and a reader was told a search stopped without being told what would let it
-        // go further — and worked out afterwards from the ends, they cannot all be seen at once.
-        java.util.Set<CompositionBudget> left = java.util.EnumSet.noneOf(CompositionBudget.class);
-        // Where there is a way down to fill a container along. A figure over how many elements one
-        // is worth carrying stopped nothing where nothing was ever filled, and a reader told to
-        // raise it would be raising a figure that took nothing away.
-        if (cap < howMany.most() && !ways.filled().isEmpty()) {
-            left.add(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER);
+        // Nothing to fill a container along, so there is no count and no shape of one to try. Said
+        // before the counts are walked rather than as a condition on each figure below: a figure
+        // reached where no container could have been built either way is one raising takes nothing
+        // away from, and the walks below are what the figures are about.
+        if (ways.filled().isEmpty()) {
+            return ways.cutBy().isEmpty()
+                    ? new TermRealizations.Realization.None(
+                            Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                            ways.said(occurrences(target)))
+                    : new TermRealizations.Realization.Stopped(ways.cutBy());
         }
-        // What the planning gave up at, which is this compiler's the same way the figures below are.
-        // A way down that was never planned is a value never composed, and a reader told only that
-        // nothing was composed would look for the rule that refuses it.
-        left.addAll(ways.cutBy());
-        // Asked where a container is added and nowhere else. What the budget counts is containers,
-        // and a walk that asked at the top of the counts was asking about containers in a place that
-        // steps by counts — so a count offering two of them stepped past the figure by one, and how
-        // many were offered was the inner walk's grain rather than what is written down here.
-        offering:
-        for (int many = Math.max(howMany.least(), 0); many <= cap; many++) {
-            // More than one element is more than one decomposition, whether or not this made a
-            // second: what is offered is two shapes of the many, and the many are what a rule taking
-            // a value out of the middle of a run tells apart.
-            if (many > 1 && !ways.filled().isEmpty()) {
-                left.add(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED);
-            }
-            for (Spread how : Spread.values()) {
-                List<BigDecimal> split = splitting(total.at(), many, ends, how, elements);
-                if (split == null) {
-                    continue;
-                }
-                // Every way down at this count, and the whole container by one of them. Which case
-                // an element is is a fact about the value, so a container whose elements are of
-                // several would be offering a shape nothing asked for; what the walk owes is to
-                // offer each case and to say the rest were never made.
-                for (Filling filling : ways.filled()) {
-                    FixtureTemplate one =
-                            filled(split, holding, view, filling, elements, ruleSource, policy);
-                    if (one == null || built.contains(one)) {
-                        continue;
-                    }
-                    if (built.size() == HOW_MANY_SHAPES_ARE_OFFERED) {
-                        left.add(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED);
-                        break offering;
-                    }
-                    built.add(one);
-                }
-            }
+        WhatWasLeft left = new WhatWasLeft();
+        // What the planning gave up at, which is a way that was there to try and was not. A way down
+        // that was never planned is a value never composed, and a reader told only that nothing was
+        // composed would look for the rule that refuses it.
+        for (CompositionBudget cut : ways.cutBy()) {
+            left.refused(cut);
         }
+        WhatIsOffered offered = new WhatIsOffered();
+        Makings makings = new Makings(total.at(), ends, holding, view, elements, ways, ruleSource,
+                policy);
+        asFarAs(countsAdmitted(howMany), new HowManyElements(makings, offered, left),
+                Repertoire.ALL_THERE_ARE, left);
+        List<FixtureTemplate> built = offered.built();
         if (!built.isEmpty()) {
-            return new TermRealizations.Realization.Built(built, left);
+            return new TermRealizations.Realization.Built(built, left.heldBack());
         }
-        // Nothing was composed, so what the budgets stopped is the composing itself and not the rest
-        // of an offer. Where none of them ran out, this is a total nothing here writes a container
-        // for — and what a reader is then owed is which of the ways to one were walked, since a
-        // figure having stopped the walk is exactly what says the ways were not all tried.
-        return left.isEmpty()
+        // Nothing was composed, so what a figure stopped is the composing itself and not the rest of
+        // an offer. Where none of them refused anything, this is a total nothing here writes a
+        // container for — and what a reader is then owed is which of the ways to one were walked,
+        // since a figure having stopped the walk is exactly what says the ways were not all tried.
+        return left.refused().isEmpty()
                 ? new TermRealizations.Realization.None(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                         ways.said(occurrences(target)))
-                : new TermRealizations.Realization.Stopped(left);
+                : new TermRealizations.Realization.Stopped(left.refused());
+    }
+
+    /**
+     * Whether the pieces a walk was given are all there are of them.
+     *
+     * <p>The source's answer and not the consumer's. What a consumer knows is what it did with the
+     * piece in front of it; whether the list it is being handed stands for everything of its kind is
+     * a fact about where the list came from, and a consumer answering it would be answering for a
+     * caller it cannot see.
+     */
+    enum Repertoire {
+
+        /** Everything of that kind was handed over, so a walk that ran out left nothing. */
+        ALL_THERE_ARE,
+
+        /** Some of them, so a walk that ran out has still not been everywhere it could have gone. */
+        SOME_OF_THEM
+    }
+
+    /**
+     * What the walks over one total left behind, which is two facts and not one.
+     *
+     * <p>A figure that refused a piece and a repertoire that was never all of them are different
+     * things to know. The first is somebody's to raise and is why nothing was composed where nothing
+     * was; the second is a walk having gone everywhere it knows how to go, which says nothing about
+     * whether that was everywhere — and a reader told that every value was refused, on an offer that
+     * was never the whole of what there is, has been handed a sentence to act on that nothing here
+     * established.
+     *
+     * <p><b>{@link #heldBack()} is worked out from them and is held nowhere.</b> Kept as a third
+     * set, it would be written twice at every refusal and could be made to disagree with the two it
+     * is the union of.
+     */
+    static final class WhatWasLeft {
+
+        private final Set<CompositionBudget> refused = EnumSet.noneOf(CompositionBudget.class);
+        private final Set<CompositionBudget> unoffered = EnumSet.noneOf(CompositionBudget.class);
+
+        /** A piece was in front of a walk and this figure left no room for it. */
+        void refused(CompositionBudget figure) {
+            refused.add(figure);
+        }
+
+        /** A walk under this figure went everywhere it knows how to, which was not everywhere. */
+        void unoffered(CompositionBudget figure) {
+            unoffered.add(figure);
+        }
+
+        /** The figures that refused a piece, which are the ones a composing was stopped by. */
+        Set<CompositionBudget> refused() {
+            return Set.copyOf(refused);
+        }
+
+        /** Everything an offer made under these walks leaves out, however it came to be left out. */
+        Set<CompositionBudget> heldBack() {
+            Set<CompositionBudget> both = EnumSet.noneOf(CompositionBudget.class);
+            both.addAll(refused);
+            both.addAll(unoffered);
+            return Set.copyOf(both);
+        }
+    }
+
+    /**
+     * A consumer that does as many pieces as one figure of this compiler's leaves it room for.
+     *
+     * <p>{@link Taken#NOT_TAKEN} only where {@link #figure()} leaves no room for the piece in front
+     * of it. That is the whole of what this adds to {@link Taking}: a walk reads the refusal as the
+     * figure being reached, so a consumer refusing a piece for any other reason would file its own
+     * answer under somebody else's number.
+     *
+     * <p>And the room is worked out from {@link #figure()} rather than from a number beside it.
+     * Read from a second place, what the consumer has room for and what it reports having run out of
+     * are two declarations of one policy, and they part the first time one is raised.
+     */
+    interface Spending<T> extends Taking<T> {
+
+        /** The figure this has no room past. */
+        CompositionBudget figure();
+    }
+
+    /**
+     * Every piece to the consumer, and what the walk was left with when it ended.
+     *
+     * <p><b>The one place a figure is recorded, and the two ends it records are not the same.</b> A
+     * piece the consumer would not do is a piece this was holding, which is the figure declining to
+     * go on; a walk that ran out of pieces declined nothing, and whether anything is left of that
+     * kind is what {@code repertoire} says. Worked out anywhere else, either record is a reading of
+     * how the search was set up — an unbounded container always has counts above the figure, so a
+     * walk that asked whether it had them said a figure had been reached before trying anything.
+     *
+     * <p>A walk that refused a piece is not one that ran out, so nothing is written of it under the
+     * second. What the offer leaves out is the two together and is worked out where it is read.
+     *
+     * <p>What a caller does with {@link Traversal#SATISFIED} is its own. It is not this walk that
+     * left something: a consumer that has what it came for says so, and where that is because a walk
+     * further in stopped, that walk has already recorded what it ended with here.
+     */
+    static <T> Traversal asFarAs(Iterable<T> pieces, Spending<T> doing, Repertoire repertoire,
+                                 WhatWasLeft left) {
+        for (T each : pieces) {
+            switch (doing.take(each)) {
+                case NOT_TAKEN -> {
+                    left.refused(doing.figure());
+                    return Traversal.STOPPED;
+                }
+                case AND_DONE -> {
+                    return Traversal.SATISFIED;
+                }
+                case AND_MORE -> { }
+            }
+        }
+        if (repertoire == Repertoire.SOME_OF_THEM) {
+            left.unoffered(doing.figure());
+        }
+        return Traversal.EXHAUSTED;
+    }
+
+    /**
+     * The counts the rules leave the container, from the least of them upward.
+     *
+     * <p>All of them and not the ones a figure allows. What bounds this walk is the consumer, which
+     * is handed a count and answers whether it has room for one that size — so the count that is
+     * refused is a count the rules admit, and cutting the list to the figure first would leave
+     * nothing for it to refuse.
+     */
+    private static Iterable<Integer> countsAdmitted(DeclaredBounds.CountRange howMany) {
+        int from = Math.max(howMany.least(), 0);
+        return () -> new Iterator<>() {
+
+            private int at = from;
+
+            @Override
+            public boolean hasNext() {
+                return at >= from && at <= howMany.most();
+            }
+
+            @Override
+            public Integer next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return at++;
+            }
+        };
+    }
+
+    /**
+     * The makings of one container: where its elements stand, what holds them and how to fill them.
+     *
+     * <p>Everything about the total that neither of the walks below changes. Held together because
+     * both of them fill from it and neither owns it — the counts walk hands a size to the shapes
+     * walk, and what a shape of that size is made of is the same either way down.
+     *
+     * @param total     the number the elements are to come to
+     * @param container the position the container stands at, read once and worn by what is built
+     */
+    private record Makings(BigDecimal total, Ends ends, Shape.Sequence holding, TypeView container,
+                           Carrier elements, Ways ways, RuleReadingSource ruleSource,
+                           ReadingPolicy policy) {}
+
+    /**
+     * How many elements the container is filled with, walked from the least the rules leave upward.
+     *
+     * <p>The figure is on the count and not on how many counts were tried. What it says is how many
+     * elements a row is worth carrying, so a count past it is a count with no room whatever came
+     * before it — and a walk counting its own steps would have taken sixty-four counts from a rule
+     * that starts at a hundred.
+     *
+     * <p>Its shapes are a walk of their own at every count. Held as one across the counts, the
+     * figure would be how many decompositions the whole total is offered in rather than how many one
+     * count is spread as, which is a different policy nobody wrote down.
+     */
+    private static final class HowManyElements implements Spending<Integer> {
+
+        private final Makings makings;
+        private final WhatIsOffered offered;
+        private final WhatWasLeft left;
+
+        HowManyElements(Makings makings, WhatIsOffered offered, WhatWasLeft left) {
+            this.makings = makings;
+            this.offered = offered;
+            this.left = left;
+        }
+
+        @Override
+        public Taken take(Integer many) {
+            if (many > figure().maximum()) {
+                return Taken.NOT_TAKEN;
+            }
+            // The shapes this count is spread as, and what came of walking them. A walk that ran
+            // out of shapes to spread this count as says nothing about the next count: another one
+            // has decompositions of its own, and what this one left is recorded where it was left.
+            // Only a walk that has what it came for ends this one.
+            return asFarAs(List.of(Spread.values()),
+                    new HowItIsSpread(makings, many, offered, left), arrangementsOf(many), left)
+                    == Traversal.SATISFIED ? Taken.AND_DONE : Taken.AND_MORE;
+        }
+
+        /**
+         * Whether the shapes a difference is spread in are all the ways this many elements take it.
+         *
+         * <p>One element takes the whole of the difference and no element takes none of it, so a
+         * count of one or of nought has the one arrangement and both shapes are it. Past that they
+         * are two of the many: what a third would put where is a value neither of these writes, and
+         * a walk that ran out of them has been everywhere it knows how to go and not everywhere.
+         */
+        private static Repertoire arrangementsOf(int many) {
+            return many <= 1 ? Repertoire.ALL_THERE_ARE : Repertoire.SOME_OF_THEM;
+        }
+
+        @Override
+        public CompositionBudget figure() {
+            return CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER;
+        }
+    }
+
+    /**
+     * The shapes one count of elements is spread as, offered as far as the figure goes.
+     *
+     * <p>One count's, so the figure is what a decomposition of this many is offered in. A shape that
+     * reaches no decomposition of them is a shape that was tried and came to nothing, which is this
+     * walk carrying on rather than a figure of anybody's.
+     */
+    private static final class HowItIsSpread implements Spending<Spread> {
+
+        private final Makings makings;
+        private final int many;
+        private final WhatIsOffered offered;
+        private final WhatWasLeft left;
+        private int tried;
+
+        HowItIsSpread(Makings makings, int many, WhatIsOffered offered, WhatWasLeft left) {
+            this.makings = makings;
+            this.many = many;
+            this.offered = offered;
+            this.left = left;
+        }
+
+        @Override
+        public Taken take(Spread how) {
+            if (tried == figure().maximum()) {
+                return Taken.NOT_TAKEN;
+            }
+            tried++;
+            List<BigDecimal> split = splitting(makings.total(), many, makings.ends(), how,
+                    makings.elements());
+            if (split == null) {
+                return Taken.AND_MORE;
+            }
+            // Every way down at this count, and the whole container by one of them. Which case an
+            // element is is a fact about the value, so a container whose elements are of several
+            // would be offering a shape nothing asked for; what the walk owes is to offer each case
+            // and to say the rest were never made.
+            return asFarAs(containers(split), offered, Repertoire.ALL_THERE_ARE, left)
+                    == Traversal.EXHAUSTED ? Taken.AND_MORE : Taken.AND_DONE;
+        }
+
+        /**
+         * The containers this split fills, one per way down that builds one.
+         *
+         * <p>Built as the walk asks for them. Made in a list first, the ways after the one that
+         * filled the offer would be values composed for nobody, which is work at exactly the moment
+         * this compiler has said it will do no more.
+         */
+        private Iterable<FixtureTemplate> containers(List<BigDecimal> split) {
+            return () -> makings.ways().filled().stream()
+                    .map(each -> filled(split, makings.holding(), makings.container(), each,
+                            makings.elements(), makings.ruleSource(), makings.policy()))
+                    .filter(Objects::nonNull)
+                    .iterator();
+        }
+
+        @Override
+        public CompositionBudget figure() {
+            return CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED;
+        }
+    }
+
+    /**
+     * The containers offered for the total, as many of them as the figure is written at.
+     *
+     * <p>A container alike to one already offered is not another of them, and it is not a piece this
+     * had no room for either: what the figure counts is what a reader is handed, and a walk that met
+     * the figure on a repeat would name it having refused nothing.
+     */
+    static final class WhatIsOffered implements Spending<FixtureTemplate> {
+
+        private final List<FixtureTemplate> built = new ArrayList<>();
+
+        @Override
+        public Taken take(FixtureTemplate one) {
+            if (built.contains(one)) {
+                return Taken.AND_MORE;
+            }
+            if (built.size() == figure().maximum()) {
+                return Taken.NOT_TAKEN;
+            }
+            built.add(one);
+            return Taken.AND_MORE;
+        }
+
+        /** What was offered, in the order it was built. */
+        List<FixtureTemplate> built() {
+            return List.copyOf(built);
+        }
+
+        @Override
+        public CompositionBudget figure() {
+            return CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED;
+        }
     }
 
     /**
@@ -314,7 +586,7 @@ final class ContainersAddingUp {
         BigDecimal by = BigDecimal.valueOf(among);
         return elements.spacing() == Granularity.DISCRETE
                 ? owed.divideToIntegralValue(by)
-                : owed.divide(by, Math.max(owed.scale(), 1), java.math.RoundingMode.DOWN);
+                : owed.divide(by, Math.max(owed.scale(), 1), RoundingMode.DOWN);
     }
 
     /**
@@ -385,12 +657,12 @@ final class ContainersAddingUp {
      * @param filled  one per way that planned, in the order they were reached
      * @param cutBy   the figures the planning stopped at, which are this compiler's
      */
-    private record Ways(List<Filling> filled, java.util.Set<CompositionBudget> cutBy,
+    private record Ways(List<Filling> filled, Set<CompositionBudget> cutBy,
                         List<TermPath> nothingStandsAt) {
 
         Ways {
             filled = List.copyOf(filled);
-            cutBy = java.util.Set.copyOf(cutBy);
+            cutBy = Set.copyOf(cutBy);
             nothingStandsAt = List.copyOf(nothingStandsAt);
         }
 
@@ -416,7 +688,7 @@ final class ContainersAddingUp {
 
         private static String spelling(List<TermPath> paths) {
             return paths.stream().map(each -> "`" + each + "`")
-                    .collect(java.util.stream.Collectors.joining(", "));
+                    .collect(Collectors.joining(", "));
         }
     }
 
@@ -477,7 +749,7 @@ final class ContainersAddingUp {
                         asking.add(narrowed(fixed, where, narrowing));
                     }
                 }
-                case ConstructionPlan.Result.Beyond(java.util.Set<CompositionBudget> by) ->
+                case ConstructionPlan.Result.Beyond(Set<CompositionBudget> by) ->
                         asking.gaveUpAt(by);
                 // Two narrowings at one position, which nothing here writes: every one of them was
                 // stated by this walk, one at a time, at a position the plan named.
@@ -508,9 +780,9 @@ final class ContainersAddingUp {
         private final Type element;
         private final TermPath at;
         private final RuleReadingSource ruleSource;
-        private final java.util.Deque<TermPath> left = new java.util.ArrayDeque<>();
-        private final java.util.Set<CompositionBudget> stoppedBy =
-                java.util.EnumSet.noneOf(CompositionBudget.class);
+        private final Deque<TermPath> left = new ArrayDeque<>();
+        private final Set<CompositionBudget> stoppedBy =
+                EnumSet.noneOf(CompositionBudget.class);
         private TermPath asked;
         private int asks;
 
@@ -535,14 +807,17 @@ final class ContainersAddingUp {
             if (left.isEmpty()) {
                 return null;
             }
-            if (asks == MOST_WAYS_DOWN_TRIED) {
-                stoppedBy.add(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED);
+            // Read here and handed on, so that one place decides both that this asks no more and
+            // which figure it stopped at. Named again where the answer is made, the two could part.
+            CompositionBudget tried = CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED;
+            if (asks == tried.maximum()) {
+                stoppedBy.add(tried);
                 return null;
             }
             asks++;
             asked = left.removeFirst();
             return ConstructionPlan.of(element, at, ruleSource.symbols(),
-                    java.util.Set.of(asked), Requirements.NONE,
+                    Set.of(asked), Requirements.NONE,
                     (_, building) -> Partitions.leastHeld(building, ruleSource));
         }
 
@@ -552,12 +827,12 @@ final class ContainersAddingUp {
         }
 
         /** What the planning of one way gave up at, which is this compiler's as the figure here is. */
-        void gaveUpAt(java.util.Set<CompositionBudget> by) {
+        void gaveUpAt(Set<CompositionBudget> by) {
             stoppedBy.addAll(by);
         }
 
         /** Every figure reached, whether by the planning or by this walk. */
-        java.util.Set<CompositionBudget> stoppedBy() {
+        Set<CompositionBudget> stoppedBy() {
             return stoppedBy;
         }
     }
@@ -630,7 +905,7 @@ final class ContainersAddingUp {
                 return at.at();
             }
             BoundaryDomain beside = BoundaryDomain.on(elements);
-            java.util.Optional<Place> next =
+            Optional<Place> next =
                     upward ? beside.successor(at) : beside.predecessor(at);
             return next.orElse(null) instanceof Count on ? on.at() : null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -133,67 +133,55 @@ final class ContainersAddingUp {
         WhatIsOffered offered = new WhatIsOffered();
         Makings makings = new Makings(total.at(), ends, holding, view, elements, ways, ruleSource,
                 policy);
-        asFarAs(countsAdmitted(howMany), new HowManyElements(makings, offered, left),
-                Repertoire.ALL_THERE_ARE, left);
+        // Every count the rules leave, which are all the counts there are: what the container may
+        // hold is what the rules say, so a walk that runs out of them has run out of the population
+        // and not only of what this compiler writes.
+        asFarAs(countsAdmitted(howMany), new HowManyElements(makings, offered, left), left);
         List<FixtureTemplate> built = offered.built();
         if (!built.isEmpty()) {
-            return new TermRealizations.Realization.Built(built, left.heldBack());
+            return new TermRealizations.Realization.Built(built, left.refused(), left.notAllOf());
         }
-        // Nothing was composed, so what a figure stopped is the composing itself and not the rest of
-        // an offer. Where none of them refused anything, this is a total nothing here writes a
-        // container for — and what a reader is then owed is which of the ways to one were walked,
-        // since a figure having stopped the walk is exactly what says the ways were not all tried.
-        return left.refused().isEmpty()
-                ? new TermRealizations.Realization.None(
-                        Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                        ways.said(occurrences(target)))
-                : new TermRealizations.Realization.Stopped(left.refused());
-    }
-
-    /**
-     * Whether the pieces a walk was given are all there are of them.
-     *
-     * <p>The source's answer and not the consumer's. What a consumer knows is what it did with the
-     * piece in front of it; whether the list it is being handed stands for everything of its kind is
-     * a fact about where the list came from, and a consumer answering it would be answering for a
-     * caller it cannot see.
-     */
-    enum Repertoire {
-
-        /** Everything of that kind was handed over, so a walk that ran out left nothing. */
-        ALL_THERE_ARE,
-
-        /** Some of them, so a walk that ran out has still not been everywhere it could have gone. */
-        SOME_OF_THEM
+        // Nothing was composed, and what a reader may make of that is what these two say. A figure
+        // that refused a candidate is why nothing came of it and is somebody's to raise; a
+        // population this walks some of leaves an emptiness nothing established, and neither is the
+        // other. Where there is neither, what this looked at was everything it could have.
+        if (!left.refused().isEmpty()) {
+            return new TermRealizations.Realization.Stopped(left.refused(), left.notAllOf());
+        }
+        if (!left.notAllOf().isEmpty()) {
+            return new TermRealizations.Realization.Unexhausted(left.notAllOf(),
+                    ways.said(occurrences(target)));
+        }
+        return new TermRealizations.Realization.None(
+                Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                ways.said(occurrences(target)));
     }
 
     /**
      * What the walks over one total left behind, which is two facts and not one.
      *
-     * <p>A figure that refused a piece and a repertoire that was never all of them are different
-     * things to know. The first is somebody's to raise and is why nothing was composed where nothing
-     * was; the second is a walk having gone everywhere it knows how to go, which says nothing about
-     * whether that was everywhere — and a reader told that every value was refused, on an offer that
-     * was never the whole of what there is, has been handed a sentence to act on that nothing here
-     * established.
+     * <p>A figure that refused a piece and a population this walks some of are different things to
+     * know, and they are held in different vocabularies so that nothing downstream can put them in
+     * one set. The first is somebody's to raise; raising anything reaches none of the second.
      *
-     * <p><b>{@link #heldBack()} is worked out from them and is held nowhere.</b> Kept as a third
-     * set, it would be written twice at every refusal and could be made to disagree with the two it
-     * is the union of.
+     * <p>Both leave an offer that is not the whole of what there is, which is the one thing they
+     * have in common and the reason both travel. A reader told every value was refused, on an offer
+     * that was never everything, has been handed a sentence to act on that nothing here established.
      */
     static final class WhatWasLeft {
 
         private final Set<CompositionBudget> refused = EnumSet.noneOf(CompositionBudget.class);
-        private final Set<CompositionBudget> unoffered = EnumSet.noneOf(CompositionBudget.class);
+        private final Set<CompositionRepertoire> notAllOf =
+                EnumSet.noneOf(CompositionRepertoire.class);
 
         /** A piece was in front of a walk and this figure left no room for it. */
         void refused(CompositionBudget figure) {
             refused.add(figure);
         }
 
-        /** A walk under this figure went everywhere it knows how to, which was not everywhere. */
-        void unoffered(CompositionBudget figure) {
-            unoffered.add(figure);
+        /** A walk over this population went everywhere it knows how to, which was not everywhere. */
+        void notAllOf(CompositionRepertoire population) {
+            notAllOf.add(population);
         }
 
         /** The figures that refused a piece, which are the ones a composing was stopped by. */
@@ -201,12 +189,9 @@ final class ContainersAddingUp {
             return Set.copyOf(refused);
         }
 
-        /** Everything an offer made under these walks leaves out, however it came to be left out. */
-        Set<CompositionBudget> heldBack() {
-            Set<CompositionBudget> both = EnumSet.noneOf(CompositionBudget.class);
-            both.addAll(refused);
-            both.addAll(unoffered);
-            return Set.copyOf(both);
+        /** The populations an offer made under these walks holds some of and not all of. */
+        Set<CompositionRepertoire> notAllOf() {
+            return Set.copyOf(notAllOf);
         }
     }
 
@@ -229,24 +214,24 @@ final class ContainersAddingUp {
     }
 
     /**
-     * Every piece to the consumer, and what the walk was left with when it ended.
+     * Every piece to the consumer, and the figure where the walk was left holding one.
      *
-     * <p><b>The one place a figure is recorded, and the two ends it records are not the same.</b> A
-     * piece the consumer would not do is a piece this was holding, which is the figure declining to
-     * go on; a walk that ran out of pieces declined nothing, and whether anything is left of that
-     * kind is what {@code repertoire} says. Worked out anywhere else, either record is a reading of
-     * how the search was set up — an unbounded container always has counts above the figure, so a
-     * walk that asked whether it had them said a figure had been reached before trying anything.
+     * <p><b>The one place a figure is recorded.</b> A piece the consumer would not do is a piece
+     * this was holding, which is what makes the figure a search declining to go on rather than a
+     * property of how the search was set up. Worked out anywhere else, the record is a reading of
+     * the arrangement — an unbounded container always has counts above the figure, so a walk that
+     * asked whether it had them said a figure had been reached before trying anything.
      *
-     * <p>A walk that refused a piece is not one that ran out, so nothing is written of it under the
-     * second. What the offer leaves out is the two together and is worked out where it is read.
+     * <p>Nothing is said here about whether the pieces were the whole of their kind. That is not
+     * something a walk over them can see, and it is not a figure: what it takes to reach the rest
+     * of a population is somebody writing the rest, so it is claimed and shown where the pieces are
+     * chosen ({@link CompositionRepertoire}).
      *
      * <p>What a caller does with {@link Traversal#SATISFIED} is its own. It is not this walk that
-     * left something: a consumer that has what it came for says so, and where that is because a walk
-     * further in stopped, that walk has already recorded what it ended with here.
+     * left something: a consumer that has what it came for says so, and where that is because a
+     * walk further in stopped, that walk has already recorded its figure here.
      */
-    static <T> Traversal asFarAs(Iterable<T> pieces, Spending<T> doing, Repertoire repertoire,
-                                 WhatWasLeft left) {
+    static <T> Traversal asFarAs(Iterable<T> pieces, Spending<T> doing, WhatWasLeft left) {
         for (T each : pieces) {
             switch (doing.take(each)) {
                 case NOT_TAKEN -> {
@@ -259,9 +244,6 @@ final class ContainersAddingUp {
                 case AND_MORE -> { }
             }
         }
-        if (repertoire == Repertoire.SOME_OF_THEM) {
-            left.unoffered(doing.figure());
-        }
         return Traversal.EXHAUSTED;
     }
 
@@ -272,6 +254,10 @@ final class ContainersAddingUp {
      * is handed a count and answers whether it has room for one that size — so the count that is
      * refused is a count the rules admit, and cutting the list to the figure first would leave
      * nothing for it to refuse.
+     *
+     * <p>Which is also what ends this where the rules cap nothing. A range the rules leave open at
+     * the top runs to the largest count there is, and what stops the walk before then is the
+     * consumer having no room, as it is at every other length.
      */
     private static Iterable<Integer> countsAdmitted(DeclaredBounds.CountRange howMany) {
         int from = Math.max(howMany.least(), 0);
@@ -281,7 +267,7 @@ final class ContainersAddingUp {
 
             @Override
             public boolean hasNext() {
-                return at >= from && at <= howMany.most();
+                return at <= howMany.most();
             }
 
             @Override
@@ -337,72 +323,31 @@ final class ContainersAddingUp {
             if (many > figure().maximum()) {
                 return Taken.NOT_TAKEN;
             }
-            // The shapes this count is spread as, and what came of walking them. A walk that ran
-            // out of shapes to spread this count as says nothing about the next count: another one
-            // has decompositions of its own, and what this one left is recorded where it was left.
-            // Only a walk that has what it came for ends this one.
-            return asFarAs(List.of(Spread.values()),
-                    new HowItIsSpread(makings, many, offered, left), arrangementsOf(many), left)
-                    == Traversal.SATISFIED ? Taken.AND_DONE : Taken.AND_MORE;
-        }
-
-        /**
-         * Whether the shapes a difference is spread in are all the ways this many elements take it.
-         *
-         * <p>One element takes the whole of the difference and no element takes none of it, so a
-         * count of one or of nought has the one arrangement and both shapes are it. Past that they
-         * are two of the many: what a third would put where is a value neither of these writes, and
-         * a walk that ran out of them has been everywhere it knows how to go and not everywhere.
-         */
-        private static Repertoire arrangementsOf(int many) {
-            return many <= 1 ? Repertoire.ALL_THERE_ARE : Repertoire.SOME_OF_THEM;
-        }
-
-        @Override
-        public CompositionBudget figure() {
-            return CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER;
-        }
-    }
-
-    /**
-     * The shapes one count of elements is spread as, offered as far as the figure goes.
-     *
-     * <p>One count's, so the figure is what a decomposition of this many is offered in. A shape that
-     * reaches no decomposition of them is a shape that was tried and came to nothing, which is this
-     * walk carrying on rather than a figure of anybody's.
-     */
-    private static final class HowItIsSpread implements Spending<Spread> {
-
-        private final Makings makings;
-        private final int many;
-        private final WhatIsOffered offered;
-        private final WhatWasLeft left;
-        private int tried;
-
-        HowItIsSpread(Makings makings, int many, WhatIsOffered offered, WhatWasLeft left) {
-            this.makings = makings;
-            this.many = many;
-            this.offered = offered;
-            this.left = left;
-        }
-
-        @Override
-        public Taken take(Spread how) {
-            if (tried == figure().maximum()) {
-                return Taken.NOT_TAKEN;
+            // Said of the shapes this count is spread in, before any of them is walked, because it
+            // is about which arrangements there are rather than about what came of trying two of
+            // them. Nothing bounds this loop but the shapes there are to write, so a shape is never
+            // refused here and no figure of this compiler's is reached by spreading.
+            if (!coversEveryArrangement(many)) {
+                left.notAllOf(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD);
             }
-            tried++;
-            List<BigDecimal> split = splitting(makings.total(), many, makings.ends(), how,
-                    makings.elements());
-            if (split == null) {
-                return Taken.AND_MORE;
+            for (Spread how : Spread.values()) {
+                List<BigDecimal> split = splitting(makings.total(), many, makings.ends(), how,
+                        makings.elements());
+                if (split == null) {
+                    continue;
+                }
+                // Every way down at this count, and the whole container by one of them. Which case
+                // an element is is a fact about the value, so a container whose elements are of
+                // several would be offering a shape nothing asked for; what the walk owes is to
+                // offer each case and to say the rest were never made.
+                //
+                // An offer with no room for another container has none at any count, so this is the
+                // end of the counts as well and not only of the shapes.
+                if (asFarAs(containers(split), offered, left) == Traversal.STOPPED) {
+                    return Taken.AND_DONE;
+                }
             }
-            // Every way down at this count, and the whole container by one of them. Which case an
-            // element is is a fact about the value, so a container whose elements are of several
-            // would be offering a shape nothing asked for; what the walk owes is to offer each case
-            // and to say the rest were never made.
-            return asFarAs(containers(split), offered, Repertoire.ALL_THERE_ARE, left)
-                    == Traversal.EXHAUSTED ? Taken.AND_MORE : Taken.AND_DONE;
+            return Taken.AND_MORE;
         }
 
         /**
@@ -420,9 +365,32 @@ final class ContainersAddingUp {
                     .iterator();
         }
 
+        /**
+         * Whether the shapes written here are every arrangement of this many elements there is.
+         *
+         * <p><b>Shown, or not said.</b> An offer that claims to hold every way of reaching the
+         * total is a claim about all the arrangements, and two shapes are two of the many — so this
+         * answers for the counts where the many are provably not more than two, and every other
+         * count is one this walks some of.
+         *
+         * <p>Two showings, and both are arithmetic on what the elements stand on. A count of one
+         * takes the whole of the difference and a count of nought takes none of it, so there is the
+         * one arrangement either way and both shapes are it. And where every element moved as far
+         * as its order allows still does not reach the total, no arrangement of that many does —
+         * the shapes cover the arrangements by there being none of them.
+         *
+         * <p>Which way it errs is the whole point. A count whose arrangements this does happen to
+         * cover is walked as one it does not, and an offer says it holds less than it does; the
+         * other way round, a reader is told every value was refused by a walk that never wrote most
+         * of them.
+         */
+        private boolean coversEveryArrangement(int many) {
+            return many <= 1 || !makings.ends().reaches(makings.total(), many);
+        }
+
         @Override
         public CompositionBudget figure() {
-            return CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED;
+            return CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER;
         }
     }
 
@@ -876,8 +844,34 @@ final class ContainersAddingUp {
      *               has no value beside
      * @param upTo   the same at the other end
      */
-    private record Ends(BigDecimal from, BigDecimal downTo, BigDecimal upTo,
-                        NumericDomain.Bounds runs) {
+    record Ends(BigDecimal from, BigDecimal downTo, BigDecimal upTo,
+                NumericDomain.Bounds runs) {
+
+        /**
+         * Whether {@code many} elements standing on these ends can come to {@code total} at all.
+         *
+         * <p>Arithmetic on the ends and nothing else. Every element starts at {@link #from} and may
+         * be moved as far as the end it is moving toward, so the furthest {@code many} of them
+         * reach together is that distance taken {@code many} times — and a total past it is one no
+         * arrangement of that many comes to, whatever the arrangement.
+         *
+         * <p>True where the end it would be moving toward names no value, since an order open that
+         * way puts nothing in the way of reaching any total. And true wherever the sums allow it
+         * without asking whether the values between are the carrier's: what this is asked for is
+         * whether there is nothing to reach, so admitting a total the carrier turns out to refuse
+         * costs a claim of completeness nobody had to make, and denying one it admits would be a
+         * claim of completeness nothing showed.
+         */
+        boolean reaches(BigDecimal total, int many) {
+            BigDecimal owed = total.subtract(from.multiply(BigDecimal.valueOf(many)));
+            if (owed.signum() == 0) {
+                return true;
+            }
+            BigDecimal end = owed.signum() > 0 ? upTo : downTo;
+            return end == null
+                    || owed.abs().compareTo(
+                            end.subtract(from).abs().multiply(BigDecimal.valueOf(many))) <= 0;
+        }
 
         static Ends of(NumericDomain.Bounds runs, Carrier elements) {
             // A value of the carrier that the rules leave, which is the one reader of that question.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -507,7 +507,7 @@ public final class Generator {
             public Realization.Unknown.Reason asAWalksAnswer() {
                 return switch (this) {
                     case NOTHING_COMPOSES_ONE -> Realization.Unknown.Reason.NOTHING_COMPOSED_ONE;
-                    case THE_SEARCH_LEFT_SOMETHING_UNTRIED -> Realization.Unknown.Reason.THE_SEARCH_RAN_OUT;
+                    case THE_SEARCH_LEFT_SOMETHING_UNTRIED -> Realization.Unknown.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
                     // What a walk of a coverage item comes back with is what it did, and these are
                     // what somebody else did: the model settling the point, a candidate refused, a
                     // module with no classes, a position held back, a group never offered.
@@ -2557,16 +2557,7 @@ public final class Generator {
             Edge edge = edgeAt(subject, each.getKey(), each.getValue(),
                     fixing.size() > 1, reaching.region());
             if (edge.values().isEmpty()) {
-                // What stopped the composing where a budget of this compiler's did, and the word
-                // for a search that came to nothing where none did. The two license different
-                // sentences and only the first names something anybody could raise.
-                return edge.stoppedBy().isEmpty()
-                        ? new BoundaryAttempt.Unresolved(
-                                new UnresolvedCombination(List.of(label), edge.reason(),
-                                        edge.detail()),
-                                where.unrepresented())
-                        : BoundaryAttempt.Stopped.at(label, edge.stoppedBy(),
-                                where.unrepresented());
+                return edge.cameToNothing(label, where.unrepresented());
             }
             TermPath at = each.getKey().writeRoot();
             // Two terms at one location is that location asked for two things at once — a string of
@@ -2632,8 +2623,15 @@ public final class Generator {
             // reading of it: an offer still holding values means nothing has been exhausted, and a
             // plan short of the point is not yet anything a reader is owed.
             Outcome answered = switch (tried) {
-                // Neither is a search that came back empty over an offer. One named a figure that
-                // stopped it, and one never ran.
+                // None of these is a search claiming every candidate was refused, which is the one
+                // claim what the edge held back bears on ({@link #whatTheEdgeHeldBack}). A search
+                // that stopped, one that ran to the end of what this compiler writes, and one that
+                // never ran are already saying the point is open on this compiler, and adding what
+                // an edge was short of would be a second account of the same emptiness.
+                //
+                // Which is true in both vocabularies and not only in the figures. What the edge was
+                // short of travels with the answer that is about it, and never onto one that was
+                // settled before the edge's offer was in question.
                 case Outcome.Built _, Outcome.Stopped _, Outcome.Unexhausted _,
                      Outcome.Unplanned _ -> tried;
                 case Outcome.Unresolved(UnresolvedCombination.Reason word, String said) -> {
@@ -4779,6 +4777,32 @@ public final class Generator {
                 case TermRealizations.Realization.Built _ -> throw new IllegalStateException(
                         "an edge that offered values asked why it offered none");
             };
+        }
+
+        /**
+         * What an edge that offered nothing comes to, as the outcome an account is handed.
+         *
+         * <p><b>Which arm it is decided here and nowhere else.</b> An edge is short of everything
+         * there is in two vocabularies, and a caller choosing the arm by asking one of them whether
+         * it is empty is a caller that has to be taught every vocabulary there will ever be — which
+         * is how the second of them came to be dropped at the one place that asked about the first.
+         * Asked of the edge, a vocabulary added is a case here rather than a silence at every
+         * caller.
+         *
+         * <p>The figures first, because only they name something anybody could raise; what is
+         * walked in part travels with them all the same, since a stop does not make it untrue.
+         */
+        BoundaryAttempt cameToNothing(String label,
+                                      List<ReachabilityGap.Uncomposed> unrepresented) {
+            if (!stoppedBy().isEmpty()) {
+                return BoundaryAttempt.Stopped.at(label, detail(), stoppedBy(), notAllOf(),
+                        unrepresented);
+            }
+            if (!notAllOf().isEmpty()) {
+                return BoundaryAttempt.Unexhausted.at(label, detail(), notAllOf(), unrepresented);
+            }
+            return new BoundaryAttempt.Unresolved(
+                    new UnresolvedCombination(List.of(label), reason(), detail()), unrepresented);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -453,8 +453,7 @@ public final class Generator {
                         case ELEMENTS_A_PROPOSAL_HOLDS, CHARACTERS_A_PROPOSAL_HOLDS,
                              PLACES_A_PAIR_IS_TRIED_AT -> NOTHING_COMPOSES_ONE;
                         case PAIRINGS_BUILT_AT_ONCE, ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
-                             SHAPES_OF_A_TOTAL_OFFERED, DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
-                             WAYS_DOWN_TO_A_TOTAL_TRIED,
+                             SHAPES_OF_A_TOTAL_OFFERED, WAYS_DOWN_TO_A_TOTAL_TRIED,
                              STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES,
                              VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
                              LEVELS_A_SIDE_IS_ASKED_AT -> SEARCH_LIMIT;
@@ -2376,6 +2375,41 @@ public final class Generator {
         }
 
         /**
+         * No row came of it, and what this compiler writes of a population is why.
+         *
+         * <p>Beside {@link Stopped} and never one of its shapes. That one was holding a candidate a
+         * figure had no room for, and its word is read off the figures; nothing was refused here,
+         * and there is no number to read a word off or for a reader to raise. Written as a
+         * {@code Stopped} with an empty set of figures, every reader of one would be reading a stop
+         * that never happened.
+         *
+         * <p>The word is the same word all the same. What a reader concludes is that the point is
+         * open because this compiler did not look at everything, which is true of both; what closes
+         * it differs, and that is what travels here.
+         */
+        record Unexhausted(UnresolvedCombination why, java.util.Set<CompositionRepertoire> writes,
+                           List<ReachabilityGap.Uncomposed> unrepresented)
+                implements BoundaryAttempt {
+
+            public Unexhausted {
+                unrepresented = List.copyOf(unrepresented);
+                writes = java.util.Set.copyOf(writes);
+                if (writes.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a search that says it saw some of them says some of what");
+                }
+            }
+
+            /** One at the label given, of a search that has something to say about what it saw. */
+            static Unexhausted at(String label, String detail,
+                                  java.util.Set<CompositionRepertoire> writes,
+                                  List<ReachabilityGap.Uncomposed> unrepresented) {
+                return new Unexhausted(new UnresolvedCombination(List.of(label),
+                        UnresolvedCombination.Reason.SEARCH_LIMIT, detail), writes, unrepresented);
+            }
+        }
+
+        /**
          * A search that came to its own answer, over less than the point had.
          *
          * <p><b>Beside {@link Stopped} rather than one of its shapes.</b> A stopped search has no
@@ -2488,6 +2522,9 @@ public final class Generator {
         // two and says nothing about which figure; kept as the word, a refusal that turned out to
         // be this compiler stopping could not say what stopping it cost.
         Map<TermPath, java.util.Set<CompositionBudget>> heldBack = new LinkedHashMap<>();
+        // Beside it and not in it. What one edge did not offer is two facts of two kinds, and a
+        // reader that had them in one map would have to know which of them it could raise.
+        Map<TermPath, java.util.Set<CompositionRepertoire>> writesSomeOf = new LinkedHashMap<>();
         // Where every position of this row stands: the item's, and the ones the way to it bounds.
         // One map, because a row is one row — walked as two, the second was chosen from what the
         // declarations leave and the first from what reaches the border, and only one of them was
@@ -2541,6 +2578,7 @@ public final class Generator {
                 settled.put(at, edge.settledAt());
             }
             heldBack.put(at, edge.stoppedBy());
+            writesSomeOf.put(at, edge.notAllOf());
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
@@ -2578,11 +2616,13 @@ public final class Generator {
             Outcome answered = switch (tried) {
                 // Neither is a search that came back empty over an offer. One named a figure that
                 // stopped it, and one never ran.
-                case Outcome.Built _, Outcome.Stopped _, Outcome.Unplanned _ -> tried;
+                case Outcome.Built _, Outcome.Stopped _, Outcome.Unexhausted _,
+                     Outcome.Unplanned _ -> tried;
                 case Outcome.Unresolved(UnresolvedCombination.Reason word, String said) -> {
                     UnresolvedCombination.Reason itsWord =
                             nothingStoodWhereItWasBuilt(uncertified[0], word);
                     yield whatTheSearchCameTo(whatTheEdgeHeldBack(heldBack, here, itsWord),
+                            whatTheEdgeHeldBack(writesSomeOf, here, itsWord),
                             Set.of(), new Outcome.Unresolved(itsWord, said));
                 }
                 // Taken apart into what the search itself came to and what the plan was short of,
@@ -2594,6 +2634,7 @@ public final class Generator {
                     UnresolvedCombination.Reason itsWord =
                             nothingStoodWhereItWasBuilt(uncertified[0], word);
                     yield whatTheSearchCameTo(whatTheEdgeHeldBack(heldBack, here, itsWord),
+                            whatTheEdgeHeldBack(writesSomeOf, here, itsWord),
                             planCut, new Outcome.Unresolved(itsWord, said));
                 }
             };
@@ -2604,6 +2645,9 @@ public final class Generator {
                                 where.unrepresented());
                 case Outcome.Stopped(Set<CompositionBudget> by, String said) ->
                         BoundaryAttempt.Stopped.at(label, said, by, where.unrepresented());
+                case Outcome.Unexhausted(Set<CompositionRepertoire> writes, String said) ->
+                        BoundaryAttempt.Unexhausted.at(label, said, writes,
+                                where.unrepresented());
                 case Outcome.Limited(UnresolvedCombination.Reason word, String said,
                                      Set<CompositionBudget> by) ->
                         BoundaryAttempt.Limited.at(label, word, said, by, where.unrepresented());
@@ -3556,6 +3600,9 @@ public final class Generator {
                 case Outcome.Stopped stopped -> {
                     return Attempt.no(stopped.why(), stopped.detail());
                 }
+                case Outcome.Unexhausted some -> {
+                    return Attempt.no(some.why(), some.detail());
+                }
                 case Outcome.Limited(UnresolvedCombination.Reason why, String detail,
                                      java.util.Set<CompositionBudget> _) -> {
                     return Attempt.no(why, detail);
@@ -3689,7 +3736,7 @@ public final class Generator {
             // offered at a position the plan stopped short of is whole values of a type it declined
             // to look inside, and none being available is that decision and not a fact about the
             // model.
-            return whatTheSearchCameTo(Set.of(), choices.missingUnderAFigure(),
+            return whatTheSearchCameTo(Set.of(), Set.of(), choices.missingUnderAFigure(),
                     new Outcome.Unresolved(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                             choices.missingAt()));
         }
@@ -3730,8 +3777,11 @@ public final class Generator {
                     UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, null);
             // What each of them was short of, handed over unmerged and unranked. Which of the two
             // a reader is owed is one decision and it is made in one place.
+            // Nothing of a population is short here. What a proposal holds back is a figure of this
+            // compiler's over what it builds, and every value of the kind it does build is one it
+            // would offer.
             case HeldBack.Short(Set<CompositionBudget> offer, Set<CompositionBudget> plans) ->
-                    whatTheSearchCameTo(offer, plans, product);
+                    whatTheSearchCameTo(offer, Set.of(), plans, product);
         };
     }
 
@@ -3748,6 +3798,7 @@ public final class Generator {
      * being told about this compiler's bookkeeping.
      */
     private static Outcome whatTheSearchCameTo(Set<CompositionBudget> offerCut,
+                                               Set<CompositionRepertoire> offerWritesSomeOf,
                                                Set<CompositionBudget> planCut, Outcome came) {
         return switch (came) {
             case Outcome.Unresolved(UnresolvedCombination.Reason why, String detail) -> {
@@ -3757,16 +3808,24 @@ public final class Generator {
                 // the plan being short is not yet anything a reader is owed: raise the offer's
                 // figure and the search may compose a row without the plan changing at all. Said
                 // together, an author is sent to raise a figure that would change nothing.
+                //
+                // Which holds however the offer came to be short of everything, and the two ways it
+                // does are not joined either. One is a figure to raise and one is work nobody has
+                // done, so what outranks the plan is that the offer is incomplete, and what a
+                // reader is then told is which of the two made it so.
                 if (!offerCut.isEmpty()) {
                     yield new Outcome.Stopped(offerCut, detail);
+                }
+                if (!offerWritesSomeOf.isEmpty()) {
+                    yield new Outcome.Unexhausted(offerWritesSomeOf, detail);
                 }
                 yield planCut.isEmpty() ? came : new Outcome.Limited(why, detail, planCut);
             }
             // A search a figure stopped already names one, and nothing here turns that into a
             // second account of the same emptiness. A row stands whatever the plan gave up on, and
             // a value nothing planned had no search for this to be about.
-            case Outcome.Built _, Outcome.Stopped _, Outcome.Limited _, Outcome.Unplanned _ ->
-                    came;
+            case Outcome.Built _, Outcome.Stopped _, Outcome.Unexhausted _, Outcome.Limited _,
+                 Outcome.Unplanned _ -> came;
         };
     }
 
@@ -3783,8 +3842,8 @@ public final class Generator {
      * parameter, and which of their edges the refusal was about is not something this knows; taken
      * from whichever came first, the reason named the wrong position's search.
      */
-    private static Set<CompositionBudget> whatTheEdgeHeldBack(
-            Map<TermPath, Set<CompositionBudget>> heldBack,
+    private static <T> Set<T> whatTheEdgeHeldBack(
+            Map<TermPath, Set<T>> heldBack,
             Map<TermPath, List<FixtureTemplate>> here, UnresolvedCombination.Reason why) {
         if (here.size() != 1 || why != UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
             return Set.of();
@@ -4376,6 +4435,37 @@ public final class Generator {
         }
 
         /**
+         * A search that ran through everything this compiler writes, which is not everything there
+         * is.
+         *
+         * <p><b>Beside {@link Stopped} and never a shape of it.</b> A stopped search was holding a
+         * candidate a figure had no room for, and raising the figure tries it. Nothing was refused
+         * here: what this compiler writes ran out, and what reaches the rest is somebody writing
+         * more of it. Held as one, a reader is sent to raise a number that changes nothing.
+         *
+         * <p>The word is the same word, and that is not the two being one thing. What a reader
+         * concludes is alike — the point is open because this compiler did not look at everything —
+         * and what closes it is not, which is why the populations travel rather than the word alone.
+         */
+        record Unexhausted(Set<CompositionRepertoire> notAllOf, String detail)
+                implements Outcome {
+
+            public Unexhausted {
+                notAllOf = Set.copyOf(notAllOf);
+                if (notAllOf.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a search that says it saw some of them says some of what");
+                }
+            }
+
+            /** The word such a search comes back with, which says the point is open on this
+             *  compiler and names nothing to raise. */
+            UnresolvedCombination.Reason why() {
+                return UnresolvedCombination.Reason.SEARCH_LIMIT;
+            }
+        }
+
+        /**
          * No search was run: the value could not be planned.
          *
          * <p>No word, because a word here is a search's answer and none was made. The one thing
@@ -4590,6 +4680,25 @@ public final class Generator {
             return switch (came) {
                 case TermRealizations.Realization.Built built -> built.heldBack();
                 case TermRealizations.Realization.Stopped stopped -> stopped.by();
+                case TermRealizations.Realization.Unexhausted _,
+                     TermRealizations.Realization.None _ -> java.util.Set.of();
+            };
+        }
+
+        /**
+         * What this edge holds some of rather than all of, and empty where it holds all of what
+         * there is.
+         *
+         * <p>Beside {@link #stoppedBy()} and never folded into it. Both say the edge is not
+         * everything there is, and only one of them is a number somebody could raise — so a reader
+         * handed one set would raise what it could of it and read the rest as work it had already
+         * asked for.
+         */
+        java.util.Set<CompositionRepertoire> notAllOf() {
+            return switch (came) {
+                case TermRealizations.Realization.Built built -> built.notAllOf();
+                case TermRealizations.Realization.Stopped stopped -> stopped.notAllOf();
+                case TermRealizations.Realization.Unexhausted some -> some.notAllOf();
                 case TermRealizations.Realization.None _ -> java.util.Set.of();
             };
         }
@@ -4602,7 +4711,12 @@ public final class Generator {
          * would be telling them apart by what the sentence does not say.
          */
         String detail() {
-            return came instanceof TermRealizations.Realization.None none ? none.detail() : null;
+            return switch (came) {
+                case TermRealizations.Realization.None none -> none.detail();
+                case TermRealizations.Realization.Unexhausted some -> some.detail();
+                case TermRealizations.Realization.Built _,
+                     TermRealizations.Realization.Stopped _ -> null;
+            };
         }
 
         /** What to report where no value was offered here at all. */
@@ -4611,6 +4725,12 @@ public final class Generator {
                 case TermRealizations.Realization.None none -> none.why();
                 case TermRealizations.Realization.Stopped stopped ->
                         UnresolvedCombination.Reason.wordFor(stopped.by());
+                // The same word a figure comes back with, and for the same reason a reader has: the
+                // point is open because this compiler did not look at everything, not because the
+                // model answered. What differs is what would close it, which is the sentence beside
+                // the word and not the word.
+                case TermRealizations.Realization.Unexhausted _ ->
+                        UnresolvedCombination.Reason.SEARCH_LIMIT;
                 case TermRealizations.Realization.Built _ -> throw new IllegalStateException(
                         "an edge that offered values asked why it offered none");
             };
@@ -4622,10 +4742,17 @@ public final class Generator {
          * <p>Not always that they were refused. Where the values are some of the values and the rest
          * were never built, the search stopping is the more of the two facts, and the one a reader
          * would act on: another value of this edge may be the one that builds.
+         *
+         * <p>Which holds however the rest came to be unbuilt. A figure that refused one and a
+         * population this writes some of leave the same thing untried, and a reader told every value
+         * was refused would be acting on a walk that never wrote most of them.
          */
         UnresolvedCombination.Reason refused() {
-            return stoppedBy().isEmpty() ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED
-                    : UnresolvedCombination.Reason.wordFor(stoppedBy());
+            if (!stoppedBy().isEmpty()) {
+                return UnresolvedCombination.Reason.wordFor(stoppedBy());
+            }
+            return notAllOf().isEmpty() ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED
+                    : UnresolvedCombination.Reason.SEARCH_LIMIT;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -279,8 +279,21 @@ public final class Generator {
             NOTHING_COMPOSES_ONE,
             /** Every value tried was refused at construction. */
             ALL_CANDIDATES_REJECTED,
-            /** The search stopped before it got here. */
-            SEARCH_LIMIT,
+            /**
+             * The search left something untried.
+             *
+             * <p>Not that it stopped. A figure with no room for the candidate in front of it leaves
+             * something untried, and so does a walk that ran to the end of a population this
+             * compiler writes some of — the second stopped nothing and there is no number in it, and
+             * a word saying a search halted would send a reader looking for one. What was left, and
+             * whether raising anything reaches it, is what travels beside this
+             * ({@link CompositionBudget}, {@link CompositionRepertoire}).
+             *
+             * <p>What it licenses is one thing either way, which is why it is one word: nothing here
+             * was shown about the model, so a reader may not act on it as they may act on
+             * {@link #THE_RULES_LEAVE_NOTHING_THERE}.
+             */
+            THE_SEARCH_LEFT_SOMETHING_UNTRIED,
             /**
              * The rules leave no value here, and the whole of what they leave was walked.
              *
@@ -323,7 +336,7 @@ public final class Generator {
              * class here may be one already sitting in the file, which is a specific piece of work
              * handed to somebody who has done it.
              *
-             * <p>Told apart from {@link #SEARCH_LIMIT} because they are different pieces of news
+             * <p>Told apart from {@link #THE_SEARCH_LEFT_SOMETHING_UNTRIED} because they are different pieces of news
              * and only one of them is about this search: that one says the budget ran out with the
              * class still owed, this says the class was never a thing to look for.
              */
@@ -332,7 +345,7 @@ public final class Generator {
              * The group of decisions this belongs to was wider than the walk offers, so no
              * combination of it was looked in.
              *
-             * <p>Told apart from {@link #SEARCH_LIMIT} for the reason {@link
+             * <p>Told apart from {@link #THE_SEARCH_LEFT_SOMETHING_UNTRIED} for the reason {@link
              * #THE_POSITION_WAS_WITHHELD} is: that one says the budget ran out while walking, and
              * this says the walk never started. Raising the row budget changes the first and not
              * the second.
@@ -420,7 +433,7 @@ public final class Generator {
                     case THE_RULES_LEAVE_NOTHING_THERE, ONE_POSITION_CANNOT_BE_BOTH -> true;
                     // Every one of these is this compiler falling short, and none of them is the
                     // model saying anything: another value of the same classes may well build.
-                    case NOTHING_COMPOSES_ONE, ALL_CANDIDATES_REJECTED, SEARCH_LIMIT,
+                    case NOTHING_COMPOSES_ONE, ALL_CANDIDATES_REJECTED, THE_SEARCH_LEFT_SOMETHING_UNTRIED,
                          NOTHING_TO_BUILD_AGAINST, NO_VALUES_WERE_ASKED_FOR, LINKAGE_FAILED,
                          NO_CERTIFIED_WITNESS, THE_GROUP_WAS_NOT_OFFERED,
                          THE_POSITION_WAS_WITHHELD, THE_ROWS_WERE_NOT_READ,
@@ -456,7 +469,7 @@ public final class Generator {
                              SHAPES_OF_A_TOTAL_OFFERED, WAYS_DOWN_TO_A_TOTAL_TRIED,
                              STEPS_A_SEARCH_MAY_TAKE, ASSIGNMENTS_A_SEARCH_COMPOSES,
                              VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
-                             LEVELS_A_SIDE_IS_ASKED_AT -> SEARCH_LIMIT;
+                             LEVELS_A_SIDE_IS_ASKED_AT -> THE_SEARCH_LEFT_SOMETHING_UNTRIED;
                         // Reaching these stops no composing, so no search comes back from one of
                         // them and there is no word to give. Asked for one all the same, this says
                         // so rather than lending a word from a budget that does stop something.
@@ -494,7 +507,7 @@ public final class Generator {
             public Realization.Unknown.Reason asAWalksAnswer() {
                 return switch (this) {
                     case NOTHING_COMPOSES_ONE -> Realization.Unknown.Reason.NOTHING_COMPOSED_ONE;
-                    case SEARCH_LIMIT -> Realization.Unknown.Reason.THE_SEARCH_RAN_OUT;
+                    case THE_SEARCH_LEFT_SOMETHING_UNTRIED -> Realization.Unknown.Reason.THE_SEARCH_RAN_OUT;
                     // What a walk of a coverage item comes back with is what it did, and these are
                     // what somebody else did: the model settling the point, a candidate refused, a
                     // module with no classes, a position held back, a group never offered.
@@ -1052,7 +1065,7 @@ public final class Generator {
                     Axis axis = axes.get(owed.get(cut)[0]);
                     UnresolvedCombination why = new UnresolvedCombination(
                             List.of(label(axis, owed.get(cut)[1])),
-                            UnresolvedCombination.Reason.SEARCH_LIMIT);
+                            UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED);
                     attempts.add(new ClassAttempt.Unresolved(axis.id(),
                             axis.classes().get(owed.get(cut)[1]).id(), why));
                     unresolved.add(why);
@@ -1146,7 +1159,7 @@ public final class Generator {
                         // The search stopped, which is this run's news and not the model's. Said as
                         // that, whatever the candidates it did try came to.
                         noRow(unresolved, failed, probe, new UnresolvedCombination(none.classes(),
-                                UnresolvedCombination.Reason.SEARCH_LIMIT));
+                                UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED));
                         continue;
                     }
                     case Witness.Certified made -> {
@@ -1208,7 +1221,7 @@ public final class Generator {
                 armAnswers.put(asked, new ArmDisposition.Built(row));
             } else if (cutOff.contains(probe)) {
                 why.add(new UnresolvedCombination(List.of(),
-                        UnresolvedCombination.Reason.SEARCH_LIMIT));
+                        UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED));
                 armAnswers.put(asked, new ArmDisposition.Unresolved(why));
             } else if (!why.isEmpty()) {
                 armAnswers.put(asked, new ArmDisposition.Unresolved(why));
@@ -1581,7 +1594,7 @@ public final class Generator {
             // it did build came to: the refusal of the sixty-fourth is a fact about that candidate,
             // and offered as the class's answer it stands for a space the search never entered.
             case Completeness.Nothing.SEARCH_STOPPED -> new UnresolvedCombination(List.of(label),
-                    UnresolvedCombination.Reason.SEARCH_LIMIT);
+                    UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED);
             case Completeness.Nothing.LOOKED_EVERYWHERE -> last == null
                     ? new UnresolvedCombination(List.of(label),
                             UnresolvedCombination.Reason.NO_CANDIDATE_WAS_OFFERED)
@@ -2341,12 +2354,14 @@ public final class Generator {
          * so that the two cannot part.
          */
         record Stopped(UnresolvedCombination why, java.util.Set<CompositionBudget> by,
+                       java.util.Set<CompositionRepertoire> notAllOf,
                        List<ReachabilityGap.Uncomposed> unrepresented)
                 implements BoundaryAttempt {
 
             public Stopped {
                 unrepresented = List.copyOf(unrepresented);
                 by = java.util.Set.copyOf(by);
+                notAllOf = java.util.Set.copyOf(notAllOf);
                 if (by.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a search this compiler stopped says which budget stopped it");
@@ -2363,14 +2378,17 @@ public final class Generator {
             /** One at the label given, in the word its budgets come back with. */
             static Stopped at(String label, java.util.Set<CompositionBudget> by,
                               List<ReachabilityGap.Uncomposed> unrepresented) {
-                return at(label, null, by, unrepresented);
+                return at(label, null, by, java.util.Set.of(), unrepresented);
             }
 
-            /** The same, of a search that has something to say about where it stopped. */
+            /** The same, of a search that has something to say about where it stopped, and that
+             *  separately walked some of a population. */
             static Stopped at(String label, String detail, java.util.Set<CompositionBudget> by,
+                              java.util.Set<CompositionRepertoire> notAllOf,
                               List<ReachabilityGap.Uncomposed> unrepresented) {
                 return new Stopped(new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.wordFor(by), detail), by, unrepresented);
+                        UnresolvedCombination.Reason.wordFor(by), detail), by, notAllOf,
+                        unrepresented);
             }
         }
 
@@ -2405,7 +2423,7 @@ public final class Generator {
                                   java.util.Set<CompositionRepertoire> writes,
                                   List<ReachabilityGap.Uncomposed> unrepresented) {
                 return new Unexhausted(new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.SEARCH_LIMIT, detail), writes, unrepresented);
+                        UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED, detail), writes, unrepresented);
             }
         }
 
@@ -2643,8 +2661,10 @@ public final class Generator {
                         new BoundaryAttempt.Unresolved(
                                 new UnresolvedCombination(List.of(label), word, said),
                                 where.unrepresented());
-                case Outcome.Stopped(Set<CompositionBudget> by, String said) ->
-                        BoundaryAttempt.Stopped.at(label, said, by, where.unrepresented());
+                case Outcome.Stopped(Set<CompositionBudget> by,
+                                     Set<CompositionRepertoire> writes, String said) ->
+                        BoundaryAttempt.Stopped.at(label, said, by, writes,
+                                where.unrepresented());
                 case Outcome.Unexhausted(Set<CompositionRepertoire> writes, String said) ->
                         BoundaryAttempt.Unexhausted.at(label, said, writes,
                                 where.unrepresented());
@@ -3757,16 +3777,30 @@ public final class Generator {
         // can be written at, and a search still holding assignments it never composed has not
         // established that.
         Set<CompositionBudget> stopped = EnumSet.noneOf(CompositionBudget.class);
+        Set<CompositionRepertoire> writes = EnumSet.noneOf(CompositionRepertoire.class);
         for (Outcome each : List.of(product, conditioned)) {
             // Both passes' budgets and not one of them. Neither pass outranks the other here: each
             // stopped where it stopped, and a reader wanting to know what would let this go further
             // is owed every budget that would.
-            if (each instanceof Outcome.Stopped(Set<CompositionBudget> by, String _)) {
+            //
+            // And what either of them walked in part, which is the same reckoning in the other
+            // vocabulary: a pass that wrote some of a population has not shown that nothing else is
+            // there, whether or not the other pass met a figure.
+            if (each instanceof Outcome.Stopped(Set<CompositionBudget> by,
+                    Set<CompositionRepertoire> notAllOf, String _)) {
                 stopped.addAll(by);
+                writes.addAll(notAllOf);
+            }
+            if (each instanceof Outcome.Unexhausted(Set<CompositionRepertoire> notAllOf,
+                    String _)) {
+                writes.addAll(notAllOf);
             }
         }
         if (!stopped.isEmpty()) {
-            return new Outcome.Stopped(stopped, null);
+            return new Outcome.Stopped(stopped, writes, null);
+        }
+        if (!writes.isEmpty()) {
+            return new Outcome.Unexhausted(writes, null);
         }
         // Every value that was offered was refused, which is only the whole story where every value
         // the rules allow was offered. A position that read a count past what a row is built to carry,
@@ -3813,8 +3847,12 @@ public final class Generator {
                 // does are not joined either. One is a figure to raise and one is work nobody has
                 // done, so what outranks the plan is that the offer is incomplete, and what a
                 // reader is then told is which of the two made it so.
+                // And the two together where both are, since neither is the other's absence: a
+                // figure refused a candidate and a population was walked in part, and a reader owed
+                // one of them is owed the other. Kept as the stop alone, the second is lost at the
+                // one boundary that had it.
                 if (!offerCut.isEmpty()) {
-                    yield new Outcome.Stopped(offerCut, detail);
+                    yield new Outcome.Stopped(offerCut, offerWritesSomeOf, detail);
                 }
                 if (!offerWritesSomeOf.isEmpty()) {
                     yield new Outcome.Unexhausted(offerWritesSomeOf, detail);
@@ -4418,14 +4456,21 @@ public final class Generator {
          * <p>No word of its own, because the word such a search comes back with is the budgets' to
          * say and is read off them wherever it is wanted. Kept here as well, the two could part.
          */
-        record Stopped(Set<CompositionBudget> by, String detail) implements Outcome {
+        record Stopped(Set<CompositionBudget> by, Set<CompositionRepertoire> notAllOf,
+                       String detail) implements Outcome {
 
             public Stopped {
                 by = Set.copyOf(by);
+                notAllOf = Set.copyOf(notAllOf);
                 if (by.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a search this compiler stopped says which figure stopped it");
                 }
+            }
+
+            /** One where nothing was separately known about a population this writes some of. */
+            Stopped(Set<CompositionBudget> by, String detail) {
+                this(by, Set.of(), detail);
             }
 
             /** The word a search these stopped comes back with. */
@@ -4461,7 +4506,7 @@ public final class Generator {
             /** The word such a search comes back with, which says the point is open on this
              *  compiler and names nothing to raise. */
             UnresolvedCombination.Reason why() {
-                return UnresolvedCombination.Reason.SEARCH_LIMIT;
+                return UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
             }
         }
 
@@ -4730,7 +4775,7 @@ public final class Generator {
                 // model answered. What differs is what would close it, which is the sentence beside
                 // the word and not the word.
                 case TermRealizations.Realization.Unexhausted _ ->
-                        UnresolvedCombination.Reason.SEARCH_LIMIT;
+                        UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
                 case TermRealizations.Realization.Built _ -> throw new IllegalStateException(
                         "an edge that offered values asked why it offered none");
             };
@@ -4752,7 +4797,7 @@ public final class Generator {
                 return UnresolvedCombination.Reason.wordFor(stoppedBy());
             }
             return notAllOf().isEmpty() ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED
-                    : UnresolvedCombination.Reason.SEARCH_LIMIT;
+                    : UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -4705,7 +4705,7 @@ public final class Generator {
      * same question building it asked, and the reading is what answers it both times — kept here,
      * an answer would travel from the one to the other and the two would be free to part.
      */
-    private record Edge(TermRealizations.Realization came, Place settledAt) {
+    record Edge(TermRealizations.Realization came, Place settledAt) {
 
         static Edge none(UnresolvedCombination.Reason why) {
             return new Edge(new TermRealizations.Realization.None(why), null);

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -240,10 +240,11 @@ public final class LevelRealizer {
         if (bounded && over.where() instanceof Criterion.AtTheLevel) {
             return new Realization.Impossible();
         }
-        // A side is never settled by looking, so what this comes back with is that the search ran
-        // out — which is what it has always come back with, whether or not a figure of this
-        // compiler's was reached. The figures are said beside that answer and do not choose it.
-        return Realization.Unknown.searchRanOut(stoppedBy);
+        // A side is never settled by looking, so what this comes back with is that something was
+        // left untried — which is what it has always come back with, whether or not a figure of
+        // this compiler's was reached. The figures are said beside that answer and do not choose
+        // it, which is why the answer is not named for one of them running out.
+        return Realization.Unknown.searchLeftSomethingUntried(stoppedBy);
     }
 
     /** How many assignments the search will try before it stops and says it did not settle it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Realization.java
@@ -94,22 +94,32 @@ public sealed interface Realization {
         }
 
         /**
-         * A walk that tried what it had and settled nothing, and the budgets it ran out of.
+         * A walk that tried what it had and settled nothing, and the budgets it met on the way.
          *
          * <p>Beside {@link #nothingComposedOne} for the reason above: which of the two a walk says
          * is the walk's own answer, and this one is what a side comes back with whether or not a
-         * figure was reached.
+         * figure was reached. Which is why it is not named for running out — the figures are said
+         * beside the answer and do not choose it.
          */
-        public static Unknown searchRanOut(java.util.Set<CompositionBudget> stoppedBy) {
-            return new Unknown(Reason.THE_SEARCH_RAN_OUT, stoppedBy);
+        public static Unknown searchLeftSomethingUntried(
+                java.util.Set<CompositionBudget> stoppedBy) {
+            return new Unknown(Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED, stoppedBy);
         }
 
         public enum Reason {
             /** This compiler composed no candidate — a position whose type it cannot write at, a
              *  term that is a measure of a value rather than the value. */
             NOTHING_COMPOSED_ONE,
-            /** Candidates were tried and the search stopped before it settled the question. */
-            THE_SEARCH_RAN_OUT
+            /**
+             * Candidates were tried and something was left untried before the question was
+             * settled.
+             *
+             * <p>Not that the search stopped. A side is never settled by looking, so this is what
+             * one comes back with whether or not a figure of this compiler's was reached — and a
+             * word saying it halted would name a stop that may not have happened. What was left,
+             * and whether raising anything reaches it, is said beside this.
+             */
+            THE_SEARCH_LEFT_SOMETHING_UNTRIED
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -87,10 +87,9 @@ final class TermRealizations {
          *
          * <p><b>So a figure is here only where a candidate was in front of the walk and this figure
          * left no room for it.</b> Raise it and that candidate gets tried — which is what makes the
-         * word one an author can act on. A figure a walk merely ran under, having gone everywhere it
-         * knows how to go, stopped nothing and belongs to no arm of this: what it leaves out is
-         * {@link Built#heldBack()} where something was built, and where nothing was, nothing here
-         * declined to look and the answer is {@link None}.
+         * word one an author can act on. A population this compiler walks some of stopped nothing
+         * and is never a figure: it travels beside them ({@code notAllOf}) where a figure was met as
+         * well, and where none was it is {@link Unexhausted} rather than anything here.
          *
          * <p>Never where a value was built. A budget that cut an offering short after something was
          * composed is {@link Built#heldBack()}: what it stopped is the rest of the offer, and the
@@ -210,7 +209,9 @@ final class TermRealizations {
      *
      * <p>A target that exists and a target nothing writes at are two different sentences, and both
      * of them are said here. {@link RealizationTarget} answers the first for every number there is;
-     * a {@link Realization.None} or a {@link Realization.Stopped} is the second.
+     * the second is a {@link Realization.None}, a {@link Realization.Stopped} or a
+     * {@link Realization.Unexhausted}, which differ in what a reader may do about it and not in
+     * whether a value was written.
      */
     static Realization at(Type sourceType, TermOrders orders,
                           Place answer, souther.compiler.inputs.SearchRegion within,

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -48,6 +48,12 @@ final class TermRealizations {
          * <p>Two halves of one answer, as {@link Witnesses.Sized} keeps them. A caller reading only
          * the first says every value was refused where some were never built, which is a different
          * thing to tell an author.
+         *
+         * <p><b>Everything the offer leaves out, and not only what a figure refused.</b> A walk that
+         * went everywhere it knows how to go and a walk a figure turned back both leave values a
+         * reader was not shown, and the reader deciding whether every value was refused needs the
+         * two alike. Which of them a figure came to be here by is what {@link Stopped} is told
+         * apart by, and it is not this.
          */
         record Built(List<FixtureTemplate> values,
                      java.util.Set<CompositionBudget> heldBack) implements Realization {
@@ -74,6 +80,13 @@ final class TermRealizations {
          * policy running out leaves the question of whether a value exists open in a way somebody
          * could act on by raising it.
          *
+         * <p><b>So a figure is here only where a candidate was in front of the walk and this figure
+         * left no room for it.</b> Raise it and that candidate gets tried — which is what makes the
+         * word one an author can act on. A figure a walk merely ran under, having gone everywhere it
+         * knows how to go, stopped nothing and belongs to no arm of this: what it leaves out is
+         * {@link Built#heldBack()} where something was built, and where nothing was, nothing here
+         * declined to look and the answer is {@link None}.
+         *
          * <p>Never where a value was built. A budget that cut an offering short after something was
          * composed is {@link Built#heldBack()}: what it stopped is the rest of the offer, and the
          * point it was composed for has a value at it either way.
@@ -91,6 +104,11 @@ final class TermRealizations {
 
         /**
          * Nothing here writes a value answering it, and no budget of this compiler's is why.
+         *
+         * <p>Which is a walk that looked everywhere it was going to look and found nothing, and not
+         * one that declined to look. A figure may still have bounded what it offered — the ways a
+         * total is spread are two of the many however far a search runs — and that is a thing to
+         * say about an offer rather than a reason there is none.
          *
          * <p>The word is how a reader downstream treats it and {@code detail} is what happened in
          * this attempt, which is the arrangement {@link Generator.UnresolvedCombination} has. A

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -55,16 +55,21 @@ final class TermRealizations {
          * two alike. Which of them a figure came to be here by is what {@link Stopped} is told
          * apart by, and it is not this.
          */
-        record Built(List<FixtureTemplate> values,
-                     java.util.Set<CompositionBudget> heldBack) implements Realization {
+        record Built(List<FixtureTemplate> values, java.util.Set<CompositionBudget> heldBack,
+                     java.util.Set<CompositionRepertoire> notAllOf) implements Realization {
 
             public Built {
                 values = List.copyOf(values);
                 heldBack = java.util.Set.copyOf(heldBack);
+                notAllOf = java.util.Set.copyOf(notAllOf);
                 if (values.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a realization that built nothing is one that built none, and says why");
                 }
+            }
+
+            Built(List<FixtureTemplate> values, java.util.Set<CompositionBudget> heldBack) {
+                this(values, heldBack, java.util.Set.of());
             }
 
             static Built whole(List<FixtureTemplate> values) {
@@ -91,13 +96,46 @@ final class TermRealizations {
          * composed is {@link Built#heldBack()}: what it stopped is the rest of the offer, and the
          * point it was composed for has a value at it either way.
          */
-        record Stopped(java.util.Set<CompositionBudget> by) implements Realization {
+        record Stopped(java.util.Set<CompositionBudget> by,
+                       java.util.Set<CompositionRepertoire> notAllOf) implements Realization {
 
             public Stopped {
                 by = java.util.Set.copyOf(by);
+                notAllOf = java.util.Set.copyOf(notAllOf);
                 if (by.isEmpty()) {
                     throw new IllegalArgumentException(
                             "a composing this compiler stopped says which budget stopped it");
+                }
+            }
+
+            Stopped(java.util.Set<CompositionBudget> by) {
+                this(by, java.util.Set.of());
+            }
+        }
+
+        /**
+         * Nothing was composed, and what this walked was some of what there is to walk.
+         *
+         * <p>Apart from {@link None}, and the difference is what a reader may conclude. Nothing was
+         * refused by a figure, so there is no number to raise; and nothing here looked at every
+         * value the point has, so an emptiness this came to establishes nothing about the model.
+         * Told as {@code None}, a reader acts on a search that never wrote most of what it was
+         * searching.
+         *
+         * <p>Apart from {@link Stopped} for the same reason in the other direction. A figure is
+         * somebody's to raise and reaches what the search was holding; what reaches the rest of one
+         * of these is somebody writing the rest, which is not work an author of a model can do.
+         *
+         * @param detail what this walk found, or null where it has nothing to add
+         */
+        record Unexhausted(java.util.Set<CompositionRepertoire> notAllOf, String detail)
+                implements Realization {
+
+            public Unexhausted {
+                notAllOf = java.util.Set.copyOf(notAllOf);
+                if (notAllOf.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a walk that says it saw some of them says some of what");
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
@@ -260,8 +260,9 @@ public final class PublicationOrders {
      * <p>A value that was built and did not come back whole is nearer an answer than one that was
      * never built, which is the order the reasons inside each of them are in as well.
      *
-     * <p>The arms and not what they hold. Which observation codes an arm says, and which budgets,
-     * are the orders above; said again here they would be a second order over kinds that have one.
+     * <p>The arms and not what they hold. Which observation codes an arm says, which figures and
+     * which populations, are the orders above; said again here they would be a second order over
+     * kinds that have one.
      */
     public static final CanonicalSelection.Order<EstablishmentGap> ESTABLISHMENT_GAPS =
             CanonicalSelection.Order.overFamilies(List.<Class<? extends EstablishmentGap>>of(

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
@@ -5,6 +5,7 @@ import souther.compiler.diag.Citation;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.RunSensitivity;
 import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.ReadingGap;
 import souther.compiler.query.EstablishmentGap;
 import souther.compiler.query.ItemAssessment;
@@ -232,7 +233,6 @@ public final class PublicationOrders {
                     CompositionBudget.PAIRINGS_BUILT_AT_ONCE,
                     CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
                     CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
-                    CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED,
                     CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED,
                     CompositionBudget.VALUES_OF_AN_UNBOUNDED_PROGRESSION_TRIED,
                     CompositionBudget.PLACES_A_PAIR_IS_TRIED_AT,
@@ -242,6 +242,17 @@ public final class PublicationOrders {
                     CompositionBudget.TIMES_THE_RULES_ARE_ASKED_AGAIN,
                     CompositionBudget.STEPS_A_SEARCH_MAY_TAKE,
                     CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS));
+
+    /**
+     * What this compiler writes some of rather than all of, in the order a reader meets them.
+     *
+     * <p>Its own order and not the figures'. Reaching a figure and writing some of a population are
+     * different things to be told — one is a number to raise and the other is work nobody has done
+     * — so an order over the two together would be arranging a sentence out of two vocabularies.
+     */
+    public static final CanonicalSelection.Order<CompositionRepertoire> COMPOSITION_REPERTOIRES =
+            CanonicalSelection.Order.overValues(
+                    List.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD));
 
     /**
      * What stopped this compiler showing a row can be written, by how far it had got.

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3227,6 +3227,11 @@ public final class Adequacy {
                     // figure ended it is the point's own to say and is said where a reader asks
                     // about the point, not in a list of what this run did not offer.
                     case ItemAssessment.Attempt.Stopped why -> unresolved.add(why.why());
+                    // And a search that ran to the end of what this compiler writes. It came to
+                    // nothing the way the one above did, and what it writes some of is the point's
+                    // own to say, in the same place — a list of what this run did not offer is no
+                    // more the place for that than it is for a figure.
+                    case ItemAssessment.Attempt.Unexhausted why -> unresolved.add(why.why());
                     // And a search whose answer was about less than the point had. It came to
                     // nothing in the same sense the two above did, and which figure made its answer
                     // short is the point's own to say, in the same place.

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -1152,6 +1152,14 @@ final class Coverages {
             case souther.compiler.partition.Generator.BoundaryAttempt.Stopped left ->
                     new ItemAssessment.Attempt.Stopped(left.why(), within, left.unrepresented(),
                             EstablishmentGap.Composition.of(left.by()));
+            // A search that ran to the end of what this compiler writes, where that is not the end
+            // of what there is to write. It leaves the point open the way the one above does and
+            // names nothing anybody could raise, which is why it arrives as its own arm and its
+            // gap holds a vocabulary of its own.
+            case souther.compiler.partition.Generator.BoundaryAttempt.Unexhausted left ->
+                    new ItemAssessment.Attempt.Unexhausted(left.why(), within,
+                            left.unrepresented(),
+                            EstablishmentGap.Composition.of(java.util.List.of(), left.writes()));
             // A search that ran to the end of what it was handed, where what it was handed was
             // short of the point. It names a figure like the one above and its word is its own, so
             // the two are carried side by side rather than one being read off the other.

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -7,6 +7,7 @@ import souther.compiler.inputs.InputQuestion;
 import souther.compiler.inputs.RulesWithNoLine;
 import souther.compiler.inputs.StandingQuestion;
 import souther.compiler.partition.LinesWhereTheyFall;
+import souther.compiler.publish.PublicationOrders;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.PathReachability;
 import souther.compiler.check.RuleReadingSource;
@@ -910,7 +911,9 @@ final class Coverages {
                                     new souther.compiler.partition.Generator.UnresolvedCombination(
                                             java.util.List.of(label), wordOf(unknown)),
                                     within, java.util.List.of(),
-                                    EstablishmentGap.Composition.of(unknown.stoppedBy()));
+                                    PublicationOrders.COMPOSITION_BUDGETS.keep(unknown.stoppedBy()),
+                                    PublicationOrders.COMPOSITION_REPERTOIRES.keep(
+                                            java.util.List.of()));
                 };
             }
         };
@@ -1060,7 +1063,7 @@ final class Coverages {
             case NOTHING_COMPOSED_ONE -> souther.compiler.partition.Generator
                     .UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
             case THE_SEARCH_RAN_OUT -> souther.compiler.partition.Generator
-                    .UnresolvedCombination.Reason.SEARCH_LIMIT;
+                    .UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
         };
     }
 
@@ -1151,7 +1154,8 @@ final class Coverages {
             // declined to work on left the count as one the model admits no row at.
             case souther.compiler.partition.Generator.BoundaryAttempt.Stopped left ->
                     new ItemAssessment.Attempt.Stopped(left.why(), within, left.unrepresented(),
-                            EstablishmentGap.Composition.of(left.by()));
+                            PublicationOrders.COMPOSITION_BUDGETS.keep(left.by()),
+                            PublicationOrders.COMPOSITION_REPERTOIRES.keep(left.notAllOf()));
             // A search that ran to the end of what this compiler writes, where that is not the end
             // of what there is to write. It leaves the point open the way the one above does and
             // names nothing anybody could raise, which is why it arrives as its own arm and its
@@ -1159,19 +1163,19 @@ final class Coverages {
             case souther.compiler.partition.Generator.BoundaryAttempt.Unexhausted left ->
                     new ItemAssessment.Attempt.Unexhausted(left.why(), within,
                             left.unrepresented(),
-                            EstablishmentGap.Composition.of(java.util.List.of(), left.writes()));
+                            PublicationOrders.COMPOSITION_REPERTOIRES.keep(left.writes()));
             // A search that ran to the end of what it was handed, where what it was handed was
             // short of the point. It names a figure like the one above and its word is its own, so
             // the two are carried side by side rather than one being read off the other.
             case souther.compiler.partition.Generator.BoundaryAttempt.Limited left ->
                     new ItemAssessment.Attempt.Limited(left.why(), within, left.unrepresented(),
-                            EstablishmentGap.Composition.of(left.by()));
+                            PublicationOrders.COMPOSITION_BUDGETS.keep(left.by()));
             // And a point no search was made for at all. It names a figure like the two above and
             // is not an outcome of a search, which is what keeps it out of what the readings of a
             // line together establish.
             case souther.compiler.partition.Generator.BoundaryAttempt.Unplanned left ->
                     new ItemAssessment.Attempt.Unplanned(left.why(), within, left.unrepresented(),
-                            EstablishmentGap.Composition.of(left.by()));
+                            PublicationOrders.COMPOSITION_BUDGETS.keep(left.by()));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -1062,7 +1062,7 @@ final class Coverages {
         return switch (unknown.why()) {
             case NOTHING_COMPOSED_ONE -> souther.compiler.partition.Generator
                     .UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
-            case THE_SEARCH_RAN_OUT -> souther.compiler.partition.Generator
+            case THE_SEARCH_LEFT_SOMETHING_UNTRIED -> souther.compiler.partition.Generator
                     .UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -2,10 +2,12 @@ package souther.compiler.query;
 
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.publish.CanonicalSelection;
 import souther.compiler.publish.PublicationOrders;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * What stopped this compiler establishing that a row can be written at a point.
@@ -86,18 +88,36 @@ public sealed interface EstablishmentGap {
      * <p>As many figures as were reached, because no two of them are the same piece of work.
      * Ranked, the one a reader was told about would be whichever was met first.
      */
-    record Composition(CanonicalSelection<CompositionBudget> budgets) implements EstablishmentGap {
+    record Composition(CanonicalSelection<CompositionBudget> budgets,
+                       CanonicalSelection<CompositionRepertoire> repertoires)
+            implements EstablishmentGap {
 
         public Composition {
-            if (budgets == null || budgets.isEmpty()) {
+            if (budgets == null || repertoires == null
+                    || (budgets.isEmpty() && repertoires.isEmpty())) {
                 throw new IllegalArgumentException(
-                        "a point this compiler left open says which figure left it open");
+                        "a point this compiler left open says what left it open");
             }
         }
 
-        /** The gap the budgets a search met are, in the order a document says them. */
+        /**
+         * The gap what a composing met is, in the order a document says each of them.
+         *
+         * <p>Two vocabularies and one gap. Both say the composing settled nothing, which is the one
+         * thing a reader of a gap is being told; what differs is what would close it, and that is
+         * why they are two fields and not a set. A figure is a number to raise and reaches what the
+         * search was holding; a population is one this compiler writes some of, and what reaches
+         * the rest is somebody writing the rest.
+         */
+        public static Composition of(Collection<CompositionBudget> budgets,
+                                     Collection<CompositionRepertoire> repertoires) {
+            return new Composition(PublicationOrders.COMPOSITION_BUDGETS.keep(budgets),
+                    PublicationOrders.COMPOSITION_REPERTOIRES.keep(repertoires));
+        }
+
+        /** The gap the budgets a search met are, where it met no population it writes some of. */
         public static Composition of(Collection<CompositionBudget> budgets) {
-            return new Composition(PublicationOrders.COMPOSITION_BUDGETS.keep(budgets));
+            return of(budgets, List.of());
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * What stopped this compiler establishing that a row can be written at a point.
+ * What of this compiler's left the point short of established, where a row can be written at it.
  *
  * <p>Not a reason a row cannot be written. Every case here is something of this compiler's own met
  * on the way to an answer — a figure it holds its work to, or a population it writes some of — so
@@ -30,7 +30,7 @@ import java.util.List;
  * nothing like each other. So a producer that falls short hands this over, and one that has nothing
  * to hand over says so by there being no gap rather than by a gap nobody made.
  *
- * <p>Two cases, and what tells them apart is how far this compiler had got when it stopped. An
+ * <p>Two cases, and what tells them apart is how far this compiler had got. An
  * observation is of a value that exists and did not come back whole; a composing is of a value that
  * was never built. They leave the same question open and they are different work to close: one
  * takes keeping more of what is built, the other takes building more of what the rules leave.
@@ -65,7 +65,10 @@ public sealed interface EstablishmentGap {
     }
 
     /**
-     * A figure of this compiler's is why no value composed for the point settles it.
+     * Something of this compiler's is why no value composed for the point settles it.
+     *
+     * <p>A figure it holds its work to, a population it writes some of, or both. Which of them it
+     * was is what each field says, and neither is read off the other's absence.
      *
      * <p><b>Not that the figure is why nothing was composed.</b> Where a search ran over a plan
      * short of the point, raising the figure may well leave every candidate refused as before —

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -22,12 +22,13 @@ import java.util.List;
  * number, or somebody writing the rest of what this walks — and that is a vocabulary the gap
  * carries rather than a case it is.
  *
- * <p><b>Made where the establishing stopped, and never worked out afterwards.</b> The outcome a
- * search comes back with says that nothing came of it; which budget ran out is known only where it
- * ran out, and a reader recovering it from the outcome would be recovering it from something that
- * has already lost it — one reason a search comes back with is written wherever a search can stop,
- * by files that stop for nothing like each other. So a producer that stops hands this over, and one
- * that has nothing to hand over says so by there being no gap rather than by a gap nobody made.
+ * <p><b>Made where the establishing fell short, and never worked out afterwards.</b> The outcome a
+ * search comes back with says that nothing came of it; which figure was reached, and which
+ * population was walked in part, are known only where that happened, and a reader recovering either
+ * from the outcome would be recovering it from something that has already lost it — one reason a
+ * search comes back with is written wherever a search can fall short, by files that fall short for
+ * nothing like each other. So a producer that falls short hands this over, and one that has nothing
+ * to hand over says so by there being no gap rather than by a gap nobody made.
  *
  * <p>Two cases, and what tells them apart is how far this compiler had got when it stopped. An
  * observation is of a value that exists and did not come back whole; a composing is of a value that
@@ -72,11 +73,11 @@ public sealed interface EstablishmentGap {
      * than the point had. Written the other way, a reader is told a figure caused an emptiness it
      * may have had nothing to do with.
      *
-     * <p>Made where the figure was reached and carried out, never worked out afterwards. What a
-     * search comes back with is a word, and two of this compiler's budgets come back with the same
-     * word while one of them is written wherever a walk stops for any reason at all — so a reader
-     * recovering a budget from that word would be recovering one that may never have been reached.
-     * Some of the figures written here come back with no word at all.
+     * <p>Made where the figure was reached, or where the walk ran to the end of what this compiler
+     * writes, and carried out from there — never worked out afterwards. What a search comes back
+     * with is a word, and one word covers both of those and more besides, so a reader recovering
+     * either from the word would be recovering something that may never have happened. Some of the
+     * figures written here come back with no word at all.
      *
      * <p><b>Only where nothing was composed.</b> A budget that cut an offering short after a value
      * was built took nothing away from the point: the value is there, and what was lost is the rest

--- a/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/EstablishmentGap.java
@@ -12,10 +12,15 @@ import java.util.List;
 /**
  * What stopped this compiler establishing that a row can be written at a point.
  *
- * <p>Not a reason a row cannot be written. Every case here is a budget of this compiler's own
- * reached on the way to an answer, so what it licenses is that the question is open — and a reader
- * that turned one of these into a statement about the model would be reporting a policy as a
- * property of what somebody wrote.
+ * <p>Not a reason a row cannot be written. Every case here is something of this compiler's own met
+ * on the way to an answer — a figure it holds its work to, or a population it writes some of — so
+ * what it licenses is that the question is open, and a reader that turned one of these into a
+ * statement about the model would be reporting a policy as a property of what somebody wrote.
+ *
+ * <p><b>Which of the two is not a kind of gap.</b> A reader of a gap is being told the same thing
+ * either way: nothing here settled the point. What differs is what would settle it — raising a
+ * number, or somebody writing the rest of what this walks — and that is a vocabulary the gap
+ * carries rather than a case it is.
  *
  * <p><b>Made where the establishing stopped, and never worked out afterwards.</b> The outcome a
  * search comes back with says that nothing came of it; which budget ran out is known only where it
@@ -79,14 +84,15 @@ public sealed interface EstablishmentGap {
      * as the point having been left open by this compiler rather than by the model.
      *
      * <p>Which covers each way that happens. A figure may end the search before it had tried what
-     * it held; a figure may leave the search running over less than the point had; and a figure may
-     * leave nothing for a search to run over at all. The first comes back with the budgets' own
-     * word, the second with a word of its own, and the third with a word saying no search was made
-     * — and in every one of them what is written here is that the question is open on a figure
-     * somebody could raise.
+     * it held; the search may run to the end of a population this compiler writes some of; a figure
+     * may leave the search running over less than the point had; and a figure may leave nothing for
+     * a search to run over at all. The first comes back with the budgets' own word, the second with
+     * that word and no number in it, the third with a word of its own, and the last with a word
+     * saying no search was made — and in every one of them what is written here is that the
+     * question is open on something of this compiler's rather than on anything the model settles.
      *
-     * <p>As many figures as were reached, because no two of them are the same piece of work.
-     * Ranked, the one a reader was told about would be whichever was met first.
+     * <p>As many of each as were met, because no two of them are the same piece of work. Ranked,
+     * the one a reader was told about would be whichever was met first.
      */
     record Composition(CanonicalSelection<CompositionBudget> budgets,
                        CanonicalSelection<CompositionRepertoire> repertoires)

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -402,7 +402,7 @@ public sealed interface ItemAssessment {
      *
      * <p><b>The outcomes, and the things that may be true of one.</b> The outcomes are what
      * happened and are exclusive, so a reader asking which of them this is asks an exhaustive
-     * switch. What may be true of one — that a row came of it, that a search ran, that a figure of
+     * switch. What may be true of one — that a row came of it, that a search ran, that something of
      * this compiler's left the point unestablished — cuts across them: a row that was built and not
      * read back is both a row somebody may have and a point this compiler left open, and neither of
      * those is the other's special case. Written as one hierarchy, one of the three had to be the
@@ -484,15 +484,17 @@ public sealed interface ItemAssessment {
         }
 
         /**
-         * An attempt whose showing cannot establish the point, because of a figure of this
+         * An attempt whose showing cannot establish the point, because of something of this
          * compiler's.
          *
-         * <p>Across the outcomes rather than one of them, because what a figure costs depends on
-         * how far the attempt had got. Before anything was composed, there is no row and the point
-         * is left with nothing; after, there is a row and what is missing is the reading that would
-         * have placed it; and a plan short of the value's positions leaves an answer that is about
-         * less than the point had. All of them are this compiler's own limit and none of them is
-         * anything the model said, which is the one question an account puts to them.
+         * <p>Across the outcomes rather than one of them, because what it costs depends on how far
+         * the attempt had got. Before anything was composed, there is no row and the point is left
+         * with nothing; after, there is a row and what is missing is the reading that would have
+         * placed it; a walk that went to the end of what this compiler writes leaves an offer that
+         * was never the whole of what there is; and a plan short of the value's positions leaves an
+         * answer that is about less than the point had. All of them are this compiler's own and
+         * none of them is anything the model said, which is the one question an account puts to
+         * them.
          *
          * <p><b>The one thing they share, and the reason it is said here and not further down.</b>
          * These outcomes have different histories — one search stopped, one ran to the end of what

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -408,8 +408,9 @@ public sealed interface ItemAssessment {
      * had in hand.
      */
     sealed interface Attempt
-            permits Attempt.Certified, Attempt.Unverified, Attempt.Stopped, Attempt.Limited,
-                    Attempt.Unplanned, Attempt.Unresolved, Attempt.Unavailable {
+            permits Attempt.Certified, Attempt.Unverified, Attempt.Stopped,
+                    Attempt.Unexhausted, Attempt.Limited, Attempt.Unplanned, Attempt.Unresolved,
+                    Attempt.Unavailable {
 
         /**
          * What a search of the region came to, whichever way it came out.
@@ -426,7 +427,7 @@ public sealed interface ItemAssessment {
          * nobody could run — outside a hierarchy it belongs in.
          */
         sealed interface Searched
-                permits Certified, Unverified, Stopped, Limited, Unresolved {
+                permits Certified, Unverified, Stopped, Unexhausted, Limited, Unresolved {
 
             /** What the way to the point took in and what it could not, which is what says how much
              *  the outcome beside it is worth. */
@@ -500,7 +501,8 @@ public sealed interface ItemAssessment {
          * <p><b>Nothing here says a row cannot be written.</b> What each of these licenses is that
          * the question is open — which is what tells it from a point nothing ever promised.
          */
-        sealed interface Prevented permits Unverified, Stopped, Limited, Unplanned {
+        sealed interface Prevented permits Unverified, Stopped, Unexhausted, Limited,
+                Unplanned {
 
             /** Which figure of this compiler's the point is open on, in the words the account
              *  reads. */
@@ -589,6 +591,40 @@ public sealed interface ItemAssessment {
             @Override
             public EstablishmentGap by() {
                 return stoppedBy;
+            }
+        }
+
+        /**
+         * The search ran to the end of what this compiler writes, which is not the end of what
+         * there is.
+         *
+         * <p><b>Beside {@link Stopped} and not a shape of it.</b> That one was holding a candidate
+         * a figure had no room for: its word is the figures' to say, it is checked against them at
+         * both ends, and what a reader does about it is raise one. Nothing was refused here and
+         * there is no number in it — what reaches the rest of what this walks is somebody writing
+         * the rest, which is not work an author of a model can do. Held as one, a reader is sent to
+         * raise something that would change nothing.
+         *
+         * <p>What it licenses is what {@link Stopped} licenses and nothing more: the question is
+         * open, and open because this compiler did not look at everything. Which is why the word is
+         * the same word and the gap is not.
+         */
+        record Unexhausted(Generator.UnresolvedCombination why,
+                           souther.compiler.partition.WayToTheBorder way,
+                           List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
+                           EstablishmentGap.Composition writesSomeOf)
+                implements Attempt, Searched, Prevented {
+
+            public Unexhausted {
+                uncomposed = List.copyOf(uncomposed);
+                Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
+                Objects.requireNonNull(writesSomeOf, "a search that saw some of them says some of"
+                        + " what");
+            }
+
+            @Override
+            public EstablishmentGap by() {
+                return writesSomeOf;
             }
         }
 
@@ -750,6 +786,13 @@ public sealed interface ItemAssessment {
                 // A search a budget ended walked as far as it walked, and what it could not compose
                 // against on the way is the first thing that would explain what it came back with.
                 case Stopped it -> {
+                    way = it.way();
+                    uncomposed = it.uncomposed();
+                }
+                // And one that ran to the end of what this compiler writes. It walked the way like
+                // any other and settled nothing, so what it could not compose against is owed to a
+                // reader for the reason it is owed above.
+                case Unexhausted it -> {
                     way = it.way();
                     uncomposed = it.uncomposed();
                 }

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -1,6 +1,8 @@
 package souther.compiler.query;
 
 import souther.compiler.observe.MeasureReason;
+import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.NotOwedReason;
@@ -493,10 +495,16 @@ public sealed interface ItemAssessment {
          * anything the model said, which is the one question an account puts to them.
          *
          * <p><b>The one thing they share, and the reason it is said here and not further down.</b>
-         * These outcomes have different histories — one search stopped, one ran to the end of a
-         * short plan, one never ran at all — and holding them as one outcome would make the history
-         * something a reader recovers from a field. What is common is what an account needs and no
-         * more: the question is open, and open because of a figure somebody could raise.
+         * These outcomes have different histories — one search stopped, one ran to the end of what
+         * this compiler writes, one ran to the end of a short plan, one never ran at all — and
+         * holding them as one outcome would make the history something a reader recovers from a
+         * field. What is common is what an account needs and no more: the question is open, and open
+         * because of something of this compiler's rather than anything the model settles.
+         *
+         * <p>What would close it is not common, which is why {@link #by()} hands over a vocabulary
+         * rather than a number. Most of these are open on a figure somebody could raise; one is open
+         * on work nobody has done, and an author sent to raise something for it would raise it and
+         * get the same answer.
          *
          * <p><b>Nothing here says a row cannot be written.</b> What each of these licenses is that
          * the question is open — which is what tells it from a point nothing ever promised.
@@ -504,8 +512,8 @@ public sealed interface ItemAssessment {
         sealed interface Prevented permits Unverified, Stopped, Unexhausted, Limited,
                 Unplanned {
 
-            /** Which figure of this compiler's the point is open on, in the words the account
-             *  reads. */
+            /** What of this compiler's the point is open on — a figure it holds its work to, a
+             *  population it writes some of, or both — in the words the account reads. */
             EstablishmentGap by();
         }
 
@@ -566,31 +574,42 @@ public sealed interface ItemAssessment {
          * <p>{@code why} says what such a search comes back with, which is the word it has always
          * come back with; {@code by} is which budget it was. The first cannot be read back from the
          * second's absence and the second is not recoverable from the first, so both are carried.
+         *
+         * <p><b>What each vocabulary is, rather than the gap they make together.</b> Which arm this
+         * is turns on {@code by} alone; {@code notAllOf} is what was separately known about the same
+         * offer, and a stop that also walked some of a population loses neither by carrying both
+         * under their own names. Held as the gap an account reads, this would be a history saying
+         * one thing and a value able to say another, and the two would have nothing keeping them in
+         * step — which is the arrangement a figure and a population were taken out of.
          */
         record Stopped(Generator.UnresolvedCombination why,
                        souther.compiler.partition.WayToTheBorder way,
                        List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
-                       EstablishmentGap.Composition stoppedBy)
+                       CanonicalSelection<CompositionBudget> stoppedBy,
+                       CanonicalSelection<CompositionRepertoire> notAllOf)
                 implements Attempt, Searched, Prevented {
 
             public Stopped {
                 uncomposed = List.copyOf(uncomposed);
                 Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
-                Objects.requireNonNull(stoppedBy, "a search this compiler stopped says which"
-                        + " budget stopped it");
+                Objects.requireNonNull(notAllOf, "a search says what it walked some of, or none");
+                if (stoppedBy == null || stoppedBy.isEmpty()) {
+                    throw new IllegalArgumentException("a search this compiler stopped says which"
+                            + " budget stopped it");
+                }
                 // Carried across the boundary and checked again here, because a copy that travels
                 // is a copy that can be made to travel wrong. What the word is remains the budgets'
                 // to say at both ends, so neither end holds a pair that disagrees.
-                if (why.reason() != Generator.UnresolvedCombination.Reason
-                        .wordFor(stoppedBy.budgets().written())) {
-                    throw new IllegalArgumentException("a search stopped by "
-                            + stoppedBy.budgets() + " does not come back with " + why.reason());
+                if (why.reason()
+                        != Generator.UnresolvedCombination.Reason.wordFor(stoppedBy.written())) {
+                    throw new IllegalArgumentException("a search stopped by " + stoppedBy
+                            + " does not come back with " + why.reason());
                 }
             }
 
             @Override
             public EstablishmentGap by() {
-                return stoppedBy;
+                return new EstablishmentGap.Composition(stoppedBy, notAllOf);
             }
         }
 
@@ -612,19 +631,21 @@ public sealed interface ItemAssessment {
         record Unexhausted(Generator.UnresolvedCombination why,
                            souther.compiler.partition.WayToTheBorder way,
                            List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
-                           EstablishmentGap.Composition writesSomeOf)
+                           CanonicalSelection<CompositionRepertoire> notAllOf)
                 implements Attempt, Searched, Prevented {
 
             public Unexhausted {
                 uncomposed = List.copyOf(uncomposed);
                 Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
-                Objects.requireNonNull(writesSomeOf, "a search that saw some of them says some of"
-                        + " what");
+                if (notAllOf == null || notAllOf.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "a search that saw some of them says some of what");
+                }
             }
 
             @Override
             public EstablishmentGap by() {
-                return writesSomeOf;
+                return EstablishmentGap.Composition.of(List.of(), notAllOf.written());
             }
         }
 
@@ -646,19 +667,21 @@ public sealed interface ItemAssessment {
         record Limited(Generator.UnresolvedCombination why,
                        souther.compiler.partition.WayToTheBorder way,
                        List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
-                       EstablishmentGap.Composition limitedBy)
+                       CanonicalSelection<CompositionBudget> limitedBy)
                 implements Attempt, Searched, Prevented {
 
             public Limited {
                 uncomposed = List.copyOf(uncomposed);
                 Objects.requireNonNull(why, "a search that came to nothing says so in its own word");
-                Objects.requireNonNull(limitedBy, "an answer short of what the point had says which"
-                        + " figure made it short");
+                if (limitedBy == null || limitedBy.isEmpty()) {
+                    throw new IllegalArgumentException("an answer short of what the point had says"
+                            + " which figure made it short");
+                }
             }
 
             @Override
             public EstablishmentGap by() {
-                return limitedBy;
+                return EstablishmentGap.Composition.of(limitedBy.written());
             }
         }
 
@@ -686,19 +709,21 @@ public sealed interface ItemAssessment {
         record Unplanned(Generator.UnresolvedCombination why,
                          souther.compiler.partition.WayToTheBorder way,
                          List<souther.compiler.partition.ReachabilityGap.Uncomposed> uncomposed,
-                         EstablishmentGap.Composition limitedBy)
+                         CanonicalSelection<CompositionBudget> limitedBy)
                 implements Attempt, Prevented {
 
             public Unplanned {
                 uncomposed = List.copyOf(uncomposed);
                 Objects.requireNonNull(why, "an attempt says what it came to in its own word");
-                Objects.requireNonNull(limitedBy, "a point nothing could be planned for says which"
-                        + " figure left it unplanned");
+                if (limitedBy == null || limitedBy.isEmpty()) {
+                    throw new IllegalArgumentException("a point nothing could be planned for says"
+                            + " which figure left it unplanned");
+                }
             }
 
             @Override
             public EstablishmentGap by() {
-                return limitedBy;
+                return EstablishmentGap.Composition.of(limitedBy.written());
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -136,6 +136,12 @@ public final class PointResolver {
                         case ItemAssessment.Attempt.Stopped(var why, var _, var _, var _) ->
                                 walked.put(reading,
                                         new SearchCoverage.ReadingSearch.Attempted(why));
+                        // And a search that ran to the end of what this compiler writes. This walk
+                        // records of it what it records of the one above — a search ran and no row
+                        // came of it — and what it writes some of travels on the point's account.
+                        case ItemAssessment.Attempt.Unexhausted(var why, var _, var _, var _) ->
+                                walked.put(reading,
+                                        new SearchCoverage.ReadingSearch.Attempted(why));
                         // And a search whose answer was about less than the point had. What this
                         // walk records of it is the same as of the two above — a search ran and no
                         // row came of it — and the figure that made the answer short travels on the

--- a/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PointResolver.java
@@ -133,7 +133,7 @@ public final class PointResolver {
                         // the one above. What offering a row is short of is the same either way,
                         // and which figure ended it is the point's own to say rather than this
                         // walk's: what is recorded here is that a search ran and produced no row.
-                        case ItemAssessment.Attempt.Stopped(var why, var _, var _, var _) ->
+                        case ItemAssessment.Attempt.Stopped(var why, var _, var _, var _, var _) ->
                                 walked.put(reading,
                                         new SearchCoverage.ReadingSearch.Attempted(why));
                         // And a search that ran to the end of what this compiler writes. This walk

--- a/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/SearchOutcomes.java
@@ -18,9 +18,9 @@ import java.util.Set;
  * first, and what the other found out was gone before anything could read it.
  *
  * <p><b>Nothing here ranks them.</b> A row that was composed, a search a budget of this compiler's
- * ended, and a search that ran through what it had are three facts about one point; there is no
- * order in which one of them stands for another, and every question a reader puts is answered by
- * looking at all of them. What is chosen is a row to offer somebody ({@link #rowToOffer}), which is
+ * ended, a search that ran to the end of what this compiler writes, and a search that ran through
+ * what it had are facts about one point; there is no order in which one of them stands for another,
+ * and every question a reader puts is answered by looking at all of them. What is chosen is a row to offer somebody ({@link #rowToOffer}), which is
  * a choice about what to show and not about what happened.
  */
 public record SearchOutcomes(List<ItemAssessment.Attempt> each) {

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.publish.CanonicalSelection;
 import souther.compiler.publish.PublicationOrders;
 
@@ -89,18 +90,26 @@ public sealed interface WritabilityKnowledge {
         public static Prevented of(Collection<EstablishmentGap> gaps) {
             Set<Incompleteness.Code> observed = EnumSet.noneOf(Incompleteness.Code.class);
             Set<CompositionBudget> budgets = EnumSet.noneOf(CompositionBudget.class);
+            // Beside the figures and not among them. Two composings that came to nothing for two
+            // kinds of reason are one composing gap, which is what a reader of a gap is told; what
+            // each of them would take to close stays its own, and a fold that put them in one set
+            // would have to lose one of the two.
+            Set<CompositionRepertoire> repertoires = EnumSet.noneOf(CompositionRepertoire.class);
             for (EstablishmentGap each : gaps) {
                 switch (each) {
                     case EstablishmentGap.Observation it -> observed.addAll(it.causes().written());
-                    case EstablishmentGap.Composition it -> budgets.addAll(it.budgets().written());
+                    case EstablishmentGap.Composition it -> {
+                        budgets.addAll(it.budgets().written());
+                        repertoires.addAll(it.repertoires().written());
+                    }
                 }
             }
             List<EstablishmentGap> kinds = new ArrayList<>();
             if (!observed.isEmpty()) {
                 kinds.add(EstablishmentGap.Observation.of(observed));
             }
-            if (!budgets.isEmpty()) {
-                kinds.add(EstablishmentGap.Composition.of(budgets));
+            if (!budgets.isEmpty() || !repertoires.isEmpty()) {
+                kinds.add(EstablishmentGap.Composition.of(budgets, repertoires));
             }
             return new Prevented(PublicationOrders.ESTABLISHMENT_GAPS.keep(kinds));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/WritabilityKnowledge.java
@@ -140,13 +140,14 @@ public sealed interface WritabilityKnowledge {
             return new Established(evidence);
         }
         // Asked of the outcome's own case and never of the reason inside it: a search that came
-        // back with nothing has already lost which budget it was, so a reader rebuilding that from
-        // the word left over is rebuilding what the word does not hold.
+        // back with nothing has already lost what it fell short by, so a reader rebuilding that
+        // from the word left over is rebuilding what the word does not hold.
         //
         // Exhaustive, so that an outcome added is classified here rather than falling to the last
-        // arm. Which of the five this is decides nothing on its own — what decides is whether it is
-        // one a budget of this compiler's stopped, and that is a question the outcomes answer by
-        // implementing {@link ItemAssessment.Attempt.Prevented} or not.
+        // arm. Which of them this is decides nothing on its own — what decides is whether it is one
+        // this compiler fell short on, by a figure or by writing some of a population, and that is
+        // a question the outcomes answer by implementing {@link ItemAssessment.Attempt.Prevented}
+        // or not.
         //
         // Over every search of the point and not one of them. A point is searched once per reading
         // of its line, two readings can have been stopped by two different figures, and what a

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1998,7 +1998,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                                 + said(budgets))
                                 + (repertoires.isEmpty() ? ""
                                         : ", and this compiler writes some of "
-                                                + writes(repertoires) + " rather than all of them");
+                                                + writes(repertoires)
+                                                + " rather than all of them");
             });
         }
         return String.join(", and ", out);
@@ -2081,8 +2082,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return switch (attempt) {
             case ItemAssessment.Attempt.Certified _, ItemAssessment.Attempt.Unverified _,
                  ItemAssessment.Attempt.Unavailable _ -> "";
+            // And what it separately writes some of, where it does. Both are things the offer is
+            // short of and only one is a number, so the second is said in its own clause rather
+            // than folded into the figures or left out because a figure was there to name.
             case ItemAssessment.Attempt.Stopped it ->
-                    " — this compiler stopped at " + said(it.stoppedBy().budgets()) + ": "
+                    " — this compiler stopped at " + said(it.stoppedBy())
+                            + andWritesSomeOf(it.notAllOf()) + ": "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
                             + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
             // Said as what this compiler writes rather than as a number it stopped at, because
@@ -2090,7 +2095,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // offer. What would change this is somebody writing the rest of what it walks, and the
             // sentence says so.
             case ItemAssessment.Attempt.Unexhausted it ->
-                    " — this compiler writes some of " + writes(it.writesSomeOf().repertoires())
+                    " — this compiler writes some of " + writes(it.notAllOf())
                             + " rather than all of them: "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
                             + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
@@ -2100,14 +2105,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // for; said as the figure alone, they go looking for a search that stopped.
             case ItemAssessment.Attempt.Limited it ->
                     " — as far as this compiler plans, which stops at "
-                            + said(it.limitedBy().budgets()) + ": "
+                            + said(it.limitedBy()) + ": "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
                             + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
             // No search to report on, which is what this says instead of saying what one found. The
             // figure is what an author would raise to get one made at all.
             case ItemAssessment.Attempt.Unplanned it ->
                     " — nothing was planned for it, because this compiler stops at "
-                            + said(it.limitedBy().budgets())
+                            + said(it.limitedBy())
                             + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
             case ItemAssessment.Attempt.Unresolved it ->
                     (it.why().reason().provesInfeasible() ? " — " : " — nothing composed one: ")
@@ -2176,6 +2181,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                         + said(by) + ")";
                     };
         };
+    }
+
+    /**
+     * What a search that met a figure also walked in part, said after the figure, or nothing.
+     *
+     * <p>Beside the figure and never among them. What a reader does about the two differs, and a
+     * stop that also wrote some of a population is a point where raising the figure is worth doing
+     * and is not the whole of what is missing.
+     */
+    private static String andWritesSomeOf(
+            CanonicalSelection<CompositionRepertoire> repertoires) {
+        return repertoires.isEmpty() ? ""
+                : ", and writes some of " + writes(repertoires) + " rather than all of them";
     }
 
     /**
@@ -2268,7 +2286,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return switch (why.reason()) {
             case NOTHING_COMPOSES_ONE -> "nothing here could build a representative for " + at;
             case ALL_CANDIDATES_REJECTED -> "every value tried at " + at + " was refused";
-            case SEARCH_LIMIT -> "the search stopped before reaching " + at;
+            // Not "stopped", which is one of the two ways a search leaves something untried and is
+            // the only one with a number in it. Said as a stop, a walk that went to the end of what
+            // this compiler writes is reported as one that halted, and an author looks for the
+            // figure that halted it.
+            case THE_SEARCH_LEFT_SOMETHING_UNTRIED ->
+                    "the search left something untried before reaching " + at;
             // What is missing here, and not what cannot exist. The combinations are there and this
             // declined to walk them, so a reader is told the offer was not made rather than that
             // nothing reaches the arm — and told that raising the row budget is not what lifts it.

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -15,6 +15,7 @@ import souther.compiler.partition.AuthoredLine;
 import souther.compiler.partition.BorderObligationPoint;
 import souther.compiler.partition.ClosureGap;
 import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.DomainPoint;
 import souther.compiler.partition.FarEnd;
 import souther.compiler.partition.Generator;
@@ -1985,9 +1986,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // this was, so what is written is what both of them establish: nothing was
                 // composed, and a figure of this compiler's is why. Which way it happened is said
                 // per search, where the outcome that knows is still in hand.
-                case EstablishmentGap.Composition(var budgets) ->
-                        "nothing was composed for it, and a figure of this compiler's is why: "
-                                + said(budgets);
+                // Two sentences and not one list, because what a reader does about them differs. A
+                // figure is a number to raise and reaching it is why the search went no further; a
+                // population this writes some of is work nobody has done, and no number anybody
+                // raises reaches the rest of it. Run together, an author reads the second as
+                // something to raise and finds that raising it changes nothing.
+                case EstablishmentGap.Composition(var budgets, var repertoires) ->
+                        "nothing was composed for it"
+                                + (budgets.isEmpty() ? ""
+                                        : ", and a figure of this compiler's is why: "
+                                                + said(budgets))
+                                + (repertoires.isEmpty() ? ""
+                                        : ", and this compiler writes some of "
+                                                + writes(repertoires) + " rather than all of them");
             });
         }
         return String.join(", and ", out);
@@ -2072,6 +2083,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                  ItemAssessment.Attempt.Unavailable _ -> "";
             case ItemAssessment.Attempt.Stopped it ->
                     " — this compiler stopped at " + said(it.stoppedBy().budgets()) + ": "
+                            + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
+                            + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
+            // Said as what this compiler writes rather than as a number it stopped at, because
+            // there is no number: an author told to raise one would raise it and get the same
+            // offer. What would change this is somebody writing the rest of what it walks, and the
+            // sentence says so.
+            case ItemAssessment.Attempt.Unexhausted it ->
+                    " — this compiler writes some of " + writes(it.writesSomeOf().repertoires())
+                            + " rather than all of them: "
                             + it.why().said().orElseGet(() -> whyUnresolved(it.why()))
                             + whatTheRegionLeftOut(it.unaccountedFor(), names, declaredIn);
             // Both halves, because neither says what the other does. The word is what the search
@@ -2159,6 +2179,24 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /**
+     * What a population this compiler writes some of is called where a reader meets one.
+     *
+     * <p>Its own sentence and not one of the figures'. Nothing here is a number, so what a reader
+     * is told is what this compiler writes rather than how much of it — and a population added
+     * arrives here as a compile error rather than as a name nobody wrote a sentence for.
+     */
+    private static String writes(CanonicalSelection<CompositionRepertoire> repertoires) {
+        List<String> out = new ArrayList<>();
+        for (CompositionRepertoire each : repertoires.written()) {
+            out.add(switch (each) {
+                case WAYS_A_TOTAL_IS_SPREAD ->
+                        "the ways a total may be spread over what adds up to it";
+            });
+        }
+        return String.join(", ", out);
+    }
+
+    /**
      * What a budget of this compiler's is called where a reader meets one.
      *
      * <p>Its own words and not the constant's name. What the compiler calls a figure is a name for
@@ -2176,8 +2214,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 case ELEMENTS_A_TOTAL_IS_SPREAD_OVER ->
                         "how many elements a total is spread over";
                 case SHAPES_OF_A_TOTAL_OFFERED -> "how many containers are offered for one total";
-                case DECOMPOSITIONS_OF_A_TOTAL_OFFERED ->
-                        "how many ways a total is decomposed";
                 case WAYS_DOWN_TO_A_TOTAL_TRIED ->
                         "how many ways down to what a total adds up are tried";
                 case PLACES_A_PAIR_IS_TRIED_AT -> "how many places a pair is tried at";

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -700,7 +700,9 @@ public final class GeneratedRows {
             case ALL_CANDIDATES_REJECTED ->
                     "every value tried was refused at construction, which does not make the"
                             + " combination impossible";
-            case SEARCH_LIMIT -> "the search stopped before reaching it";
+            // As above: one of the two ways a search leaves something untried has a number in it
+            // and the other has none, so neither is said as a halt here.
+            case THE_SEARCH_LEFT_SOMETHING_UNTRIED -> "the search left something untried";
             case THE_GROUP_WAS_NOT_OFFERED ->
                     "the decisions that settle it have more combinations together than this offers"
                             + " a row for, so none of them was looked in";

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -527,7 +527,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         assertEquals(List.of(), filled.rows(),
                 "no row, because the pairings ran out before one of them was tried");
         assertTrue(filled.unresolved().stream().allMatch(left ->
-                        left.reason() == Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
+                        left.reason() == Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED),
                 "and the pairings this did not build are said as a search that stopped: "
                         + filled.unresolved());
     }
@@ -576,7 +576,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         assertEquals(List.of(), filled.rows(), "no key and value clearing all eight rules was found");
         assertTrue(filled.unresolved().stream().allMatch(left ->
                         left.reason() == Generator.UnresolvedCombination.Reason
-                                .SEARCH_LIMIT),
+                                .THE_SEARCH_LEFT_SOMETHING_UNTRIED),
                 "the pairing was built and the search for its parts is what stopped: "
                         + filled.unresolved());
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -635,7 +635,7 @@ class CompileExampleGenerateTest {
 
         assertFalse(left.isEmpty(), "nothing builds, so something is left");
         for (Generator.UnresolvedCombination each : left) {
-            assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT, each.reason(),
+            assertEquals(Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED, each.reason(),
                     each.toString());
             assertTrue(each.subject().startsWith("request.flag="),
                     "and it is still about the combination: " + each.subject());

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -297,7 +297,7 @@ class CompilePartialAdequacyTest {
      * <p>Two different pieces of news. A search that ran out of room leaves a class still owed and
      * a row still writable by this compiler; a position held back leaves a class nothing was ever
      * going to look for, and a row offered there may be one already sitting in the file. Said the
-     * first way, the block printed `the search stopped before reaching it` two lines under the
+     * first way, the block printed `the search left something untried before reaching it` two lines under the
      * line saying the position had been withheld.
      *
      * <p>What made this possible: the finding's answer is read off there being no attempt recorded

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
@@ -556,7 +556,7 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
                 """);
 
         assertTrue(report.contains("read as f/a + b: = 2000000"), report);
-        assertFalse(report.contains("the search stopped before reaching a + b = 2000000"),
+        assertFalse(report.contains("the search left something untried before reaching a + b = 2000000"),
                 "one equation with one answer, in a box a million wide:\n" + report);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APointBelowWhatThisPlansIsOpenOnAFigureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APointBelowWhatThisPlansIsOpenOnAFigureTest.java
@@ -201,16 +201,20 @@ class APointBelowWhatThisPlansIsOpenOnAFigureTest {
      */
     @Test
     void anOfferStillHoldingValuesLeavesThePlansFigureUnsaid() {
-        ItemAssessment.Attempt.Stopped stopped = assertInstanceOf(
-                ItemAssessment.Attempt.Stopped.class, onlyPreventedOf(BOTH, "both"),
-                "the edge offered less than it had, which is a search that never had the whole of"
-                        + " what there was to try");
+        ItemAssessment.Attempt.Unexhausted some = assertInstanceOf(
+                ItemAssessment.Attempt.Unexhausted.class, onlyPreventedOf(BOTH, "both"),
+                "the edge offered less than there is, which is a search that never had the whole of"
+                        + " what there was to try — and not one a figure stopped");
+        EstablishmentGap.Composition why = assertInstanceOf(
+                EstablishmentGap.Composition.class, some.by());
 
-        assertEquals(List.of(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED),
-                assertInstanceOf(EstablishmentGap.Composition.class, stopped.by())
-                        .budgets().written(),
-                "so the point is open on what the edge held back, and the plan's own figure waits"
-                        + " until there is nothing left to offer");
+        assertEquals(List.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD),
+                why.repertoires().written(),
+                "so the point is open on what the edge writes some of, and the plan's own figure"
+                        + " waits until there is nothing left to offer");
+        assertEquals(List.of(), why.budgets().written(),
+                "and no figure is named, because none refused anything: a reader told to raise one"
+                        + " would raise it and get the same offer back");
     }
 
     /** The one search of this behavior the account reads as this compiler's own limit. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionNothingBoundsIsGivenAValueTheRestCanCompleteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionNothingBoundsIsGivenAValueTheRestCanCompleteTest.java
@@ -100,7 +100,7 @@ class APositionNothingBoundsIsGivenAValueTheRestCanCompleteTest {
 
         assertTrue(report.contains("! no row is at the ON point (comparison"), report);
         assertTrue(report.contains("read as f/3 * p.a + 6 * p.b: = 3"), report);
-        assertFalse(report.contains("the search stopped before reaching 3 * p.a + 6 * p.b = 3"),
+        assertFalse(report.contains("the search left something untried before reaching 3 * p.a + 6 * p.b = 3"),
                 report);
     }
 
@@ -112,7 +112,7 @@ class APositionNothingBoundsIsGivenAValueTheRestCanCompleteTest {
 
         assertTrue(report.contains("! no row is at the OFF point (comparison"), report);
         assertTrue(report.contains("read as f/p.a + 3 * p.b: = 1"), report);
-        assertFalse(report.contains("the search stopped before reaching p.a + 3 * p.b = 1"), report);
+        assertFalse(report.contains("the search left something untried before reaching p.a + 3 * p.b = 1"), report);
     }
 
     private static String report(String model) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
@@ -301,11 +301,11 @@ class ARowIsComposedForAPointOnATotalTest {
             if (at instanceof ItemAssessment.Owed owed
                     && owed.searches().only() instanceof ItemAssessment.Attempt.Unexhausted some) {
                 said.add(some.why().reason().toString());
-                budgets.add(some.writesSomeOf().repertoires().written());
+                budgets.add(some.notAllOf().written());
             }
         }
 
-        assertEquals(List.of("SEARCH_LIMIT"), said,
+        assertEquals(List.of("THE_SEARCH_LEFT_SOMETHING_UNTRIED"), said,
                 "two of the ways it may be spread were made and the rest were not, so what a reader"
                         + " is told is that this did not look at everything");
         assertEquals(List.of(List.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD)), budgets,

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsComposedForAPointOnATotalTest.java
@@ -299,18 +299,18 @@ class ARowIsComposedForAPointOnATotalTest {
             }
             ItemAssessment at = border.at(PointRole.ON);
             if (at instanceof ItemAssessment.Owed owed
-                    && owed.searches().only() instanceof ItemAssessment.Attempt.Stopped why) {
-                said.add(why.why().reason().toString());
-                budgets.add(why.stoppedBy().budgets().written());
+                    && owed.searches().only() instanceof ItemAssessment.Attempt.Unexhausted some) {
+                said.add(some.why().reason().toString());
+                budgets.add(some.writesSomeOf().repertoires().written());
             }
         }
 
         assertEquals(List.of("SEARCH_LIMIT"), said,
-                "two of the decompositions were made and the rest were not, so what a reader is"
-                        + " told is that this stopped");
-        assertEquals(List.of(List.of(CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED)), budgets,
-                "and which figure of this compiler's decided it, which is the half of the answer"
-                        + " that says what would have to give for the point to be settled");
+                "two of the ways it may be spread were made and the rest were not, so what a reader"
+                        + " is told is that this did not look at everything");
+        assertEquals(List.of(List.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD)), budgets,
+                "and what it writes some of, which is the half of the answer that says what would"
+                        + " have to give for the point to be settled — and it is not a number");
         assertEquals(List.of(), otherThanTheAnswer(MODEL + "\nexample noShapeOfferedReachesIt\n"
                         + "    | (Two { xs = [Awkward(2), Awkward(5)] }) -> " + WHATEVER + "\n"),
                 "and the row an author writes for it is one the model holds, which is why the other"

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -267,7 +267,7 @@ class ARowNothingRanFillsNoCombinationTest {
             ArmDisposition at = filled.discharge().at(new Generator.ArmOwed(probe));
             assertInstanceOf(ArmDisposition.Unresolved.class, at,
                     "the arm has an entry rather than the silence of one nothing claims: " + probe);
-            assertEquals(List.of(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
+            assertEquals(List.of(Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED),
                     ((ArmDisposition.Unresolved) at).why().stream()
                             .map(Generator.UnresolvedCombination::reason).toList(),
                     "and says the search stopped, nothing having been tried at it");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARunBoundedAtBothEndsIsLookedInsideTest.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>What the order takes and what a search could name used to be two answers, and on an order whose
  * values fill they disagreed: {@code 3 * n} over decimals reaches every third of one, and the only
  * levels anything offered were the whole multiples of three. A run between one and two holds
- * infinitely many of the first and none of the second, so the point inside it was reported as one
- * the search stopped before reaching — with no search having run at all (issue #903).
+ * infinitely many of the first and none of the second, so the point inside it was reported as one a
+ * search had left something untried before reaching — with no search having run at all.
  *
  * <p>Measured against a run three times as wide, which differs in one thing: whether a whole multiple
  * of the generator happens to fall inside it. That one already worked, and an expectation on it alone

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -92,7 +92,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
         Model model = Model.of(TWO_FREE, "shippingFee");
         FillResult filled = fill(model, _ -> missed(model));
 
-        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+        assertEquals(Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
                 "a fourth set of values, and no run left to watch it at: " + filled.unresolved());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATotalNothingReachesIsNotOneThisCompilerStoppedAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATotalNothingReachesIsNotOneThisCompilerStoppedAtTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A total the rules leave no container for comes back as one nothing here writes a container for.
+ *
+ * <p>Every count the rules admit is tried and every shape of each of them, and the figures are
+ * nowhere near: the rules hold the container to fewer elements than one is worth carrying, and the
+ * shapes a decomposition takes are all offered at each count. So what is left when nothing is
+ * composed is the model, and a walk that came back naming a figure would be sending a reader to
+ * raise a number that took nothing away from them.
+ *
+ * <p><b>Held to a container the counts run out inside.</b> A list nothing bounds has counts above
+ * the figure that were never tried, and a figure reached there is a figure that really did decline
+ * to go on — which is a different answer and not this one. What this pins is the case where the
+ * counts are exhausted before any figure is met.
+ */
+class ATotalNothingReachesIsNotOneThisCompilerStoppedAtTest {
+
+    private static final Symbols SYMBOLS = Symbols.none(DefaultStdlib.get());
+
+    private static final RuleReadingSource RULES = RuleReadings.ofNoClauseFiled(SYMBOLS);
+
+    private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
+
+    /** A list of whole numbers, which is what the rules below hold to three values either way. */
+    private static final Type OF_WHOLE_NUMBERS = new Type.ListOf(Type.INT);
+
+    /**
+     * Three values every position of the region runs over, which is nought to two.
+     *
+     * <p>Both the count and the elements, since the region answers alike for every term. So the
+     * container holds at most two and each of them is at most two, and every count the rules admit
+     * is inside the figure.
+     */
+    private static final int A_RUN_OF_THREE = 3;
+
+    /** More than the largest container the rules leave: two elements of two come to four. */
+    private static final Count FIVE = Count.of(5);
+
+    /**
+     * Nothing composes it, and no figure of this compiler's was reached working that out.
+     *
+     * <p>The word and the evidence both. A reader told the walk stopped would look for a number to
+     * raise; what happened is that the rules leave no container adding up to this, which is an
+     * answer about the model.
+     */
+    @Test
+    void aTotalTheRulesLeaveNoContainerForIsComposedByNothing() {
+        TermRealizations.Realization made = totalOf(FIVE);
+
+        TermRealizations.Realization.None none = assertInstanceOf(
+                TermRealizations.Realization.None.class, made,
+                () -> "no container of at most two whole numbers, each at most two, comes to five,"
+                        + " and no figure declined to look for one: " + made);
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, none.why(),
+                "which is the word for a point nothing here writes a value at");
+    }
+
+    /** And a total the same rules do leave a container for is composed, so the run is walked. */
+    @Test
+    void aTotalTheyDoLeaveOneForIsComposed() {
+        TermRealizations.Realization made = totalOf(Count.of(4));
+
+        assertInstanceOf(TermRealizations.Realization.Built.class, made,
+                () -> "two elements of two come to four, which the same rules admit: " + made);
+    }
+
+    /** Containers of whole numbers adding up to {@code total}, under a region that bounds both how
+     *  many the container holds and what each of them is. */
+    private static TermRealizations.Realization totalOf(Count total) {
+        NumericTerm.TakenOf sum = NumericTerm.TakenOf.of(
+                ValueName.Stdlib.operation("List", "sum"), TermPath.of("ns"), OF_WHOLE_NUMBERS,
+                SYMBOLS);
+        assertNotNull(sum, "a walk that adds up a list of whole numbers is a number of it");
+        TermOrders orders = TermOrdersFixtures.at(sum, OF_WHOLE_NUMBERS, SYMBOLS);
+        return TermRealizations.at(OF_WHOLE_NUMBERS, orders, total,
+                new ARunOfThisMany(A_RUN_OF_THREE), RULES, POLICY);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AValueTheRulesTakeOutOfARunIsSteppedOffForAFormTooTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AValueTheRulesTakeOutOfARunIsSteppedOffForAFormTooTest.java
@@ -59,7 +59,7 @@ class AValueTheRulesTakeOutOfARunIsSteppedOffForAFormTooTest {
         String report = report(A_HOLE_IN_BOTH_POSITIONS);
 
         assertTrue(report.contains("read as f/p.a + p.b: = 0"), report);
-        assertFalse(report.contains("the search stopped before reaching p.a + p.b = 0"), report);
+        assertFalse(report.contains("the search left something untried before reaching p.a + p.b = 0"), report);
     }
 
     /** And the point above it, which the same walk reaches at the value the coset names. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.ContainersAddingUp.Repertoire;
+import souther.compiler.partition.ContainersAddingUp.Spending;
+import souther.compiler.partition.ContainersAddingUp.WhatWasLeft;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The two ends a bounded walk has, and what each of them leaves.
+ *
+ * <p>A walk that was handed a piece its consumer had no room for stopped at a figure: raise it and
+ * that piece gets tried. A walk that ran out of pieces stopped at nothing, and whether anything is
+ * left of that kind is a fact about where the pieces came from — so a repertoire that was some of
+ * them leaves work nobody did, and one that was all of them leaves none.
+ *
+ * <p><b>Both, because the walk that decides them cannot tell them apart afterwards.</b> The number
+ * of pieces handed over and the figure are the same two numbers whichever end the walk came to, and
+ * a reader working out which happened from a subtraction would call every bounded walk a stop. That
+ * is what leaves a total nothing composes a container for reported as one this compiler declined to
+ * look for.
+ *
+ * <p>Put to the mechanism rather than through a model. Which member the figure is says nothing here:
+ * what is being asked is what a walk records, and a walk records what it was left with.
+ */
+class AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest {
+
+    /** The figure the consumer below has room up to, which it reads rather than holding a copy. */
+    private static final CompositionBudget FIGURE =
+            CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED;
+
+    /** As many pieces as {@link #FIGURE} leaves room for, and no piece refused for anything else. */
+    private static final class AsManyAsTheFigure implements Spending<Integer> {
+
+        private int done;
+
+        @Override
+        public Taken take(Integer each) {
+            if (done == figure().maximum()) {
+                return Taken.NOT_TAKEN;
+            }
+            done++;
+            return Taken.AND_MORE;
+        }
+
+        @Override
+        public CompositionBudget figure() {
+            return FIGURE;
+        }
+    }
+
+    /** Every piece of everything there is, taken: nothing refused and nothing left over. */
+    @Test
+    void aWalkThroughEverythingThereIsLeavesNothing() {
+        WhatWasLeft left = new WhatWasLeft();
+
+        Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum()),
+                new AsManyAsTheFigure(), Repertoire.ALL_THERE_ARE, left);
+
+        assertEquals(Traversal.EXHAUSTED, walked, "the pieces ran out before the figure did");
+        assertEquals(Set.of(), left.refused(),
+                "so no piece was in front of the walk for the figure to have no room for");
+        assertEquals(Set.of(), left.heldBack(),
+                "and the pieces were everything of their kind, so nothing of it went undone");
+    }
+
+    /**
+     * The same walk over some of them, which leaves the kind of work it never saw.
+     *
+     * <p>The one difference is where the pieces came from. A consumer answering this would be
+     * answering for a caller it cannot see, and the walk would be recording the arrangement it was
+     * set up in rather than what it did.
+     */
+    @Test
+    void aWalkThroughSomeOfThemLeavesWhatItNeverSaw() {
+        WhatWasLeft left = new WhatWasLeft();
+
+        Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum()),
+                new AsManyAsTheFigure(), Repertoire.SOME_OF_THEM, left);
+
+        assertEquals(Traversal.EXHAUSTED, walked, "the pieces ran out before the figure did");
+        assertEquals(Set.of(), left.refused(),
+                "nothing was refused, so nothing here is a composing this compiler stopped");
+        assertEquals(Set.of(FIGURE), left.heldBack(),
+                "and the offer is short of what a piece of that kind would have added, which is"
+                        + " what a reader deciding whether everything was tried is owed");
+    }
+
+    /**
+     * One piece past the figure, which is the figure refusing something that was there.
+     *
+     * <p>The piece was in front of the walk, so raising the figure tries it. Nothing is recorded of
+     * a walk running out, because this one did not: the pieces were still coming.
+     */
+    @Test
+    void aPieceThereWasNoRoomForIsTheFigureDecliningToGoOn() {
+        WhatWasLeft left = new WhatWasLeft();
+
+        Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum() + 1),
+                new AsManyAsTheFigure(), Repertoire.ALL_THERE_ARE, left);
+
+        assertEquals(Traversal.STOPPED, walked, "a piece was in front of it and was not done");
+        assertEquals(Set.of(FIGURE), left.refused(),
+                "which is the figure declining to go on, and is what a reader raises");
+        assertEquals(Set.of(FIGURE), left.heldBack(),
+                "and it is one of the things the offer leaves out, as everything refused is");
+    }
+
+    /**
+     * A piece that repeats is not a piece there was no room for.
+     *
+     * <p>What the figure counts is what a reader is handed. A walk that met the figure on a repeat
+     * would name it having refused nothing, which is the reading this whole arrangement is against.
+     */
+    @Test
+    void aContainerAlreadyOfferedIsNotAContainerRefused() {
+        ContainersAddingUp.WhatIsOffered offered = new ContainersAddingUp.WhatIsOffered();
+        WhatWasLeft left = new WhatWasLeft();
+        List<FixtureTemplate> filling = distinct(offered.figure().maximum());
+
+        assertEquals(Traversal.EXHAUSTED,
+                ContainersAddingUp.asFarAs(filling, offered, Repertoire.ALL_THERE_ARE, left),
+                "as many containers as are offered is what is offered");
+        assertEquals(Traversal.EXHAUSTED,
+                ContainersAddingUp.asFarAs(List.of(filling.get(0)), offered,
+                        Repertoire.ALL_THERE_ARE, left),
+                "and one already offered is nothing this had to make room for");
+        assertEquals(Set.of(), left.heldBack(),
+                "so nothing was held back, whatever the offer is full of");
+
+        assertEquals(Traversal.STOPPED,
+                ContainersAddingUp.asFarAs(distinct(offered.figure().maximum() + 1), offered,
+                        Repertoire.ALL_THERE_ARE, left),
+                "and one that is not already offered is a container there is no room for");
+        assertEquals(Set.of(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED), left.refused(),
+                "which is the figure over how many are offered, declining to offer another");
+    }
+
+    /** The whole numbers below {@code many}, which is a piece of nothing in particular. */
+    private static List<Integer> upTo(int many) {
+        List<Integer> pieces = new ArrayList<>();
+        for (int each = 0; each < many; each++) {
+            pieces.add(each);
+        }
+        return List.copyOf(pieces);
+    }
+
+    /** That many values no two of which are the same. */
+    private static List<FixtureTemplate> distinct(int many) {
+        List<FixtureTemplate> values = new ArrayList<>();
+        for (int each = 0; each < many; each++) {
+            values.add(FixtureTemplate.string("x".repeat(each + 1)));
+        }
+        return List.copyOf(values);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest.java
@@ -2,23 +2,26 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.partition.ContainersAddingUp.Repertoire;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.partition.ContainersAddingUp.Ends;
 import souther.compiler.partition.ContainersAddingUp.Spending;
 import souther.compiler.partition.ContainersAddingUp.WhatWasLeft;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The two ends a bounded walk has, and what each of them leaves.
  *
  * <p>A walk that was handed a piece its consumer had no room for stopped at a figure: raise it and
- * that piece gets tried. A walk that ran out of pieces stopped at nothing, and whether anything is
- * left of that kind is a fact about where the pieces came from — so a repertoire that was some of
- * them leaves work nobody did, and one that was all of them leaves none.
+ * that piece gets tried. A walk that ran out of pieces stopped at nothing, and a figure recorded
+ * there is one that took nothing away from anybody.
  *
  * <p><b>Both, because the walk that decides them cannot tell them apart afterwards.</b> The number
  * of pieces handed over and the figure are the same two numbers whichever end the walk came to, and
@@ -33,7 +36,7 @@ class AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest {
 
     /** The figure the consumer below has room up to, which it reads rather than holding a copy. */
     private static final CompositionBudget FIGURE =
-            CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED;
+            CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED;
 
     /** As many pieces as {@link #FIGURE} leaves room for, and no piece refused for anything else. */
     private static final class AsManyAsTheFigure implements Spending<Integer> {
@@ -55,61 +58,34 @@ class AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest {
         }
     }
 
-    /** Every piece of everything there is, taken: nothing refused and nothing left over. */
+    /** Every piece taken and none left: nothing refused, so no figure is anybody's to raise. */
     @Test
-    void aWalkThroughEverythingThereIsLeavesNothing() {
+    void aWalkThatRanOutOfPiecesRecordsNoFigure() {
         WhatWasLeft left = new WhatWasLeft();
 
         Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum()),
-                new AsManyAsTheFigure(), Repertoire.ALL_THERE_ARE, left);
+                new AsManyAsTheFigure(), left);
 
         assertEquals(Traversal.EXHAUSTED, walked, "the pieces ran out before the figure did");
         assertEquals(Set.of(), left.refused(),
                 "so no piece was in front of the walk for the figure to have no room for");
-        assertEquals(Set.of(), left.heldBack(),
-                "and the pieces were everything of their kind, so nothing of it went undone");
-    }
-
-    /**
-     * The same walk over some of them, which leaves the kind of work it never saw.
-     *
-     * <p>The one difference is where the pieces came from. A consumer answering this would be
-     * answering for a caller it cannot see, and the walk would be recording the arrangement it was
-     * set up in rather than what it did.
-     */
-    @Test
-    void aWalkThroughSomeOfThemLeavesWhatItNeverSaw() {
-        WhatWasLeft left = new WhatWasLeft();
-
-        Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum()),
-                new AsManyAsTheFigure(), Repertoire.SOME_OF_THEM, left);
-
-        assertEquals(Traversal.EXHAUSTED, walked, "the pieces ran out before the figure did");
-        assertEquals(Set.of(), left.refused(),
-                "nothing was refused, so nothing here is a composing this compiler stopped");
-        assertEquals(Set.of(FIGURE), left.heldBack(),
-                "and the offer is short of what a piece of that kind would have added, which is"
-                        + " what a reader deciding whether everything was tried is owed");
     }
 
     /**
      * One piece past the figure, which is the figure refusing something that was there.
      *
-     * <p>The piece was in front of the walk, so raising the figure tries it. Nothing is recorded of
-     * a walk running out, because this one did not: the pieces were still coming.
+     * <p>The piece was in front of the walk, so raising the figure tries it.
      */
     @Test
     void aPieceThereWasNoRoomForIsTheFigureDecliningToGoOn() {
         WhatWasLeft left = new WhatWasLeft();
 
         Traversal walked = ContainersAddingUp.asFarAs(upTo(FIGURE.maximum() + 1),
-                new AsManyAsTheFigure(), Repertoire.ALL_THERE_ARE, left);
+                new AsManyAsTheFigure(), left);
 
         assertEquals(Traversal.STOPPED, walked, "a piece was in front of it and was not done");
         assertEquals(Set.of(FIGURE), left.refused(),
                 "which is the figure declining to go on, and is what a reader raises");
-        assertEquals(Set.of(FIGURE), left.heldBack(),
-                "and it is one of the things the offer leaves out, as everything refused is");
     }
 
     /**
@@ -125,21 +101,53 @@ class AWalkThatRanOutOfPiecesIsNotAWalkThatWasStoppedTest {
         List<FixtureTemplate> filling = distinct(offered.figure().maximum());
 
         assertEquals(Traversal.EXHAUSTED,
-                ContainersAddingUp.asFarAs(filling, offered, Repertoire.ALL_THERE_ARE, left),
+                ContainersAddingUp.asFarAs(filling, offered, left),
                 "as many containers as are offered is what is offered");
         assertEquals(Traversal.EXHAUSTED,
-                ContainersAddingUp.asFarAs(List.of(filling.get(0)), offered,
-                        Repertoire.ALL_THERE_ARE, left),
+                ContainersAddingUp.asFarAs(List.of(filling.get(0)), offered, left),
                 "and one already offered is nothing this had to make room for");
-        assertEquals(Set.of(), left.heldBack(),
-                "so nothing was held back, whatever the offer is full of");
+        assertEquals(Set.of(), left.refused(),
+                "so nothing was refused, whatever the offer is full of");
 
         assertEquals(Traversal.STOPPED,
-                ContainersAddingUp.asFarAs(distinct(offered.figure().maximum() + 1), offered,
-                        Repertoire.ALL_THERE_ARE, left),
+                ContainersAddingUp.asFarAs(distinct(offered.figure().maximum() + 1), offered, left),
                 "and one that is not already offered is a container there is no room for");
         assertEquals(Set.of(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED), left.refused(),
                 "which is the figure over how many are offered, declining to offer another");
+    }
+
+    /**
+     * Whether any arrangement of a given many reaches the total, which is what a claim of having
+     * written every arrangement rests on.
+     *
+     * <p>The elements start at nought and run to two, so two of them reach four and no more. What
+     * this is for is the counts where the shapes this compiler writes are every arrangement there
+     * is by there being none — and a total past the ends is one no arrangement comes to, whichever
+     * way the difference is spread.
+     */
+    @Test
+    void aTotalPastWhereEveryElementCanReachIsReachedByNoArrangement() {
+        Ends ends = new Ends(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.valueOf(2),
+                NumericDomain.Bounds.OPEN);
+
+        assertTrue(ends.reaches(BigDecimal.valueOf(4), 2),
+                "two elements of two come to four, so an arrangement of two reaches it");
+        assertFalse(ends.reaches(BigDecimal.valueOf(5), 2),
+                "and nothing two of them do comes to five, so there is no arrangement to have"
+                        + " written");
+        assertTrue(ends.reaches(BigDecimal.valueOf(5), 3),
+                "a third element reaches it, which is a count of its own");
+    }
+
+    /** An order open the way an element would have to move puts nothing in the way of a total. */
+    @Test
+    void anOrderOpenTheWayAnElementMovesReachesAnything() {
+        Ends open = new Ends(BigDecimal.ZERO, BigDecimal.ZERO, null, NumericDomain.Bounds.OPEN);
+
+        assertTrue(open.reaches(BigDecimal.valueOf(1_000_000), 1),
+                "nothing names a value this element cannot be moved up to");
+        assertFalse(open.reaches(BigDecimal.valueOf(-1), 1),
+                "and the end it would move down to is named, and is where it starts");
     }
 
     /** The whole numbers below {@code many}, which is a piece of nothing in particular. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnEdgeThatOfferedNothingSaysWhichOfTheTwoItIsShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnEdgeThatOfferedNothingSaysWhichOfTheTwoItIsShortOfTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * An edge that offered no value says what it was short of, in whichever vocabulary it was short in.
+ *
+ * <p>An edge falls short of everything there is in two ways — a figure of this compiler's refused a
+ * candidate, and a population this compiler writes some of ran out — and only the first is a number
+ * anybody could raise. Whichever it was, the point is open on this compiler and not on the model.
+ *
+ * <p><b>Put to the one place that decides it.</b> A caller that worked the arm out by asking one of
+ * the two whether it was empty is a caller that has to be taught every vocabulary there will ever
+ * be, and the one that existed before this was asked about figures alone: an edge short only of a
+ * population came back as a search that simply found nothing, with what it had walked in part gone
+ * before anything downstream could read it. Nothing at the model's end saw the difference, because
+ * the word is the same word either way — which is why this is asked here rather than through a
+ * model.
+ */
+class AnEdgeThatOfferedNothingSaysWhichOfTheTwoItIsShortOfTest {
+
+    private static final String LABEL = "List.sum(q.xs) = 7";
+
+    /** A figure refused a candidate, and the same walk had written some of a population. */
+    @Test
+    void anEdgeAFigureStoppedSaysTheFigureAndWhatItWalkedInPart() {
+        Generator.BoundaryAttempt came = shortOf(
+                Set.of(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED),
+                Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD));
+
+        Generator.BoundaryAttempt.Stopped stopped = assertInstanceOf(
+                Generator.BoundaryAttempt.Stopped.class, came,
+                "a figure refused a candidate, which is the outcome that names something to raise");
+        assertEquals(Set.of(CompositionBudget.WAYS_DOWN_TO_A_TOTAL_TRIED), stopped.by(),
+                "and it is the figure that refused one");
+        assertEquals(Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD), stopped.notAllOf(),
+                "and what the same walk wrote some of, which the figure does not make untrue and"
+                        + " which nothing else downstream would ever hear about");
+    }
+
+    /**
+     * No figure refused anything, and the walk went to the end of what this compiler writes.
+     *
+     * <p>The one this got wrong. There is nothing to raise, so an outcome naming a figure would be
+     * a lie and an outcome naming nothing would leave a reader free to conclude that every value
+     * was refused.
+     */
+    @Test
+    void anEdgeShortOnlyOfAPopulationSaysThePopulation() {
+        Generator.BoundaryAttempt came =
+                shortOf(Set.of(), Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD));
+
+        Generator.BoundaryAttempt.Unexhausted some = assertInstanceOf(
+                Generator.BoundaryAttempt.Unexhausted.class, came,
+                "nothing was refused, so this is not a search a figure stopped");
+        assertEquals(Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD), some.writes(),
+                "and what it is open on is what this compiler writes some of");
+    }
+
+    /** And an edge short of neither is a search that had everything and came to nothing. */
+    @Test
+    void anEdgeShortOfNeitherIsASearchThatHadEverything() {
+        Generator.BoundaryAttempt came = shortOf(Set.of(), Set.of());
+
+        assertInstanceOf(Generator.BoundaryAttempt.Unresolved.class, came,
+                "nothing of this compiler's is why, so nothing here may name one");
+    }
+
+    /** An edge that offered nothing and was short of these, as the outcome it comes to. */
+    private static Generator.BoundaryAttempt shortOf(Set<CompositionBudget> stoppedBy,
+                                                     Set<CompositionRepertoire> notAllOf) {
+        return new Generator.Edge(realization(stoppedBy, notAllOf), null)
+                .cameToNothing(LABEL, List.of());
+    }
+
+    /** What such a walk came back with, which is the arm its own two answers put it in. */
+    private static TermRealizations.Realization realization(Set<CompositionBudget> stoppedBy,
+                                                            Set<CompositionRepertoire> notAllOf) {
+        if (!stoppedBy.isEmpty()) {
+            return new TermRealizations.Realization.Stopped(stoppedBy, notAllOf);
+        }
+        if (!notAllOf.isEmpty()) {
+            return new TermRealizations.Realization.Unexhausted(notAllOf, null);
+        }
+        return new TermRealizations.Realization.None(
+                Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -66,18 +66,29 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
                         + built.values().stream().map(FixtureTemplate::text).toList());
     }
 
-    /** And the ones it did not make are what it says it did not make. */
+    /**
+     * And what the offer leaves out is said, whichever way it came to be left out.
+     *
+     * <p>Two of them and for two different reasons. A fifth container was in front of the walk and
+     * the figure left no room for it; the shapes a count of two is spread in were all offered, and
+     * two shapes are not all the ways two elements take a difference. Both are things this offer
+     * does not hold, which is what a reader deciding whether every container was refused needs.
+     *
+     * <p><b>And the count's own figure is not among them.</b> The counts above the one the walk
+     * reached were never asked for, because the containers ran out first — so a reader told to raise
+     * it would raise it and get the same four.
+     */
     @Test
     void whatWasNotOfferedIsSaid() {
         TermRealizations.Realization.Built built =
                 assertInstanceOf(TermRealizations.Realization.Built.class, offering());
 
-        assertEquals(Set.of(CompositionBudget.ELEMENTS_A_TOTAL_IS_SPREAD_OVER,
-                        CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
+        assertEquals(Set.of(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
                         CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED),
                 built.heldBack(),
-                "the walk stopped at the figure with counts left to try, and a reader told every"
-                        + " container had been refused would act on a walk that never made them");
+                "the walk had a fifth container and no room for it, and offered two of the ways a"
+                        + " count of two is spread — and a reader told every container had been"
+                        + " refused would act on a walk that never made them");
         assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
                 Generator.UnresolvedCombination.Reason.wordFor(built.heldBack()),
                 "and the word such a walk has always come back with is the one it comes back with");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -83,12 +83,13 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
         TermRealizations.Realization.Built built =
                 assertInstanceOf(TermRealizations.Realization.Built.class, offering());
 
-        assertEquals(Set.of(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED,
-                        CompositionBudget.DECOMPOSITIONS_OF_A_TOTAL_OFFERED),
-                built.heldBack(),
-                "the walk had a fifth container and no room for it, and offered two of the ways a"
-                        + " count of two is spread — and a reader told every container had been"
-                        + " refused would act on a walk that never made them");
+        assertEquals(Set.of(CompositionBudget.SHAPES_OF_A_TOTAL_OFFERED), built.heldBack(),
+                "the walk had a fifth container and no room for it, which is the figure a reader"
+                        + " raises — and the counts above the one it reached were never asked for,"
+                        + " so no figure over them took anything away");
+        assertEquals(Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD), built.notAllOf(),
+                "and the ways a count of more than one element is spread are two of the many,"
+                        + " which is not a number anybody raises and is said apart from one");
         assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
                 Generator.UnresolvedCombination.Reason.wordFor(built.heldBack()),
                 "and the word such a walk has always come back with is the one it comes back with");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AsManyContainersAreOfferedAsAreWrittenDownTest.java
@@ -90,7 +90,7 @@ class AsManyContainersAreOfferedAsAreWrittenDownTest {
         assertEquals(Set.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD), built.notAllOf(),
                 "and the ways a count of more than one element is spread are two of the many,"
                         + " which is not a number anybody raises and is said apart from one");
-        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+        assertEquals(Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED,
                 Generator.UnresolvedCombination.Reason.wordFor(built.heldBack()),
                 "and the word such a walk has always come back with is the one it comes back with");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
@@ -26,9 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * a line.
  *
  * <p>The bound still says what it says. A walk that ran out of assignments and one that ran out of
- * budget are different facts about the search, and the second is what {@code SEARCH_LIMIT} is for —
- * it decides the class's answer where nothing else could be written for it, rather than in front of
- * the composition.
+ * budget are different facts about the search, and the second is one of the things
+ * {@code THE_SEARCH_LEFT_SOMETHING_UNTRIED} is for — it decides the class's answer where nothing
+ * else could be written for it, rather than in front of the composition. What the word says is that
+ * something was left, and which of the two ways it was left is what travels beside it.
  */
 class TheCompositionIsNotBehindTheBaselinesBudgetTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest.java
@@ -63,7 +63,7 @@ class ASearchThatSettlesThePointOwesNoAccountOfTheWayToItTest {
     @Test
     void aSearchThatSettledNothingOwesWhatTheWayLeftOut() {
         assertEquals(List.of(new souther.compiler.partition.ReachabilityGap.Unstated(LEFT_OUT)),
-                came(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT).unaccountedFor());
+                came(Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED).unaccountedFor());
         assertEquals(List.of(new souther.compiler.partition.ReachabilityGap.Unstated(LEFT_OUT)),
                 came(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS).unaccountedFor());
         assertEquals(List.of(new souther.compiler.partition.ReachabilityGap.Unstated(LEFT_OUT)),

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
@@ -10,6 +10,7 @@ import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.WayToTheBorder;
+import souther.compiler.publish.PublicationOrders;
 import souther.compiler.source.SourceId;
 
 import java.util.ArrayList;
@@ -227,7 +228,8 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
         return new ItemAssessment.Attempt.Stopped(
                 new Generator.UnresolvedCombination(List.of("p.x = 11"),
                         Generator.UnresolvedCombination.Reason.wordFor(Set.of(budget))),
-                WAY, List.of(), EstablishmentGap.Composition.of(EnumSet.of(budget)));
+                WAY, List.of(), PublicationOrders.COMPOSITION_BUDGETS.keep(EnumSet.of(budget)),
+                PublicationOrders.COMPOSITION_REPERTOIRES.keep(List.of()));
     }
 
     /**
@@ -242,8 +244,8 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
     private static ItemAssessment.Attempt unexhausted() {
         return new ItemAssessment.Attempt.Unexhausted(
                 new Generator.UnresolvedCombination(List.of("List.sum(p.xs) = 7"),
-                        Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
-                WAY, List.of(), EstablishmentGap.Composition.of(List.of(),
+                        Generator.UnresolvedCombination.Reason.THE_SEARCH_LEFT_SOMETHING_UNTRIED),
+                WAY, List.of(), PublicationOrders.COMPOSITION_REPERTOIRES.keep(
                         EnumSet.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD)));
     }
 
@@ -259,7 +261,7 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
         return new ItemAssessment.Attempt.Limited(
                 new Generator.UnresolvedCombination(List.of("p.x = 11"),
                         Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED),
-                WAY, List.of(), EstablishmentGap.Composition.of(
+                WAY, List.of(), PublicationOrders.COMPOSITION_BUDGETS.keep(
                         EnumSet.of(CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS)));
     }
 
@@ -275,7 +277,7 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
                 new Generator.UnresolvedCombination(List.of("p.x = 11"),
                         Generator.UnresolvedCombination.Reason
                                 .NO_READING_OF_THE_LINE_COULD_BE_SEARCHED),
-                WAY, List.of(), EstablishmentGap.Composition.of(
+                WAY, List.of(), PublicationOrders.COMPOSITION_BUDGETS.keep(
                         EnumSet.of(CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.CompositionBudget;
+import souther.compiler.partition.CompositionRepertoire;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.OnTheWay;
 import souther.compiler.partition.WayToTheBorder;
@@ -45,8 +46,8 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
     /** One of each outcome, by the leaf that names it. */
     private static Map<Class<?>, ItemAssessment.Attempt> oneOfEach() {
         Map<Class<?>, ItemAssessment.Attempt> out = new LinkedHashMap<>();
-        for (ItemAssessment.Attempt each : List.of(certified(), unverified(), stopped(), limited(),
-                unplanned(), unresolved(), unavailable())) {
+        for (ItemAssessment.Attempt each : List.of(certified(), unverified(), stopped(),
+                unexhausted(), limited(), unplanned(), unresolved(), unavailable())) {
             out.put(each.getClass(), each);
         }
         return out;
@@ -227,6 +228,23 @@ class EveryOutcomeOfASearchIsClassifiedWhereTheAccountReadsItTest {
                 new Generator.UnresolvedCombination(List.of("p.x = 11"),
                         Generator.UnresolvedCombination.Reason.wordFor(Set.of(budget))),
                 WAY, List.of(), EstablishmentGap.Composition.of(EnumSet.of(budget)));
+    }
+
+    /**
+     * A search that ran to the end of what this compiler writes, which is not the end of what there
+     * is.
+     *
+     * <p>Written with no figure at all, which is the half of this the one above cannot have. Given
+     * a budget as well, the representative would be a stop by another name and would say nothing
+     * about the case this arm exists for: a point left open by work nobody has done rather than by
+     * a number somebody could raise.
+     */
+    private static ItemAssessment.Attempt unexhausted() {
+        return new ItemAssessment.Attempt.Unexhausted(
+                new Generator.UnresolvedCombination(List.of("List.sum(p.xs) = 7"),
+                        Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
+                WAY, List.of(), EstablishmentGap.Composition.of(List.of(),
+                        EnumSet.of(CompositionRepertoire.WAYS_A_TOTAL_IS_SPREAD)));
     }
 
     /**


### PR DESCRIPTION
Closes #1309.

## What was wrong

A total's figures were read off the way the search was set up rather than off what it did. An unbounded container always has counts above the figure over them, so a walk that asked whether it had them recorded that figure before trying anything; entering a count of more than one element recorded the ways a difference is spread as having run out. Neither said a search had stopped. So the set was never empty, the arm below it could not answer that nothing here writes a container for the total, and a point came back naming figures a reader could raise without changing anything.

## The cause underneath

Two facts were sharing one vocabulary.

- A **figure** is a number somebody wrote down. A candidate was in front of the walk and there was no room for it; raise the figure and that candidate gets tried.
- A **population this compiler writes some of** is work nobody has done. The ways a total may be spread over what adds up to it are two, the arrangements of more than one element are many, and no number reaches the rest.

Both leave an offer that is not everything there is, which is why both have to travel. Only the first is anything to raise. Held as one enum, the second arrived at a reader as a figure — and the isEmpty that chose between "nothing composes one" and "this compiler stopped" was reading a set that answered the other question.

## What replaces it

The walks hand each piece to a consumer that says whether its own figure leaves room for it, which is what `Taking` and `Traversal` are already for in this package: a refusal is a piece the walk was holding, and that is the one end that makes a search incomplete. One place writes a figure down, and the composing no longer names a budget, reads a maximum, or holds a predicate about when to record one.

Beside it, `CompositionRepertoire` — a population this compiler offers some of. It is a different type, so nothing downstream can union the two, and it stays beside the figures through every hop to the account: a search that ran to the end of what this compiler writes says so in its own arm rather than as a stop carrying no figure, and the gap at the end holds the two in two fields. A report writes them as two sentences, because raising a number and writing the rest are not the same work.

## What an offer may claim

Completeness is now shown rather than assumed. Two shapes are every arrangement of one element, and every arrangement of a count that no arrangement reaches; anything else is some of them. Assumed the other way, a point where two arrangements were offered and refused is reported as one where every value was refused — the sentence ADR-0091 exists to keep off a point.

## What follows

Writing a third way of spreading a total and letting the search reach it stop being one edit. Every figure is now a number written down, and the sheet that holds the composing stage to registering its figures says so.

## Not covered

Whether a total whose ways down cross a sum now comes back as one nothing composes a container for depends on whether the planning finds a way at all, and no model in this repository takes a total of a list through one. That wants measuring against a model that does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)