### PR TITLE
Tell a walk that could not be made from a reading that found nothing

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -404,7 +404,15 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
         };
     }
 
-    /** The count at a value, keeping why there is none where there is none. */
+    /**
+     * The count at a value, keeping why there is none where there is none.
+     *
+     * <p><b>At a value, which a reading of one always has.</b> Whether a walk arrived and what it
+     * found are settled before a term is asked, so nothing here stands for a place nobody reached
+     * or a position a row wrote nothing at — those are said where they happen, in the words their
+     * own layer has for them. An arm for them here would be a word that means none of them and
+     * takes all of them, which is what a reader downstream then has to unpick.
+     */
     sealed interface Reading {
 
         record Number(Place value) implements Reading {}
@@ -414,22 +422,11 @@ public sealed interface NumericTerm permits NumericTerm.FromOnePosition, Numeric
          *
          * <p>What {@link Incompleteness.Code} names is what an observation met, so only an
          * observation may put one here. A walk that arrived at no value at all has met nothing and
-         * says {@link NoValue}: given a code instead, the nearest one is borrowed, and a reader
+         * never reaches this type: given a code instead, the nearest one is borrowed, and a reader
          * downstream that words a code as what an observation did then says an observation did
          * something that never happened.
          */
         record Missing(Incompleteness.Code code) implements Reading {}
-
-        /**
-         * The walk answered with no value here, which is not an observation of one.
-         *
-         * <p>Apart from {@link Missing} because what a reader may do with it is not the same. A
-         * value the observation shortened is a value that exists and this compiler declined to
-         * keep; nothing arriving is this compiler unable to walk to a place, or a place that holds
-         * nothing under the reading being tried. Neither says anything about the number, and only
-         * the first is something a wider budget would have kept.
-         */
-        record NoValue() implements Reading {}
 
         /** The value was read and this term is not a number of it. An answer about the value and not
          * about the observation: a {@code Text} where a number was expected is a class nothing holds,

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -192,9 +192,6 @@ final class TermReading {
         }
         java.math.BigDecimal total = java.math.BigDecimal.ZERO;
         for (ObservedValue each : values) {
-            if (each == null) {
-                return new Reading.NoValue();
-            }
             Membership.Incomplete unread = Membership.unread(each);
             if (unread != null) {
                 return new Reading.Missing(unread.code());

--- a/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/TermReading.java
@@ -7,6 +7,8 @@ import souther.compiler.numeric.Place;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.semantics.TakenAs;
 
+import java.util.Objects;
+
 import souther.compiler.inputs.NumericTerm.Reading;
 
 /**
@@ -41,12 +43,11 @@ final class TermReading {
     static Reading at(TermOrders on, ObservedValue at) {
         NumericTerm.FromOnePosition term = on.term().atOnePosition();
         Carrier observed = on.observed();
-        // Nothing arrived, which is the walk saying it has no value here rather than an observation
-        // saying it could not keep one. Named apart, because the reader that words an observation's
-        // code says what an observation did — and here there was none.
-        if (at == null) {
-            return new Reading.NoValue();
-        }
+        // A value or nothing at all, and nothing at all is not one of the answers here. Whether a
+        // walk arrived and what it found are the caller's to have settled before a term is asked
+        // for a number; answered with a reading, this would be where a place nobody looked at comes
+        // back as a place holding no number, which is what having no value here means.
+        Objects.requireNonNull(at, "a term is read at a value the walk came to");
         Membership.Incomplete unread = Membership.unread(at);
         if (unread != null) {
             return new Reading.Missing(unread.code());
@@ -82,19 +83,13 @@ final class TermReading {
      */
     static Reading over(TermOrders on, java.util.List<ObservedValue> values) {
         NumericTerm.TakenOver term = (NumericTerm.TakenOver) on.term();
-        // Nothing to read, which a caller that could not walk to the run answers with. The absence
-        // a walk answers with and not the values being no number of this term: said as the second,
-        // a run this compiler could not reach comes out as the model putting the row elsewhere.
-        if (values == null) {
-            return new Reading.NoValue();
-        }
+        // The values of a run the walk came to, and every one of them a value. A run this compiler
+        // could not reach has none of these and is not a run of none, so the caller settles that
+        // before asking a term for a number -- given nothing here instead, a run nobody walked to
+        // would come out as the model having written an empty one.
+        Objects.requireNonNull(values, "a term is read over the values a walk came to");
         for (ObservedValue each : values) {
-            // An element the walk arrived at nothing for, which is not an observation of one. Said
-            // apart for the reason the one value a place holds is, since a total over a run is over
-            // whatever the run holds and one of them being nothing is not a limit having fired.
-            if (each == null) {
-                return new Reading.NoValue();
-            }
+            Objects.requireNonNull(each, "every value of a run the walk came to is a value");
             Membership.Incomplete unread = Membership.unread(each);
             if (unread != null) {
                 return new Reading.Missing(unread.code());

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -13,6 +13,7 @@ import souther.compiler.types.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * What a behavior takes: what its inputs are called, what they are declared to be, and what those
@@ -136,6 +137,9 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
 
         public Occurrence {
             at = Map.copyOf(at);
+            // An occurrence is a value the walk arrived at. Where none did, the walk says so with
+            // its own answer and hands back no occurrences at all.
+            Objects.requireNonNull(value, "an occurrence is a value standing at the path");
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -81,10 +81,10 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * and a row writes one of the cases, so a walk asking where a value is written reaches nothing
      * at a name every reading of the model may use.
      *
-     * <p>Empty where the walk was taken and no value stands there, and null where it could not be
-     * taken at all. A caller asking what is covered at a position is answered with what was
-     * written, and a list of none is nothing written there — which an empty list is, and which the
-     * walk not having been made is not.
+     * <p>{@link WalkResult.Reached} holding none where the walk was taken and no value stands
+     * there, and {@link WalkResult.CouldNotWalk} where it could not be taken at all. A caller
+     * asking what is covered at a position is answered with what was written, and a list of none is
+     * nothing written there — which the walk not having been made is not.
      *
      * <p>The one walk into a row's values, done with the declared types beside them. A field of a
      * record is reached through the names the record is written under: {@code data SlotN = Slot} is
@@ -109,9 +109,12 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * position, or a value that is not the construction the reading says stands there. Neither is
      * something an observation did, and no observation says why because nothing went wrong with one.
      */
-    List<ObservedValue> valuesAt(List<ObservedValue> inputs, TermPath path) {
-        List<Occurrence> found = occurrencesAt(inputs, path);
-        return found == null ? null : found.stream().map(Occurrence::value).toList();
+    WalkResult<List<ObservedValue>> valuesAt(List<ObservedValue> inputs, TermPath path) {
+        return switch (occurrencesAt(inputs, path)) {
+            case WalkResult.Reached(List<Occurrence> found) ->
+                    WalkResult.reached(found.stream().map(Occurrence::value).toList());
+            case WalkResult.CouldNotWalk<List<Occurrence>> _ -> WalkResult.couldNotWalk();
+        };
     }
 
     /**
@@ -169,10 +172,10 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
      * candidate this package composed are both read at these positions, and both have to be read
      * the way a written row is or the classes they land in are two readings rather than one.
      */
-    List<Occurrence> occurrencesAt(List<ObservedValue> inputs, TermPath path) {
+    WalkResult<List<Occurrence>> occurrencesAt(List<ObservedValue> inputs, TermPath path) {
         int at = indexOf(path);
         if (at < 0 || at >= inputs.size()) {
-            return null;
+            return WalkResult.couldNotWalk();
         }
         List<Standing> standing = List.of(new Standing(inputs.get(at), types.get(at),
                 TermPath.of(path.head()), Map.of()));
@@ -191,14 +194,15 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
             // as one flag for the whole walk, what survived was answered with and whatever could
             // not be reached was left out with nothing saying so.
             if (took != standing.size()) {
-                return null;
+                return WalkResult.couldNotWalk();
             }
             standing = next;
         }
         // Nothing here is a row that wrote no element, which is a reading that arrived: a step that
-        // could not be taken has already answered null above. Answered alike, a row writing the
-        // empty list would be reported as one nothing could be read from.
-        return standing.stream().map(each -> new Occurrence(each.at(), each.value())).toList();
+        // could not be taken has already said so above. Answered alike, a row writing the empty
+        // list would be reported as one nothing could be read from.
+        return WalkResult.reached(
+                standing.stream().map(each -> new Occurrence(each.at(), each.value())).toList());
     }
 
     /**
@@ -278,25 +282,6 @@ public record BehaviorInputs(List<String> parameters, List<Type> types, RuleRead
                                 : presence.present() ? optional.element() : view.declared();
             };
         };
-    }
-
-    /**
-     * The value at {@code path}, or null where there is not one readable value there.
-     *
-     * <p>For a position one value stands at. A position inside a sequence has as many as were
-     * written, and answering a caller that wants one with the first of them would report what is
-     * covered off an element it chose — so such a position answers null here and {@link #valuesAt}
-     * is what reads it.
-     *
-     * <p><b>Null runs three answers together, and a caller that has to tell them apart asks
-     * {@link #occurrencesAt}.</b> The walk could not be taken, or it was taken and the row stands
-     * nowhere here — the empty list, an element of nothing or a position under a case the row is
-     * not at — or several values stand and none of them is the one. What is covered and what a
-     * measurement is short of are different answers about a row, and only that one keeps them.
-     */
-    public ObservedValue valueAt(List<ObservedValue> inputs, TermPath path) {
-        List<ObservedValue> values = valuesAt(inputs, path);
-        return values != null && values.size() == 1 ? values.get(0) : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -106,7 +106,8 @@ public sealed interface BorderQuantity {
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
             return switch (readAt(of, observation.at(term.position()))) {
                 case WhatATermRead.CameToNothing(ReadingGap why) -> Stands.couldNotTell(why);
-                case WhatATermRead.NoNumberOfTheValue _ -> Stands.NO;
+                case WhatATermRead.NoNumberOfTheValue _, WhatATermRead.NothingWrittenThere _ ->
+                        Stands.NO;
                 case WhatATermRead.Number(Place value) ->
                         where.holds(new Level.OnACarrier(of.answered(), value))
                                 ? Stands.YES : Stands.NO;
@@ -317,6 +318,12 @@ public sealed interface BorderQuantity {
             // look at first.
             Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             for (WhatATermRead end : List.of(here, there)) {
+                // A row that wrote nothing at one end has no pair to stand anywhere, whatever the
+                // other end came to. Answered after the reasons instead, a row that settles the
+                // point would leave it open because the end nobody needed was unreadable.
+                if (end instanceof WhatATermRead.NothingWrittenThere) {
+                    return Stands.NO;
+                }
                 if (end instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
                     stopped.add(why);
                 }
@@ -562,6 +569,14 @@ public sealed interface BorderQuantity {
                     case NumericTerm.TakenOver over ->
                             readOver(orders, observation.everyValueAt(over.subjectPath()));
                 };
+                // A term whose position the row wrote nothing at leaves the form no value at this
+                // row, and that is the row's answer rather than a reading that came to nothing. It
+                // outranks every reason collected here for the same reason it is not one of them:
+                // the others are what this compiler could not find out, and this is what the row
+                // says.
+                if (read instanceof WhatATermRead.NothingWrittenThere) {
+                    return Stands.NO;
+                }
                 if (read instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
                     stopped.add(why);
                     continue;
@@ -891,6 +906,17 @@ public sealed interface BorderQuantity {
          *  and not about anything that stopped. */
         record NoNumberOfTheValue() implements WhatATermRead { }
 
+        /**
+         * The row wrote nothing at the term's position, so this quantity has no value at this row.
+         *
+         * <p>Which settles the row rather than leaving it open, and settles it whatever else the
+         * quantity met. A number over a position a row put nothing at is a number the row does not
+         * have, and it does not have it any more once a wider run keeps what it shortened
+         * elsewhere — so a reading stopped at another term is not what a reader is told about this
+         * row.
+         */
+        record NothingWrittenThere() implements WhatATermRead { }
+
         /** No number, and this is what the reading met instead. */
         record CameToNothing(ReadingGap why) implements WhatATermRead { }
     }
@@ -902,11 +928,15 @@ public sealed interface BorderQuantity {
                     new WhatATermRead.CameToNothing(ReadingGap.COULD_NOT_WALK);
             case WalkResult.Reached(ObservationAtPoint standing) -> switch (standing) {
                 case ObservationAtPoint.Value(ObservedValue value) -> said(on.read(value));
-                // Both are the walk arriving and no value of the row standing here, which is what
-                // the reading has a word for. Which of the two it was is the measure's own business
-                // and nothing a number is read off.
-                case ObservationAtPoint.WroteNothing _, ObservationAtPoint.BelongsToAnotherReading _
-                        -> new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
+                // A fact about the row, which answers for it. The row was read and put no element
+                // here, so this quantity has no value at it -- and reporting that as a reading that
+                // came to nothing leaves a point undecided over a row that plainly settles it.
+                case ObservationAtPoint.WroteNothing _ -> new WhatATermRead.NothingWrittenThere();
+                // The row's values here are under elements another reading chose. The walk arrived
+                // and none of this row's values stands here under this one, which is the reading
+                // coming to nothing and is what the word is for.
+                case ObservationAtPoint.BelongsToAnotherReading _ ->
+                        new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
             };
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -7,7 +7,6 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Place;
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.List;
@@ -104,7 +103,7 @@ public sealed interface BorderQuantity {
             // measured on. The two are one carrier for a position's own content and part for a term
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
-            return switch (readAt(of, observation.at(term.position()))) {
+            return switch (WhatATermRead.at(of, observation.at(term.position()))) {
                 case WhatATermRead.CameToNothing(ReadingGap why) -> Stands.couldNotTell(why);
                 case WhatATermRead.NoNumberOfTheValue _, WhatATermRead.NothingWrittenThere _ ->
                         Stands.NO;
@@ -311,27 +310,32 @@ public sealed interface BorderQuantity {
             // Each on its own order. Read on one order for the pair, a position written back
             // differently from the other was read as a value it does not hold — a date read as a
             // whole number is no number at all, and the row stood at nothing (#1018).
-            WhatATermRead here = readAt(on, observation.at(on.term().subjectPath()));
-            WhatATermRead there = readAt(against, observation.at(against.term().subjectPath()));
+            WhatATermRead here = WhatATermRead.at(on, observation.at(on.term().subjectPath()));
+            WhatATermRead there =
+                    WhatATermRead.at(against, observation.at(against.term().subjectPath()));
             // Both sides, and not the first of them. The pair is unreadable for whatever stopped
             // either, and a reader told about one end is being told which end this happened to
             // look at first.
             Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
+            boolean wroteNothing = false;
             for (WhatATermRead end : List.of(here, there)) {
-                // A row that wrote nothing at one end has no pair to stand anywhere, whatever the
-                // other end came to. Answered after the reasons instead, a row that settles the
-                // point would leave it open because the end nobody needed was unreadable.
-                if (end instanceof WhatATermRead.NothingWrittenThere) {
-                    return Stands.NO;
+                switch (end) {
+                    case WhatATermRead.CameToNothing(ReadingGap why) -> stopped.add(why);
+                    case WhatATermRead.NothingWrittenThere _ -> wroteNothing = true;
+                    case WhatATermRead.NoNumberOfTheValue _, WhatATermRead.Number _ -> { }
                 }
-                if (end instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
-                    stopped.add(why);
-                }
+            }
+            // A row that wrote nothing at one end has no pair to stand anywhere, whatever the other
+            // end came to. Answered after the reasons instead, a row that settles the point would
+            // leave it open because the end nobody needed was unreadable.
+            if (wroteNothing) {
+                return Stands.NO;
             }
             Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
                 return unread;
             }
+            // Which leaves the numbers to take out, the ends having been told apart above.
             if (!(here instanceof WhatATermRead.Number onAt)
                     || !(there instanceof WhatATermRead.Number againstAt)) {
                 return Stands.NO;
@@ -555,6 +559,7 @@ public sealed interface BorderQuantity {
             // model's answer.
             Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             boolean noNumber = false;
+            boolean wroteNothing = false;
             for (Map.Entry<NumericTerm, java.math.BigDecimal> each : form.coefs().entrySet()) {
                 // Each on its own order. Read on one order for the whole form, a position written
                 // back differently from its neighbour was read as a value it does not hold.
@@ -565,27 +570,29 @@ public sealed interface BorderQuantity {
                 TermOrders orders = on.get(each.getKey());
                 WhatATermRead read = switch (each.getKey()) {
                     case NumericTerm.FromOnePosition one ->
-                            readAt(orders, observation.at(one.position()));
+                            WhatATermRead.at(orders, observation.at(one.position()));
                     case NumericTerm.TakenOver over ->
-                            readOver(orders, observation.everyValueAt(over.subjectPath()));
+                            WhatATermRead.over(orders, observation.everyValueAt(over.subjectPath()));
                 };
-                // A term whose position the row wrote nothing at leaves the form no value at this
-                // row, and that is the row's answer rather than a reading that came to nothing. It
-                // outranks every reason collected here for the same reason it is not one of them:
-                // the others are what this compiler could not find out, and this is what the row
-                // says.
-                if (read instanceof WhatATermRead.NothingWrittenThere) {
-                    return Stands.NO;
+                switch (read) {
+                    case WhatATermRead.CameToNothing(ReadingGap why) -> stopped.add(why);
+                    case WhatATermRead.NoNumberOfTheValue _ -> noNumber = true;
+                    case WhatATermRead.NothingWrittenThere _ -> wroteNothing = true;
+                    case WhatATermRead.Number(Place value) ->
+                            at = at.add(Count.number(value).at().multiply(each.getValue()));
                 }
-                if (read instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
-                    stopped.add(why);
-                    continue;
-                }
-                if (!(read instanceof WhatATermRead.Number(Place value))) {
-                    noNumber = true;
-                    continue;
-                }
-                at = at.add(Count.number(value).at().multiply(each.getValue()));
+            }
+            // Every term, and the answer after them. Left as soon as one of these was known, the
+            // terms behind it would go unasked — and asking them is how the measure finds out how
+            // many elements each position holds, which is what says how many readings of the row
+            // there are to try. A quantity that answered early would be choosing the readings.
+            //
+            // A term whose position the row wrote nothing at leaves the form no value at this row,
+            // and that is the row's answer rather than a reading that came to nothing. It outranks
+            // the reasons for the reason it is not one of them: those are what this compiler could
+            // not find out, and this is what the row says.
+            if (wroteNothing) {
+                return Stands.NO;
             }
             Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
@@ -887,79 +894,6 @@ public sealed interface BorderQuantity {
         static Stands couldNotTell(Set<ReadingGap> why) {
             return why.isEmpty() ? null : new CouldNotTell(why);
         }
-    }
-
-    /**
-     * What one term of a quantity came to at one row: the number it names, or why it names none.
-     *
-     * <p>The arms every reading of a term ends in, rather than {@link NumericTerm.Reading}'s. A walk
-     * that was not taken is one of the ways a term comes to no number and is not a reading of a
-     * value, so it has no arm there — and each of the three quantities would otherwise carry its
-     * own guard for that before switching, which is one rule written three times.
-     */
-    sealed interface WhatATermRead {
-
-        /** The number the term names at this row. */
-        record Number(Place value) implements WhatATermRead { }
-
-        /** The value was read and this term is no number of it, which is an answer about the value
-         *  and not about anything that stopped. */
-        record NoNumberOfTheValue() implements WhatATermRead { }
-
-        /**
-         * The row wrote nothing at the term's position, so this quantity has no value at this row.
-         *
-         * <p>Which settles the row rather than leaving it open, and settles it whatever else the
-         * quantity met. A number over a position a row put nothing at is a number the row does not
-         * have, and it does not have it any more once a wider run keeps what it shortened
-         * elsewhere — so a reading stopped at another term is not what a reader is told about this
-         * row.
-         */
-        record NothingWrittenThere() implements WhatATermRead { }
-
-        /** No number, and this is what the reading met instead. */
-        record CameToNothing(ReadingGap why) implements WhatATermRead { }
-    }
-
-    /** What {@code on} reads where the walk to its one position came to {@code answered}. */
-    private static WhatATermRead readAt(TermOrders on, WalkResult<ObservationAtPoint> answered) {
-        return switch (answered) {
-            case WalkResult.CouldNotWalk<ObservationAtPoint> _ ->
-                    new WhatATermRead.CameToNothing(ReadingGap.COULD_NOT_WALK);
-            case WalkResult.Reached(ObservationAtPoint standing) -> switch (standing) {
-                case ObservationAtPoint.Value(ObservedValue value) -> said(on.read(value));
-                // A fact about the row, which answers for it. The row was read and put no element
-                // here, so this quantity has no value at it -- and reporting that as a reading that
-                // came to nothing leaves a point undecided over a row that plainly settles it.
-                case ObservationAtPoint.WroteNothing _ -> new WhatATermRead.NothingWrittenThere();
-                // The row's values here are under elements another reading chose. The walk arrived
-                // and none of this row's values stands here under this one, which is the reading
-                // coming to nothing and is what the word is for.
-                case ObservationAtPoint.BelongsToAnotherReading _ ->
-                        new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
-            };
-        };
-    }
-
-    /** The same over the values of a run, which a walk that was not taken has none of. */
-    private static WhatATermRead readOver(TermOrders on,
-                                          WalkResult<java.util.List<ObservedValue>> answered) {
-        return switch (answered) {
-            case WalkResult.CouldNotWalk<java.util.List<ObservedValue>> _ ->
-                    new WhatATermRead.CameToNothing(ReadingGap.COULD_NOT_WALK);
-            case WalkResult.Reached(java.util.List<ObservedValue> values) -> said(on.readOver(values));
-        };
-    }
-
-    /** What a term's own reading of a value comes to here. */
-    private static WhatATermRead said(NumericTerm.Reading read) {
-        return switch (read) {
-            case NumericTerm.Reading.Number(Place value) ->
-                    new WhatATermRead.Number(value);
-            case NumericTerm.Reading.Missing(Incompleteness.Code code) ->
-                    new WhatATermRead.CameToNothing(ReadingGap.of(code));
-            case NumericTerm.Reading.NotNumber _ -> new WhatATermRead.NoNumberOfTheValue();
-        };
     }
 
     /** What one row holds at each of a behavior's positions, for a quantity reading its own value

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -7,6 +7,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Place;
+import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.List;
@@ -103,13 +104,11 @@ public sealed interface BorderQuantity {
             // measured on. The two are one carrier for a position's own content and part for a term
             // that is what an operation answered — a time counts the seconds of its day and its hour
             // counts by one, so a reader handed the second decodes the first as nothing (#1027).
-            return switch (of.read(observation.at(term.position()))) {
-                case NumericTerm.Reading.Missing missing ->
-                        Stands.couldNotTell(ReadingGap.of(missing.code()));
-                case NumericTerm.Reading.NoValue _ -> Stands.couldNotTell(ReadingGap.NO_VALUE);
-                case NumericTerm.Reading.NotNumber _ -> Stands.NO;
-                case NumericTerm.Reading.Number number ->
-                        where.holds(new Level.OnACarrier(of.answered(), number.value()))
+            return switch (readAt(of, observation.at(term.position()))) {
+                case WhatATermRead.CameToNothing(ReadingGap why) -> Stands.couldNotTell(why);
+                case WhatATermRead.NoNumberOfTheValue _ -> Stands.NO;
+                case WhatATermRead.Number(Place value) ->
+                        where.holds(new Level.OnACarrier(of.answered(), value))
                                 ? Stands.YES : Stands.NO;
             };
         }
@@ -311,27 +310,23 @@ public sealed interface BorderQuantity {
             // Each on its own order. Read on one order for the pair, a position written back
             // differently from the other was read as a value it does not hold — a date read as a
             // whole number is no number at all, and the row stood at nothing (#1018).
-            NumericTerm.Reading here = on.read(observation.at(on.term().subjectPath()));
-            NumericTerm.Reading there =
-                    against.read(observation.at(against.term().subjectPath()));
+            WhatATermRead here = readAt(on, observation.at(on.term().subjectPath()));
+            WhatATermRead there = readAt(against, observation.at(against.term().subjectPath()));
             // Both sides, and not the first of them. The pair is unreadable for whatever stopped
             // either, and a reader told about one end is being told which end this happened to
             // look at first.
             Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
-            for (NumericTerm.Reading end : List.of(here, there)) {
-                if (end instanceof NumericTerm.Reading.Missing missing) {
-                    stopped.add(ReadingGap.of(missing.code()));
-                }
-                if (end instanceof NumericTerm.Reading.NoValue) {
-                    stopped.add(ReadingGap.NO_VALUE);
+            for (WhatATermRead end : List.of(here, there)) {
+                if (end instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
+                    stopped.add(why);
                 }
             }
             Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
                 return unread;
             }
-            if (!(here instanceof NumericTerm.Reading.Number onAt)
-                    || !(there instanceof NumericTerm.Reading.Number againstAt)) {
+            if (!(here instanceof WhatATermRead.Number onAt)
+                    || !(there instanceof WhatATermRead.Number againstAt)) {
                 return Stands.NO;
             }
             if (!counts()) {
@@ -561,24 +556,21 @@ public sealed interface BorderQuantity {
                 // term, every value where the term is over a run of them. Asked for one either way,
                 // a total would be read off whichever element the row's reading happened to pick.
                 TermOrders orders = on.get(each.getKey());
-                NumericTerm.Reading read = switch (each.getKey()) {
-                    case NumericTerm.FromOnePosition one -> orders.read(observation.at(one.position()));
+                WhatATermRead read = switch (each.getKey()) {
+                    case NumericTerm.FromOnePosition one ->
+                            readAt(orders, observation.at(one.position()));
                     case NumericTerm.TakenOver over ->
-                            orders.readOver(observation.everyValueAt(over.subjectPath()));
+                            readOver(orders, observation.everyValueAt(over.subjectPath()));
                 };
-                if (read instanceof NumericTerm.Reading.Missing missing) {
-                    stopped.add(ReadingGap.of(missing.code()));
+                if (read instanceof WhatATermRead.CameToNothing(ReadingGap why)) {
+                    stopped.add(why);
                     continue;
                 }
-                if (read instanceof NumericTerm.Reading.NoValue) {
-                    stopped.add(ReadingGap.NO_VALUE);
-                    continue;
-                }
-                if (!(read instanceof NumericTerm.Reading.Number number)) {
+                if (!(read instanceof WhatATermRead.Number(Place value))) {
                     noNumber = true;
                     continue;
                 }
-                at = at.add(Count.number(number.value()).at().multiply(each.getValue()));
+                at = at.add(Count.number(value).at().multiply(each.getValue()));
             }
             Stands unread = Stands.couldNotTell(stopped);
             if (unread != null) {
@@ -882,13 +874,80 @@ public sealed interface BorderQuantity {
         }
     }
 
+    /**
+     * What one term of a quantity came to at one row: the number it names, or why it names none.
+     *
+     * <p>The arms every reading of a term ends in, rather than {@link NumericTerm.Reading}'s. A walk
+     * that was not taken is one of the ways a term comes to no number and is not a reading of a
+     * value, so it has no arm there — and each of the three quantities would otherwise carry its
+     * own guard for that before switching, which is one rule written three times.
+     */
+    sealed interface WhatATermRead {
+
+        /** The number the term names at this row. */
+        record Number(Place value) implements WhatATermRead { }
+
+        /** The value was read and this term is no number of it, which is an answer about the value
+         *  and not about anything that stopped. */
+        record NoNumberOfTheValue() implements WhatATermRead { }
+
+        /** No number, and this is what the reading met instead. */
+        record CameToNothing(ReadingGap why) implements WhatATermRead { }
+    }
+
+    /** What {@code on} reads where the walk to its one position came to {@code answered}. */
+    private static WhatATermRead readAt(TermOrders on, WalkResult<ObservationAtPoint> answered) {
+        return switch (answered) {
+            case WalkResult.CouldNotWalk<ObservationAtPoint> _ ->
+                    new WhatATermRead.CameToNothing(ReadingGap.COULD_NOT_WALK);
+            case WalkResult.Reached(ObservationAtPoint standing) -> switch (standing) {
+                case ObservationAtPoint.Value(ObservedValue value) -> said(on.read(value));
+                // Both are the walk arriving and no value of the row standing here, which is what
+                // the reading has a word for. Which of the two it was is the measure's own business
+                // and nothing a number is read off.
+                case ObservationAtPoint.WroteNothing _, ObservationAtPoint.BelongsToAnotherReading _
+                        -> new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
+            };
+        };
+    }
+
+    /** The same over the values of a run, which a walk that was not taken has none of. */
+    private static WhatATermRead readOver(TermOrders on,
+                                          WalkResult<java.util.List<ObservedValue>> answered) {
+        return switch (answered) {
+            case WalkResult.CouldNotWalk<java.util.List<ObservedValue>> _ ->
+                    new WhatATermRead.CameToNothing(ReadingGap.COULD_NOT_WALK);
+            case WalkResult.Reached(java.util.List<ObservedValue> values) -> said(on.readOver(values));
+        };
+    }
+
+    /** What a term's own reading of a value comes to here. */
+    private static WhatATermRead said(NumericTerm.Reading read) {
+        return switch (read) {
+            case NumericTerm.Reading.Number(Place value) ->
+                    new WhatATermRead.Number(value);
+            case NumericTerm.Reading.Missing(Incompleteness.Code code) ->
+                    new WhatATermRead.CameToNothing(ReadingGap.of(code));
+            case NumericTerm.Reading.NoValue _ ->
+                    new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
+            case NumericTerm.Reading.NotNumber _ -> new WhatATermRead.NoNumberOfTheValue();
+        };
+    }
+
     /** What one row holds at each of a behavior's positions, for a quantity reading its own value
      *  off it. Handed in rather than reached for: which rows there are and how a value is found in
      *  one belong to the measure, and a quantity only asks what stands at a path. */
     interface Observation {
 
-        /** The one value standing at {@code path}, for a number taken of what is there. */
-        ObservedValue at(TermPath path);
+        /**
+         * What stands at {@code path}, for a number taken of what is there.
+         *
+         * <p>The walk's own answer first, because a position this compiler could not walk to is not
+         * a position a row holds nothing at. What a reading of a number does about the two differs,
+         * and a measure handing back one shape for both would settle that here, where nothing knows
+         * enough to.
+         */
+        WalkResult<ObservationAtPoint> at(TermPath path);
 
         /**
          * Every value standing at {@code path}, for a number taken over a run of them.
@@ -899,7 +958,11 @@ public sealed interface BorderQuantity {
          * about what they add up to is about all of them and does not. Answered by one method, the
          * caller that wanted one would be handed a list to choose from and the choosing would move
          * to whoever asked — which is the reading of a row being made twice.
+         *
+         * <p>Under the same walk as {@link #at}, and holding none where the row wrote no element. A
+         * total over nothing is what a run starts from rather than a value nobody could read, so
+         * there is nothing here for a row that wrote an empty container to be told apart as.
          */
-        java.util.List<ObservedValue> everyValueAt(TermPath path);
+        WalkResult<java.util.List<ObservedValue>> everyValueAt(TermPath path);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -958,8 +958,6 @@ public sealed interface BorderQuantity {
                     new WhatATermRead.Number(value);
             case NumericTerm.Reading.Missing(Incompleteness.Code code) ->
                     new WhatATermRead.CameToNothing(ReadingGap.of(code));
-            case NumericTerm.Reading.NoValue _ ->
-                    new WhatATermRead.CameToNothing(ReadingGap.NO_VALUE);
             case NumericTerm.Reading.NotNumber _ -> new WhatATermRead.NoNumberOfTheValue();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2869,48 +2869,56 @@ public final class Generator {
         List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
                 java.util.Collections.nCopies(subject.parameters().size(), null));
         row.set(parameter, observed);
-        if (!(subject.inputs().valuesAt(row, target.term().subjectPath())
-                instanceof WalkResult.Reached(List<souther.compiler.observe.ObservedValue> values))) {
-            return new RealizationReadback.CouldNotTell(new ReadbackGap.WalkAndTypeDisagree());
-        }
-        if (values.isEmpty()) {
-            return new RealizationReadback.CouldNotTell(new ReadbackGap.NoValueAtThePosition());
-        }
-        // What the number is of, asked the way the term's own reader asks it. A number one position
-        // answers is read at each value standing there, and a row stands at a point where one of its
-        // readings does; a number over a run is read of all of them at once, since that is what the
-        // walk was given and any one of them is not it.
-        Set<Incompleteness.Code> unread = EnumSet.noneOf(Incompleteness.Code.class);
-        boolean stands = switch (target) {
-            case RealizationTarget.AtOnePosition _ -> {
-                boolean any = false;
-                for (souther.compiler.observe.ObservedValue value : values) {
-                    switch (on.read(value)) {
-                        case NumericTerm.Reading.Number number ->
-                                any |= number.value().compareTo(at) == 0;
-                        case NumericTerm.Reading.Missing missing -> unread.add(missing.code());
-                        case NumericTerm.Reading.NotNumber _ -> { }
+        // Over the arms, so a walk that comes to answer a third way is one this is taught about
+        // rather than one read as the walk and the type disagreeing.
+        return switch (subject.inputs().valuesAt(row, target.term().subjectPath())) {
+            case WalkResult.CouldNotWalk<List<souther.compiler.observe.ObservedValue>> _ ->
+                    new RealizationReadback.CouldNotTell(new ReadbackGap.WalkAndTypeDisagree());
+            case WalkResult.Reached(List<souther.compiler.observe.ObservedValue> values) -> {
+                if (values.isEmpty()) {
+                    yield new RealizationReadback.CouldNotTell(
+                            new ReadbackGap.NoValueAtThePosition());
+                }
+                // What the number is of, asked the way the term's own reader asks it. A number one
+                // position answers is read at each value standing there, and a row stands at a
+                // point where one of its readings does; a number over a run is read of all of them
+                // at once, since that is what the walk was given and any one of them is not it.
+                Set<Incompleteness.Code> unread = EnumSet.noneOf(Incompleteness.Code.class);
+                boolean stands = switch (target) {
+                    case RealizationTarget.AtOnePosition _ -> {
+                        boolean any = false;
+                        for (souther.compiler.observe.ObservedValue value : values) {
+                            switch (on.read(value)) {
+                                case NumericTerm.Reading.Number number ->
+                                        any |= number.value().compareTo(at) == 0;
+                                case NumericTerm.Reading.Missing missing ->
+                                        unread.add(missing.code());
+                                case NumericTerm.Reading.NotNumber _ -> { }
+                            }
+                        }
+                        yield any;
                     }
+                    case RealizationTarget.OverARun _ -> switch (on.readOver(values)) {
+                        case NumericTerm.Reading.Number number ->
+                                number.value().compareTo(at) == 0;
+                        case NumericTerm.Reading.Missing missing -> {
+                            unread.add(missing.code());
+                            yield false;
+                        }
+                        case NumericTerm.Reading.NotNumber _ -> false;
+                    };
+                };
+                if (stands) {
+                    yield new RealizationReadback.AtRequestedPlace();
                 }
-                yield any;
+                if (!unread.isEmpty()) {
+                    yield new RealizationReadback.CouldNotTell(
+                            new ReadbackGap.Observation(unread));
+                }
+                yield new RealizationReadback.Elsewhere("it was composed to put " + target.term()
+                        + " at " + at + " and does not stand there");
             }
-            case RealizationTarget.OverARun _ -> switch (on.readOver(values)) {
-                case NumericTerm.Reading.Number number -> number.value().compareTo(at) == 0;
-                case NumericTerm.Reading.Missing missing -> {
-                    unread.add(missing.code());
-                    yield false;
-                }
-                case NumericTerm.Reading.NotNumber _ -> false;
-            };
         };
-        if (stands) {
-            return new RealizationReadback.AtRequestedPlace();
-        }
-        if (!unread.isEmpty()) {
-            return new RealizationReadback.CouldNotTell(new ReadbackGap.Observation(unread));
-        }
-        return new RealizationReadback.Elsewhere("it was composed to put " + target.term()
-                + " at " + at + " and does not stand there");
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2869,9 +2869,8 @@ public final class Generator {
         List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
                 java.util.Collections.nCopies(subject.parameters().size(), null));
         row.set(parameter, observed);
-        List<souther.compiler.observe.ObservedValue> values =
-                subject.inputs().valuesAt(row, target.term().subjectPath());
-        if (values == null) {
+        if (!(subject.inputs().valuesAt(row, target.term().subjectPath())
+                instanceof WalkResult.Reached(List<souther.compiler.observe.ObservedValue> values))) {
             return new RealizationReadback.CouldNotTell(new ReadbackGap.WalkAndTypeDisagree());
         }
         if (values.isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2881,7 +2881,6 @@ public final class Generator {
         // readings does; a number over a run is read of all of them at once, since that is what the
         // walk was given and any one of them is not it.
         Set<Incompleteness.Code> unread = EnumSet.noneOf(Incompleteness.Code.class);
-        boolean nothing = false;
         boolean stands = switch (target) {
             case RealizationTarget.AtOnePosition _ -> {
                 boolean any = false;
@@ -2890,10 +2889,6 @@ public final class Generator {
                         case NumericTerm.Reading.Number number ->
                                 any |= number.value().compareTo(at) == 0;
                         case NumericTerm.Reading.Missing missing -> unread.add(missing.code());
-                        // Nothing at this occurrence, which the walk answers with and another
-                        // occurrence may not. Neither placed nor elsewhere, and not something an
-                        // observation stopped either.
-                        case NumericTerm.Reading.NoValue _ -> nothing = true;
                         case NumericTerm.Reading.NotNumber _ -> { }
                     }
                 }
@@ -2905,10 +2900,6 @@ public final class Generator {
                     unread.add(missing.code());
                     yield false;
                 }
-                case NumericTerm.Reading.NoValue _ -> {
-                    nothing = true;
-                    yield false;
-                }
                 case NumericTerm.Reading.NotNumber _ -> false;
             };
         };
@@ -2917,9 +2908,6 @@ public final class Generator {
         }
         if (!unread.isEmpty()) {
             return new RealizationReadback.CouldNotTell(new ReadbackGap.Observation(unread));
-        }
-        if (nothing) {
-            return new RealizationReadback.CouldNotTell(new ReadbackGap.NoValueAtThePosition());
         }
         return new RealizationReadback.Elsewhere("it was composed to put " + target.term()
                 + " at " + at + " and does not stand there");

--- a/souther-compiler/src/main/java/souther/compiler/partition/InputClassifications.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InputClassifications.java
@@ -88,8 +88,8 @@ public final class InputClassifications {
      */
     private static Classification classify(List<ObservedValue> inputs, BehaviorInputs where,
                                            Axis axis) {
-        List<BehaviorInputs.Occurrence> values = where.occurrencesAt(inputs, axis.path());
-        if (values == null) {
+        if (!(where.occurrencesAt(inputs, axis.path())
+                instanceof WalkResult.Reached(List<BehaviorInputs.Occurrence> values))) {
             return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
                     axis.id().behavior(), axis.id().term());
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/InputClassifications.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InputClassifications.java
@@ -88,11 +88,19 @@ public final class InputClassifications {
      */
     private static Classification classify(List<ObservedValue> inputs, BehaviorInputs where,
                                            Axis axis) {
-        if (!(where.occurrencesAt(inputs, axis.path())
-                instanceof WalkResult.Reached(List<BehaviorInputs.Occurrence> values))) {
-            return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
-                    axis.id().behavior(), axis.id().term());
-        }
+        // Over the arms, so a walk that comes to answer a third way is one this is taught about
+        // rather than one folded into the word for a walk that could not be made.
+        return switch (where.occurrencesAt(inputs, axis.path())) {
+            case WalkResult.CouldNotWalk<List<BehaviorInputs.Occurrence>> _ ->
+                    Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
+                            axis.id().behavior(), axis.id().term());
+            case WalkResult.Reached(List<BehaviorInputs.Occurrence> values) ->
+                    among(axis, values);
+        };
+    }
+
+    /** Where each value the walk arrived at falls, and what stopped any that nothing could read. */
+    private static Classification among(Axis axis, List<BehaviorInputs.Occurrence> values) {
         // Every value here, the class it is in, and the element it came from. One value at most
         // positions; as many as were written at a position inside a sequence, where they need not
         // fall together — and where one of them being unreadable leaves the classes the others

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservationAtPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservationAtPoint.java
@@ -2,6 +2,8 @@ package souther.compiler.partition;
 
 import souther.compiler.observe.ObservedValue;
 
+import java.util.Objects;
+
 /**
  * What a row holds at one position, where the walk to that position was taken.
  *
@@ -17,8 +19,19 @@ import souther.compiler.observe.ObservedValue;
  */
 public sealed interface ObservationAtPoint {
 
-    /** One value of the row stands here. */
-    record Value(ObservedValue value) implements ObservationAtPoint { }
+    /**
+     * One value of the row stands here.
+     *
+     * <p>Which there is one of. The arms beside this one are what a position with no value of the
+     * row at it says, so an emptiness held in here would be a fourth answer that none of them names
+     * and every reader would have to guess at.
+     */
+    record Value(ObservedValue value) implements ObservationAtPoint {
+
+        public Value {
+            Objects.requireNonNull(value, "a value standing at a position is a value");
+        }
+    }
 
     /** The row wrote nothing at this position, so nothing of it stands anywhere below. */
     record WroteNothing() implements ObservationAtPoint { }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ObservationAtPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ObservationAtPoint.java
@@ -1,0 +1,39 @@
+package souther.compiler.partition;
+
+import souther.compiler.observe.ObservedValue;
+
+/**
+ * What a row holds at one position, where the walk to that position was taken.
+ *
+ * <p>Under {@link WalkResult} and not beside it. Whether the walk could be made is a question about
+ * the declarations and this compiler's reading of them; these are answers about the row, and a walk
+ * that was refused has none of them. Laid out flat with a fourth arm for the refusal, a reader
+ * switching over them would be told that not having looked is one of the things a row can hold —
+ * which is the shape that had the two arriving as one word to begin with.
+ *
+ * <p>Each says what happened and none of them says what a reader should do about it. What a
+ * quantity concludes from a row that stands nowhere is the quantity's, and it changes without these
+ * changing.
+ */
+public sealed interface ObservationAtPoint {
+
+    /** One value of the row stands here. */
+    record Value(ObservedValue value) implements ObservationAtPoint { }
+
+    /** The row wrote nothing at this position, so nothing of it stands anywhere below. */
+    record WroteNothing() implements ObservationAtPoint { }
+
+    /**
+     * The row's values here were reached through elements this reading did not choose.
+     *
+     * <p>A row inside a sequence has as many values at a position as it wrote, and standing at a
+     * point is one element standing there — so a reading names an element per step, and a position
+     * whose values are all under other elements holds none under this one. Another reading of the
+     * same row is where they are.
+     */
+    record BelongsToAnotherReading() implements ObservationAtPoint { }
+
+    ObservationAtPoint WROTE_NOTHING = new WroteNothing();
+
+    ObservationAtPoint ANOTHER_READING = new BelongsToAnotherReading();
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
@@ -51,8 +51,8 @@ public sealed interface ReadingGap {
         }
     }
 
-    /** The walk arrived at the position and no value of the row stands there, so there was none to
-     *  observe. */
+    /** The walk arrived at the position and no value of the row stands there under the reading
+     *  being tried, so there was none to observe. */
     record NoValue() implements ReadingGap {
 
         /** Nothing was compared against a figure: the walk met no value, and it meets none however

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
@@ -6,11 +6,17 @@ import souther.compiler.observe.RunSensitivity;
 /**
  * Why a reading of a number came to none.
  *
- * <p>Two kinds and neither outranks the other. A value the observation did not keep whole is a value
- * that is there, named by the code an observation writes; a walk that arrived at no value met none,
- * and has no such code. What a reader does about them differs — the first is something a wider
- * budget keeps and the second is not — so both travel, and a quantity stopped in both ways says
- * both.
+ * <p>What is there and was not kept, and what this compiler never got to. A value the observation
+ * did not keep whole is a value that is there, named by the code an observation writes; the rest
+ * arrived at no value and have no such code. What a reader does about them differs — the first is
+ * something a wider budget keeps and the others are not — so all of them travel, and a quantity
+ * stopped in more than one way says each.
+ *
+ * <p><b>{@link NoValue} is a place that was reached.</b> A walk that could not be taken and a row
+ * that could not be read are this compiler unable to look, which is not the model putting a value
+ * somewhere else; said with the same word, a report tells a reader that nothing was written at a
+ * position nothing ever looked at. Each of the three is its own arm so that the sentence written
+ * for it is chosen from what happened rather than from an emptiness they share.
  *
  * <p><b>Collected and never chosen between.</b> A rule over several terms is read once per term and
  * a point is tried against several readings of several rows, so the reasons arrive a few at a time
@@ -45,7 +51,8 @@ public sealed interface ReadingGap {
         }
     }
 
-    /** The walk arrived at no value, so there was none to observe. */
+    /** The walk arrived at the position and no value of the row stands there, so there was none to
+     *  observe. */
     record NoValue() implements ReadingGap {
 
         /** Nothing was compared against a figure: the walk met no value, and it meets none however
@@ -56,7 +63,47 @@ public sealed interface ReadingGap {
         }
     }
 
+    /**
+     * The walk into the row could not be taken, so there was no position to read at.
+     *
+     * <p>What refuses a step is the reading and the value disagreeing about what is at a position,
+     * which is a fact about this compiler's walk and says nothing about the row. A row that stands
+     * nowhere below a step took it ({@link NoValue}); this one never got that far.
+     */
+    record CouldNotWalk() implements ReadingGap {
+
+        /** The reading either exposes a name at a position or it does not, and how much a run is
+         *  allowed does not enter into it. */
+        @Override
+        public RunSensitivity runSensitivity() {
+            return RunSensitivity.UNAFFECTED;
+        }
+    }
+
+    /**
+     * A row was asked for and did not come back, so there was nothing to walk.
+     *
+     * <p>Which of the ways it did not come back — nothing built its values, or the model refused
+     * them — is not said here. Both are this compiler unable to put a row in front of the walk, and
+     * nothing downstream of the reading acts on the difference; what does tell them apart is
+     * {@code RowAsRead.whyNotRead}, and a reader that comes to need it carries it from there rather
+     * than from an arm invented here.
+     */
+    record CouldNotReadRow() implements ReadingGap {
+
+        /** Values that would not build and values the model would not take come back the same way
+         *  however much a run is allowed. */
+        @Override
+        public RunSensitivity runSensitivity() {
+            return RunSensitivity.UNAFFECTED;
+        }
+    }
+
     ReadingGap NO_VALUE = new NoValue();
+
+    ReadingGap COULD_NOT_WALK = new CouldNotWalk();
+
+    ReadingGap COULD_NOT_READ_ROW = new CouldNotReadRow();
 
     /** The gap an observation's code is, for a reader holding one. */
     static ReadingGap of(Incompleteness.Code code) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingGap.java
@@ -8,9 +8,15 @@ import souther.compiler.observe.RunSensitivity;
  *
  * <p>What is there and was not kept, and what this compiler never got to. A value the observation
  * did not keep whole is a value that is there, named by the code an observation writes; the rest
- * arrived at no value and have no such code. What a reader does about them differs — the first is
- * something a wider budget keeps and the others are not — so all of them travel, and a quantity
- * stopped in more than one way says each.
+ * arrived at no value and have no such code. What a reader does about them differs, so all of them
+ * travel, and a quantity stopped in more than one way says each.
+ *
+ * <p>Whether a wider run would come to another answer is not what tells them apart. An observation
+ * answers it out of the code it carries and the codes do not agree with each other — one a wider
+ * run keeps, another it meets again — while the three that reached no value answer alike. So it is
+ * a question put to a reason rather than a way of sorting them, and {@link
+ * souther.compiler.publish.WeakeningWord}, which sorts them more coarsely still for a document,
+ * settles it for none of them.
  *
  * <p><b>{@link NoValue} is a place that was reached.</b> A walk that could not be taken and a row
  * that could not be read are this compiler unable to look, which is not the model putting a value
@@ -29,10 +35,10 @@ public sealed interface ReadingGap {
     /**
      * Whether a run of this compiler that allows more could come to a different answer here.
      *
-     * <p>Which is the difference this type's own comment already states — one is something a wider
-     * budget keeps and the other is not — said as a value rather than as prose. Each arm asks
-     * whatever holds the fact rather than answering for it: an observation that stopped carries the
-     * code, and the code is what every producer of it agrees about.
+     * <p>Each arm asks whatever holds the fact rather than answering for it: an observation that
+     * stopped carries the code, and the code is what every producer of it agrees about. Which is
+     * why the answer does not follow from which arm this is — two observations carry two codes and
+     * the codes answer differently — and why nothing coarser than an arm may be asked it.
      */
     RunSensitivity runSensitivity();
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
@@ -110,6 +110,9 @@ public final class Recognitions {
      * <p>The three answers a reading has, in one place. A value that is not a number is a value the
      * class does not hold; a number that could not be read is why nobody can say; and only a number
      * that arrived reaches the question the class is actually about.
+     *
+     * <p>Asked of a value, so there is no fourth. Whether there is a value here was settled by
+     * whatever walked to the position, and a class is put to the ones that stand.
      */
     private static Membership counted(Recognition.OfACount count, ObservedValue value) {
         // Read on the order the value is written on; asked on the order the count is compared
@@ -118,10 +121,6 @@ public final class Recognitions {
             case NumericTerm.Reading.Number number -> Membership.of(
                     holds(count.is(), number.value(), count.carrier()));
             case NumericTerm.Reading.Missing missing -> new Membership.Incomplete(missing.code());
-            // Nothing to place, which no class holds and none refuses either. Said in this
-            // classifier's word for it, as the value that never arrived is above.
-            case NumericTerm.Reading.NoValue _ ->
-                    new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
             case NumericTerm.Reading.NotNumber _ -> Membership.NO_MATCH;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Recognitions.java
@@ -3,11 +3,11 @@ package souther.compiler.partition;
 import souther.compiler.inputs.Membership;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.numeric.Place;
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.values.Value;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * Reading one {@link Recognition} against one value.
@@ -40,6 +40,11 @@ public final class Recognitions {
      * say, so it is handed the observation as it stands ({@link Membership}).
      */
     public static Membership membershipOf(Recognition what, ObservedValue value) {
+        // A class is put to a value that stands, and whether one stands there was settled by
+        // whatever walked to the position. Answered here instead, this entry would say one thing
+        // for a class that looks at a shape and another for a class that reads a number — one
+        // question with two answers, decided by which kind of class a caller happened to hold.
+        Objects.requireNonNull(value, "a class is put to a value that stands at the position");
         return switch (what) {
             case Recognition.Under under ->
                     membershipOf(under.inner(), Classifier.inside(under.worn(), value));
@@ -58,15 +63,9 @@ public final class Recognitions {
         };
     }
 
-    /** One told apart by looking at the value, which there has to be one of to look at. */
+    /** One told apart by looking at the value, which there is one of to look at. */
     private static Membership byShape(ObservedValue value,
                                       java.util.function.Predicate<ObservedValue> holds) {
-        // No class holds what is not there, and which class it is in is what nothing can say. The
-        // word is this classifier's own: what a walk arrived at is not an observation, and the
-        // sentence read off this code is about placing a value rather than about a limit.
-        if (value == null) {
-            return new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
-        }
         Membership.Incomplete unread = Membership.unread(value);
         return unread != null ? unread : Membership.of(holds.test(value));
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -192,28 +192,36 @@ public final class StandingAtAPoint {
 
         @Override
         public WalkResult<ObservationAtPoint> at(TermPath path) {
-            if (!(where.occurrencesAt(observedInputs.inputs(), path)
-                    instanceof WalkResult.Reached(List<BehaviorInputs.Occurrence> values))) {
+            // Over the arms, so that a walk coming to answer a third way is one this has to be
+            // taught about rather than one quietly read as a walk that could not be made.
+            return switch (where.occurrencesAt(observedInputs.inputs(), path)) {
                 // The walk and the type disagree, which is the quantity's to report.
-                return WalkResult.couldNotWalk();
-            }
+                case WalkResult.CouldNotWalk<List<BehaviorInputs.Occurrence>> _ ->
+                        WalkResult.couldNotWalk();
+                case WalkResult.Reached(List<BehaviorInputs.Occurrence> values) ->
+                        WalkResult.reached(standingAmong(values));
+            };
+        }
+
+        /** Which of the row's answers this reading gets at a position the walk arrived at. */
+        private ObservationAtPoint standingAmong(List<BehaviorInputs.Occurrence> values) {
             if (values.isEmpty()) {
                 // The row wrote no element here, which is a row that was read. What that leaves a
                 // quantity is the quantity's to say, and it says it where it knows what the
                 // position is worth to the number it is reading.
-                return WalkResult.reached(ObservationAtPoint.WROTE_NOTHING);
+                return ObservationAtPoint.WROTE_NOTHING;
             }
             for (BehaviorInputs.Occurrence each : values) {
                 each.at().forEach((step, ordinal) -> held.merge(step, ordinal + 1, Math::max));
             }
             for (BehaviorInputs.Occurrence each : values) {
                 if (agrees(each)) {
-                    return WalkResult.reached(new ObservationAtPoint.Value(each.value()));
+                    return new ObservationAtPoint.Value(each.value());
                 }
             }
             // No value here under this reading. Not a stop: the reading names an element this
             // position does not have, and another reading is where its values are.
-            return WalkResult.reached(ObservationAtPoint.ANOTHER_READING);
+            return ObservationAtPoint.ANOTHER_READING;
         }
 
         /**
@@ -244,7 +252,6 @@ public final class StandingAtAPoint {
             }
             return true;
         }
-
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -119,15 +119,10 @@ public final class StandingAtAPoint {
             Set<ReadingGap> stopped = new java.util.LinkedHashSet<>();
             for (OneReadingOfARow reading : readings(where, one, quantity, criterion, first, held)) {
                 switch (quantity.standsAt(criterion, reading)) {
-                    // A reading that could not look, unless what it could not find was an element
-                    // the row wrote none of — that is a row that was read and does not stand, and
-                    // said of the reading it happened in rather than of the row, since another
-                    // reading of the same row may reach the point.
-                    case BorderQuantity.Stands.CouldNotTell it -> {
-                        if (!reading.wroteNothing()) {
-                            stopped.addAll(it.why());
-                        }
-                    }
+                    // A reading that could not look. What the row wrote nothing at is not among
+                    // these: the quantity answers for the row there, since it is the quantity that
+                    // knows whether a position it wrote nothing at leaves it a value.
+                    case BorderQuantity.Stands.CouldNotTell it -> stopped.addAll(it.why());
                     case BorderQuantity.Stands.No _ -> { }
                     case BorderQuantity.Stands.Yes _ -> stands = true;
                 }
@@ -185,7 +180,6 @@ public final class StandingAtAPoint {
         private final Map<TermPath, Integer> chosen;
         /** How many elements each step was found to have, over every reading so far. */
         private final Map<TermPath, Integer> held;
-        private boolean wroteNothing;
 
         OneReadingOfARow(BehaviorInputs where, ObservedInputs observedInputs,
                          Map<TermPath, Integer> chosen,
@@ -204,11 +198,9 @@ public final class StandingAtAPoint {
                 return WalkResult.couldNotWalk();
             }
             if (values.isEmpty()) {
-                // The row wrote no element here, so nothing of it stands anywhere on this line.
-                // That is a row that was read and does not reach the point, and reporting it as a
-                // value nothing could read leaves the point undecided over a row that plainly
-                // settles it.
-                wroteNothing = true;
+                // The row wrote no element here, which is a row that was read. What that leaves a
+                // quantity is the quantity's to say, and it says it where it knows what the
+                // position is worth to the number it is reading.
                 return WalkResult.reached(ObservationAtPoint.WROTE_NOTHING);
             }
             for (BehaviorInputs.Occurrence each : values) {
@@ -253,10 +245,6 @@ public final class StandingAtAPoint {
             return true;
         }
 
-        /** Whether the row wrote nothing at some position this line is over. */
-        boolean wroteNothing() {
-            return wroteNothing;
-        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -198,8 +198,8 @@ public final class StandingAtAPoint {
 
         @Override
         public ObservedValue at(TermPath path) {
-            List<BehaviorInputs.Occurrence> values = where.occurrencesAt(observedInputs.inputs(), path);
-            if (values == null) {
+            if (!(where.occurrencesAt(observedInputs.inputs(), path)
+                    instanceof WalkResult.Reached(List<BehaviorInputs.Occurrence> values))) {
                 return null;   // the walk and the type disagree, which is the quantity's to report
             }
             if (values.isEmpty()) {
@@ -238,7 +238,8 @@ public final class StandingAtAPoint {
         public List<ObservedValue> everyValueAt(TermPath path) {
             // Null where the walk and the type disagree, which is the quantity's to report, as it
             // is for the one value a place holds.
-            return where.valuesAt(observedInputs.inputs(), path);
+            return where.valuesAt(observedInputs.inputs(), path)
+                    instanceof WalkResult.Reached(List<ObservedValue> values) ? values : null;
         }
 
         /** Whether {@code each} was reached through the elements this reading chose. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StandingAtAPoint.java
@@ -197,10 +197,11 @@ public final class StandingAtAPoint {
         }
 
         @Override
-        public ObservedValue at(TermPath path) {
+        public WalkResult<ObservationAtPoint> at(TermPath path) {
             if (!(where.occurrencesAt(observedInputs.inputs(), path)
                     instanceof WalkResult.Reached(List<BehaviorInputs.Occurrence> values))) {
-                return null;   // the walk and the type disagree, which is the quantity's to report
+                // The walk and the type disagree, which is the quantity's to report.
+                return WalkResult.couldNotWalk();
             }
             if (values.isEmpty()) {
                 // The row wrote no element here, so nothing of it stands anywhere on this line.
@@ -208,19 +209,19 @@ public final class StandingAtAPoint {
                 // value nothing could read leaves the point undecided over a row that plainly
                 // settles it.
                 wroteNothing = true;
-                return null;
+                return WalkResult.reached(ObservationAtPoint.WROTE_NOTHING);
             }
             for (BehaviorInputs.Occurrence each : values) {
                 each.at().forEach((step, ordinal) -> held.merge(step, ordinal + 1, Math::max));
             }
             for (BehaviorInputs.Occurrence each : values) {
                 if (agrees(each)) {
-                    return each.value();
+                    return WalkResult.reached(new ObservationAtPoint.Value(each.value()));
                 }
             }
             // No value here under this reading. Not a stop: the reading names an element this
             // position does not have, and another reading is where its values are.
-            return null;
+            return WalkResult.reached(ObservationAtPoint.ANOTHER_READING);
         }
 
         /**
@@ -235,11 +236,10 @@ public final class StandingAtAPoint {
          * written nothing here: it wrote a container, and what it holds is none.
          */
         @Override
-        public List<ObservedValue> everyValueAt(TermPath path) {
-            // Null where the walk and the type disagree, which is the quantity's to report, as it
-            // is for the one value a place holds.
-            return where.valuesAt(observedInputs.inputs(), path)
-                    instanceof WalkResult.Reached(List<ObservedValue> values) ? values : null;
+        public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+            // The walk's own answer handed on, which is the quantity's to report where it could not
+            // be taken, as it is for the one value a place holds.
+            return where.valuesAt(observedInputs.inputs(), path);
         }
 
         /** Whether {@code each} was reached through the elements this reading chose. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/WalkResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WalkResult.java
@@ -1,0 +1,38 @@
+package souther.compiler.partition;
+
+/**
+ * What a walk down a path came to, where a walk is a thing that may not be possible to take.
+ *
+ * <p>Two questions and not one. Whether a path can be walked at all is settled by the declarations
+ * and the value in hand, and what stands at the end of it is settled by the row — and a walk that
+ * could not be taken has no answer to the second, so it answers the first instead of handing back
+ * an emptiness a reader has to give a meaning to. Answered with one shape, the two arrive as one
+ * word downstream: a place this compiler could not reach is reported as a place a row wrote
+ * nothing, which is news about the model where nothing about the model was found out.
+ *
+ * <p><b>What {@link Reached} holds may itself hold nothing.</b> A walk that arrived and found the
+ * row standing nowhere below it is a walk that arrived, and its emptiness is an answer rather than
+ * the lack of one. That is the whole distinction this type exists to keep, so a reader that means
+ * to ask about the row asks it of what {@code Reached} carries and never of which of these two came
+ * back.
+ *
+ * @param <T> what the walk answers with where it was taken
+ */
+public sealed interface WalkResult<T> {
+
+    /** The walk was taken, and this is what it came to. */
+    record Reached<T>(T value) implements WalkResult<T> { }
+
+    /** The walk could not be taken, so there is nothing it came to. */
+    record CouldNotWalk<T>() implements WalkResult<T> { }
+
+    /** The walk taken, answering with {@code value}. */
+    static <T> WalkResult<T> reached(T value) {
+        return new Reached<>(value);
+    }
+
+    /** The walk not taken, which every caller says the same way. */
+    static <T> WalkResult<T> couldNotWalk() {
+        return new CouldNotWalk<>();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/WalkResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WalkResult.java
@@ -1,5 +1,7 @@
 package souther.compiler.partition;
 
+import java.util.Objects;
+
 /**
  * What a walk down a path came to, where a walk is a thing that may not be possible to take.
  *
@@ -10,18 +12,27 @@ package souther.compiler.partition;
  * word downstream: a place this compiler could not reach is reported as a place a row wrote
  * nothing, which is news about the model where nothing about the model was found out.
  *
- * <p><b>What {@link Reached} holds may itself hold nothing.</b> A walk that arrived and found the
- * row standing nowhere below it is a walk that arrived, and its emptiness is an answer rather than
- * the lack of one. That is the whole distinction this type exists to keep, so a reader that means
- * to ask about the row asks it of what {@code Reached} carries and never of which of these two came
- * back.
+ * <p><b>What {@link Reached} holds may stand for none, and is never absent.</b> A walk that arrived
+ * and found the row standing nowhere below it is a walk that arrived, and it says so with an
+ * answer that holds none — an empty run, or the arm of {@link ObservationAtPoint} that names it.
+ * That is the whole distinction this type exists to keep, so a reader that means to ask about the
+ * row asks it of what {@code Reached} carries and never of which of these two came back.
+ *
+ * <p>Which is why nothing is what {@code Reached} may not hold. Given one, a caller unpacking the
+ * arm that means the walk arrived would be back to reading a meaning into an emptiness, one layer
+ * inside the value that was made to stop that.
  *
  * @param <T> what the walk answers with where it was taken
  */
 public sealed interface WalkResult<T> {
 
     /** The walk was taken, and this is what it came to. */
-    record Reached<T>(T value) implements WalkResult<T> { }
+    record Reached<T>(T value) implements WalkResult<T> {
+
+        public Reached {
+            Objects.requireNonNull(value, "a walk that was taken came to something");
+        }
+    }
 
     /** The walk could not be taken, so there is nothing it came to. */
     record CouldNotWalk<T>() implements WalkResult<T> { }

--- a/souther-compiler/src/main/java/souther/compiler/partition/WhatATermRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WhatATermRead.java
@@ -7,6 +7,7 @@ import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * What one term of a quantity came to at one row: the number it names, or why it names none.
@@ -28,7 +29,12 @@ import java.util.List;
 sealed interface WhatATermRead {
 
     /** The number the term names at this row. */
-    record Number(Place value) implements WhatATermRead { }
+    record Number(Place value) implements WhatATermRead {
+
+        public Number {
+            Objects.requireNonNull(value, "a term that names a number names one");
+        }
+    }
 
     /** The value was read and this term is no number of it, which is an answer about the value and
      *  not about anything that stopped. */
@@ -45,7 +51,12 @@ sealed interface WhatATermRead {
     record NothingWrittenThere() implements WhatATermRead { }
 
     /** No number, and this is what the reading met instead. */
-    record CameToNothing(ReadingGap why) implements WhatATermRead { }
+    record CameToNothing(ReadingGap why) implements WhatATermRead {
+
+        public CameToNothing {
+            Objects.requireNonNull(why, "a reading that came to nothing says what it met");
+        }
+    }
 
     /** What {@code on} reads where the walk to its one position came to {@code answered}. */
     static WhatATermRead at(TermOrders on, WalkResult<ObservationAtPoint> answered) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/WhatATermRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/WhatATermRead.java
@@ -1,0 +1,88 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.numeric.Place;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+
+import java.util.List;
+
+/**
+ * What one term of a quantity came to at one row: the number it names, or why it names none.
+ *
+ * <p>The arms every reading of a term ends in, rather than {@link NumericTerm.Reading}'s. A walk
+ * that was not taken is one of the ways a term comes to no number and is not a reading of a value,
+ * so it has no arm there — and each of the quantities would otherwise carry its own guard for that
+ * before asking, which is one rule written as many times as there are quantities.
+ *
+ * <p>Made here and nowhere else. What a walk answered and what a term reads of a value are put
+ * together in one place, so the arms below are the whole of what a quantity has to answer for, and
+ * a quantity that met something new is one this file has been taught about.
+ *
+ * <p><b>Every reader switches over these.</b> The point of the arms is that a quantity says what it
+ * does about each; read with a chain of tests ending in a fall-through, an arm added later would
+ * quietly take whatever the last line does, which is how a term that could not be read came to be
+ * answered as a row standing somewhere else.
+ */
+sealed interface WhatATermRead {
+
+    /** The number the term names at this row. */
+    record Number(Place value) implements WhatATermRead { }
+
+    /** The value was read and this term is no number of it, which is an answer about the value and
+     *  not about anything that stopped. */
+    record NoNumberOfTheValue() implements WhatATermRead { }
+
+    /**
+     * The row wrote nothing at the term's position, so this quantity has no value at this row.
+     *
+     * <p>Which settles the row rather than leaving it open, and settles it whatever else the
+     * quantity met. A number over a position a row put nothing at is a number the row does not
+     * have, and it does not have it any more once a wider run keeps what it shortened elsewhere —
+     * so a reading stopped at another term is not what a reader is told about this row.
+     */
+    record NothingWrittenThere() implements WhatATermRead { }
+
+    /** No number, and this is what the reading met instead. */
+    record CameToNothing(ReadingGap why) implements WhatATermRead { }
+
+    /** What {@code on} reads where the walk to its one position came to {@code answered}. */
+    static WhatATermRead at(TermOrders on, WalkResult<ObservationAtPoint> answered) {
+        return switch (answered) {
+            case WalkResult.CouldNotWalk<ObservationAtPoint> _ ->
+                    new CameToNothing(ReadingGap.COULD_NOT_WALK);
+            case WalkResult.Reached(ObservationAtPoint standing) -> switch (standing) {
+                case ObservationAtPoint.Value(ObservedValue value) -> of(on.read(value));
+                // A fact about the row, which answers for it. The row was read and put no element
+                // here, so this quantity has no value at it -- and reporting that as a reading that
+                // came to nothing leaves a point undecided over a row that plainly settles it.
+                case ObservationAtPoint.WroteNothing _ -> new NothingWrittenThere();
+                // The row's values here are under elements another reading chose. The walk arrived
+                // and none of this row's values stands here under this one, which is the reading
+                // coming to nothing and is what the word is for.
+                case ObservationAtPoint.BelongsToAnotherReading _ ->
+                        new CameToNothing(ReadingGap.NO_VALUE);
+            };
+        };
+    }
+
+    /** The same over the values of a run, which a walk that was not taken has none of. */
+    static WhatATermRead over(TermOrders on, WalkResult<List<ObservedValue>> answered) {
+        return switch (answered) {
+            case WalkResult.CouldNotWalk<List<ObservedValue>> _ ->
+                    new CameToNothing(ReadingGap.COULD_NOT_WALK);
+            case WalkResult.Reached(List<ObservedValue> values) -> of(on.readOver(values));
+        };
+    }
+
+    /** What a term's own reading of a value comes to here. */
+    private static WhatATermRead of(NumericTerm.Reading read) {
+        return switch (read) {
+            case NumericTerm.Reading.Number(Place value) -> new Number(value);
+            case NumericTerm.Reading.Missing(Incompleteness.Code code) ->
+                    new CameToNothing(ReadingGap.of(code));
+            case NumericTerm.Reading.NotNumber _ -> new NoNumberOfTheValue();
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublicationOrders.java
@@ -203,7 +203,9 @@ public final class PublicationOrders {
      * code is that code, so the two orders agreeing is not something to keep in step — there is one
      * order, and this is it with the one reason that is no observation's put after them. A walk
      * that reached no value is last for the same reason the codes are in the order they are: it is
-     * the furthest from an answer.
+     * the furthest from an answer. The two that never reached a value to begin with follow it, a
+     * step further out again — a position that was read and holds nothing is nearer a number than a
+     * position nothing arrived at, and a walk that was refused is nearer than a row that never came.
      */
     public static final CanonicalSelection.Order<ReadingGap> READING_GAPS =
             CanonicalSelection.Order.overValues(everyReadingGap());
@@ -214,6 +216,8 @@ public final class PublicationOrders {
             out.add(ReadingGap.of(code));
         }
         out.add(ReadingGap.NO_VALUE);
+        out.add(ReadingGap.COULD_NOT_WALK);
+        out.add(ReadingGap.COULD_NOT_READ_ROW);
         return out;
     }
 
@@ -311,6 +315,7 @@ public final class PublicationOrders {
                 WeakeningWord.INPUT_CASES_UNREADABLE,
                 WeakeningWord.BORDER_VALUE_UNREADABLE,
                 WeakeningWord.BORDER_VALUE_ABSENT,
+                WeakeningWord.BORDER_OBSERVATION_UNAVAILABLE,
                 WeakeningWord.BODIES_NOT_ELABORATED,
                 WeakeningWord.BEHAVIOR_INPUT_NOT_READ,
                 WeakeningWord.BEHAVIOR_BOUNDARY_NOT_DERIVED,

--- a/souther-compiler/src/main/java/souther/compiler/publish/WeakeningWord.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/WeakeningWord.java
@@ -44,6 +44,20 @@ public enum WeakeningWord {
      */
     BORDER_VALUE_ABSENT,
 
+    /**
+     * A row's value at one border was never looked at: the walk to the position could not be taken,
+     * or no row came back to walk.
+     *
+     * <p>One word for the two, because what a reader does about them is the same. Both are this
+     * compiler unable to look rather than the model putting a value elsewhere, and a wider budget
+     * changes neither — which is the whole of what this vocabulary sorts on. Which of the two it
+     * was is said by the reading's own reason underneath, and the sentence the document writes is
+     * chosen from that; a second word here would be that taxonomy kept in two places, free to drift
+     * apart. They part when their weakening does: when a run, a budget or the order over these
+     * comes to treat one differently from the other.
+     */
+    BORDER_OBSERVATION_UNAVAILABLE,
+
     /** A rule of the model that a reader set aside. */
     RULE_UNREAD,
 

--- a/souther-compiler/src/main/java/souther/compiler/publish/WeakeningWord.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/WeakeningWord.java
@@ -48,13 +48,16 @@ public enum WeakeningWord {
      * A row's value at one border was never looked at: the walk to the position could not be taken,
      * or no row came back to walk.
      *
-     * <p>One word for the two, because what a reader does about them is the same. Both are this
-     * compiler unable to look rather than the model putting a value elsewhere, and a wider budget
-     * changes neither — which is the whole of what this vocabulary sorts on. Which of the two it
+     * <p>One word for the two, because what a reader does about them is the same: both are this
+     * compiler unable to look rather than the model putting a value elsewhere. Which of the two it
      * was is said by the reading's own reason underneath, and the sentence the document writes is
      * chosen from that; a second word here would be that taxonomy kept in two places, free to drift
-     * apart. They part when their weakening does: when a run, a budget or the order over these
-     * comes to treat one differently from the other.
+     * apart. They part when what a reader does about them parts.
+     *
+     * <p>Which is the grouping this vocabulary is for, and not a finer claim about the reasons
+     * under a word. {@link #BORDER_VALUE_UNREADABLE} covers an observation a wider run would have
+     * kept and one it would meet again, and covers them as one word for the same reason: the code
+     * travels underneath. A word here says what happened at the coarseness a reader acts on.
      */
     BORDER_OBSERVATION_UNAVAILABLE,
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -1012,14 +1012,16 @@ final class Coverages {
         souther.compiler.partition.ObservedInputs read =
                 probe.read(built.row().inputs()).asInputs();
         if (read == null) {
-            // Nothing came back to read the row off, which is not an observation of it. What did
-            // not happen here is the running: the values would not build a second time, or the
-            // model refused them, or the classes would not link — and every one of those is
-            // something this run did rather than a value a limit shortened. Named as the second, a
-            // linkage failure arrives at the account as an observation that was stopped, and the
-            // report says a limit did something that never fired.
+            // Nothing came back to read the row off, which is not an observation of it and is not a
+            // position holding no value either. What did not happen here is the running: the values
+            // would not build a second time, or the model refused them, or the classes would not
+            // link — and every one of those is something this run did rather than a value a limit
+            // shortened or a place a row wrote nothing at. Named as the first, a linkage failure
+            // arrives at the account as an observation that was stopped and the report says a limit
+            // did something that never fired; named as the second, it says the row put nothing
+            // where nothing ever looked.
             return new StandingAtAPoint.Met.CouldNotTell(
-                    Set.of(souther.compiler.partition.ReadingGap.NO_VALUE));
+                    Set.of(souther.compiler.partition.ReadingGap.COULD_NOT_READ_ROW));
         }
         return StandingAtAPoint.met(line, List.of(read), criterion, site);
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1952,13 +1952,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return said.isEmpty() ? "" : ", and " + String.join(", and ", said);
     }
 
-    /** What one reading met at a border instead of a number, in the reading's own words. */
-    private static String atTheBorder(ReadingGap why) {
+    /**
+     * What one reading met at a border instead of a number, in the reading's own words.
+     *
+     * <p>Where the reasons stay apart. Several of them weaken a document the same way and are one
+     * word to the vocabulary that sorts on that; a reader is still owed which of them happened, and
+     * this is what says it. So it is open to the census that holds every reason to a sentence
+     * nothing else writes.
+     */
+    static String atTheBorder(ReadingGap why) {
         return switch (why) {
             case ReadingGap.Observation(Incompleteness.Code code) -> whatStopped(code);
             // Nothing was observed here, so nothing about an observation is said. What a reader is
             // owed is that no value arrived at all, which no budget would have changed.
             case ReadingGap.NoValue _ -> "the walk reached no value there to read";
+            // And where nothing was looked at, what a reader is owed is that the position was never
+            // read -- said the way it happened, since "no value there" is a claim about the row and
+            // nothing here found anything out about one.
+            case ReadingGap.CouldNotWalk _ -> "the walk to that position could not be taken";
+            case ReadingGap.CouldNotReadRow _ -> "no row came back to read there";
         };
     }
 
@@ -3824,6 +3836,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case Weakening.BorderValueUnreadable it -> switch (it.why()) {
                 case ReadingGap.Observation _ -> WeakeningWord.BORDER_VALUE_UNREADABLE;
                 case ReadingGap.NoValue _ -> WeakeningWord.BORDER_VALUE_ABSENT;
+                // One word, and the reason underneath keeps which of the two it was. A position
+                // that was read and holds nothing is news about the row; neither of these is, and a
+                // reader weighing the document acts on both the same way.
+                case ReadingGap.CouldNotWalk _, ReadingGap.CouldNotReadRow _ ->
+                        WeakeningWord.BORDER_OBSERVATION_UNAVAILABLE;
             };
             case Weakening.ModelReadingIncomplete it -> switch (it.cause()) {
                 case ClosureGap.PositionNotReachedInto _ ->

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-12.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-12.json
@@ -190,6 +190,7 @@
           "row_did_not_finish",
           "border_value_unreadable",
           "border_value_absent",
+          "border_observation_unavailable",
           "rule_unread",
           "position_not_read",
           "question_unanswered",

--- a/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ALimitThatFiredIsNotALimitTheTermReadTest.java
@@ -20,7 +20,9 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.partition.BorderQuantity;
 import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Level;
+import souther.compiler.partition.ObservationAtPoint;
 import souther.compiler.partition.ReadingGap;
+import souther.compiler.partition.WalkResult;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -143,13 +145,13 @@ class ALimitThatFiredIsNotALimitTheTermReadTest {
         return new BorderQuantity.Observation() {
 
             @Override
-            public ObservedValue at(TermPath path) {
+            public WalkResult<ObservationAtPoint> at(TermPath path) {
                 assertEquals(TermPath.of("lines"), path, "read at the container the count is of");
-                return observed;
+                return WalkResult.reached(new ObservationAtPoint.Value(observed));
             }
 
             @Override
-            public List<ObservedValue> everyValueAt(TermPath path) {
+            public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
                 throw new AssertionError("a count of a container is not read over a run");
             }
         };
@@ -160,14 +162,14 @@ class ALimitThatFiredIsNotALimitTheTermReadTest {
         return new BorderQuantity.Observation() {
 
             @Override
-            public ObservedValue at(TermPath path) {
+            public WalkResult<ObservationAtPoint> at(TermPath path) {
                 throw new AssertionError("a number over a run is not read from one value");
             }
 
             @Override
-            public List<ObservedValue> everyValueAt(TermPath path) {
-                return observed instanceof ObservedValue.Sequence held ? held.elements()
-                        : List.of(observed);
+            public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+                return WalkResult.reached(observed instanceof ObservedValue.Sequence held
+                        ? held.elements() : List.of(observed));
             }
         };
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANumberOverARunIsMeasuredWithoutAPositionTest.java
@@ -154,15 +154,15 @@ class ANumberOverARunIsMeasuredWithoutAPositionTest {
         return new BorderQuantity.Observation() {
 
             @Override
-            public ObservedValue at(TermPath path) {
+            public WalkResult<ObservationAtPoint> at(TermPath path) {
                 throw new AssertionError("a number over a run is not read from one value, and"
                         + " asking for one is the defect this term exists to stop");
             }
 
             @Override
-            public List<ObservedValue> everyValueAt(TermPath path) {
+            public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
                 assertEquals(UNDER, path, "read from where the run says its values are");
-                return values;
+                return WalkResult.reached(values);
             }
         };
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionARowWroteNothingAtAnswersForTheRowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionARowWroteNothingAtAnswersForTheRowTest.java
@@ -13,8 +13,10 @@ import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -100,12 +102,40 @@ class APositionARowWroteNothingAtAnswersForTheRowTest {
                 "and the same of a pair whose ends were both stopped");
     }
 
+    /**
+     * And it asks every term it has, the answer being settled or not.
+     *
+     * <p>Asking is how the measure finds out how many elements each of the line's positions holds,
+     * and that is what says how many readings of the row there are to try — so a quantity that
+     * stopped asking as soon as it knew its answer would be deciding which readings the row gets.
+     * The two are one call, and this is what keeps the second whole while the first short-circuits.
+     *
+     * <p>Held of the row's own answer because that is the one that settles a form outright. The
+     * reasons do not: a term that came to nothing goes on to the next term already.
+     */
+    @Test
+    void aFormAsksEveryTermThoughOneOfThemSettlesTheRow() {
+        Set<TermPath> asked = new LinkedHashSet<>();
+
+        form(AT_THE_EMPTY, AT_THE_STOPPED).standsAt(AT_A_HUNDRED, oneOfEach(asked));
+
+        assertEquals(Set.of(NOTHING_WRITTEN, STOPPED), asked,
+                "both positions were asked, so what each holds is known to whoever enumerates the"
+                        + " readings");
+    }
+
     /** A row that wrote nothing at one position and a value the limits stopped at the other. */
     private static BorderQuantity.Observation oneOfEach() {
+        return oneOfEach(new LinkedHashSet<>());
+    }
+
+    /** The same, recording every position it was asked about. */
+    private static BorderQuantity.Observation oneOfEach(Set<TermPath> asked) {
         return new BorderQuantity.Observation() {
 
             @Override
             public WalkResult<ObservationAtPoint> at(TermPath path) {
+                asked.add(path);
                 return WalkResult.reached(NOTHING_WRITTEN.equals(path)
                         ? ObservationAtPoint.WROTE_NOTHING
                         : new ObservationAtPoint.Value(new ObservedValue.Truncated()));

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionARowWroteNothingAtAnswersForTheRowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionARowWroteNothingAtAnswersForTheRowTest.java
@@ -1,0 +1,138 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermOrders;
+import souther.compiler.inputs.TermOrdersFixtures;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.LinearForm;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A position a row wrote nothing at answers for the row, and outranks what stopped elsewhere.
+ *
+ * <p>Two things a quantity meets that both leave it no number, and they are not the same news. A
+ * reading that was stopped is this compiler unable to find out where the row stands; a position the
+ * row put nothing at is the row saying it has no value for this quantity, which is an answer. So the
+ * second settles the row however much of the rest could not be read — a quantity over a position the
+ * row wrote nothing at is a row that does not stand, not a row nobody could place.
+ *
+ * <p><b>Both ways round, where round is a way there is.</b> A rule that held only when the row's own
+ * answer was reached first would be a rule about the order the terms were walked in. A pair's ends
+ * are walked in the order it holds them, so the pair is written twice with them swapped and an
+ * answer that turns on which came first fails one of them. A form's terms are walked in the order
+ * its coefficients happen to hash into, which is nobody's to choose — so writing one twice with the
+ * terms exchanged is the same walk, and what the two lines below hold is that the answer does not
+ * depend on how the form was spelled.
+ */
+class APositionARowWroteNothingAtAnswersForTheRowTest {
+
+    private static final TermPath NOTHING_WRITTEN = TermPath.of("lines").element().then("amount");
+
+    private static final TermPath STOPPED = TermPath.of("fees").element().then("amount");
+
+    private static final NumericTerm.ValueOf AT_THE_EMPTY =
+            new NumericTerm.ValueOf(NOTHING_WRITTEN);
+
+    private static final NumericTerm.ValueOf AT_THE_STOPPED = new NumericTerm.ValueOf(STOPPED);
+
+    /** A second stopped position, since a distance runs between two and not one named twice. */
+    private static final NumericTerm.ValueOf AT_ANOTHER_STOPPED =
+            new NumericTerm.ValueOf(TermPath.of("levies").element().then("amount"));
+
+    private static final Criterion AT_A_HUNDRED =
+            new Criterion.AtTheLevel(new Level.ACount(Count.of(100)));
+
+    /** The row's answer, however the form carrying the term is written. */
+    @Test
+    void aFormOverAPositionTheRowWroteNothingAtDoesNotStand() {
+        assertEquals(BorderQuantity.Stands.NO,
+                form(AT_THE_EMPTY, AT_THE_STOPPED).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "the row wrote nothing at a position the form is over, so it has no value here");
+        assertEquals(BorderQuantity.Stands.NO,
+                form(AT_THE_STOPPED, AT_THE_EMPTY).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "and the same with the two terms written the other way round");
+    }
+
+    /**
+     * A pair with one end the row wrote nothing at says the same, whichever end it is.
+     *
+     * <p>The other quantity that reads more than one position, and it collects its reasons from
+     * both ends before concluding. So it is asked here too rather than left to the form's answer:
+     * two quantities are two places the rule can be got wrong.
+     */
+    @Test
+    void aPairWithOneEndTheRowWroteNothingAtDoesNotStand() {
+        assertEquals(BorderQuantity.Stands.NO,
+                pair(AT_THE_EMPTY, AT_THE_STOPPED).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "an end the row wrote nothing at leaves the pair no distance to stand at");
+        assertEquals(BorderQuantity.Stands.NO,
+                pair(AT_THE_STOPPED, AT_THE_EMPTY).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "and the same with the ends swapped");
+    }
+
+    /**
+     * And a quantity whose every term was stopped says so, which is the control.
+     *
+     * <p>Without it the two above pass for a quantity that answers that nothing stands whatever it
+     * meets — which is the answer the row's own is being told apart from.
+     */
+    @Test
+    void aQuantityStoppedAndNothingElseIsUndecided() {
+        BorderQuantity.Stands undecided = BorderQuantity.Stands.couldNotTell(
+                ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED));
+
+        assertEquals(undecided,
+                form(AT_THE_STOPPED, AT_THE_STOPPED).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "nothing here is the row's answer, so the point is one this could not tell about");
+        assertEquals(undecided,
+                pair(AT_THE_STOPPED, AT_ANOTHER_STOPPED).standsAt(AT_A_HUNDRED, oneOfEach()),
+                "and the same of a pair whose ends were both stopped");
+    }
+
+    /** A row that wrote nothing at one position and a value the limits stopped at the other. */
+    private static BorderQuantity.Observation oneOfEach() {
+        return new BorderQuantity.Observation() {
+
+            @Override
+            public WalkResult<ObservationAtPoint> at(TermPath path) {
+                return WalkResult.reached(NOTHING_WRITTEN.equals(path)
+                        ? ObservationAtPoint.WROTE_NOTHING
+                        : new ObservationAtPoint.Value(new ObservedValue.Truncated()));
+            }
+
+            @Override
+            public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+                throw new AssertionError("a number of one position is not read over a run");
+            }
+        };
+    }
+
+    private static BorderQuantity.OverAForm form(NumericTerm.ValueOf first,
+                                                 NumericTerm.ValueOf second) {
+        Map<NumericTerm, TermOrders> on = new LinkedHashMap<>();
+        on.put(first, ordersOf(first));
+        on.put(second, ordersOf(second));
+        return new BorderQuantity.OverAForm("decide",
+                LinearForm.atom((NumericTerm) first).plus(LinearForm.atom((NumericTerm) second)),
+                on);
+    }
+
+    private static BorderQuantity.Apart pair(NumericTerm.ValueOf on, NumericTerm.ValueOf against) {
+        return new BorderQuantity.Apart("decide", ordersOf(on), ordersOf(against));
+    }
+
+    private static TermOrders ordersOf(NumericTerm.ValueOf term) {
+        return TermOrdersFixtures.itself(term, new Carrier.Whole());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
@@ -112,13 +112,20 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
                 .then(field);
     }
 
+    /** What the walk came to, held to its having been taken first. */
+    private static List<ObservedValue> stood(WalkResult<List<ObservedValue>> walked) {
+        if (walked instanceof WalkResult.Reached(List<ObservedValue> values)) {
+            return values;
+        }
+        throw new AssertionError("the walk was taken: nothing went wrong with the row");
+    }
+
     /** The row that wrote the case stands at the positions under it. */
     @Test
     void aRowAtTheCaseStandsAtItsFields() {
         Read read = read();
-        List<ObservedValue> values = read.inputs().valuesAt(read.rows().get(0).inputs(),
-                under("example.q", "GlobalQuery", "tag"));
-        assertNotNull(values, "the walk was taken");
+        List<ObservedValue> values = stood(read.inputs().valuesAt(read.rows().get(0).inputs(),
+                under("example.q", "GlobalQuery", "tag")));
         assertEquals(1, values.size(), values.toString());
     }
 
@@ -131,9 +138,8 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
     @Test
     void aRowAtAnotherCaseIsReadAndStandsNowhere() {
         Read read = read();
-        List<ObservedValue> values = read.inputs().valuesAt(read.rows().get(1).inputs(),
-                under("example.q", "GlobalQuery", "tag"));
-        assertNotNull(values, "the walk was taken: nothing went wrong with the row");
+        List<ObservedValue> values = stood(read.inputs().valuesAt(read.rows().get(1).inputs(),
+                under("example.q", "GlobalQuery", "tag")));
         assertEquals(List.of(), values, "and the row put nothing at a position it is not at");
     }
 
@@ -142,7 +148,8 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
     void thePathAndTheDeclarationAgreeAtBothRows() {
         Read read = read();
         for (RowOutcome row : read.rows()) {
-            assertNotNull(read.inputs().occurrencesAt(row.inputs(),
+            assertInstanceOf(WalkResult.Reached.class,
+                    read.inputs().occurrencesAt(row.inputs(),
                             under("example.q", "FeedQuery", "limit")),
                     () -> "the walk was taken for " + row.inputs());
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -210,8 +210,8 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
     /**
      * What the boundary's caller sees, which is why this changes nothing for it.
      *
-     * <p>{@code valueAt} already hands back a stopped observation where the path ends on one — the
-     * loop runs out of fields and returns what it is holding — so a caller that asks it for a number
+     * <p>The walk already hands back a stopped observation where the path ends on one — the loop
+     * runs out of fields and returns what it is holding — so a caller that asks it for a number
      * already meets one and reads it as no number. Keeping the same value from one field earlier
      * gives that caller a value it already handles rather than a new one.
      */
@@ -220,12 +220,22 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
         Read read = read();
 
         assertInstanceOf(ObservedValue.Truncated.class,
-                read.subject().inputs().valueAt(givingInterval(read, intervalHolding(read,
-                        new ObservedValue.Truncated())).inputs(), position(read)),
+                theOneValueAt(read, givingInterval(read, intervalHolding(read,
+                        new ObservedValue.Truncated())).inputs()),
                 "the limit was reached at the position");
         assertInstanceOf(ObservedValue.Truncated.class,
-                read.subject().inputs().valueAt(
-                        givingInterval(read, new ObservedValue.Truncated()).inputs(), position(read)),
+                theOneValueAt(read,
+                        givingInterval(read, new ObservedValue.Truncated()).inputs()),
                 "the limit was reached one field above the position");
+    }
+
+    /** The value the walk to the position came to, which the model under test writes one of. */
+    private static ObservedValue theOneValueAt(Read read, List<ObservedValue> inputs) {
+        if (read.subject().inputs().valuesAt(inputs, position(read))
+                instanceof WalkResult.Reached(List<ObservedValue> values)
+                && values.size() == 1) {
+            return values.getFirst();
+        }
+        throw new AssertionError("one value stands at " + position(read));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * A row is read at a position by what the reading exposes there, and never by what its value
@@ -92,7 +91,7 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
     @Test
     void aNameEveryCaseSpreadsIsReadAtEveryCase() {
         assertEquals(List.of(new ObservedValue.Integer(6), new ObservedValue.Integer(7)),
-                read(SPREAD, aCardAndACash(), amount()),
+                stood(SPREAD, aCardAndACash(), amount()),
                 "the amount is readable at the sum, so a row is read at it whichever case it wrote");
     }
 
@@ -111,7 +110,8 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
      */
     @Test
     void aFieldOnlyOneCaseDeclaresIsNotReadableAtTheSum() {
-        assertNull(read(SPREAD, List.of(card(6), card(7)), cardNumber()),
+        assertInstanceOf(WalkResult.CouldNotWalk.class,
+                read(SPREAD, List.of(card(6), card(7)), cardNumber()),
                 "nothing is readable at the sum but what its cases share, so this walk cannot be"
                         + " made at all");
     }
@@ -120,7 +120,7 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
     @Test
     void aNarrowingIsHowACaseOwnFieldIsReached() {
         assertEquals(List.of(new ObservedValue.Text("x")),
-                read(SPREAD, aCardAndACash(), cardNumberAsACard()),
+                stood(SPREAD, aCardAndACash(), cardNumberAsACard()),
                 "a path that names the case may read what only that case declares");
     }
 
@@ -133,10 +133,10 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
      */
     @Test
     void aRowAtAnotherCaseStandsNowhereRatherThanFailingTheWalk() {
-        List<ObservedValue> found = read(SPREAD, List.of(cash(7)), cardNumberAsACard());
-
-        assertNotNull(found, "the narrowing is a step this path may take, whatever the row wrote");
-        assertEquals(List.of(), found,
+        assertInstanceOf(WalkResult.Reached.class,
+                read(SPREAD, List.of(cash(7)), cardNumberAsACard()),
+                "the narrowing is a step this path may take, whatever the row wrote");
+        assertEquals(List.of(), stood(SPREAD, List.of(cash(7)), cardNumberAsACard()),
                 "and a row at the other case stands nowhere below it");
     }
 
@@ -156,12 +156,12 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
     void aSpreadNameReadsLikeOneDeclaredOnTheElement() {
         List<ObservedValue> written = List.of(new ObservedValue.Integer(6));
 
-        assertEquals(written, read(SPREAD, List.of(card(6)), amount()),
+        assertEquals(written, stood(SPREAD, List.of(card(6)), amount()),
                 "the run holds the number the row wrote at the name the cases spread");
-        assertEquals(written, read(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
+        assertEquals(written, stood(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
                 "and the same number where the element declares it");
-        assertEquals(read(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
-                read(SPREAD, List.of(card(6)), amount()),
+        assertEquals(stood(ON_THE_ELEMENT, List.of(onTheElement(6)), amount()),
+                stood(SPREAD, List.of(card(6)), amount()),
                 "the cases spreading the name change nothing about what a run of it holds");
     }
 
@@ -182,12 +182,12 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
     @Test
     void whatTheStepsBesideAFieldAdmitIsSaidHere() {
         assertEquals(List.of(new ObservedValue.Integer(6), new ObservedValue.Integer(7)),
-                read(SPREAD, aCardAndACash(), amount()),
+                stood(SPREAD, aCardAndACash(), amount()),
                 "an element of the list is every element the row wrote");
         assertEquals(List.of(new ObservedValue.Text("x")),
-                read(SPREAD, aCardAndACash(), cardNumberAsACard()),
+                stood(SPREAD, aCardAndACash(), cardNumberAsACard()),
                 "and a narrowing keeps what the row wrote as that case");
-        assertEquals(List.of(), read(SPREAD, List.of(cash(7)), cardNumberAsACard()),
+        assertEquals(List.of(), stood(SPREAD, List.of(cash(7)), cardNumberAsACard()),
                 "and drops what it wrote as another, which is a step taken");
     }
 
@@ -218,15 +218,24 @@ class AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest {
                 + sum + "`");
     }
 
-    /** What the walk reads at {@code path}, off a row holding {@code entries}. */
-    private static List<ObservedValue> read(String source, List<ObservedValue> entries,
-                                            TermPath path) {
+    /** What the walk at {@code path} came to, off a row holding {@code entries}. */
+    private static WalkResult<List<ObservedValue>> read(String source, List<ObservedValue> entries,
+                                                        TermPath path) {
         RuleReadingSource rules = RuleReadings.ofSource(source);
         BehaviorInputs inputs = new BehaviorInputs(List.of("ns"),
                 List.of(new Type.ListOf(named("Entry"))), rules, POLICY);
         return inputs.valuesAt(List.of(new ObservedValue.Sequence(
                 entries.stream().map(AnObservedValueIsReadByWhatIsReadableAndNotByWhatItCarriesTest
                         ::entry).toList())), path);
+    }
+
+    /** The same where the walk was taken, which is what a test about the values is asking for. */
+    private static List<ObservedValue> stood(String source, List<ObservedValue> entries,
+                                             TermPath path) {
+        if (read(source, entries, path) instanceof WalkResult.Reached(List<ObservedValue> values)) {
+            return values;
+        }
+        throw new AssertionError("the walk down " + path + " could not be taken");
     }
 
     private static List<ObservedValue> aCardAndACash() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest.java
@@ -124,15 +124,15 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
                 new BorderQuantity.Observation() {
 
                     @Override
-                    public ObservedValue at(TermPath path) {
+                    public WalkResult<ObservationAtPoint> at(TermPath path) {
                         throw new AssertionError("a number over a run is not read from one value");
                     }
 
                     @Override
-                    public List<ObservedValue> everyValueAt(TermPath path) {
-                        return UNDER.equals(path)
+                    public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+                        return WalkResult.reached(UNDER.equals(path)
                                 ? List.of(new ObservedValue.Truncated())
-                                : List.of(new ObservedValue.Unknown("no"));
+                                : List.of(new ObservedValue.Unknown("no")));
                     }
                 });
 
@@ -143,7 +143,7 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
     }
 
     /**
-     * A walk that arrived at no value says that, and not that an observation stopped.
+     * A walk that arrived and found no value says that, and not that an observation stopped.
      *
      * <p>The two leave different work and only one of them names a budget. A reader that words a
      * code as what an observation did — and something downstream does, since that is what the code
@@ -152,30 +152,32 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
      */
     @Test
     void aWalkThatReachedNoValueIsNotAnObservationThatStopped() {
-        BorderQuantity.Stands stands = form().standsAt(AT_A_HUNDRED,
+        BorderQuantity.Stands stands = atAPlace().standsAt(AT_A_HUNDRED,
                 new BorderQuantity.Observation() {
 
                     @Override
-                    public ObservedValue at(TermPath path) {
-                        return null;
+                    public WalkResult<ObservationAtPoint> at(TermPath path) {
+                        return WalkResult.reached(ObservationAtPoint.ANOTHER_READING);
                     }
 
                     @Override
-                    public List<ObservedValue> everyValueAt(TermPath path) {
-                        return java.util.Collections.singletonList(null);
+                    public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+                        throw new AssertionError("a number of one place is not read over a run");
                     }
                 });
 
         assertEquals(BorderQuantity.Stands.couldNotTell(ReadingGap.NO_VALUE), stands,
-                "nothing arrived, which is not a value an observation could not keep");
+                "the walk arrived and no value of the row stands there, which is not a value an"
+                        + " observation could not keep");
     }
 
     /**
-     * And a run the walk never reached says the same, rather than that the row does not stand.
+     * And a run the walk never reached says something else again, not that the row missed the line.
      *
-     * <p>The other way nothing arrives. A caller that could not walk to the run hands over no list
-     * at all, and answering "this is no number of that" would make a place this compiler could not
-     * reach into the model putting the row somewhere else — {@code Stands.No}, and a point missed.
+     * <p>A caller that could not walk to the run hands over no run at all. Answering "this is no
+     * number of that" would make a place this compiler could not reach into the model putting the
+     * row somewhere else — {@code Stands.No}, and a point missed; answering that no value stands
+     * there says the row wrote nothing at a position nothing ever looked at.
      */
     @Test
     void aRunTheWalkNeverReachedIsNotARunThatMissedTheLine() {
@@ -183,18 +185,25 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
                 new BorderQuantity.Observation() {
 
                     @Override
-                    public ObservedValue at(TermPath path) {
-                        return null;
+                    public WalkResult<ObservationAtPoint> at(TermPath path) {
+                        throw new AssertionError("a number over a run is not read from one value");
                     }
 
                     @Override
-                    public List<ObservedValue> everyValueAt(TermPath path) {
-                        return null;
+                    public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
+                        return WalkResult.couldNotWalk();
                     }
                 });
 
-        assertEquals(BorderQuantity.Stands.couldNotTell(ReadingGap.NO_VALUE), stands,
+        assertEquals(BorderQuantity.Stands.couldNotTell(ReadingGap.COULD_NOT_WALK), stands,
                 "the walk did not reach the run, which says nothing about where the row stands");
+    }
+
+    /** The same quantity over one position's own value, for what is asked of a place. */
+    private static BorderQuantity.OverAForm atAPlace() {
+        NumericTerm.ValueOf here = new NumericTerm.ValueOf(UNDER);
+        return new BorderQuantity.OverAForm("decide", LinearForm.atom((NumericTerm) here),
+                Map.of(here, TermOrdersFixtures.itself(here, new Carrier.Whole())));
     }
 
     private static BorderQuantity.OverAForm form() {
@@ -207,14 +216,14 @@ class WhatAnObservationCouldNotKeepIsNotWhereARowStandsTest {
         return new BorderQuantity.Observation() {
 
             @Override
-            public ObservedValue at(TermPath path) {
+            public WalkResult<ObservationAtPoint> at(TermPath path) {
                 throw new AssertionError("a number over a run is not read from one value");
             }
 
             @Override
-            public List<ObservedValue> everyValueAt(TermPath path) {
+            public WalkResult<List<ObservedValue>> everyValueAt(TermPath path) {
                 assertEquals(UNDER, path, "read from where the run says its values are");
-                return List.of(values);
+                return WalkResult.reached(List.of(values));
             }
         };
     }

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
@@ -3,7 +3,7 @@ package souther.compiler.report;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.Incompleteness;
-import souther.compiler.observe.RunSensitivity;
+import souther.compiler.observe.ObservedValue;
 import souther.compiler.partition.ReadingGap;
 import souther.compiler.publish.WeakeningWord;
 import souther.compiler.query.Weakening;
@@ -26,15 +26,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * projection answering one sentence for two takes the difference out at the last step, and
  * everything upstream of it becomes a distinction nobody can see.
  *
- * <p><b>The sentence, and not the word.</b> {@link WeakeningWord} sorts documents by how they are
- * weakened, and reasons that weaken one the same way are one word there on purpose. That is an
- * abstraction rather than a loss, and what makes it one is that the reason itself travels underneath
- * and is what the sentence is written from — so the census is over sentences, and what it asks of
- * the words is only that reasons sharing one weaken alike.
+ * <p><b>The sentence, and not the word.</b> {@link WeakeningWord} groups the reasons more coarsely
+ * than the reading tells them apart, which is a decision rather than a loss: the reason itself
+ * travels underneath and is what the sentence is written from. So the census is over sentences, and
+ * what is asked of the words is that they group the reasons the way this was decided to group them
+ * — written out below, so that a fold added later is one somebody had to write down.
  *
  * <p><b>Over the cases and not over a list somebody wrote.</b> The reasons are asked of the sealed
- * type, so a reason added to {@link ReadingGap} arrives here as a case with no sentence rather than
- * as one it quietly shares — which is how two of them arrived.
+ * type, and the codes an observation can arrive with are asked of the values that carry one, so a
+ * reason or a code added anywhere arrives here as a case with no sentence rather than as one it
+ * quietly shares.
  */
 class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
 
@@ -58,26 +59,35 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
     }
 
     /**
-     * And reasons that come out as one word weaken a document the same way.
+     * And the words group them the way this was decided to group them.
      *
-     * <p>Which is the condition the folding is allowed under, asked of the reasons rather than
-     * remembered. Whether a wider run would have got a number is the whole of what a reader weighing
-     * the document does with one of these, so two reasons that answer it differently are two words —
-     * and the day one of the pair here comes to answer it differently, this is what says so.
+     * <p>The decision itself, since nothing else keeps it. A place the walk could not reach and a
+     * row that never came are one word because a reader weighing the document does the same thing
+     * about both; they are apart from a position that was read and holds nothing, which is news
+     * about the model rather than about this compiler's reach. What travels underneath is the
+     * reason, so the grouping costs a reader nothing — and it is written here because a grouping
+     * nothing states is one the next fold can join without saying so.
+     *
+     * <p><b>Not that reasons under one word are weakened alike.</b> They are not: the codes an
+     * observation arrives with come out as one word and answer differently about whether a wider
+     * run would have got a number. That is exactly why the reason and not the word is what the
+     * sentence is written from, and a test asserting the tidier property would be asserting
+     * something the vocabulary has never kept.
      */
     @Test
-    void reasonsUnderOneWordAreWeakenedAlike() {
-        Map<WeakeningWord, Set<RunSensitivity>> under = new LinkedHashMap<>();
+    void theWordsGroupTheReasonsAsThisDecidedToGroupThem() {
+        Map<WeakeningWord, Set<String>> under = new LinkedHashMap<>();
         for (ReadingGap each : everyReason()) {
             under.computeIfAbsent(wordFor(each), _ -> new LinkedHashSet<>())
-                    .add(each.runSensitivity());
+                    .add(each.getClass().getSimpleName());
         }
 
-        for (Map.Entry<WeakeningWord, Set<RunSensitivity>> each : under.entrySet()) {
-            assertEquals(1, each.getValue().size(),
-                    () -> "one word over reasons a wider run does not treat alike: "
-                            + each.getKey() + " over " + each.getValue());
-        }
+        assertEquals(Set.of(
+                        Set.of("Observation"),
+                        Set.of("NoValue"),
+                        Set.of("CouldNotWalk", "CouldNotReadRow")),
+                new LinkedHashSet<>(under.values()),
+                () -> "the words no longer group the reasons as they were meant to: " + under);
     }
 
     private static WeakeningWord wordFor(ReadingGap why) {
@@ -87,25 +97,71 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
     /**
      * One of each, taken from what the type permits rather than from what a reader remembers.
      *
-     * <p>An observation carries a code, and the codes an observation of a value can meet are the
-     * two it can meet — the rest of {@link Incompleteness.Code} is about rows and modules and
-     * reaches no border. They are one reason here all the same: what the sentence says is that an
-     * observation stopped, and which one it met is said under it.
+     * <p>An observation carries a code, and which codes one can carry is asked of the values that
+     * carry them rather than named here — a value says whether it went unread and with which word,
+     * so the codes an observation of a value arrives with are however many those turn out to be.
+     * Picked by hand, the population would be as wide as whoever wrote it remembered, and a word
+     * that groups two of them would look like a word that groups one.
      */
     private static List<ReadingGap> everyReason() {
         List<ReadingGap> out = new ArrayList<>();
         for (Class<?> permitted : ReadingGap.class.getPermittedSubclasses()) {
-            out.add(switch (permitted.getSimpleName()) {
-                case "Observation" -> ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED);
-                case "NoValue" -> ReadingGap.NO_VALUE;
-                case "CouldNotWalk" -> ReadingGap.COULD_NOT_WALK;
-                case "CouldNotReadRow" -> ReadingGap.COULD_NOT_READ_ROW;
+            switch (permitted.getSimpleName()) {
+                case "Observation" -> everyCodeAValueArrivesUnreadWith().forEach(
+                        code -> out.add(ReadingGap.of(code)));
+                case "NoValue" -> out.add(ReadingGap.NO_VALUE);
+                case "CouldNotWalk" -> out.add(ReadingGap.COULD_NOT_WALK);
+                case "CouldNotReadRow" -> out.add(ReadingGap.COULD_NOT_READ_ROW);
                 // A reason added to the type and not to this list. Written as a failure rather than
                 // skipped: a reason nothing here can build is one nothing here is checking.
                 default -> throw new IllegalStateException(
                         "a reason a reading can meet that this test cannot make: " + permitted);
-            });
+            }
         }
         return out;
+    }
+
+    /**
+     * The codes a value says it went unread with, asked of every shape a value can take.
+     *
+     * <p>{@link ObservedValue#unread()} is what every producer of one of these agrees about, and
+     * the shapes are asked of the sealed type rather than named here. Named here, the population
+     * would be as wide as whoever wrote it remembered — which is how a word that groups two codes
+     * came to be checked as a word that groups one.
+     */
+    private static Set<Incompleteness.Code> everyCodeAValueArrivesUnreadWith() {
+        Set<Incompleteness.Code> out = new LinkedHashSet<>();
+        for (Class<?> shape : ObservedValue.class.getPermittedSubclasses()) {
+            Incompleteness.Code code = oneOf(shape).unread();
+            if (code != null) {
+                out.add(code);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * One value of {@code shape}, so that it can be asked whether it went unread.
+     *
+     * <p>A shape added to {@link ObservedValue} and not to this stops the test rather than being
+     * skipped: a shape nothing here can make is a shape whose word nothing here is looking for.
+     */
+    private static ObservedValue oneOf(Class<?> shape) {
+        return switch (shape.getSimpleName()) {
+            case "Bool" -> new ObservedValue.Bool(true);
+            case "Integer" -> new ObservedValue.Integer(1);
+            case "Decimal" -> new ObservedValue.Decimal(java.math.BigDecimal.ONE);
+            case "Text" -> new ObservedValue.Text("x");
+            case "Temporal" -> new ObservedValue.Temporal("2026-01-01");
+            case "Unit" -> new ObservedValue.Unit(null);
+            case "Constructed" -> new ObservedValue.Constructed(null, Map.of());
+            case "Sequence" -> new ObservedValue.Sequence(List.of());
+            case "Mapping" -> new ObservedValue.Mapping(List.of());
+            case "Absent" -> new ObservedValue.Absent();
+            case "Unknown" -> new ObservedValue.Unknown("nothing read it");
+            case "Truncated" -> new ObservedValue.Truncated();
+            default -> throw new IllegalStateException(
+                    "a shape a value can take that this test cannot make: " + shape);
+        };
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest.java
@@ -3,49 +3,85 @@ package souther.compiler.report;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.RunSensitivity;
 import souther.compiler.partition.ReadingGap;
 import souther.compiler.publish.WeakeningWord;
 import souther.compiler.query.Weakening;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Every reason a reading of a border came to no number reaches the report as a word of its own.
+ * Every reason a reading of a border came to no number reaches the report as a sentence of its own.
  *
- * <p>The reading tells a value an observation stopped from a place the walk never reached, and
- * carries the pair through the quantity, the point and the weakening. What it is carried <em>for</em>
- * is that a reader is told which one happened; a projection answering one word for both takes the
- * difference out at the last step, and everything upstream of it becomes a distinction nobody can
- * see.
+ * <p>The reading tells a value an observation stopped from a position the walk never reached and
+ * from a row that never came, and carries which it was through the quantity, the point and the
+ * weakening. What it is carried <em>for</em> is that a reader is told which one happened; a
+ * projection answering one sentence for two takes the difference out at the last step, and
+ * everything upstream of it becomes a distinction nobody can see.
+ *
+ * <p><b>The sentence, and not the word.</b> {@link WeakeningWord} sorts documents by how they are
+ * weakened, and reasons that weaken one the same way are one word there on purpose. That is an
+ * abstraction rather than a loss, and what makes it one is that the reason itself travels underneath
+ * and is what the sentence is written from — so the census is over sentences, and what it asks of
+ * the words is only that reasons sharing one weaken alike.
  *
  * <p><b>Over the cases and not over a list somebody wrote.</b> The reasons are asked of the sealed
- * type, so a reason added to {@link ReadingGap} arrives here as a case with no word rather than as a
- * word it quietly shares — which is how the last one arrived. What the words are is not this test's
- * to say; that they are as many as the reasons is.
+ * type, so a reason added to {@link ReadingGap} arrives here as a case with no sentence rather than
+ * as one it quietly shares — which is how two of them arrived.
  */
 class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
 
     /**
-     * As many words as there are reasons, and no two reasons under one word.
+     * As many sentences as there are reasons, and no two reasons under one sentence.
      *
-     * <p>Both halves. Equal counts alone pass for a projection that answers one word twice and
-     * another never, and distinctness alone passes for one that leaves a reason out.
+     * <p>Both halves. Equal counts alone pass for a writer that says one sentence twice and another
+     * never, and distinctness alone passes for one that leaves a reason out.
      */
     @Test
-    void eachReasonHasAWordAndNoTwoShareOne() {
+    void eachReasonHasASentenceAndNoTwoShareOne() {
         List<ReadingGap> reasons = everyReason();
-        Set<WeakeningWord> words = new LinkedHashSet<>();
+        Set<String> said = new LinkedHashSet<>();
         for (ReadingGap each : reasons) {
-            words.add(AdequacyReport.wordFor(new Weakening.BorderValueUnreadable(null, each)));
+            said.add(AdequacyReport.atTheBorder(each));
         }
 
-        assertEquals(reasons.size(), words.size(),
-                () -> "two reasons a reading met came out as one word: " + reasons + " to " + words);
+        assertEquals(reasons.size(), said.size(),
+                () -> "two reasons a reading met came out as one sentence: " + reasons + " to "
+                        + said);
+    }
+
+    /**
+     * And reasons that come out as one word weaken a document the same way.
+     *
+     * <p>Which is the condition the folding is allowed under, asked of the reasons rather than
+     * remembered. Whether a wider run would have got a number is the whole of what a reader weighing
+     * the document does with one of these, so two reasons that answer it differently are two words —
+     * and the day one of the pair here comes to answer it differently, this is what says so.
+     */
+    @Test
+    void reasonsUnderOneWordAreWeakenedAlike() {
+        Map<WeakeningWord, Set<RunSensitivity>> under = new LinkedHashMap<>();
+        for (ReadingGap each : everyReason()) {
+            under.computeIfAbsent(wordFor(each), _ -> new LinkedHashSet<>())
+                    .add(each.runSensitivity());
+        }
+
+        for (Map.Entry<WeakeningWord, Set<RunSensitivity>> each : under.entrySet()) {
+            assertEquals(1, each.getValue().size(),
+                    () -> "one word over reasons a wider run does not treat alike: "
+                            + each.getKey() + " over " + each.getValue());
+        }
+    }
+
+    private static WeakeningWord wordFor(ReadingGap why) {
+        return AdequacyReport.wordFor(new Weakening.BorderValueUnreadable(null, why));
     }
 
     /**
@@ -53,7 +89,7 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
      *
      * <p>An observation carries a code, and the codes an observation of a value can meet are the
      * two it can meet — the rest of {@link Incompleteness.Code} is about rows and modules and
-     * reaches no border. They are one reason here all the same: what the word says is that an
+     * reaches no border. They are one reason here all the same: what the sentence says is that an
      * observation stopped, and which one it met is said under it.
      */
     private static List<ReadingGap> everyReason() {
@@ -62,6 +98,8 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
             out.add(switch (permitted.getSimpleName()) {
                 case "Observation" -> ReadingGap.of(Incompleteness.Code.VALUE_TRUNCATED);
                 case "NoValue" -> ReadingGap.NO_VALUE;
+                case "CouldNotWalk" -> ReadingGap.COULD_NOT_WALK;
+                case "CouldNotReadRow" -> ReadingGap.COULD_NOT_READ_ROW;
                 // A reason added to the type and not to this list. Written as a failure rather than
                 // skipped: a reason nothing here can build is one nothing here is checking.
                 default -> throw new IllegalStateException(

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidInItsOwnSentenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryReasonAReadingMetIsSaidInItsOwnSentenceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * reason or a code added anywhere arrives here as a case with no sentence rather than as one it
  * quietly shares.
  */
-class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
+class EveryReasonAReadingMetIsSaidInItsOwnSentenceTest {
 
     /**
      * As many sentences as there are reasons, and no two reasons under one sentence.
@@ -59,7 +59,7 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
     }
 
     /**
-     * And the words group them the way this was decided to group them.
+     * And each word stands over the reasons this decided to put under it.
      *
      * <p>The decision itself, since nothing else keeps it. A place the walk could not reach and a
      * row that never came are one word because a reader weighing the document does the same thing
@@ -75,19 +75,25 @@ class EveryReasonAReadingMetIsSaidByAWordOfItsOwnTest {
      * something the vocabulary has never kept.
      */
     @Test
-    void theWordsGroupTheReasonsAsThisDecidedToGroupThem() {
+    void eachWordStandsOverTheReasonsThisDecidedToPutUnderIt() {
         Map<WeakeningWord, Set<String>> under = new LinkedHashMap<>();
         for (ReadingGap each : everyReason()) {
             under.computeIfAbsent(wordFor(each), _ -> new LinkedHashSet<>())
                     .add(each.getClass().getSimpleName());
         }
 
-        assertEquals(Set.of(
-                        Set.of("Observation"),
-                        Set.of("NoValue"),
-                        Set.of("CouldNotWalk", "CouldNotReadRow")),
-                new LinkedHashSet<>(under.values()),
-                () -> "the words no longer group the reasons as they were meant to: " + under);
+        // The word each group is under, and not only which reasons share one. A word is written
+        // into the document and named in the schema, so which reasons it stands over is as much of
+        // the contract as which of them are together — grouped alone, the words could be dealt out
+        // among the groups differently and every reader of a published document would be told
+        // something else about the same reasons.
+        assertEquals(Map.of(
+                        WeakeningWord.BORDER_VALUE_UNREADABLE, Set.of("Observation"),
+                        WeakeningWord.BORDER_VALUE_ABSENT, Set.of("NoValue"),
+                        WeakeningWord.BORDER_OBSERVATION_UNAVAILABLE,
+                                Set.of("CouldNotWalk", "CouldNotReadRow")),
+                under,
+                () -> "the words no longer stand over the reasons they were meant to: " + under);
     }
 
     private static WeakeningWord wordFor(ReadingGap why) {


### PR DESCRIPTION
Closes #1343.

The walk into what a row wrote answered with a list, and an absence stood for
two things: the walk could not be taken, or it was taken and the row stands
nowhere there. Which it was travelled as which shape the absence arrived in,
and every caller had to know that. Downstream the two were joined again — the
reading's vocabulary had one word for both, and the report wrote a place this
compiler never looked at as a place the model put no value.

## What the answer is now

A walk says whether it was taken, and what it came to is under that. What a row
holds at a position is its own vocabulary: a value, a position the row wrote
nothing at, or values that are under elements another reading chose. Nothing
offers not-having-looked as one of the things a row can hold, and what carries a
value refuses to carry nothing — an emptiness inside the arm that means the walk
arrived is the same fold one layer in.

A term is handed a value or nothing at all, and nothing at all is refused where
it arrives rather than read as a place holding no number. What a term came to is
its own vocabulary as well, so a quantity says what it does about each way a term
names no number rather than testing for the one it wanted; every reader of the
walk switches over the arms for the same reason.

The reading's own reason for coming to none is three arms where it was one, and
the report writes each of them its own sentence.

## What the words do

The publication vocabulary groups the reasons more coarsely than the reading
tells them apart, and that is a decision rather than a loss: the reason travels
underneath and is what the sentence is written from. Whether a wider run would
have got a number does not follow from the grouping — two observations carry two
codes and answer differently — so it is asked of the reason and of nothing
coarser.

The grouping is written down, and so is the word each group is under. A word is
written into a document and named in the schema, so which reasons it stands over
is as much of the contract as which of them are together.

## What came with it

A position the row wrote nothing at was answered as a reading that came to
nothing, and a flag beside the reading put it back by discarding whatever else
that reading had collected. The quantity says it now, where it knows what the
position is worth to the number it is reading. That is what it did before; what
changed is that the rule is where the terms are, and a reading can no longer
carry a state its own answer denies. A quantity asks every term it has whether or
not one of them settles the row, because asking is how the measure learns what
each position holds and that is what says how many readings of the row there are.

The last producer writing "the walk reached no value" for something else was the
one that never had a row to walk. Nothing the tests carry reaches it — a probe in
its place is not thrown — so what is corrected is which reason the arm names.

Which leaves the reading a term had for a value that is not there. Once whether a
walk arrived stopped travelling inside a term's reading, that arm held no fact of
its own: a term is handed a value. It goes, and three readers lose a case for it —
not as an unreachable branch tidied away, but as a state the protocol forbids and
the type was still offering to the next reader with an absence to put somewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)