### PR TITLE
Leave the repository's own population out of the run somebody waits on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
+  schedule:
+    # Nightly, so a population left behind by a day's merges is found by morning.
+    - cron: '0 18 * * *'
 
 permissions:
   contents: read
 
 jobs:
+  # What a pull request waits on: everything except the tests whose subjects are the models,
+  # sources and specification this repository carries. Those are the job below.
   build:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -21,3 +27,20 @@ jobs:
           cache: maven
       - name: Build and test
         run: mvn -B --no-transfer-progress verify
+
+  # And the population, asked where waiting for it costs nobody an edit: on the merge into
+  # develop or main, and once a night. Emptying the property is what asks them; everything the
+  # job above runs is run here too, so this is the whole suite and not the remainder of it.
+  population:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: Build and test, the population included
+        run: mvn -B --no-transfer-progress verify -Dtest.excluded.groups=

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,10 @@
              plugin's configuration is not overridable, and what these flags are worth has to be
              measurable against the suite as it stands rather than the one they were chosen on. -->
         <test.jvm.args>-XX:TieredStopAtLevel=1 -XX:+UseSerialGC -Xss4m</test.jvm.args>
+        <!-- The tag a test carries when its subjects are enumerated from what this repository
+             carries rather than written in the test. Left out of a plain run and asked for by
+             emptying this. -->
+        <test.excluded.groups>population</test.excluded.groups>
         <!-- What a row of an example is held to while the suite runs. The shipped default is a
              hundred million, which is what a model somebody wrote deserves; the models here write a
              literal or a small record, and dozens of them hold a helper that loops on purpose,
@@ -215,6 +219,12 @@
                              did first. Override with -DforkCount=N; 1 is one JVM for everything. -->
                         <forkCount>${forkCount}</forkCount>
                         <reuseForks>true</reuseForks>
+                        <!-- Left out of a plain run: what a test tagged this way is about is every
+                             model, source or specification this repository carries, and answering
+                             those is most of what the suite costs. A run that means to ask them
+                             empties this — `-Dtest.excluded.groups=` — which is what the merge into
+                             develop and the nightly build do. -->
+                        <excludedGroups>${test.excluded.groups}</excludedGroups>
                         <!-- Classes go to the forks by what they took last time, which is recorded
                              in a `.surefire-*` file beside the module. Handed out in file order
                              instead, one fork draws the longest class and a share of the rest, and

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
              this. A fork brings its own compiler and collector threads, and one per core leaves
              nothing for them but the cores the tests are on. -->
         <forkCount>0.5C</forkCount>
+        <!-- The JVM a fork runs on. Named for the same reason the fork count is: a literal in the
+             plugin's configuration is not overridable, and what these flags are worth has to be
+             measurable against the suite as it stands rather than the one they were chosen on. -->
+        <test.jvm.args>-XX:TieredStopAtLevel=1 -XX:+UseSerialGC -Xss4m</test.jvm.args>
         <!-- What a row of an example is held to while the suite runs. The shipped default is a
              hundred million, which is what a model somebody wrote deserves; the models here write a
              literal or a small record, and dozens of them hold a helper that loops on purpose,
@@ -229,7 +233,7 @@
                              megabyte, and what is checked here has to be checked on the stack the
                              bound was set for. A test that wants a smaller one makes its own
                              thread. -->
-                        <argLine>-XX:TieredStopAtLevel=1 -XX:+UseSerialGC -Xss4m</argLine>
+                        <argLine>${test.jvm.args}</argLine>
                         <systemPropertyVariables>
                             <souther.example.step.limit>${test.example.step.limit}</souther.example.step.limit>
                         </systemPropertyVariables>

