### PR TITLE
Read a row at a position by what is readable there

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
@@ -44,9 +44,6 @@ import java.util.Map;
  */
 public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> fields) {
 
-    /** Nothing is readable off a value here without narrowing it first. */
-    private static final ReadableFields NONE = new ReadableFields(List.of(), Map.of());
-
     public ReadableFields {
         declaredBy = List.copyOf(declaredBy);
         fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
@@ -60,24 +57,65 @@ public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> fiel
      * works out again.
      */
     public static ReadableFields of(Shape shape) {
+        Readable here = readableOn(shape);
+        return new ReadableFields(here.declaredBy(), here.fields());
+    }
+
+    /**
+     * What {@code name} is declared to be where it is readable off a value of this shape, or null
+     * where nothing of that name is.
+     *
+     * <p>The same question as {@link #of} asked about one name, for a reader that has one in hand
+     * and no use for the rest — a walk taking a step of a path is asking whether it may take this
+     * one. Answered off the same map rather than beside it, so there is no second rule about which
+     * names are readable and no answer here that {@link #of} does not also give.
+     *
+     * <p>Here rather than at the caller because the map {@link #of} hands back is a copy: what a
+     * reader after one name would otherwise do is have every name at the position copied out to
+     * index one of them, once per step of every path walked over every row.
+     */
+    public static Type at(Shape shape, String name) {
+        return readableOn(shape).fields().get(name);
+    }
+
+    /** What is readable, as the declarations hold it. Beside {@link ReadableFields} and not one:
+     *  the maps here are the declarations' own, which is what lets a reader after one name index
+     *  one without every name at the position being copied out first. */
+    private record Readable(List<TypeSymbol> declaredBy, Map<String, Type> fields) {}
+
+    private static final Readable NOTHING = new Readable(List.of(), Map.of());
+
+    /**
+     * What is readable off a value of this shape, and what declares it.
+     *
+     * <p>Exhaustive over {@link Shape}, with no {@code default}. A shape admitted later is answered
+     * for here or stops this compiling, rather than arriving as a position whose names each reader
+     * works out again.
+     *
+     * <p>One switch and not one per projection. Which names are readable and what they are written
+     * on are answered together because they are one reading of the shape — asked apart, a shape
+     * admitted later could have names here and nothing declaring them there, and what a rule over
+     * one of those fields is written on would be missing with nothing refusing it.
+     */
+    private static Readable readableOn(Shape shape) {
         return switch (shape) {
-            case Shape.Product product -> new ReadableFields(List.of(product.name()),
-                    product.fields());
+            case Shape.Product product -> new Readable(List.of(product.name()), product.fields());
             // Read without opening a case, so what a value here carries whichever case it turned
             // out to be — and nothing where the cases share no spread. A field two cases happen to
             // declare alike is not shared: the sharing is nominal, and what is written on the sum
             // is what was written once and spread.
             case Shape.Sum sum -> switch (sum.common()) {
                 case Shape.CommonProduct.Shared shared ->
-                        new ReadableFields(shared.origins(), shared.fields());
-                case Shape.CommonProduct.None _ -> NONE;
+                        new Readable(shared.origins(), shared.fields());
+                case Shape.CommonProduct.None _ -> NOTHING;
             };
             // A newtype's contents are read where the names are taken off, which is TypeView's; what
             // a container holds is reached by holding it and not by naming it; and the rest carry no
             // names at all. None of them is a field access anybody may write here.
             case Shape.Scalar _, Shape.Unit _, Shape.Sequence _, Shape.Mapping _, Shape.Optional _,
                  Shape.Unresolved _, Shape.Cases _, Shape.Tuple _, Shape.Function _,
-                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ -> NONE;
+                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ ->
+                    NOTHING;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
@@ -19,9 +19,15 @@ import java.util.Map;
  * two answers are the same map at a record and are not the same question: a value of a sum is a
  * value of one of its cases, and a product of the shared fields is a value of none of them. Read
  * from there, a plan would compose a sum out of the part its cases have in common; read from here,
- * a walk into what a row wrote would go somewhere no row writes anything. The coincidence at a
- * record is a law over the two answers and is not a reason for either to be the other's
- * implementation.
+ * a walk deciding where to <em>write</em> a value would go somewhere no row writes anything. The
+ * coincidence at a record is a law over the two answers and is not a reason for either to be the
+ * other's implementation.
+ *
+ * <p><b>And this is what a walk over a value already written asks.</b> Reading is what such a walk
+ * does: the case is settled in the value it holds, so what it may take is what every value of the
+ * position carries, and a name only some case declares is not readable however many rows turn out
+ * to be that case. The written relation answers nothing at a sum's shared name, so a walk that took
+ * it read no value at every name a model reads through a sum.
  *
  * <p><b>Asked of a {@link Shape} and not of a {@link Type}.</b> How far to look through the names a
  * value wears is the reader's own policy — the elaboration of a field read looks through none of

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -73,8 +73,13 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
     }
 
     /**
-     * The values written at {@code path}, which is one value at most positions and however many
-     * were written at a position inside a sequence.
+     * The values read at {@code path} off what a row wrote, which is one value at most positions and
+     * however many were written at a position inside a sequence.
+     *
+     * <p>Read at the path and not written at it. Where a row puts a value and where a reading names
+     * one part at a sum every case of which spreads a declaration: the name is readable at the sum
+     * and a row writes one of the cases, so a walk asking where a value is written reaches nothing
+     * at a name every reading of the model may use.
      *
      * <p>Empty where none readable is there, and never null: a caller asking what is covered at a
      * position is answered with what was written, and a list of none is nothing written there —
@@ -98,9 +103,10 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * there is nothing under it, but it is also not a chain that leads nowhere: it is the reason
      * this position has no value, and it says that itself.
      *
-     * <p>Which leaves nothing for the walk's own answer, and only that: a record that does not hold
-     * the field named next, or a position whose type is not a record at all. The path and the type
-     * disagree, and no observation says why because nothing went wrong with one.
+     * <p>Which leaves nothing for the walk's own answer, and only that: the standing type and value
+     * cannot take the step named next. At a field that is the reading not exposing the name at this
+     * position, or a value that is not the construction the reading says stands there. Neither is
+     * something an observation did, and no observation says why because nothing went wrong with one.
      */
     List<ObservedValue> valuesAt(List<ObservedValue> inputs, TermPath path) {
         List<Occurrence> found = occurrencesAt(inputs, path);
@@ -198,9 +204,9 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * What the declarations put where a value at {@code path} is written, or null where a value is
      * not written there at all.
      *
-     * <p>The same walk {@link #occurrencesAt} takes, with the values left out. A position's type is
-     * a fact about the declarations and a row is not needed to ask it — which is what a caller
-     * composing a value at a position wants, since there is no row yet.
+     * <p>The path read as where a new value goes, and not the walk {@link #occurrencesAt} takes. A
+     * position's type is a fact about the declarations and a row is not needed to ask it — which is
+     * what a caller composing a value at a position wants, since there is no row yet.
      *
      * <p><b>For composing a value and for nothing else.</b> This walk stops where a value is built,
      * so a sum whose cases share a spread answers nothing here — right for a caller writing a value
@@ -208,11 +214,10 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * has an owner ({@link souther.compiler.inputs.Quantities#ordersOf}), and it is asked of the
      * reading of the input rather than worked out from what this returns.
      *
-     * <p><b>Here because the walk is here.</b> How a step of a path moves the type is one rule with
-     * several cases — a field is reached through the names its record is written under, an element
-     * is what a sequence holds, a refinement is the position read as one of its cases — and written
-     * a second time for a caller that only wanted the type, the two would agree until one of them
-     * learned a step the other did not.
+     * <p>Which is why reading a row takes its own steps rather than these. The two relations a path
+     * step stands for — where a written value has a part, and what a value standing here may be read
+     * as — are one answer at a record and part at that sum, and a walk over an observation that took
+     * these would reach nothing at every name a model reads through a sum.
      *
      * <p>Null where the path and the declarations disagree, and null for a path this behavior has no
      * parameter for. Neither is a position with a type nothing could name: they are paths that name
@@ -237,16 +242,21 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * The type one step of a written value reaches from {@code from}, or null where a value written
      * here is at no such place.
      *
-     * <p>Exhaustive over {@link TermPath.Step}, with no {@code default}, and the one place a step
-     * into what a row wrote is turned into a type. A step added later stops this compiling rather
-     * than arriving as a walk that quietly takes it one way here and another way where a row is
-     * read.
+     * <p>Exhaustive over {@link TermPath.Step}, with no {@code default}. A step added later stops
+     * this compiling, and stops {@link Standing#step} compiling as well, so neither relation is left
+     * taking a new step by a rule the other one wrote.
      *
      * <p>A field is where a value written here put one, which is a field of the record it was
      * written as. A name every case of a sum spreads is somewhere else: a row writes one of the
      * cases, so what stands at that name is under whichever case was written and nothing stands at
      * the name itself. What is readable off such a value is a question with an owner
      * ({@link ReadableFields}), and it is asked of the reading rather than worked out from this.
+     *
+     * <p><b>Answered for whoever writes a value, and for nobody else.</b> Reading a row is the other
+     * relation and takes its own steps ({@link Standing#step}), which is not a duplicate of this: the
+     * two are one answer at a record and part at a sum whose cases share a spread, and that agreement
+     * is a law over them rather than a reason for either to be the other's implementation. The one
+     * caller is {@link #typeAtWrittenPath}, and it is watched.
      */
     static Type stepWrittenValue(TermPath.Step step, Type from, Symbols symbols) {
         TypeView view = TypeView.of(from, symbols);
@@ -288,15 +298,31 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
     }
 
     /**
-     * One value on the way down a path, with the type the declaration puts there.
+     * One observed value on the way down a path, with the type the reading exposes at that position.
      *
      * <p>A list of these and not one, because a step into what a sequence holds turns one value
      * into as many as it holds. Everything else keeps the count it had.
+     *
+     * <p><b>How an observed value is read, which is not where a written one has its parts.</b> The
+     * steps here are this walk's own and none of them is taken by asking
+     * {@link BehaviorInputs#stepWrittenValue}. A field every case of a sum spreads is where the two
+     * relations part: it is readable at every value of the sum and a row writes one of the cases, so
+     * a walk taking the written relation reached nothing at a name every reading of the model uses.
+     * That they agree at a record is a law over the two and not a reason to share one of them.
      */
     private record Standing(ObservedValue value, Type type, TermPath reached,
                             Map<TermPath, Integer> at) {
 
-        /** Takes {@code step}, adding what stands below. False where it could not be taken. */
+        /**
+         * Takes {@code step}, adding what stands below. False where this type and value cannot take
+         * it.
+         *
+         * <p>False and standing nowhere are two answers. False is the reading and the observation
+         * disagreeing about what is at this position — a step this walk cannot take at all — and
+         * adding nothing is a step taken by a value that turns out to stand nowhere below it: the
+         * empty list at an element, a case the row is not at under a refinement. A caller reads the
+         * first as a walk it could not make and the second as a row that is somewhere else.
+         */
         boolean step(TermPath.Step step, Symbols symbols, List<Standing> out) {
             if (value.unread() != null) {
                 out.add(this);
@@ -309,8 +335,15 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                 return true;
             }
             switch (step) {
+                // Two things and in this order: the reading says whether the name may be read at
+                // this position, and the value in hand says what is there. A concrete case carries
+                // its own fields as well as the ones it spreads, so a walk that took the name off
+                // the value it happens to hold would read `method.cardNumber` on the rows that are
+                // cards and refuse it on the rest — a readability decided per row, which is not
+                // something the model states. The name is admitted by what every value of the
+                // position carries, and then the case is where it is taken from.
                 case TermPath.Step.Field named -> {
-                    Type next = stepWrittenValue(step, type, symbols);
+                    Type next = ReadableFields.of(view.shape()).fields().get(named.name());
                     if (next == null || !(here instanceof ObservedValue.Constructed made)) {
                         return false;
                     }
@@ -325,7 +358,8 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                 // and what a class comes to over them is the caller's to decide. A list holding
                 // none is a step taken: the walk arrived and the row wrote nothing there.
                 case TermPath.Step.Element _ -> {
-                    Type element = stepWrittenValue(step, type, symbols);
+                    Type element = view.shape() instanceof Shape.Sequence sequence
+                            ? sequence.element() : null;
                     if (element == null || !(here instanceof ObservedValue.Sequence written)) {
                         return false;
                     }
@@ -343,8 +377,17 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                 // same answer a row writing the empty list gives at an element, and not the answer
                 // a row nothing could read gives. What refuses the step is the type and the path
                 // disagreeing about what is at this position, which is nothing about the row.
+                // And the position it narrows to is where a case's own field becomes readable: a
+                // path that names the case may read what only that case declares, which is the
+                // model saying so rather than a row happening to be one.
                 case TermPath.Step.Refine refine -> {
-                    Type narrowed = stepWrittenValue(step, type, symbols);
+                    Type narrowed = switch (refine.refinement()) {
+                        case Refinement.SumCase one -> view.shape() instanceof Shape.Sum
+                                ? Type.ref(one.leaf()) : null;
+                        case Refinement.Presence presence ->
+                                !(view.shape() instanceof Shape.Optional optional) ? null
+                                        : presence.present() ? optional.element() : view.declared();
+                    };
                     if (narrowed == null) {
                         return false;
                     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -253,10 +253,11 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * ({@link ReadableFields}), and it is asked of the reading rather than worked out from this.
      *
      * <p><b>Answered for whoever writes a value, and for nobody else.</b> Reading a row is the other
-     * relation and takes its own steps ({@link Standing#step}), which is not a duplicate of this: the
-     * two are one answer at a record and part at a sum whose cases share a spread, and that agreement
-     * is a law over them rather than a reason for either to be the other's implementation. The one
-     * caller is {@link #typeAtWrittenPath}, and it is watched.
+     * relation and takes its own steps ({@link Standing#step}), which is not a duplicate of this:
+     * the two are one answer at a record and part at a sum whose cases share a spread. Where they
+     * agree, each is written down on its own rather than one being read out of the other, so a
+     * reader that means to move one is not moving both. The one caller is
+     * {@link #typeAtWrittenPath}, and it is watched.
      */
     static Type stepWrittenValue(TermPath.Step step, Type from, Symbols symbols) {
         TypeView view = TypeView.of(from, symbols);
@@ -308,7 +309,12 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * {@link BehaviorInputs#stepWrittenValue}. A field every case of a sum spreads is where the two
      * relations part: it is readable at every value of the sum and a row writes one of the cases, so
      * a walk taking the written relation reached nothing at a name every reading of the model uses.
-     * That they agree at a record is a law over the two and not a reason to share one of them.
+     *
+     * <p>The steps beside a field come to one answer under both today, and each says so on its own:
+     * what this walk admits at an element and at a narrowing is written down where the walk is
+     * tested and what the written relation lands on is written down where that is, rather than
+     * either being read out of the other. Nothing holds the two together, deliberately — the day
+     * one of them means to move, the other has to go on saying what it said.
      */
     private record Standing(ObservedValue value, Type type, TermPath reached,
                             Map<TermPath, Integer> at) {
@@ -344,7 +350,7 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                 // something the model states. The name is admitted by what every value of the
                 // position carries, and then the case is where it is taken from.
                 case TermPath.Step.Field named -> {
-                    Type next = ReadableFields.of(view.shape()).fields().get(named.name());
+                    Type next = ReadableFields.at(view.shape(), named.name());
                     if (next == null || !(here instanceof ObservedValue.Constructed made)) {
                         return false;
                     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -317,11 +317,12 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
          * Takes {@code step}, adding what stands below. False where this type and value cannot take
          * it.
          *
-         * <p>False and standing nowhere are two answers. False is the reading and the observation
-         * disagreeing about what is at this position — a step this walk cannot take at all — and
-         * adding nothing is a step taken by a value that turns out to stand nowhere below it: the
-         * empty list at an element, a case the row is not at under a refinement. A caller reads the
-         * first as a walk it could not make and the second as a row that is somewhere else.
+         * <p>False and standing nowhere are two answers. False is a step this walk cannot take at
+         * all — the reading does not expose the name here, or what stands here is not the
+         * construction the reading says does — and adding nothing is a step taken by a value that
+         * turns out to stand nowhere below it: the empty list at an element, a case the row is not
+         * at under a refinement. A caller reads the first as a walk it could not make and the
+         * second as a row that is somewhere else.
          */
         boolean step(TermPath.Step step, Symbols symbols, List<Standing> out) {
             if (value.unread() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -81,9 +81,10 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * and a row writes one of the cases, so a walk asking where a value is written reaches nothing
      * at a name every reading of the model may use.
      *
-     * <p>Empty where none readable is there, and never null: a caller asking what is covered at a
-     * position is answered with what was written, and a list of none is nothing written there —
-     * which an empty list is.
+     * <p>Empty where the walk was taken and no value stands there, and null where it could not be
+     * taken at all. A caller asking what is covered at a position is answered with what was
+     * written, and a list of none is nothing written there — which an empty list is, and which the
+     * walk not having been made is not.
      *
      * <p>The one walk into a row's values, done with the declared types beside them. A field of a
      * record is reached through the names the record is written under: {@code data SlotN = Slot} is

--- a/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
@@ -188,20 +188,31 @@ class ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest {
      * <p>Without where the comparison is written or what the term is spelled as, which are the two
      * things that differ between the models by construction. What is left is which point of which
      * kind went unmet, which is what the two are being held to.
+     *
+     * <p><b>A border with no gaps and a border this could not find are two answers.</b> Both are no
+     * lines, and a caller reading the first out of the second would say a line is fully covered
+     * because the section it is in moved. So the section not being there is said here, where it can
+     * still be told apart, rather than handed on as an empty list.
      */
     private static List<String> borderGapsIn(String report) {
         List<String> gaps = new ArrayList<>();
+        boolean found = false;
         boolean inBorder = false;
         for (String line : report.lines().toList()) {
             String said = line.strip();
             if (line.startsWith("    ") && !line.startsWith("     ")) {
                 inBorder = said.startsWith("border");
+                found |= inBorder;
                 continue;
             }
             if (inBorder && (said.startsWith("!") || said.startsWith("?"))) {
                 int at = said.indexOf(" (comparison@");
                 gaps.add(at < 0 ? said : said.substring(0, at));
             }
+        }
+        if (!found) {
+            throw new AssertionError("this reads the points of a border out of the report, and"
+                    + " there is no border section in it: " + report);
         }
         return gaps;
     }

--- a/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
@@ -1,0 +1,207 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A total whose values are read through a name every case of a sum spreads is measured from a run of
+ * them.
+ *
+ * <p>The cases of the sum spread the field the total adds up, so the term's path names a position of
+ * the sum and no case of it. That spelling is what the reading gives it and it is right — the rule
+ * is about the shared name — and what has to hold is that the values a run walks are gathered under
+ * the same name the term stands at, wherever the value at each occurrence turns out to be a case.
+ *
+ * <p>It did not. The walk over a row's values asked where a value is <em>written</em>, which at that
+ * name is nowhere, so every point of the line came back undecided with two sentences: that the walk
+ * reached no value there to read, and that nothing composed a row seen reaching it. The row standing
+ * exactly on the point was in the file the whole time.
+ *
+ * <p><b>Two models and the same answer.</b> One spreads the amount through the cases and one puts it
+ * on the element, and they owe the same points and meet the same ones. Held as a count alone, both
+ * could go wrong together and agree about it; held as the points themselves, what each owes is
+ * checked before the two are compared.
+ */
+class ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest {
+
+    /** The amount spread through the cases of a sum, with a row exactly on the point. */
+    private static final String SPREAD = """
+            module example.trip
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Common = { amount: Amount }
+
+            data Card = { ...Common, issuer: Issuer }
+            data Cash = { ...Common, note: Note }
+
+            data Issuer = String
+                invariant String.length(value) >= 1
+
+            data Note = String
+                invariant String.length(value) >= 1
+
+            data Method = Card | Cash
+
+            data Entry = { method: Method }
+
+            data Many
+            data Few
+
+            behavior decide : (entries: List<Entry>) -> Many | Few
+
+            let decide (entries) =
+                if List.sum(List.map(one -> one.method.amount.value, entries)) >= 100
+                then Many else Few
+
+            example decide
+                | "on the point" : ([ Entry { method = Card { amount = Amount(100), issuer = Issuer("x") } } ]) -> Many
+            """;
+
+    /** The same rule with the amount on the element, which is the shape that always worked. */
+    private static final String ON_THE_ELEMENT = """
+            module example.trip
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Entry = { amount: Amount }
+
+            data Many
+            data Few
+
+            behavior decide : (entries: List<Entry>) -> Many | Few
+
+            let decide (entries) =
+                if List.sum(List.map(one -> one.amount.value, entries)) >= 100
+                then Many else Few
+
+            example decide
+                | "on the point" : ([ Entry { amount = Amount(100) } ]) -> Many
+            """;
+
+    /**
+     * What the line owes, worked out from the model rather than read off a run.
+     *
+     * <p>A comparison at a hundred draws four points — the value it names, the one below it, and the
+     * two sides — and the file holds one row, whose entries come to exactly the hundred. So the point
+     * that row is on is met and the other three are owed, whichever way the amount is declared.
+     *
+     * <p>Named as the gaps rather than as which point was met, because that is what a report prints:
+     * a point a row covers is not written out. The two together say which one it was — four points,
+     * three of them owed and none of those the one the row is on.
+     */
+    private static final List<String> OWED = List.of(
+            "! no row is at the OFF point",
+            "! no row is at an IN point",
+            "! no row is at an OUT point");
+
+    private static final String COUNTED = "1/4";
+
+    /**
+     * The spread model owes what the rule says it owes, and meets the point its row is on.
+     *
+     * <p>The count and the points, because neither says the other. Three gaps and a count of four
+     * leave exactly one met and say it is not one of the three; the count alone would go on reading
+     * the same while a point moved from one kind to another.
+     */
+    @Test
+    void aTotalReadThroughASharedNameMeetsThePointItsRowIsOn() {
+        String report = report(SPREAD);
+
+        assertEquals(COUNTED, obligationsIn(report),
+                () -> "one row is on the point the comparison names, and the other three are"
+                        + " owed: " + report);
+        assertEquals(OWED, borderGapsIn(report),
+                () -> "and the three owed are the ones the row is not on: " + report);
+    }
+
+    /**
+     * And nothing about the line is left undecided.
+     *
+     * <p>The other half of what a point that was not met can be. An owed point says the model has
+     * nothing there; an undecided one says this compiler could not look — and the walk that could not
+     * look is what put every point of this line into the second while a row sat on one of them.
+     */
+    @Test
+    void noPointOfTheLineIsLeftUndecided() {
+        String report = report(SPREAD);
+
+        assertFalse(report.contains("the walk reached no value there to read"),
+                () -> "the run is read through the name the cases spread: " + report);
+        assertFalse(report.contains("undecided whether a row is at"),
+                () -> "so no point of the line is one this compiler could not look at: " + report);
+    }
+
+    /**
+     * And the model that puts the amount on the element comes to the same thing.
+     *
+     * <p>Compared after each has been held to what its own rule owes, so this says the sum changes
+     * nothing rather than that the two agree. Only the behavior's own line: the models declare
+     * different types, so what their declarations owe is different and is not the same question.
+     */
+    @Test
+    void theSumChangesNothingAboutWhatTheLineOwes() {
+        String spread = report(SPREAD);
+        String element = report(ON_THE_ELEMENT);
+
+        assertEquals(COUNTED, obligationsIn(element),
+                () -> "the amount on the element owes the same four points: " + element);
+        assertEquals(OWED, borderGapsIn(element),
+                () -> "and is short of the same three: " + element);
+        assertEquals(borderGapsIn(spread), borderGapsIn(element),
+                "the cases spreading the name change nothing about what the line owes");
+        assertEquals(obligationsIn(spread), obligationsIn(element),
+                "nor about how much of it is met");
+    }
+
+    /** What the border section says a behavior's obligations came to. */
+    private static String obligationsIn(String report) {
+        return report.lines()
+                .filter(each -> each.contains("border") && each.contains("obligations"))
+                .map(each -> each.substring(each.indexOf("obligations") + "obligations ".length()))
+                .findFirst().orElseThrow(() -> new AssertionError(report));
+    }
+
+    /**
+     * The points of the border a row is short of, as the report writes them.
+     *
+     * <p>Without where the comparison is written or what the term is spelled as, which are the two
+     * things that differ between the models by construction. What is left is which point of which
+     * kind went unmet, which is what the two are being held to.
+     */
+    private static List<String> borderGapsIn(String report) {
+        List<String> gaps = new ArrayList<>();
+        boolean inBorder = false;
+        for (String line : report.lines().toList()) {
+            String said = line.strip();
+            if (line.startsWith("    ") && !line.startsWith("     ")) {
+                inBorder = said.startsWith("border");
+                continue;
+            }
+            if (inBorder && (said.startsWith("!") || said.startsWith("?"))) {
+                int at = said.indexOf(" (comparison@");
+                gaps.add(at < 0 ? said : said.substring(0, at));
+            }
+        }
+        return gaps;
+    }
+
+    private static String report(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A total whose values are read through a name every case of a sum spreads is measured from a run of
@@ -128,21 +127,30 @@ class ATotalReadThroughANameEveryCaseSpreadsIsMeasuredFromARunTest {
     }
 
     /**
-     * And nothing about the line is left undecided.
+     * And no point of the line is one this compiler could not look at, whatever the points are.
      *
      * <p>The other half of what a point that was not met can be. An owed point says the model has
-     * nothing there; an undecided one says this compiler could not look — and the walk that could not
-     * look is what put every point of this line into the second while a row sat on one of them.
+     * nothing there; an undecided one says this compiler could not look — and the walk that could
+     * not look is what put every point of this line into the second while a row sat on one of them.
+     *
+     * <p>Said of the mark and not of the sentence. Which of the two a point is is what the mark
+     * carries, and a check written against the words would go green the day either sentence is
+     * reworded, over a line every point of which had gone back to being undecidable. And said of
+     * whatever the border holds rather than of the three above: this is the property the line has,
+     * where the list is what this model happens to owe.
      */
     @Test
     void noPointOfTheLineIsLeftUndecided() {
         String report = report(SPREAD);
 
-        assertFalse(report.contains("the walk reached no value there to read"),
-                () -> "the run is read through the name the cases spread: " + report);
-        assertFalse(report.contains("undecided whether a row is at"),
-                () -> "so no point of the line is one this compiler could not look at: " + report);
+        assertEquals(List.of(), borderGapsIn(report).stream()
+                        .filter(each -> each.startsWith(UNDECIDED)).toList(),
+                () -> "every point the line is short of is one the model owes a row at: " + report);
     }
+
+    /** How a report marks a point it could not be told about, beside {@code !} for one that is
+     *  owed. */
+    private static final String UNDECIDED = "?";
 
     /**
      * And the model that puts the amount on the element comes to the same thing.

--- a/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
@@ -14,11 +14,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Each question about a shape is asked of the one that answers it, and of nothing else.
  *
  * <p>Four are asked: what is readable off a value standing at a position, what a value there is
- * composed out of, which positions a reading has under it, and where a step into a written value
- * lands. They come to the same fields at a record and part at a sum whose cases share a spread, and
+ * composed out of, which positions a reading has under it, and what a written value has under a
+ * step. They come to the same fields at a record and part at a sum whose cases share a spread, and
  * that agreement is a law over the answers — checked as one in
  * {@code WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest}, which holds however the four
  * are worked out.
+ *
+ * <p>Four and not five. How an observed value is read down a path consumes a value and answers with
+ * as many standings as it finds, so it is not one of these and no equality holds between it and
+ * them; what it owes is that it admits a field by what is readable and never by what the value in
+ * hand turns out to carry, which is checked where that walk is.
  *
  * <p>Which is why that law is not enough on its own. A question answered out of another's answer
  * satisfies it exactly while the two agree at a record: the reading of a value or the walk into a
@@ -44,13 +49,17 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
 
     /** Who asks what is readable off a value: the elaboration of a field read, the accessor a sum's
      *  interface declares, what a construction may spread, what the model writes where a value
-     *  stands, and the reading of a behavior's inputs. */
+     *  stands, the reading of a behavior's inputs, and the walk that reads a row at a position —
+     *  which asks whether a name may be read there before taking it off the value it holds, so that
+     *  a case carrying a name of its own does not make it readable for the rows that are that
+     *  case. */
     private static final List<String> ASK_WHAT_IS_READABLE = List.of(
             "souther.compiler.check.DataChecker",
             "souther.compiler.check.Elaborator",
             "souther.compiler.check.ValueReading",
             "souther.compiler.codegen.ValueClassGen",
-            "souther.compiler.inputs.InputDomain");
+            "souther.compiler.inputs.InputDomain",
+            "souther.compiler.partition.BehaviorInputs$Standing");
 
     /** Who asks what a value is composed out of. Composing one is what the question is for, so there
      *  is one asker, and a second is a reader with some other question. */
@@ -62,10 +71,15 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
     private static final List<String> ASK_WHAT_STANDS_UNDER =
             List.of("souther.compiler.inputs.InputDomain");
 
-    /** Who asks where a step into a written value lands. Nobody outside the walk that takes the
-     *  step — a reader working it out again turns a row's own path into a second reading of the
-     *  declarations. */
-    private static final List<String> ASK_WHERE_A_STEP_LANDS = List.of();
+    /** Who asks what a written value has under a step. Nobody outside the class that answers it — a
+     *  reader working it out again turns a row's own path into a second reading of the declarations.
+     *
+     *  <p>Named for the written relation and not for a step's landing place. A step has two of them
+     *  — where a written value has a part, and what a value standing here may be read as — and a
+     *  list called after the step rather than after the question is one a reader satisfies by
+     *  taking whichever answer is nearest. Which is what happened: the walk over a row's values
+     *  took this one, and every name a model reads through a sum came back unread. */
+    private static final List<String> ASK_WHAT_A_WRITTEN_VALUE_HAS_UNDER_A_STEP = List.of();
 
     @Test
     void whatIsReadableIsAskedOfTheOneThatAnswersIt() {
@@ -96,19 +110,25 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
     }
 
     /**
-     * Where a step into a written value lands, asked by the walk that takes the step.
+     * What a written value has under a step, asked inside the class that answers it.
      *
      * <p>Both halves, because the expected set is empty and an empty set is what a question nobody
      * can name comes to as well: the first says the question is asked at all, the second that it is
      * asked nowhere but inside its owner.
+     *
+     * <p>And only that far. This helper leaves out the owner and everything nested in it, so the
+     * two readers that live inside {@code BehaviorInputs} are invisible here however they ask —
+     * which is how a walk over a row's values came to take this answer without anything saying so.
+     * Who asks it inside the class is a separate invariant, in
+     * {@code OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest}.
      */
     @Test
-    void whereAStepIntoAWrittenValueLandsIsAskedOfTheOneThatAnswersIt() {
+    void whatAWrittenValueHasUnderAStepIsAskedOfTheOneThatAnswersIt() {
         Class<?> owner = souther.compiler.partition.BehaviorInputs.class;
         assertFalse(WhatWasCompiled.callersOf(owner, "stepWrittenValue").isEmpty(),
                 "a step into a written value is turned into a type somewhere, or this is watching a"
                         + " name nothing calls");
-        assertEquals(ASK_WHERE_A_STEP_LANDS, callersOf(owner, "stepWrittenValue"),
+        assertEquals(ASK_WHAT_A_WRITTEN_VALUE_HAS_UNDER_A_STEP, callersOf(owner, "stepWrittenValue"),
                 "a step into what a row wrote is turned into a type in one place");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
@@ -81,9 +81,16 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
      *  took this one, and every name a model reads through a sum came back unread. */
     private static final List<String> ASK_WHAT_A_WRITTEN_VALUE_HAS_UNDER_A_STEP = List.of();
 
+    /**
+     * Both ways in, counted together.
+     *
+     * <p>Every name at a position and one name of it are the same question asked twice over, so who
+     * asks it is one list. Counted apart, a reader could move from one to the other and leave the
+     * list it was on — which reads as a reader having gone away.
+     */
     @Test
     void whatIsReadableIsAskedOfTheOneThatAnswersIt() {
-        assertEquals(ASK_WHAT_IS_READABLE, callersOf(ReadableFields.class, "of"),
+        assertEquals(ASK_WHAT_IS_READABLE, callersOf(ReadableFields.class, "of", "at"),
                 "these ask what is readable off a value, and this is who does");
     }
 
@@ -148,11 +155,14 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
                 "the fields a sum's cases share are read where the readable surface is made");
     }
 
-    /** Who calls {@code method} on {@code on}, leaving out the class that declares it and anything
-     *  nested inside it — a record holds its own accessor, a lambda is compiled into the class that
-     *  wrote it, and naming itself is not reading itself. */
-    private static List<String> callersOf(Class<?> on, String method) {
-        Set<String> found = WhatWasCompiled.callersOf(on, method);
+    /** Who calls any of {@code methods} on {@code on}, leaving out the class that declares them and
+     *  anything nested inside it — a record holds its own accessor, a lambda is compiled into the
+     *  class that wrote it, and naming itself is not reading itself. */
+    private static List<String> callersOf(Class<?> on, String... methods) {
+        Set<String> found = new java.util.LinkedHashSet<>();
+        for (String method : methods) {
+            found.addAll(WhatWasCompiled.callersOf(on, method));
+        }
         return found.stream()
                 .filter(each -> !each.equals(on.getName()) && !each.startsWith(on.getName() + "$"))
                 .sorted().toList();

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
@@ -139,14 +139,25 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
     }
 
     /**
-     * The two models come back with the same values.
+     * The two models come back with the same values, each having answered with the row's own first.
      *
      * <p>Which is the whole of what the sum was supposed not to change: a total read through a name
      * the cases share is the same run of numbers as one read off the element, and every question
      * about the line follows from the run.
+     *
+     * <p><b>Each held to the number in the row before they are put beside each other.</b> Two walks
+     * that both came back with nothing are equal, so a comparison alone would go on passing over the
+     * defect this is about — the model with the amount on the element is the shape that always
+     * worked and is not the answer either of them is checked against.
      */
     @Test
     void aSpreadNameReadsLikeOneDeclaredOnTheElement() {
+        List<ObservedValue> written = List.of(new ObservedValue.Integer(6));
+
+        assertEquals(written, read(SPREAD, List.of(card(6)), amount()),
+                "the run holds the number the row wrote at the name the cases spread");
+        assertEquals(written, read(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
+                "and the same number where the element declares it");
         assertEquals(read(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
                 read(SPREAD, List.of(card(6)), amount()),
                 "the cases spreading the name change nothing about what a run of it holds");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
@@ -101,10 +101,15 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
      * ({@link #aNarrowingIsHowACaseOwnFieldIsReached}), so what refuses this walk is the reading and
      * not the row. Admitted off the value instead, this path would answer for the cards and refuse
      * the rest, and what a model may name would be decided by which rows somebody wrote.
+     *
+     * <p><b>Every element a card, and that is the point of the row.</b> A row holding one of the
+     * other case is refused by that element having no such field, which a walk admitting names off
+     * the value it holds does too — so the row that tells the two apart is the one where every value
+     * carries the name and the reading is the only thing that can refuse it.
      */
     @Test
     void aFieldOnlyOneCaseDeclaresIsNotReadableAtTheSum() {
-        assertNull(read(SPREAD, aCardAndACash(), cardNumber()),
+        assertNull(read(SPREAD, List.of(card(6), card(7)), cardNumber()),
                 "nothing is readable at the sum but what its cases share, so this walk cannot be"
                         + " made at all");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
@@ -1,0 +1,222 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
+import souther.compiler.inputs.Case;
+import souther.compiler.inputs.Distinctions;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A row is read at a position by what the reading exposes there, and never by what its value
+ * happens to carry.
+ *
+ * <p>Two ways of getting this wrong and they are opposite. A walk that asks where a value is
+ * <em>written</em> reaches nothing at a name every case of a sum spreads — the name is readable at
+ * the sum and a row writes one of the cases — so every point on a line over such a total came back
+ * undecided while the row standing on it was in the file. A walk that took the name off whatever
+ * value it held instead would read a case's own field on the rows that are that case and refuse it
+ * on the rest, which is a readability decided per row and is not something the model states.
+ *
+ * <p>So a field is admitted by {@code check.ReadableFields} and then taken from the value in hand.
+ * The rows here carry the second half of that: a {@code Card} holds its own {@code cardNumber} as
+ * well as the {@code amount} it spreads, so the case that must not be readable is one every row of
+ * it does carry.
+ *
+ * <p><b>And a narrowing is how a case's own field is reached.</b> A path that names the case reads
+ * what only that case declares, which the model says by spelling the case; a row at another case
+ * takes that step and stands nowhere below it, which is a row that is somewhere else and not a walk
+ * that could not be made. Those two answers are what tells a point nothing covers from a point
+ * nothing could be told about.
+ */
+class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
+
+    /** Two cases spreading one declaration, each with a field of its own. */
+    private static final String SPREAD = """
+            module g
+
+            data Common = { amount: Int }
+
+            data Card = { ...Common, cardNumber: String }
+            data Cash = { ...Common, note: String }
+
+            data Method = Card | Cash
+
+            data Entry = { method: Method, settled: Bool }
+
+            data Page = { count: Int }
+
+            behavior readArticles : (ns: List<Entry>) -> Page
+            """;
+
+    /** The same model with the amount on the element, which is the shape that always worked. */
+    private static final String ON_THE_ELEMENT = """
+            module g
+
+            data Method = { amount: Int, cardNumber: String }
+
+            data Entry = { method: Method, settled: Bool }
+
+            data Page = { count: Int }
+
+            behavior readArticles : (ns: List<Entry>) -> Page
+            """;
+
+    private static final ReadingPolicy POLICY = new ReadingPolicy(64, 12);
+
+    /**
+     * The name every case spreads is read at each of them, whichever case the row turned out to be.
+     *
+     * <p>Both values and in the order the row wrote them, so what comes back is the run a total over
+     * this path adds up rather than the elements one case happened to be at.
+     */
+    @Test
+    void aNameEveryCaseSpreadsIsReadAtEveryCase() {
+        assertEquals(List.of(new ObservedValue.Integer(6), new ObservedValue.Integer(7)),
+                read(SPREAD, aCardAndACash(), amount()),
+                "the amount is readable at the sum, so a row is read at it whichever case it wrote");
+    }
+
+    /**
+     * And a case's own field is not readable at the sum, though the row carrying it holds it.
+     *
+     * <p>The value is right there: the same row answers with it under a path that names the case
+     * ({@link #aNarrowingIsHowACaseOwnFieldIsReached}), so what refuses this walk is the reading and
+     * not the row. Admitted off the value instead, this path would answer for the cards and refuse
+     * the rest, and what a model may name would be decided by which rows somebody wrote.
+     */
+    @Test
+    void aFieldOnlyOneCaseDeclaresIsNotReadableAtTheSum() {
+        assertNull(read(SPREAD, aCardAndACash(), cardNumber()),
+                "nothing is readable at the sum but what its cases share, so this walk cannot be"
+                        + " made at all");
+    }
+
+    /** And the row does hold it, which is what makes the refusal above a rule and not an absence. */
+    @Test
+    void aNarrowingIsHowACaseOwnFieldIsReached() {
+        assertEquals(List.of(new ObservedValue.Text("x")),
+                read(SPREAD, aCardAndACash(), cardNumberAsACard()),
+                "a path that names the case may read what only that case declares");
+    }
+
+    /**
+     * A row at another case stands nowhere below the narrowing, which is not a walk that failed.
+     *
+     * <p>The two answers a caller tells apart: nothing to read here, and could not look. Answered
+     * alike, a point no row covers would be reported as one this compiler could not decide, and the
+     * line would be owed a row it already has.
+     */
+    @Test
+    void aRowAtAnotherCaseStandsNowhereRatherThanFailingTheWalk() {
+        List<ObservedValue> found = read(SPREAD, List.of(cash(7)), cardNumberAsACard());
+
+        assertNotNull(found, "the narrowing is a step this path may take, whatever the row wrote");
+        assertEquals(List.of(), found,
+                "and a row at the other case stands nowhere below it");
+    }
+
+    /**
+     * The two models come back with the same values.
+     *
+     * <p>Which is the whole of what the sum was supposed not to change: a total read through a name
+     * the cases share is the same run of numbers as one read off the element, and every question
+     * about the line follows from the run.
+     */
+    @Test
+    void aSpreadNameReadsLikeOneDeclaredOnTheElement() {
+        assertEquals(read(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
+                read(SPREAD, List.of(card(6)), amount()),
+                "the cases spreading the name change nothing about what a run of it holds");
+    }
+
+    private static TermPath amount() {
+        return TermPath.of("ns").element().then("method").then("amount");
+    }
+
+    private static TermPath cardNumber() {
+        return TermPath.of("ns").element().then("method").then("cardNumber");
+    }
+
+    /** The card's own number, read at the position the case narrows the sum to. */
+    private static TermPath cardNumberAsACard() {
+        return TermPath.of("ns").element().then("method")
+                .refine(theCase(SPREAD, "Method", "Card")).then("cardNumber");
+    }
+
+    /** The narrowing to {@code leaf}, taken from what the position's type divides into. */
+    private static Refinement theCase(String source, String sum, String leaf) {
+        Symbols symbols = RuleReadings.ofSource(source).symbols();
+        TypeSymbol wanted = sym(leaf);
+        for (Case one : Distinctions.ofType(TypeView.of(named(sum), symbols), symbols)) {
+            if (one instanceof Case.SumCase found && found.leaf().equals(wanted)) {
+                return Refinement.of(one);
+            }
+        }
+        throw new AssertionError("the model under test declares `" + leaf + "` as a case of `"
+                + sum + "`");
+    }
+
+    /** What the walk reads at {@code path}, off a row holding {@code entries}. */
+    private static List<ObservedValue> read(String source, List<ObservedValue> entries,
+                                            TermPath path) {
+        RuleReadingSource rules = RuleReadings.ofSource(source);
+        BehaviorInputs inputs = new BehaviorInputs(List.of("ns"),
+                List.of(new Type.ListOf(named("Entry"))), rules, POLICY);
+        return inputs.valuesAt(List.of(new ObservedValue.Sequence(
+                entries.stream().map(AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest
+                        ::entry).toList())), path);
+    }
+
+    private static List<ObservedValue> aCardAndACash() {
+        return List.of(card(6), cash(7));
+    }
+
+    private static ObservedValue entry(ObservedValue method) {
+        return new ObservedValue.Constructed(sym("Entry"),
+                Map.of("method", method, "settled", new ObservedValue.Bool(true)));
+    }
+
+    private static ObservedValue card(int amount) {
+        return new ObservedValue.Constructed(sym("Card"),
+                Map.of("amount", new ObservedValue.Integer(amount),
+                        "cardNumber", new ObservedValue.Text("x")));
+    }
+
+    private static ObservedValue cash(int amount) {
+        return new ObservedValue.Constructed(sym("Cash"),
+                Map.of("amount", new ObservedValue.Integer(amount),
+                        "note", new ObservedValue.Text("y")));
+    }
+
+    private static ObservedValue onTheElement(int amount) {
+        return new ObservedValue.Constructed(sym("Method"),
+                Map.of("amount", new ObservedValue.Integer(amount),
+                        "cardNumber", new ObservedValue.Text("x")));
+    }
+
+    private static Type named(String data) {
+        return Type.ref(sym(data));
+    }
+
+    private static TypeSymbol sym(String data) {
+        return TypeSymbols.declared(new TypeKey("g", data));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
@@ -163,6 +163,32 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
                 "the cases spreading the name change nothing about what a run of it holds");
     }
 
+    /**
+     * The steps that are not a field admit what they admit here, said apart from the written walk.
+     *
+     * <p>An element and a narrowing come to the same type under either relation today, and the two
+     * walks answer them separately so that they may stop. Pinned here and in
+     * {@link WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest} rather than compared, for
+     * the reason the four questions about a shape are: two answers held against each other are one
+     * answer wearing two names, and the day somebody means to move one of them, what the other says
+     * has to fail on its own.
+     *
+     * <p>An element of a list, a narrowing to the case the row wrote, and a narrowing to the other
+     * one. The last is the step being taken and finding nothing, which is what tells the pair apart
+     * from a step that cannot be taken at all.
+     */
+    @Test
+    void whatTheStepsBesideAFieldAdmitIsSaidHere() {
+        assertEquals(List.of(new ObservedValue.Integer(6), new ObservedValue.Integer(7)),
+                read(SPREAD, aCardAndACash(), amount()),
+                "an element of the list is every element the row wrote");
+        assertEquals(List.of(new ObservedValue.Text("x")),
+                read(SPREAD, aCardAndACash(), cardNumberAsACard()),
+                "and a narrowing keeps what the row wrote as that case");
+        assertEquals(List.of(), read(SPREAD, List.of(cash(7)), cardNumberAsACard()),
+                "and drops what it wrote as another, which is a step taken");
+    }
+
     private static TermPath amount() {
         return TermPath.of("ns").element().then("method").then("amount");
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
@@ -6,7 +6,10 @@ import java.io.IOException;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.CodeModel;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.DirectMethodHandleDesc;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -43,6 +46,9 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
 
     private static final String OWNER = "souther.compiler.partition.BehaviorInputs";
 
+    /** The same class as {@link #OWNER}, as a method handle spells its owner. */
+    private static final String SHORT = "BehaviorInputs";
+
     private static final String ANSWERS = "stepWrittenValue";
 
     /**
@@ -75,9 +81,7 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
                     continue;
                 }
                 for (var element : code) {
-                    if (element instanceof InvokeInstruction call
-                            && call.owner().asInternalName().replace('/', '.').equals(OWNER)
-                            && call.name().stringValue().equals(ANSWERS)) {
+                    if (reaches(element)) {
                         asks.add(from + "#" + method.methodName().stringValue()
                                 + method.methodType().stringValue());
                     }
@@ -114,6 +118,38 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
                         + "Lsouther/compiler/check/Symbols;)Lsouther/compiler/types/Type;"),
                 declared,
                 "where a written value has a part is one question, so it is answered by one method");
+    }
+
+    /**
+     * Whether this piece of a method's code reaches the answer, however it was written.
+     *
+     * <p>Two encodings and they are one reading. A call written as a call is an invocation naming
+     * the method; a method reference is an {@code invokedynamic} whose bootstrap carries the same
+     * method as a handle, and the name of the method appears nowhere in the instruction. Read for
+     * the first alone, {@code BehaviorInputs::stepWrittenValue} handed to a {@code map} would put
+     * the written relation back inside the reading walk and this would go on naming one caller.
+     */
+    private static boolean reaches(java.lang.classfile.CodeElement element) {
+        if (element instanceof InvokeInstruction call) {
+            return names(call.owner().asInternalName().replace('/', '.'),
+                    call.name().stringValue());
+        }
+        if (!(element instanceof InvokeDynamicInstruction made)) {
+            return false;
+        }
+        for (ConstantDesc argument : made.bootstrapArgs()) {
+            if (argument instanceof DirectMethodHandleDesc handle
+                    && names(handle.owner().displayName(), handle.methodName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Whether a call names the answer. The owner by its display name where a handle carries it and
+     *  by its binary name where an instruction does, which are the same name for a nested class. */
+    private static boolean names(String owner, String method) {
+        return (owner.equals(OWNER) || owner.equals(SHORT)) && method.equals(ANSWERS);
     }
 
     private static Path fileOf(String binaryName) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
@@ -1,0 +1,133 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Where a written value has a part is asked by the one walk that writes values.
+ *
+ * <p>{@code BehaviorInputs.stepWrittenValue} answers one of the two relations a path step stands
+ * for: where a value written at a position has the part a step names. The other is what a value
+ * standing there may be read as, and the two are one answer at a record and part at a sum whose
+ * cases share a spread — a name every case spreads is readable at the sum and no row writes
+ * anything at it.
+ *
+ * <p>So a reader that wants the second and takes this one reads no value at every name a model
+ * reads through a sum. That is what the walk over a row's values did, and nothing said so: the
+ * census in {@code NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest} leaves out the class
+ * that declares an answer and everything nested in it, which is right for the question it asks —
+ * whether the answer left its owner — and blind to the two readers that live inside
+ * {@link BehaviorInputs}. One of them wrote the defect.
+ *
+ * <p><b>So this counts methods and not classes.</b> The two callers were in one class file and a
+ * class-level count cannot tell them apart. Read off what javac made rather than off the sources,
+ * for the reason every check here is: a call is in the code however it was spelled.
+ */
+class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
+
+    private static final String OWNER = "souther.compiler.partition.BehaviorInputs";
+
+    private static final String ANSWERS = "stepWrittenValue";
+
+    /**
+     * The one method that reads a path as where a value goes.
+     *
+     * <p>With the descriptor, so that a second method of the name would be a second entry rather
+     * than the same one seen twice.
+     */
+    private static final String COMPOSES =
+            OWNER + "#typeAtWrittenPath(Lsouther/compiler/inputs/TermPath;)"
+                    + "Lsouther/compiler/types/Type;";
+
+    /**
+     * And it is the only one, wherever it is written.
+     *
+     * <p>The walk that reads a row at a position takes its own steps ({@code BehaviorInputs
+     * .Standing.step}) and appears here if it ever stops. What it would look like is this test
+     * naming a second method — which is the reading of a row deciding where a value would be
+     * written, one relation standing in for the other again.
+     */
+    @Test
+    void oneMethodAsksWhereAWrittenValueHasItsParts() throws IOException {
+        Set<String> asks = new TreeSet<>();
+        for (Path each : classes()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            String from = model.thisClass().asInternalName().replace('/', '.');
+            for (var method : model.methods()) {
+                CodeModel code = method.code().orElse(null);
+                if (code == null) {
+                    continue;
+                }
+                for (var element : code) {
+                    if (element instanceof InvokeInstruction call
+                            && call.owner().asInternalName().replace('/', '.').equals(OWNER)
+                            && call.name().stringValue().equals(ANSWERS)) {
+                        asks.add(from + "#" + method.methodName().stringValue()
+                                + method.methodType().stringValue());
+                    }
+                }
+            }
+        }
+
+        assertFalse(asks.isEmpty(),
+                "nothing asks where a written value has its parts at all; this check is reading no"
+                        + " calls");
+        assertEquals(Set.of(COMPOSES), asks,
+                "a path is read as where a value goes in the one place that composes one, and a"
+                        + " second reader is the written relation standing in for the read one");
+    }
+
+    /**
+     * And there is one of it to ask, so the count above is the whole of the rule.
+     *
+     * <p>An overload beside it would be a second answer under one name: the count would go on
+     * naming one caller while two questions were being answered, and which of them a caller meant
+     * would be settled by the types it happened to hold.
+     */
+    @Test
+    void thereIsOneAnswerUnderThatName() throws IOException {
+        Set<String> declared = new TreeSet<>();
+        ClassModel model = ClassFile.of().parse(Files.readAllBytes(fileOf(OWNER)));
+        for (var method : model.methods()) {
+            if (method.methodName().stringValue().equals(ANSWERS)) {
+                declared.add(method.methodType().stringValue());
+            }
+        }
+
+        assertEquals(Set.of("(Lsouther/compiler/inputs/TermPath$Step;Lsouther/compiler/types/Type;"
+                        + "Lsouther/compiler/check/Symbols;)Lsouther/compiler/types/Type;"),
+                declared,
+                "where a written value has a part is one question, so it is answered by one method");
+    }
+
+    private static Path fileOf(String binaryName) {
+        return root().resolve(binaryName.replace('.', '/') + ".class");
+    }
+
+    private static List<Path> classes() throws IOException {
+        try (Stream<Path> walk = Files.walk(root())) {
+            return new ArrayList<>(new LinkedHashSet<>(
+                    walk.filter(each -> each.toString().endsWith(".class")).toList()));
+        }
+    }
+
+    private static Path root() {
+        return Path.of("target", "classes").toAbsolutePath();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest.java
@@ -51,6 +51,9 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
 
     private static final String ANSWERS = "stepWrittenValue";
 
+    /** The walk of it, which is the whole relation rather than one step of it. */
+    private static final String WALKS = "typeAtWrittenPath";
+
     /**
      * The one method that reads a path as where a value goes.
      *
@@ -58,7 +61,7 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      * than the same one seen twice.
      */
     private static final String COMPOSES =
-            OWNER + "#typeAtWrittenPath(Lsouther/compiler/inputs/TermPath;)"
+            OWNER + "#" + WALKS + "(Lsouther/compiler/inputs/TermPath;)"
                     + "Lsouther/compiler/types/Type;";
 
     /**
@@ -71,6 +74,50 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      */
     @Test
     void oneMethodAsksWhereAWrittenValueHasItsParts() throws IOException {
+        Set<String> asks = callersOf(ANSWERS);
+
+        assertFalse(asks.isEmpty(),
+                "nothing asks where a written value has its parts at all; this check is reading no"
+                        + " calls");
+        assertEquals(Set.of(COMPOSES), asks,
+                "a path is read as where a value goes in the one place that composes one, and a"
+                        + " second reader is the written relation standing in for the read one");
+    }
+
+    /**
+     * And the walk that takes those steps is asked where a value is composed, and nowhere else.
+     *
+     * <p>The step is the thing this began about and it is not the whole of what has to be shut. A
+     * reader wanting to know what a path names could call the walk rather than the step, and the
+     * count above would go on naming one caller while a reading of a row was again being answered
+     * out of where a value is written. At a field that would fail the reading's own law; at an
+     * element or a narrowing it would not, because the two relations agree there today — which is
+     * exactly the agreement that is a law and not a reason to share.
+     *
+     * <p>So what is named here is on the composing side, and being on it is what the entry is for.
+     * {@code Generator.edgeAt} takes the root a value is to be written at and hands what it finds
+     * to the composition; a method that arrived here having read a row would be the same category
+     * error one call further out.
+     */
+    @Test
+    void theWalkIsAskedWhereAValueIsComposed() throws IOException {
+        Set<String> asks = callersOf(WALKS);
+
+        assertFalse(asks.isEmpty(),
+                "nothing asks where a value at a path is written at all; this check is reading no"
+                        + " calls");
+        assertEquals(Set.of("souther.compiler.partition.Generator#edgeAt("
+                        + "Lsouther/compiler/partition/MeasuredInput;"
+                        + "Lsouther/compiler/partition/RealizationTarget;"
+                        + "Lsouther/compiler/numeric/Place;Z"
+                        + "Lsouther/compiler/inputs/SearchRegion;)"
+                        + "Lsouther/compiler/partition/Generator$Edge;"), asks,
+                "where a value is written is asked where one is composed, and a second asker is a"
+                        + " reader answering its own question out of that one");
+    }
+
+    /** Every production method that reaches {@code answer} on the owner, however it spelled it. */
+    private static Set<String> callersOf(String answer) throws IOException {
         Set<String> asks = new TreeSet<>();
         for (Path each : classes()) {
             ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
@@ -81,20 +128,14 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
                     continue;
                 }
                 for (var element : code) {
-                    if (reaches(element)) {
+                    if (reaches(element, answer)) {
                         asks.add(from + "#" + method.methodName().stringValue()
                                 + method.methodType().stringValue());
                     }
                 }
             }
         }
-
-        assertFalse(asks.isEmpty(),
-                "nothing asks where a written value has its parts at all; this check is reading no"
-                        + " calls");
-        assertEquals(Set.of(COMPOSES), asks,
-                "a path is read as where a value goes in the one place that composes one, and a"
-                        + " second reader is the written relation standing in for the read one");
+        return asks;
     }
 
     /**
@@ -129,17 +170,17 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
      * the first alone, {@code BehaviorInputs::stepWrittenValue} handed to a {@code map} would put
      * the written relation back inside the reading walk and this would go on naming one caller.
      */
-    private static boolean reaches(java.lang.classfile.CodeElement element) {
+    private static boolean reaches(java.lang.classfile.CodeElement element, String answer) {
         if (element instanceof InvokeInstruction call) {
             return names(call.owner().asInternalName().replace('/', '.'),
-                    call.name().stringValue());
+                    call.name().stringValue(), answer);
         }
         if (!(element instanceof InvokeDynamicInstruction made)) {
             return false;
         }
         for (ConstantDesc argument : made.bootstrapArgs()) {
             if (argument instanceof DirectMethodHandleDesc handle
-                    && names(handle.owner().displayName(), handle.methodName())) {
+                    && names(handle.owner().displayName(), handle.methodName(), answer)) {
                 return true;
             }
         }
@@ -148,8 +189,8 @@ class OnlyTypeAtWrittenPathStepsIntoAWrittenValueTest {
 
     /** Whether a call names the answer. The owner by its display name where a handle carries it and
      *  by its binary name where an instruction does, which are the same name for a nested class. */
-    private static boolean names(String owner, String method) {
-        return (owner.equals(OWNER) || owner.equals(SHORT)) && method.equals(ANSWERS);
+    private static boolean names(String owner, String method, String answer) {
+        return (owner.equals(OWNER) || owner.equals(SHORT)) && method.equals(answer);
     }
 
     private static Path fileOf(String binaryName) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
@@ -9,7 +9,9 @@ import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
+import souther.compiler.inputs.Case;
 import souther.compiler.inputs.Distinctions;
+import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.query.Bodies;
@@ -17,12 +19,16 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -109,6 +115,67 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
         assertNull(BehaviorInputs.stepWrittenValue(new TermPath.Step.Field("deadline"), sum,
                         symbols()),
                 "and a row writes one of the cases, so nothing is written at the shared name");
+    }
+
+    /**
+     * Where the steps that are not a field land for a value being written, said apart from the walk.
+     *
+     * <p>An element of a sequence and a narrowing to a case are one answer under this relation and
+     * under the reading of a row, and the two walks work them out separately so that they may one
+     * day stop being one. What holds them together is that each is pinned — here for the written
+     * relation, and in {@code AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest} for
+     * the reading — rather than one being compared against the other, which is one answer wearing
+     * two names.
+     */
+    @Test
+    void whereTheStepsBesideAFieldLandForAWrittenValue() {
+        assertEquals(Type.INT, BehaviorInputs.stepWrittenValue(new TermPath.Step.Element(),
+                        new Type.ListOf(Type.INT), symbols()),
+                "a sequence puts what it holds under an element");
+        assertEquals(typeOf("p"), BehaviorInputs.stepWrittenValue(
+                        new TermPath.Step.Refine(caseOf("P")), typeOf("r"), symbols()),
+                "and a narrowing to a case is that case at the same position");
+        assertNull(BehaviorInputs.stepWrittenValue(new TermPath.Step.Element(), typeOf("r"),
+                        symbols()),
+                "and a sum holds nothing under an element");
+    }
+
+    /** The narrowing to {@code leaf}, taken from what the sum's type divides into. */
+    private static Refinement caseOf(String leaf) {
+        TypeSymbol wanted = TypeSymbols.declared(new TypeKey(module(), leaf));
+        for (Case one : Distinctions.ofType(TypeView.of(typeOf("r"), symbols()), symbols())) {
+            if (one instanceof Case.SumCase found && found.leaf().equals(wanted)) {
+                return Refinement.of(one);
+            }
+        }
+        throw new AssertionError("the model under test declares `" + leaf + "` as a case");
+    }
+
+    /**
+     * The two ways of asking what is readable give the one answer.
+     *
+     * <p>Every name at a position and one name of it, which a reader after a single step asks
+     * because it has one name and no use for the rest. Two entries into a question is two chances
+     * to answer it differently, so what the narrow one says is held to what the wide one holds —
+     * including where it holds nothing, since a name nothing declares and a name declared to be
+     * something are what a step turns on.
+     */
+    @Test
+    void oneNameIsReadTheWayEveryNameIs() {
+        for (Type type : List.of(typeOf("p"), typeOf("r"))) {
+            Shape shape = shapeOf(type);
+            Map<String, Type> readable = ReadableFields.of(shape).fields();
+
+            assertFalse(readable.isEmpty(),
+                    () -> "the model under test has names readable at " + Type.show(type));
+            for (Map.Entry<String, Type> name : readable.entrySet()) {
+                assertEquals(name.getValue(), ReadableFields.at(shape, name.getKey()),
+                        () -> "one name is what every name says it is, at " + name.getKey());
+            }
+            assertNull(ReadableFields.at(shape, "nothingDeclaresThis"),
+                    () -> "and a name nothing declares is readable nowhere, at "
+                            + Type.show(type));
+        }
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
@@ -32,15 +32,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Four questions are asked of one shape, and they are four.
  *
  * <p>What is readable off a value standing here, what a value here is composed out of, which
- * positions a reading has under it, and where a step into a written value lands. At a record all
- * four come to the same fields, which is close enough to take one of them for all four; at a sum
- * whose cases share a spread only the first has anything to say, because those names are readable at
- * every value of the sum and a value there is one of the cases.
+ * positions a reading has under it, and what a written value has under a step. At a record all four
+ * come to the same fields, which is close enough to take one of them for all four; at a sum whose
+ * cases share a spread only the first has anything to say, because those names are readable at every
+ * value of the sum and a value there is one of the cases.
  *
  * <p><b>The agreement at a record is what is checked, not what is implemented.</b> Each of the four
  * reads {@code Shape.Product}'s fields where it needs them, and the four answers are held together
  * here rather than by one of them being the others' answer. Written the other way round, a question
  * that learned a new case would take the three it does not own along with it.
+ *
+ * <p><b>Four and not five.</b> How an observed value is read down a path is the relation the written
+ * one is most often mistaken for, and it is not one of these: it consumes a value, answers with as
+ * many standings as it finds, and can find none, so there is no equality to hold between it and a
+ * map of fields. What it owes is stated where it lives
+ * ({@link AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest}) — that a field is
+ * admitted by what is readable at the position and never by what the value in hand carries.
  */
 class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
 
@@ -78,7 +85,7 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
         assertEquals(inOrder(readable), inOrder(decomposedUnder(record)),
                 "and the reading has those same positions under it");
         assertEquals(inOrder(readable), inOrder(stepped(record, readable)),
-                "and a step into a written value lands on each of them");
+                "and a written value has one of them under each step");
     }
 
     /**


### PR DESCRIPTION
Closes #1320.

A path step stands for two relations. One is where a value written at a position has the part a step names; the other is what a value standing there may be read as. They are one answer at a record and part at a sum whose cases share a spread — the shared name is readable at the sum, and a row writes one of the cases, so nothing is written at the name itself.

The walk over a row's values took the first. So a total read through such a name reached no value, and every point of its line came back undecided while the row standing on one of them was in the file. Both sentences the report wrote for it — that the walk reached nothing to read, and that no composed row was seen reaching the point — came from that one step.

The walk now takes its own steps. A field is admitted by what is readable at the position and then taken from the value in hand, and the element and refinement steps are its own rather than the composing walk's. They agree today wherever both have an answer, and that agreement is a law over the two rather than a reason for one to be the other's implementation.

Admitted by the reading and never by the value, because a case carries its own fields as well as the ones it spreads. Taken off whatever value was held, a name only one case declares would be readable on the rows that are that case and refused on the rest — a readability decided by which rows somebody wrote. A path that names the case is how such a field is reached, and a row at another case stands nowhere below it rather than failing the walk.

## What keeps it from coming back

The census over who asks what is readable leaves out the class that declares an answer and everything nested in it, which is right for the question it asks — whether the answer left its owner — and is why the two readers living inside one class file were invisible while one of them wrote this. So there is a second invariant beside it, counting methods rather than classes: the relation about written values is asked by the one method that reads a path as where a value goes.

Each of the three guards was checked by putting the defect back. Restoring the field step fails the reading law, the census, and the method count; restoring the element step fails the method count alone, which is what it exists for; admitting a field off the value in hand fails the case-private reading — that one passed at first over a row whose other case did not carry the name, so the row was changed to one where only the reading can refuse it.

The line's own points are worked out from the model before either model is run, and the model with the amount on the element is not the oracle: it is held to the same statement and then compared, so the two cannot go wrong together and agree about it.

## Left out

Two of the same shape, filed rather than folded in: a fixture projecting through such a name is refused on the arm that reads declared values (#1342), and the walk's answer runs a step it could not take together with a row that stands nowhere (#1343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)