### PR TITLE
Read a clause under the binding a helper's expansion made

### DIFF
--- a/docs/adr/0106-a-binders-meaning-belongs-to-the-environment.md
+++ b/docs/adr/0106-a-binders-meaning-belongs-to-the-environment.md
@@ -112,10 +112,23 @@ every rule an author stated by naming it rather than writing it out.
 
 The fold now hands an environment downward beside the answer it carries upward. `ClauseExpr.Scoped`
 marks where that environment changes and composes nothing; `ClauseScope` answers what a binding is
-entered as, and for a reading carrying `Denotations` the answer is `Terms.inside`. No evaluator sees
-that a binding was there, and none of them holds an environment of its own any more: a leaf is read
-at where it stands. `Predicates` reads the body of a binding under the same environment, asking the
-same one place for it, though it still recognises the connectives for itself.
+entered as, and for a reading carrying `Denotations` the answer is `Terms.inside`. No clause
+evaluator is handed a binding **as the clause's shape**, and none of them holds an environment of its
+own any more: a leaf is read at where it stands. `Predicates` reads the body of a binding under the
+same environment, asking the same one place for it, though it still recognises the connectives for
+itself.
+
+**A binding nested inside a leaf stays part of that leaf**, and the decision reaches it there rather
+than by taking the shape further in. Every question asked about the inside of a leaf crosses the
+binding through the environment instead of interpreting the binder: which position an operand is
+(`Terms.subjectOf`), what written value it is (`Terms.asWrittenValue`, and `Terms.folded` over it),
+and which positions a part names (the descents in `AdmissibleReading`, `StatedByClauses` and
+`Predicates`). What the shape settles is where the environment changes; what the leaf language reads
+is unchanged by any of it.
+
+So binding transparency is not a property of the clause's topology. It is a property of every
+semantic question a reading asks about what is inside a leaf, and a question that answers from the
+tree alone is one this decision has not been applied to yet.
 
 A helper-expanded clause is therefore read under the same denotation environment as the equivalent
 inline clause. In particular, passing through a helper is no longer a way for a rule to reach an

