### PR TITLE
Ask what the rules leave room for before descending

### DIFF
--- a/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest.java
@@ -163,7 +163,7 @@ class EveryBudgetOfThisCompilerIsReadWhereItIsDeclaredToBeTest {
                             + "Lsouther/compiler/check/Symbols;I"
                             + "Ljava/util/Set;"
                             + "Lsouther/compiler/inputs/Requirements;"
-                            + "Ljava/util/function/ToIntBiFunction;)"
+                            + "Lsouther/compiler/partition/ConstructionPlan$HowManyItHolds;)"
                             + "Lsouther/compiler/partition/ConstructionPlan$NodeResult;",
                     "stops descending where a value is still made of positions, and says which"
                             + " figure — on the position where it stopped, or as the whole plan"

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -570,11 +570,6 @@ final class ConstructionPlan {
             // however far this had read, so a figure named beside it sends an author to raise one
             // that changes nothing, and a figure named instead of it says this compiler did not
             // look, of a position it has the answer for.
-            // Asked before the figure and before the descent, because this is the model's answer
-            // and those are this compiler's. A list the rules leave no room in holds nothing
-            // however far this had read, so a figure named beside it sends an author to raise one
-            // that changes nothing, and a figure named instead of it says this compiler did not
-            // look, of a position it has the answer for.
             if (demanded && holds.most() < needed) {
                 return new NodeResult.Refused(new ModelRefusal.NoRoom(here, needed, holds));
             }
@@ -628,38 +623,27 @@ final class ConstructionPlan {
         }
         Map<String, Node> under = new LinkedHashMap<>();
         Set<CompositionBudget> beyond = new LinkedHashSet<>();
-        NodeResult.Unnarrowed owed = null;
         for (Map.Entry<String, Type> field : composed.fields().entrySet()) {
             switch (node(field.getValue(), here.then(field.getKey()), symbols, depth + 1, decided,
                     required, howMany)) {
                 case NodeResult.Made(Node built) -> under.put(field.getKey(), built);
-                // The model settling that there is no value ends the walk: nothing a field further
-                // along could say outranks it, and one proof is the whole of what a reader gets —
-                // a second would name another position to look at where there is no row to look
-                // for.
-                case NodeResult.Refused refused -> { return refused; }
-                // Every field's, and not the first one's. Two fields whose demands are out of reach
-                // are two figures a reader could raise, and taking whichever the walk met first
-                // would make the answer turn on the order the fields are declared in.
-                case NodeResult.Beyond(Set<CompositionBudget> by) -> beyond.addAll(by);
-                // One position, and the first of them. A narrowing is stated at a position rather
-                // than gathered up, and the caller states one and asks again — so what it is owed
-                // is somewhere to begin, and the field a second one is under may not even be
-                // reached under the narrowing it settles on here.
+                // One position, and the first of them, which is what both of these are.
                 //
-                // Kept rather than returned, because a field after it may be one the model refuses
-                // outright — and a caller sent to state a narrowing would state it and be told
-                // there was never a row. Which one is owed does not change: it is still the first,
-                // in the order the declarations write them.
-                case NodeResult.Unnarrowed unnarrowed -> {
-                    if (owed == null) {
-                        owed = unnarrowed;
-                    }
-                }
+                // <p>Neither outranks the other, because they are not about one position. What
+                // #1315 orders is a refusal against a figure met at the same place, and a sequence
+                // settles that before it descends. Between two fields there is nothing to order: a
+                // caller told to state a narrowing at one field is told something true of that
+                // field whatever the next one comes to, and a caller told the model refuses another
+                // is told something true of that one. Walking on to prefer one of them would buy no
+                // answer and would take the walk into fields the first answer says nothing about.
+                case NodeResult.Refused refused -> { return refused; }
+                case NodeResult.Unnarrowed unnarrowed -> { return unnarrowed; }
+                // Every field's, and not the first one's — which is where this parts from the two
+                // above. Two fields whose demands are out of reach are two figures a reader could
+                // raise, and a reader owed one of them is owed both; taking whichever the walk met
+                // first would make what they are told turn on the order the fields are declared in.
+                case NodeResult.Beyond(Set<CompositionBudget> by) -> beyond.addAll(by);
             }
-        }
-        if (owed != null) {
-            return owed;
         }
         if (!beyond.isEmpty()) {
             return new NodeResult.Beyond(beyond);
@@ -808,7 +792,7 @@ final class ConstructionPlan {
      * <p>And at the position as well as under it. A refinement does not move to another position,
      * so a second narrowing of one an absence settled is written at that same path: leaving it out
      * as "not below" reads a rule about steps into a value as one about narrowings, which take
-     * none. That is what {@link Result.Conflict} is about at a position two narrowings disagree
+     * none. That is what {@link ModelRefusal.Conflict} is about at a position two narrowings disagree
      * over, and this is the other half of it — the narrowings agree, and there is nothing there for
      * the second to be about.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -169,8 +169,9 @@ final class ConstructionPlan {
      *
      * <p>One element and not however many. What a class at an element asks for is a list holding a
      * value in it; what the other elements are is a separate question, and answering it here would
-     * decide it for every rule at once. A list of one holds an element in the class and nothing
-     * else, which is the least a row can be and still meet what was asked.
+     * decide it for every rule at once. So what is built here holds the element in the class and
+     * whatever else the rules ask the list for, which is the least a row can be and still meet both
+     * ({@link #neededToHold}).
      *
      * @param worn  {@link Node#worn}: every name the position wears, since what is composed here
      *              is bare
@@ -331,6 +332,24 @@ final class ConstructionPlan {
     }
 
     /**
+     * How many a collection has to hold for a value to be placed in it, given what the rules leave
+     * it.
+     *
+     * <p><b>The one place the rules' floor becomes a count to build.</b> They are two numbers: the
+     * floor is how many the whole collection has to hold and says nothing about anything being
+     * placed, and this is what the composing has to make. They agree wherever the rules ask for
+     * more than none, which is why a second copy of this reads plausibly and why the two names
+     * collapsed back into one every time there was a second copy.
+     *
+     * <p>So everything that needs the count takes it from here — what the plan records at a
+     * collection, what a refusal compares the cap against, and what the composing builds — and a
+     * caller holding one of these numbers can say which it is by where it came from.
+     */
+    static int neededToHold(DeclaredBounds.CountRange holds) {
+        return Math.max(1, holds.least());
+    }
+
+    /**
      * What the model settles, where what it settles is that there is nothing to build.
      *
      * <p>Each of these is a fact about the declarations, established before anything was searched
@@ -366,7 +385,7 @@ final class ConstructionPlan {
         record NoRoom(TermPath at, DeclaredBounds.CountRange holds) implements ModelRefusal {
 
             public NoRoom {
-                if (holds.most() >= Math.max(1, holds.least())) {
+                if (holds.most() >= neededToHold(holds)) {
                     throw new IllegalArgumentException("a collection with room for what is placed"
                             + " in it refuses nothing: " + at + " holds " + holds);
                 }
@@ -380,7 +399,7 @@ final class ConstructionPlan {
              * for none, one is what a collection holding it comes to.
              */
             int needed() {
-                return Math.max(1, holds.least());
+                return neededToHold(holds);
             }
         }
     }
@@ -575,7 +594,7 @@ final class ConstructionPlan {
             // of them, so what a collection holding it comes to is the floor, or one where the
             // rules ask for none.
             DeclaredBounds.CountRange holds = demanded ? howMany.at(here, building) : null;
-            int needed = demanded ? Math.max(1, holds.least()) : 0;
+            int needed = demanded ? neededToHold(holds) : 0;
             // Asked before the figure and before the descent, because this is the model's answer
             // and those are this compiler's. A list the rules leave no room in holds nothing
             // however far this had read, so a figure named beside it sends an author to raise one

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Case;
@@ -173,20 +174,24 @@ final class ConstructionPlan {
      *
      * @param worn  {@link Node#worn}: every name the position wears, since what is composed here
      *              is bare
-     * @param under the element's own position
-     * @param least how many the rules say the list holds at the fewest, which is one where they say
-     *              nothing. The element being placed is one of them and the rest are values of the
-     *              element's type: a class at an element asks for a list holding a value in it, and
-     *              a list that met that and broke the rule about how many it holds is not a row
+     * @param under  the element's own position
+     * @param needed how many this has to hold for the value to be placed in it: the fewest the
+     *               rules allow, and never fewer than one. The element being placed is one of them
+     *               and the rest are values of the element's type — a class at an element asks for
+     *               a list holding a value in it, and a list that met that and broke the rule about
+     *               how many it holds is not a row.
+     *               <p>Named for what it is and not for the end it is read off. The floor is the
+     *               rules'; this is what the composing has to make, and the two part wherever the
+     *               rules ask for none.
      */
-    record Held(TermPath at, Type type, List<TypeSymbol> worn, Node under, int least)
+    record Held(TermPath at, Type type, List<TypeSymbol> worn, Node under, int needed)
             implements Node {
 
         Held {
             worn = List.copyOf(worn);
-            if (least < 1) {
+            if (needed < 1) {
                 throw new IllegalArgumentException(
-                        "a list built around an element holds it: " + least);
+                        "a list built around an element holds it: " + needed);
             }
         }
     }
@@ -258,8 +263,16 @@ final class ConstructionPlan {
         /** The plan, which is what a caller that got one goes on with. */
         record Planned(ConstructionPlan plan) implements Result {}
 
-        /** No value is at both, and this is the position and the two it would have to be. */
-        record Conflict(TermPath at, Refinement one, Refinement other) implements Result {}
+        /**
+         * The model settles that there is no value to plan for, and this is what settles it.
+         *
+         * <p>One arm for every way of that, so a reader takes them together or not at all. What a
+         * reader does with one of these is the same whichever it is — there is no row and no figure
+         * to raise — and what parts them is only what to say. Beside {@link Beyond} as separate
+         * arms, each new way the model can settle it would be a fourth arm somebody had to notice
+         * belonged with the first rather than the second.
+         */
+        record Refused(ModelRefusal why) implements Result {}
 
         /**
          * What the caller asked for stands under a position this compiler stopped short of reading.
@@ -270,9 +283,9 @@ final class ConstructionPlan {
          * value out of the row. That is the one shape of this a reader could not tell from an
          * ordinary row.
          *
-         * <p>Told apart from {@link Conflict} by whose fact it is. A conflict is the model settling
-         * that no value is at both positions; this is a figure of this compiler's, and what would
-         * change it is somebody raising the figure.
+         * <p>Told apart from {@link Refused} by whose fact it is. That is the model settling that
+         * there is no value; this is a figure of this compiler's, and what would change it is
+         * somebody raising the figure.
          *
          * <p>Carries the figures and no word for them. What a search that gets this comes back with
          * is the caller's to say — the plan knows the demand was out of reach and not what the
@@ -318,6 +331,51 @@ final class ConstructionPlan {
     }
 
     /**
+     * What the model settles, where what it settles is that there is nothing to build.
+     *
+     * <p>Each of these is a fact about the declarations, established before anything was searched
+     * for and standing however far this compiler went on to look. So one of these is what a reader
+     * is told, and a figure this compiler reached at the same position is not — an author sent to
+     * raise it would raise it and be told the same thing.
+     *
+     * <p>Which is why they are one type. A reader of a refusal acts on it the same way whichever it
+     * is, and the ordering against a figure is written once, over this, rather than once per way
+     * the model can settle it.
+     */
+    sealed interface ModelRefusal {
+
+        /** Where the model settles it, which is what a report about it is written at. */
+        TermPath at();
+
+        /** No value is at both, and this is the position and the two it would have to be. */
+        record Conflict(TermPath at, Refinement one, Refinement other) implements ModelRefusal {}
+
+        /**
+         * A value is to be placed inside a collection the rules leave no room in.
+         *
+         * <p>Both numbers off one reading of the rules, taken where the plan is made and against
+         * the positions the caller has settled. What the floor says is how many the collection has
+         * to hold besides the one being placed, so what is needed is never fewer than one; what the
+         * cap says is whether that many fit. Read apart, the two can be of different states of the
+         * row.
+         *
+         * @param needed how many the collection would have to hold for the value to be placed in it
+         * @param holds  from how few to how many the rules let it hold
+         */
+        record NoRoom(TermPath at, int needed, DeclaredBounds.CountRange holds)
+                implements ModelRefusal {
+
+            public NoRoom {
+                if (needed <= holds.most()) {
+                    throw new IllegalArgumentException("a collection with room for what is placed"
+                            + " in it refuses nothing: " + at + " holds " + holds
+                            + " and needs " + needed);
+                }
+            }
+        }
+    }
+
+    /**
      * The plan for one parameter, against everything that has to hold of it.
      *
      * <p><b>The requirements are put together here and nowhere else.</b> A path states what has to
@@ -336,14 +394,15 @@ final class ConstructionPlan {
      *                   exists to stop
      */
     static Result of(Type declared, TermPath at, Symbols symbols, Set<TermPath> decided,
-                     Requirements additional,
-                     java.util.function.ToIntBiFunction<TermPath, Type> least) {
+                     Requirements additional, HowManyItHolds howMany) {
         Requirements required = additional;
         for (TermPath fixed : decided) {
             switch (required.merge(fixed.requirements())) {
                 case Requirements.Merge.Merged both -> required = both.requirements();
-                case Requirements.Merge.Conflict against ->
-                        { return new Result.Conflict(against.at(), against.one(), against.other()); }
+                case Requirements.Merge.Conflict against -> {
+                    return new Result.Refused(new ModelRefusal.Conflict(
+                            against.at(), against.one(), against.other()));
+                }
             }
         }
         // A position said twice. A caller that fixed a value at a position and also requires a
@@ -361,12 +420,28 @@ final class ConstructionPlan {
                         + " keeping two accounts of one position");
             }
         }
-        return switch (node(declared, at, symbols, 0, decided, required, least)) {
+        return switch (node(declared, at, symbols, 0, decided, required, howMany)) {
             case NodeResult.Made(Node root) -> new Result.Planned(new ConstructionPlan(root));
+            case NodeResult.Refused(ModelRefusal why) -> new Result.Refused(why);
             case NodeResult.Beyond(Set<CompositionBudget> by) -> new Result.Beyond(by);
             case NodeResult.Unnarrowed(TermPath where, List<Refinement> narrowings) ->
                     new Result.Unnarrowed(where, narrowings);
         };
+    }
+
+    /**
+     * How many the rules let the value at a position hold, read against what the caller has settled.
+     *
+     * <p>Asked rather than read here, because which rules those are is the caller's to know: a
+     * position of a parameter is read against the record it sits in and the values fixed beside it,
+     * and a position of a container being built to a total is read against the element's own type.
+     * Handed over as one answer with both ends, so that the floor and the cap are of one state of
+     * the row.
+     */
+    interface HowManyItHolds {
+
+        /** What the rules let the value built at {@code at}, of type {@code building}, hold. */
+        DeclaredBounds.CountRange at(TermPath at, Type building);
     }
 
     /**
@@ -381,6 +456,10 @@ final class ConstructionPlan {
 
         /** The position, worked out. */
         record Made(Node node) implements NodeResult {}
+
+        /** Nothing was, because the model settles that there is no value to build here or under
+         *  here. */
+        record Refused(ModelRefusal why) implements NodeResult {}
 
         /** Nothing was, because what the caller asked for is under a figure this reached. */
         record Beyond(Set<CompositionBudget> by) implements NodeResult {}
@@ -422,26 +501,6 @@ final class ConstructionPlan {
                 .anyMatch(each -> !each.equals(here) && each.isAtOrUnder(here));
     }
 
-    /** The collections this plan builds out of what stands at their element. */
-    List<Held> held() {
-        List<Held> out = new ArrayList<>();
-        collectHeld(root, out);
-        return List.copyOf(out);
-    }
-
-    private static void collectHeld(Node node, List<Held> out) {
-        switch (node) {
-            // Nothing is built under either: one holds a value the search chooses and the other a
-            // value the requirement settled, and a collection is neither.
-            case Slot _, Exact _ -> { }
-            case Built built -> built.under().values().forEach(each -> collectHeld(each, out));
-            case Held held -> {
-                out.add(held);
-                collectHeld(held.under(), out);
-            }
-        }
-    }
-
     /** Every position a value is chosen at, in the order they are composed. */
     List<Slot> slots() {
         List<Slot> out = new ArrayList<>();
@@ -462,7 +521,7 @@ final class ConstructionPlan {
 
     private static NodeResult node(Type declared, TermPath at, Symbols symbols, int depth,
                                    Set<TermPath> decided, Requirements required,
-                                   java.util.function.ToIntBiFunction<TermPath, Type> least) {
+                                   HowManyItHolds howMany) {
         // What the requirements leave standing here, worked out before anything is decided about
         // the position. Read once and in full: what is built, whether the search chooses it, and
         // where every path below it hangs all follow from it.
@@ -496,30 +555,52 @@ final class ConstructionPlan {
         CompositionBudget descent = CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS;
         boolean asDeepAsThisGoes = depth >= descent.maximum();
         if (view.shape() instanceof souther.compiler.check.Shape.Sequence sequence) {
+            // Asked once, here, and handed to everything below that turns on it. What is built at
+            // this position, whether the descent has anything to reach, and whether the rules leave
+            // room for it are one question — is the caller asking for something inside this list —
+            // and read twice they are free to come apart over one list.
+            boolean demanded = anythingIsAskedUnder(here, decided, required);
+            // How many it would have to hold, and how many it may, off one reading. What the floor
+            // says is how many the rules ask for besides the value being placed, so what is needed
+            // is that and never fewer than the one.
+            DeclaredBounds.CountRange holds = demanded ? howMany.at(here, building) : null;
+            int needed = demanded ? Math.max(1, holds.least()) : 0;
+            // Asked before the figure and before the descent, because this is the model's answer
+            // and those are this compiler's. A list the rules leave no room in holds nothing
+            // however far this had read, so a figure named beside it sends an author to raise one
+            // that changes nothing, and a figure named instead of it says this compiler did not
+            // look, of a position it has the answer for.
+            // Asked before the figure and before the descent, because this is the model's answer
+            // and those are this compiler's. A list the rules leave no room in holds nothing
+            // however far this had read, so a figure named beside it sends an author to raise one
+            // that changes nothing, and a figure named instead of it says this compiler did not
+            // look, of a position it has the answer for.
+            if (demanded && holds.most() < needed) {
+                return new NodeResult.Refused(new ModelRefusal.NoRoom(here, needed, holds));
+            }
             // A sequence is planned by asking what stands at its element, so the figure is met here
             // rather than below: read as a shape nothing composes — which is what a sequence is to
             // the descent under this — a list this stopped short of looking into would be a
             // position the declarations put nothing under.
             if (asDeepAsThisGoes) {
-                return givenUpAt(descent, here, building, settled.outer(), decided, required);
+                return givenUpAt(descent, here, building, settled.outer(), demanded);
             }
             NodeResult inside = node(sequence.element(), here.element(), symbols, depth + 1,
-                    decided, required, least);
+                    decided, required, howMany);
             if (!(inside instanceof NodeResult.Made(Node element))) {
                 return inside;
             }
-            Under under = under(element);
-            if (under.demanded()) {
-                return new NodeResult.Made(new Held(here, building, worn, element,
-                        Math.max(1, least.applyAsInt(here, building))));
+            if (demanded) {
+                return new NodeResult.Made(new Held(here, building, worn, element, needed));
             }
             // Nothing was asked for inside it, so the list is chosen whole — but where the walk
             // that would have found something gave up part-way, that is not the same answer. Read
             // as "no class is placed in here", a plan that never reached the class says there is
             // none.
-            if (!under.cutBy().isEmpty()) {
+            Set<CompositionBudget> cutBy = cutBy(element);
+            if (!cutBy.isEmpty()) {
                 return new NodeResult.Made(new Slot(here, building, settled.outer(),
-                        new Leaf.Beneath(under.cutBy())));
+                        new Leaf.Beneath(cutBy)));
             }
         }
         ConstructionDescent.ProductBuild composed = ConstructionDescent.toBuild(view.shape());
@@ -542,14 +623,21 @@ final class ConstructionPlan {
                     new Slot(here, building, settled.outer(), new Leaf.Open()));
         }
         if (asDeepAsThisGoes) {
-            return givenUpAt(descent, here, building, settled.outer(), decided, required);
+            return givenUpAt(descent, here, building, settled.outer(),
+                    anythingIsAskedUnder(here, decided, required));
         }
         Map<String, Node> under = new LinkedHashMap<>();
         Set<CompositionBudget> beyond = new LinkedHashSet<>();
+        NodeResult.Unnarrowed owed = null;
         for (Map.Entry<String, Type> field : composed.fields().entrySet()) {
             switch (node(field.getValue(), here.then(field.getKey()), symbols, depth + 1, decided,
-                    required, least)) {
+                    required, howMany)) {
                 case NodeResult.Made(Node built) -> under.put(field.getKey(), built);
+                // The model settling that there is no value ends the walk: nothing a field further
+                // along could say outranks it, and one proof is the whole of what a reader gets —
+                // a second would name another position to look at where there is no row to look
+                // for.
+                case NodeResult.Refused refused -> { return refused; }
                 // Every field's, and not the first one's. Two fields whose demands are out of reach
                 // are two figures a reader could raise, and taking whichever the walk met first
                 // would make the answer turn on the order the fields are declared in.
@@ -558,8 +646,20 @@ final class ConstructionPlan {
                 // than gathered up, and the caller states one and asks again — so what it is owed
                 // is somewhere to begin, and the field a second one is under may not even be
                 // reached under the narrowing it settles on here.
-                case NodeResult.Unnarrowed unnarrowed -> { return unnarrowed; }
+                //
+                // Kept rather than returned, because a field after it may be one the model refuses
+                // outright — and a caller sent to state a narrowing would state it and be told
+                // there was never a row. Which one is owed does not change: it is still the first,
+                // in the order the declarations write them.
+                case NodeResult.Unnarrowed unnarrowed -> {
+                    if (owed == null) {
+                        owed = unnarrowed;
+                    }
+                }
             }
+        }
+        if (owed != null) {
+            return owed;
         }
         if (!beyond.isEmpty()) {
             return new NodeResult.Beyond(beyond);
@@ -577,10 +677,9 @@ final class ConstructionPlan {
      * written at, and a plan handed back would compose a row the caller's value is missing from.
      */
     private static NodeResult givenUpAt(CompositionBudget figure, TermPath here, Type building,
-                                        List<TypeSymbol> outer, Set<TermPath> decided,
-                                        Requirements required) {
+                                        List<TypeSymbol> outer, boolean demanded) {
         Set<CompositionBudget> by = Set.of(figure);
-        return anythingIsAskedUnder(here, decided, required) ? new NodeResult.Beyond(by)
+        return demanded ? new NodeResult.Beyond(by)
                 : new NodeResult.Made(new Slot(here, building, outer, new Leaf.Beneath(by)));
     }
 
@@ -741,77 +840,33 @@ final class ConstructionPlan {
     }
 
     /**
-     * What a walk of the positions under one found, for the two questions a caller of it has.
+     * Every figure this compiler gave up reading at, in {@code inside} and everything under it.
      *
-     * <p><b>Both, because "nothing was asked for here" is not what an empty-handed walk found.</b>
-     * A walk that gave up at a figure part-way down came back without a demand it never reached,
-     * and a reader taking that for the model's answer says there is no class inside a list the plan
-     * never opened. The two are one walk and are held together so that a reader of the first has
-     * the second in hand.
-     *
-     * @param demanded whether the caller asked something of a position under here — a value fixed
-     *                 at one, a narrowing stated at one, or a value a requirement settled
-     * @param cutBy    every figure the walk gave up at, which is empty where it reached the bottom
+     * <p>Read off the plan that was built rather than off how the paths are written, because this
+     * is about what the walk did and the paths say nothing about that. What the caller asked for is
+     * a separate question, answered where the demand is
+     * ({@link #anythingIsAskedUnder}) and once — a plan read back for it would be this compiler
+     * working out from what it built what it had been told.
      */
-    private record Under(boolean demanded, Set<CompositionBudget> cutBy) {
-
-        Under {
-            cutBy = Set.copyOf(cutBy);
-        }
-    }
-
-    /**
-     * {@code inside} and everything under it, read for both.
-     *
-     * <p>Asked of the plan that was built for it rather than of how the paths are written. Whether
-     * one position is under another is a fact about the steps between them, and a rendering runs
-     * those together with whatever each is spelled with — so a test on the text has to name every
-     * separator a step can wear, and a position one collection further in follows its container with
-     * no dot and matched none of them. Built and then read, the only thing compared is one path with
-     * itself.
-     */
-    private static Under under(Node inside) {
-        Under below = switch (inside) {
+    private static Set<CompositionBudget> cutBy(Node inside) {
+        return switch (inside) {
             case Slot(TermPath _, Type _, List<TypeSymbol> _, Leaf leaf) -> switch (leaf) {
-                case Leaf.Fixed _ -> new Under(true, Set.of());
-                case Leaf.Open _ -> new Under(false, Set.of());
-                // Nothing was asked below one of these, and that is settled where the position is
-                // made rather than assumed here: a demand under a figure is refused there and no
-                // plan comes back at all. Read as an ordinary empty hand, this would be the answer
-                // whether or not that check exists.
-                case Leaf.Beneath(Set<CompositionBudget> cutBy) -> new Under(false, cutBy);
+                case Leaf.Fixed _, Leaf.Open _ -> Set.of();
+                case Leaf.Beneath(Set<CompositionBudget> cutBy) -> cutBy;
             };
             case Built built -> across(built.under().values());
-            case Held held -> under(held.under());
-            // A value the requirement settled is as much something asked of the position as one the
-            // caller fixed: a list asked to hold a `None` is a list built around it. Reached where
-            // the path above it does not narrow, which is a requirement stated at this position
-            // rather than at one the path passed through.
-            case Exact _ -> new Under(true, Set.of());
+            case Held held -> cutBy(held.under());
+            case Exact _ -> Set.of();
         };
-        // A position the caller narrowed is one it asked something of, as much as one it fixed a
-        // value at: a class placing a case inside a list is a class placed under the list. Read off
-        // the fixed values alone, a list holding a case of a sum was chosen whole and every element
-        // of it came back as whatever stands for the element's type.
-        //
-        // Answered beside what the walk found rather than in place of it. Returned on its own, a
-        // narrowed position would hide every figure the walk below it gave up at — which is the
-        // reading this type exists to keep whole.
-        return inside.at().narrowsWhatItReaches()
-                ? new Under(true, below.cutBy()) : below;
     }
 
-    /** The same of several positions: asked for where any of them was, and given up at wherever
-     *  any of them was. */
-    private static Under across(Collection<Node> nodes) {
-        boolean demanded = false;
-        Set<CompositionBudget> cutBy = new LinkedHashSet<>();
+    /** The same of several positions: given up at wherever any of them was. */
+    private static Set<CompositionBudget> across(Collection<Node> nodes) {
+        Set<CompositionBudget> out = new LinkedHashSet<>();
         for (Node each : nodes) {
-            Under one = under(each);
-            demanded |= one.demanded();
-            cutBy.addAll(one.cutBy());
+            out.addAll(cutBy(each));
         }
-        return new Under(demanded, cutBy);
+        return out;
     }
 
     /**
@@ -824,7 +879,7 @@ final class ConstructionPlan {
      * compiler not having looked.
      */
     Set<CompositionBudget> cutBy() {
-        return under(root).cutBy();
+        return cutBy(root);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -353,24 +353,34 @@ final class ConstructionPlan {
         /**
          * A value is to be placed inside a collection the rules leave no room in.
          *
-         * <p>Both numbers off one reading of the rules, taken where the plan is made and against
-         * the positions the caller has settled. What the floor says is how many the collection has
-         * to hold besides the one being placed, so what is needed is never fewer than one; what the
-         * cap says is whether that many fit. Read apart, the two can be of different states of the
-         * row.
+         * <p><b>One reading, and {@link #needed} is read off it here rather than handed in.</b> The
+         * two numbers are ends of one answer, and what this refusal says is that they do not meet:
+         * the collection has to hold at least as many as the floor and at least the one being
+         * placed, and the cap is under that. A maker that brought its own count could bring one
+         * read where the row had settled something this one had not — which is the reading in two
+         * places that this refusal exists because of.
          *
-         * @param needed how many the collection would have to hold for the value to be placed in it
-         * @param holds  from how few to how many the rules let it hold
+         * @param holds from how few to how many the rules let it hold, against the positions the
+         *              caller has settled
          */
-        record NoRoom(TermPath at, int needed, DeclaredBounds.CountRange holds)
-                implements ModelRefusal {
+        record NoRoom(TermPath at, DeclaredBounds.CountRange holds) implements ModelRefusal {
 
             public NoRoom {
-                if (needed <= holds.most()) {
+                if (holds.most() >= Math.max(1, holds.least())) {
                     throw new IllegalArgumentException("a collection with room for what is placed"
-                            + " in it refuses nothing: " + at + " holds " + holds
-                            + " and needs " + needed);
+                            + " in it refuses nothing: " + at + " holds " + holds);
                 }
+            }
+
+            /**
+             * How many it would have to hold for the value to be placed in it.
+             *
+             * <p>The floor is how many the rules ask the whole collection to hold, and the value
+             * being placed is one of them rather than another beside them — so where the rules ask
+             * for none, one is what a collection holding it comes to.
+             */
+            int needed() {
+                return Math.max(1, holds.least());
             }
         }
     }
@@ -560,9 +570,10 @@ final class ConstructionPlan {
             // room for it are one question — is the caller asking for something inside this list —
             // and read twice they are free to come apart over one list.
             boolean demanded = anythingIsAskedUnder(here, decided, required);
-            // How many it would have to hold, and how many it may, off one reading. What the floor
-            // says is how many the rules ask for besides the value being placed, so what is needed
-            // is that and never fewer than the one.
+            // How many it would have to hold, and how many it may, off one reading. The floor is
+            // how many the rules ask the whole collection to hold and the value being placed is one
+            // of them, so what a collection holding it comes to is the floor, or one where the
+            // rules ask for none.
             DeclaredBounds.CountRange holds = demanded ? howMany.at(here, building) : null;
             int needed = demanded ? Math.max(1, holds.least()) : 0;
             // Asked before the figure and before the descent, because this is the model's answer
@@ -571,7 +582,7 @@ final class ConstructionPlan {
             // that changes nothing, and a figure named instead of it says this compiler did not
             // look, of a position it has the answer for.
             if (demanded && holds.most() < needed) {
-                return new NodeResult.Refused(new ModelRefusal.NoRoom(here, needed, holds));
+                return new NodeResult.Refused(new ModelRefusal.NoRoom(here, holds));
             }
             // A sequence is planned by asking what stands at its element, so the figure is met here
             // rather than below: read as a shape nothing composes — which is what a sequence is to
@@ -623,27 +634,40 @@ final class ConstructionPlan {
         }
         Map<String, Node> under = new LinkedHashMap<>();
         Set<CompositionBudget> beyond = new LinkedHashSet<>();
+        NodeResult.Unnarrowed owed = null;
         for (Map.Entry<String, Type> field : composed.fields().entrySet()) {
             switch (node(field.getValue(), here.then(field.getKey()), symbols, depth + 1, decided,
                     required, howMany)) {
                 case NodeResult.Made(Node built) -> under.put(field.getKey(), built);
-                // One position, and the first of them, which is what both of these are.
-                //
-                // <p>Neither outranks the other, because they are not about one position. What
-                // #1315 orders is a refusal against a figure met at the same place, and a sequence
-                // settles that before it descends. Between two fields there is nothing to order: a
-                // caller told to state a narrowing at one field is told something true of that
-                // field whatever the next one comes to, and a caller told the model refuses another
-                // is told something true of that one. Walking on to prefer one of them would buy no
-                // answer and would take the walk into fields the first answer says nothing about.
+                // The model settling that there is no value ends the walk. Nothing a field further
+                // along could say outranks it, and one proof is the whole of what a reader gets — a
+                // second would name another position to look at where there is no row to look for.
                 case NodeResult.Refused refused -> { return refused; }
-                case NodeResult.Unnarrowed unnarrowed -> { return unnarrowed; }
-                // Every field's, and not the first one's — which is where this parts from the two
-                // above. Two fields whose demands are out of reach are two figures a reader could
-                // raise, and a reader owed one of them is owed both; taking whichever the walk met
-                // first would make what they are told turn on the order the fields are declared in.
+                // Every field's, and not the first one's. Two fields whose demands are out of reach
+                // are two figures a reader could raise, and a reader owed one of them is owed both;
+                // taking whichever the walk met first would make what they are told turn on the
+                // order the fields are declared in.
                 case NodeResult.Beyond(Set<CompositionBudget> by) -> beyond.addAll(by);
+                // One position, and the first of them. A narrowing is stated at a position rather
+                // than gathered up, and the caller states one and asks again — so what it is owed
+                // is somewhere to begin, and the field a second one is under may not even be
+                // reached under the narrowing it settles on here.
+                //
+                // Kept rather than returned, because these two are not alike: a refusal is an
+                // answer about the value, and this is a question put to whoever asked for it. A
+                // caller sent to state a narrowing where a field further along leaves no row at all
+                // has been sent to do work that cannot help, so the walk goes on to find out
+                // whether there is one. Which narrowing is owed does not change — it is still the
+                // first, in the order the declarations write them.
+                case NodeResult.Unnarrowed unnarrowed -> {
+                    if (owed == null) {
+                        owed = unnarrowed;
+                    }
+                }
             }
+        }
+        if (owed != null) {
+            return owed;
         }
         if (!beyond.isEmpty()) {
             return new NodeResult.Beyond(beyond);

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -626,14 +626,12 @@ final class ContainersAddingUp {
      * @param cutBy   the figures the planning stopped at, which are this compiler's
      */
     private record Ways(List<Filling> filled, Set<CompositionBudget> cutBy,
-                        List<TermPath> nothingStandsAt,
-                        List<ConstructionPlan.ModelRefusal.NoRoom> withNoRoom) {
+                        List<TermPath> nothingStandsAt) {
 
         Ways {
             filled = List.copyOf(filled);
             cutBy = Set.copyOf(cutBy);
             nothingStandsAt = List.copyOf(nothingStandsAt);
-            withNoRoom = List.copyOf(withNoRoom);
         }
 
         /**
@@ -641,20 +639,14 @@ final class ContainersAddingUp {
          *
          * <p>One sentence per thing that happened, and never one for two of them. A way that was
          * walked and built nothing says the ways are exhausted; a position nothing stands under
-         * says there was never a way to try; a collection the rules leave no room in says there was
-         * a way and the rules refuse what it asks for. Told the same thing, a reader would be
-         * working out which of them it was from what the sentence left out.
+         * says there was never a way to try. Told the same thing, a reader would be working out
+         * which of them it was from what the sentence left out.
          */
         String said(TermPath demand) {
             if (!filled.isEmpty()) {
                 return spelling(filled.stream().map(Filling::fixed).toList())
                         + (filled.size() == 1 ? " was a way down to `" : " were ways down to `")
                         + demand + "`, and none of them composed a value";
-            }
-            if (!withNoRoom.isEmpty()) {
-                return spelling(withNoRoom.stream()
-                                .map(ConstructionPlan.ModelRefusal.NoRoom::at).toList())
-                        + " holds nothing the way down to `" + demand + "` could stand in";
             }
             return nothingStandsAt.isEmpty()
                     ? "nothing here reaches `" + demand + "`"
@@ -698,7 +690,6 @@ final class ContainersAddingUp {
                                  RuleReadingSource ruleSource) {
         List<Filling> found = new ArrayList<>();
         List<TermPath> nothingStandsAt = new ArrayList<>();
-        List<ConstructionPlan.ModelRefusal.NoRoom> withNoRoom = new ArrayList<>();
         Asking asking = new Asking(element, at, ruleSource);
         asking.add(demand);
         for (ConstructionPlan.Result answer = asking.next(); answer != null;
@@ -738,18 +729,19 @@ final class ContainersAddingUp {
                                         + " to be both " + conflict.one().spelled() + " and "
                                         + conflict.other().spelled()
                                         + ", though one narrowing was stated");
-                        // A collection on the way down holds nothing, so no element of this
-                        // container reaches the number. Its own answer rather than one of the two
-                        // beside it: a way that was walked and built nothing says the ways are
-                        // exhausted, and a position nothing stands under says there was never a
-                        // way — this says there was one and the rules refuse what it asks for.
+                        // A collection on the way down holds nothing, so nothing stands inside it
+                        // and there was never a way to try. Which is what the list beside this one
+                        // already says: a position nothing stands under is a position nothing
+                        // stands under whether the declarations put nothing there or the rules
+                        // leave no room for it, and a walk that never had a way is the same news
+                        // either way.
                         case ConstructionPlan.ModelRefusal.NoRoom noRoom ->
-                                withNoRoom.add(noRoom);
+                                nothingStandsAt.add(noRoom.at());
                     }
                 }
             }
         }
-        return new Ways(found, asking.stoppedBy(), nothingStandsAt, withNoRoom);
+        return new Ways(found, asking.stoppedBy(), nothingStandsAt);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -626,12 +626,14 @@ final class ContainersAddingUp {
      * @param cutBy   the figures the planning stopped at, which are this compiler's
      */
     private record Ways(List<Filling> filled, Set<CompositionBudget> cutBy,
-                        List<TermPath> nothingStandsAt) {
+                        List<TermPath> nothingStandsAt,
+                        List<ConstructionPlan.ModelRefusal.NoRoom> withNoRoom) {
 
         Ways {
             filled = List.copyOf(filled);
             cutBy = Set.copyOf(cutBy);
             nothingStandsAt = List.copyOf(nothingStandsAt);
+            withNoRoom = List.copyOf(withNoRoom);
         }
 
         /**
@@ -639,14 +641,20 @@ final class ContainersAddingUp {
          *
          * <p>One sentence per thing that happened, and never one for two of them. A way that was
          * walked and built nothing says the ways are exhausted; a position nothing stands under
-         * says there was never a way to try. Told the same thing, a reader would be working out
-         * which of them it was from what the sentence left out.
+         * says there was never a way to try; a collection the rules leave no room in says there was
+         * a way and the rules refuse what it asks for. Told the same thing, a reader would be
+         * working out which of them it was from what the sentence left out.
          */
         String said(TermPath demand) {
             if (!filled.isEmpty()) {
                 return spelling(filled.stream().map(Filling::fixed).toList())
                         + (filled.size() == 1 ? " was a way down to `" : " were ways down to `")
                         + demand + "`, and none of them composed a value";
+            }
+            if (!withNoRoom.isEmpty()) {
+                return spelling(withNoRoom.stream()
+                                .map(ConstructionPlan.ModelRefusal.NoRoom::at).toList())
+                        + " holds nothing the way down to `" + demand + "` could stand in";
             }
             return nothingStandsAt.isEmpty()
                     ? "nothing here reaches `" + demand + "`"
@@ -690,6 +698,7 @@ final class ContainersAddingUp {
                                  RuleReadingSource ruleSource) {
         List<Filling> found = new ArrayList<>();
         List<TermPath> nothingStandsAt = new ArrayList<>();
+        List<ConstructionPlan.ModelRefusal.NoRoom> withNoRoom = new ArrayList<>();
         Asking asking = new Asking(element, at, ruleSource);
         asking.add(demand);
         for (ConstructionPlan.Result answer = asking.next(); answer != null;
@@ -729,16 +738,18 @@ final class ContainersAddingUp {
                                         + " to be both " + conflict.one().spelled() + " and "
                                         + conflict.other().spelled()
                                         + ", though one narrowing was stated");
-                        // A container this element stands in holds nothing, so there is no way down
-                        // to the number — which is the same news as a position nothing stands
-                        // under, and not a way that was tried and refused.
+                        // A collection on the way down holds nothing, so no element of this
+                        // container reaches the number. Its own answer rather than one of the two
+                        // beside it: a way that was walked and built nothing says the ways are
+                        // exhausted, and a position nothing stands under says there was never a
+                        // way — this says there was one and the rules refuse what it asks for.
                         case ConstructionPlan.ModelRefusal.NoRoom noRoom ->
-                                nothingStandsAt.add(noRoom.at());
+                                withNoRoom.add(noRoom);
                     }
                 }
             }
         }
-        return new Ways(found, asking.stoppedBy(), nothingStandsAt);
+        return new Ways(found, asking.stoppedBy(), nothingStandsAt, withNoRoom);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ContainersAddingUp.java
@@ -719,12 +719,23 @@ final class ContainersAddingUp {
                 }
                 case ConstructionPlan.Result.Beyond(Set<CompositionBudget> by) ->
                         asking.gaveUpAt(by);
-                // Two narrowings at one position, which nothing here writes: every one of them was
-                // stated by this walk, one at a time, at a position the plan named.
-                case ConstructionPlan.Result.Conflict conflict ->
-                        throw new IllegalStateException("`" + conflict.at() + "` would have to be"
-                                + " both " + conflict.one().spelled() + " and "
-                                + conflict.other().spelled() + ", though one narrowing was stated");
+                case ConstructionPlan.Result.Refused(ConstructionPlan.ModelRefusal why) -> {
+                    switch (why) {
+                        // Two narrowings at one position, which nothing here writes: every one of
+                        // them was stated by this walk, one at a time, at a position the plan
+                        // named.
+                        case ConstructionPlan.ModelRefusal.Conflict conflict ->
+                                throw new IllegalStateException("`" + conflict.at() + "` would have"
+                                        + " to be both " + conflict.one().spelled() + " and "
+                                        + conflict.other().spelled()
+                                        + ", though one narrowing was stated");
+                        // A container this element stands in holds nothing, so there is no way down
+                        // to the number — which is the same news as a position nothing stands
+                        // under, and not a way that was tried and refused.
+                        case ConstructionPlan.ModelRefusal.NoRoom noRoom ->
+                                nothingStandsAt.add(noRoom.at());
+                    }
+                }
             }
         }
         return new Ways(found, asking.stoppedBy(), nothingStandsAt);
@@ -786,7 +797,7 @@ final class ContainersAddingUp {
             asked = left.removeFirst();
             return ConstructionPlan.of(element, at, ruleSource.symbols(),
                     Set.of(asked), Requirements.NONE,
-                    (_, building) -> Partitions.leastHeld(building, ruleSource));
+                    (_, building) -> Partitions.heldRange(building, ruleSource, null));
         }
 
         /** The way the last answer is about. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3764,7 +3764,7 @@ public final class Generator {
         // Nothing of a population is short here. What a proposal holds back is a figure of this
         // compiler's over what it builds, and every value of the kind it does build is one it would
         // offer.
-        HeldBack held = heldBack(subject, p, plan, under);
+        HeldBack held = heldBack(subject, plan, under);
         return whatTheSearchCameTo(held.offer(), Set.of(), held.plan(), product);
     }
 
@@ -3900,7 +3900,7 @@ public final class Generator {
      * second time here, the two readings are of one row and are free to come apart the first time
      * either is given something the other is not.
      */
-    private static HeldBack heldBack(MeasuredInput subject, int p, ConstructionPlan plan,
+    private static HeldBack heldBack(MeasuredInput subject, ConstructionPlan plan,
                                      FieldDomains rules) {
         // Every budget that held a position back, and not the first or the strongest. Two positions
         // stopped by two budgets are two things this compiler declined to do, and a reader asking

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3670,13 +3670,12 @@ public final class Generator {
                                     "`" + against.at() + "` would have to be both "
                                             + against.one().spelled() + " and "
                                             + against.other().spelled());
-                    case ConstructionPlan.ModelRefusal.NoRoom(TermPath at, int needed,
-                                                              DeclaredBounds.CountRange holds) ->
+                    case ConstructionPlan.ModelRefusal.NoRoom noRoom ->
                             new Outcome.Unresolved(
                                     UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
-                                    "`" + at + "` would have to hold " + needed
+                                    "`" + noRoom.at() + "` would have to hold " + noRoom.needed()
                                             + " for the value placed in it, and the rules leave"
-                                            + " room for " + holds.most());
+                                            + " room for " + noRoom.holds().most());
                 };
             }
             // What the caller asked for is under a position the plan stopped short of reading, so
@@ -3880,7 +3879,7 @@ public final class Generator {
      *
      * <p>Both ends off one reading of {@code rules}, which is the reading the values are chosen
      * against. A collection built around an element has to meet both — the floor says how many it
-     * holds besides the one being placed, and the cap says whether that one fits at all — and taken
+     * holds in all, and the cap says whether that many fit — and taken
      * as two readings the two answered about different states of the row.
      */
     private static DeclaredBounds.CountRange heldRange(FieldDomains rules, TermPath path,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -7,6 +7,7 @@ import souther.compiler.coverage.ControlPointId;
 import souther.compiler.check.ReadingPolicy;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleKey;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Shape;
 import souther.compiler.check.TypeView;
@@ -3651,18 +3652,32 @@ public final class Generator {
                 subject.inputs().policy(), under(root, settled));
         ConstructionPlan.Result planned = ConstructionPlan.of(subject.types().get(p), root,
                 subject.symbols(), decided.keySet(), additional,
-                (at, building) -> leastHeld(under, at, building, subject.rules()));
+                (at, building) -> heldRange(under, at, building, subject.rules()));
         ConstructionPlan plan;
         switch (planned) {
             case ConstructionPlan.Result.Planned made -> plan = made.plan();
-            // A row that would have to be two things at one position, which is what the model
-            // settles and not something this fell short of — the same answer the class search gives
-            // when two classes select different refinements of one position.
-            case ConstructionPlan.Result.Conflict against -> {
-                return new Outcome.Unresolved(
-                        UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH,
-                        "`" + against.at() + "` would have to be both " + against.one().spelled()
-                                + " and " + against.other().spelled());
+            // What the model settles, which is not something this fell short of. Said before
+            // anything was searched for and standing however far the search then went, so no figure
+            // of this compiler's stands beside it: an author raising one would raise it and be told
+            // the same thing.
+            case ConstructionPlan.Result.Refused(ConstructionPlan.ModelRefusal why) -> {
+                return switch (why) {
+                    // The same answer the class search gives when two classes select different
+                    // refinements of one position.
+                    case ConstructionPlan.ModelRefusal.Conflict against ->
+                            new Outcome.Unresolved(
+                                    UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH,
+                                    "`" + against.at() + "` would have to be both "
+                                            + against.one().spelled() + " and "
+                                            + against.other().spelled());
+                    case ConstructionPlan.ModelRefusal.NoRoom(TermPath at, int needed,
+                                                              DeclaredBounds.CountRange holds) ->
+                            new Outcome.Unresolved(
+                                    UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                                    "`" + at + "` would have to hold " + needed
+                                            + " for the value placed in it, and the rules leave"
+                                            + " room for " + holds.most());
+                };
             }
             // What the caller asked for is under a position the plan stopped short of reading, so
             // there is nothing to search: a row composed against such a plan would be one the
@@ -3745,17 +3760,13 @@ public final class Generator {
         // the rules allow was offered. A position that read a count past what a row is built to carry,
         // or that has more pairings than are built at once, held something back, and saying so is the
         // difference between a fact about the model and a fact about this.
-        return switch (heldBack(subject, p, plan, settled)) {
-            case HeldBack.NoRoomForOne _ -> new Outcome.Unresolved(
-                    UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, null);
-            // What each of them was short of, handed over unmerged and unranked. Which of the two
-            // a reader is owed is one decision and it is made in one place.
-            // Nothing of a population is short here. What a proposal holds back is a figure of this
-            // compiler's over what it builds, and every value of the kind it does build is one it
-            // would offer.
-            case HeldBack.Short(Set<CompositionBudget> offer, Set<CompositionBudget> plans) ->
-                    whatTheSearchCameTo(offer, Set.of(), plans, product);
-        };
+        // What each of them was short of, handed over unmerged and unranked. Which of the two a
+        // reader is owed is one decision and it is made in one place.
+        // Nothing of a population is short here. What a proposal holds back is a figure of this
+        // compiler's over what it builds, and every value of the kind it does build is one it would
+        // offer.
+        HeldBack held = heldBack(subject, p, plan, settled);
+        return whatTheSearchCameTo(held.offer(), Set.of(), held.plan(), product);
     }
 
     /**
@@ -3865,26 +3876,19 @@ public final class Generator {
     }
 
     /**
-     * How many the rules say the list at {@code path} holds at the most, or every number where they
-     * say nothing about how many.
+     * From how few to how many the rules let the value built at {@code path} hold.
      *
-     * <p>Beside the floor and asked separately, because a collection built around an element has to
-     * meet both: the floor says how many it needs beside the one being placed, and this says whether
-     * there is room for that one at all. Read only for the floor, a rule capping a collection at
-     * none was met with a collection of one and every combination of the row came back as one every
-     * value was refused at — over a position the rules leave no room in, and over the positions
-     * beside it that have nothing to do with it.
+     * <p>Both ends off one reading of {@code rules}, which is the reading the values are chosen
+     * against. A collection built around an element has to meet both — the floor says how many it
+     * holds besides the one being placed, and the cap says whether that one fits at all — and taken
+     * as two readings the two answered about different states of the row.
      */
-    private static int mostHeld(FieldDomains rules, TermPath path, Type building, RuleReadingSource ruleSource) {
+    private static DeclaredBounds.CountRange heldRange(FieldDomains rules, TermPath path,
+                                                       Type building,
+                                                       RuleReadingSource ruleSource) {
         RuleKey field = fieldUnder(path);
-        return Partitions.mostHeld(building, ruleSource, field == null ? null : rules.heldAt(field));
-    }
-
-    /** How many the rules say the value built at {@code path} holds at the fewest, or zero where
-     *  they say nothing about how many. Read the same two ways as the cap beside it. */
-    private static int leastHeld(FieldDomains rules, TermPath path, Type building, RuleReadingSource ruleSource) {
-        RuleKey field = fieldUnder(path);
-        return Partitions.leastHeld(building, ruleSource, field == null ? null : rules.heldAt(field));
+        return Partitions.heldRange(building, ruleSource,
+                field == null ? null : rules.heldAt(field));
     }
 
     /**
@@ -3901,15 +3905,6 @@ public final class Generator {
         Type declared = subject.types().get(p);
         FieldDomains rules = rulesOf(declared, subject.rules(), subject.inputs().policy(),
                 under(root, settled));
-        // A collection asked to hold a value in a class, whose rules say it holds fewer than that.
-        // Nothing composes one: what the search would offer is a collection the rules refuse, and
-        // saying every candidate was refused sends an author looking for a value where the rule
-        // says there is no room for one.
-        for (ConstructionPlan.Held each : plan.held()) {
-            if (mostHeld(rules, each.at(), each.type(), subject.rules()) < each.least()) {
-                return new HeldBack.NoRoomForOne();
-            }
-        }
         // Every budget that held a position back, and not the first or the strongest. Two positions
         // stopped by two budgets are two things this compiler declined to do, and a reader asking
         // what would let the search go further is owed both — read as one, whichever the walk met
@@ -3921,7 +3916,7 @@ public final class Generator {
             budgets.addAll(Partitions.notBuilt(each.type(), subject.rules(),
                     subject.inputs().policy(), field == null ? null : rules.heldAt(field)));
         }
-        return new HeldBack.Short(budgets, plan.cutBy());
+        return new HeldBack(budgets, plan.cutBy());
     }
 
     /**
@@ -3939,24 +3934,22 @@ public final class Generator {
      * ({@link #whatTheSearchCameTo}) and not here. Decided here as well, the rule would be written
      * twice, and the second reader to learn of a short offer — the one that learns it only after
      * the search came back — would have nowhere to say so.
+     *
+     * <p><b>Both are this compiler's, and nothing read here says the model refuses anything.</b>
+     * What the model settles about a collection with no room for what is placed in it is settled
+     * where the plan is made ({@link ConstructionPlan.ModelRefusal.NoRoom}), before any of this
+     * ran. Asked again here, it would be asked of a search that had already happened — and
+     * whichever answer came back first would be the one a reader got.
+     *
+     * @param offer what the offers were short of
+     * @param plan  what the plan was short of. Either may be empty, and both being empty is a
+     *              search that had the whole of what the point had
      */
-    private sealed interface HeldBack {
+    private record HeldBack(Set<CompositionBudget> offer, Set<CompositionBudget> plan) {
 
-        /** A collection is asked to hold more than its rules leave room for, which is the model
-         *  settling it and not a budget of this compiler's. */
-        record NoRoomForOne() implements HeldBack {}
-
-        /**
-         * What the offers were short of, and what the plan was short of. Either may be empty, and
-         * both being empty is a search that had the whole of what the point had.
-         */
-        record Short(Set<CompositionBudget> offer, Set<CompositionBudget> plan)
-                implements HeldBack {
-
-            public Short {
-                offer = Set.copyOf(offer);
-                plan = Set.copyOf(plan);
-            }
+        private HeldBack {
+            offer = Set.copyOf(offer);
+            plan = Set.copyOf(plan);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3765,7 +3765,7 @@ public final class Generator {
         // Nothing of a population is short here. What a proposal holds back is a figure of this
         // compiler's over what it builds, and every value of the kind it does build is one it would
         // offer.
-        HeldBack held = heldBack(subject, p, plan, settled);
+        HeldBack held = heldBack(subject, p, plan, under);
         return whatTheSearchCameTo(held.offer(), Set.of(), held.plan(), product);
     }
 
@@ -3894,17 +3894,15 @@ public final class Generator {
     /**
      * Why a position of this parameter offered less than its rules allow, or null where none did.
      *
-     * <p>Under the same settled positions the values were chosen against. A rule counting one field
-     * against another asks for nothing in particular until the row fixes the other, so a reading
-     * without them answers about a rule this row is no longer under — and would say "every value
-     * tried was refused" of a position whose values were never built.
+     * <p>Off the reading the values were chosen against, handed in rather than made again. A rule
+     * counting one field against another asks for nothing in particular until the row fixes the
+     * other, so a reading without them answers about a rule this row is no longer under — and would
+     * say "every value tried was refused" of a position whose values were never built. Read a
+     * second time here, the two readings are of one row and are free to come apart the first time
+     * either is given something the other is not.
      */
     private static HeldBack heldBack(MeasuredInput subject, int p, ConstructionPlan plan,
-                                     Map<TermPath, Place> settled) {
-        TermPath root = TermPath.of(subject.parameters().get(p));
-        Type declared = subject.types().get(p);
-        FieldDomains rules = rulesOf(declared, subject.rules(), subject.inputs().policy(),
-                under(root, settled));
+                                     FieldDomains rules) {
         // Every budget that held a position back, and not the first or the strongest. Two positions
         // stopped by two budgets are two things this compiler declined to do, and a reader asking
         // what would let the search go further is owed both — read as one, whichever the walk met

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1634,6 +1634,20 @@ public final class Partitions {
     }
 
     /**
+     * From how few to how many the rules let a value at the position hold, as one answer.
+     *
+     * <p><b>Both ends of one reading.</b> A caller deciding whether there is room for a value being
+     * placed needs the floor to know how many the rules ask for besides it and the cap to know
+     * whether the one fits at all. Taken as two readings, the two can be of different states of the
+     * row — which is how a floor settled where the caller had fixed a field came to be compared
+     * with a cap read where it had not.
+     */
+    static DeclaredBounds.CountRange heldRange(Type type, RuleReadingSource ruleSource,
+                                               FieldDomains.Held held) {
+        return DeclaredBounds.countsHeld(TypeView.of(type, ruleSource.symbols()), ruleSource, held);
+    }
+
+    /**
      * Why a position offered less than its rules allow, or null where it offered everything.
      *
      * <p>Two things are told apart from a refusal here, and both are facts about this rather than about

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1612,35 +1612,21 @@ public final class Partitions {
         return DeclaredBounds.leastCountOf(view, ruleSource);
     }
 
-    /** The same, of a position nothing here has read yet. */
-    static int leastHeld(Type type, RuleReadingSource ruleSource) {
-        return leastHeld(TypeView.of(type, ruleSource.symbols()), ruleSource);
-    }
-
     /** The same, where the record the position sits in has a rule about it too. */
     static int leastHeld(TypeView view, RuleReadingSource ruleSource, FieldDomains.Held held) {
         return DeclaredBounds.leastCountOf(view, ruleSource, held);
     }
 
-    /** The same, of a position nothing here has read yet. */
-    static int leastHeld(Type type, RuleReadingSource ruleSource, FieldDomains.Held held) {
-        return leastHeld(TypeView.of(type, ruleSource.symbols()), ruleSource, held);
-    }
-
-    /** How many the rules on a value of the position allow it to hold, where the record it sits in
-     *  has a rule about it too: {@link DeclaredBounds#mostCountOf}. */
-    static int mostHeld(Type type, RuleReadingSource ruleSource, FieldDomains.Held held) {
-        return DeclaredBounds.mostCountOf(TypeView.of(type, ruleSource.symbols()), ruleSource, held);
-    }
-
     /**
      * From how few to how many the rules let a value at the position hold, as one answer.
      *
-     * <p><b>Both ends of one reading.</b> A caller deciding whether there is room for a value being
-     * placed needs the floor to know how many the rules ask for besides it and the cap to know
-     * whether the one fits at all. Taken as two readings, the two can be of different states of the
-     * row — which is how a floor settled where the caller had fixed a field came to be compared
-     * with a cap read where it had not.
+     * <p><b>Both ends of one reading, and there is no reading of the cap alone.</b> A caller
+     * deciding whether there is room for a value being placed needs the floor to know how many the
+     * rules ask for besides it and the cap to know whether the one fits at all. Taken as two
+     * readings, the two can be of different states of the row — which is how a floor settled where
+     * the caller had fixed a field came to be compared with a cap read where it had not. So the
+     * cap has no projection of its own here: a caller wanting it takes both and is holding one
+     * answer.
      */
     static DeclaredBounds.CountRange heldRange(Type type, RuleReadingSource ruleSource,
                                                FieldDomains.Held held) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -1622,7 +1622,7 @@ public final class Partitions {
      *
      * <p><b>Both ends of one reading, and there is no reading of the cap alone.</b> A caller
      * deciding whether there is room for a value being placed needs the floor to know how many the
-     * rules ask for besides it and the cap to know whether the one fits at all. Taken as two
+     * whole collection has to hold and the cap to know whether that many fit. Taken as two
      * readings, the two can be of different states of the row — which is how a floor settled where
      * the caller had fixed a field came to be compared with a cap read where it had not. So the
      * cap has no projection of its own here: a caller wanting it takes both and is holding one

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -99,7 +99,7 @@ final class PlanComposer {
             return null;
         }
         FixtureTemplate collection =
-                Witnesses.holdingAlso(carrier, element, plan.least(), ruleSource, policy);
+                Witnesses.holdingAlso(carrier, element, plan.needed(), ruleSource, policy);
         if (collection == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PlanComposer.java
@@ -78,7 +78,11 @@ final class PlanComposer {
     }
 
     /**
-     * The list of one this plan builds around what stands at its element.
+     * The collection this plan builds around what stands at its element.
+     *
+     * <p>Holding as many as the plan says and not one: what a class at an element asks for is a
+     * collection holding a value in it, and where the rules ask the collection for more than that
+     * a collection of one is not a row.
      *
      * <p>Under the names the position is written with, as a record is: a row at a
      * {@code data Basket = List<Item>} carries {@code Basket([...])}, and a list composed without

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -337,29 +337,38 @@ final class Witnesses {
     }
 
     /**
-     * A collection of {@code carrier} holding {@code chosen} and counting at least {@code least}, or
-     * null where none was built.
+     * A collection of {@code carrier} holding {@code chosen} and counting {@code needed}, or null
+     * where none was built.
      *
      * <p>For a row being built around one element. What the rest are is not what was asked for, and
      * what they may be is: a list may hold the same value again and a set may not, and a caller
      * padding one by hand would have to know which — the thing this reader is for.
+     *
+     * <p><b>How many, and not a floor to read one off.</b> What the rules leave the position and
+     * what a collection holding the chosen value comes to are two numbers, and the second is made
+     * from the first in one place ({@link ConstructionPlan#neededToHold}). Read again here, the
+     * conversion would be written twice and a caller handing over the floor would build the same
+     * collection as one handing over the count.
      */
     static FixtureTemplate holdingAlso(souther.compiler.check.Shape.Sequence carrier,
-                                       FixtureTemplate chosen, int least,
+                                       FixtureTemplate chosen, int needed,
                                        RuleReadingSource ruleSource, ReadingPolicy policy) {
-        int want = Math.max(1, least);
+        if (needed < 1) {
+            throw new IllegalArgumentException(
+                    "a collection built around a value holds it: " + needed);
+        }
         if (carrier.kind() == souther.compiler.check.Shape.Sequence.Kind.LIST) {
             List<FixtureTemplate> elements = new ArrayList<>();
-            while (elements.size() < want) {
+            while (elements.size() < needed) {
                 elements.add(chosen);
             }
             return FixtureTemplate.collection(elements);
         }
         List<FixtureTemplate> elements =
-                distinctFrom(chosen, carrier.element(), want, policy, ruleSource, Set.of());
+                distinctFrom(chosen, carrier.element(), needed, policy, ruleSource, Set.of());
         // Fewer than asked for is a type with too few values, which is a set the rules want and
         // nothing can build — said as nothing built rather than as a set of the wrong size.
-        return elements.size() < want ? null : FixtureTemplate.collection(elements);
+        return elements.size() < needed ? null : FixtureTemplate.collection(elements);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.test.RepositoryLayout;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
@@ -64,6 +65,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AConstructionPositionIsNotAnInputPositionTest {
 
+    /** The rules counting nothing, which is what every model here leaves them saying. */
+    private static final ConstructionPlan.HowManyItHolds ANY =
+            (_, _) -> new DeclaredBounds.CountRange(0, Integer.MAX_VALUE);
+
+
     /** Read once: what this asks of it does not change between its checks. */
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
@@ -92,7 +98,7 @@ class AConstructionPositionIsNotAnInputPositionTest {
         ConstructionPlan.Result planned = ConstructionPlan.of(read.sig().inputTypes().get(0),
                 TermPath.of(read.spec().params().get(0).name()), read.rules().symbols(), Set.of(),
                 required,
-                (_, _) -> 0);
+                ANY);
         return assertInstanceOf(ConstructionPlan.Result.Planned.class, planned,
                 "nothing here asks one position to be two things").plan();
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.RuleKey;
+import souther.compiler.check.TypeView;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -40,6 +41,16 @@ class AFloorHoldsWhereverItIsWrittenTest {
         Type ref(String type) {
             return new Type.Ref(TypeSymbols.declared(new TypeKey(module, type)));
         }
+
+        /** The floor of a position of {@code type}, read as this model's rules leave it. */
+        int floorOf(Type type) {
+            return Partitions.leastHeld(TypeView.of(type, rules.symbols()), rules);
+        }
+
+        /** The same, where the record the position sits in has a rule about it too. */
+        int floorOf(Type type, FieldDomains.Held held) {
+            return Partitions.leastHeld(TypeView.of(type, rules.symbols()), rules, held);
+        }
     }
 
     /** A model to read floors off, held to compiling. A rule the language refuses still reaches this
@@ -69,7 +80,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
                     invariant atLeastTwo = List.length(xs) >= 2
                 """);
 
-        assertEquals(2, Partitions.leastHeld(new Type.ListOf(Type.INT), model.rules(),
+        assertEquals(2, model.floorOf(new Type.ListOf(Type.INT),
                 model.domainsOf("Bag").heldAt(RuleKey.of("xs"))));
     }
 
@@ -86,7 +97,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
                 data Bag = { xs: NonEmpty }
                 """);
 
-        assertEquals(1, Partitions.leastHeld(model.ref("NonEmpty"), model.rules(),
+        assertEquals(1, model.floorOf(model.ref("NonEmpty"),
                 model.domainsOf("Bag").heldAt(RuleKey.of("xs"))));
     }
 
@@ -111,7 +122,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
                     invariant atLeastTwo = List.length(xs.value) >= 2
                 """);
 
-        assertEquals(3, Partitions.leastHeld(model.ref("AtLeastThree"), model.rules(),
+        assertEquals(3, model.floorOf(model.ref("AtLeastThree"),
                 model.domainsOf("Bag").heldAt(RuleKey.of("xs"))));
     }
 
@@ -135,9 +146,9 @@ class AFloorHoldsWhereverItIsWrittenTest {
                 """);
         FieldDomains domains = model.domainsOf("Possible");
 
-        assertEquals(0, Partitions.leastHeld(new Type.ListOf(Type.INT), model.rules(),
+        assertEquals(0, model.floorOf(new Type.ListOf(Type.INT),
                 domains.heldAt(RuleKey.of("accounts"))), "an empty list of accounts stands beside a contact");
-        assertEquals(0, Partitions.leastHeld(new Type.ListOf(Type.INT), model.rules(),
+        assertEquals(0, model.floorOf(new Type.ListOf(Type.INT),
                 domains.heldAt(RuleKey.of("contacts"))), "and the same the other way round");
     }
 
@@ -154,7 +165,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
                     invariant atLeastOne = List.length(value) >= 1
                 """);
 
-        assertEquals(1, Partitions.leastHeld(model.ref("Kids"), model.rules()));
+        assertEquals(1, model.floorOf(model.ref("Kids")));
     }
 
     /**
@@ -174,6 +185,6 @@ class AFloorHoldsWhereverItIsWrittenTest {
                     invariant nonEmpty = String.length(value) >= 1
                 """);
 
-        assertEquals(1, Partitions.leastHeld(model.ref("Name"), model.rules()));
+        assertEquals(1, model.floorOf(model.ref("Name")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
@@ -1,0 +1,246 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A collection the rules leave no room in is answered as that, and not as a figure this compiler
+ * reached while finding out.
+ *
+ * <p>The two can be true of one point at once, and it is the ordinary case rather than a contrived
+ * one: where the model has no row, the search refuses everything it composes and goes on composing
+ * until it meets a bound. So which of the two a reader is told turns on nothing about the model,
+ * and everything about which was asked first.
+ *
+ * <p><b>What settles it is that only one of them is actionable.</b> A proof that no collection
+ * holds what is being placed in it stands however far this compiler read; an author sent to raise
+ * the figure beside it would raise it and be told the same thing. So the proof is made where the
+ * plan is, before any search runs, and the search that would have named a figure never happens.
+ *
+ * <p>The pair below is the same rule read against two states of the row. Where the cap's own field
+ * is settled at nought, the rules leave no room and the plan refuses; where it is settled at one,
+ * they leave room for exactly what is placed, and a row is written. The proof is not a property of
+ * the rule but of the rule and what the row has fixed.
+ */
+class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
+
+    /**
+     * A list capped at a field beside it, asked for with a value inside it.
+     *
+     * <p>The line asks both at once, so a combination fixes {@code cap} and asks for a class at an
+     * element of {@code xs}. Where it fixes {@code cap} at nought the two cannot both hold: the
+     * rules cap the list at none, and what is asked for is a list holding one.
+     *
+     * <p>The fields beside them are what make the search wide enough to meet its bound. They relate
+     * to nothing here and are refused for nothing of their own, which is the point — the figure a
+     * reader would be sent to raise has nothing to do with why no row exists.
+     */
+    private static final String CAPPED = """
+            module example.placing
+
+            data Awkward = Int
+                invariant lo = value >= 0
+                invariant hi = value <= 10
+                invariant no3 = value /= 3
+                invariant no4 = value /= 4
+                invariant no7 = value /= 7
+
+            data Box =
+                { cap: Int
+                , xs: List<Awkward>
+                , a: Awkward
+                , b: Awkward
+                , c: Awkward
+                , d: Awkward
+                , e: Awkward
+                , f: Awkward
+                , g: Awkward
+                , h: Awkward
+                , i: Awkward
+                , j: Awkward
+                , k: Awkward
+                , l: Awkward
+                }
+                invariant floor = cap >= 0
+                invariant capped = List.length(xs) <= cap
+
+            data Yes
+            data No
+            data Verdict = Yes | No
+
+            behavior placing : (box: Box) -> Verdict
+            let placing (box) =
+                if box.cap >= 1 && List.length(List.filter(x -> x.value >= 5, box.xs)) >= 1
+                then Yes
+                else No
+            """;
+
+    /**
+     * The combination the rules leave no room for is answered by the model, and by nothing else.
+     *
+     * <p>Both halves. That the word is the model's is what sends an author somewhere they can act;
+     * that no figure of this compiler's is named is what keeps them from raising one that changes
+     * nothing. Before the refusal was made where the plan is, this combination came back saying the
+     * search had left something untried — which was true and was not what a reader needed.
+     */
+    @Test
+    void theCombinationWithNoRoomIsAnsweredByTheModel() {
+        List<Generator.UnresolvedCombination> made = unresolved();
+
+        assertFalse(made.isEmpty(), "the combination is one no row was written for");
+        for (Generator.UnresolvedCombination each : made) {
+            assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                    each.reason(),
+                    () -> "the model settles it, whatever the search then did: " + each);
+        }
+    }
+
+    /** And the answer says which collection, how many it would have to hold, and how many it may. */
+    @Test
+    void theAnswerSaysWhatTheRulesLeaveRoomFor() {
+        String said = unresolved().getFirst().detail();
+
+        assertNotNull(said, "the answer says what it is about: " + unresolved());
+        assertTrue(said.contains("box.xs") && said.contains("hold 1") && said.contains("room for 0"),
+                "and says the collection, what it would have to hold, and what the rules leave"
+                        + " room for: " + said);
+    }
+
+    /**
+     * A point whose cap the row has not fixed is left open on the figure the search reached.
+     *
+     * <p>The control against reading too much into the rules. Nothing here settles {@code cap}, so
+     * the rules leave the list holding whatever a larger one would allow and no refusal is proved —
+     * and what this compiler has to say is what it did. A refusal made from the cap alone would
+     * take these with it.
+     */
+    @Test
+    void aPointTheRowHasNotFixedTheCapAtStaysOpenOnTheFigure() {
+        List<ItemAssessment.Attempt> made = insideTheList("placing");
+
+        assertFalse(made.isEmpty(), "the classes of the element are asked about");
+        for (ItemAssessment.Attempt each : made) {
+            ItemAssessment.Attempt.Stopped stopped = assertInstanceOf(
+                    ItemAssessment.Attempt.Stopped.class, each,
+                    () -> "the search met a figure and says so: " + each);
+            assertEquals(List.of(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES),
+                    stopped.stoppedBy().written(),
+                    "and names the figure rather than a refusal it has not proved");
+        }
+    }
+
+    /**
+     * And the same rule leaves the rows it has room for.
+     *
+     * <p>The other control. What is refused above turns on the cap the row fixed and not on the
+     * rule alone, so a cap of one leaves a list holding one.
+     */
+    @Test
+    void theSameRuleLeavesTheRowsItHasRoomFor() {
+        assertTrue(rowsOf("placing").stream()
+                        .anyMatch(each -> each.contains("cap = 1") && !each.contains("xs = []")),
+                "a row holding one under a cap of one is written: " + rowsOf("placing"));
+    }
+
+    /** The combinations no row was written for, as the filling records them. */
+    private static List<Generator.UnresolvedCombination> unresolved() {
+        Adequacy.Filling filling = measured().db()
+                .ask(new Adequacy.Generated("example.placing", "placing")).value();
+        assertNotNull(filling, "rows are asked for");
+        return filling.composed().unresolved();
+    }
+
+    /**
+     * Every search of a point standing inside the capped list, asked with nothing on the way to it.
+     *
+     * <p>Those asked under a condition on {@code cap} are a different question: the way already
+     * says what the row has to be. What is left is the points the combination itself fixes the cap
+     * at, which is where a reading of the rules is all there is to go on.
+     */
+    private static List<ItemAssessment.Attempt> insideTheList(String behavior) {
+        List<ItemAssessment.Attempt> out = new ArrayList<>();
+        for (BorderAssessment border : lines(behavior)) {
+            for (PointRole role : PointRole.values()) {
+                if (border.at(role) instanceof ItemAssessment.Owed owed) {
+                    owed.searches().each().stream()
+                            .filter(each -> about(each).contains("xs["))
+                            .filter(each -> wayTo(each).onTheWay().isEmpty())
+                            .forEach(out::add);
+                }
+            }
+        }
+        return out;
+    }
+
+    /** What a search was about, in the words the account names its classes by. */
+    private static String about(ItemAssessment.Attempt made) {
+        return switch (made) {
+            case ItemAssessment.Attempt.Certified it -> it.row().purposes().toString();
+            case ItemAssessment.Attempt.Unverified it -> it.row().purposes().toString();
+            case ItemAssessment.Attempt.Stopped it -> it.why().classes().toString();
+            case ItemAssessment.Attempt.Unexhausted it -> it.why().classes().toString();
+            case ItemAssessment.Attempt.Limited it -> it.why().classes().toString();
+            case ItemAssessment.Attempt.Unplanned it -> it.why().classes().toString();
+            case ItemAssessment.Attempt.Unresolved it -> it.why().classes().toString();
+            case ItemAssessment.Attempt.Unavailable it -> it.toString();
+        };
+    }
+
+    /** What had to hold on the way to the point the search was for. */
+    private static WayToTheBorder wayTo(ItemAssessment.Attempt made) {
+        return switch (made) {
+            case ItemAssessment.Attempt.Certified it -> it.way();
+            case ItemAssessment.Attempt.Unverified it -> it.way();
+            case ItemAssessment.Attempt.Stopped it -> it.way();
+            case ItemAssessment.Attempt.Unexhausted it -> it.way();
+            case ItemAssessment.Attempt.Limited it -> it.way();
+            case ItemAssessment.Attempt.Unplanned it -> it.way();
+            case ItemAssessment.Attempt.Unresolved it -> it.way();
+            case ItemAssessment.Attempt.Unavailable _ -> new WayToTheBorder(List.of());
+        };
+    }
+
+    /** The rows the behavior was offered, as they are written out. */
+    private static List<String> rowsOf(String behavior) {
+        Adequacy.Filling filling = measured().db()
+                .ask(new Adequacy.Generated("example.placing", behavior)).value();
+        assertNotNull(filling, "rows are asked for");
+        return filling.composed().rows().stream()
+                .map(row -> row.inputs().get(0).text()).toList();
+    }
+
+    /** The lines a behavior draws. */
+    private static List<BorderAssessment> lines(String behavior) {
+        Map<String, List<BorderAssessment>> read =
+                Adequacy.readingsOf(measured().db(), "example.placing");
+        assertNotNull(read, "the model under test compiles");
+        List<BorderAssessment> lines = read.get(behavior);
+        assertNotNull(lines, "the behavior was measured");
+        return lines;
+    }
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSource(CAPPED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                        .flatMap(List::stream)
+                        .map(each -> each.diagnostic().code()).toList(),
+                "the model under test compiles");
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
@@ -2,12 +2,18 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.DeclaredBounds;
+import souther.compiler.check.FieldDomains;
+import souther.compiler.check.RuleKey;
+import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleReadings;
+import souther.compiler.numeric.Count;
 import souther.compiler.query.Adequacy;
-import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.ItemAssessment;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -123,25 +129,40 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
     }
 
     /**
-     * A search that met a figure of this compiler's still says so.
+     * What the rules leave the list, at each of the three states the row can put its cap in.
      *
-     * <p>The control against reading too much into the rules. Where the row has not fixed the cap
-     * the rules leave the list holding whatever a larger one would allow, nothing is proved, and
-     * what this compiler has to say is what it did. A refusal made from the cap alone rather than
-     * from the cap the row fixed would take these with it and leave the figure unreachable.
+     * <p><b>The control the refusal above rests on, held where the count is nameable.</b> What is
+     * refused turns on the cap the row has fixed, and the account has no way to say which of its
+     * searches was asked with which cap — so a reading of it either picks its subjects out of how a
+     * class is spelled or says something weaker than it means. Both were tried here and both were
+     * wrong about which searches they were about.
      *
-     * <p>Asked of every search the account holds and not of a chosen few. Which of them are about
-     * a position inside the list is a question the account does not answer, and picking them out of
-     * how a class is spelled is how a reading of this model came to be about the wrong ones.
+     * <p>So it is asked of the reading itself. Nothing settled leaves the list capped in no way,
+     * which is what keeps a rule naming an unchosen field from proving anything; a cap of nought
+     * leaves no room and a cap of one leaves room for what is placed. The refusal reads that
+     * middle number and nothing else, so these three are the whole of what it can come to.
      */
     @Test
-    void aSearchThatMetTheFigureStillSaysSo() {
-        assertTrue(everySearch().stream()
-                        .anyMatch(each -> each instanceof ItemAssessment.Attempt.Stopped stopped
-                                && stopped.stoppedBy().written()
-                                        .contains(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES)),
-                "a search of this behavior meets the assignments a search composes: "
-                        + everySearch());
+    void whatTheRulesLeaveTheListFollowsTheCapTheRowFixed() {
+        assertEquals(Integer.MAX_VALUE, roomInTheList(Map.of()).most(),
+                "nothing has chosen the cap, so the rules cap the list in no way");
+        assertEquals(0, roomInTheList(Map.of(RuleKey.of("cap"), Count.of(0))).most(),
+                "a cap of nought leaves no room for a value to be placed in it");
+        assertEquals(1, roomInTheList(Map.of(RuleKey.of("cap"), Count.of(1))).most(),
+                "and a cap of one leaves room for the one being placed");
+    }
+
+    /** How many the rules let {@code xs} hold, read with {@code settled} fixed as the row fixes it. */
+    private static DeclaredBounds.CountRange roomInTheList(Map<RuleKey, Count> settled) {
+        RuleReadingSource rules = RuleReadings.of(measured(), "example.placing");
+        assertNotNull(rules, "the model under test compiles");
+        FieldDomains read = FieldDomains.of(
+                TypeSymbols.declared(new TypeKey("example.placing", "Box")), rules,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES, settled);
+        return Partitions.heldRange(
+                new Type.ListOf(new Type.Ref(
+                        TypeSymbols.declared(new TypeKey("example.placing", "Awkward")))),
+                rules, read.heldAt(RuleKey.of("xs")));
     }
 
     /**
@@ -165,19 +186,6 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
         return filling.composed().unresolved();
     }
 
-    /** Every search this behavior's account holds, whatever point or role it was for. */
-    private static List<ItemAssessment.Attempt> everySearch() {
-        List<ItemAssessment.Attempt> out = new ArrayList<>();
-        for (BorderAssessment border : lines("placing")) {
-            for (PointRole role : PointRole.values()) {
-                if (border.at(role) instanceof ItemAssessment.Owed owed) {
-                    out.addAll(owed.searches().each());
-                }
-            }
-        }
-        return out;
-    }
-
     /** The rows the behavior was offered, as they are written out. */
     private static List<String> rowsOf(String behavior) {
         Adequacy.Filling filling = measured().db()
@@ -187,17 +195,20 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
                 .map(row -> row.inputs().get(0).text()).toList();
     }
 
-    /** The lines a behavior draws. */
-    private static List<BorderAssessment> lines(String behavior) {
-        Map<String, List<BorderAssessment>> read =
-                Adequacy.readingsOf(measured().db(), "example.placing");
-        assertNotNull(read, "the model under test compiles");
-        List<BorderAssessment> lines = read.get(behavior);
-        assertNotNull(lines, "the behavior was measured");
-        return lines;
-    }
+    /**
+     * The one model here, measured once.
+     *
+     * <p>Every answer below is about the same model, so measuring it per question is the same work
+     * done over: the source is compiled, the report asked for and every question answered each
+     * time. Held because what the assertions read back is what one measurement came to, which is
+     * also what an author gets — two of them agreeing is not something this is about.
+     */
+    private static Compilation measured;
 
-    private static Compilation measured() {
+    private static synchronized Compilation measured() {
+        if (measured != null) {
+            return measured;
+        }
         Compilation compilation = Compilation.ofSource(CAPPED, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
@@ -205,6 +216,7 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
                         .flatMap(List::stream)
                         .map(each -> each.diagnostic().code()).toList(),
                 "the model under test compiles");
-        return compilation;
+        measured = compilation;
+        return measured;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -109,38 +108,40 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
         }
     }
 
-    /** And the answer says which collection, how many it would have to hold, and how many it may. */
+    /** And every one of them says which collection, how many it needs, and how many it may hold. */
     @Test
     void theAnswerSaysWhatTheRulesLeaveRoomFor() {
-        String said = unresolved().getFirst().detail();
+        for (Generator.UnresolvedCombination each : unresolved()) {
+            String said = each.detail();
 
-        assertNotNull(said, "the answer says what it is about: " + unresolved());
-        assertTrue(said.contains("box.xs") && said.contains("hold 1") && said.contains("room for 0"),
-                "and says the collection, what it would have to hold, and what the rules leave"
-                        + " room for: " + said);
+            assertNotNull(said, () -> "the answer says what it is about: " + each);
+            assertTrue(said.contains("box.xs") && said.contains("hold 1")
+                            && said.contains("room for 0"),
+                    () -> "and says the collection, what it would have to hold, and what the rules"
+                            + " leave room for: " + said);
+        }
     }
 
     /**
-     * A point whose cap the row has not fixed is left open on the figure the search reached.
+     * A search that met a figure of this compiler's still says so.
      *
-     * <p>The control against reading too much into the rules. Nothing here settles {@code cap}, so
-     * the rules leave the list holding whatever a larger one would allow and no refusal is proved —
-     * and what this compiler has to say is what it did. A refusal made from the cap alone would
-     * take these with it.
+     * <p>The control against reading too much into the rules. Where the row has not fixed the cap
+     * the rules leave the list holding whatever a larger one would allow, nothing is proved, and
+     * what this compiler has to say is what it did. A refusal made from the cap alone rather than
+     * from the cap the row fixed would take these with it and leave the figure unreachable.
+     *
+     * <p>Asked of every search the account holds and not of a chosen few. Which of them are about
+     * a position inside the list is a question the account does not answer, and picking them out of
+     * how a class is spelled is how a reading of this model came to be about the wrong ones.
      */
     @Test
-    void aPointTheRowHasNotFixedTheCapAtStaysOpenOnTheFigure() {
-        List<ItemAssessment.Attempt> made = insideTheList("placing");
-
-        assertFalse(made.isEmpty(), "the classes of the element are asked about");
-        for (ItemAssessment.Attempt each : made) {
-            ItemAssessment.Attempt.Stopped stopped = assertInstanceOf(
-                    ItemAssessment.Attempt.Stopped.class, each,
-                    () -> "the search met a figure and says so: " + each);
-            assertEquals(List.of(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES),
-                    stopped.stoppedBy().written(),
-                    "and names the figure rather than a refusal it has not proved");
-        }
+    void aSearchThatMetTheFigureStillSaysSo() {
+        assertTrue(everySearch().stream()
+                        .anyMatch(each -> each instanceof ItemAssessment.Attempt.Stopped stopped
+                                && stopped.stoppedBy().written()
+                                        .contains(CompositionBudget.ASSIGNMENTS_A_SEARCH_COMPOSES)),
+                "a search of this behavior meets the assignments a search composes: "
+                        + everySearch());
     }
 
     /**
@@ -164,54 +165,17 @@ class AModelWithNoRoomIsAnsweredBeforeAFigureOfThisCompilersTest {
         return filling.composed().unresolved();
     }
 
-    /**
-     * Every search of a point standing inside the capped list, asked with nothing on the way to it.
-     *
-     * <p>Those asked under a condition on {@code cap} are a different question: the way already
-     * says what the row has to be. What is left is the points the combination itself fixes the cap
-     * at, which is where a reading of the rules is all there is to go on.
-     */
-    private static List<ItemAssessment.Attempt> insideTheList(String behavior) {
+    /** Every search this behavior's account holds, whatever point or role it was for. */
+    private static List<ItemAssessment.Attempt> everySearch() {
         List<ItemAssessment.Attempt> out = new ArrayList<>();
-        for (BorderAssessment border : lines(behavior)) {
+        for (BorderAssessment border : lines("placing")) {
             for (PointRole role : PointRole.values()) {
                 if (border.at(role) instanceof ItemAssessment.Owed owed) {
-                    owed.searches().each().stream()
-                            .filter(each -> about(each).contains("xs["))
-                            .filter(each -> wayTo(each).onTheWay().isEmpty())
-                            .forEach(out::add);
+                    out.addAll(owed.searches().each());
                 }
             }
         }
         return out;
-    }
-
-    /** What a search was about, in the words the account names its classes by. */
-    private static String about(ItemAssessment.Attempt made) {
-        return switch (made) {
-            case ItemAssessment.Attempt.Certified it -> it.row().purposes().toString();
-            case ItemAssessment.Attempt.Unverified it -> it.row().purposes().toString();
-            case ItemAssessment.Attempt.Stopped it -> it.why().classes().toString();
-            case ItemAssessment.Attempt.Unexhausted it -> it.why().classes().toString();
-            case ItemAssessment.Attempt.Limited it -> it.why().classes().toString();
-            case ItemAssessment.Attempt.Unplanned it -> it.why().classes().toString();
-            case ItemAssessment.Attempt.Unresolved it -> it.why().classes().toString();
-            case ItemAssessment.Attempt.Unavailable it -> it.toString();
-        };
-    }
-
-    /** What had to hold on the way to the point the search was for. */
-    private static WayToTheBorder wayTo(ItemAssessment.Attempt made) {
-        return switch (made) {
-            case ItemAssessment.Attempt.Certified it -> it.way();
-            case ItemAssessment.Attempt.Unverified it -> it.way();
-            case ItemAssessment.Attempt.Stopped it -> it.way();
-            case ItemAssessment.Attempt.Unexhausted it -> it.way();
-            case ItemAssessment.Attempt.Limited it -> it.way();
-            case ItemAssessment.Attempt.Unplanned it -> it.way();
-            case ItemAssessment.Attempt.Unresolved it -> it.way();
-            case ItemAssessment.Attempt.Unavailable _ -> new WayToTheBorder(List.of());
-        };
     }
 
     /** The rows the behavior was offered, as they are written out. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.Prepared;
@@ -38,6 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  * out wrong for another reason.
  */
 class ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest {
+
+    /** The rules asking a collection to hold one and capping it in no way. */
+    private static final ConstructionPlan.HowManyItHolds ONE_AT_LEAST =
+            (_, _) -> new DeclaredBounds.CountRange(1, Integer.MAX_VALUE);
+
 
     /** A case of a sum that is a newtype over an optional: the name is uncovered by the case and
      *  taken off again by the presence. */
@@ -112,7 +118,7 @@ class ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest {
         ConstructionPlan plan = assertInstanceOf(ConstructionPlan.Result.Planned.class,
                 ConstructionPlan.of(read.sig().inputTypes().get(0),
                         TermPath.of(read.parameter()), read.rules().symbols(), Set.of(),
-                        axis.requiring(cls), (_, _) -> 1),
+                        axis.requiring(cls), ONE_AT_LEAST),
                 "nothing here asks one position to be two things").plan();
 
         return names(under(plan.root(), axis.path().refine(cls.selects())));

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -45,6 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the two are merged. The scan below is a tripwire under that.
  */
 class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
+
+    /** The rules counting nothing, which is what every model here leaves them saying. */
+    private static final ConstructionPlan.HowManyItHolds ANY =
+            (_, _) -> new DeclaredBounds.CountRange(0, Integer.MAX_VALUE);
 
     private static final String FILTER = """
             module g
@@ -110,11 +115,13 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
 
         ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(), TermPath.of("query"),
                 symbols(), Set.of(tag.refine(caseOf("Tag"))),
-                Requirements.NONE.and(tag, caseOf("NoTag")), (_, _) -> 0);
+                Requirements.NONE.and(tag, caseOf("NoTag")), ANY);
 
-        ConstructionPlan.Result.Conflict against =
-                assertInstanceOf(ConstructionPlan.Result.Conflict.class, asked,
-                        "no value at `query.tag` is both a `Tag` and a `NoTag`");
+        ConstructionPlan.ModelRefusal.Conflict against = assertInstanceOf(
+                ConstructionPlan.ModelRefusal.Conflict.class,
+                assertInstanceOf(ConstructionPlan.Result.Refused.class, asked,
+                        "no value at `query.tag` is both a `Tag` and a `NoTag`").why(),
+                "and it is the model settling it, said as the two it would have to be");
         assertEquals(tag, against.at());
         assertEquals(Set.of("Tag", "NoTag"),
                 Set.of(against.one().spelled(), against.other().spelled()),
@@ -139,7 +146,7 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
 
         IllegalStateException said = assertThrows(IllegalStateException.class,
                 () -> ConstructionPlan.of(typeOf(), TermPath.of("query"), symbols(), Set.of(tag),
-                        Requirements.NONE.and(tag, caseOf("Tag")), (_, _) -> 0));
+                        Requirements.NONE.and(tag, caseOf("Tag")), ANY));
 
         assertTrue(said.getMessage().contains("query.tag") && said.getMessage().contains("Tag"),
                 "the answer names the position said twice: " + said.getMessage());
@@ -175,7 +182,7 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
                         Set.of(),
                         Requirements.NONE.and(tag, Refinement.of(new Case.Presence(false)))
                                 .and(absent, caseOf("Tag")),
-                        (_, _) -> 0));
+                        ANY));
 
         assertTrue(said.getMessage().contains("query.tag@None"),
                 "the answer names the position that holds no value: " + said.getMessage());
@@ -197,7 +204,7 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
                 () -> ConstructionPlan.of(heldType(), TermPath.of("query"), heldSymbols(),
                         Set.of(absent.then("value")),
                         Requirements.NONE.and(tag, Refinement.of(new Case.Presence(false))),
-                        (_, _) -> 0));
+                        ANY));
 
         assertTrue(said.getMessage().contains("query.tag@None.value"),
                 "the answer names the value fixed where nothing stands: " + said.getMessage());
@@ -214,7 +221,7 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
     private static ConstructionPlan planned(Set<TermPath> decided, Requirements additional) {
         return assertInstanceOf(ConstructionPlan.Result.Planned.class,
                 ConstructionPlan.of(typeOf(), TermPath.of("query"), symbols(), decided, additional,
-                        (_, _) -> 0),
+                        ANY),
                 "nothing here asks one position to be two things").plan();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhereItStoppedShortOfWhatTheValueHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhereItStoppedShortOfWhatTheValueHasTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -41,6 +42,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * and nothing unresolved.
  */
 class APlanSaysWhereItStoppedShortOfWhatTheValueHasTest {
+
+    /** The rules counting nothing, which is what every model here leaves them saying. */
+    private static final ConstructionPlan.HowManyItHolds ANY =
+            (_, _) -> new DeclaredBounds.CountRange(0, Integer.MAX_VALUE);
+
+    /** The rules leaving a collection holding none, which is the model settling that nothing can be
+     *  placed inside one. */
+    private static final ConstructionPlan.HowManyItHolds NONE_OF_THEM =
+            (_, _) -> new DeclaredBounds.CountRange(0, 0);
+
 
     /**
      * Eight records each holding the next, which is one more than the figure allows.
@@ -150,7 +161,7 @@ class APlanSaysWhereItStoppedShortOfWhatTheValueHasTest {
         TermPath deeper = down(9);
 
         ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(DEEP), TermPath.of("query"),
-                symbolsOf(DEEP), Set.of(deeper), Requirements.NONE, (_, _) -> 0);
+                symbolsOf(DEEP), Set.of(deeper), Requirements.NONE, ANY);
 
         assertEquals(Set.of(CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS),
                 assertInstanceOf(ConstructionPlan.Result.Beyond.class, asked,
@@ -174,12 +185,65 @@ class APlanSaysWhereItStoppedShortOfWhatTheValueHasTest {
         ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(DEEP), TermPath.of("query"),
                 symbolsOf(DEEP), Set.of(),
                 Requirements.NONE.and(down(9), Refinement.of(new Case.Presence(true))),
-                (_, _) -> 0);
+                ANY);
 
         assertEquals(Set.of(CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS),
                 assertInstanceOf(ConstructionPlan.Result.Beyond.class, asked,
                         "the caller stated something of a position this plan never reached").by(),
                 "and it says which figure put the position out of reach");
+    }
+
+    /**
+     * A demand under a collection the rules leave no room in is the model's answer, and the figure
+     * below it is not named.
+     *
+     * <p>Both are true of this plan at once: the list holds nothing, and what the caller asked for
+     * is deeper than the descent goes. Which is the ordinary way for them to meet — a demand this
+     * compiler cannot reach is a demand it has not shown anything about, and the rules have already
+     * settled it above. Named as the figure, an author would raise it and be told the list still
+     * holds nothing.
+     */
+    @Test
+    void aDemandUnderACollectionWithNoRoomIsTheModelsAnswerAndNotTheFigure() {
+        ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(TREE), TermPath.of("query"),
+                symbolsOf(TREE), Set.of(insideTheTree(6)), Requirements.NONE, NONE_OF_THEM);
+
+        ConstructionPlan.ModelRefusal.NoRoom why = assertInstanceOf(
+                ConstructionPlan.ModelRefusal.NoRoom.class,
+                assertInstanceOf(ConstructionPlan.Result.Refused.class, asked,
+                        "the rules leave the list nothing, which they say whatever this compiler"
+                                + " went on to read").why(),
+                "and it is the collection that has no room");
+        assertEquals(1, why.needed(),
+                "one is what the list would have to hold for the value to be placed in it");
+        assertEquals(0, why.holds().most(), "and none is what the rules leave room for");
+    }
+
+    /**
+     * The same demand where the rules leave room is the figure, and nothing about the model.
+     *
+     * <p>The control of the one above, and the half that says the refusal is not being read off the
+     * demand. Only the count the rules leave differs between the two.
+     */
+    @Test
+    void theSameDemandWhereThereIsRoomIsTheFigure() {
+        ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(TREE), TermPath.of("query"),
+                symbolsOf(TREE), Set.of(insideTheTree(6)), Requirements.NONE, ANY);
+
+        assertEquals(Set.of(CompositionBudget.DEPTH_A_CONSTRUCTION_PLAN_DESCENDS),
+                assertInstanceOf(ConstructionPlan.Result.Beyond.class, asked,
+                        "nothing the rules say stops this, so what is in the way is the figure")
+                        .by(),
+                "and it says which figure put the position out of reach");
+    }
+
+    /** A position {@code deep} lists down the tree, which is deeper than the descent goes. */
+    private static TermPath insideTheTree(int deep) {
+        TermPath at = TermPath.of("query").then("tree");
+        for (int each = 0; each < deep; each++) {
+            at = at.then("kids").element();
+        }
+        return at;
     }
 
     /**
@@ -193,7 +257,7 @@ class APlanSaysWhereItStoppedShortOfWhatTheValueHasTest {
         TermPath inside = down(8);
 
         ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(DEEP), TermPath.of("query"),
-                symbolsOf(DEEP), Set.of(inside), Requirements.NONE, (_, _) -> 0);
+                symbolsOf(DEEP), Set.of(inside), Requirements.NONE, ANY);
 
         ConstructionPlan plan = assertInstanceOf(ConstructionPlan.Result.Planned.class, asked,
                 "the position is one this plans at").plan();
@@ -288,7 +352,7 @@ class APlanSaysWhereItStoppedShortOfWhatTheValueHasTest {
                                             Requirements additional) {
         return assertInstanceOf(ConstructionPlan.Result.Planned.class,
                 ConstructionPlan.of(typeOf(source), TermPath.of("query"), symbolsOf(source),
-                        decided, additional, (_, _) -> 0),
+                        decided, additional, ANY),
                 "nothing here asks one position to be two things").plan();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
@@ -179,6 +179,79 @@ class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
                         .map(ConstructionPlan.Slot::at).toList());
     }
 
+    /**
+     * The same sum with a collection declared after it, so that the walk meets the narrowing first.
+     *
+     * <p>What is asked of both at once: a value under the sum, which nothing has said which case
+     * of, and a value inside the list.
+     */
+    private static final String BESIDE_A_LIST = """
+            module g
+
+            data Common = { amount: Int }
+            data Card = { ...Common, issuer: Int }
+            data Cash = { ...Common, note: Int }
+            data Method = Card | Cash
+            data Item = { method: Method, bag: List<Int> }
+
+            data Query = { item: Item }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+            """;
+
+    /**
+     * A field the model refuses outranks a narrowing owed at the field before it.
+     *
+     * <p>The two are not alike. A refusal is an answer about the value being built and holds
+     * whatever the caller does next; a narrowing owed is a question put to whoever asked for the
+     * value. A caller answered with the question states a narrowing, asks again, and is told there
+     * was never a row — so the walk goes on past the question to find out whether there is one.
+     *
+     * <p>Held because the other way round reads like tidying. The narrowing is the first thing the
+     * walk has in hand and returning it there is one line shorter, and what it costs is a round
+     * trip through the caller that cannot end anywhere.
+     */
+    @Test
+    void aRefusalFurtherAlongOutranksANarrowingOwedBeforeIt() {
+        TermPath bag = TermPath.of("query").then("item").then("bag");
+
+        ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(BESIDE_A_LIST),
+                TermPath.of("query"), symbolsOf(BESIDE_A_LIST),
+                Set.of(TermPath.of("query").then("item").then("method").then("amount"),
+                        bag.element()),
+                Requirements.NONE,
+                (at, _) -> at.equals(bag) ? new DeclaredBounds.CountRange(0, 0)
+                        : new DeclaredBounds.CountRange(0, Integer.MAX_VALUE));
+
+        assertInstanceOf(ConstructionPlan.ModelRefusal.NoRoom.class,
+                assertInstanceOf(ConstructionPlan.Result.Refused.class, asked,
+                        "the list leaves no room, and no narrowing the caller states changes that")
+                        .why(),
+                "so what comes back is the refusal and not the narrowing owed at the field before"
+                        + " it");
+    }
+
+    /**
+     * And where the list has room, the narrowing owed is what comes back.
+     *
+     * <p>The control. Only what the rules leave the list differs between the two, so a walk that
+     * returned the refusal whatever the count was would pass the one above.
+     */
+    @Test
+    void aNarrowingOwedIsWhatComesBackWhereNothingIsRefused() {
+        ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(BESIDE_A_LIST),
+                TermPath.of("query"), symbolsOf(BESIDE_A_LIST),
+                Set.of(TermPath.of("query").then("item").then("method").then("amount"),
+                        TermPath.of("query").then("item").then("bag").element()),
+                Requirements.NONE, ANY);
+
+        assertEquals(TermPath.of("query").then("item").then("method"),
+                assertInstanceOf(ConstructionPlan.Result.Unnarrowed.class, asked,
+                        "nothing is refused, so what the caller is owed is the narrowing").at(),
+                "at the position it is owed at");
+    }
+
     /** The narrowing to one leaf, spelled the way the checker's resolution of an arm spells it: a
      *  leaf is a case that covers itself, so selecting it narrows to that one distinction. */
     private static Refinement caseOf(String leaf) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanSaysWhichNarrowingADemandUnderASumIsOwedTest.java
@@ -3,6 +3,7 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -45,6 +46,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the caller's value is quietly missing from what was built.
  */
 class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
+
+    /** The rules counting nothing, which is what every model here leaves them saying. */
+    private static final ConstructionPlan.HowManyItHolds ANY =
+            (_, _) -> new DeclaredBounds.CountRange(0, Integer.MAX_VALUE);
+
 
     /**
      * A list of items whose method is a sum of two cases, both spreading the same amount.
@@ -186,7 +192,7 @@ class APlanSaysWhichNarrowingADemandUnderASumIsOwedTest {
 
     private static ConstructionPlan.Result planningOf(String source, Set<TermPath> decided) {
         return ConstructionPlan.of(typeOf(source), TermPath.of("query"), symbolsOf(source),
-                decided, Requirements.NONE, (_, _) -> 0);
+                decided, Requirements.NONE, ANY);
     }
 
     private static Type typeOf(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOptionalsClassesStateWhichNarrowingTheyAreTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOptionalsClassesStateWhichNarrowingTheyAreTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.RuleReadingSource;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.ast.Hir;
@@ -34,6 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * class beneath it at the same time, and no reader could see that no value is both.
  */
 class AnOptionalsClassesStateWhichNarrowingTheyAreTest {
+
+    /** The rules asking a collection to hold one and capping it in no way. */
+    private static final ConstructionPlan.HowManyItHolds ONE_AT_LEAST =
+            (_, _) -> new DeclaredBounds.CountRange(1, Integer.MAX_VALUE);
+
 
     private static final String FLAGGED = """
             module example.flagged
@@ -131,7 +137,7 @@ class AnOptionalsClassesStateWhichNarrowingTheyAreTest {
         Read read = read(HOLDING);
         return assertInstanceOf(ConstructionPlan.Result.Planned.class,
                 ConstructionPlan.of(read.sig().inputTypes().get(0), TermPath.of("query"),
-                        read.rules().symbols(), Set.of(), required, (_, _) -> 1),
+                        read.rules().symbols(), Set.of(), required, ONE_AT_LEAST),
                 "nothing here asks one position to be two things").plan();
     }
 


### PR DESCRIPTION
Closes #1315.

A collection asked to hold a value in a class, whose rules leave no room for
one, is the model settling that there is no row. This compiler established
that after the search, from a second reading of the rules — by which point a
figure the search had reached was already the answer a reader got.

The two hold together in the ordinary case rather than a contrived one: where
no row exists, the search refuses everything it composes and goes on composing
until it meets a bound. So the order was decided by which question was asked
first, and the model's was asked last.

## What changed

The count is read where the plan is made, from the same reading of the rules
the values are chosen against, and both its ends at once. A sequence asks it
before the depth figure and before the descent, so a refusal the model settles
cannot arrive behind a figure of this compiler's.

`Result.Refused` carries it beside the conflict that was already there, since a
reader acts on the two the same way and the ordering against a figure is then
written once rather than once per way the model can settle it.

What made the old order hard to see was that the two halves of one question
were read in two places — the floor at planning time, the cap after the search.
They are one answer now, and the plan carries what the composing has to make
rather than the end it was read off. The question of whether the caller asked
for anything inside a list was likewise answered twice, off the paths and off
the plan that was built for them; it is asked once and handed on.

## What holds it

A model where both are true at one point, held to what the account says, and
two controls beside it: a point whose cap the row has not fixed stays open on
the figure, and the same rule leaves the rows it has room for.

The ordering itself is held at the plan, where it lives — the same demand under
the same depth cut, answered by the model where the rules leave no room and by
the figure where they do. Moving the reading after the descent leaves the
account test green and reddens that one, which is what says the order is in the
recursion rather than in the order of returns downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)