### PR TITLE
Read a field by what the position makes readable

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -856,7 +856,7 @@ public final class DataChecker {
                                                  SourcePos pos, CheckContext ctx) {
         Map<String, Type> shared =
                 TypeView.of(Type.ref(sum.declares()), ctx.symbols()).shape() instanceof Shape.Sum s
-                        ? ReadableFields.of(s).fields() : Map.of();
+                        ? ReadableFields.of(s).declaredFields() : Map.of();
         if (shared.isEmpty()) {
             throw CompileException.of(Diagnostic.at(pos)
                     .say(new DataMessage.SpreadOfASumWhoseCasesShareNothing(name, Type.show(bound)))

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
@@ -22,11 +22,13 @@ import java.util.Set;
  * written after a {@code .}. Two walks would be two answers about the same declarations, and the one
  * that answered later would find nothing.
  *
- * <p>How the evidence flows through an expression is this walk's, and what a field of a declaration
- * holds is not. Crossing a {@code .} is a question about a declaration rather than about the
- * expression that reached it, and it is put to {@link #fields} — so a caller in a world where the
- * check has settled what a value is made of gets that answer here, and the walk cannot reach a
- * second one by reading the declaration itself.
+ * <p>How the evidence flows through an expression is this walk's, and what a {@code .} on a value
+ * may name is not. Which names a position makes readable, and how far the names it wears come off,
+ * are {@link FieldRead}'s — one reading, the same one an elaboration types a text by — and what one
+ * of those declarations holds under a name is {@link #fields}'. So a caller in a world where the
+ * check has settled what a value is made of gets that answer here, the walk cannot reach a second
+ * one by reading the declaration itself, and a name every case of a sum spreads is answered for
+ * because it is readable, rather than left unanswered because a sum lays out no field of its own.
  *
  * <p>Nothing is run. Every step reads a name {@code Resolve} already settled or a declaration a
  * module already made, so asking costs no helper a second application against a row's budget.
@@ -84,8 +86,8 @@ public record DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
             case Hir.Apply c when constructsANewtype(c) -> Type.ref(constructs(c));
             case Hir.FieldAccess fa -> {
                 Type target = declaredTypeOf(fa.target(), seen, inForce);
-                yield target instanceof Type.Ref(TypeSymbol owner)
-                        ? fields.field(owner, fa.field()) : null;
+                yield target == null ? null
+                        : new FieldRead(symbols, fields).of(target, fa.field());
             }
             case Hir.LetIn let -> {
                 BindingId binding = let.binder().id();

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
-import souther.compiler.observe.FieldTypes;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -23,35 +22,42 @@ import java.util.Set;
  * that answered later would find nothing.
  *
  * <p>How the evidence flows through an expression is this walk's, and what a {@code .} on a value
- * may name is not. Which names a position makes readable, and how far the names it wears come off,
- * are {@link FieldRead}'s — one reading, the same one an elaboration types a text by — and what one
- * of those declarations holds under a name is {@link #fields}'. So a caller in a world where the
- * check has settled what a value is made of gets that answer here, the walk cannot reach a second
- * one by reading the declaration itself, and a name every case of a sum spreads is answered for
- * because it is readable, rather than left unanswered because a sum lays out no field of its own.
+ * may name is not. Which names a position makes readable, how far the names it wears come off, and
+ * what one of those declarations holds under a name are {@link FieldRead}'s — one reading, the same
+ * one an elaboration types a text by. So a caller in a world where the check has settled what a
+ * value is made of gets that answer here, the walk cannot reach a second one by reading the
+ * declaration itself, and a name every case of a sum spreads is answered for because it is
+ * readable, rather than left unanswered because a sum lays out no field of its own.
  *
  * <p>Nothing is run. Every step reads a name {@code Resolve} already settled or a declaration a
  * module already made, so asking costs no helper a second application against a row's budget.
  *
- * @param fields what a declaration's fields hold, in the world this reading is being made in
+ * @param read   the reading of a {@code .}, in the world this walk is being made in — handed over
+ *               rather than made here, so which world that is, in both halves of it, is settled by
+ *               whoever is doing the reading and not once per walk
  * @param values the definitions a bare name may stand for
  * @param bound  what the bindings in force where the walk starts have to say about themselves, which
  *               the walk adds to as it enters more of them
  */
-public record DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
+public record DeclaredTypeEvidence(FieldRead read,
                                    Map<String, Hir.FnDef> values,
                                    Map<BindingId, BindingEvidence> bound) {
 
-    public DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
-                                Map<String, Hir.FnDef> values) {
-        this(symbols, fields, values, Map.of());
+    public DeclaredTypeEvidence(FieldRead read, Map<String, Hir.FnDef> values) {
+        this(read, values, Map.of());
+    }
+
+    /** What the names in a position denote, which is the reading's. One of them and not one here
+     *  beside it: two that could differ are two answers about what a name means. */
+    public Symbols symbols() {
+        return read.symbols();
     }
 
     /** The same, with {@code binding} standing for {@code value} as well. */
     public DeclaredTypeEvidence with(BindingId binding, Hir.Expr value) {
         Map<BindingId, BindingEvidence> wider = new LinkedHashMap<>(bound);
         wider.put(binding, new BindingEvidence.BoundTo(value));
-        return new DeclaredTypeEvidence(symbols, fields, values, wider);
+        return new DeclaredTypeEvidence(read, values, wider);
     }
 
     /** Bindings that each stand for an expression, as this walk holds them — what a caller keeping
@@ -86,8 +92,7 @@ public record DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
             case Hir.Apply c when constructsANewtype(c) -> Type.ref(constructs(c));
             case Hir.FieldAccess fa -> {
                 Type target = declaredTypeOf(fa.target(), seen, inForce);
-                yield target == null ? null
-                        : new FieldRead(symbols, fields).of(target, fa.field());
+                yield target == null ? null : read.of(target, fa.field());
             }
             case Hir.LetIn let -> {
                 BindingId binding = let.binder().id();
@@ -144,8 +149,8 @@ public record DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
      */
     public boolean heldToARule(Type type) {
         return type instanceof Type.Ref(TypeSymbol named)
-                && symbols.declaredNode(named) instanceof Hir.Data data
-                && !TypeOps.settledInvariants(data, symbols).isEmpty();
+                && symbols().declaredNode(named) instanceof Hir.Data data
+                && !TypeOps.settledInvariants(data, symbols()).isEmpty();
     }
 
     /** The body a name stands for, where it names a value of this reading's own. */
@@ -156,7 +161,7 @@ public record DeclaredTypeEvidence(Symbols symbols, FieldTypes fields,
     }
 
     private boolean isNewtype(TypeSymbol name) {
-        return isNewtype(name, symbols);
+        return isNewtype(name, symbols());
     }
 
     /** Whether an application is a newtype's construction written in call form (ADR-0032). */

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -513,9 +513,11 @@ public final class Elaborator {
     }
 
     /** What a {@code .} may name, in the world an elaboration reads: the declarations as this text
-     *  has resolved them, which is what a check settling them has to go on. */
+     *  has resolved them, which is what a check settling them has to go on — and refusing where one
+     *  of them does not read, which a check is what reports. */
     private static FieldRead fieldRead(CheckContext ctx) {
-        return new FieldRead(ctx.symbols(), new ResolvedFieldTypes(ctx.symbols()));
+        return new FieldRead(ctx.symbols(), new ResolvedFieldTypes(ctx.symbols()),
+                FieldRead.Unreadable.REFUSED);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -471,32 +471,21 @@ public final class Elaborator {
     static Core elaborateFieldAccess(Hir.FieldAccess fa, Scope env, CheckContext ctx) {
         Core targetCore = elaborate(fa.target(), env, ctx);
         Type target = targetCore.type();
-        if (target instanceof Type.Ref ref && ctx.symbols().declaredNode(ref.name()) instanceof Hir.Data owner) {
-            Type ft = TypeOps.fieldType(owner, fa.field(), ctx.symbols());
-            if (ft != null) {
-                return new Core.FieldAccess(targetCore, fa.field(), ft, fa.pos());
-            }
+        // What a `.` may name here, asked of the one reader of it: a record's own fields, a name
+        // every case of a sum spreads, and a newtype's `value` and nothing of what it wraps. Which
+        // of those this position is, and how far the names it wears come off, are answered there —
+        // an elaboration deciding either for itself is a second reading of a field access, and the
+        // reading a text is typed by and the reading an editor is told would then be two.
+        Type read = fieldRead(ctx).of(target, fa.field());
+        if (read != null) {
+            return new Core.FieldAccess(targetCore, fa.field(), read, fa.pos());
         }
-        // Asked of a sum only. What a type is made of answers for anything — a data that is no sum
-        // is the one atom it is — and the question here is whether there are cases to read at all,
-        // which a type that is its own single leaf is not.
+        // Nothing is readable, and what is left here is saying so. Asked of a sum only: what a type
+        // is made of answers for anything — a data that is no sum is the one atom it is — and the
+        // question is whether there are cases the author could open, which a type that is its own
+        // single leaf has not.
         if (TypeOps.isSumType(target, ctx.symbols())) {
             List<TypeSymbol> cases = AtomSpace.subjectAtoms(target, ctx.symbols());
-            // A field every case spreads is the sum's own: the sharing is nominal, and the generated
-            // sealed interface declares the accessor its cases already carry (issue #160). Only a
-            // named sum, whose interface this compile emits — an anonymous union's cases are not
-            // written together, so nothing declares their shared part.
-            // Asked of the type as written and not through the names it wears: how far a read looks
-            // through a newtype is this elaboration's policy, and a `data X = S` over a sum is a
-            // value of X, whose fields are X's. `TypeView` keeps both directions available for that
-            // reason, and this reader takes the one it has always taken.
-            TypeView view = TypeView.of(target, ctx.symbols());
-            if (!view.isWrapped() && view.shape() instanceof Shape.Sum shape) {
-                Type readable = ReadableFields.of(shape).fields().get(fa.field());
-                if (readable != null) {
-                    return new Core.FieldAccess(targetCore, fa.field(), readable, fa.pos());
-                }
-            }
             // A sum carries no fields of its own — its cases do, and which case it is is not known
             // until it is opened. Saying that is the difference between "this value has no such
             // field" and "read it in each case", which is what the author has to write.
@@ -521,6 +510,12 @@ public final class Elaborator {
         }
         throw CompileException.of(Diagnostic
                         .at(fa.name().reportedAt()).say(new DeclarationMessage.CannotReadAFieldOnThisValue(fa.field())).build());
+    }
+
+    /** What a {@code .} may name, in the world an elaboration reads: the declarations as this text
+     *  has resolved them, which is what a check settling them has to go on. */
+    private static FieldRead fieldRead(CheckContext ctx) {
+        return new FieldRead(ctx.symbols(), new ResolvedFieldTypes(ctx.symbols()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
@@ -38,8 +38,14 @@ import java.util.Map;
 public record FieldRead(Symbols symbols, FieldTypes world, Unreadable unreadable) {
 
     /**
-     * What a reading does where the declarations at a position do not read — a data that declares
-     * one name twice, a spread of something that is no product, two spreads supplying one name.
+     * What a reading does where reading a position refuses.
+     *
+     * <p>Any refusal it raises, and not a list of them. What a value at a position is cannot be
+     * settled without following the names it wears and the spreads under them, so a reading of a
+     * position meets whatever those refuse — today a data that declares one name twice, a spread of
+     * something that is no product, two spreads supplying one name, and tomorrow whatever else is
+     * found there. Naming three would be a closure this does not have, and the reader that has to
+     * answer has to answer whichever it met.
      *
      * <p>Two worlds and not a fallback. Which of them a reader is in is what it was built with, the
      * way {@link FieldTypes} already is for what a field holds, so that neither has to decide what
@@ -54,7 +60,8 @@ public record FieldRead(Symbols symbols, FieldTypes world, Unreadable unreadable
         /** Nothing is readable there, which is an answer. A module still being typed has
          *  declarations that do not read yet and an author reading a name in it is owed what does —
          *  the rule {@link ResolvedFieldTypes} follows for what a field holds, followed here for
-         *  which names there are. */
+         *  which names there are. What was wrong is reported where the module is checked, so
+         *  nothing is lost by this reading not repeating it. */
         MAKES_NOTHING_READABLE
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.CompileException;
 import souther.compiler.observe.FieldTypes;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -22,21 +23,46 @@ import java.util.Map;
  * wrote, and an editor asking what may follow a {@code .} are one answer, so a reader adding a
  * second decision about the names would be answering a question this has already answered.
  *
- * <p><b>Which world, from the caller.</b> Which names are readable is nominal and comes from the
- * declarations ({@link ReadableFields}); what one of them holds is {@code world}'s. An accepted
- * program's fields are what its check settled and a text that has not checked has what its
- * declarations resolve to so far, and neither reader may fall back to the other's answer.
+ * <p><b>Which world, from the caller, in both halves.</b> Which names are readable is nominal and
+ * comes from the declarations ({@link ReadableFields}); what one of them holds is {@code world}'s.
+ * An accepted program's fields are what its check settled and a text that has not checked has what
+ * its declarations resolve to so far, and neither reader may fall back to the other's answer. The
+ * nominal half has the same two worlds and {@code unreadable} is where they part: a declaration
+ * that does not read is a thing a check reports and a thing an editor is asked in front of.
  *
- * @param symbols what the names in a position denote
- * @param world   what a declaration holds under each of its names, in the world this reading is
- *                being made in
+ * @param symbols    what the names in a position denote
+ * @param world      what a declaration holds under each of its names, in the world this reading is
+ *                   being made in
+ * @param unreadable what this reading does where the declarations at a position do not read
  */
-public record FieldRead(Symbols symbols, FieldTypes world) {
+public record FieldRead(Symbols symbols, FieldTypes world, Unreadable unreadable) {
+
+    /**
+     * What a reading does where the declarations at a position do not read — a data that declares
+     * one name twice, a spread of something that is no product, two spreads supplying one name.
+     *
+     * <p>Two worlds and not a fallback. Which of them a reader is in is what it was built with, the
+     * way {@link FieldTypes} already is for what a field holds, so that neither has to decide what
+     * an absence meant.
+     */
+    public enum Unreadable {
+
+        /** Refused where it is read. A check has to report a declaration that does not read, and
+         *  this is one of the walks that reaches it. */
+        REFUSED,
+
+        /** Nothing is readable there, which is an answer. A module still being typed has
+         *  declarations that do not read yet and an author reading a name in it is owed what does —
+         *  the rule {@link ResolvedFieldTypes} follows for what a field holds, followed here for
+         *  which names there are. */
+        MAKES_NOTHING_READABLE
+    }
 
     public FieldRead {
-        if (symbols == null || world == null) {
+        if (symbols == null || world == null || unreadable == null) {
             throw new IllegalArgumentException(
-                    "a field read is made against declarations and a world that says what they hold");
+                    "a field read is made against declarations, a world that says what they hold,"
+                            + " and what it does where they do not read");
         }
     }
 
@@ -54,6 +80,7 @@ public record FieldRead(Symbols symbols, FieldTypes world) {
         return switch (surfaceOf(position)) {
             case Surface.OfAName(TypeSymbol worn) -> world.of(worn);
             case Surface.OfAShape(Shape shape) -> ReadableFields.of(shape).in(world);
+            case Surface.OfNothing _ -> Map.of();
         };
     }
 
@@ -70,11 +97,12 @@ public record FieldRead(Symbols symbols, FieldTypes world) {
         return switch (surfaceOf(position)) {
             case Surface.OfAName(TypeSymbol worn) -> world.of(worn).get(field);
             case Surface.OfAShape(Shape shape) -> ReadableFields.at(shape, field, world);
+            case Surface.OfNothing _ -> null;
         };
     }
 
-    /** What a {@code .} on a value here reads: the one declaration a worn name is, or the shape a
-     *  value under no name has. */
+    /** What a {@code .} on a value here reads: the one declaration a worn name is, the shape a
+     *  value under no name has, or neither where the declarations do not read. */
     private sealed interface Surface {
 
         /** A name the value is written under. Its own declaration and no further — the single field
@@ -83,17 +111,33 @@ public record FieldRead(Symbols symbols, FieldTypes world) {
 
         /** A value under no name of its own: what the shape makes readable. */
         record OfAShape(Shape shape) implements Surface {}
+
+        /** The declarations here do not read, and this reading answers rather than refusing. */
+        record OfNothing() implements Surface {}
     }
 
     /**
-     * Which of the two {@code position} is.
+     * Which of those {@code position} is.
      *
      * <p>Beside the two entries and in neither, so the names a value wears come off in one place
      * however wide the question being asked is. Decided in each, the surface a reader lists and the
      * name it looks up could stop being the same reading.
+     *
+     * <p>Reading the position is what finds a declaration that does not read: what a value here is
+     * cannot be settled without following the spreads under it. So the refusal arrives here, and
+     * what becomes of it is the world this reading was built for — passed on where a check is being
+     * made, and a position nothing is readable at where a text is being typed.
      */
     private Surface surfaceOf(Type position) {
-        TypeView view = TypeView.of(position, symbols);
+        TypeView view;
+        try {
+            view = TypeView.of(position, symbols);
+        } catch (CompileException doesNotRead) {
+            if (unreadable == Unreadable.REFUSED) {
+                throw doesNotRead;
+            }
+            return new Surface.OfNothing();
+        }
         return view.isWrapped() ? new Surface.OfAName(view.wrappers().getFirst())
                 : new Surface.OfAShape(view.shape());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
@@ -78,7 +78,10 @@ public record FieldRead(Symbols symbols, FieldTypes world, Unreadable unreadable
      */
     public Map<String, Type> at(Type position) {
         return switch (surfaceOf(position)) {
-            case Surface.OfAName(TypeSymbol worn) -> world.of(worn);
+            case Surface.OfAName(TypeSymbol worn) -> {
+                Type held = wrapped(worn);
+                yield held == null ? Map.of() : Map.of(WRITTEN_WITH, held);
+            }
             case Surface.OfAShape(Shape shape) -> ReadableFields.of(shape).in(world);
             case Surface.OfNothing _ -> Map.of();
         };
@@ -95,10 +98,26 @@ public record FieldRead(Symbols symbols, FieldTypes world, Unreadable unreadable
      */
     public Type of(Type position, String field) {
         return switch (surfaceOf(position)) {
-            case Surface.OfAName(TypeSymbol worn) -> world.of(worn).get(field);
+            case Surface.OfAName(TypeSymbol worn) ->
+                    WRITTEN_WITH.equals(field) ? wrapped(worn) : null;
             case Surface.OfAShape(Shape shape) -> ReadableFields.at(shape, field, world);
             case Surface.OfNothing _ -> null;
         };
+    }
+
+    /**
+     * The one name a value written under a name makes readable (spec §newtype).
+     *
+     * <p>Nominal, and said here rather than left to the world. A newtype is written with a single
+     * implicit field and that is the whole of what a {@code .} on it may take; read as whatever the
+     * world happens to hold for that declaration, a world with more to say about it would widen what
+     * a name makes readable, which is not a world's to decide.
+     */
+    private static final String WRITTEN_WITH = "value";
+
+    /** What the name is written over, as {@code world} says the declaration holds it. */
+    private Type wrapped(TypeSymbol worn) {
+        return world.of(worn).get(WRITTEN_WITH);
     }
 
     /** What a {@code .} on a value here reads: the one declaration a worn name is, the shape a

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldRead.java
@@ -1,0 +1,100 @@
+package souther.compiler.check;
+
+import souther.compiler.observe.FieldTypes;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.Map;
+
+/**
+ * What a {@code .} written on a value standing at a position may name.
+ *
+ * <p>The one reading of a field access, and the only place a type is crossed at a {@code .}. What is
+ * readable off a value is not what a value of a declaration is laid out as: a sum is laid out as
+ * nothing — a value of it is a value of one of its cases — while a name every one of its cases
+ * spreads is readable on every value of it. Asked of the layout, a reader is told a shared name is a
+ * field nothing declares; asked here, it is told what the language reads there.
+ *
+ * <p><b>The nominal barrier is here.</b> A name worn over a value is not looked through: a
+ * {@code data AmountN = Int} reads its own {@code value} and nothing of the {@code Int}, and a
+ * {@code data StageN = Stage} reads no case's field of the sum it names. That is what a {@code .}
+ * means and not a policy of whoever is reading — an elaboration, a walk that types what a text
+ * wrote, and an editor asking what may follow a {@code .} are one answer, so a reader adding a
+ * second decision about the names would be answering a question this has already answered.
+ *
+ * <p><b>Which world, from the caller.</b> Which names are readable is nominal and comes from the
+ * declarations ({@link ReadableFields}); what one of them holds is {@code world}'s. An accepted
+ * program's fields are what its check settled and a text that has not checked has what its
+ * declarations resolve to so far, and neither reader may fall back to the other's answer.
+ *
+ * @param symbols what the names in a position denote
+ * @param world   what a declaration holds under each of its names, in the world this reading is
+ *                being made in
+ */
+public record FieldRead(Symbols symbols, FieldTypes world) {
+
+    public FieldRead {
+        if (symbols == null || world == null) {
+            throw new IllegalArgumentException(
+                    "a field read is made against declarations and a world that says what they hold");
+        }
+    }
+
+    /**
+     * Every name a {@code .} on a value of {@code position} may write, with what it holds.
+     *
+     * <p>The surface and not one lookup, because the surface is the question: an editor listing what
+     * may follow a {@code .} and an elaboration typing the one name that was written read the same
+     * answer, and a second producer of it is how the two came to disagree.
+     *
+     * <p>Empty where nothing is readable without opening a case first — which is an answer about the
+     * position and not a failure to read it.
+     */
+    public Map<String, Type> at(Type position) {
+        return switch (surfaceOf(position)) {
+            case Surface.OfAName(TypeSymbol worn) -> world.of(worn);
+            case Surface.OfAShape(Shape shape) -> ReadableFields.of(shape).in(world);
+        };
+    }
+
+    /**
+     * What {@code field} holds on a value of {@code position}, or null where nothing readable there
+     * is written under that name.
+     *
+     * <p>The same question as {@link #at} asked about one name, and answered without every name at
+     * the position being asked of the world and copied out to index one of them. Off the same
+     * reading of the position, so there is no second rule here about how far the names a value wears
+     * come off and no name answered here that {@link #at} does not also give.
+     */
+    public Type of(Type position, String field) {
+        return switch (surfaceOf(position)) {
+            case Surface.OfAName(TypeSymbol worn) -> world.of(worn).get(field);
+            case Surface.OfAShape(Shape shape) -> ReadableFields.at(shape, field, world);
+        };
+    }
+
+    /** What a {@code .} on a value here reads: the one declaration a worn name is, or the shape a
+     *  value under no name has. */
+    private sealed interface Surface {
+
+        /** A name the value is written under. Its own declaration and no further — the single field
+         *  a newtype is written with (spec §newtype), and nothing of what that field holds. */
+        record OfAName(TypeSymbol worn) implements Surface {}
+
+        /** A value under no name of its own: what the shape makes readable. */
+        record OfAShape(Shape shape) implements Surface {}
+    }
+
+    /**
+     * Which of the two {@code position} is.
+     *
+     * <p>Beside the two entries and in neither, so the names a value wears come off in one place
+     * however wide the question being asked is. Decided in each, the surface a reader lists and the
+     * name it looks up could stop being the same reading.
+     */
+    private Surface surfaceOf(Type position) {
+        TypeView view = TypeView.of(position, symbols);
+        return view.isWrapped() ? new Surface.OfAName(view.wrappers().getFirst())
+                : new Surface.OfAShape(view.shape());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
@@ -38,10 +38,15 @@ import java.util.Map;
  * it read no value at every name a model reads through a sum.
  *
  * <p><b>Asked of a {@link Shape} and not of a {@link Type}.</b> A shape has had the names a value
- * wears taken off already, and whether they come off is a rule about what a {@code .} may name
- * rather than a policy each reader settles — {@link FieldRead} holds it, and is what a reader with
- * a type in hand asks. Started here, a shape would be read for a position whose names nobody had
- * decided about.
+ * wears taken off already, and how far to look through them is the reader's own: a {@code .} an
+ * author wrote looks through none of them, and a walk over a behavior's positions looks through all
+ * of them — {@link TypeView} holds both directions for that reason. Started here, that policy would
+ * be decided for every reader by whichever one asked first.
+ *
+ * <p>Which is why the readers of the first kind go through {@link FieldRead} rather than reaching a
+ * shape themselves: for them the barrier is not a policy but what a {@code .} means, and one of them
+ * settling it again is what left an editor and a compiler answering differently about one
+ * {@code x.f}. A walk over positions is the other kind and takes a shape here, as it did.
  *
  * @param declaredBy     the declarations the names are written on, outermost spread first. What a
  *                       rule over one of these fields is written on, which is not the same as what a

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
@@ -131,21 +131,28 @@ public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> decl
     /**
      * The same surface, with what each name holds answered by {@code world}.
      *
-     * <p>The one step from the declarations a name is readable on to what they hold there. A reader
-     * of an accepted program takes its field types from the check and may not read them off the
-     * declarations beside it, and a reader of a text that has not checked has no such answer to
-     * take — so which world is being read in is the caller's, and neither of them works the step
-     * out for itself.
+     * <p><b>The names are this reading's and the types are the world's.</b> Which names a value here
+     * makes readable is nominal — a record's own fields, what every case of a sum spreads — and a
+     * world says what a declaration holds under a name, never which names there are. Asked for the
+     * whole of a declaration and merged, a world could widen the surface with a name nothing here
+     * makes readable or narrow it by leaving one out, and a reader going through the one owner of
+     * this question would still be reading a surface the world had decided.
      *
-     * <p>In the order {@link #declaredBy} writes them, which is the order a value is laid out in and
-     * the order this is walked in. A sum's shared names come from the declarations its cases spread,
-     * so an accepted program answers for each of those as it answers for any other declaration it
-     * holds.
+     * <p>A name this reading has and the world says nothing about is not readable in that world.
+     * That is the state a text still being typed is in — a field written at a type that does not
+     * resolve yet is a field its world says nothing about — and it does not arise in an accepted
+     * program, whose world answers for every name its declarations write.
+     *
+     * <p>In the order this reading holds the names, which is the order the declarations write them:
+     * the order a value is laid out in, and the order this is walked and reported in.
      */
     public Map<String, Type> in(FieldTypes world) {
         Map<String, Type> out = new LinkedHashMap<>();
-        for (TypeSymbol declaration : declaredBy) {
-            out.putAll(world.of(declaration));
+        for (String name : declaredFields.keySet()) {
+            Type held = heldIn(declaredBy, name, world);
+            if (held != null) {
+                out.put(name, held);
+            }
         }
         return Collections.unmodifiableMap(out);
     }
@@ -158,15 +165,28 @@ public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> decl
      * name in hand would otherwise have every name at the position asked of the world and copied out
      * to index one of them.
      *
-     * <p>The declarations are asked in the order {@link #declaredBy} holds them and the last that
-     * answers wins, which is what {@code in(world)} merging them in that order comes to. At most one
-     * of them writes a given name in a program that was accepted — a name two of a sum's shared
-     * spreads both declared is refused where the spread is checked — so the order settles nothing
-     * today, and it is followed rather than relied on being idle.
+     * <p>Whether the name is readable at all is settled here before the world is asked, so the two
+     * widths admit the same names — and neither lets a world make a name readable that this reading
+     * does not.
      */
     public static Type at(Shape shape, String name, FieldTypes world) {
+        Readable here = readableOn(shape);
+        return here.fields().containsKey(name) ? heldIn(here.declaredBy(), name, world) : null;
+    }
+
+    /**
+     * What {@code declaredBy} holds under {@code name} in {@code world}, or null where none of them
+     * says.
+     *
+     * <p>The one rule both widths use, so a name is looked up the same way whether it was asked for
+     * on its own or with every other. Asked in the order the declarations are held and the last that
+     * answers wins: at most one of them writes a given name in a program that was accepted — a name
+     * two of a sum's shared spreads both declared is refused where the spread is checked — so the
+     * order settles nothing today, and it is followed rather than relied on being idle.
+     */
+    private static Type heldIn(List<TypeSymbol> declaredBy, String name, FieldTypes world) {
         Type held = null;
-        for (TypeSymbol declaration : readableOn(shape).declaredBy()) {
+        for (TypeSymbol declaration : declaredBy) {
             Type there = world.of(declaration).get(name);
             if (there != null) {
                 held = there;

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadableFields.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.observe.FieldTypes;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -15,6 +16,13 @@ import java.util.Map;
  * are its own fields; a sum's are the fields of the declarations every one of its cases spreads,
  * which are readable at every value of the sum because every value of it carries them.
  *
+ * <p><b>Which names, and not what they hold.</b> Which declarations make a name readable is nominal
+ * and is answered here. What one of those declarations holds under that name is
+ * {@link FieldTypes}', asked of the world the reading is being made in — {@link #in} is that step,
+ * and it is how a reader of an accepted program reads a surface without deriving a second answer to
+ * what a field holds. {@link #declaredFields} is the same surface with the types the declarations
+ * were read with, which is what a reader in that world already has.
+ *
  * <p><b>Not what a value here is built out of.</b> {@link ConstructionDescent} answers that, and the
  * two answers are the same map at a record and are not the same question: a value of a sum is a
  * value of one of its cases, and a product of the shared fields is a value of none of them. Read
@@ -29,24 +37,25 @@ import java.util.Map;
  * to be that case. The written relation answers nothing at a sum's shared name, so a walk that took
  * it read no value at every name a model reads through a sum.
  *
- * <p><b>Asked of a {@link Shape} and not of a {@link Type}.</b> How far to look through the names a
- * value wears is the reader's own policy — the elaboration of a field read looks through none of
- * them, and a walk over a behavior's positions looks through all of them — and {@link TypeView}
- * holds both directions for that reason. Started here, that policy would be decided for every
- * reader by whichever one asked first.
+ * <p><b>Asked of a {@link Shape} and not of a {@link Type}.</b> A shape has had the names a value
+ * wears taken off already, and whether they come off is a rule about what a {@code .} may name
+ * rather than a policy each reader settles — {@link FieldRead} holds it, and is what a reader with
+ * a type in hand asks. Started here, a shape would be read for a position whose names nobody had
+ * decided about.
  *
- * @param declaredBy the declarations the names are written on, outermost spread first. What a rule
- *                   over one of these fields is written on, which is not the same as what a value
- *                   standing here is written as: a sum's shared names are declared by the data its
- *                   cases spread, and a value there is written as one of the cases
- * @param fields     what is readable, in the order the declarations write it — which is the order
- *                   it is walked and reported in
+ * @param declaredBy     the declarations the names are written on, outermost spread first. What a
+ *                       rule over one of these fields is written on, which is not the same as what a
+ *                       value standing here is written as: a sum's shared names are declared by the
+ *                       data its cases spread, and a value there is written as one of the cases
+ * @param declaredFields what is readable, with what the declarations this was read from say each
+ *                       name holds, in the order those declarations write it — which is the order it
+ *                       is walked and reported in
  */
-public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> fields) {
+public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> declaredFields) {
 
     public ReadableFields {
         declaredBy = List.copyOf(declaredBy);
-        fields = Collections.unmodifiableMap(new LinkedHashMap<>(fields));
+        declaredFields = Collections.unmodifiableMap(new LinkedHashMap<>(declaredFields));
     }
 
     /**
@@ -117,5 +126,52 @@ public record ReadableFields(List<TypeSymbol> declaredBy, Map<String, Type> fiel
                  Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ ->
                     NOTHING;
         };
+    }
+
+    /**
+     * The same surface, with what each name holds answered by {@code world}.
+     *
+     * <p>The one step from the declarations a name is readable on to what they hold there. A reader
+     * of an accepted program takes its field types from the check and may not read them off the
+     * declarations beside it, and a reader of a text that has not checked has no such answer to
+     * take — so which world is being read in is the caller's, and neither of them works the step
+     * out for itself.
+     *
+     * <p>In the order {@link #declaredBy} writes them, which is the order a value is laid out in and
+     * the order this is walked in. A sum's shared names come from the declarations its cases spread,
+     * so an accepted program answers for each of those as it answers for any other declaration it
+     * holds.
+     */
+    public Map<String, Type> in(FieldTypes world) {
+        Map<String, Type> out = new LinkedHashMap<>();
+        for (TypeSymbol declaration : declaredBy) {
+            out.putAll(world.of(declaration));
+        }
+        return Collections.unmodifiableMap(out);
+    }
+
+    /**
+     * What {@code name} holds where it is readable off a value of this shape in {@code world}, or
+     * null where nothing of that name is readable there.
+     *
+     * <p>{@link #in} asked about one name, and here for the reason {@link #at} is: a reader with one
+     * name in hand would otherwise have every name at the position asked of the world and copied out
+     * to index one of them.
+     *
+     * <p>The declarations are asked in the order {@link #declaredBy} holds them and the last that
+     * answers wins, which is what {@code in(world)} merging them in that order comes to. At most one
+     * of them writes a given name in a program that was accepted — a name two of a sum's shared
+     * spreads both declared is refused where the spread is checked — so the order settles nothing
+     * today, and it is followed rather than relied on being idle.
+     */
+    public static Type at(Shape shape, String name, FieldTypes world) {
+        Type held = null;
+        for (TypeSymbol declaration : readableOn(shape).declaredBy()) {
+            Type there = world.of(declaration).get(name);
+            if (there != null) {
+                held = there;
+            }
+        }
+        return held;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
@@ -101,7 +101,7 @@ sealed interface ValueReading {
 
         @Override
         public Map<String, Type> named() {
-            return readable.fields();
+            return readable.declaredFields();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -235,7 +235,7 @@ final class ValueClassGen {
             // A field every case spreads is readable on the sum (issue #160): declared here, and
             // implemented by each case record's accessor of the same name and descriptor.
             if (TypeView.of(Type.ref(sum.declares()), symbols).shape() instanceof Shape.Sum shape) {
-                for (Map.Entry<String, Type> e : ReadableFields.of(shape).fields().entrySet()) {
+                for (Map.Entry<String, Type> e : ReadableFields.of(shape).declaredFields().entrySet()) {
                     cb.withMethod(e.getKey(), MethodTypeDesc.of(jvmType(e.getValue())),
                             ClassFile.ACC_PUBLIC | ClassFile.ACC_ABSTRACT, mb -> { });
                 }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -979,14 +979,12 @@ public final class FixtureReader {
                 }
                 yield out;
             }
-            // A row's operand is compiled and run, so a field a row takes is read by the module's
-            // own code and typed by the elaboration like any other. What is read here is a value
-            // composed elsewhere and asked about at this module's boundary, and nothing composes one
-            // of those out of a field access. Read instead of refused, this would be a second
-            // reading of what a `.` names, answering beside the one the language is checked by.
-            case Hir.FieldAccess _ -> throw new IllegalStateException(
-                    "a value asked about at a boundary is composed, and no composition takes a field"
-                            + " off another value");
+            // A field taken off another value is one of the forms this does not read, and it is
+            // refused here as they all are. Reading it would be a second reading of what a `.`
+            // names, answering beside the one the language is checked by: a row's operand is
+            // compiled and run, so the field a row takes is typed by the elaboration like any
+            // other, and what reaches here instead is a value named at a boundary — which stands
+            // for whatever the module wrote, up to and including this.
             default -> throw new FixtureException("an example fixture must be a literal or a construction");
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -1136,6 +1136,11 @@ public final class FixtureReader {
                             || isFromList(c)) ->
                     STATES_NO_NAME;
             case Hir.Apply _ -> ELSEWHERE;
+            // A field taken off another value is a form this reading refuses, and it is refused
+            // where it is read. Answered as a value under no name, the rule about names would reach
+            // it first and tell whoever wrote it about the name a position takes, which is not what
+            // is wrong with it.
+            case Hir.FieldAccess _ -> ELSEWHERE;
             case null, default -> STATES_NO_NAME;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -5,9 +5,7 @@ import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.CallElaborator;
-import souther.compiler.check.DeclaredTypeEvidence;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.core.Kernel;
 import souther.compiler.observe.Asserted;
 import souther.compiler.observe.Expectation;
@@ -41,8 +39,6 @@ import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -984,151 +980,15 @@ public final class FixtureReader {
                 }
                 yield out;
             }
-            case Hir.FieldAccess fa -> rawProjection(fa, at, admission);
+            // A row's operand is compiled and run, so a field a row takes is read by the module's
+            // own code and typed by the elaboration like any other. What is read here is a value
+            // composed elsewhere and asked about at this module's boundary, and nothing composes one
+            // of those out of a field access. Read instead of refused, this would be a second
+            // reading of what a `.` names, answering beside the one the language is checked by.
+            case Hir.FieldAccess _ -> throw new IllegalStateException(
+                    "a value asked about at a boundary is composed, and no composition takes a field"
+                            + " off another value");
             default -> throw new FixtureException("an example fixture must be a literal or a construction");
-        };
-    }
-
-    /**
-     * A value a field is taken off, and what says what that value is.
-     *
-     * <p>This is not a type for reading a target and throwing away. Projection consumes one of these
-     * and produces one, so a chain stays in this domain: what a helper answered is still its answer
-     * at the second field and at the third. A value that has been through {@link NeutralForm#of} no
-     * longer says what it is — a newtype is read there as what it wraps — so anything that turned a
-     * step of a chain back into an ordinary value would lose the evidence the next step is held by.
-     */
-    private sealed interface Projected {
-
-        /** Built by this reader, under the type a declaration gives it. */
-        record Declared(Position at, Object value) implements Projected {}
-
-        /** A helper's answer, before it became a form: the value itself says what it is. */
-        record Live(Object value, String written) implements Projected {}
-    }
-
-    /**
-     * The value a field is taken off. A name and a {@code let} stand for what they hold, as they do
-     * anywhere, so a helper's answer is its answer whether the row wrote the call or a name for it.
-     *
-     * <p>The answer is taken before it becomes a form, and the helper runs once — here, at the foot
-     * of however long the chain above it is.
-     */
-    private Projected projectTarget(Hir.Expr e, Admission admission) {
-        Admission below = admission == Admission.UNHELD ? admission : Admission.HELD_BELOW;
-        return switch (e) {
-            case Hir.FieldAccess inner -> takeField(projectTarget(inner.target(), admission), inner);
-            case Hir.LetIn let -> {
-                BindingId binding = let.binder().id();
-                bindings.put(binding, let.value());
-                try {
-                    yield projectTarget(let.body(), admission);
-                } finally {
-                    bindings.remove(binding);
-                }
-            }
-            // A name that names nothing falls to the reading below with everything else a field
-            // cannot be taken off, and is refused there rather than guessed at here.
-            case Hir.Var.Denoting v -> {
-                ValueName denotes = v.denotes();
-                Hir.Expr body = denotes instanceof ValueName.Local local ? bindings.get(local.id())
-                        : denotes instanceof ValueName.Helper ? valueBody(v.name()) : null;
-                // A name standing for no value is not one a field can be taken off; the ordinary
-                // reading below says what it is instead of this one guessing.
-                // Read at the type the name is declared with, which is the position it stands at:
-                // the same type this hands on as the evidence of what was projected. Reading it at
-                // no position would leave the form to be worked out from the case rather than from
-                // where the value is (issue #683).
-                yield body == null ? projectedAtItsDeclaredType(v, below)
-                        : expanding(denotes, () -> projectTarget(body, admission));
-            }
-            default -> projectedAtItsDeclaredType(e, below);
-        };
-    }
-
-    /** What a projection takes a field off, read at the type it is declared with — the one type the
-     *  evidence it carries is stated in, so the value and the type it is read at come from one place. */
-    private Projected projectedAtItsDeclaredType(Hir.Expr e, Admission below) {
-        Type declared = declaredTypeOf(e, new HashSet<>());
-        // Nothing declares what a name that stands for no value is, so nothing reads it here either.
-        Position at = declared == null ? Position.UNREAD : Position.at(declared);
-        return new Projected.Declared(at, raw(e, at, below));
-    }
-
-    /** One step of a chain: evidence in, evidence out. */
-    private Projected takeField(Projected target, Hir.FieldAccess fa) {
-        return switch (target) {
-            case Projected.Live(Object value, String written) -> {
-                // Which field may be taken is the declaration's to say, and it is asked before
-                // anything is read off the value. What reads it is reflection over a no-arg method,
-                // and a fixture is not elaborated, so a value's Java surface would otherwise be
-                // reachable as though it were the data's — `.isEmpty` on a `String` is a method
-                // here and a field nowhere.
-                TypeSymbol answered = typeOf(value);
-                if (answered == null || fieldTypeOf(Type.ref(answered), fa.field()) == null) {
-                    throw new FixtureException("`" + written + "` answered with a value that"
-                            + " declares no field `" + fa.field() + "`");
-                }
-                // A Souther value never answers a Java null — an absent optional is a value of its
-                // own — so a null here is an accessor this value does not have.
-                Object taken = ObservedValues.readOrNull(value, fa.field());
-                if (taken == null) {
-                    throw new FixtureException("`" + written + "` answered with a value that has no"
-                            + " field `" + fa.field() + "`");
-                }
-                yield new Projected.Live(taken, written + "." + fa.field());
-            }
-            case Projected.Declared(Position at, Object value) -> {
-                Type type = at instanceof Position.At(Type read) ? read : null;
-                Type taken = type == null ? null : fieldTypeOf(type, fa.field());
-                if (taken == null) {
-                    // A value that has no fields at all and a record that has not this one are two
-                    // mistakes, and a row is told which of them it made.
-                    throw new FixtureException(
-                            type instanceof Type.Ref r && !r.name().isPrimitive()
-                                    ? "`" + Type.show(type) + "` declares no field `" + fa.field() + "`"
-                                    : "`" + fa.field() + "` is read off a value that is not a record,"
-                                            + " so it has no field to take");
-                }
-                // A newtype is read as what it wraps (ADR-0032), so there is no field map to ask
-                // for it. What makes this one is the declaration and not the shape the value
-                // happens to have — a bare number is not a newtype for having reached here.
-                if (type instanceof Type.Ref r && neutral.isNewtype(r.name())) {
-                    yield new Projected.Declared(Position.at(taken), value);
-                }
-                if (!(value instanceof Map<?, ?> fields)) {
-                    throw new FixtureException("`" + fa.field()
-                            + "` is read off a value that is not a record, so it has no field to take");
-                }
-                // A `?` field holding nothing leaves its key out, which is the absent optional itself.
-                yield new Projected.Declared(Position.at(taken), fields.get(fa.field()));
-            }
-        };
-    }
-
-    /**
-     * A field taken off a value, in the neutral form the decoder reads. Only the outermost step
-     * stands at a position, so only it admits and only it becomes a form.
-     */
-    private Object rawProjection(Hir.FieldAccess fa, Position at, Admission admission) {
-        return switch (projectTarget(fa, admission)) {
-            // Held by `states` before this frame was read, but built at the position the field
-            // declares rather than at this one. A neutral form is decided by a position and not
-            // only by a type, so a newtype admitted into a sum that lists it is written the way
-            // that position reads before it reaches a decoder.
-            case Projected.Declared(Position built, Object value) -> neutral.reread(value, built, at);
-            case Projected.Live(Object value, String written) -> {
-                // What the answer says is read off the answer, so a field holding an empty
-                // collection names no element type here — the limit every helper's answer is read
-                // under, and not one taking a field off it introduces.
-                if (admission == Admission.HELD) {
-                    admitBuilt(value, at, written);
-                }
-                // Named by the path it was reached along, not as what something answered with: by
-                // here `written` has a field appended for every step taken ({@link #takeField}), so
-                // it names this value rather than the application that produced the one above it.
-                yield neutral.of(value, at, "`" + written + "`");
-            }
         };
     }
 
@@ -1195,12 +1055,6 @@ public final class FixtureReader {
         /** A construction, or a name denoting a case: this name, said here. */
         record Name(TypeSymbol name) implements Stated {}
 
-        /** A field taken: its declaration says the whole of what was supplied, and the value found
-         *  there is not read. This is the one frame that states a complete type, which is why it is
-         *  held by assignability rather than by a name — a field declaring a {@code List<AmountN>}
-         *  supplies one while it is empty, and no value there could have said so. */
-        record Declared(Type type) implements Stated {}
-
         /** A value under no name: a literal, a written collection, a temporal, an arithmetic fold. */
         record NoName() implements Stated {}
 
@@ -1249,21 +1103,6 @@ public final class FixtureReader {
                     throw wrongName(named, held, expected);
                 }
             }
-            // A complete type against a complete position, at every depth in one answer: the name a
-            // collection's elements wear is part of what the position is, and reading it off the
-            // elements would say nothing where there are none. An optional makes room for what it
-            // holds, so the position it holds is the one this stands at.
-            case Stated.Declared(Type supplied) -> {
-                // The whole position first. An optional takes what it holds as well as a value of
-                // itself, so unwrapping it before asking would refuse the field that declares the
-                // same optional the position does.
-                if (!TypeOps.assignable(supplied, expected, symbols)
-                        && !(expected instanceof Type.OptionOf o
-                                && TypeOps.assignable(supplied, o.element(), symbols))) {
-                    throw new FixtureException("a field declaring `" + Type.show(supplied)
-                            + "` states no value of `" + Type.show(expected) + "`");
-                }
-            }
             case Stated.NoName _ -> {
                 if (held instanceof Admits.OneOf(Set<TypeSymbol> names)) {
                     throw noName(names, expected);
@@ -1276,8 +1115,7 @@ public final class FixtureReader {
      * What the written form says here.
      *
      * <p>Read off the text and never by running anything: an application answers {@code Elsewhere},
-     * so the helper is run once, where it is read, and {@link #admitBuilt} holds the value it
-     * answered with.
+     * so the helper is run once, where it is read, and the value it answered with is held there.
      *
      * <p>A name that is not a value, and a call that is no construction, answer {@code Elsewhere}
      * too. Each is refused where it is read, for being what it is, and a rule about names would
@@ -1301,10 +1139,6 @@ public final class FixtureReader {
                             || isFromList(c)) ->
                     STATES_NO_NAME;
             case Hir.Apply _ -> ELSEWHERE;
-            case Hir.FieldAccess fa -> {
-                Type declared = declaredTypeOf(fa, new HashSet<>());
-                yield declared == null ? ELSEWHERE : new Stated.Declared(declared);
-            }
             case null, default -> STATES_NO_NAME;
         };
     }
@@ -1313,42 +1147,6 @@ public final class FixtureReader {
      *  asks, and {@link #represents} is the same discipline the other way about. */
     TypeSymbol typeOf(Object value) {
         return neutral.typeOf(value);
-    }
-
-    /**
-     * The type a field is declared to be, one step. What a value of a declaration is made of is
-     * what the check settled, and this is that answer — the same one the place a field's value is
-     * compared at is read from, so a projection cannot be typed by one reading and compared by
-     * another.
-     */
-    private Type fieldTypeOf(Type record, String field) {
-        return record instanceof Type.Ref(TypeSymbol owner)
-                ? fields.field(owner, field) : null;
-    }
-
-    /** What declarations say about what this row wrote, with what a {@code let} has in force here.
-     *  The pass that emits the methods a row's calls need reads the same walk, so what settles a
-     *  call there is what settles it here. */
-    private DeclaredTypeEvidence evidence() {
-        return new DeclaredTypeEvidence(symbols, fields, values,
-                DeclaredTypeEvidence.boundTo(bindings));
-    }
-
-    /**
-     * What a fixture expression is declared to be, or null where no declaration of this module's
-     * says — which is where a helper stands, since what a helper was declared to answer with is not
-     * read and what it supplied is its answer's to say.
-     *
-     * <p>Nothing is run here. This walk reads names {@code Resolve} already settled, so asking it
-     * costs no helper a second application against the row's one budget.
-     */
-    private Type declaredTypeOf(Hir.Expr e, Set<ValueName> seen) {
-        // The walk's own binding environment starts from what the reading around it has in force: a
-        // `let` the walk enters has to be in force for the name it binds, and so does one the
-        // reading entered before it got here. Two walks over one expression that disagree about
-        // what is in scope disagree about what is admitted.
-        return evidence().declaredTypeOf(e, seen,
-                new HashMap<>(DeclaredTypeEvidence.boundTo(bindings)));
     }
 
     /** A name resolved to a case, or a value under no name where this module has no such case — the
@@ -1373,25 +1171,6 @@ public final class FixtureReader {
             // a fixture can name, which the reading says of it.
             case null, default -> ELSEWHERE;
         };
-    }
-
-    /**
-     * What a helper answered with, held to the position it stands at and to every position inside it.
-     *
-     * <p>The value is the whole of the evidence: what the helper was declared to answer with is not
-     * read, so one that declares nothing is held to the same rule as one that declares everything.
-     * Inside it too, because a name a position wears is worn at every depth — a helper answering a
-     * {@code List<Int>} has not answered a {@code List<AmountN>}, and reading it back element by
-     * element would put each number where a name stands.
-     */
-    private void admitBuilt(Object answer, Position at, String written) {
-        // Where nothing reads the value there is no type it could fail to be a value of; what admits
-        // a helper's answer there is the case it turned out to be, asked where the answer stands.
-        if (!(at instanceof Position.At(Type expected)) || holds(answer, expected)) {
-            return;
-        }
-        throw new FixtureException("`" + written + "` answered with a `" + nameOfBuilt(answer)
-                + "`, which is not a value of `" + Type.show(expected) + "`");
     }
 
     private FixtureException wrongName(TypeSymbol supplied, Admits admits, Type expected) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -44,7 +44,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Reads a written fixture as the value it states, against the type of the position it is written in.
@@ -252,10 +251,10 @@ public final class FixtureReader {
     /**
      * Whether {@code position} holds {@code value} as it stands at run time, at every depth.
      *
-     * <p>The one reading of a built value, which the stand-in a row writes and the value a helper
-     * answered with are both put through: a scalar is the class its values arrive in, a name is any
-     * of the leaves it holds — a sum has no class of its own — an optional is absence or what it
-     * holds, and a collection of the right container holds what its element type holds.
+     * <p>The one reading of a built value, which the stand-in a row writes is put through: a scalar
+     * is the class its values arrive in, a name is any of the leaves it holds — a sum has no class
+     * of its own — an optional is absence or what it holds, and a collection of the right container
+     * holds what its element type holds.
      *
      * <p>A position that says none of those holds anything. There is nothing here to refuse it with:
      * a type variable is decided by each call and a position with no declared type says nothing, and
@@ -1331,17 +1330,13 @@ public final class FixtureReader {
      */
     private final Deque<ValueName> expanding = new ArrayDeque<>();
 
+    /**
+     * The body a name stands for, read where the name is written — with the name held open while it
+     * is, so a value defined in terms of itself is reported as the cycle it is rather than read
+     * until the stack runs out.
+     */
     private Object expandedValue(ValueName named, Hir.Expr body, Position at,
                                  Admission admission) {
-        return expanding(named, () -> raw(body, at, admission));
-    }
-
-    /**
-     * The cycle check every expansion of a name goes through, whatever reading is doing the
-     * expanding. One check, so a cycle reached through a field taken off a value is reported as the
-     * cycle it is rather than as whatever the second walk happened to make of it.
-     */
-    private <T> T expanding(ValueName named, Supplier<T> read) {
         if (expanding.contains(named)) {
             List<String> cycle = new ArrayList<>();
             expanding.forEach(open -> cycle.add(open.name()));
@@ -1351,7 +1346,7 @@ public final class FixtureReader {
         }
         expanding.addLast(named);
         try {
-            return read.get();
+            return raw(body, at, admission);
         } finally {
             expanding.removeLast();
         }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -83,8 +83,6 @@ public final class FixtureReader {
     private final OperandRunner operands;
     /** What a value looks like in the form a decoder reads — the rules both directions of a row read. */
     private final NeutralForm neutral;
-    /** What a value of a declaration is made of, as the check settled it. */
-    private final FieldTypes fields;
     /** The same answer as the places a comparison reads a value's parts at. */
     private final ValueTypes types;
 
@@ -93,10 +91,12 @@ public final class FixtureReader {
                   MemoryClassLoader loader) {
         this.module = module;
         this.symbols = symbols;
-        this.fields = fields;
         this.values = values;
         this.loader = loader;
         this.operands = new OperandRunner(module.name(), loader);
+        // What a declaration is laid out as reaches this reading through the two that read a value
+        // by it, and is not held beside them: a reader here asks one of those, and one that asked
+        // the declarations itself would be a third answer about what a value's parts are.
         this.neutral = new NeutralForm(symbols, fields);
         this.types = ValueTypes.over(fields);
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -2,7 +2,6 @@ package souther.compiler.examples;
 
 import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.ast.Hir;
-import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Boundary;
 import souther.compiler.check.DeclaredTypeEvidence;
 import souther.compiler.check.Symbols;
@@ -300,105 +299,6 @@ final class NeutralForm {
     }
 
     /**
-     * A value already in the neutral form of {@code from}, read at {@code to}.
-     *
-     * <p>A neutral form is decided by a position and not only by a type: a newtype is bare where the
-     * position reads it as itself and wears the envelope where the position is a sum that lists it
-     * (<<sum-discrimination>>). So a value that was built at one position and now stands at another
-     * is written the way the second one reads, and a collection's elements move with it.
-     *
-     * <p>Only the widening direction has to be answered, because it is the only one admission lets
-     * through: a case reaches a position typed by a sum that lists it, never the other way.
-     *
-     * <p>Moving to a {@link Position.Unread} leaves the value as it stands. What a position adds is
-     * what it asks to be written beside the case, and a place nothing reads asks for nothing — it
-     * does not ask for what is already there to come off. Re-rendering a value into the case's own
-     * form on the way to one would lose what the form it is in carries: an enumeration's {@code
-     * "Draft"} says which case it is, and the {@code {}} it would become says nothing, with nothing
-     * left to put it back from.
-     *
-     * <p>Moving from one is not a reading. A value whose form nothing decided is in the case's own
-     * form, and that form does not say which case it is — {@code {}} is every unit case — so there is
-     * nothing here to write a discriminator from. Nothing asks for it: a value reaches this having
-     * been built at the type a declaration gave it, and a projection whose target declares nothing is
-     * refused before it gets here. Stated rather than answered with the value, which would be right
-     * only for as long as that stays true.
-     */
-    Object reread(Object value, Position from, Position to) {
-        if (from instanceof Position.At(Type a) && to instanceof Position.At(Type b)) {
-            return reread(value, a, b);
-        }
-        if (from instanceof Position.Unread && to instanceof Position.At) {
-            throw new IllegalStateException("a value nothing read is in the case's own form, which"
-                    + " does not say which case it is, so it cannot be read at " + to);
-        }
-        return value;
-    }
-
-    private Object reread(Object value, Type from, Type to) {
-        if (value == null || from.equals(to)) {
-            return value;
-        }
-        if (from instanceof Type.OptionOf a) {
-            return reread(value, a.element(), to instanceof Type.OptionOf b ? b.element() : to);
-        }
-        if (to instanceof Type.OptionOf b) {
-            return reread(value, from, b.element());
-        }
-        if (sequenceElementOf(from) instanceof Type a && sequenceElementOf(to) instanceof Type b
-                && value instanceof List<?> elements) {
-            List<Object> out = new ArrayList<>(elements.size());
-            for (Object each : elements) {
-                out.add(reread(each, a, b));
-            }
-            return out;
-        }
-        if (from instanceof Type.MapOf a && to instanceof Type.MapOf b
-                && value instanceof Map<?, ?> entries) {
-            Map<Object, Object> out = new LinkedHashMap<>();
-            for (Map.Entry<?, ?> each : entries.entrySet()) {
-                out.put(reread(each.getKey(), a.key(), b.key()),
-                        reread(each.getValue(), a.value(), b.value()));
-            }
-            return out;
-        }
-        if (from instanceof Type.Ref r && isNewtype(r.name())) {
-            // Bare here, because `from` is the newtype's own reference and reads it as itself.
-            return newtypeAt(Position.at(to), r.name(), value);
-        }
-        // A unit case travels as a bare name where its position reads one — an enumeration — and
-        // carries its sum's discriminator where it does not. So a case standing at an enumeration
-        // stops being a name the moment it is admitted into a sum that also lists a product.
-        if (value instanceof String written && from instanceof Type.Ref r
-                && !r.name().isPrimitive()) {
-            // Which case this is, is `from`'s to say. Resolving the name here would answer for
-            // whatever this module declares under that spelling, and the type the value stands at
-            // may be one another module published — the reason the overload above takes a resolved
-            // name rather than one spelled at the call.
-            for (TypeSymbol caseName : AtomSpace.subjectAtoms(from, symbols)) {
-                if (!caseName.name().equals(written)
-                        || symbols.declaredNode(caseName) instanceof Hir.Data) {
-                    continue;
-                }
-                if (readsABareName(Position.at(to))) {
-                    return written;
-                }
-                Map<String, Object> unit = new LinkedHashMap<>();
-                tagged(Position.at(to), caseName, unit);
-                return unit;
-            }
-        }
-        return value;
-    }
-
-    /** The element a list or a set holds, or null where the type holds neither. Narrower than the
-     *  reading a position gives, which opens an optional and reads a map's entry as a pair. */
-    private static Type sequenceElementOf(Type type) {
-        return type instanceof Type.ListOf l ? l.element()
-                : type instanceof Type.SetOf s ? s.element() : null;
-    }
-
-    /**
      * Whether this place reads a unit case as a bare name: it is typed as an enumeration, whose
      * external form is the case's name (spec §sum-discrimination).
      *
@@ -440,7 +340,7 @@ final class NeutralForm {
     /** What a newtype wraps: the one field it is written with (spec §newtype), read like any other
      *  field, so a generic base ({@code data 在庫 = Map<商品ID, Int>}) keeps its type arguments. */
     Type newtypeBaseType(TypeSymbol name) {
-        return fields.field(name, NEWTYPE_FIELD);
+        return fields.of(name).get(NEWTYPE_FIELD);
     }
 
     /** What a newtype's one field is called (spec §newtype). */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -697,7 +697,7 @@ public final class InputDomain {
             // language reads a value.
             case TermPath.Step.Field field -> under instanceof StructuralInspection.Decomposed made
                     ? made.under().get(field.name())
-                    : ReadableFields.of(shape).fields().get(field.name());
+                    : ReadableFields.of(shape).declaredFields().get(field.name());
             case TermPath.Step.Element _ -> under instanceof StructuralInspection.Retained on
                     && on.continuation() instanceof StructuralInspection.Continuation.Elements held
                     ? held.element() : null;
@@ -1001,7 +1001,7 @@ public final class InputDomain {
      * reached without one.
      */
     private static List<String> sharedAt(ReadablePosition input) {
-        return List.copyOf(ReadableFields.of(input.shape()).fields().keySet());
+        return List.copyOf(ReadableFields.of(input.shape()).declaredFields().keySet());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/observe/FieldTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/FieldTypes.java
@@ -8,11 +8,26 @@ import java.util.Map;
 /**
  * What a declared data's fields hold.
  *
- * <p>The one question anything reading a value's parts asks of the declarations, and the only one:
- * given the declaration a value is of, what each field of it contains. Where a reader takes a field
- * of a value, decides what order a sequence there is compared on, or types the {@code x.field} a
- * text wrote, this is what it asks — so the answer a comparison is made against and the answer a
- * projection is typed by are the same answer.
+ * <p>One declaration's own layout, and nothing about a type. What is asked here is what a value of
+ * <em>this declaration</em> is laid out as, so a caller has already settled which declaration it is
+ * walking — the case a value turned out to be, the newtype a name was taken off. A whole declaration
+ * and not one field of it, because the fields of one are an order as much as a set: a value is laid
+ * out in it, and a reader writing a value's parts out follows it.
+ *
+ * <p><b>Not what a {@code .} may name.</b> {@code souther.compiler.check.FieldRead} answers that,
+ * and it is the only thing that crosses a {@code .} on a type. The two are the same map at a record
+ * and are not the same question: a sum lays out no field of its own, and a name every one of its
+ * cases spreads is readable on every value of it. Asked here, that name comes back as a field
+ * nothing declares — which is a true answer to this question and the wrong answer to that one.
+ *
+ * <p><b>What keeps that apart is the census over the callers of {@link #of}, and not this type.</b>
+ * A reader holding a position can still spell {@code of(ref.name())} and get the layout, and one
+ * did — the snapshot an editor asks what may follow a {@code .} was written that way and offered an
+ * author nothing where the language reads a shared name. Both worlds are keyed by the declaration's
+ * name, which is what a {@code Type.Ref} carries, so a key this could take that a position could not
+ * be turned into does not exist. {@code NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest}
+ * holds the callers of this method as an exact set instead, and a reader that arrives is a finding
+ * there rather than a silence here.
  *
  * <p>Whoever holds the declarations answers it, and a reader may not work one out beside them. A
  * checked program's fields are what its check settled ({@code core.ValueShape}); an editor reading
@@ -20,11 +35,6 @@ import java.util.Map;
  * worlds and not two accounts of one: what a reader is handed says which world it is reading in,
  * and no reader in the accepted one may fall back to reading declarations itself when the checked
  * answer is missing.
- *
- * <p>{@link #of} answers for a whole declaration because the fields of one are an order as much as
- * a set: a value is laid out in it, and a reader writing a value's parts out follows it. A reader
- * after one field asks for one ({@link #field}), and the two cannot disagree because the second is
- * the first.
  */
 public interface FieldTypes {
 
@@ -52,10 +62,4 @@ public interface FieldTypes {
      * A newtype is a product of the one field it is written with, and is answered like any other.
      */
     Map<String, Type> of(TypeSymbol owner);
-
-    /** What {@code owner} declares its {@code field} to hold, or null where it declares no such
-     *  field. */
-    default Type field(TypeSymbol owner, String field) {
-        return of(owner).get(field);
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/ValueTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/ValueTypes.java
@@ -43,7 +43,7 @@ public final class ValueTypes {
      * written with.
      */
     public Position field(TypeSymbol owner, String field) {
-        Type declared = fields.field(owner, field);
+        Type declared = fields.of(owner).get(field);
         return declared == null ? Position.UNREAD : Position.at(declared);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3362,8 +3362,14 @@ public final class Adequacy {
             // What a value is declared to be, asked of the one walk that answers it. A second
             // reading of a definition's type here would be a second answer about what a row may
             // name, differing from the reading that builds the row at whatever either forgot.
+            // Refusing where a declaration does not read, because this is downstream of a check:
+            // one that does not read was refused there, so meeting one here is this compiler being
+            // wrong rather than a module being written.
             souther.compiler.check.DeclaredTypeEvidence evidence =
-                    new souther.compiler.check.DeclaredTypeEvidence(symbols, fields, values);
+                    new souther.compiler.check.DeclaredTypeEvidence(
+                            new souther.compiler.check.FieldRead(symbols, fields,
+                                    souther.compiler.check.FieldRead.Unreadable.REFUSED),
+                            values);
             Map<TypeSymbol, List<String>> stated = new LinkedHashMap<>();
             for (Map.Entry<String, Hir.FnDef> each : values.entrySet()) {
                 if (!each.getValue().params().isEmpty()

--- a/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
@@ -153,7 +153,7 @@ public final class SemanticSnapshot {
      * the resolved module here.
      */
     private DeclaredTypeEvidence declarations() {
-        return new DeclaredTypeEvidence(symbols, fields(), Map.of());
+        return new DeclaredTypeEvidence(fieldRead(), Map.of());
     }
 
     /**
@@ -358,7 +358,20 @@ public final class SemanticSnapshot {
      * a name in it is owed what its declarations denote now.
      */
     public Map<String, Type> fieldsOf(TypeFact held) {
-        return new FieldRead(symbols, fields()).at(held.type());
+        return fieldRead().at(held.type());
+    }
+
+    /**
+     * What a {@code .} may name, as the text stands.
+     *
+     * <p>The same reading the compiler types a field access by, in the world an editor reads: a
+     * declaration that does not read yet — one name written twice, a spread of something that is no
+     * product — makes nothing readable rather than being refused here. What is wrong with it is
+     * reported where the module is checked, and an author who is being told that already is not
+     * also told that the buffer cannot answer what may follow a {@code .}.
+     */
+    private FieldRead fieldRead() {
+        return new FieldRead(symbols, fields(), FieldRead.Unreadable.MAKES_NOTHING_READABLE);
     }
 
     /** What a declaration holds, as the text has resolved it so far. */
@@ -392,7 +405,7 @@ public final class SemanticSnapshot {
             return null;
         }
         Map<BindingId, BindingEvidence> parameters = parametersOfEveryBehavior();
-        return new DeclaredTypeEvidence(symbols, fields(), values.value(), parameters)
+        return new DeclaredTypeEvidence(fieldRead(), values.value(), parameters)
                 .declaredTypeOf(e, new HashSet<>(), new HashMap<>(parameters));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
+++ b/souther-compiler/src/main/java/souther/compiler/sites/SemanticSnapshot.java
@@ -5,6 +5,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.check.BindingEvidence;
 import souther.compiler.check.DeclaredTypeEvidence;
+import souther.compiler.check.FieldRead;
 import souther.compiler.check.ResolvedFieldTypes;
 import souther.compiler.check.Sig;
 import souther.compiler.check.DerivedSymbols;
@@ -22,7 +23,6 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.ValueName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSpelling;
-import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -345,16 +345,20 @@ public final class SemanticSnapshot {
     }
 
     /**
-     * The fields a value of {@code held} has, each with what it is declared to be.
+     * The names a {@code .} written on a value of {@code held} may take, each with what it holds.
+     *
+     * <p>The same reading a field access is typed by, so what an author is offered here is what the
+     * compiler will accept: a record's own fields, a name every case of a sum spreads, a newtype's
+     * {@code value} and nothing of what it wraps. Answered from the layout of the declaration the
+     * type names instead, a sum would offer nothing while the language reads its shared names on
+     * every value of it.
      *
      * <p>Asked of what a declaration holds at this revision, which is the reading an editor is owed:
      * a module still being typed has no checked answer about a value of it, and a reader looking at
-     * a name in it is owed what its declarations denote now. What a newtype has, what a spread
-     * brings in, what is not a declared type at all — none of that is decided here.
+     * a name in it is owed what its declarations denote now.
      */
     public Map<String, Type> fieldsOf(TypeFact held) {
-        return held.type() instanceof Type.Ref(TypeSymbol owner)
-                ? fields().of(owner) : Map.of();
+        return new FieldRead(symbols, fields()).at(held.type());
     }
 
     /** What a declaration holds, as the text has resolved it so far. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
@@ -149,7 +149,8 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
         assertEquals(Map.of(), c.db().ask(new Shapes.ValueShapes("demo")).value(),
                 "the clause did not elaborate, so the check settled nothing about `Bad`");
 
-        assertEquals(Type.INT, new ResolvedFieldTypes(scope).field(bad, "n"),
+        assertEquals(Type.INT,
+                new FieldRead(scope, new ResolvedFieldTypes(scope)).of(Type.ref(bad), "n"),
                 "and what the declaration denotes is still there to be read");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldAccessIsTypedByTheWorldsOwnAnswerTest.java
@@ -61,7 +61,7 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
     /** What the check settled, which is what an accepted program's readers are handed. */
     @Test
     void aFieldIsWhatTheCheckSettledItHolds() {
-        Type taken = new DeclaredTypeEvidence(symbols, checked(), values)
+        Type taken = new DeclaredTypeEvidence(reading(checked()), values)
                 .declaredTypeOf(bodyOf("taken"));
         assertEquals("Line", assertInstanceOf(Type.Ref.class, taken).name().name(),
                 "`sample.line` is declared to hold a `Line`");
@@ -78,7 +78,7 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
     @Test
     void andNotWhatTheDeclarationsWouldSayBesideIt() {
         FieldTypes saysAString = _ -> Map.of("line", Type.STRING);
-        Type taken = new DeclaredTypeEvidence(symbols, saysAString, values)
+        Type taken = new DeclaredTypeEvidence(reading(saysAString), values)
                 .declaredTypeOf(bodyOf("taken"));
         assertEquals(Type.STRING, taken,
                 "the walk read the declarations rather than the world it was handed");
@@ -118,7 +118,7 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
 
     /** The declaration {@code Order}, as the reading of this module names it. */
     private TypeSymbol orderOf() {
-        Type sample = new DeclaredTypeEvidence(symbols, checked(), values)
+        Type sample = new DeclaredTypeEvidence(reading(checked()), values)
                 .declaredTypeOf(bodyOf("sample"));
         return assertInstanceOf(Type.Ref.class, sample).name();
     }
@@ -150,8 +150,14 @@ class AFieldAccessIsTypedByTheWorldsOwnAnswerTest {
                 "the clause did not elaborate, so the check settled nothing about `Bad`");
 
         assertEquals(Type.INT,
-                new FieldRead(scope, new ResolvedFieldTypes(scope)).of(Type.ref(bad), "n"),
+                new FieldRead(scope, new ResolvedFieldTypes(scope), FieldRead.Unreadable.REFUSED)
+                        .of(Type.ref(bad), "n"),
                 "and what the declaration denotes is still there to be read");
+    }
+
+    /** The reading of a {@code .} this walk is handed, in {@code world}. */
+    private FieldRead reading(FieldTypes world) {
+        return new FieldRead(symbols, world, FieldRead.Unreadable.REFUSED);
     }
 
     private FieldTypes checked() {

--- a/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.WhatWasCompiled;
+import souther.compiler.observe.FieldTypes;
 
 import java.util.List;
 import java.util.Set;
@@ -13,9 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 /**
  * Each question about a shape is asked of the one that answers it, and of nothing else.
  *
- * <p>Four are asked: what is readable off a value standing at a position, what a value there is
- * composed out of, which positions a reading has under it, and what a written value has under a
- * step. They come to the same fields at a record and part at a sum whose cases share a spread, and
+ * <p>Four are asked of a shape: what is readable off a value standing at a position, what a value
+ * there is composed out of, which positions a reading has under it, and what a written value has
+ * under a step. Two more stand either side of the first — crossing a {@code .} on a type, which is
+ * the reading a text is typed by, and what one declaration holds under its own names, which is the
+ * layout a value already narrowed to a declaration is walked by. A reader that took the second where
+ * it wanted the first is told a name every case of a sum spreads is a field nothing declares.
+ *
+ * <p>The four come to the same fields at a record and part at a sum whose cases share a spread, and
  * that agreement is a law over the answers — checked as one in
  * {@code WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest}, which holds however the four
  * are worked out.
@@ -47,19 +53,43 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
 
-    /** Who asks what is readable off a value: the elaboration of a field read, the accessor a sum's
+    /** Who asks what is readable off a value: the reading of a field access, the accessor a sum's
      *  interface declares, what a construction may spread, what the model writes where a value
      *  stands, the reading of a behavior's inputs, and the walk that reads a row at a position —
      *  which asks whether a name may be read there before taking it off the value it holds, so that
-     *  a case carrying a name of its own does not make it readable for the rows that are that
-     *  case. */
+     *  a case carrying a name of its own does not make it readable for the rows that are that case.
+     *
+     *  <p>The first of those is {@link FieldRead} and not the elaboration. Reading a field access is
+     *  one question — which names a position makes readable, and how far the names a value wears
+     *  come off — and the elaboration is one of the readers that asks it rather than the one that
+     *  answers it. */
     private static final List<String> ASK_WHAT_IS_READABLE = List.of(
             "souther.compiler.check.DataChecker",
-            "souther.compiler.check.Elaborator",
+            "souther.compiler.check.FieldRead",
             "souther.compiler.check.ValueReading",
             "souther.compiler.codegen.ValueClassGen",
             "souther.compiler.inputs.InputDomain",
             "souther.compiler.partition.BehaviorInputs$Standing");
+
+    /** Who crosses a {@code .} on a type: the elaboration that types what a text wrote, the walk
+     *  that says what declarations already state about an expression, and the snapshot an editor
+     *  asks what may follow a {@code .}. Readers of one answer, so what a compiler accepts, what a
+     *  measurement of a written value reads, and what an author is offered are the same names. */
+    private static final List<String> CROSS_A_DOT = List.of(
+            "souther.compiler.check.DeclaredTypeEvidence",
+            "souther.compiler.check.Elaborator",
+            "souther.compiler.sites.SemanticSnapshot");
+
+    /** Who asks what one declaration holds under its names. A caller here has already settled which
+     *  declaration it is walking — the case a value turned out to be, the name a newtype is written
+     *  under, the declarations a readable surface is written on. A reader with a type in hand and a
+     *  {@code .} to cross belongs in {@link #CROSS_A_DOT}: asked here, a sum answers that a name
+     *  every one of its cases spreads is a field nothing declares. */
+    private static final List<String> ASK_WHAT_A_DECLARATION_HOLDS = List.of(
+            "souther.compiler.check.FieldRead",
+            "souther.compiler.check.ReadableFields",
+            "souther.compiler.examples.NeutralForm",
+            "souther.compiler.observe.ValueTypes");
 
     /** Who asks what a value is composed out of. Composing one is what the question is for, so there
      *  is one asker, and a second is a reader with some other question. */
@@ -92,6 +122,41 @@ class NoQuestionAboutAShapeIsAnsweredOutOfAnothersAnswerTest {
     void whatIsReadableIsAskedOfTheOneThatAnswersIt() {
         assertEquals(ASK_WHAT_IS_READABLE, callersOf(ReadableFields.class, "of", "at"),
                 "these ask what is readable off a value, and this is who does");
+    }
+
+    /**
+     * And crossing a {@code .} is asked of the one that answers it.
+     *
+     * <p>Both halves: that somebody crosses one at all, and that nobody crosses one anywhere else.
+     * The first matters because the readers of this answer are what the question exists for — a
+     * reading nobody asks is a reading that has been worked out again beside it.
+     *
+     * <p>Both ways in are counted together. The surface a position makes readable and the one name a
+     * text wrote are one question asked at two widths, and a reader moving from the narrow entry to
+     * the wide one would leave a census that watched only the first looking like a reader that had
+     * stopped asking.
+     */
+    @Test
+    void crossingADotIsAskedOfTheOneThatAnswersIt() {
+        assertFalse(callersOf(FieldRead.class, "at", "of").isEmpty(),
+                "a field access is typed somewhere, or this is watching a name nothing calls");
+        assertEquals(CROSS_A_DOT, callersOf(FieldRead.class, "at", "of"),
+                "these cross a `.` on a type, and this is who answers what one may name");
+    }
+
+    /**
+     * And what a declaration holds is asked by readers that have already settled which declaration.
+     *
+     * <p>The other side of the one above, and the reason it holds. There is no step from a type to a
+     * field on {@link FieldTypes} — a caller names a declaration — so a reader with a position in
+     * hand has to say which declaration it means, and the only thing that turns a position into
+     * declarations is {@link ReadableFields}. That is what keeps the answer about a sum from being
+     * "no fields" where the question was what a value of it makes readable.
+     */
+    @Test
+    void whatADeclarationHoldsIsAskedByReadersThatSettledWhichDeclaration() {
+        assertEquals(ASK_WHAT_A_DECLARATION_HOLDS, callersOf(FieldTypes.class, "of"),
+                "these read one declaration's own layout, and each names the declaration it means");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
@@ -1,0 +1,224 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
+import souther.compiler.observe.FieldTypes;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ExampleExecutions;
+import souther.compiler.query.Scopes;
+import souther.compiler.sites.Evidence;
+import souther.compiler.sites.SemanticSnapshot;
+import souther.compiler.sites.TypeFact;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a {@code .} written on a value may name, and who says so.
+ *
+ * <p>Two questions stand either side of this one and neither is it. What a value of a declaration is
+ * <em>laid out</em> as is {@link FieldTypes}', and a sum lays out nothing — a value of it is a value
+ * of one of its cases. What a value standing here makes <em>readable</em> is this, and at a sum it is
+ * the names every one of its cases spreads, because every value of it carries them. The two are one
+ * map at a record, which is what makes taking the first for the second look right until a sum
+ * arrives.
+ *
+ * <p>So the reading is {@link FieldRead}'s, and the readers that cross a {@code .} — the elaboration
+ * that types what a text wrote, the walk that says what declarations already state about an
+ * expression, the snapshot an editor asks what may follow a {@code .} — read it rather than each
+ * working out a surface of its own. The last of these is why the agreement is checked and not left
+ * to follow from one implementation: an author offered a name the compiler will refuse, or refused a
+ * name it accepts, is the defect whichever of the two is right.
+ */
+class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
+
+    /**
+     * A sum whose cases share a spread, a case that declares one name of its own, and two names
+     * worn over things that do have fields.
+     *
+     * <p>{@code Wrapped} and {@code Named} are the two directions a name can be worn: over a record,
+     * and over the sum itself. Both matter, because a reading that looked through the name would
+     * reach a surface in either case, and they are different surfaces.
+     */
+    private static final String MODEL = """
+            module demo
+
+            data Common  = { id: String }
+            data Open    = { ...Common }
+            data Closed  = { ...Common, closedOn: Date }
+            data Deal    = Open | Closed
+            data Wrapped = Closed
+            data Named   = Deal
+            data Holder  = { deal: Deal }
+
+            let held  = Holder { deal = Closed { id = "d-1", closedOn = Date("2026-07-30") } }
+            let taken = held.deal.id
+            """;
+
+    private static final Compilation COMPILATION = compiled();
+
+    private final Symbols symbols = Scopes.derived(COMPILATION.db(), "demo").value();
+    private final FieldTypes world =
+            ExampleExecutions.of(COMPILATION.db(), "demo").fieldTypes();
+    private final FieldRead read = new FieldRead(symbols, world);
+
+    // --- what one position makes readable -------------------------------------------------------
+
+    /**
+     * At a record, what is readable is the declaration's own layout.
+     *
+     * <p>Stated as the layout the world answers with rather than as a map written out here: the two
+     * being the same answer is the property, and a literal on both sides would hold while neither
+     * was what the world says.
+     */
+    @Test
+    void atARecordWhatIsReadableIsWhatTheDeclarationIsLaidOutAs() {
+        assertEquals(List.copyOf(world.of(named("Closed")).entrySet()),
+                List.copyOf(read.at(Type.ref(named("Closed"))).entrySet()),
+                "a record makes its own fields readable, in the order it is laid out");
+        assertTrue(read.at(Type.ref(named("Closed"))).containsKey("closedOn"),
+                "the model under test declares a record with a name of its own");
+    }
+
+    /**
+     * At a sum, a name every case spreads is readable, and it holds what the declaration that wrote
+     * it says.
+     *
+     * <p>Read off {@code Common} — the declaration the spread came from — rather than off a case
+     * that happens to carry it. What makes the name readable at the sum is that it was written once
+     * and spread, so that is where what it holds is read from.
+     */
+    @Test
+    void atASumANameEveryCaseSpreadsIsReadable() {
+        assertEquals(world.of(named("Common")).get("id"), read.of(Type.ref(named("Deal")), "id"),
+                "the name every case spreads is readable, holding what the spread declares");
+        assertEquals(Type.STRING, read.of(Type.ref(named("Deal")), "id"),
+                "which is a `String` in the model under test");
+    }
+
+    /** And a name only one case declares is not, however many values in hand carry it. */
+    @Test
+    void atASumANameOnlyOneCaseDeclaresIsNot() {
+        assertTrue(world.of(named("Closed")).containsKey("closedOn"),
+                "one case declares it");
+        assertNull(read.of(Type.ref(named("Deal")), "closedOn"),
+                "and it is not readable without opening that case");
+    }
+
+    /** And a name nothing declares is not, which is the same answer said of a different absence. */
+    @Test
+    void andANameNothingDeclaresIsNot() {
+        assertNull(read.of(Type.ref(named("Deal")), "nothing"),
+                "no case declares it, so a value of the sum carries no such name");
+    }
+
+    /**
+     * A name worn over a value is read as itself, and what it wraps is not reached through it.
+     *
+     * <p>Both directions of wearing one: over a record, whose fields would otherwise be offered at
+     * the name, and over a sum, whose shared names would. A value written {@code Wrapped(c)} is a
+     * {@code Wrapped}, and what a {@code .} on it names is the one field it is written with.
+     */
+    @Test
+    void aNameWornOverAValueIsReadAsItselfAndNotThroughToWhatItWraps() {
+        assertEquals(Type.ref(named("Closed")), read.of(Type.ref(named("Wrapped")), "value"),
+                "a newtype makes its own `value` readable");
+        assertNull(read.of(Type.ref(named("Wrapped")), "id"),
+                "and not a field of the record it wraps");
+        assertNull(read.of(Type.ref(named("Named")), "id"),
+                "nor a name the sum it wraps makes readable");
+        assertEquals(Type.STRING, read.of(Type.ref(named("Deal")), "id"),
+                "which is readable on the sum itself, so the barrier is the name and not the shape");
+    }
+
+    // --- and one answer for every reader of it --------------------------------------------------
+
+    /**
+     * The three readers of a {@code .} answer the same thing about one written {@code held.deal.id}.
+     *
+     * <p>Each is asked in its own words, because that is what a reader of it has: the elaboration
+     * settles what a body's expression is and refuses a model that says otherwise, the walk over the
+     * declarations answers a type, and the snapshot answers the names an author may write. All three
+     * are held to {@code String} rather than to each other — two readings compared with each other
+     * agree while both are wrong, and both were.
+     */
+    @Test
+    void thePeopleWhoCrossADotAnswerTheSameThing() {
+        Type declared = new DeclaredTypeEvidence(symbols, world, definitions())
+                .declaredTypeOf(bodyOf("taken"));
+        assertEquals(Type.STRING, declared,
+                "the walk over the declarations says `held.deal.id` is a `String`");
+
+        Map<String, Type> offered = SemanticSnapshot.of(COMPILATION.db(), "demo").orElseThrow()
+                .fieldsOf(new TypeFact(Type.ref(named("Deal")), new Evidence.Declared()));
+        assertEquals(Type.STRING, offered.get("id"),
+                "and an author writing `.` after a `Deal` is offered `id` holding the same");
+
+        assertEquals(Map.of("id", Type.STRING), offered,
+                "and nothing else, since one name is all the cases share");
+    }
+
+    /**
+     * And the elaboration types the same read the same way, said by a model that only compiles if it
+     * does.
+     *
+     * <p>With the refusal beside it. A model accepted says the read was typed as something the
+     * output admits; the second says it was not typed as anything else, which acceptance alone does
+     * not.
+     */
+    @Test
+    void andTheElaborationTypesTheSameReadTheSameWay() {
+        Compiler.compile(behaviorAnswering("String"));
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compile(behaviorAnswering("Int")));
+        assertTrue(refused.getMessage().contains("Int"), refused.getMessage());
+    }
+
+    /** A behavior reading the shared name off the sum and answering with {@code answers}. */
+    private static String behaviorAnswering(String answers) {
+        return """
+                module demo
+
+                data Common = { id: String }
+                data Open   = { ...Common }
+                data Closed = { ...Common, closedOn: Date }
+                data Deal   = Open | Closed
+
+                behavior idOf : (deal: Deal) -> %s
+
+                let idOf (deal) = deal.id
+                """.formatted(answers);
+    }
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofSource(MODEL, "Main");
+        c.answerEverything();
+        return c;
+    }
+
+    private static TypeSymbol named(String declaration) {
+        return TypeSymbols.declared(new TypeKey("demo", declaration));
+    }
+
+    private static Map<String, Hir.FnDef> definitions() {
+        return COMPILATION.db().ask(new Bodies.ModuleDefinitions("demo")).value();
+    }
+
+    private static Hir.Expr bodyOf(String name) {
+        return assertInstanceOf(Hir.FnBody.Written.class, definitions().get(name).body()).expr();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,8 +73,16 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
     private static final Compilation COMPILATION = compiled();
 
     private final Symbols symbols = Scopes.derived(COMPILATION.db(), "demo").value();
-    private final FieldTypes world =
-            ExampleExecutions.of(COMPILATION.db(), "demo").fieldTypes();
+
+    /**
+     * The surface is read against the declarations as this text resolves them, and not against what
+     * the check settled.
+     *
+     * <p>Because the surface is what a check goes on. A reading held to an accepted program would be
+     * a reading of what this answer already decided, so a change here that stopped a model compiling
+     * would come back as a setup that could not be built rather than as the surface that moved.
+     */
+    private final FieldTypes world = new ResolvedFieldTypes(symbols);
     private final FieldRead read = new FieldRead(symbols, world);
 
     // --- what one position makes readable -------------------------------------------------------
@@ -158,7 +167,12 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
      */
     @Test
     void thePeopleWhoCrossADotAnswerTheSameThing() {
-        Type declared = new DeclaredTypeEvidence(symbols, world, definitions())
+        // Held to what the check settled, because these are readers of an accepted program and that
+        // is the world they are handed.
+        assertNotNull(ExampleExecutions.of(COMPILATION.db(), "demo"),
+                "the model under test is accepted, or these readers have no program to read");
+        FieldTypes checked = ExampleExecutions.of(COMPILATION.db(), "demo").fieldTypes();
+        Type declared = new DeclaredTypeEvidence(symbols, checked, definitions())
                 .declaredTypeOf(bodyOf("taken"));
         assertEquals(Type.STRING, declared,
                 "the walk over the declarations says `held.deal.id` is a `String`");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
@@ -155,6 +155,25 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
                 "which is readable on the sum itself, so the barrier is the name and not the shape");
     }
 
+    /**
+     * And a world does not decide what a worn name makes readable either.
+     *
+     * <p>A newtype is written with one implicit field and that is the whole of its surface. Read as
+     * whatever the world holds for that declaration, a world with more to say about it would widen
+     * what a name makes readable — the same thing a world adding a name to a shape's surface would
+     * do, said of the other half of this reading.
+     */
+    @Test
+    void aWorldDoesNotDecideWhatAWornNameMakesReadable() {
+        FieldTypes inventsOne = _ -> Map.of("value", Type.INT, "andAnother", Type.STRING);
+        FieldRead reading = new FieldRead(symbols, inventsOne, FieldRead.Unreadable.REFUSED);
+
+        assertEquals(Map.of("value", Type.INT), reading.at(Type.ref(named("Wrapped"))),
+                "a name makes its one written field readable and nothing the world adds");
+        assertNull(reading.of(Type.ref(named("Wrapped")), "andAnother"),
+                "and the name the world added is not looked up either");
+    }
+
     // --- and one answer for every reader of it --------------------------------------------------
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatADotMayNameIsOneAnswerForEveryReaderOfItTest.java
@@ -83,7 +83,8 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
      * would come back as a setup that could not be built rather than as the surface that moved.
      */
     private final FieldTypes world = new ResolvedFieldTypes(symbols);
-    private final FieldRead read = new FieldRead(symbols, world);
+    private final FieldRead read =
+            new FieldRead(symbols, world, FieldRead.Unreadable.REFUSED);
 
     // --- what one position makes readable -------------------------------------------------------
 
@@ -172,7 +173,8 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
         assertNotNull(ExampleExecutions.of(COMPILATION.db(), "demo"),
                 "the model under test is accepted, or these readers have no program to read");
         FieldTypes checked = ExampleExecutions.of(COMPILATION.db(), "demo").fieldTypes();
-        Type declared = new DeclaredTypeEvidence(symbols, checked, definitions())
+        Type declared = new DeclaredTypeEvidence(
+                new FieldRead(symbols, checked, FieldRead.Unreadable.REFUSED), definitions())
                 .declaredTypeOf(bodyOf("taken"));
         assertEquals(Type.STRING, declared,
                 "the walk over the declarations says `held.deal.id` is a `String`");
@@ -200,6 +202,79 @@ class WhatADotMayNameIsOneAnswerForEveryReaderOfItTest {
         CompileException refused = assertThrows(CompileException.class,
                 () -> Compiler.compile(behaviorAnswering("Int")));
         assertTrue(refused.getMessage().contains("Int"), refused.getMessage());
+    }
+
+    /**
+     * A declaration that does not read is refused where a check reads it and makes nothing readable
+     * where a text is being typed.
+     *
+     * <p>The nominal half of the reading has the two worlds the field half has, and this is where
+     * they part. What a value here is cannot be settled without following the spreads under it, so
+     * a declaration that does not read is found by reading a position and not only by checking the
+     * declaration — and an author who is already being told what is wrong with it is not also told
+     * that the buffer cannot say what may follow a {@code .}.
+     *
+     * <p>Both worlds on each source, so that a reading which simply never refused would fail here
+     * as surely as one that always did.
+     */
+    @Test
+    void aDeclarationThatDoesNotReadIsRefusedForACheckAndAnsweredForAText() {
+        for (String[] each : new String[][] {
+                {"A", """
+                        module demo
+                        data A = { x: Int, x: String }
+                        """},
+                {"Bad", """
+                        module demo
+                        data Open   = { id: String }
+                        data Closed = { id: String }
+                        data Deal   = Open | Closed
+                        data Bad    = { ...Deal }
+                        """},
+                {"Bad", """
+                        module demo
+                        data One = { id: String }
+                        data Two = { id: String }
+                        data Bad = { ...One, ...Two }
+                        """}}) {
+            // Resolved and not checked, which is the state these readings are made in: the check
+            // refuses the module, and an editor is looking at it while it does.
+            Compilation c = Compilation.ofSource(each[1], "Main");
+            Symbols scope = Scopes.derived(c.db(), "demo").value();
+            Type position = Type.ref(TypeSymbols.declared(new TypeKey("demo", each[0])));
+            FieldTypes text = new ResolvedFieldTypes(scope);
+
+            assertEquals(Map.of(),
+                    new FieldRead(scope, text, FieldRead.Unreadable.MAKES_NOTHING_READABLE)
+                            .at(position),
+                    () -> "a text still being typed is answered at " + Type.show(position));
+            assertThrows(CompileException.class,
+                    () -> new FieldRead(scope, text, FieldRead.Unreadable.REFUSED).at(position),
+                    () -> "and a check reads the same position and refuses it, at "
+                            + Type.show(position));
+        }
+    }
+
+    /**
+     * And the editor's own reading is the one that answers.
+     *
+     * <p>Held of the snapshot rather than of a {@code FieldRead} built here, because which of the
+     * two worlds it is in is what the snapshot decides — built with the other, it would compile and
+     * throw a declaration diagnostic out of the one reader whose whole contract is to answer from
+     * what the declarations denote now.
+     */
+    @Test
+    void andTheSnapshotAnAuthorAsksIsTheOneThatAnswers() {
+        Compilation c = Compilation.ofSource("""
+                module demo
+                data A = { x: Int, x: String }
+                """, "Main");
+        Type a = Type.ref(TypeSymbols.declared(new TypeKey("demo", "A")));
+        assertEquals(Map.of(),
+                SemanticSnapshot.of(c.db(), "demo").orElseThrow()
+                        .fieldsOf(new TypeFact(a, new Evidence.Declared())),
+                "an author writing `.` after a declaration that does not read is told nothing,"
+                        + " rather than the buffer refusing to answer");
     }
 
     /** A behavior reading the shared name off the sum and answering with {@code answers}. */

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -17,7 +17,6 @@ import souther.compiler.types.TypeSymbols;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The envelope a value wears is the one the position reads it through, not one its case is owed
@@ -204,30 +203,4 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
                 and.of(value(with, "Filed", Map.of()), at(theirs, "Revision"), "h"));
     }
 
-    /**
-     * A value moving to a place nothing reads keeps the form it is in. What a position adds is what
-     * it asks to be written beside the case; a place that reads nothing asks for nothing, and does
-     * not ask for what is already there to come off. Rendering the case's own form here would lose
-     * which case it is — {@code "Draft"} says, the {@code {}} it would become does not, and nothing
-     * is left to put it back from.
-     */
-    @Test
-    void aValueRereadWhereNothingReadsItKeepsTheFormItIsIn() {
-        assertEquals("Draft", neutral.reread("Draft", at("Stage"), Position.UNREAD));
-        assertEquals(Map.of("id", 1L, "type", "Approved"),
-                neutral.reread(Map.of("id", 1L, "type", "Approved"), at("Decision"), Position.UNREAD));
-    }
-
-    /**
-     * The other direction is not a reading and says so. A value nothing read is in the case's own
-     * form, which does not say which case it is — every unit case is {@code {}} there — so no
-     * discriminator could be written from it. Nothing asks for it today: a projection whose target
-     * declares nothing is refused before a value reaches this. Held so that a call site added later
-     * is told, rather than being handed the value back unchanged and reading it as an answer.
-     */
-    @Test
-    void aValueNothingReadIsNotRereadAtAPosition() {
-        assertThrows(IllegalStateException.class,
-                () -> neutral.reread(Map.of(), Position.UNREAD, at("Step")));
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
@@ -187,24 +187,60 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
      * has the same two widths — a surface to list, and one name to look up. So it has the same two
      * chances to be answered differently, and the narrow one is held to the wide one here rather
      * than being trusted to fold the declarations in the same order.
+     *
+     * <p>Driven from the names this reading makes readable and not from what the world came back
+     * with. Read off the wide answer, a world that had widened or narrowed the surface would be
+     * compared against itself and the two widths would agree while both were wrong.
      */
     @Test
     void oneNameIsReadInAWorldTheWayEveryNameIs() {
         FieldTypes world = new ResolvedFieldTypes(symbols());
         for (Type type : List.of(typeOf("p"), typeOf("r"))) {
             Shape shape = shapeOf(type);
-            Map<String, Type> readable = ReadableFields.of(shape).in(world);
+            ReadableFields readable = ReadableFields.of(shape);
 
-            assertFalse(readable.isEmpty(),
+            assertFalse(readable.declaredFields().isEmpty(),
                     () -> "the model under test has names readable at " + Type.show(type));
-            for (Map.Entry<String, Type> name : readable.entrySet()) {
-                assertEquals(name.getValue(), ReadableFields.at(shape, name.getKey(), world),
-                        () -> "one name is what every name says it is, at " + name.getKey());
+            for (String name : readable.declaredFields().keySet()) {
+                assertEquals(readable.in(world).get(name),
+                        ReadableFields.at(shape, name, world),
+                        () -> "one name is what every name says it is, at " + name);
             }
             assertNull(ReadableFields.at(shape, "nothingDeclaresThis", world),
                     () -> "and a name nothing declares is readable nowhere, at "
                             + Type.show(type));
         }
+    }
+
+    /**
+     * A world says what a name holds and never which names there are.
+     *
+     * <p>The two halves of a reading are told apart by what each may decide, and a world that could
+     * add or drop a name would be deciding the nominal half from the other side. So a world with a
+     * name of its own does not make it readable, and one that says nothing about a name this reading
+     * has leaves it unreadable rather than putting a hole in the surface at both widths.
+     *
+     * <p>Held of both widths, because the whole point of having two is that neither is the other's
+     * implementation.
+     */
+    @Test
+    void aWorldSaysWhatANameHoldsAndNotWhichNamesThereAre() {
+        Shape shape = shapeOf(typeOf("r"));
+        ReadableFields readable = ReadableFields.of(shape);
+        assertTrue(readable.declaredFields().containsKey("deadline"),
+                "the model under test makes one name readable at the sum");
+
+        FieldTypes inventsOne = _ -> Map.of("nothingDeclaresThis", Type.STRING);
+        assertEquals(Map.of(), readable.in(inventsOne),
+                "a name only the world has is readable nowhere");
+        assertNull(ReadableFields.at(shape, "nothingDeclaresThis", inventsOne),
+                "and is not looked up either");
+
+        FieldTypes saysNothing = _ -> Map.of();
+        assertEquals(Map.of(), readable.in(saysNothing),
+                "and a name the world says nothing about is not readable in it");
+        assertNull(ReadableFields.at(shape, "deadline", saysNothing),
+                "at either width");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.ConstructionDescent;
 import souther.compiler.check.ReadableFields;
+import souther.compiler.check.ResolvedFieldTypes;
 import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -14,6 +15,7 @@ import souther.compiler.inputs.Distinctions;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TermPath;
+import souther.compiler.observe.FieldTypes;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
@@ -164,7 +166,7 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
     void oneNameIsReadTheWayEveryNameIs() {
         for (Type type : List.of(typeOf("p"), typeOf("r"))) {
             Shape shape = shapeOf(type);
-            Map<String, Type> readable = ReadableFields.of(shape).fields();
+            Map<String, Type> readable = ReadableFields.of(shape).declaredFields();
 
             assertFalse(readable.isEmpty(),
                     () -> "the model under test has names readable at " + Type.show(type));
@@ -173,6 +175,33 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
                         () -> "one name is what every name says it is, at " + name.getKey());
             }
             assertNull(ReadableFields.at(shape, "nothingDeclaresThis"),
+                    () -> "and a name nothing declares is readable nowhere, at "
+                            + Type.show(type));
+        }
+    }
+
+    /**
+     * And the same, of the two ways of asking it in a world.
+     *
+     * <p>What a name holds is the world's answer wherever the reader is reading, and that question
+     * has the same two widths — a surface to list, and one name to look up. So it has the same two
+     * chances to be answered differently, and the narrow one is held to the wide one here rather
+     * than being trusted to fold the declarations in the same order.
+     */
+    @Test
+    void oneNameIsReadInAWorldTheWayEveryNameIs() {
+        FieldTypes world = new ResolvedFieldTypes(symbols());
+        for (Type type : List.of(typeOf("p"), typeOf("r"))) {
+            Shape shape = shapeOf(type);
+            Map<String, Type> readable = ReadableFields.of(shape).in(world);
+
+            assertFalse(readable.isEmpty(),
+                    () -> "the model under test has names readable at " + Type.show(type));
+            for (Map.Entry<String, Type> name : readable.entrySet()) {
+                assertEquals(name.getValue(), ReadableFields.at(shape, name.getKey(), world),
+                        () -> "one name is what every name says it is, at " + name.getKey());
+            }
+            assertNull(ReadableFields.at(shape, "nothingDeclaresThis", world),
                     () -> "and a name nothing declares is readable nowhere, at "
                             + Type.show(type));
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest.java
@@ -81,7 +81,7 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
     @Test
     void atARecordTheFourAnswersAreOneMap() {
         Type record = typeOf("p");
-        Map<String, Type> readable = ReadableFields.of(shapeOf(record)).fields();
+        Map<String, Type> readable = ReadableFields.of(shapeOf(record)).declaredFields();
 
         assertEquals(Map.of("deadline", Type.INT, "x", Type.INT), readable,
                 "the model under test declares a record of two fields");
@@ -104,7 +104,7 @@ class WhatIsReadableAndWhatIsBuiltAgreeAtARecordAndPartAtASumTest {
     @Test
     void atASumSharingASpreadOnlyWhatIsReadableHasFields() {
         Type sum = typeOf("r");
-        Map<String, Type> readable = ReadableFields.of(shapeOf(sum)).fields();
+        Map<String, Type> readable = ReadableFields.of(shapeOf(sum)).declaredFields();
 
         assertEquals(Map.of("deadline", Type.INT), readable,
                 "the name every case spreads is readable at every value of the sum");


### PR DESCRIPTION
Closes #1342.

## What was wrong

Crossing a `.` and laying a declaration out are two questions, and they were asked through one step.

What a value of a declaration is **laid out** as is `FieldTypes`. A sum lays out nothing — a value of it is a value of one of its cases — and that is a true answer to that question. What a value standing at a position makes **readable** is `ReadableFields`, and at a sum it is the names every one of its cases spreads, because every value of it carries them. The two are one map at a record, which is what makes taking the first for the second look right until a sum arrives.

`FieldTypes` carried a step from a name to a field, so a reader with a type in hand and a `.` to cross had one thing to reach for and it answered the other question. Three readers reached for it. Two are live: the walk that says what declarations already state about an expression, and the snapshot an editor asks what may follow a `.`. Both told an author that a name every case of a sum spreads is a field nothing declares, while the compiler accepts a read of it.

The issue was reported against a fixture, and that surface does not reach it — see the issue for what was measured.

## What this does

`FieldRead` is the reading of a field access, and the only thing that crosses a `.` on a type. It holds the nominal barrier as well: a name worn over a value reads its own `value` and nothing of what it wraps. That was a guard the elaboration kept for itself, and it is what a `.` means rather than a policy of whoever is reading.

Which names are readable stays nominal and stays with `ReadableFields`. What one of those declarations holds under a name is the world's, and `ReadableFields.in` hands the surface to whichever world the reader is in — the check's answer for an accepted program, what the declarations resolve to for a text still being typed. Neither reader derives the other's.

`FieldTypes` loses the step. What is left answers for one declaration a caller has already settled — the case a value turned out to be, the name a newtype is written under — so a reader with a position in hand has to say which declaration it means and cannot reach the layout by spelling a reference.

The fixture reader's own reading of a field access goes rather than being corrected. Row operands became the module's own compiled code, and nothing has reached that reading since; a value asked about at a boundary is composed and takes no field, which it now says rather than reading one.

## How it is held

The surface a position makes readable, the barrier a worn name is, and the readers of a `.` answering alike. Each reader is held to the type rather than to the others — two readings compared with each other agree while both are wrong, and both were. A census says who crosses a `.` and who reads a declaration's own layout, counting both ways into the reading, so a reader that grew a surface of its own is a change to that list and not a silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)