--- a/souther-architecture-test/src/test/java/souther/architecture/EveryTestAboutTheRepositorysPopulationSaysSoTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/EveryTestAboutTheRepositorysPopulationSaysSoTest.java
@@ -1,0 +1,200 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.Annotation;
+import java.lang.classfile.AnnotationValue;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every test whose subjects come from this repository says that it is one.
+ *
+ * <p>A test that sweeps the models this repository carries, or its sources, or its specification, is
+ * asking about the language rather than about a source somebody wrote to ask one question. Answering
+ * such a subject is most of what the suite costs, so a plain run leaves them out and the merge into
+ * develop asks them. What decides which run a test lands in is the tag it carries.
+ *
+ * <p><b>So the tag cannot be a thing to remember.</b> A test reaching a corpus without one is left in
+ * the run everybody waits on, and nothing about writing it would say so — the class compiles, passes,
+ * and is slow somewhere else. The population is read off the compiled tests here instead: every test
+ * class that reaches a corpus, by its own constant pool or through another test class that does.
+ *
+ * <p>The corpora are named below rather than recognised. A corpus is a thing somebody wrote to be
+ * swept, and there are few of them; a rule that guessed which classes were corpora would be a second
+ * account of the same short list, and the two would disagree the first time one moved.
+ */
+class EveryTestAboutTheRepositorysPopulationSaysSoTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** What this tag is spelled as where a test carries it. */
+    private static final String TAG = "population";
+
+    /**
+     * What hands out a population, as binary names.
+     *
+     * <p>Each reads something the repository carries and hands it out to be swept: the conformance
+     * corpora and the models compiled beside them, and the sources the formatter is held to. A test
+     * that reaches one of these is asking about all of what it hands out.
+     */
+    private static final Set<String> CORPORA = Set.of(
+            "souther/compiler/conformance/ConformanceCorpus",
+            "souther/compiler/conformance/RepositoryModels",
+            "souther/compiler/fmt/FormatterCorpus",
+            "souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest",
+            "souther/bench/Corpus");
+
+    @Test
+    void everyTestReachingACorpusCarriesTheTag() {
+        Map<String, Set<String>> references = referencesByClass();
+        assertFalse(references.isEmpty(),
+                "no compiled test was read, so this walked nothing and would hold either way");
+
+        Set<String> reaching = reachingACorpus(references);
+        TreeSet<String> untagged = new TreeSet<>();
+        for (String each : reaching) {
+            if (!each.endsWith("Test")) {
+                // A helper a test reaches through. It runs nothing of its own, so no tag decides
+                // anything about it.
+                continue;
+            }
+            if (!tags(each).contains(TAG)) {
+                untagged.add(each.replace('/', '.'));
+            }
+        }
+
+        assertEquals(List.of(), List.copyOf(untagged),
+                "a test whose subjects come from this repository, in the run somebody waits on while"
+                        + " editing: it carries @Tag(\"" + TAG + "\") or it stops reaching a corpus");
+    }
+
+    /**
+     * And something reaches one, which is what says the walk read the pools rather than empty files.
+     *
+     * <p>Without it a walk that parsed nothing, or one whose corpora had all been renamed, would pass
+     * the check above by finding no test to hold to it.
+     */
+    @Test
+    void andSomeTestDoesReachACorpus() {
+        Set<String> reaching = reachingACorpus(referencesByClass());
+        assertTrue(reaching.stream().anyMatch(each -> each.endsWith("Test")),
+                "no test reaches any of " + CORPORA + ", so the names above are stale and this holds"
+                        + " for a reason other than the one it states");
+    }
+
+    /** Every compiled test, with the classes each names in its constant pool. */
+    private static Map<String, Set<String>> referencesByClass() {
+        Map<String, Set<String>> out = new LinkedHashMap<>();
+        for (Path module : REPOSITORY.modules()) {
+            Path where = testClassesOf(module);
+            if (!Files.isDirectory(where)) {
+                continue;
+            }
+            for (Path compiled : classesUnder(where)) {
+                ClassModel model = parse(compiled);
+                Set<String> named = new LinkedHashSet<>();
+                for (PoolEntry entry : model.constantPool()) {
+                    if (entry instanceof ClassEntry it) {
+                        named.add(it.asInternalName());
+                    }
+                }
+                out.put(model.thisClass().asInternalName(), named);
+            }
+        }
+        return out;
+    }
+
+    /** The classes that name a corpus, and the classes that reach one through them. */
+    private static Set<String> reachingACorpus(Map<String, Set<String>> references) {
+        Set<String> reaching = new LinkedHashSet<>();
+        Deque<String> pending = new ArrayDeque<>(CORPORA);
+        while (!pending.isEmpty()) {
+            String target = pending.removeFirst();
+            for (Map.Entry<String, Set<String>> each : references.entrySet()) {
+                if (each.getValue().contains(target) && reaching.add(each.getKey())) {
+                    pending.addLast(each.getKey());
+                }
+            }
+        }
+        // A corpus that is itself a test class reaches itself and is one of these.
+        CORPORA.stream().filter(references::containsKey).forEach(reaching::add);
+        return reaching;
+    }
+
+    /** The tags one compiled test carries, as they are written at the class. */
+    private static Set<String> tags(String internalName) {
+        for (Path module : REPOSITORY.modules()) {
+            Path compiled = testClassesOf(module).resolve(internalName + ".class");
+            if (Files.isRegularFile(compiled)) {
+                return tagsOf(parse(compiled));
+            }
+        }
+        return Set.of();
+    }
+
+    private static Set<String> tagsOf(ClassModel model) {
+        Set<String> out = new LinkedHashSet<>();
+        model.findAttribute(Attributes.runtimeVisibleAnnotations()).ifPresent(annotations -> {
+            for (Annotation each : annotations.annotations()) {
+                String type = each.className().stringValue();
+                if (!"Lorg/junit/jupiter/api/Tag;".equals(type)) {
+                    continue;
+                }
+                each.elements().stream()
+                        .filter(element -> "value".equals(element.name().stringValue()))
+                        .forEach(element -> {
+                            if (element.value() instanceof AnnotationValue.OfString it) {
+                                out.add(it.stringValue());
+                            }
+                        });
+            }
+        });
+        return out;
+    }
+
+    private static ClassModel parse(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException("a compiled test is not readable: " + compiled, e);
+        }
+    }
+
+    private static Path testClassesOf(Path module) {
+        return module.resolve("target").resolve("test-classes");
+    }
+
+    private static List<Path> classesUnder(Path where) {
+        try (Stream<Path> found = Files.walk(where)) {
+            List<Path> out = new ArrayList<>();
+            found.filter(each -> each.toString().endsWith(".class")).forEach(out::add);
+            return out;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/CorpusTest.java
+++ b/souther-bench/src/test/java/souther/bench/CorpusTest.java
@@ -1,5 +1,6 @@
 package souther.bench;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Compilation;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * nothing: these sources are timed, not read back, and every measure a report carries could move
  * without one of them failing to compile.
  */
+@Tag("population")
 class CorpusTest {
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/conformance/AConformanceCorpusReachesEveryConstructTheLanguageDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/AConformanceCorpusReachesEveryConstructTheLanguageDeclaresTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.conformance;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.DefaultStdlib;
@@ -52,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * keeps, and what a corpus reaches of their product is asked here as the tokens are asked above —
  * computed from the corpus rather than written out beside it.
  */
+@Tag("population")
 class AConformanceCorpusReachesEveryConstructTheLanguageDeclaresTest {
 
     /** Every meaningful token of every source in the corpus, one list per source. */

--- a/souther-compiler/src/test/java/souther/compiler/conformance/RepositoryModels.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/RepositoryModels.java
@@ -1,0 +1,77 @@
+package souther.compiler.conformance;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.test.RepositoryLayout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Every model this repository carries, compiled and answered.
+ *
+ * <p>The population a test asks about when its subject is the language rather than one source: the
+ * conformance corpora, which are what the language declares it accepts, and the bench corpora, which
+ * are models written to be worked with. A test that sweeps positions, rules or readings is asking
+ * about all of them, and asking about a smaller set would make its answer one about the fixtures it
+ * happened to name.
+ *
+ * <p><b>Built once for the JVM that asks.</b> Answering these is most of what such a test costs, and
+ * a class with three questions about the population would otherwise pay for the population three
+ * times. The compilations are handed out to be read: the answers are kept in each one's store, so a
+ * second reader finds the questions already put. A caller that would change one — update its
+ * documents, give it another budget — makes its own rather than taking these.
+ */
+public final class RepositoryModels {
+
+    /** The bench corpora, as the files each is compiled from, relative to the repository root. */
+    private static final List<List<String>> BENCH = List.of(
+            List.of("souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou",
+                    "souther-bench/src/main/resources/souther/bench/corpus/crm/pipeline.sou",
+                    "souther-bench/src/main/resources/souther/bench/corpus/crm/quoting.sou"),
+            List.of("souther-bench/src/main/resources/souther/bench/corpus/issuetracker/issues.sou"),
+            List.of("souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou"));
+
+    private static final List<Compilation> ALL = compileEverything();
+
+    private RepositoryModels() {
+    }
+
+    /** Every model this repository carries, each with everything about it answered. */
+    public static List<Compilation> all() {
+        return ALL;
+    }
+
+    private static List<Compilation> compileEverything() {
+        List<Compilation> out = new ArrayList<>();
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            // The analysing entry point, which is what says a conformance corpus was analysed: it
+            // puts the adequacy questions as well as compiling.
+            out.add(corpus.analyse().compilation());
+        }
+        Path root = RepositoryLayout.ofWorkingDirectory().root();
+        for (List<String> corpus : BENCH) {
+            List<String> sources = new ArrayList<>();
+            for (String each : corpus) {
+                sources.add(read(root.resolve(each)));
+            }
+            Compilation compilation = Compilation.ofSources(sources, ModulePath.EMPTY);
+            compilation.answerEverything();
+            out.add(compilation);
+        }
+        return List.copyOf(out);
+    }
+
+    private static String read(Path source) {
+        try {
+            return Files.readString(source);
+        } catch (IOException e) {
+            throw new UncheckedIOException("a corpus this repository carries is not readable: "
+                    + source, e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/conformance/TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.conformance;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.List;
  *
  * <p>What it does not claim is that the answers are good ones. It records what they are.
  */
+@Tag("population")
 class TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.conformance;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.OfferItem;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * come back {@code Undetermined} here. Strengthening the assertion to {@code Settles} would be
  * asserting something nothing establishes.
  */
+@Tag("population")
 class WhatAnOfferedRowWouldSettleIsMeasuredOverTheCorpusTest {
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/core/EveryTermCanBeReadWithoutItsPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/EveryTermCanBeReadWithoutItsPlaceTest.java
@@ -5,6 +5,7 @@ import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * language's own list of what a term can be, so a kind added later is unreached here until someone
  * says what its place is.
  */
+@Tag("population")
 class EveryTermCanBeReadWithoutItsPlaceTest {
 
 

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryChildANodeHandsOverStandsInANamedSlotTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * elsewhere, rather than of a model written to have one of everything. A model like that says what
  * its author remembered to put in it.
  */
+@Tag("population")
 class EveryChildANodeHandsOverStandsInANamedSlotTest {
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * wants is to be told, not to be handed a place that was invented for the occasion — so it throws,
  * and this is where the corpus says whether it ever has to.
  */
+@Tag("population")
 class EveryNameABodyReadsIsBoundSomewhereThisCanPointAtTest {
 
     private static final String SPLICED = """

--- a/souther-compiler/src/test/java/souther/compiler/coverage/TwoWalksOfOneBodyNameItsPlacesAlikeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/TwoWalksOfOneBodyNameItsPlacesAlikeTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * survive is expansion and lowering: a helper spliced into two calls is two places that look alike
  * and stand in different slots, and that is the case the whole thing is for.
  */
+@Tag("population")
 class TwoWalksOfOneBodyNameItsPlacesAlikeTest {
 
     /** A helper spliced twice, so two places are equal trees standing in different slots. */

--- a/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.flow;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the ways to a truth that holds none of them says the value is never settled that way, so it is only
  * ever answered where the reading of what the body does agrees.
  */
+@Tag("population")
 class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormMeansWhatTheSourceMeantTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormMeansWhatTheSourceMeantTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.fmt;
 
 import souther.compiler.diag.msg.MessageKeys;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * comparison drops. Everything else a node carries is compared, names and modifiers and structure
  * included.
  */
+@Tag("population")
 class TheCanonicalFormMeansWhatTheSourceMeantTest {
 
     /** The sources the layout rules are swept over: the bundled standard library, and the written

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * why the population here is every position of every model this repository carries, and the reason
  * is read off the finding rather than looked for in one place.
  */
+@Tag("population")
 class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
@@ -7,15 +7,13 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Sig;
-import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.conformance.RepositoryModels;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Shapes;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -120,28 +118,10 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
                 () -> "and nothing is short of the position's rules: " + at.reading());
     }
 
-    /** Every corpus this repository carries, as the files each is compiled from. */
-    private static final List<List<String>> CORPORA = List.of(
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/pipeline.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/quoting.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/issuetracker/issues.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou"));
-
     /** The reading of every behavior of every model this repository carries. */
-    private static List<InputDomain> everyReading() throws Exception {
+    private static List<InputDomain> everyReading() {
         List<InputDomain> out = new ArrayList<>();
-        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
-            readings(corpus.analyse().compilation(), out);
-        }
-        Path root = souther.test.RepositoryLayout.ofWorkingDirectory().root();
-        for (List<String> corpus : CORPORA) {
-            List<String> sources = new ArrayList<>();
-            for (String each : corpus) {
-                sources.add(Files.readString(root.resolve(each)));
-            }
-            Compilation compilation = Compilation.ofSources(sources, ModulePath.EMPTY);
-            compilation.answerEverything();
+        for (Compilation compilation : RepositoryModels.all()) {
             readings(compilation, out);
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * and decides what a reader should be told about it. So a shorter list is a failure as much as a
  * longer one.
  */
+@Tag("population")
 class NoRuleIsPlacedWhereNothingAccountsForItTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
@@ -7,14 +7,13 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
-import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.conformance.RepositoryModels;
+import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.ReadAs;
 import souther.compiler.query.Shapes;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -181,57 +180,36 @@ class NoRuleIsPlacedWhereNothingAccountsForItTest {
             behavior atTheSum : (q: Q) -> Ok
             """;
 
-    /** Every corpus this repository carries, as the files each is compiled from. */
-    private static final List<List<String>> CORPORA = List.of(
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/pipeline.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/quoting.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/issuetracker/issues.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou"));
+    /**
+     * The models asked about here: what the repository carries, and one this class writes.
+     *
+     * <p>The written one crosses a name through a sum, which the corpora do not, and the questions
+     * below are about every model that reaches them either way. Answered once for the class, as the
+     * repository's are, because each question here asks about all of them.
+     */
+    private static final List<Compilation> ASKED_ABOUT = askedAbout();
+
+    private static List<Compilation> askedAbout() {
+        List<Compilation> out = new ArrayList<>(RepositoryModels.all());
+        Compilation crossed = Compilation.ofSources(List.of(NAMES_THROUGH_A_SUM), ModulePath.EMPTY);
+        crossed.answerEverything();
+        out.add(crossed);
+        return List.copyOf(out);
+    }
 
     /** The reading of every behavior of every model this repository carries. */
-    private static List<InputDomain> everyReading() throws Exception {
+    private static List<InputDomain> everyReading() {
         List<InputDomain> out = new ArrayList<>();
-        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
-            readings(corpus.analyse().compilation(), out);
-        }
-        Compilation crossed = Compilation.ofSources(List.of(NAMES_THROUGH_A_SUM),
-                souther.compiler.meta.ModulePath.EMPTY);
-        crossed.answerEverything();
-        readings(crossed, out);
-        Path root = souther.test.RepositoryLayout.ofWorkingDirectory().root();
-        for (List<String> corpus : CORPORA) {
-            List<String> sources = new ArrayList<>();
-            for (String each : corpus) {
-                sources.add(Files.readString(root.resolve(each)));
-            }
-            Compilation compilation =
-                    Compilation.ofSources(sources, souther.compiler.meta.ModulePath.EMPTY);
-            compilation.answerEverything();
+        for (Compilation compilation : ASKED_ABOUT) {
             readings(compilation, out);
         }
         return out;
     }
 
     /** The rules of every value every reading of this repository's models opens. */
-    private static List<PlacedRules> everyValueRead() throws Exception {
+    private static List<PlacedRules> everyValueRead() {
         List<PlacedRules> out = new ArrayList<>();
-        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
-            valuesRead(corpus.analyse().compilation(), out);
-        }
-        Compilation crossed = Compilation.ofSources(List.of(NAMES_THROUGH_A_SUM),
-                souther.compiler.meta.ModulePath.EMPTY);
-        crossed.answerEverything();
-        valuesRead(crossed, out);
-        Path root = souther.test.RepositoryLayout.ofWorkingDirectory().root();
-        for (List<String> corpus : CORPORA) {
-            List<String> sources = new ArrayList<>();
-            for (String each : corpus) {
-                sources.add(Files.readString(root.resolve(each)));
-            }
-            Compilation compilation =
-                    Compilation.ofSources(sources, souther.compiler.meta.ModulePath.EMPTY);
-            compilation.answerEverything();
+        for (Compilation compilation : ASKED_ABOUT) {
             valuesRead(compilation, out);
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionIsUnderivableOnlyWhereSomethingStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionIsUnderivableOnlyWhereSomethingStandsAtItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.Compiler;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * reconstruction the accounting exists to take away — so the population here is the positions
  * themselves and the accounts that answer for them.
  */
+@Tag("population")
 class APositionIsUnderivableOnlyWhereSomethingStandsAtItTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.RepositoryModels;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * not exercise, since what is being checked is a property of the readers rather than of any one
  * model.
  */
+@Tag("population")
 class ARuleWhoseReadingStoppedLeavesAQuestionTest {
 
     /** A position whose two coordinates are both spoken for, which no accounting decides. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARuleWhoseReadingStoppedLeavesAQuestionTest.java
@@ -2,15 +2,13 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.conformance.RepositoryModels;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -118,11 +116,8 @@ class ARuleWhoseReadingStoppedLeavesAQuestionTest {
     }
 
     /** The models this repository carries, and the three readers they do not exercise. */
-    private static List<Compilation> every() throws Exception {
-        List<Compilation> out = new ArrayList<>();
-        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
-            out.add(corpus.analyse().compilation());
-        }
+    private static List<Compilation> every() {
+        List<Compilation> out = new ArrayList<>(RepositoryModels.all());
         for (String each : List.of(COMPETING_COORDINATES, A_COMPARISON_NOBODY_READS,
                 AN_ENSURES_NOBODY_READS)) {
             Compilation one = Compilation.ofSource(each, "Main");
@@ -130,24 +125,6 @@ class ARuleWhoseReadingStoppedLeavesAQuestionTest {
             one.answerEverything();
             out.add(one);
         }
-        Path root = souther.test.RepositoryLayout.ofWorkingDirectory().root();
-        for (List<String> corpus : CORPORA) {
-            List<String> sources = new ArrayList<>();
-            for (String each : corpus) {
-                sources.add(Files.readString(root.resolve(each)));
-            }
-            Compilation compilation =
-                    Compilation.ofSources(sources, souther.compiler.meta.ModulePath.EMPTY);
-            compilation.answerEverything();
-            out.add(compilation);
-        }
         return out;
     }
-
-    private static final List<List<String>> CORPORA = List.of(
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/crm/crm.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/pipeline.sou",
-                    "souther-bench/src/main/resources/souther/bench/corpus/crm/quoting.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/issuetracker/issues.sou"),
-            List.of("souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou"));
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnUnderivablePositionIsPublishedWithSomethingToActOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnUnderivablePositionIsPublishedWithSomethingToActOnTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * reader shown the first is not left with nothing to act on, and that a reader shown a position the
  * model states something about is not sent after a limit that is not there.
  */
+@Tag("population")
 class AnUnderivablePositionIsPublishedWithSomethingToActOnTest {
 
     /** A rule about a pair of positions, which each of them is read through and neither divided by. */

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest.java
@@ -4,6 +4,7 @@ import souther.compiler.Compiler;
 import souther.compiler.conformance.ConformanceCorpus;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.report.GeneratedRows;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * the suite would be a list of stimuli invented to reach a list, and a question added to one of these
  * operations would arrive uncovered while the arithmetic still added up.
  */
+@Tag("population")
 class EveryQuestionThisCompilerDeclaresIsReachedOrOutsideABatchRunTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/EverythingAnAnswerHoldsMeansSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EverythingAnAnswerHoldsMeansSomethingTest.java
@@ -3,6 +3,7 @@ package souther.compiler.query;
 import souther.compiler.conformance.ConformanceCorpus;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.diag.SourceNameResolver;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * to and what the compile said getting there, and {@code Db} compares both — so a corpus of models
  * nothing is said about exercises one half of every answer in the store.
  */
+@Tag("population")
 class EverythingAnAnswerHoldsMeansSomethingTest {
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatACallerAssumesIsWhatWasStatedNotWhereItWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatACallerAssumesIsWhatWasStatedNotWhereItWasWrittenTest.java
@@ -4,6 +4,7 @@ import souther.compiler.conformance.ConformanceCorpus;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.types.ValueName;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * numbered after the ones the blank lines did not add, so a place surviving anywhere in a contract
  * shows up here as an inequality.
  */
+@Tag("population")
 class WhatACallerAssumesIsWhatWasStatedNotWhereItWasWrittenTest {
 
     /** Every behavior that states something, in every module of every corpus. */

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryFindingAboutAnObligationJoinsToItsAccountTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryFindingAboutAnObligationJoinsToItsAccountTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.report;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.conformance.ConformanceCorpus;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * is that a shape which should carry one does. Here the two ends are compared: every finding of a
  * kind that is about an obligation, against the array that account publishes.
  */
+@Tag("population")
 class EveryFindingAboutAnObligationJoinsToItsAccountTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryObligationTheCountHoldsIsMetOrNamedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryObligationTheCountHoldsIsMetOrNamedTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.report;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.DoesNotComeBack;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * which no source reaches is a law that passes by not applying, and the counts below are what says
  * it does apply.
  */
+@Tag("population")
 class EveryObligationTheCountHoldsIsMetOrNamedTest {
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * decided — nothing the layout wrote points at the group. So what a source gap is matched against
  * is the opportunity, which is there either way.
  */
+@Tag("population")
 class ABreakOpportunityBelongsToAGroupTest {
 
     /** A group that fits: its opportunities are there, and none of them was written as a break. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * as the text would have to be rewritten for a change it is not about — which is the complaint
  * issue #938 makes about the formatter itself.
  */
+@Tag("population")
 class ARowOfATableIsWrittenAtItsTablesColumnTest {
 
     /** Two tables, each with rows of unequal width, and a row with no description. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * almost nothing to disagree about; a source written down the page where the canonical form writes
  * it flat, or indented two columns where it writes four, is the case the gathering was made for.
  */
+@Tag("population")
 class AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest {
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/AllOfABracketedConstructsCardinalitiesAreSweptTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/AllOfABracketedConstructsCardinalitiesAreSweptTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * And a match arm's record destructuring, which is built as a run of tokens rather than as a
  * document, wrote {@code A { }} where every other empty bracket is written together.
  */
+@Tag("population")
 class AllOfABracketedConstructsCardinalitiesAreSweptTest {
 
     /** A pair of brackets a construct is written between, and what the corpus writes in it. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryAdjacencyHasOneBoundaryTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryAdjacencyHasOneBoundaryTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>This does not say that the construct each boundary names is the one the canonical form has.
  * That is a separate check and it is not made yet — see issue #476.
  */
+@Tag("population")
 class EveryAdjacencyHasOneBoundaryTest {
 
     @Test

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * run that way here because it takes three minutes, and what the reduction rests on is the sentence
  * above rather than that measurement.
  */
+@Tag("population")
 class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryDeviationStatesADifferenceTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryDeviationStatesADifferenceTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * from the canonical form in a way that is not the choice the rule as a whole made: it broke down
  * the page as it should have, and one of the places it settles was run together.
  */
+@Tag("population")
 class EveryDeviationStatesADifferenceTest {
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryPlaceIsSomewhereInTheOutputTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryPlaceIsSomewhereInTheOutputTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * place is the whole output. Recording only the first left sixty-three places of this repository's
  * corpus with no answer, and a reader of a difference has to be able to point at any of them.
  */
+@Tag("population")
 class EveryPlaceIsSomewhereInTheOutputTest {
 
     private static Formatter.CanonicalForm canonical(String source) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * never emitted is missing from the document and from the output alike and this check passes; that
  * one is the golden corpus's to catch.
  */
+@Tag("population")
 class EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest {
 
     /** Every token of {@code doc}, in the order it is laid out. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/NothingIsWrittenAtTheEndOfALineTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/NothingIsWrittenAtTheEndOfALineTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Every line of the source, and not only the ones the canonical form has. What the rule expects
  * is nothing, which is true of a line wherever it stands, so this needs no correspondence to ask.
  */
+@Tag("population")
 class NothingIsWrittenAtTheEndOfALineTest {
 
     @Test

--- a/souther-fmt/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * repeating the repair — a source it is true of is one where every difference from the canonical
  * form was named by a rule.
  */
+@Tag("population")
 class RepairingWhatTheRulesSayWritesTheCanonicalFormTest {
 
     static Stream<Path> sources() {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TheConstructABoundaryNamesIsTheOneTheOutputHasTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TheConstructABoundaryNamesIsTheOneTheOutputHasTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the rule's name is the construct together with the two kinds — so the construct has to be one its
  * reader can find in the canonical form rather than one only the formatter knows.
  */
+@Tag("population")
 class TheConstructABoundaryNamesIsTheOneTheOutputHasTest {
 
     /** Every code token of a source, in the order it is written. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * width. Recovering that from the text means measuring the group again, which is running the layout
  * a second time and calling the answer evidence.
  */
+@Tag("population")
 class TheLayoutKeepsWhatItsTextCannotSayTest {
 
     /** Two documents laid out to one text, for two reasons. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.cst.CstParser;
 import souther.compiler.cst.SyntaxKind;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * differ: its parameters move to the left of the {@code =}, and what is written after the {@code =}
  * is the lambda's body rather than the child the source has there.
  */
+@Tag("population")
 class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -34,6 +35,7 @@ import static souther.compiler.cst.SyntaxKind.*;
  * before another does not tie with it — it wins — so a disagreement is one list answering for a
  * construct that writes the boundary the other way, and nothing downstream can see that it did.
  */
+@Tag("population")
 class TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest {
 
     private static Set<SyntaxKind> of(SyntaxKind... k) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TheSpacingRuleAgreesWithTheCanonicalFormTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TheSpacingRuleAgreesWithTheCanonicalFormTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>Only the intervals the output left unbroken. What is written at a boundary the layout broke is
  * a newline and an indent, and those are the break rules' — the function has no answer for them.
  */
+@Tag("population")
 class TheSpacingRuleAgreesWithTheCanonicalFormTest {
 
     /** Every pair the corpus writes, written as the function says it is. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TheSpacingRuleIsAskedOnlyWhereACanonicalLineHoldsBothTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TheSpacingRuleIsAskedOnlyWhereACanonicalLineHoldsBothTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.cst.CstParser;
 import souther.compiler.cst.SyntaxElement;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * What it owes is that every such hole is explained by that and not by a missing row — the domain is
  * total and the expectation is partial, with the break decision above it saying where.
  */
+@Tag("population")
 class TheSpacingRuleIsAskedOnlyWhereACanonicalLineHoldsBothTest {
 
     /** The spacing rule's unit: two token kinds and the construct that joins them. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/TwoRulesOnOneLineAreBothWrittenTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/TwoRulesOnOneLineAreBothWrittenTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import souther.compiler.cst.CstParser;
 
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the record body opening down the page are two decisions on one source line, and they do not
  * disagree about anything — only about which characters they are written in.
  */
+@Tag("population")
 class TwoRulesOnOneLineAreBothWrittenTest {
 
     private static List<Witness> witnesses(String source, Formatter.CanonicalForm canonical) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@link SyntaxKind} is built at least once, and that is asserted — a kind added to the grammar
  * without a source here fails rather than going unmeasured.
  */
+@Tag("population")
 class WhatGoesBetweenTwoTokensOnALineTest {
 
     /** Sources written to reach the constructs the bundled standard library does not use. */

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.fmt;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.cst.CstParser;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * happen to ask about. Which of them a family asks is that family's to change, and a table that
  * agreed only where it is asked today would be one the next question can find a hole in.
  */
+@Tag("population")
 class WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest {
 
     /** Which adjacency {@code at} stands in, by walking: the first one it is inside. */


### PR DESCRIPTION
The suite a person waits on while editing was mostly answering questions about the
models, sources and specification this repository carries. Those are questions about
the language rather than about the code being edited, and they are asked here where
waiting for them costs nobody an edit: on the merge into develop, and once a night.

A test says which run it belongs in by carrying a tag, and nothing about writing one
would say the tag was missing — the class compiles, passes, and is slow somewhere
else. So the population is read off the compiled tests rather than remembered: a check
walks their constant pools and names any test that reaches a corpus without the tag.
The corpora themselves are named in that check, because a corpus is something written
to be swept and a rule that worked out which classes were corpora would be a second
account of the same short list, disagreeing with it the first time one moved.

Three classes each carried their own copy of the same corpus files, read them,
compiled them and answered everything about them, once per test method — so a class
with two questions about the population paid for the population twice. That population
is named once now and built once for the JVM that asks.

The JVM a fork runs on is named as a property rather than written as a literal, so
what its flags are worth can be measured against the suite as it stands rather than
the one they were chosen on. Measured now that it can be: letting C2 back in makes the
suite markedly slower, because every fork brings compiler threads that take the cores
the tests are on, and lowering the example step limit no longer moves it at all. The
flags stay as they were.

The nightly job runs the whole suite rather than the remainder of it: a split where
each half is run by one job alone would let a change pass by being checked in neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)