--- a/docs/adr/0106-a-binders-meaning-belongs-to-the-environment.md
+++ b/docs/adr/0106-a-binders-meaning-belongs-to-the-environment.md
@@ -103,6 +103,31 @@ readers and is a separate gap (#866); every binder-introducing form is a place w
 has to be applied rather than restated, and where it has not been applied yet the reader in question
 still owns an account of its own.
 
+### Applied to the clause readings
+
+The readings that ask what a declaration's positions admit were such a place. They folded a clause
+into one answer carried upward and had nowhere for a binding to be, so a clause under one arrived as
+a shape none of them had a word for — and since a helper call is expanded as a binding, that is
+every rule an author stated by naming it rather than writing it out.
+
+The fold now hands an environment downward beside the answer it carries upward. `ClauseExpr.Scoped`
+marks where that environment changes and composes nothing; `ClauseScope` answers what a binding is
+entered as, and for a reading carrying `Denotations` the answer is `Terms.inside`. No evaluator sees
+that a binding was there, and none of them holds an environment of its own any more: a leaf is read
+at where it stands. `Predicates` reads the body of a binding under the same environment, asking the
+same one place for it, though it still recognises the connectives for itself.
+
+A helper-expanded clause is therefore read under the same denotation environment as the equivalent
+inline clause. In particular, passing through a helper is no longer a way for a rule to reach an
+admitted-values question without any reading recognising its positions.
+
+This does not make every standing question attributable to a rule-level reading failure. A reading
+may consume the rule completely and still be unable to construct the exact answer its rules come to
+within its allowance; such a loss is about the answer rather than about any rule that paid into it,
+and it remains represented separately (`RuleAccounting.Why.NothingTookItIn`, which is where a
+question with no reason filed under its rule arrives). A question with neither a rule's account nor
+the answer's is the accounting disagreeing with itself and is refused where it is made.
+
 The initializer is now read where a read of the binder asks for it, rather than once before the body.
 A binding the body never reads is no longer read at all, which is the intended reading: what a name
 was given is part of what the name means, and a name nothing reads means nothing to this check.
@@ -113,6 +138,8 @@ is which values reach it.
 ## References
 
 - Issue #867 — an expansion binding a value the arithmetic cannot read is one atom
+- Issue #1333 — a clause reaching its rule through a helper is read less than the same rule written
+  out (this decision applied to the clause readings)
 - ADR-0092 — a helper carries the variables its body leaves open (why almost every binding this
   check reads is one an expansion made)
 - `[#invariant-discharge-terms]`, `[#invariant-discharge-reduction]`

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -219,7 +219,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/check/Resolve#applied(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Ast$Var;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> NewData.read x1",
-            "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;Ljava/util/Map;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
+            "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;Lsouther/compiler/check/Denotations;Ljava/util/Map;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
             "souther/compiler/partition/FixtureTemplate#newtype(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1",
             "souther/compiler/partition/FixtureTemplate#record(Lsouther/compiler/types/TypeReachName$Written;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
             "souther/compiler/partition/FixtureTemplate#spreading(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryPlaceAnAnswerAboutAConstructionIsNamedTest.java
@@ -219,7 +219,7 @@ class EveryPlaceAnAnswerAboutAConstructionIsNamedTest {
             "souther/compiler/check/Resolve#applied(Lsouther/compiler/ast/Ast$Apply;Lsouther/compiler/ast/Ast$Var;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> Apply.read x1",
             "souther/compiler/check/Resolve#expr(Lsouther/compiler/ast/Ast$Expr;Lsouther/compiler/check/Resolve$InForce;)Lsouther/compiler/ast/Hir$Expr; -> NewData.read x1",
-            "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
+            "souther/compiler/check/Terms#asWrittenValue(Lsouther/compiler/core/Core;Ljava/util/Map;)Lsouther/compiler/ast/Hir$Expr; -> Apply.synthetic(String) x2",
             "souther/compiler/partition/FixtureTemplate#newtype(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;)Lsouther/compiler/partition/FixtureTemplate; -> Apply.synthetic(String) x1",
             "souther/compiler/partition/FixtureTemplate#record(Lsouther/compiler/types/TypeReachName$Written;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",
             "souther/compiler/partition/FixtureTemplate#spreading(Lsouther/compiler/types/TypeReachName$Written;Lsouther/compiler/partition/FixtureTemplate;Ljava/util/Map;)Lsouther/compiler/partition/FixtureTemplate; -> NewData.syntheticWithEveryFieldWritten x1",

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadWhatAStringPredicateMeansTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayReadWhatAStringPredicateMeansTest.java
@@ -94,7 +94,8 @@ class WhoMayReadWhatAStringPredicateMeansTest {
             READS,
             READS + IN_A_DESCRIPTOR,
             READS + "#statedByChecked(Lsouther/compiler/core/Core;"
-                    + "Lsouther/compiler/check/Symbols;)L" + OWNER + "$Stated;",
+                    + "Lsouther/compiler/check/Symbols;Lsouther/compiler/check/Terms;"
+                    + "Lsouther/compiler/check/Denotations;)L" + OWNER + "$Stated;",
             READS + "$Reading",
             READS + "$Reading$Accepting",
             READS + "$Reading$Accepting#accepts()Lsouther/compiler/regex/PatternSyntax;",

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -173,7 +173,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * reading stopped at something other than this reading's own limit.
      */
     private PlannedValues<FactSubject> pattern(Core e, boolean states, Denotations at) {
-        StringPredicates.Stated stated = statedIn(e);
+        StringPredicates.Stated stated = statedIn(e, at);
         FactSubject position = stated == null ? null : positionIn(stated.subject(), at);
         if (position == null) {
             return null;
@@ -276,7 +276,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
     private PlannedValues<FactSubject> sided(Core where, Core what, boolean states, Denotations at) {
         FactSubject position = positionIn(where, at);
         Type type = position == null ? null : byName.get(position);
-        Value value = type == null ? null : valueOf(what);
+        Value value = type == null ? null : valueOf(what, at);
         return value == null ? null
                 : PlannedValues.at(position, AdmittedPlan.of(admits(value, states, type)));
     }
@@ -303,7 +303,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      */
     Map<FactSubject, StringRestriction> stringRuleIn(Core e, PlannedValues<FactSubject> said,
                                                     Denotations at) {
-        StringPredicates.Stated stated = statedIn(e);
+        StringPredicates.Stated stated = statedIn(e, at);
         FactSubject position = stated == null ? null : positionIn(stated.subject(), at);
         if (position == null) {
             return Map.of();
@@ -345,11 +345,11 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * about. Asked twice of the table, the two would be one question with two derivations — which
      * is the arrangement {@link StringPredicates} exists to stop, one file further down.
      */
-    private StringPredicates.Stated statedIn(Core e) {
+    private StringPredicates.Stated statedIn(Core e, Denotations at) {
         if (asStated.containsKey(e)) {
             return asStated.get(e);
         }
-        StringPredicates.Stated said = StringPredicates.statedByChecked(e, symbols);
+        StringPredicates.Stated said = StringPredicates.statedByChecked(e, symbols, terms, at);
         asStated.put(e, said);
         return said;
     }
@@ -388,11 +388,11 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * strings joined — is the value it comes to. A case of an enumeration holds nothing and is not
      * folded to anything; what it is is which declaration it is.
      */
-    private Value valueOf(Core e) {
+    private Value valueOf(Core e, Denotations at) {
         if (e instanceof Core.UnitValue unit) {
             return Value.of(unit.data());
         }
-        Object folded = Terms.folded(e, symbols);
+        Object folded = Terms.folded(e, symbols, at);
         if (folded instanceof String text) {
             return Value.text(text);
         }
@@ -419,6 +419,13 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
     }
 
     private void gather(Core e, Set<FactSubject> found, Denotations at) {
+        // A binding is crossed as a binding: its body is what the clause states, read inside it,
+        // and what it was given is not a part of the clause on its own. Walked as an ordinary node,
+        // an argument a helper never reads was counted among the positions the rule names.
+        if (e instanceof Core.LetIn li) {
+            gather(li.body(), found, terms.inside(li, at));
+            return;
+        }
         FactSubject here = terms.subjectOf(e, at);
         if (here != null && byName.containsKey(here)) {
             found.add(here);

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -39,10 +39,9 @@ import java.util.Set;
  * the values can be written out ({@link ValueUniverse}) and is kept as a denial where they cannot,
  * so nothing reaches emptiness except through values this had in hand.
  */
-final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject>> {
+final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject>, Denotations> {
 
     private final Terms terms;
-    private final Denotations at;
     /** What each position of the value is called, and what type stands there. A position is here
      * whether or not it is a number: which values a boolean has is as much an answer as which
      * values an integer has, and the reading that asked the carrier had no word for the first. */
@@ -67,20 +66,23 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      */
     private final Map<Core, StringPredicates.Stated> asStated = new IdentityHashMap<>();
 
-    private AdmissibleReading(Terms terms, Denotations at, Map<FactSubject, Type> byName,
+    private AdmissibleReading(Terms terms, Map<FactSubject, Type> byName,
                               Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
         this.terms = terms;
-        this.at = at;
         this.byName = byName;
         this.symbols = symbols;
         this.alternatives = alternatives;
         this.allowed = allowed;
     }
 
-    /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of. */
-    static AdmissibleReading of(Terms terms, Denotations at, Map<FactSubject, Type> byName,
+    /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of.
+     *
+     *  <p>No environment is held. A leaf is read at where it stands, which the fold hands down; a
+     *  reading holding the environment the clause began in would read a rule under a binding at
+     *  names that mean nothing there, and every such rule came out as a form nothing reads. */
+    static AdmissibleReading of(Terms terms, Map<FactSubject, Type> byName,
                                 Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
-        return new AdmissibleReading(terms, at, byName, symbols, alternatives, allowed);
+        return new AdmissibleReading(terms, byName, symbols, alternatives, allowed);
     }
 
     /** What this reading is spending, for whoever meets its answer with the next rule's. */
@@ -126,25 +128,25 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * ({@link Conditions#restated}), so nothing here asks how the author spelled it.
      */
     @Override
-    public PlannedValues<FactSubject> leaf(Core e, boolean positive) {
+    public PlannedValues<FactSubject> leaf(Core e, boolean positive, Denotations at) {
         if (e instanceof Core.Binary b
                 && Comparison.of(b).map(Comparison::claim).orElse(null)
                         instanceof ComparisonClaim.Singled singled) {
             // Which of the two it states, once the denials above have been counted: what the
             // comparison holds at the value it names, turned over by each denial it stands under.
-            return comparison(b, singled.holdsAtTheValue() == positive);
+            return comparison(b, singled.holdsAtTheValue() == positive, at);
         }
-        PlannedValues<FactSubject> truth = truthValued(e, positive);
+        PlannedValues<FactSubject> truth = truthValued(e, positive, at);
         if (truth != null) {
             return truth;
         }
-        PlannedValues<FactSubject> matched = pattern(e, positive);
-        return matched != null ? matched : unreadable(e);
+        PlannedValues<FactSubject> matched = pattern(e, positive, at);
+        return matched != null ? matched : unreadable(e, at);
     }
 
     /** What naming a position of two values says about it, or null where {@code e} is not one. */
-    private PlannedValues<FactSubject> truthValued(Core e, boolean states) {
-        FactSubject position = positionIn(e);
+    private PlannedValues<FactSubject> truthValued(Core e, boolean states, Denotations at) {
+        FactSubject position = positionIn(e, at);
         Type type = position == null ? null : byName.get(position);
         return type == Type.BOOL
                 ? PlannedValues.at(position,
@@ -170,9 +172,9 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * of the same thing. That is every leaf that is not one of these, and every one of these whose
      * reading stopped at something other than this reading's own limit.
      */
-    private PlannedValues<FactSubject> pattern(Core e, boolean states) {
+    private PlannedValues<FactSubject> pattern(Core e, boolean states, Denotations at) {
         StringPredicates.Stated stated = statedIn(e);
-        FactSubject position = stated == null ? null : positionIn(stated.subject());
+        FactSubject position = stated == null ? null : positionIn(stated.subject(), at);
         if (position == null) {
             return null;
         }
@@ -227,13 +229,13 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
     }
 
     /** What one comparison of a position with a value says, or nothing where it is not one. */
-    private PlannedValues<FactSubject> comparison(Core.Binary b, boolean states) {
-        PlannedValues<FactSubject> read = sided(b.left(), b.right(), states);
+    private PlannedValues<FactSubject> comparison(Core.Binary b, boolean states, Denotations at) {
+        PlannedValues<FactSubject> read = sided(b.left(), b.right(), states, at);
         if (read == null) {
             // `"A" == value` says what `value == "A"` says.
-            read = sided(b.right(), b.left(), states);
+            read = sided(b.right(), b.left(), states, at);
         }
-        return read != null ? read : unreadable(b);
+        return read != null ? read : unreadable(b, at);
     }
 
     /**
@@ -252,8 +254,8 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * ordering comparison and an equality answer alike — written per shape, {@code <} fell through
      * one path and {@code ==} another, and a relation came out as a form nobody could read.
      */
-    private PlannedValues<FactSubject> unreadable(Core e) {
-        return PlannedValues.unreadable(names(e), relatesTwoPositions(e)
+    private PlannedValues<FactSubject> unreadable(Core e, Denotations at) {
+        return PlannedValues.unreadable(names(e, at), relatesTwoPositions(e, at)
                 ? UnreadReason.RELATES_TWO_POSITIONS : UnreadReason.FORM_NOT_READ);
     }
 
@@ -265,14 +267,14 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * there tells an author two different things about one clause. What stays here is how this
      * reading looks a position up.
      */
-    private boolean relatesTwoPositions(Core e) {
-        return Relates.twoPositions(e, this::positionIn);
+    private boolean relatesTwoPositions(Core e, Denotations at) {
+        return Relates.twoPositions(e, part -> positionIn(part, at));
     }
 
     /** The same, with {@code where} read as the position and {@code what} as the value, or null
      * where they are not those. */
-    private PlannedValues<FactSubject> sided(Core where, Core what, boolean states) {
-        FactSubject position = positionIn(where);
+    private PlannedValues<FactSubject> sided(Core where, Core what, boolean states, Denotations at) {
+        FactSubject position = positionIn(where, at);
         Type type = position == null ? null : byName.get(position);
         Value value = type == null ? null : valueOf(what);
         return value == null ? null
@@ -299,9 +301,10 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * the conjunct states such a rule about — a denial and a choice inside it are still the
      * conjunct's.
      */
-    Map<FactSubject, StringRestriction> stringRuleIn(Core e, PlannedValues<FactSubject> said) {
+    Map<FactSubject, StringRestriction> stringRuleIn(Core e, PlannedValues<FactSubject> said,
+                                                    Denotations at) {
         StringPredicates.Stated stated = statedIn(e);
-        FactSubject position = stated == null ? null : positionIn(stated.subject());
+        FactSubject position = stated == null ? null : positionIn(stated.subject(), at);
         if (position == null) {
             return Map.of();
         }
@@ -352,7 +355,7 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
     }
 
     /** The position {@code e} is, or null where it is not one of the positions being read for. */
-    private FactSubject positionIn(Core e) {
+    private FactSubject positionIn(Core e, Denotations at) {
         FactSubject named = terms.subjectOf(e, at);
         return named != null && byName.containsKey(named) ? named : null;
     }
@@ -409,18 +412,18 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * nothing here relates one position to another, so a rule narrowing a position names it — and a
      * rule relating two of them names both and is itself one of these.
      */
-    private Set<FactSubject> names(Core e) {
+    private Set<FactSubject> names(Core e, Denotations at) {
         Set<FactSubject> found = new LinkedHashSet<>();
-        gather(e, found);
+        gather(e, found, at);
         return found;
     }
 
-    private void gather(Core e, Set<FactSubject> found) {
+    private void gather(Core e, Set<FactSubject> found, Denotations at) {
         FactSubject here = terms.subjectOf(e, at);
         if (here != null && byName.containsKey(here)) {
             found.add(here);
             return;   // a position names itself, and nothing under it is a position of its own
         }
-        Core.forEachChild(e, child -> gather(child, found));
+        Core.forEachChild(e, child -> gather(child, found, at));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -74,6 +74,7 @@ public final class AffineForms {
          *  name means is settled once and no reader interprets a binder for itself. */
         E inside(Core.LetIn li, E at);
 
+
         /**
          * The value {@code read}'s name denotes, where the name and that value are one value — or
          * null where the name stands for something of its own and reading through it would say of
@@ -385,6 +386,7 @@ public final class AffineForms {
         public E inside(Core.LetIn li, E at) {
             return of.inside(li, at);
         }
+
 
         @Override
         public ReadThrough<E> readThrough(Core.Read read, E at) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -31,6 +31,14 @@ import java.util.List;
  * a denial and what is under it map to the same shape and both are named. Shapes are not gathered
  * across brackets for the same reason: {@code (a && b) && c} holds a node for {@code a && b}, and a
  * reader asking about it is asking about something the author wrote.
+ *
+ * <p><b>A binding is a shape here, and it is not a connective.</b> What a helper call expands to is
+ * a binding holding the argument and the helper's body written against it (spec
+ * §invariant-discharge-representation), so a clause stating its rule through a helper is a clause
+ * under a binding. {@link Scoped} is where the environment a reading carries changes and nothing
+ * else: it composes no statements, and what is under it is read exactly as the same rule written out
+ * would be. Left as a leaf, it was a form every reading below had no word for, and an author who
+ * named a rule lost the reading an author who repeated it kept.
  */
 sealed interface ClauseExpr {
 
@@ -70,6 +78,23 @@ sealed interface ClauseExpr {
         }
     }
 
+    /**
+     * A binding and the clause under it, which is read in the environment the binding makes.
+     *
+     * <p>Not a connective: it composes nothing, and what it says is what {@link #body} says. What it
+     * marks is where the environment changes, so that a reading meets the leaves under it holding
+     * what their names mean rather than the names alone.
+     *
+     * @param binding the binding as the tree holds it, which the fold hands to {@link ClauseScope}
+     *                — the shape says a binding stands here, and what it means is settled elsewhere
+     */
+    record Scoped(List<Core> spelled, Core.LetIn binding, ClauseExpr body) implements ClauseExpr {
+
+        public Scoped {
+            spelled = named(spelled);
+        }
+    }
+
     private static List<Core> named(List<Core> spelled) {
         if (spelled == null || spelled.isEmpty()) {
             throw new IllegalArgumentException("a shape is what some part of the tree was written as");
@@ -91,6 +116,12 @@ sealed interface ClauseExpr {
     private static ClauseExpr of(Core clause, boolean positive, List<Core> above) {
         List<Core> spelled = new ArrayList<>(above);
         spelled.add(clause);
+        // The scope first, so that what is read under it is read in the environment its names mean
+        // something in. Everything below — a denial, a connective, a leaf — is then the same rule
+        // written out, and a helper whose body denies or joins is this one rule and not another.
+        if (clause instanceof Core.LetIn let) {
+            return new Scoped(spelled, let, of(let.body(), positive, List.of()));
+        }
         Conditions.Restated under = Conditions.restated(clause);
         if (under != null) {
             return of(under.condition(), under.denied() != positive, spelled);

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -17,21 +17,38 @@ import souther.compiler.core.Core;
  * between a branch no order admits and a branch no set of values admits came out open, each language
  * having found nothing wrong with the branch the other one refused.
  *
+ * <p><b>What a clause states is answered upward and what its names mean is handed downward.</b> A
+ * reading composes its leaves into one answer, and that answer is a function of the leaves; the
+ * environment a leaf is read in is a function of the bindings above it, which is the other
+ * direction. Carried only upward, there was nowhere for a binding to be, so a clause under one was
+ * a shape every reading had no word for — and since almost every binding this check meets is one a
+ * helper's expansion made, a rule stated through a helper was read less than the same rule written
+ * out.
+ *
+ * <p>So {@code E} is handed down and {@code S} comes back up, and a leaf is read at the environment
+ * it stands in. What a binding does to that environment is not asked of a reading: the fold finds
+ * the boundary and {@link ClauseScope} answers it, which is what keeps a binder's meaning the
+ * environment's (ADR-0106) rather than something each of three readings works out again.
+ *
  * @param <S> what a reading of a clause comes to
+ * @param <E> what the reading carries into a binding — what its leaves are read at
  */
-interface ClauseReading<S> {
+interface ClauseReading<S, E> {
 
     /** What a clause this reading has no word for leaves, which is everything it had. */
     S nothingSaid();
 
     /**
      * What one clause of no connective says, stated where {@code positive} and denied where it is
-     * not.
+     * not, read at the environment {@code at} it stands in.
      *
      * <p>Reached with the denials already counted, so a reading of a comparison is a reading of the
-     * comparison it states rather than of the one that was written.
+     * comparison it states rather than of the one that was written. And reached with the bindings
+     * above it entered, so a name a helper's expansion introduced denotes what it was given — a
+     * reading that answered from the environment the whole clause began in would be reading one
+     * value's rule at another value's names.
      */
-    S leaf(Core e, boolean positive);
+    S leaf(Core e, boolean positive, E at);
 
     /** Both readings holding at once. */
     S both(S one, S other);
@@ -40,15 +57,16 @@ interface ClauseReading<S> {
     S either(S one, S other);
 
     /**
-     * What {@code e} leaves, stated where {@code positive} and denied where it is not.
+     * What {@code e} leaves, stated where {@code positive} and denied where it is not, read from
+     * {@code at} with {@code scope} answering for the bindings inside it.
      *
      * <p>A denial is carried to the leaves rather than applied to what a branch came to. What a
      * state says is a fact per position, and the denial of that is not one — the values a
      * conjunction rules out are a choice between the positions it named, which no map of positions
      * holds. Carried down, every denial meets a leaf, where it is one.
      */
-    default S read(Core e, boolean positive) {
-        return read(e, positive, null);
+    default S read(Core e, boolean positive, E at, ClauseScope<E> scope) {
+        return read(e, positive, at, scope, null);
     }
 
     /**
@@ -59,16 +77,13 @@ interface ClauseReading<S> {
      * reader is a second reading of the part, and two readings of one conjunct agree only for as
      * long as nobody changes one of them.
      */
-    default S read(Core e, boolean positive, java.util.function.BiConsumer<Core, S> per) {
-        S out = from(e, readInto(e, positive, per));
+    default S read(Core e, boolean positive, E at, ClauseScope<E> scope,
+                   java.util.function.BiConsumer<Core, S> per) {
+        S out = from(e, over(ClauseExpr.of(e, positive), at, scope, per));
         if (per != null) {
             per.accept(e, out);
         }
         return out;
-    }
-
-    private S readInto(Core e, boolean positive, java.util.function.BiConsumer<Core, S> per) {
-        return over(ClauseExpr.of(e, positive), per);
     }
 
     /**
@@ -79,17 +94,24 @@ interface ClauseReading<S> {
      * place and every reading agrees about it by having been given the answer. Two readings that
      * each recognised {@code &&} for themselves agreed until one of them learned something.
      */
-    private S over(ClauseExpr shape, java.util.function.BiConsumer<Core, S> per) {
+    private S over(ClauseExpr shape, E at, ClauseScope<E> scope,
+                   java.util.function.BiConsumer<Core, S> per) {
         S out = switch (shape) {
-            case ClauseExpr.Leaf it -> leaf(it.of(), it.positive());
+            case ClauseExpr.Leaf it -> leaf(it.of(), it.positive(), at);
             case ClauseExpr.Joined it -> switch (it.how()) {
-                case BOTH -> both(over(it.left(), per), over(it.right(), per));
-                case EITHER -> either(over(it.left(), per), over(it.right(), per));
+                case BOTH -> both(over(it.left(), at, scope, per), over(it.right(), at, scope, per));
+                case EITHER -> either(over(it.left(), at, scope, per),
+                        over(it.right(), at, scope, per));
             };
+            // The one place the environment changes, and it changes for what is under the binding
+            // alone. What the binding means is not worked out here and not by the reading either.
+            case ClauseExpr.Scoped it ->
+                    over(it.body(), scope.inside(it.binding(), at), scope, per);
         };
         // Every node that was written as this shape, so a reader asking about the node it is
         // holding finds what this made of it — the denial as well as what is under it, since the
-        // two are one shape.
+        // two are one shape, and the binding as well as the clause under it, since a binding states
+        // what the clause under it states.
         for (Core each : shape.spelled()) {
             out = from(each, out);
             if (per != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseScope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseScope.java
@@ -1,0 +1,35 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+
+/**
+ * What the body of a binding is read in.
+ *
+ * <p>Apart from {@link ClauseReading} because the two answer different questions about one clause. A
+ * reading says what a leaf states and how two statements compose; this says what a name means, which
+ * is the environment's answer and not the reader's (ADR-0106). Held together, every reading would
+ * carry an account of a binder, and three accounts of one thing agree only until somebody changes
+ * one of them.
+ *
+ * <p>So the fold below finds the scope boundary and asks this; no evaluator sees that a binding was
+ * there at all. For a reading carrying {@link Denotations} the answer is {@link Terms#inside}, which
+ * is the one place a {@code let} is entered.
+ *
+ * @param <E> what a reading carries as it goes inside a binding
+ */
+@FunctionalInterface
+interface ClauseScope<E> {
+
+    /** What {@code li}'s body is read in, given what stood outside it. */
+    E inside(Core.LetIn li, E outside);
+
+    /**
+     * The scope of a reading that carries nothing, for which a binding changes nothing.
+     *
+     * <p>Not "a binding this one cannot enter". A reading whose state is a count has no environment
+     * to enter it in, so the body is read as it stands and the answer is exact.
+     */
+    static <E> ClauseScope<E> unchanged() {
+        return (_, outside) -> outside;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseScope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseScope.java
@@ -11,9 +11,15 @@ import souther.compiler.core.Core;
  * carry an account of a binder, and three accounts of one thing agree only until somebody changes
  * one of them.
  *
- * <p>So the fold below finds the scope boundary and asks this; no evaluator sees that a binding was
- * there at all. For a reading carrying {@link Denotations} the answer is {@link Terms#inside}, which
- * is the one place a {@code let} is entered.
+ * <p>So the fold below finds the scope boundary and asks this; no evaluator is handed a binding as
+ * the clause's shape. For a reading carrying {@link Denotations} the answer is {@link Terms#inside},
+ * which is the one place a {@code let} is entered.
+ *
+ * <p><b>A binding nested inside a leaf is still part of that leaf</b>, and this is not where it is
+ * crossed. What crosses it there is each question the leaf language asks about its own inside —
+ * which position an operand is, what written value it is, which positions a part names — and each
+ * of those asks the environment rather than working the binder out. A question there that answers
+ * from the tree alone is one this decision has not reached (ADR-0106).
  *
  * @param <E> what a reading carries as it goes inside a binding
  */

--- a/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
@@ -29,8 +29,13 @@ import java.util.List;
  * <p>The count saturates at one past the limit it was asked about. Past that the number is not
  * wanted — what is asked of it is whether the limit is exceeded — and a conjunction of choices
  * leaves the range of a count long before it leaves the range of what an author can write.
+ *
+ * <p>A binding neither adds nor multiplies: what a clause under one comes to is what the clause
+ * comes to. So this carries no environment and its scope leaves what it was given
+ * ({@link ClauseScope#unchanged}) — the count is over the shape, and a shape that composes nothing
+ * costs nothing of its own.
  */
-final class ExpansionCost implements ClauseReading<Long> {
+final class ExpansionCost implements ClauseReading<Long, Void> {
 
     /** One past the limit, which is where the arithmetic stops.
      *
@@ -54,7 +59,7 @@ final class ExpansionCost implements ClauseReading<Long> {
         ExpansionCost counting = new ExpansionCost(limit);
         long cost = counting.nothingSaid();
         for (Core clause : clauses) {
-            cost = counting.both(cost, counting.read(clause, true));
+            cost = counting.both(cost, counting.read(clause, true, null, ClauseScope.unchanged()));
         }
         return cost;
     }
@@ -73,7 +78,7 @@ final class ExpansionCost implements ClauseReading<Long> {
      * leaves come out costing nothing and be admitted under any budget.
      */
     @Override
-    public Long leaf(Core e, boolean positive) {
+    public Long leaf(Core e, boolean positive, Void at) {
         return 1L;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1059,10 +1059,32 @@ public final class FieldDomains {
             return new RuleAccounting.Why.TheValueReadingSays(why);
         }
         if (unreadByName.getOrDefault(at, List.of()).stream()
-                .noneMatch(each -> each.about() == UnreadReason.About.THE_ANSWER)) {
+                .noneMatch(FieldDomains::standsInForARulesOwnAccount)) {
             throw new AStandingQuestionWithNoAccount(rule, named);
         }
         return new RuleAccounting.Why.NothingTookItIn();
+    }
+
+    /**
+     * Whether {@code why} accounts for a question a rule left standing, in place of the rule's own
+     * account of it.
+     *
+     * <p>Named and asked once, because it is the whole of the refusal above: written inline as a
+     * test of the shape a reason is not, a reason of the third kind stood in for an account that is
+     * not there. Its three answers are the three kinds a reason is about, so a reason added to any
+     * of them is decided here rather than by where it happens to be written.
+     *
+     * <p>A reason about the answer does stand in: an allowance run down by everything a position
+     * admits is a fact about what the rules come to and about none of them, so no rule is answerable
+     * for it and none is filed. A reason about a rule does not — it is filed under its rule and
+     * reached before this. A reason about neither accounts for nothing, which is what it says: the
+     * reading never got to the position.
+     */
+    static boolean standsInForARulesOwnAccount(UnreadReason why) {
+        return switch (why.about()) {
+            case THE_ANSWER -> true;
+            case A_RULE, NEITHER -> false;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1038,17 +1038,20 @@ public final class FieldDomains {
      * there is named beside a limit that belongs to its neighbour, which is the misattribution the
      * whole accounting is asked per rule to avoid.
      *
-     * <p>A form this reading has no word for where it recorded nothing of the rule there. What
-     * reaches here is a rule no reading took in, so this reading was short of it however little it
-     * wrote down — and an empty answer would say a question stands with nothing behind it. Not the
-     * name's reasons: those belong to whichever rule left them.
+     * <p>Not the name's other reasons: those belong to whichever rule left them, and a rule answered
+     * from the name is named beside a limit that is its neighbour's.
      *
-     * <p><b>Except for the reasons no rule can be answerable for</b>, which is the one thing the
-     * name is asked. An allowance run down by everything a position admits is a fact about the
-     * answer and not about any rule that paid into it, and {@link ReadingEvidence#stoppedBy} refuses
-     * such a reason rather than filing it under a rule — so a question standing for that reason has
-     * nothing under the rule by construction, and finding nothing there is not the two accounts
-     * coming apart.
+     * <p><b>The name is asked one thing, and it is whether the answer accounts for the question.</b>
+     * An allowance run down by everything a position admits is a fact about the answer and not about
+     * any rule that paid into it ({@link UnreadReason.About#THE_ANSWER}), and
+     * {@link ReadingEvidence#stoppedBy} refuses such a reason rather than filing it under a rule. So
+     * a question standing for that reason has nothing under its rule by construction, and that is
+     * what tells it from the accounting coming apart.
+     *
+     * <p>Asked as itself and not as "not about a rule". A reason is about a rule, about the answer,
+     * or about neither, and the third is a reading that never reached the position — which accounts
+     * for nothing, as its name says. Written as the complement of the first, one of those at the
+     * name would stand in for an account that is not there.
      */
     private RuleAccounting.Why stoppedBy(RuleRef rule, RuleKey at, List<FactSubject> named) {
         List<UnreadReason> why = took.stoppedBy(rule, named);
@@ -1056,7 +1059,7 @@ public final class FieldDomains {
             return new RuleAccounting.Why.TheValueReadingSays(why);
         }
         if (unreadByName.getOrDefault(at, List.of()).stream()
-                .allMatch(each -> each.about() == UnreadReason.About.A_RULE)) {
+                .noneMatch(each -> each.about() == UnreadReason.About.THE_ANSWER)) {
             throw new AStandingQuestionWithNoAccount(rule, named);
         }
         return new RuleAccounting.Why.NothingTookItIn();

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1015,7 +1015,7 @@ public final class FieldDomains {
         // one conjunct is not an account of the conjunct written beside it.
         if (took.anyLeftStanding(rule, named)) {
             return new RuleAccounting.Outcome.Unaccounted(
-                    stoppedBy(rule, named));
+                    stoppedBy(rule, at, named));
         }
         // The reading that turns this clause into where the values stop, said by the end it placed.
         if (directs.stream()
@@ -1027,7 +1027,7 @@ public final class FieldDomains {
         if (took.tookIn(rule, named)) {
             return new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_VALUE_READING);
         }
-        return new RuleAccounting.Outcome.Unaccounted(stoppedBy(rule, named));
+        return new RuleAccounting.Outcome.Unaccounted(stoppedBy(rule, at, named));
     }
 
     /**
@@ -1042,16 +1042,45 @@ public final class FieldDomains {
      * reaches here is a rule no reading took in, so this reading was short of it however little it
      * wrote down — and an empty answer would say a question stands with nothing behind it. Not the
      * name's reasons: those belong to whichever rule left them.
+     *
+     * <p><b>Except for the reasons no rule can be answerable for</b>, which is the one thing the
+     * name is asked. An allowance run down by everything a position admits is a fact about the
+     * answer and not about any rule that paid into it, and {@link ReadingEvidence#stoppedBy} refuses
+     * such a reason rather than filing it under a rule — so a question standing for that reason has
+     * nothing under the rule by construction, and finding nothing there is not the two accounts
+     * coming apart.
      */
-    private RuleAccounting.Why stoppedBy(RuleRef rule, List<FactSubject> named) {
+    private RuleAccounting.Why stoppedBy(RuleRef rule, RuleKey at, List<FactSubject> named) {
         List<UnreadReason> why = took.stoppedBy(rule, named);
-        // Nothing recorded, so nothing is answerable for it. A rule reaches the readings that
-        // recognise the names it writes, and one about a name none of them knows — a field
-        // of a value a helper reads, reached through the call — is claimed by none of them and
-        // gave none of them anything to write down. Named as the value reading's, an author is
-        // sent to a reader that never held their clause.
-        return why.isEmpty() ? new RuleAccounting.Why.NothingTookItIn()
-                : new RuleAccounting.Why.TheValueReadingSays(why);
+        if (!why.isEmpty()) {
+            return new RuleAccounting.Why.TheValueReadingSays(why);
+        }
+        if (unreadByName.getOrDefault(at, List.of()).stream()
+                .allMatch(each -> each.about() == UnreadReason.About.A_RULE)) {
+            throw new AStandingQuestionWithNoAccount(rule, named);
+        }
+        return new RuleAccounting.Why.NothingTookItIn();
+    }
+
+    /**
+     * A question left standing that neither a rule nor the answer has an account of.
+     *
+     * <p>Two walks and one clause. A rule reaches this reading, which either adopts it or records
+     * where it gave up; a question stands where nothing adopted it. So a question standing with no
+     * account under the rule and none at the name either is the two coming apart — the rule was met
+     * by the walk that asks and by nothing that reads.
+     *
+     * <p>Not an ordinary limit, so not swallowed. Answered as one, an author is told that this
+     * compiler has no word for their rule, which is a sentence about their model printed because two
+     * of this compiler's accounts disagreed.
+     */
+    static final class AStandingQuestionWithNoAccount extends TheCheckDisagreesWithItself {
+
+        private static final long serialVersionUID = 1L;
+
+        AStandingQuestionWithNoAccount(RuleRef rule, List<FactSubject> named) {
+            super("a question stands that nothing accounts for: " + rule + " at " + named);
+        }
     }
 
     /** Every subject the place at {@code path} answers to. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -772,7 +772,7 @@ public final class InvariantChecker {
             // One reader for this value's positions, used over however many clauses reach it, and
             // the one that decides the choices in what they came to.
             StatedByClauses.Reading reader = StatedByClauses
-                    .readingOf(c.terms, at, positions, symbols, alternatives, allowed);
+                    .readingOf(c.terms, positions, symbols, alternatives, allowed);
             // What each clause said and what each part of it said, kept as they were read and
             // asked afterwards. Which branch of a choice anybody can take turns on clauses not yet
             // read and on machines nobody has made at this point, and every one of these questions
@@ -786,7 +786,7 @@ public final class InvariantChecker {
             // where its clauses landed in a table.
             StatedByClauses.Asked<Written> asked = new StatedByClauses.Asked<>();
             for (Written each : written) {
-                asked.read(reader, each, each.clause());
+                asked.read(reader, at, each, each.clause());
             }
             // And now that every rule about this value has been said, what its positions admit is
             // worked out — and with it what each clause and each part of it took in, since a branch

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1586,7 +1586,7 @@ public final class InvariantChecker {
         // either: what it compares the coordinate to is a constant this read perfectly. So it falls
         // out here rather than being filed as a clause that could have moved an edge.
         InvariantBound.Read end = found != null && said instanceof ComparisonClaim.Cut cut
-                ? InvariantBound.at(cut, Terms.asWrittenValue(bound), found.carrier())
+                ? InvariantBound.at(cut, Terms.asWrittenValue(bound, at), found.carrier())
                 : new InvariantBound.Read.NoEnd();
         Coordinate about = found;
         // What the clause is about, asked of the comparison and not of what `end` came to. A

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1476,6 +1476,22 @@ public final class InvariantChecker {
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing,
                         PartsLeftOut withoutParts) {
+        // A binding is crossed, and what is under it is one part however it is written. The body is
+        // what the clause states, read inside it (ADR-0106) — so a rule stating its end through a
+        // helper places the line the same rule written out places, where it used to reach no
+        // comparison at all and the declaration came back with no line drawn on it.
+        //
+        // And crossed rather than descended into: the conjuncts of a clause are what its author
+        // wrote ({@link ClauseHelpers#conjunctsOf}, over the tree before any expansion), so a
+        // helper whose body joins two rules is one conjunct. Split here, this reading would number
+        // parts the reading beside it does not, and a line drawn here would be recognised as
+        // another one's.
+        if (clause instanceof Core.LetIn li) {
+            underABinding(li.body(), from, conjunct, terms.inside(li, at), byName, out, noLines,
+                    withoutAnEnd, naming, namingTheStrings, narrowers, raised, took, typeAt, parts,
+                    raisedByPart, standing, withoutParts);
+            return;
+        }
         if (clause instanceof Core.Binary and
                 && ConditionJoin.of(and.op()).orElse(null) == ConditionJoin.BOTH) {
             // One rule the author wrote, so what it raises is what its conjuncts raise together.
@@ -1489,6 +1505,39 @@ public final class InvariantChecker {
             direct(and.right(), from, conjunct, at, byName, out, noLines, withoutAnEnd, naming,
                     namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart,
                     standing, withoutParts);
+            return;
+        }
+        underABinding(clause, from, conjunct, at, byName, out, noLines, withoutAnEnd, naming,
+                namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart, standing,
+                withoutParts);
+    }
+
+    /**
+     * One conjunct of the clause, read where it stands.
+     *
+     * <p>Apart from {@link #direct} because what is above it is the conjunct topology and what is
+     * here is one part of it. A binding is crossed here too — a helper calling a helper is bindings
+     * all the way down — and crossing one never makes another part: which parts a clause has is
+     * what its author wrote, and an expansion writes nothing.
+     */
+    private void underABinding(Core clause, RuleRef.Invariant from, int[] conjunct, Denotations at,
+                        Map<FactSubject, Coordinate> byName, List<Direct> out,
+                        List<FieldDomains.NoLine> noLines,
+                        List<FieldDomains.WithoutAnEnd> withoutAnEnd,
+                        List<FieldDomains.AboutOneCoordinate> naming,
+                        List<FieldDomains.AboutOneCoordinate> namingTheStrings,
+                        Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
+                        Map<RuleRef, Required> raised, ReadingEvidence took,
+                        Map<RuleKey, Type> typeAt,
+                        PartsRead parts,
+                        Map<RuleRef, Map<Core, Required>> raisedByPart,
+                        Map<FieldDomains.BoundaryQuestion,
+                                FieldDomains.BoundaryStanding> standing,
+                        PartsLeftOut withoutParts) {
+        if (clause instanceof Core.LetIn li) {
+            underABinding(li.body(), from, conjunct, terms.inside(li, at), byName, out, noLines,
+                    withoutAnEnd, naming, namingTheStrings, narrowers, raised, took, typeAt, parts,
+                    raisedByPart, standing, withoutParts);
             return;
         }
         // Which conjunct of the clause this is, taken here so that every one of them is numbered —

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -124,7 +124,7 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
         if (carrier == null) {
             return OrderedIntervals.top();
         }
-        Hir.Expr written = Terms.asWrittenValue(bound);
+        Hir.Expr written = Terms.asWrittenValue(bound, at);
         // Denied, a comparison is the one that leaves what it leaves out. `!(value /= x)` is an
         // equality and is read; `!(value == x)` is a disequality and is not, which is the same
         // answer the disequality gets when it is written directly.

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -48,21 +48,23 @@ import java.util.Map;
  * end, and the values a denial leaves are a set rather than a range. Under a denial the two swap
  * places, which is the same rule read once.
  */
-final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject>> {
+final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject>, Denotations> {
 
     private final Terms terms;
-    private final Denotations at;
     /** What each position's values are ordered on, for the positions that are ordered at all. */
     private final Map<FactSubject, Carrier> carriers;
 
-    private OrderedReading(Terms terms, Denotations at, Map<FactSubject, Carrier> carriers) {
+    private OrderedReading(Terms terms, Map<FactSubject, Carrier> carriers) {
         this.terms = terms;
-        this.at = at;
         this.carriers = carriers;
     }
 
-    /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of. */
-    static OrderedReading of(Terms terms, Denotations at, Map<FactSubject, Type> byName, Symbols symbols) {
+    /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of.
+     *
+     *  <p>No environment is held. Which environment a leaf is read at is where the leaf stands,
+     *  which the fold hands down — kept here, a rule under a binding would be read at the names the
+     *  clause began with. */
+    static OrderedReading of(Terms terms, Map<FactSubject, Type> byName, Symbols symbols) {
         Map<FactSubject, Carrier> carriers = new LinkedHashMap<>();
         byName.forEach((name, type) -> {
             Carrier carrier = Carrier.ofValue(type, symbols);
@@ -70,7 +72,7 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
                 carriers.put(name, carrier);
             }
         });
-        return new OrderedReading(terms, at, carriers);
+        return new OrderedReading(terms, carriers);
     }
 
     @Override
@@ -97,23 +99,24 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
      * step.
      */
     @Override
-    public OrderedIntervals<FactSubject> leaf(Core e, boolean positive) {
-        return e instanceof Core.Binary bin ? comparison(bin, positive) : OrderedIntervals.top();
+    public OrderedIntervals<FactSubject> leaf(Core e, boolean positive, Denotations at) {
+        return e instanceof Core.Binary bin ? comparison(bin, positive, at) : OrderedIntervals.top();
     }
 
     /** Where one comparison leaves the position it names, or nothing where it names none. */
-    private OrderedIntervals<FactSubject> comparison(Core.Binary bin, boolean positive) {
+    private OrderedIntervals<FactSubject> comparison(Core.Binary bin, boolean positive,
+                                                     Denotations at) {
         Comparison read = Comparison.of(bin).orElse(null);
         if (read == null) {
             return OrderedIntervals.top();
         }
         // The position-bearing side read as the left one, as `0 <= value` says what `value >= 0`
         // says.
-        FactSubject position = positionIn(bin.left());
+        FactSubject position = positionIn(bin.left(), at);
         Core bound = bin.right();
         ComparisonClaim claim = read.claim();
         if (position == null) {
-            position = positionIn(bin.right());
+            position = positionIn(bin.right(), at);
             bound = bin.left();
             claim = claim.turned();
         }
@@ -176,7 +179,7 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
     }
 
     /** The position {@code e} is, or null where it is not one this is reading for. */
-    private FactSubject positionIn(Core e) {
+    private FactSubject positionIn(Core e, Denotations at) {
         FactSubject named = terms.subjectOf(e, at);
         return named != null && carriers.containsKey(named) ? named : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -171,6 +171,12 @@ final class Predicates {
         if (handed.contains(terms.subjectOf(e, at))) {
             return true;
         }
+        // A binding is crossed as a binding. Its body is what the clause names, read inside it; what
+        // it was given is reached through the name where the body reads it, and is not a part of the
+        // clause on its own.
+        if (e instanceof Core.LetIn li) {
+            return names(li.body(), handed, terms.inside(li, at));
+        }
         boolean[] found = {false};
         Core.forEachChild(e, child -> found[0] = found[0] || names(child, handed, at));
         return found[0];
@@ -792,7 +798,7 @@ final class Predicates {
      *  value it names. */
     private Owed owedBy(Core inv, Denotations at, Set<FactSubject> unnamed, boolean positive,
                         boolean decidesFalse) {
-        Boolean folded = decidedAt(inv);
+        Boolean folded = decidedAt(inv, at);
         Owed decided = decidedBy(folded, positive, decidesFalse);
         return decided != null ? decided
                 : owing(inv, foldOf(folded), null, null, new Conditions.Polar(inv, positive),
@@ -803,7 +809,7 @@ final class Predicates {
      *  was handed and so the one a report about the clause names. */
     private Owed owedBy(StatedComparison stated, Core inv, Denotations at, Set<FactSubject> unnamed,
                         boolean positive, boolean decidesFalse, Discharge discharge) {
-        Boolean folded = decidedAt(stated);
+        Boolean folded = decidedAt(stated, at);
         Owed decided = decidedBy(folded, positive, decidesFalse);
         if (decided != null) {
             return decided;
@@ -934,8 +940,8 @@ final class Predicates {
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
      * already standing where it read a field, folded. {@code null} where it does not fold — which is
      * every clause reading anything computed at run time. */
-    Boolean decidedAt(Core inv) {
-        Object folded = Terms.folded(inv, terms.symbols());
+    Boolean decidedAt(Core inv, Denotations at) {
+        Object folded = Terms.folded(inv, terms.symbols(), at);
         return folded instanceof Boolean b ? b : null;
     }
 
@@ -949,9 +955,9 @@ final class Predicates {
      * {@code Int.compare(1, 2) >= 0} folds through nothing the library declares, and the order it
      * states of {@code 1} and {@code 2} is settled here.
      */
-    private Boolean decidedAt(StatedComparison stated) {
-        Object left = Terms.folded(stated.left(), terms.symbols());
-        Object right = Terms.folded(stated.right(), terms.symbols());
+    private Boolean decidedAt(StatedComparison stated, Denotations at) {
+        Object left = Terms.folded(stated.left(), terms.symbols(), at);
+        Object right = Terms.folded(stated.right(), terms.symbols(), at);
         return (left == null || right == null) ? null
                 : ConstEval.stands(stated.claim().statedRelation(), left, right);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -698,6 +698,16 @@ final class Predicates {
     private Owed read(Core inv, Denotations at, Set<Core> unnamed,
                       boolean positive, boolean decidesFalse, Discharge discharge,
                       PerPart per, PartsToRead parts) {
+        // A clause under a binding states what the clause states, read where its names mean
+        // something. Almost every binding here is one a helper's expansion made, so a rule stated
+        // through a helper is one of these — and read as it stands it is a shape stating no
+        // comparison, which is why a construction the guards refute was only ever refuted where the
+        // author had written the rule out. What the binder means is not worked out here: it is the
+        // environment's answer, and this asks for it (ADR-0106).
+        if (inv instanceof Core.LetIn li) {
+            return obligations(li.body(), terms.inside(li, at), unnamed, positive, decidesFalse,
+                    discharge, per, parts);
+        }
         if (inv instanceof Core.Binary b
                 && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
                         == ConditionJoin.BOTH) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -113,6 +113,15 @@ final class Predicates {
             return;
         }
         Core e = Conditions.asSizeComparison(raw);
+        // A clause under a binding states what the clause states, read where its names mean
+        // something — the same rule the obligations of this clause are read under, and applied here
+        // because the two are read out of one clause. Stopping here alone, a quantifier an author
+        // stated through a helper was owed by the one reading and unknown to the other, which is a
+        // guarantee assembled from a clause read to two depths.
+        if (e instanceof Core.LetIn li) {
+            quantifiedBy(li.body(), terms.inside(li, at), positive, out, parts);
+            return;
+        }
         if (e instanceof Core.Binary b
                 && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
                         == ConditionJoin.BOTH) {
@@ -144,14 +153,36 @@ final class Predicates {
         out.add(new Quantified(container, carried.through(), over.step()));
     }
 
-    /** Whether {@code e} is, or names, one of {@code values}. */
-    static boolean names(Core e, Set<Core> values) {
-        if (values.contains(e)) {
+    /**
+     * Whether {@code e} is, or names, one of the values {@code handed} stands for.
+     *
+     * <p>Asked of what each part of {@code e} denotes and not of the tree it is written as. The
+     * values a site hands over stand in the clause, and a binding may stand between: an expansion
+     * leaves {@code let $n = <value> in ...}, and what is written where the value was is a read of
+     * the binder. Matched by the node, the clause a helper states came out naming none of them,
+     * while the same clause written out named one — so a value no guard can be written about was
+     * owed a guard for having been reached through a helper.
+     *
+     * <p>Which is the identity question every other reader here asks by subject, and it is asked the
+     * same way: a binding is entered as what it was given ({@link Terms#inside}), so a read of the
+     * binder is the value it was given, and the two spellings name the same thing.
+     */
+    private boolean names(Core e, Set<FactSubject> handed, Denotations at) {
+        if (handed.contains(terms.subjectOf(e, at))) {
             return true;
         }
         boolean[] found = {false};
-        Core.forEachChild(e, child -> found[0] = found[0] || names(child, values));
+        Core.forEachChild(e, child -> found[0] = found[0] || names(child, handed, at));
         return found[0];
+    }
+
+    /** What each of {@code values} is, where the site that hands them over stands. */
+    private Set<FactSubject> handedOver(Set<Core> values, Denotations at) {
+        Set<FactSubject> out = new java.util.LinkedHashSet<>();
+        for (Core value : values) {
+            out.add(terms.subjectOf(value, at));
+        }
+        return out;
     }
 
     /**
@@ -663,8 +694,10 @@ final class Predicates {
      * clause may be read against. */
     Owed obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
                      boolean decidesFalse) {
-        return obligations(inv, at, unnamed, true, decidesFalse, Discharge.spending(k), null,
-                PartsToRead.ALL);
+        // What each handed-over value is, worked out once and where the site stands. Read again
+        // further down, a value under a binding would be asked about at names the site never had.
+        return obligations(inv, at, handedOver(unnamed, at), true, decidesFalse,
+                Discharge.spending(k), null, PartsToRead.ALL);
     }
 
     /**
@@ -674,7 +707,7 @@ final class Predicates {
      * name is one thing, and the date a day after it is another — so the one that answers is the one
      * taken. Reading a predicate never takes a reading away.
      */
-    private Owed obligations(Core rawInv, Denotations at, Set<Core> unnamed,
+    private Owed obligations(Core rawInv, Denotations at, Set<FactSubject> unnamed,
                              boolean positive, boolean decidesFalse, Discharge discharge,
                              PerPart per, PartsToRead parts) {
         // A clause of one conjunct is that conjunct, so a caller leaving it out leaves out the
@@ -695,7 +728,7 @@ final class Predicates {
 
     /** What {@code inv} owes, read as it stands. Its parts are read through {@link #obligations},
      * which is where each of them is taken as the comparison it states. */
-    private Owed read(Core inv, Denotations at, Set<Core> unnamed,
+    private Owed read(Core inv, Denotations at, Set<FactSubject> unnamed,
                       boolean positive, boolean decidesFalse, Discharge discharge,
                       PerPart per, PartsToRead parts) {
         // A clause under a binding states what the clause states, read where its names mean
@@ -757,7 +790,7 @@ final class Predicates {
     /** What a clause that states no comparison owes: it may fold, and it may be a predicate a guard
      *  settles by name. Stated as itself, because a condition that is not a comparison is the one
      *  value it names. */
-    private Owed owedBy(Core inv, Denotations at, Set<Core> unnamed, boolean positive,
+    private Owed owedBy(Core inv, Denotations at, Set<FactSubject> unnamed, boolean positive,
                         boolean decidesFalse) {
         Boolean folded = decidedAt(inv);
         Owed decided = decidedBy(folded, positive, decidesFalse);
@@ -768,7 +801,7 @@ final class Predicates {
 
     /** What a clause owes where it states {@code stated}, with {@code inv} the expression the caller
      *  was handed and so the one a report about the clause names. */
-    private Owed owedBy(StatedComparison stated, Core inv, Denotations at, Set<Core> unnamed,
+    private Owed owedBy(StatedComparison stated, Core inv, Denotations at, Set<FactSubject> unnamed,
                         boolean positive, boolean decidesFalse, Discharge discharge) {
         Boolean folded = decidedAt(stated);
         Owed decided = decidedBy(folded, positive, decidesFalse);
@@ -804,11 +837,11 @@ final class Predicates {
      * this reading composed stands nowhere and would name a comparison nobody can be shown.
      */
     private Owed owing(Core where, Fold fold, NumericConstraint numeric, Piecewise piecewise,
-                       Conditions.Polar polar, Set<Core> unnamed, Denotations at) {
+                       Conditions.Polar polar, Set<FactSubject> unnamed, Denotations at) {
         // A predicate over a value no guard could be written about is not a predicate a guard will
         // settle, so it is not owed as one — where the domain can say something of that value it has
         // already said it above, and where it cannot the run-time check stands for the clause.
-        List<FactSubject> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
+        List<FactSubject> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed, at)
                 ? List.of() : factKeys(polar.expr(), at);
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -232,11 +232,14 @@ public final class RuleAccounting {
      * which is the sentence #842 is about, one level down.
      *
      * <p><b>And one arm that names no reading.</b> A question stands where no reading adopted the
-     * rule, which is not the same as a reading having been asked and fallen short: the readings a
-     * clause reaches are the ones that recognise the positions it names, and a clause about a
-     * position none of them knows is claimed by none of them. Answered with a reading's arm, such a
-     * question is attributed to a reader that never held the rule — and the account then says which
-     * capability of that reader would lift it, which is a sentence about the wrong reader.
+     * rule, and what stopped things is then not always a fact about the rule: a reading may consume
+     * the rule entirely and still be unable to build the exact answer its rules come to within its
+     * allowance. Answered with a reading's arm, such a question is attributed to a reader that was
+     * not short of anything — and the account then says which capability of that reader would lift
+     * it, which is a sentence about the wrong thing.
+     *
+     * <p>A question with neither is the accounting disagreeing with itself and is refused where it
+     * is made ({@link FieldDomains.AStandingQuestionWithNoAccount}).
      */
     public sealed interface Why {
 
@@ -321,12 +324,21 @@ public final class RuleAccounting {
         }
 
         /**
-         * No reading took the rule in, and none of them recorded why.
+         * The question stands, and no reading has a reason attributable to the rule that raised it.
          *
-         * <p>Nothing to carry, and that is what it says. The readings that record a reason are the
-         * ones that recognised the position and gave up on the rule about it; where the position is
-         * one none of them knows, the rule is claimed by nobody and there is no reader whose
-         * account this could be.
+         * <p>Nothing to carry, and that is what it says. The arms beside it are a reading's own
+         * words for where it gave up on <em>this rule</em>; here there are none, and what stands in
+         * their place is a fact about something other than the rule.
+         *
+         * <p>One way this happens is that the rule was read in full and composing the exact answer
+         * ran past the allowance. That loss is about the answer rather than about any rule that paid
+         * into it — the same rules met in another order would have been built — so it is refused
+         * where reasons are filed under rules ({@link ReadingEvidence#stoppedBy}) and reaches the
+         * question as this.
+         *
+         * <p>Said as "no reading" rather than "no reason about the rule", which is what it is. The
+         * name is older than the state it now holds and the reading did take the rule in; see the
+         * issue on what an answer-level limit should be called out there.
          */
         record NothingTookItIn() implements Why {}
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -292,11 +292,11 @@ sealed interface StatedByClauses {
 
     /** The reading of one value's positions, made once and used over however many clauses reach it.
      *  Built per clause, this walk paid for a pair of readers at every clause of every value. */
-    static Reading readingOf(Terms terms, Denotations at, Map<FactSubject, Type> byName,
+    static Reading readingOf(Terms terms, Map<FactSubject, Type> byName,
                              Symbols symbols, Alternatives alternatives,
                              souther.compiler.values.Allowance<FactSubject> allowed) {
-        return new Reading(AdmissibleReading.of(terms, at, byName, symbols, alternatives, allowed),
-                OrderedReading.of(terms, at, byName, symbols), terms, at, byName, alternatives);
+        return new Reading(AdmissibleReading.of(terms, byName, symbols, alternatives, allowed),
+                OrderedReading.of(terms, byName, symbols), terms, byName, alternatives);
     }
 
 
@@ -312,9 +312,15 @@ sealed interface StatedByClauses {
      * value there is. That is the same reconstruction {@code Predicates.Assumed} keeps a field of
      * its own to avoid, and the one this accounting was written against.
      */
-    record Reading(AdmissibleReading values, OrderedReading ordered, Terms terms, Denotations at,
+    record Reading(AdmissibleReading values, OrderedReading ordered, Terms terms,
                    Map<FactSubject, Type> byName, Alternatives alternatives)
-            implements ClauseReading<StatedByClauses> {
+            implements ClauseReading<StatedByClauses, Denotations> {
+
+        /** What a binding under a clause is entered as, for a fold over this reading. The one
+         *  answer there is, asked of the one place that gives it (ADR-0106). */
+        ClauseScope<Denotations> scope() {
+            return terms::inside;
+        }
 
         @Override
         public StatedByClauses nothingSaid() {
@@ -331,10 +337,10 @@ sealed interface StatedByClauses {
          * than one.
          */
         @Override
-        public StatedByClauses leaf(Core e, boolean positive) {
-            souther.compiler.values.PlannedValues<FactSubject> said = values.leaf(e, positive);
-            OrderedIntervals<FactSubject> range = ordered.leaf(e, positive);
-            Set<FactSubject> mentions = mentioned(e);
+        public StatedByClauses leaf(Core e, boolean positive, Denotations at) {
+            souther.compiler.values.PlannedValues<FactSubject> said = values.leaf(e, positive, at);
+            OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
+            Set<FactSubject> mentions = mentioned(e, at);
             return new Said(said, range,
                     // Each language says whether it gave up on the leaf. The reading of values
                     // carries it; the reading of order has nothing to hand back but its ranges, and
@@ -344,7 +350,7 @@ sealed interface StatedByClauses {
                     // And what the leaf states about the strings at a position, where it is a rule
                     // about them. Asked of the reading that recognises one, so this is where the
                     // answer enters and the connectives below are what compose it.
-                    values.stringRuleIn(e, said),
+                    values.stringRuleIn(e, said, at),
                     Map.of());
         }
 
@@ -354,19 +360,19 @@ sealed interface StatedByClauses {
          * <p>A fact about the clause and not about either language, which is why it is read here
          * and once. A position names itself, and nothing under it is a position of its own.
          */
-        private Set<FactSubject> mentioned(Core e) {
+        private Set<FactSubject> mentioned(Core e, Denotations at) {
             Set<FactSubject> found = new LinkedHashSet<>();
-            gather(e, found);
+            gather(e, found, at);
             return found;
         }
 
-        private void gather(Core e, Set<FactSubject> found) {
+        private void gather(Core e, Set<FactSubject> found, Denotations at) {
             FactSubject here = terms.subjectOf(e, at);
             if (here != null && byName.containsKey(here)) {
                 found.add(here);
                 return;
             }
-            Core.forEachChild(e, child -> gather(child, found));
+            Core.forEachChild(e, child -> gather(child, found, at));
         }
 
         @Override
@@ -874,10 +880,12 @@ sealed interface StatedByClauses {
         private final Map<K, java.util.List<Core>> byPart = new java.util.LinkedHashMap<>();
         private final Map<K, StatedByClauses> trees = new java.util.LinkedHashMap<>();
 
-        /** One clause read, with the parts of it noted in the order the reading reached them. */
-        StatedByClauses read(Reading reader, K key, Core clause) {
+        /** One clause read from {@code at}, with the parts of it noted in the order the reading
+         *  reached them. */
+        StatedByClauses read(Reading reader, Denotations at, K key, Core clause) {
             java.util.List<Core> parts = new java.util.ArrayList<>();
-            StatedByClauses one = reader.read(clause, true, (part, _) -> parts.add(part));
+            StatedByClauses one = reader.read(clause, true, at, reader.scope(),
+                    (part, _) -> parts.add(part));
             byClause.put(key, clause);
             byPart.put(key, parts);
             trees.put(key, one);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -367,6 +367,11 @@ sealed interface StatedByClauses {
         }
 
         private void gather(Core e, Set<FactSubject> found, Denotations at) {
+            // Crossed as a binding, for the reason {@code AdmissibleReading.gather} gives.
+            if (e instanceof Core.LetIn li) {
+                gather(li.body(), found, terms.inside(li, at));
+                return;
+            }
             FactSubject here = terms.subjectOf(e, at);
             if (here != null && byName.containsKey(here)) {
                 found.add(here);

--- a/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StringPredicates.java
@@ -277,7 +277,8 @@ public enum StringPredicates {
      * with the operation is being read at the wrong argument, and which call arrived first is no
      * part of that. So it is not asked here.
      */
-    public static Stated statedByChecked(Core clause, Symbols symbols) {
+    public static Stated statedByChecked(Core clause, Symbols symbols, Terms terms,
+                                         Denotations at) {
         if (!(clause instanceof Core.PreservedCall call)
                 || !(call.operation() instanceof ValueName.Stdlib.Operation operation)) {
             return null;
@@ -287,7 +288,7 @@ public enum StringPredicates {
             return null;
         }
         Core subject = call.args().get(predicate.subject());
-        return Terms.folded(call.args().get(predicate.written()), symbols) instanceof String written
+        return Terms.folded(call.args().get(predicate.written()), symbols, at) instanceof String written
                 ? new Stated(subject, predicate.readingOf(written))
                 : new Stated(subject, new Reading.WrittenArgumentNotKnown());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -67,8 +67,6 @@ final class Term {
         CHOICE(Payload.none()),
         /** A closure, over the number of parameters it binds and its body. */
         CLOSURE(Payload.of(Integer.class)),
-        /** A value bound and a body read under it. */
-        LET(Payload.none()),
         /** A construction, over the values its fields are given in declaration order. */
         BUILT(Payload.of(Built.class)),
         /** A call, over its arguments. */
@@ -542,7 +540,6 @@ final class Term {
             case PART -> sb.append(parts.get(0).rendered()).append('.').append(of);
             case CHOICE -> joined(sb.append("if("), ", ").append(')');
             case CLOSURE -> joined(sb.append("\\").append(of).append('('), ", ").append(')');
-            case LET -> joined(sb.append("let("), ", ").append(')');
             case BUILT -> {
                 Built built = (Built) of;
                 sb.append(built.type()).append('{');
@@ -783,10 +780,6 @@ final class Term {
 
         Term closure(int params, Term body) {
             return of(Shape.CLOSURE, params, List.of(body));
-        }
-
-        Term let(Term value, Term body) {
-            return of(Shape.LET, null, List.of(value, body));
         }
 
         /** A construction, over what each field is given in declaration order. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -591,19 +591,35 @@ final class Terms {
                 numericMeaningOf(li.value(), at));
     }
 
-    /** What {@code e} folds to where every part of it is written out, or {@code null} where any part
+    /**
+     * What {@code e} folds to where every part of it is written out, or {@code null} where any part
      * of it is computed at run time and there is nothing to fold.
      *
      * <p>Folded against {@code symbols}, because which operations fold is a fact about the library
-     * the expression was resolved against and not about the expression. */
-    static Object folded(Core e, Symbols symbols) {
-        Hir.Expr written = asWrittenValue(e);
+     * the expression was resolved against and not about the expression.
+     *
+     * <p>And read where it stands, which is what {@code at} is for. A helper call is expanded as a
+     * binding over the helper's body, so a value an author wrote at the call is read through a name;
+     * asked of the tree alone, {@code atLeast(value, 1)} states a rule about no value this can name
+     * where {@code value >= 1} states one. The readings that ask this are the ones saying which
+     * values a position holds and which strings a format admits, and both are about the values an
+     * author wrote.
+     */
+    static Object folded(Core e, Symbols symbols, Denotations at) {
+        Hir.Expr written = asWrittenValue(e, at);
         return written == null ? null : ConstEval.against(symbols).eval(written).orElse(null);
     }
 
-    /** The number {@code e} folds to at compile time, or {@code null} where it folds to none. */
+    /**
+     * The number {@code e} folds to at compile time, or {@code null} where it folds to none.
+     *
+     * <p>Over the tree alone, for a walk that carries an environment of its own and has entered the
+     * bindings above what it hands over ({@link AffineForms.Reading#inside}). A binding standing
+     * <em>inside</em> what is handed over is not read here, and the walks that meet one are named in
+     * the issue on which readings cross a binding.
+     */
     static BigDecimal constantNumber(Core e, Symbols symbols) {
-        Object folded = folded(e, symbols);
+        Object folded = folded(e, symbols, Denotations.none());
         if (folded instanceof Long n) {
             return BigDecimal.valueOf(n);
         }
@@ -2627,9 +2643,22 @@ final class Terms {
      * the constant folder. A value written out is the same value in either representation, so this is
      * a rendering and not a second tree — everything computed answers with nothing, and the fold then
      * has nothing to fold.
+     *
+     * <p><b>Read where it stands.</b> A helper call is expanded as a binding over the helper's body
+     * (spec §invariant-discharge-representation), so a value an author wrote at a call stands under
+     * one — and a rule stating its value through a helper said nothing where the same rule written
+     * out said what it says. A binding is the value its body is, with the binder standing for what
+     * it was given.
+     *
+     * <p>Which is asked of two things, because a binding reaches a reading two ways. One is still in
+     * the tree, where the value is in the node beside the name. The other was consumed as the shape
+     * of the clause ({@link ClauseExpr.Scoped}) and is left in {@code at}, which is the reading's
+     * own environment and answers what a name was given. Neither is a second account of what a name
+     * means: what a name <em>denotes</em> is {@link #inside}'s, and this is the written value's own
+     * question.
      */
-    static Hir.Expr asWrittenValue(Core e) {
-        return asWrittenValue(e, Map.of());
+    static Hir.Expr asWrittenValue(Core e, Denotations at) {
+        return asWrittenValue(e, at, Map.of());
     }
 
     /** {@code given} with {@code li}'s binder standing for what it was given. */
@@ -2639,46 +2668,37 @@ final class Terms {
         return out;
     }
 
-    /**
-     * The same, with {@code given} holding what each binding on the way in was given.
-     *
-     * <p>The one rule a binding needs here, and the reason it is needed at all: a helper call is
-     * expanded as a binding over the helper's body (spec §invariant-discharge-representation), so a
-     * value an author wrote at a call stands under one. Asked of the tree alone, {@code itself(1)}
-     * was not a written value where {@code 1} was — and the readings that ask this question are the
-     * ones that say which values a position holds and which strings a format admits, so a rule
-     * stating a value through a helper said nothing about either.
-     *
-     * <p>What the binder was given is in the node, so nothing is looked up: this is the written
-     * value's own question, answered where it is asked, and not a second account of what a name
-     * means. What a name <em>denotes</em> is the environment's ({@link #inside}), and a reader that
-     * needs that asks for it.
-     */
-    private static Hir.Expr asWrittenValue(Core e, Map<BindingId, Core> given) {
+    private static Hir.Expr asWrittenValue(Core e, Denotations at, Map<BindingId, Core> given) {
         // Written over nothing, every one of them. A value rendered back out of what was computed is
         // the value and not the characters any of it came from: the fold has already been over them,
         // and what it arrived at may be a number no line of the file spells.
         return switch (e) {
             // A binding is the value its body is, with the binder standing for what it was given.
-            case Core.LetIn li -> asWrittenValue(li.body(), withGiven(given, li));
+            // A binding is the value its body is, with the binder standing for what it was given.
+            case Core.LetIn li -> asWrittenValue(li.body(), at, withGiven(given, li));
+            // And a name whose binding the clause's shape already consumed stands for what the
+            // environment says it was given — which is the same rule, asked where the binding is no
+            // longer in the tree ({@link ClauseExpr.Scoped}).
             case Core.Read r when given.containsKey(r.binding()) ->
-                    asWrittenValue(given.get(r.binding()), given);
+                    asWrittenValue(given.get(r.binding()), at, given);
+            case Core.Read r when at.valueOf(r.binding()) != null ->
+                    asWrittenValue(at.valueOf(r.binding()), at, given);
             case Core.Int i -> new Hir.IntLit(i.value(), i.pos(), null);
             case Core.Decimal d -> new Hir.DecimalLit(d.value(), d.pos(), null);
             case Core.Str s -> new Hir.StringLit(s.value(), s.pos(), null);
             case Core.Bool b -> new Hir.BoolLit(b.value(), b.pos(), null);
             case Core.Neg n -> {
-                Hir.Expr operand = asWrittenValue(n.operand(), given);
+                Hir.Expr operand = asWrittenValue(n.operand(), at, given);
                 yield operand == null ? null : new Hir.Neg(operand, n.pos(), null);
             }
             case Core.Binary b -> {
-                Hir.Expr left = asWrittenValue(b.left(), given);
-                Hir.Expr right = asWrittenValue(b.right(), given);
+                Hir.Expr left = asWrittenValue(b.left(), at, given);
+                Hir.Expr right = asWrittenValue(b.right(), at, given);
                 yield left == null || right == null ? null
                         : new Hir.Binary(b.op(), left, right, b.origin(), b.pos(), null);
             }
             case Core.PreservedCall call -> {
-                List<Hir.Expr> args = written(call.args(), given);
+                List<Hir.Expr> args = written(call.args(), at, given);
                 yield args == null ? null
                         : Hir.Apply.synthetic(call.operation().name(), reachOf(call.operation()), args,
                                 call.pos(), null);
@@ -2711,10 +2731,11 @@ final class Terms {
     }
 
     /** Every argument as it was written, or null where any of them was computed. */
-    private static List<Hir.Expr> written(List<Core> args, Map<BindingId, Core> given) {
+    private static List<Hir.Expr> written(List<Core> args, Denotations at,
+                                          Map<BindingId, Core> given) {
         List<Hir.Expr> out = new ArrayList<>();
         for (Core arg : args) {
-            Hir.Expr each = asWrittenValue(arg, given);
+            Hir.Expr each = asWrittenValue(arg, at, given);
             if (each == null) {
                 return null;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2102,15 +2102,18 @@ final class Terms {
                 yield named(naming(b.body(), at, inner, depth + 1, leaf),
                         body -> interned.closure(b.params().size(), body));
             }
-            case Core.LetIn li -> {
-                Naming value = naming(li.value(), at, bound, depth, leaf);
-                if (value instanceof Naming.Unnamed absent) {
-                    yield absent;
-                }
-                Map<BindingId, Term> inner = binding(bound, List.of(li.binder()), depth);
-                yield named(naming(li.body(), at, inner, depth + 1, leaf),
-                        body -> interned.let(value.term(), body));
-            }
+            // A binding is named by what its body is named, read inside it. What a name means is the
+            // environment's answer (ADR-0106), and {@link #inside} is where that is settled — so
+            // `id(lo)`, which an expansion leaves as a binding over a read of it, is the term `lo`
+            // is, and a rule written through a helper is about the position the same rule written
+            // out is about.
+            //
+            // Named as a shape of its own instead, the binding was a term nothing else equalled:
+            // the very defect the environment already avoids one level down (#676), reappearing
+            // where the expression is named rather than where the fact is filed. The parameter's
+            // reads went through the de Bruijn map below, which is what a closure needs — a lambda's
+            // parameter stands for no value — and what a binding does not.
+            case Core.LetIn li -> naming(li.body(), inside(li, at), bound, depth, leaf);
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. The fields are held in declaration order, so two sites writing them
             // in different orders — or one of them through a spread — write one term.

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2113,7 +2113,21 @@ final class Terms {
             // where the expression is named rather than where the fact is filed. The parameter's
             // reads went through the de Bruijn map below, which is what a closure needs — a lambda's
             // parameter stands for no value — and what a binding does not.
-            case Core.LetIn li -> naming(li.body(), inside(li, at), bound, depth, leaf);
+            case Core.LetIn li -> {
+                // Two environments, because they answer two questions. What a name denotes is the
+                // environment's ({@link #inside}, ADR-0106), and the body is read inside it. What a
+                // name is called is this walk's own, and a binder is called what it was given —
+                // read under the names in scope here, so a closure's parameter keeps the index it
+                // was bound at. Entered in the first alone, `x -> let y = x in y` lost `x`'s place
+                // in the closure and stopped being the term `x -> x` is.
+                Naming value = naming(li.value(), at, bound, depth, leaf);
+                if (value instanceof Naming.Unnamed absent) {
+                    yield absent;
+                }
+                Map<BindingId, Term> inner = new HashMap<>(bound);
+                inner.put(li.binder().binding(), value.term());
+                yield naming(li.body(), inside(li, at), inner, depth, leaf);
+            }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. The fields are held in declaration order, so two sites writing them
             // in different orders — or one of them through a spread — write one term.
@@ -2615,26 +2629,56 @@ final class Terms {
      * has nothing to fold.
      */
     static Hir.Expr asWrittenValue(Core e) {
+        return asWrittenValue(e, Map.of());
+    }
+
+    /** {@code given} with {@code li}'s binder standing for what it was given. */
+    private static Map<BindingId, Core> withGiven(Map<BindingId, Core> given, Core.LetIn li) {
+        Map<BindingId, Core> out = new HashMap<>(given);
+        out.put(li.binder().binding(), li.value());
+        return out;
+    }
+
+    /**
+     * The same, with {@code given} holding what each binding on the way in was given.
+     *
+     * <p>The one rule a binding needs here, and the reason it is needed at all: a helper call is
+     * expanded as a binding over the helper's body (spec §invariant-discharge-representation), so a
+     * value an author wrote at a call stands under one. Asked of the tree alone, {@code itself(1)}
+     * was not a written value where {@code 1} was — and the readings that ask this question are the
+     * ones that say which values a position holds and which strings a format admits, so a rule
+     * stating a value through a helper said nothing about either.
+     *
+     * <p>What the binder was given is in the node, so nothing is looked up: this is the written
+     * value's own question, answered where it is asked, and not a second account of what a name
+     * means. What a name <em>denotes</em> is the environment's ({@link #inside}), and a reader that
+     * needs that asks for it.
+     */
+    private static Hir.Expr asWrittenValue(Core e, Map<BindingId, Core> given) {
         // Written over nothing, every one of them. A value rendered back out of what was computed is
         // the value and not the characters any of it came from: the fold has already been over them,
         // and what it arrived at may be a number no line of the file spells.
         return switch (e) {
+            // A binding is the value its body is, with the binder standing for what it was given.
+            case Core.LetIn li -> asWrittenValue(li.body(), withGiven(given, li));
+            case Core.Read r when given.containsKey(r.binding()) ->
+                    asWrittenValue(given.get(r.binding()), given);
             case Core.Int i -> new Hir.IntLit(i.value(), i.pos(), null);
             case Core.Decimal d -> new Hir.DecimalLit(d.value(), d.pos(), null);
             case Core.Str s -> new Hir.StringLit(s.value(), s.pos(), null);
             case Core.Bool b -> new Hir.BoolLit(b.value(), b.pos(), null);
             case Core.Neg n -> {
-                Hir.Expr operand = asWrittenValue(n.operand());
+                Hir.Expr operand = asWrittenValue(n.operand(), given);
                 yield operand == null ? null : new Hir.Neg(operand, n.pos(), null);
             }
             case Core.Binary b -> {
-                Hir.Expr left = asWrittenValue(b.left());
-                Hir.Expr right = asWrittenValue(b.right());
+                Hir.Expr left = asWrittenValue(b.left(), given);
+                Hir.Expr right = asWrittenValue(b.right(), given);
                 yield left == null || right == null ? null
                         : new Hir.Binary(b.op(), left, right, b.origin(), b.pos(), null);
             }
             case Core.PreservedCall call -> {
-                List<Hir.Expr> args = written(call.args());
+                List<Hir.Expr> args = written(call.args(), given);
                 yield args == null ? null
                         : Hir.Apply.synthetic(call.operation().name(), reachOf(call.operation()), args,
                                 call.pos(), null);
@@ -2667,10 +2711,10 @@ final class Terms {
     }
 
     /** Every argument as it was written, or null where any of them was computed. */
-    private static List<Hir.Expr> written(List<Core> args) {
+    private static List<Hir.Expr> written(List<Core> args, Map<BindingId, Core> given) {
         List<Hir.Expr> out = new ArrayList<>();
         for (Core arg : args) {
-            Hir.Expr each = asWrittenValue(arg);
+            Hir.Expr each = asWrittenValue(arg, given);
             if (each == null) {
                 return null;
             }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -465,10 +465,12 @@ public sealed interface BlockReason {
      * one of them, an author is told which reader fell short of their clause, and the named reader
      * may be one that has no word for such a rule at all and never claimed it.
      *
-     * <p>What produces it is the accounting, from the two answers coming apart: a rule no reading
-     * adopted, at a position no reading recorded a reason for. A helper that reads a field of a
-     * value the readings do not know the positions of is one — the clause is about that field, and
-     * every reader here passed over it.
+     * <p><b>Despite the name, the reading may well have taken the rule in.</b> What produces this is
+     * a question standing with no reason filed under the rule that raised it, and the case that
+     * reaches it is a reading that read every rule and could not build the exact answer they come to
+     * within its allowance. That loss is about the answer, so no rule is answerable for it and none
+     * is filed. What the name should be is its own question — see the issue on where an answer-level
+     * limit belongs in the published vocabulary.
      *
      * <p>Nothing is claimed about which capability would lift it, which is what makes it different
      * from every case above. What a document writes for it is the same word it writes for a rule

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -461,9 +461,9 @@ public sealed interface BlockReason {
      * of them wrote down why.
      *
      * <p>Its own case because it names no reading. The others are one reading's account of where it
-     * gave up, and a question left standing by nobody has no such account to give — answered with
-     * one of them, an author is told which reader fell short of their clause, and the named reader
-     * may be one that has no word for such a rule at all and never claimed it.
+     * gave up on a rule, and here no reading was short of the rule at all — answered with one of
+     * them, an author is told that a reader fell short of their clause, and is sent to lift a
+     * capability that was never the matter.
      *
      * <p><b>Despite the name, the reading may well have taken the rule in.</b> What produces this is
      * a question standing with no reason filed under the rule that raised it, and the case that

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -89,12 +89,14 @@ public final class ReportedReason {
             case BlockReason.PatternTooDeeplyNested _ ->
                     UndividedPosition.Reason.PATTERN_TOO_DEEPLY_NESTED;
             // Its own word, and not the one above. That one promises a rule was read and could not
-            // be used, which is a reader having engaged with it and given up; here none did, and an
-            // author sent after the form their clause is written in would be looking for a
+            // be used, which sends an author after the form their clause is written in; here the
+            // rule was read and nothing complained of the form, so they would be looking for a
             // complaint nobody made. Neither is it the rule never having been reached — it was.
             // The published words had these two and the state between them is one a model reaches,
             // so the partition is one finer rather than the state going out under a word whose
-            // promise it does not meet.
+            // promise it does not meet. What the word itself should be is #1335: it says nothing
+            // established an interpretation, and what happened is that the interpretations were
+            // established and building what they come to together ran past the allowance.
             case BlockReason.NoReadingTookItIn _ ->
                     UndividedPosition.Reason.RULE_NOT_INTERPRETED_HERE;
             // Its own word, and not the one above. Both are rules this reading did not turn into a

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -152,9 +152,14 @@ public record UndividedPosition(TermPath at, Why why) {
          *
          * <p>Nothing is claimed about which capability would make it interpretable. That is what
          * separates it from the first: an author sent after a form to rewrite would be looking for
-         * one nothing complained about, and the rule may be perfectly ordinary and read in full
-         * somewhere else. What is known is that the rule is here, that a question of it is
-         * standing, and that nothing answered it.
+         * one nothing complained about, and the rule may well have been read in full right here.
+         * What is known is that the rule is here, that a question of it is standing, and that
+         * nothing answered it.
+         *
+         * <p><b>The word promises more than the state it carries.</b> What reaches it is a rule read
+         * from end to end whose exact answer ran past what the reading may build, and "nothing
+         * established an interpretation" is not that. Where an answer-level limit belongs in this
+         * vocabulary is #1335.
          */
         RULE_NOT_INTERPRETED_HERE,
 

--- a/souther-compiler/src/test/java/souther/compiler/ADeclarationReadBackFromClassesStatesWhatItsAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADeclarationReadBackFromClassesStatesWhatItsAuthorWroteTest.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -130,23 +129,24 @@ class ADeclarationReadBackFromClassesStatesWhatItsAuthorWroteTest {
 
     /**
      * The clause calling an unexposed helper reaches the same outcome here as in its own module,
-     * which is not the readable one.
+     * and it is the outcome a clause read to the end gets.
      *
      * <p>Two halves, and both are needed. That it agrees with the module that wrote it is the claim;
-     * that the outcome is a different one from the clause read to the end is what says the agreement
-     * is about something — two readings that both stopped agree perfectly.
+     * that the outcome is the readable one is what says the agreement is about something — two
+     * readings that both stopped agree perfectly. The second half is what a helper's clause being
+     * read as the rule it states settles (ADR-0106); before that, this held the two apart.
      */
     @Test
-    void aClauseCallingAnUnexposedHelperReachesTheSameLimitAsInItsOwnModule() {
+    void aClauseCallingAnUnexposedHelperIsReadHereAsInItsOwnModule() {
         Map<String, JsonNode> here = readInTheConsumer();
         assertNotNull(here.get("onThroughHelper"), "the consumer measures it");
 
         assertEquals(inTheLibrarysOwnBuild("throughHelper"), here.get("onThroughHelper"),
                 "a clause calling a helper the dependency never exposed reaches from here exactly"
                         + " what it reaches in the module that wrote it");
-        assertNotEquals(here.get("onWritten"), here.get("onThroughHelper"),
-                "and that outcome is not the one a clause read to the end gets, so the agreement"
-                        + " above is not two readings that both said nothing");
+        assertEquals(here.get("onWritten"), here.get("onThroughHelper"),
+                "and that outcome is the one a clause read to the end gets, so the agreement above"
+                        + " is not two readings that both said nothing");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -78,9 +79,26 @@ class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
                         let holds (p: (Int) -> Bool, n: Int) = p(n)
                         """,
                         "holds(atLeastOne, value)"),
-                new Spelling("through a helper naming nothing about the value",
-                        "let alwaysSo (n: Int) = 2 >= 1",
-                        "alwaysSo(value) && value >= 1"));
+                // The rule under two bindings, one of which the body never reads. What a name means
+                // is what it was given, and a name nothing reads means nothing to this check — so
+                // entering it changes what is known about the rule not at all, and the reading below
+                // is the same reading.
+                new Spelling("through a helper given more than it reads",
+                        "let atLeastOne (n: Int, ignored: Int) = n >= 1",
+                        "atLeastOne(value, 0)"),
+                // And the helper inside the comparison rather than around it, which is a binding
+                // standing where a value goes rather than where a clause does. What the shape of a
+                // clause is made of stops at the comparison, so nothing above this reaches the
+                // binding — it is the naming of the operand that has to go inside it.
+                new Spelling("through a helper standing in the operand",
+                        "let itself (n: Int) = n",
+                        "value >= itself(1)"),
+                new Spelling("through a helper of a helper in the operand",
+                        """
+                        let itself (n: Int) = n
+                        let alsoItself (n: Int) = itself(n)
+                        """,
+                        "value >= alsoItself(1)"));
     }
 
     /** The module, with {@code guard} deciding what is known where the construction stands. */
@@ -120,6 +138,36 @@ class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
     void aConstructionTheGuardsAllowIsBuilt(Spelling spelling) {
         assertDoesNotThrow(() -> Compiler.compile(module(spelling, "n >= 1")),
                 "the rule holds of every value that reaches the construction");
+    }
+
+    /**
+     * A value no guard can be written about is owed nothing, whichever way the rule reaches it.
+     *
+     * <p>The other direction, and the one entering a binding can get wrong. What a behavior answers
+     * is a value this check can point at and no author can write a guard about, so a clause read
+     * against it is left to the run-time check rather than owed. Which value a site handed over is
+     * asked by what the clause names — and a binding stands between the clause and the value, so an
+     * answer taken from the tree finds none of them and owes a guard nobody can write.
+     */
+    @ParameterizedTest
+    @MethodSource("spellings")
+    void aValueNoGuardCanNameIsOwedNothing(Spelling spelling) {
+        assertEquals(List.<Object>of(), List.copyOf(Compiler.compileWithWarnings("""
+                module demo
+
+                %s
+
+                data Pos = Int
+                    invariant %s
+
+                behavior step : (n: Int) -> Int
+
+                behavior go : (n: Int) -> Pos
+                    constructs Pos
+                    depends on step
+                let go (n, step) = Pos(step(n))
+                """.formatted(spelling.helpers(), spelling.clause())).warnings()),
+                "nothing is owed of a value no guard could settle");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
@@ -1,0 +1,140 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule an author states by naming it is read as the rule they would have written out.
+ *
+ * <p>A helper call is expanded by binding each argument and reading the parameter through that
+ * binding (spec §invariant-discharge-representation), so a clause stating its rule through a helper
+ * is that rule under a binding. The reading that asks what a position admits and the reading that
+ * asks what a construction owes both stopped at the binding: a construction the guards prove must
+ * fail was refused where the rule was written out and passed in silence where the same rule reached
+ * through a helper, in one module, on one model. Nothing was reported wrongly — a rule a reading
+ * cannot take in widens what a position admits — but the limit was reached by using the language's
+ * own way of writing a rule once and naming it twice.
+ *
+ * <p>The corpus below is the spellings of one rule. Every one of them says that the value is at
+ * least one, so every one of them refuses the construction under {@code n <= 0} and admits the one
+ * under {@code n >= 1}: what an author wrote it as decides neither.
+ *
+ * <p>What is <em>not</em> claimed is that a binding makes a leaf readable. Entering one says what a
+ * name means and nothing about the shape standing under it, and that end is held where it can be
+ * seen — {@code AClauseUnderABindingIsReadInsideItTest} fixes that the fold hands the leaf on as
+ * the very node it was, so a change that widened what a leaf means instead would not pass there.
+ */
+class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
+
+    /** One way of writing the rule: the helpers it needs, and the clause itself. */
+    private record Spelling(String name, String helpers, String clause) {
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    private static Stream<Spelling> spellings() {
+        return Stream.of(
+                new Spelling("written out", "", "value >= 1"),
+                new Spelling("through a helper",
+                        "let atLeastOne (n: Int) = n >= 1",
+                        "atLeastOne(value)"),
+                new Spelling("through a helper of a helper",
+                        """
+                        let notBelowOne (n: Int) = n >= 1
+                        let atLeastOne (n: Int) = notBelowOne(n)
+                        """,
+                        "atLeastOne(value)"),
+                new Spelling("through a helper, denied",
+                        "let belowOne (n: Int) = n <= 0",
+                        "Bool.not(belowOne(value))"),
+                new Spelling("through a helper, denied by a truth value",
+                        "let belowOne (n: Int) = n <= 0",
+                        "belowOne(value) == false"),
+                new Spelling("through a helper that joins two rules",
+                        "let inRange (n: Int) = n >= 1 && n <= 9",
+                        "inRange(value)"),
+                new Spelling("through a helper the rule stands beside",
+                        "let atLeastOne (n: Int) = n >= 1",
+                        "atLeastOne(value) && value <= 9"),
+                // A binding holding a function, with the expansion putting the body where the
+                // application stood. Here because a reading that entered only the bindings an
+                // argument makes would leave this one where it was.
+                new Spelling("through a helper handed a helper",
+                        """
+                        let atLeastOne (n: Int) = n >= 1
+                        let holds (p: (Int) -> Bool, n: Int) = p(n)
+                        """,
+                        "holds(atLeastOne, value)"),
+                new Spelling("through a helper naming nothing about the value",
+                        "let alwaysSo (n: Int) = 2 >= 1",
+                        "alwaysSo(value) && value >= 1"));
+    }
+
+    /** The module, with {@code guard} deciding what is known where the construction stands. */
+    private static String module(Spelling spelling, String guard) {
+        return """
+                module demo
+
+                %s
+
+                data Pos = Int
+                    invariant %s
+
+                data Bad
+
+                behavior go : (n: Int) -> Pos | Bad
+                    constructs Pos
+                let go (n) = {
+                    guard %s else Bad
+
+                    Pos(n)
+                }
+                """.formatted(spelling.helpers(), spelling.clause(), guard);
+    }
+
+    @ParameterizedTest
+    @MethodSource("spellings")
+    void aConstructionTheGuardsRefuteIsRefused(Spelling spelling) {
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compile(module(spelling, "n <= 0")),
+                "the value being built is one the rule rejects, however the rule was written");
+        assertTrue(refused.getMessage().contains("E2010"),
+                () -> "refused on the rule rather than left undischarged: " + refused.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("spellings")
+    void aConstructionTheGuardsAllowIsBuilt(Spelling spelling) {
+        assertDoesNotThrow(() -> Compiler.compile(module(spelling, "n >= 1")),
+                "the rule holds of every value that reaches the construction");
+    }
+
+    /**
+     * And the corpus is one rule stated many ways, rather than sources that happen to compile.
+     *
+     * <p>Written down because the two tests above pass on a corpus of one spelling, and what is
+     * being fixed is that the spellings agree.
+     */
+    @Test
+    void theCorpusHoldsTheRuleWrittenOutAndTheSameRuleNamed() {
+        List<Spelling> corpus = spellings().toList();
+        assertTrue(corpus.stream().anyMatch(one -> one.helpers().isEmpty()),
+                "the rule written out is what the others are held to");
+        assertTrue(corpus.stream().filter(one -> !one.helpers().isEmpty()).count() > 1,
+                "and the others reach it by naming it");
+    }
+
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
@@ -141,6 +141,53 @@ class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
     }
 
     /**
+     * A value an author wrote reaches every reading of it, whichever way the rule reaches it.
+     *
+     * <p>The other half of what a binding is transparent to. What a position is settles which rule
+     * a reading is about; what a value is settles what the rule says — which values stand there,
+     * which strings a format admits, where an end falls. Both are asked of the same expression, and
+     * a helper standing in an operand is a binding over both.
+     *
+     * <p>Asked of the declaration rather than of a construction, because that is where the answer
+     * is a value rather than a verdict: a construction reads the rule through one more reader, and
+     * a verdict that agreed would not say the readings do.
+     */
+    @ParameterizedTest
+    @MethodSource("operands")
+    void aValueAnAuthorWroteIsTheSameValueThroughAHelper(String base, String rule, String named) {
+        assertEquals(admitted(base, "", rule), admitted(base, ITSELF, named),
+                "what the position admits does not turn on which spelling the value arrived by");
+    }
+
+    private static final String ITSELF = """
+            let itself (n: Int) = n
+            let itsSelf (s: String) = s
+            """;
+
+    private static Stream<org.junit.jupiter.params.provider.Arguments> operands() {
+        return Stream.of(
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "Int", "value >= 1", "value >= itself(1)"),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "Int", "value == 1", "value == itself(1)"),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "String", "String.matches(\"[a-z]+\", value)",
+                        "String.matches(itsSelf(\"[a-z]+\"), value)"));
+    }
+
+    /** What the one position of a newtype is left, as the declaration's own reading says it. */
+    private static String admitted(String base, String helpers, String clause) {
+        return souther.compiler.check.RuleReadings.admittedByTheValueOf("""
+                module demo
+
+                %s
+
+                data N = %s
+                    invariant %s
+                """.formatted(helpers, base, clause));
+    }
+
+    /**
      * A value no guard can be written about is owed nothing, whichever way the rule reaches it.
      *
      * <p>The other direction, and the one entering a binding can get wrong. What a behavior answers

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
@@ -164,17 +164,35 @@ class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
     private static final String ITSELF = """
             let itself (n: Int) = n
             let itsSelf (s: String) = s
+            let atLeast (n: Int, floor: Int) = n >= floor
+            let isOne (n: Int, one: Int) = n == one
+            let matching (p: String, s: String) = String.matches(p, s)
+            let atLeastOne (s: String) = String.length(s) >= 1
             """;
 
     private static Stream<org.junit.jupiter.params.provider.Arguments> operands() {
         return Stream.of(
+                // A binding still in the tree, standing inside the comparison.
                 org.junit.jupiter.params.provider.Arguments.of(
                         "Int", "value >= 1", "value >= itself(1)"),
                 org.junit.jupiter.params.provider.Arguments.of(
                         "Int", "value == 1", "value == itself(1)"),
                 org.junit.jupiter.params.provider.Arguments.of(
                         "String", "String.matches(\"[a-z]+\", value)",
-                        "String.matches(itsSelf(\"[a-z]+\"), value)"));
+                        "String.matches(itsSelf(\"[a-z]+\"), value)"),
+                // And a binding the clause's shape has already crossed, leaving a bare read of the
+                // parameter where the value was written. The two are different places for a reader
+                // to meet one, and holding only the first left the second reading nothing.
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "Int", "value >= 1", "atLeast(value, 1)"),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "Int", "value == 1", "isOne(value, 1)"),
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "String", "String.matches(\"[a-z]+\", value)",
+                        "matching(\"[a-z]+\", value)"),
+                // The rule #1333 was written about, which is a length rather than the value.
+                org.junit.jupiter.params.provider.Arguments.of(
+                        "String", "String.length(value) >= 1", "atLeastOne(value)"));
     }
 
     /** What the one position of a newtype is left, as the declaration's own reading says it. */

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest.java
@@ -37,8 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ARuleReachedThroughAHelperIsReadAsTheOneWrittenOutTest {
 
-    /** One way of writing the rule: the helpers it needs, and the clause itself. */
-    private record Spelling(String name, String helpers, String clause) {
+    /** One way of writing the rule: the helpers it needs, and the clause itself.
+     *
+     *  <p>As visible as the tests it is handed to, which a parameterized one has to be. */
+    record Spelling(String name, String helpers, String clause) {
 
         @Override
         public String toString() {

--- a/souther-compiler/src/test/java/souther/compiler/AStandingQuestionSaysWhatItStandsForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AStandingQuestionSaysWhatItStandsForTest.java
@@ -181,36 +181,49 @@ class AStandingQuestionSaysWhatItStandsForTest {
     }
 
     /**
-     * A question no reading claimed says what is known of it, and no more.
+     * A question a rule reaching through a helper leaves says what the same rule written out says.
      *
-     * <p>The invariant is a call, and what it comes to is a rule about a field of the value its
-     * helper was handed — a position none of the readings here is filed under, so none of them
-     * claimed the rule and none recorded why.
+     * <p>The invariant is a call, and what it comes to is a rule about a field of the value the
+     * helper was handed. The reading goes inside the binding the expansion made (ADR-0106), so the
+     * position is named and the rule is read at it — and what stands is the reading's own word for
+     * the form it could not take apart, which is the word the rule written where the clause is
+     * would leave.
      *
-     * <p>Neither of the words beside it is true of that. One promises a rule was read and could not
-     * be used, which sends an author after the form they wrote and nothing here complained of the
-     * form; the other promises the rule was never arrived at, and it was. What is known is that the
-     * rule is here, that a question of it stands, and that nothing worked out what it says — so
-     * that is the word, and it claims nothing about which capability would lift it.
+     * <p>Held as one line and not as two readings agreeing, because the line is what a person is
+     * shown: a word that turned on which of the two spellings an author reached for would be
+     * reporting this compiler's arrangement rather than their model.
      */
     @Test
-    void aQuestionNoReadingClaimedSaysWhatIsKnownOfIt() {
+    void aQuestionARuleThroughAHelperLeavesSaysWhatTheRuleWrittenOutSays() {
+        String throughAHelper = about(reportOf("""
+                module probe.helper
+
+                data Range = { min: String, max: String }
+
+                data Checked = { range: Range }
+                    invariant valid(range)
+
+                behavior read : (c: Checked) -> Ok
+
+                let valid (r: Range) : Bool = UNREAD_MAX
+                """.replace("UNREAD_MAX", ARuleNoReadingTakesIn.about("r.max"))),
+                "invariant Checked #1");
+
         assertEquals("      · not accounted for: invariant Checked #1"
                         + " — which values may stand at c.range.max:"
-                        + " it was reached, and nothing worked out what it says about the values"
-                        + " here",
-                about(reportOf("""
-                        module probe.helper
+                        + " written in a form this compiler does not read",
+                throughAHelper);
+        assertEquals(about(reportOf("""
+                module probe.helper
 
-                        data Range = { min: Int, max: Int }
+                data Range = { min: String, max: String }
 
-                        data Checked = { range: Range }
-                            invariant valid(range)
+                data Checked = { range: Range }
+                    invariant UNREAD_MAX
 
-                        behavior read : (c: Checked) -> Ok
-
-                        let valid (r: Range) : Bool = r.max >= 0
-                        """), "invariant Checked #1"));
+                behavior read : (c: Checked) -> Ok
+                """.replace("UNREAD_MAX", ARuleNoReadingTakesIn.about("range.max"))),
+                "invariant Checked #1"), throughAHelper);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhatAPositionAdmitsIsTheSameWhicheverModuleAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAPositionAdmitsIsTheSameWhicheverModuleAsksTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -209,20 +208,20 @@ class WhatAPositionAdmitsIsTheSameWhicheverModuleAsksTest {
     }
 
     /**
-     * The helper's clause is the other outcome, and it is the same outcome on both sides.
+     * The helper's clause is read as far as the literal one, from either module.
      *
-     * <p>Kept apart from the literal on purpose. How far a reading gets into an expanded helper is
-     * a limit of the reading and nothing this closed, so this holds that the limit is reached from
-     * both modules rather than that it is gone — and it holds that the two outcomes are still
-     * different from each other, which is what says the comparison above is looking at something.
+     * <p>Which is the other half of what this file holds, and it moved. A clause stating its rule
+     * through a helper reaches the reading as that rule under a binding, and the reading goes inside
+     * the binding now (ADR-0106) — so the outcome is the literal's, and agreeing across modules is
+     * agreeing about something read rather than about a limit met twice.
      */
     @Test
-    void theClauseCallingAHelperReachesTheSameLimitFromBoth() {
+    void theClauseCallingAHelperIsReadAsFarAsTheLiteralOne() {
         Map<String, JsonNode> read = howFarTheRulesWereRead();
         assertEquals(read.get("owner/fromAHelper"), read.get("importer/fromAHelper"),
                 "the reading gets as far from one module as from the other");
-        assertNotEquals(read.get("owner/fromALiteral"), read.get("owner/fromAHelper"),
-                "and it is a different outcome from the one a clause this reads to the end gets,"
-                        + " so the agreement above is not two readings that both said nothing");
+        assertEquals(read.get("owner/fromALiteral"), read.get("owner/fromAHelper"),
+                "and as far as it gets into the same rule written out, which is what says the"
+                        + " agreement above is about a rule that was read");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
@@ -173,6 +173,45 @@ class AClauseUnderABindingIsReadInsideItTest {
                 "the fold changes the environment and nothing else");
     }
 
+    /**
+     * A binding under a closure keeps the closure's own account of its parameter.
+     *
+     * <p>Two environments and two questions. What a name denotes is the environment's, and the body
+     * of a binding is read inside it; what a name is <em>called</em> is the naming walk's own, and a
+     * closure's parameter is called where it is bound rather than which binding it is, so that two
+     * lambdas written alike are one term. A binding entered in the first alone lost the second, and
+     * {@code x -> let y = x in y} stopped being the term {@code x -> x} is.
+     *
+     * <p>Held on the naming and not on a clause, because that is where the two meet: a binding is
+     * called what it was given, and what it was given is read under the names in scope where it
+     * stands.
+     */
+    @Test
+    void aBindingUnderAClosureKeepsThePlaceItsParameterIsBoundAt() {
+        Terms terms = RuleReadings.termsOfNoClauseFiled(
+                Symbols.none(souther.compiler.DefaultStdlib.get()),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        Core.Binder x = new Core.Binder("x", new BindingId(OWNER, 7));
+        Core.Binder a = new Core.Binder("a", new BindingId(OWNER, 8));
+
+        Core plain = block(x, new Core.Read("x", x.binding(), Type.INT, POS));
+        Core bound = block(x, let("y", 9, new Core.Read("x", x.binding(), Type.INT, POS),
+                new Core.Read("y", new BindingId(OWNER, 9), Type.INT, POS)));
+        Core renamed = block(a, let("b", 10, new Core.Read("a", a.binding(), Type.INT, POS),
+                new Core.Read("b", new BindingId(OWNER, 10), Type.INT, POS)));
+
+        assertEquals(terms.subjectOf(plain, Denotations.none()),
+                terms.subjectOf(bound, Denotations.none()),
+                "a name given a parameter is that parameter");
+        assertEquals(terms.subjectOf(bound, Denotations.none()),
+                terms.subjectOf(renamed, Denotations.none()),
+                "and two closures written alike are one term, whatever the names are");
+    }
+
+    private static Core block(Core.Binder param, Core body) {
+        return new Core.Block(List.of(param), body, Type.INT, POS);
+    }
+
     @Test
     void aDenialIsCarriedThroughTheBinding() {
         Core.Read bound = read("$p", 1, Type.INT);

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
@@ -1,0 +1,186 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BinOp;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.CoverageOrigin;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A binding is where the environment a clause is read in changes, and it is not a leaf.
+ *
+ * <p>What a clause states is answered upward and what its names mean is handed downward. Held as a
+ * fold with only the first direction, there was nowhere a binding could be, so it arrived at every
+ * evaluator as a shape none of them had a word for — and since a helper call expands to a binding
+ * holding the argument and the helper's body written against it, that is every rule an author stated
+ * by naming it.
+ *
+ * <p>Over the shape and the fold rather than over a compiled module, because what is fixed here is
+ * that no evaluator is ever handed a binding: an evaluator that learned to read one would be a
+ * second account of what a binder means, which is the environment's ({@code ADR-0106}). The
+ * environment is a string so that the transitions can be read off the answer — what it is in the
+ * check is {@link Denotations}, and what makes one is {@link Terms#inside}.
+ */
+class AClauseUnderABindingIsReadInsideItTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("demo", "f");
+
+    /** What a reading is handed at each leaf: the part, whether it is stated, and where it stood. */
+    private record AtALeaf(Core part, boolean positive, String at) {}
+
+    /**
+     * A reading that records what it was handed and says nothing else.
+     *
+     * <p>Its state is the leaves in the order they arrived, so a conjunction and a choice both
+     * compose by joining the lists: what is being fixed is what reached a leaf, not what any
+     * language made of it.
+     */
+    private static final class Recording implements ClauseReading<List<AtALeaf>, String> {
+
+        private final List<AtALeaf> leaves = new ArrayList<>();
+
+        @Override
+        public List<AtALeaf> nothingSaid() {
+            return List.of();
+        }
+
+        @Override
+        public List<AtALeaf> leaf(Core e, boolean positive, String at) {
+            leaves.add(new AtALeaf(e, positive, at));
+            return List.of(leaves.get(leaves.size() - 1));
+        }
+
+        @Override
+        public List<AtALeaf> both(List<AtALeaf> one, List<AtALeaf> other) {
+            return joined(one, other);
+        }
+
+        @Override
+        public List<AtALeaf> either(List<AtALeaf> one, List<AtALeaf> other) {
+            return joined(one, other);
+        }
+
+        private static List<AtALeaf> joined(List<AtALeaf> one, List<AtALeaf> other) {
+            List<AtALeaf> out = new ArrayList<>(one);
+            out.addAll(other);
+            return out;
+        }
+    }
+
+    /** Each binding entered as its binder's name, so the environment a leaf is read at spells out
+     *  the bindings it stands under. */
+    private static final ClauseScope<String> NAMING = (li, outside) -> outside + "/" + li.name();
+
+    private static Core.Read read(String name, int ordinal, Type type) {
+        return new Core.Read(name, new BindingId(OWNER, ordinal), type, POS);
+    }
+
+    private static Core.LetIn let(String name, int ordinal, Core value, Core body) {
+        return new Core.LetIn(new Core.Binder(name, new BindingId(OWNER, ordinal)), value, body,
+                body.type(), POS);
+    }
+
+    private static Core.Binary binary(BinOp op, Core left, Core right) {
+        return new Core.Binary(op, left, right, CoverageOrigin.unwritten(), Type.BOOL, POS);
+    }
+
+    /** `n >= 1`, the rule every clause below states one way or another. */
+    private static Core.Binary rule(Core subject) {
+        return binary(BinOp.GE, subject, new Core.Int(1, Type.INT, POS));
+    }
+
+    private static List<AtALeaf> reading(Core clause) {
+        Recording recording = new Recording();
+        return recording.read(clause, true, "", NAMING);
+    }
+
+    @Test
+    void theBindingIsAShapeAndTheClauseUnderItIsTheLeaf() {
+        Core.Read bound = read("$p", 1, Type.INT);
+        Core clause = let("$p", 1, read("value", 0, Type.INT), rule(bound));
+
+        assertTrue(ClauseExpr.of(clause, true) instanceof ClauseExpr.Scoped,
+                "a binding is where the environment changes, not a part with no connective");
+        assertEquals(List.of(new AtALeaf(rule(bound), true, "/$p")), reading(clause),
+                "the rule under the binding is the leaf, read inside it");
+    }
+
+    @Test
+    void noEvaluatorIsEverHandedABinding() {
+        Core clause = let("$p", 1, read("value", 0, Type.INT), rule(read("$p", 1, Type.INT)));
+
+        assertEquals(List.of(), reading(clause).stream()
+                        .filter(one -> one.part() instanceof Core.LetIn).toList(),
+                "what a binder means is the environment's answer and no evaluator's");
+    }
+
+    @Test
+    void eachBindingOnTheWayDownIsEnteredInTurn() {
+        Core inner = let("$q", 2, read("$p", 1, Type.INT), rule(read("$q", 2, Type.INT)));
+        Core clause = let("$p", 1, read("value", 0, Type.INT), inner);
+
+        assertEquals(List.of("/$p/$q"), reading(clause).stream().map(AtALeaf::at).toList(),
+                "a helper calling a helper stands under both bindings");
+    }
+
+    @Test
+    void aConnectiveUnderABindingIsReadInsideIt() {
+        Core.Read bound = read("$p", 1, Type.INT);
+        Core both = binary(BinOp.AND, rule(bound),
+                binary(BinOp.LE, bound, new Core.Int(9, Type.INT, POS)));
+        Core clause = let("$p", 1, read("value", 0, Type.INT), both);
+
+        assertEquals(List.of("/$p", "/$p"), reading(clause).stream().map(AtALeaf::at).toList(),
+                "a helper whose body joins two rules states both of them, inside the binding");
+    }
+
+    @Test
+    void aBindingUnderAConnectiveIsEnteredForItsOwnSideAlone() {
+        Core.Read bound = read("$p", 1, Type.INT);
+        Core clause = binary(BinOp.AND,
+                let("$p", 1, read("value", 0, Type.INT), rule(bound)),
+                rule(read("value", 0, Type.INT)));
+
+        assertEquals(List.of("/$p", ""), reading(clause).stream().map(AtALeaf::at).toList(),
+                "a binding reaches what stands under it and nothing beside it");
+    }
+
+    /**
+     * And a shape the fold does not recognise is handed on as itself.
+     *
+     * <p>The negative control. What a binding settles is what a name means; what a leaf means is
+     * the leaf language's, and the fold widens neither — so a part no connective and no binding, of
+     * whatever shape, arrives at the reading as the very node it was. Without this, a change that
+     * rewrote leaves on the way down would satisfy everything above.
+     */
+    @Test
+    void aLeafIsHandedOnAsTheNodeItWas() {
+        Core.Read bare = read("$p", 1, Type.INT);
+        Core clause = let("$p", 1, read("value", 0, Type.INT), bare);
+
+        assertEquals(List.of(new AtALeaf(bare, true, "/$p")), reading(clause),
+                "the fold changes the environment and nothing else");
+    }
+
+    @Test
+    void aDenialIsCarriedThroughTheBinding() {
+        Core.Read bound = read("$p", 1, Type.INT);
+        Core clause = binary(BinOp.EQ,
+                let("$p", 1, read("value", 0, Type.INT), rule(bound)),
+                new Core.Bool(false, Type.BOOL, POS));
+
+        assertEquals(List.of(new AtALeaf(rule(bound), false, "/$p")), reading(clause),
+                "denying what a helper states denies the rule its body states, read inside it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * <p><b>The conjuncts stay the author's.</b> A binding is crossed and never split: which parts a
  * clause has is what its author wrote ({@link ClauseHelpers#conjunctsOf}, over the tree before any
- * expansion), so a helper whose body joins two rules is one conjunct and not two. What that leaves
- * is held below.
+ * expansion), so a helper whose body joins two rules is one conjunct and not two. What one authored
+ * part states may still be more than one rule, and telling those two decompositions apart is not
+ * about binders — it is what a third reader of a clause's topology costs, and it is held below as
+ * that rather than as a binding this reading did not cross.
  */
 class ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest {
 
@@ -82,21 +84,26 @@ class ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest {
     }
 
     /**
-     * A helper whose body joins two rules is one conjunct, and its lines are not drawn yet.
+     * A helper whose body joins two rules is one conjunct, and one conjunct places one end here.
      *
-     * <p>Written down as it stands rather than left to be found. Crossing the binding reaches the
-     * conjunction, and reading its halves as ends would number them as parts the reading beside this
-     * one does not have — the conjuncts are the author's, and the author wrote one. So the rule
-     * places nothing here while the same rules written out place two ends, which is the difference
-     * this issue is about, still open for this one shape.
+     * <p>Not a binding this reading fails to cross. It crosses it and arrives at a conjunction,
+     * which is two rules where the reader below wants one — and reading its halves as two ends would
+     * number them as parts the reading beside this one does not have, since the conjuncts of a
+     * clause are the author's and the author wrote one.
+     *
+     * <p>So what is left is not about binders at all: an authored part may state more than one rule,
+     * and telling a clause's semantic decomposition from its authored-part decomposition is what a
+     * third reader of the topology costs. That is the subject of the issue on recognising a clause's
+     * topology once — this reading is one of the readers named there — and it is where this case
+     * belongs rather than here.
      */
     @Test
-    void aHelperWhoseBodyJoinsTwoRulesPlacesNoLineYet() {
+    void aHelperWhoseBodyJoinsTwoRulesIsOneAuthoredPart() {
         assertEquals(2, linesOf("Int", "", "value >= 1 && value <= 9").size(),
                 "written out, the two conjuncts place an end each");
         assertEquals(List.of(),
                 linesOf("Int", "let inRange (n: Int) = n >= 1 && n <= 9", "inRange(value)"),
-                "and through a helper the one conjunct places neither, which is not settled");
+                "and one authored conjunct states both rules, which this reader has one end for");
     }
 
     /** And the corpus above is about lines, so the written-out spellings have to draw some. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest.java
@@ -1,0 +1,108 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A rule that draws a line draws it wherever the rule is written.
+ *
+ * <p>What a position admits and what a construction owes were the readings #1333 was about, and a
+ * line is a third answer with a reader of its own: which authored rule placed which end
+ * ({@link FieldDomains.Placed}) is what the declared bounds and the partition's lines are built
+ * from. That reader classifies the clause it was handed, and a clause stating its rule through a
+ * helper is that rule under a binding — so it reached no comparison and the declaration came back
+ * with no line drawn on it, which is the difference the issue is written about.
+ *
+ * <p>Held on the lines themselves rather than on a verdict. A construction reads the rule through
+ * one more reader, so the two spellings can come to one verdict while the lines under them differ.
+ *
+ * <p><b>The conjuncts stay the author's.</b> A binding is crossed and never split: which parts a
+ * clause has is what its author wrote ({@link ClauseHelpers#conjunctsOf}, over the tree before any
+ * expansion), so a helper whose body joins two rules is one conjunct and not two. What that leaves
+ * is held below.
+ */
+class ALineIsDrawnWhereverTheRuleThatDrawsItIsWrittenTest {
+
+    private static List<FieldDomains.Placed> linesOf(String base, String helpers, String clause) {
+        String source = """
+                module demo
+
+                %s
+
+                data N = %s
+                    invariant %s
+                """.formatted(helpers, base, clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES).placed();
+    }
+
+    @Test
+    void anEndPlacedThroughAHelperIsTheEndTheRuleWrittenOutPlaces() {
+        assertEquals(linesOf("Int", "", "value >= 1"),
+                linesOf("Int", "let atLeast (n: Int, floor: Int) = n >= floor",
+                        "atLeast(value, 1)"),
+                "the same end, at the same coordinate, from the same conjunct");
+    }
+
+    /** The rule #1333 was written about, which draws its line on a length. */
+    @Test
+    void theEndOnALengthIsPlacedWhicheverWayTheRuleReachesIt() {
+        assertEquals(linesOf("String", "", "String.length(value) >= 1"),
+                linesOf("String", "let atLeastOne (s: String) = String.length(s) >= 1",
+                        "atLeastOne(value)"),
+                "a newtype whose rule is a length reaches the same line through a helper");
+    }
+
+    /** And a helper of a helper is bindings all the way down, which changes nothing. */
+    @Test
+    void aHelperOfAHelperPlacesTheSameEnd() {
+        assertEquals(linesOf("Int", "", "value >= 1"),
+                linesOf("Int", """
+                        let notBelow (n: Int, floor: Int) = n >= floor
+                        let atLeast (n: Int, floor: Int) = notBelow(n, floor)
+                        """, "atLeast(value, 1)"),
+                "crossing two bindings is crossing one twice");
+    }
+
+    /**
+     * A helper whose body joins two rules is one conjunct, and its lines are not drawn yet.
+     *
+     * <p>Written down as it stands rather than left to be found. Crossing the binding reaches the
+     * conjunction, and reading its halves as ends would number them as parts the reading beside this
+     * one does not have — the conjuncts are the author's, and the author wrote one. So the rule
+     * places nothing here while the same rules written out place two ends, which is the difference
+     * this issue is about, still open for this one shape.
+     */
+    @Test
+    void aHelperWhoseBodyJoinsTwoRulesPlacesNoLineYet() {
+        assertEquals(2, linesOf("Int", "", "value >= 1 && value <= 9").size(),
+                "written out, the two conjuncts place an end each");
+        assertEquals(List.of(),
+                linesOf("Int", "let inRange (n: Int) = n >= 1 && n <= 9", "inRange(value)"),
+                "and through a helper the one conjunct places neither, which is not settled");
+    }
+
+    /** And the corpus above is about lines, so the written-out spellings have to draw some. */
+    @Test
+    void theSpellingsHeldAboveDrawLines() {
+        assertFalse(linesOf("Int", "", "value >= 1").isEmpty(),
+                "a comparison written out draws a line, or nothing above is being compared");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest.java
@@ -131,7 +131,6 @@ class ATermsHashIsTakenFromValuesAndNotFromIdentitiesTest {
                 interned.part(one, 0),
                 interned.choice(one, one, one),
                 interned.closure(1, one),
-                interned.let(one, one),
                 interned.built(data, List.of("f"), List.of(one)),
                 interned.called(new ValueName.Helper("m", "f"), List.of(one)),
                 evaluated,

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
@@ -81,23 +81,33 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
             """;
 
     /**
-     * A clause about a position none of the readings knows.
+     * A rule a helper states about a field of the value it was handed, which no reading takes in.
      *
-     * <p>The invariant is a call, and what it comes to is a rule about a field of the value the
-     * helper was handed. The readings here are filed under the positions they recognise, and that
-     * field is not one of them — so the rule is claimed by none of them, and none of them has
-     * anything to say about why.
+     * <p>The clause is a call, and what it comes to is a rule about {@code range.max}. That the
+     * rule reaches through a helper decides nothing: the reading goes inside the binding the
+     * expansion made, so it names the same position and says the same thing about it as the rule
+     * written out (ADR-0106).
      */
-    private static final String A_RULE_NO_READING_CLAIMS = """
+    private static final String A_RULE_THROUGH_A_HELPER = """
             module demo
 
-            data Range = { min: Int, max: Int }
+            data Range = { min: String, max: String }
 
             data N = { range: Range }
                 invariant valid(range)
 
-            let valid (r: Range) : Bool = r.max >= 0
-            """;
+            let valid (r: Range) : Bool = UNREAD_MAX
+            """.replace("UNREAD_MAX", souther.compiler.ARuleNoReadingTakesIn.about("r.max"));
+
+    /** The same rule written where the clause is, which is what the one above is held to. */
+    private static final String THE_SAME_RULE_WRITTEN_OUT = """
+            module demo
+
+            data Range = { min: String, max: String }
+
+            data N = { range: Range }
+                invariant UNREAD_MAX
+            """.replace("UNREAD_MAX", souther.compiler.ARuleNoReadingTakesIn.about("range.max"));
 
     /** What became of every question of every rule that nothing answered. */
     private static Map<String, String> whyStanding(FieldDomains read) {
@@ -113,17 +123,21 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
     }
 
     /**
-     * A question no reading claimed says so, and does not borrow a reading's account.
+     * A question a helper's rule leaves standing is the reading's, and it is the same question the
+     * rule written out leaves.
      *
-     * <p>The other two arms are one reading's own words for where it gave up. A question standing
-     * because nobody took the rule in has no such words behind it — answered with them, an author
-     * is told which reader fell short of their clause, and the reader named is one that never held
-     * it and has no word for such a rule at all.
+     * <p>Every arm names a reading, because a rule that reaches a question reaches the readings —
+     * one of them adopts it or one of them records where it gave up. A helper is no exception: the
+     * expansion binds the argument and the reading goes inside the binding, so the position the
+     * rule names and the account left at it do not turn on which of the two spellings an author
+     * wrote.
      */
     @Test
-    void aQuestionNoReadingClaimedNamesNoReading() {
-        assertEquals(Map.of("invariant N #1 at range.max", "NothingTookItIn"),
-                whyStanding(read(A_RULE_NO_READING_CLAIMS)));
+    void aQuestionAHelpersRuleLeavesIsTheSameOneTheRuleWrittenOutLeaves() {
+        Map<String, String> throughAHelper = whyStanding(read(A_RULE_THROUGH_A_HELPER));
+
+        assertEquals(Map.of("invariant N #1 at range.max", "TheValueReadingSays"), throughAHelper);
+        assertEquals(whyStanding(read(THE_SAME_RULE_WRITTEN_OUT)), throughAHelper);
     }
 
     /** Everything the reading of ends was stopped by, per question it left standing. */

--- a/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/RuleReadings.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
 import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeSymbol;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -53,6 +54,22 @@ public final class RuleReadings {
      *  beside it. */
     public static ExpandedClauseLookup declaredBy(Db db, String module) {
         return of(db, module).invariants();
+    }
+
+    /**
+     * What the one position of {@code source}'s {@code N} is left, as its own reading says it.
+     *
+     * <p>Rendered rather than handed over, so a test outside this package can hold two declarations
+     * to answering alike without reaching into what a reading is made of.
+     */
+    public static String admittedByTheValueOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        Symbols symbols = souther.compiler.query.Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = souther.compiler.types.TypeSymbols.declared(
+                new souther.compiler.types.TypeKey(symbols.module(), "N"));
+        return String.valueOf(FieldDomains.of(name, of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES).admits(RuleKey.THE_VALUE));
     }
 
     /** A reading over the discharge tree of a scope no declaration of which wrote a clause, for a

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest.java
@@ -55,7 +55,13 @@ class WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest {
     }
 
     private static long cost(Core e) {
-        return new ExpansionCost(64).read(e, true);
+        return counted(new ExpansionCost(64), e, true);
+    }
+
+    /** The count this reading comes to. It carries no environment, so a binding leaves what it was
+     *  given ({@link ClauseScope#unchanged}) and the count is over the shape alone. */
+    private static long counted(ExpansionCost counting, Core e, boolean positive) {
+        return counting.read(e, positive, null, ClauseScope.unchanged());
     }
 
     /** A conjunction of choices, which doubles what it comes to per level and stays as long as the
@@ -92,7 +98,7 @@ class WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest {
     void aDenialCountsWhatTheClauseUnderItCountsDenied() {
         for (Core each : List.of(leaf(), or(leaf(), leaf()), and(leaf(), leaf()),
                 and(or(leaf(), leaf()), leaf()), or(and(leaf(), leaf()), leaf()))) {
-            assertEquals(new ExpansionCost(64).read(each, false), cost(not(each)),
+            assertEquals(counted(new ExpansionCost(64), each, false), cost(not(each)),
                     "a denial is carried down and not applied to what a branch came to");
         }
         assertEquals(1L, cost(not(or(leaf(), leaf()))), "a denied choice is a conjunction");
@@ -134,7 +140,8 @@ class WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest {
     @Test
     void aCountThatRunsPastTheLimitSaturates() {
         assertEquals(65, cost(doubling(64)), "saturated at one past the limit, and not overflowed");
-        assertEquals(4L, new ExpansionCost(3).read(and(or(leaf(), leaf()), or(leaf(), leaf())), true),
+        assertEquals(4L, counted(new ExpansionCost(3),
+                        and(or(leaf(), leaf()), or(leaf(), leaf())), true),
                 "a limit of its own is saturated at one past that");
     }
 
@@ -150,9 +157,9 @@ class WhatAClauseWouldExpandToIsCountedByTheFoldThatReadsItTest {
         Core wide = doubling(40);
 
         for (int limit : new int[] {Integer.MAX_VALUE - 1, Integer.MAX_VALUE}) {
-            assertEquals((long) limit + 1, new ExpansionCost(limit).read(wide, true),
+            assertEquals((long) limit + 1, counted(new ExpansionCost(limit), wide, true),
                     "one past the limit, whatever the limit is: " + limit);
-            assertTrue(new ExpansionCost(limit).read(wide, true) > limit,
+            assertTrue(counted(new ExpansionCost(limit), wide, true) > limit,
                     "and above it, so the guardrail refuses what it exists to refuse: " + limit);
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
@@ -1,0 +1,131 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A question a rule leaves standing is accounted for by a reading or by the answer, and the two are
+ * told apart.
+ *
+ * <p>Three causes reach one outcome and only two of them are about a rule. A rule whose form no
+ * reading takes apart is the reading's own account; a rule read in full whose exact answer ran past
+ * the allowance is an account of the answer, which no rule is answerable for
+ * ({@link ReadingEvidence#stoppedBy} refuses to file one). A question with neither is the accounting
+ * disagreeing with itself and is refused where it is made.
+ *
+ * <p>The third case is what this is for. Reaching an admitted-values question with no reading having
+ * recognised the rule's positions was one, and a helper was the way to it: the clause was read at
+ * the names the expansion's binding introduced and every reading passed over it. Going inside the
+ * binding closed that (ADR-0106), so the helper here is held to answering as the rule written out
+ * does — and the answer-level case is held beside it, so that closing one is not read as the other
+ * having gone away.
+ */
+class WhatAStandingQuestionIsAccountedForByTest {
+
+    /**
+     * A rule no reading takes apart, written where the clause is.
+     *
+     * <p>The reading recognised the position and gave up on the rule, which is its own account to
+     * give.
+     */
+    private static final String A_FORM_NO_READING_TAKES_APART = """
+            module demo
+
+            data Range = { min: String, max: String }
+
+            data N = { range: Range }
+                invariant UNREAD_MAX
+            """.replace("UNREAD_MAX", souther.compiler.ARuleNoReadingTakesIn.about("range.max"));
+
+    /** The same rule, reached through a helper, which is the same rule about the same position. */
+    private static final String THE_SAME_FORM_THROUGH_A_HELPER = """
+            module demo
+
+            data Range = { min: String, max: String }
+
+            data N = { range: Range }
+                invariant valid(range)
+
+            let valid (r: Range) : Bool = UNREAD_MAX
+            """.replace("UNREAD_MAX", souther.compiler.ARuleNoReadingTakesIn.about("r.max"));
+
+    /**
+     * Rules read in full whose answer is more than the allowance will build.
+     *
+     * <p>Each pattern is small and both are taken in; showing the branch they share empty takes a
+     * machine of about ninety thousand states. So nothing is short of a rule here, and what is short
+     * is the answer they come to between them — which is why the question stands with no reading
+     * naming a rule. The same model is read for what it leaves the position in
+     * {@code ABranchNobodyCouldWorkOutIsNotOneAnybodyReadTest}.
+     */
+    private static final String AN_ANSWER_BEYOND_THE_ALLOWANCE = """
+            module demo
+
+            data N = { x: String, y: String }
+                invariant r =
+                    (String.matches("a{300}", y) && String.matches("b{300}", y))
+                    || x == "A"
+            """;
+
+    @Test
+    void aFormNoReadingTakesApartIsTheReadingsOwnAccount() {
+        assertEquals(Map.of("invariant N #1 at range.max", "TheValueReadingSays"),
+                whyStanding(A_FORM_NO_READING_TAKES_APART));
+    }
+
+    /** And reaching that rule through a helper does not change whose account it is. */
+    @Test
+    void reachingThatRuleThroughAHelperLeavesTheSameAccount() {
+        assertEquals(whyStanding(A_FORM_NO_READING_TAKES_APART),
+                whyStanding(THE_SAME_FORM_THROUGH_A_HELPER));
+    }
+
+    /**
+     * And a rule the reading took in whole leaves a question no reading is answerable for.
+     *
+     * <p>Which is the arm that names none of them, standing for the one thing it now stands for. A
+     * reading's own words here would say that something fell short of the rule, and nothing did.
+     */
+    @Test
+    void anAnswerBeyondTheAllowanceIsAccountedForByNoReading() {
+        assertEquals(Map.of("invariant N (r) at y", "NothingTookItIn"),
+                whyStanding(AN_ANSWER_BEYOND_THE_ALLOWANCE));
+    }
+
+    /** What became of every question of every rule that nothing answered. */
+    private static Map<String, String> whyStanding(String source) {
+        Map<String, String> out = new LinkedHashMap<>();
+        read(source).accounting().values().forEach(accounting ->
+                accounting.answers().forEach((owed, outcome) -> {
+                    if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted) {
+                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                                unaccounted.why().getClass().getSimpleName());
+                    }
+                }));
+        return out;
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
@@ -172,16 +172,30 @@ class WhatAStandingQuestionIsAccountedForByTest {
      */
     @Test
     void onlyAReasonAboutTheAnswerStandsInForARulesOwnAccount() {
-        assertEquals(Set.of(UnreadReason.EXACT_VALUES_TOO_COSTLY),
-                Arrays.stream(UnreadReason.values())
-                        .filter(each -> each.about() == UnreadReason.About.THE_ANSWER)
-                        .collect(Collectors.toCollection(LinkedHashSet::new)),
-                "what may account for a standing question without naming a rule");
-        assertEquals(Set.of(UnreadReason.NOT_REACHED, UnreadReason.NOT_REACHED_PAST_DEPTH_LIMIT),
-                Arrays.stream(UnreadReason.values())
-                        .filter(each -> each.about() == UnreadReason.About.NEITHER)
-                        .collect(Collectors.toCollection(LinkedHashSet::new)),
-                "and what accounts for nothing, which the refusal must not take for the above");
+        assertEquals(Set.of(UnreadReason.About.THE_ANSWER), aboutWhat(true),
+                "only a reason about the answer stands in for what a rule would have said");
+        assertEquals(Set.of(UnreadReason.About.A_RULE, UnreadReason.About.NEITHER), aboutWhat(false),
+                "a rule's own reason is filed under the rule, and a reason about neither accounts"
+                        + " for nothing — the refusal must take neither for the above");
+        // And every kind is decided, so the two above are the whole of the classification rather
+        // than the part of it this enum happens to hold reasons for today.
+        assertEquals(Set.of(UnreadReason.About.values()),
+                Set.copyOf(union(aboutWhat(true), aboutWhat(false))));
+    }
+
+    /** What the reasons that do, or do not, stand in for a rule's own account are about. */
+    private static Set<UnreadReason.About> aboutWhat(boolean standingIn) {
+        return Arrays.stream(UnreadReason.values())
+                .filter(each -> FieldDomains.standsInForARulesOwnAccount(each) == standingIn)
+                .map(UnreadReason::about)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static Set<UnreadReason.About> union(Set<UnreadReason.About> one,
+                                                 Set<UnreadReason.About> other) {
+        Set<UnreadReason.About> out = new LinkedHashSet<>(one);
+        out.addAll(other);
+        return out;
     }
 
     /** What became of every question of every rule that nothing answered. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
@@ -7,10 +7,15 @@ import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.UnreadReason;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -78,6 +83,56 @@ class WhatAStandingQuestionIsAccountedForByTest {
                     || x == "A"
             """;
 
+    /**
+     * A rule relating two positions, written out and reached through a helper standing in one of
+     * its operands.
+     *
+     * <p>What the reading recognised is what tells a relation from a form it has no word for, so
+     * a binding it did not go inside turned {@code hi >= lo} into a shape nothing reads — and an
+     * author was sent after the form of a rule whose form was never the matter. Here because it is
+     * the account rather than the verdict that moves: both spellings leave the position open either
+     * way, and only the reason says which.
+     */
+    private static final String A_RELATION_WRITTEN_OUT = """
+            module demo
+
+            data N =
+                { lo: Int
+                , hi: Int
+                }
+                invariant hi >= lo
+            """;
+
+    private static final String THE_SAME_RELATION_THROUGH_A_HELPER = """
+            module demo
+
+            let itself (n: Int) = n
+
+            data N =
+                { lo: Int
+                , hi: Int
+                }
+                invariant hi >= itself(lo)
+            """;
+
+    @Test
+    void aRelationIsOneWhicheverSideReachesItThroughAHelper() {
+        assertEquals(souther.compiler.values.UnreadReason.RELATES_TWO_POSITIONS,
+                whyWider(A_RELATION_WRITTEN_OUT, "lo"),
+                "both sides are recognised, so the rule relates two positions");
+        assertEquals(whyWider(A_RELATION_WRITTEN_OUT, "lo"),
+                whyWider(THE_SAME_RELATION_THROUGH_A_HELPER, "lo"),
+                "and a binding standing in an operand is not a form nothing reads");
+    }
+
+    /** What the values reading was left short by at one name. */
+    private static souther.compiler.values.UnreadReason whyWider(String source, String field) {
+        return ((souther.compiler.values.AdmissibleSet.Widening.RuleUnread)
+                ((souther.compiler.values.AdmissibleSet.Completeness.Wider)
+                        read(source).admits(RuleKey.of(field)).completeness())
+                        .why().iterator().next()).why();
+    }
+
     @Test
     void aFormNoReadingTakesApartIsTheReadingsOwnAccount() {
         assertEquals(Map.of("invariant N #1 at range.max", "TheValueReadingSays"),
@@ -101,6 +156,32 @@ class WhatAStandingQuestionIsAccountedForByTest {
     void anAnswerBeyondTheAllowanceIsAccountedForByNoReading() {
         assertEquals(Map.of("invariant N (r) at y", "NothingTookItIn"),
                 whyStanding(AN_ANSWER_BEYOND_THE_ALLOWANCE));
+    }
+
+    /**
+     * And what may stand in for a rule's own account is the answer, and nothing else.
+     *
+     * <p>The negative control on the refusal. A reason is about a rule, about the answer, or about
+     * neither, and only the second is an account of a question the rule left standing: the third is
+     * a reading that never reached the position, which accounts for nothing — as its name says.
+     *
+     * <p>Enumerated from {@link UnreadReason} rather than listed, so a reason added to either of the
+     * other two cannot quietly become an account by being written where this one is not looking.
+     * Asked of the classification because that is what the refusal asks: written as "not about a
+     * rule", one of the third kind at the name would stand in for an account that is not there.
+     */
+    @Test
+    void onlyAReasonAboutTheAnswerStandsInForARulesOwnAccount() {
+        assertEquals(Set.of(UnreadReason.EXACT_VALUES_TOO_COSTLY),
+                Arrays.stream(UnreadReason.values())
+                        .filter(each -> each.about() == UnreadReason.About.THE_ANSWER)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                "what may account for a standing question without naming a rule");
+        assertEquals(Set.of(UnreadReason.NOT_REACHED, UnreadReason.NOT_REACHED_PAST_DEPTH_LIMIT),
+                Arrays.stream(UnreadReason.values())
+                        .filter(each -> each.about() == UnreadReason.About.NEITHER)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                "and what accounts for nothing, which the refusal must not take for the above");
     }
 
     /** What became of every question of every rule that nothing answered. */

--- a/souther-compiler/src/test/java/souther/compiler/query/InvariantCapabilitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/InvariantCapabilitiesTest.java
@@ -163,10 +163,14 @@ class InvariantCapabilitiesTest {
      * the clause.
      *
      * <p>Conjuncts are split from what the author wrote, so {@code a && b} inside a helper is not two
-     * of them. The clause is the call, which the check names as a term — and what matters here is
-     * that {@code 1 >= 0} inside the helper does not come back as a clause holding of every value.
-     * A reading that took the settled half for the whole would say no guard is needed for a rule
-     * that plainly needs one.
+     * of them. The clause is the call, and what matters here is that {@code 1 >= 0} inside the
+     * helper does not come back as a clause holding of every value. A reading that took the settled
+     * half for the whole would say no guard is needed for a rule that plainly needs one.
+     *
+     * <p>Both routes, because the rule the helper states is read as the rule it is: the domain
+     * reasons over {@code n >= 0} as a bound on the value, and the check names the call as a term
+     * that a guard may state. The clause still needs one of them, which is the whole of what is
+     * being held.
      */
     @Test
     void aConjunctionAHelperBringsDoesNotSettleFromOneHalf() {
@@ -177,8 +181,9 @@ class InvariantCapabilitiesTest {
                     invariant nonNegative(value)
                 """, "Money");
         assertEquals(1, clauses.size(), "one conjunct, because the author wrote one");
-        assertEquals(routed(new StaticRoute.AsATerm()), read(clauses, 0),
-                "the clause is the call, and a guard stating the same thing discharges it");
+        assertEquals(routed(new StaticRoute.AsABound(), new StaticRoute.AsATerm()),
+                read(clauses, 0),
+                "the rule the helper states is a bound, and the call is a term a guard may state");
     }
 
     /**


### PR DESCRIPTION
Closes #1333.

A helper call is expanded by binding each argument and reading the parameter through that binding (spec §invariant-discharge-representation), so a clause stating its rule through a helper is that rule under a binding. Measured at the start: with the rule written out, a construction the guards prove must fail is refused (`E2010`); with the same rule reached through a helper, the compile said nothing at all.

## What a clause reading is

What a clause states is answered upward and what its names mean is handed downward. `ClauseExpr.Scoped` is where the second changes and nothing else — it composes no statements — and `ClauseScope` answers what a binding is entered as, so no clause evaluator is handed a binding **as the clause's shape**. For a reading carrying `Denotations` the answer is `Terms.inside`, which is the one place a `let` is entered (ADR-0106). The readings hold no environment of their own any more: a leaf is read at where it stands.

**A binding nested inside a leaf stays part of that leaf**, and the decision reaches it there rather than by taking the shape further in. Binding transparency is not a property of the clause's topology — it is a property of every semantic question a reading asks about the inside of a leaf, and a question that answers from the tree alone is one the decision has not been applied to yet. So each of them crosses the binding through the environment: which position an operand is, what written value it is, which positions a part names, and which authored rule placed which end.

`Predicates` reads the body of a binding under the same environment, asking that same one place for it. Its own recognition of the connectives stays where it is — an asserted disjunction is not split there, so moving it onto this fold would change what a disjunctive clause owes. That is #1336.

## What the accounting had resting on the defect

The account of a question a rule leaves standing has an arm naming no reading, documented as what a rule about a position none of the readings knows comes to — a helper reading a field of the value it was handed being the example. That example is gone.

The arm stays, because it was never its only cause. A reading may take every rule in and still be unable to build the exact answer they come to within its allowance; that loss is about the answer rather than about any rule that paid into it, and `ReadingEvidence.stoppedBy` refuses to file such a reason under a rule. So a standing question is accounted for by a reading's own words about the rule, or by a reason at the name that no rule could be answerable for — and neither is the accounting disagreeing with itself, which is refused where the account is made.

The name says no reading took it in and the reading did take it in. Left as it is with the state written down — what an answer-level limit should be called in the published vocabulary is #1335.

## Held

The corpus is the spellings of one rule — written out, through a helper, through a helper of a helper, denied two ways, joined inside the helper, standing beside a written-out rule, handed to a helper as a value, given more than it reads, standing in an operand, and reaching a bare parameter the clause's shape already crossed. Every one refuses the construction the guards refute and admits the one they allow, and what the position admits is the same value, the same set and the same format whichever spelling it arrived by. The rule the issue is written about is among them.

The lines are held on their own, because a construction reads the rule through one more reader and two spellings can reach one verdict with different lines under them.

The fold is held apart from any of that: a binding is a shape and not a leaf, no evaluator is handed one, each binding on the way down is entered in turn, a connective under a binding is read inside it, a binding under a connective reaches its own side alone, a denial is carried through, a closure keeps the place its parameter is bound at, and a leaf is handed on as the very node it was — which is the control saying the fold changes the environment and nothing else.

The three causes of a standing question are told apart over their own fixtures, so closing the helper one is not read as the answer-level one having gone away.

## What closes the issue, and what it hands on

Every difference a reading's inability to cross a binding made is gone: what a position admits, where its values stop, which values and which formats it holds, what a construction owes, what a standing question is accounted for by, and which authored rule placed which end — each answers alike whichever spelling the rule arrived by.

One shape is left, and its cause is not a binder. A helper whose body joins two rules is one authored conjunct, and the line reader crosses the binding, arrives at the conjunction and reads neither end: reading its halves as two would number them as parts the reading beside it does not have. Telling a clause's semantic decomposition from its authored-part decomposition is what a third reader of the topology costs, which is #1336 — where `InvariantChecker.direct` is now named alongside `ClauseExpr` and `Predicates.read`, with this case and the characterization it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)