### PR TITLE
Say which rule a shortfall is about at the place it was asked

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
@@ -64,15 +64,15 @@ class WhoMayMakeARuleShortfallTest {
             "souther/compiler/check/StatedByClauses$Part -> " + OWNER + "#<init>");
 
     /**
-     * And every class that settles the place one is filed at.
+     * And every class that settles the place one is filed at, which is fewer.
      *
-     * <p>The same two, and no third: a site made anywhere else is one this compiler chose rather
-     * than one an author wrote. A leaf is settled where the node is being read; a choice is settled
+     * <p>A leaf is settled where the node is being read, and nowhere after: a reading that met a
+     * clause holds the place it met, and what is decided later about that clause is filed at the
+     * place it was handed rather than at one made again from a node in hand. A choice is settled
      * where the branches are joined, which is the only place the choice an author wrote is known.
      */
     private static final List<String> MAKING_A_SITE = List.of(
             "souther/compiler/check/AdmissibleReading -> " + A_LEAF + "#<init>",
-            "souther/compiler/check/StatedByClauses -> " + A_LEAF + "#<init>",
             "souther/compiler/check/StatedByClauses$Part -> " + A_CHOICE + "#<init>");
 
     @Test

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMayMakeARuleShortfallTest.java
@@ -1,0 +1,182 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may say that a rule is answerable for a position, and where the place an author wrote is
+ * settled.
+ *
+ * <p>What a rule was short of is made where the asking is: the reading that could not take a form
+ * in knows the position, the reason and the clause it was reading, and everything downstream is
+ * handed the answer. A pass reaching for the constructor makes the fact out of whatever it has —
+ * a place's reasons, most easily, which name every rule that reached the place and not the one
+ * that asked.
+ *
+ * <p>The site is held apart from that. A conjunction distributing over a choice copies a shortfall
+ * into both branches, and what says the two copies are one fact is that they carry one site. Minted
+ * again on the way, a copy would be a second fact of the same shape — and a choice asking whether
+ * the branch that went unread accounts for a position would read a shortfall standing in both
+ * branches as that branch's own.
+ *
+ * <p>Read off the compiled classes, so a maker reached through a method reference is one of these:
+ * a constructor handed to something that will call it makes a fact as surely as calling it here.
+ */
+class WhoMayMakeARuleShortfallTest {
+
+    private static final String OWNER = "souther/compiler/check/RuleShortfall";
+
+    private static final String A_LEAF = OWNER + "$Site$AtALeaf";
+
+    private static final String A_CHOICE = OWNER + "$Site$AtAChoice";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * Every class that makes one, and why it is entitled to.
+     *
+     * <p>{@code AdmissibleReading} is where a form nothing reads is met, and it holds what it was
+     * short of at the node it was reading. {@code StatedByClauses} holds the two facts a reading
+     * cannot make at a leaf: what a refused machine was asked for, which is known once the plan the
+     * leaf asked with is matched to the refusal, and what a choice left open, which is a fact about
+     * the choice and about no clause under it.
+     */
+    private static final List<String> MAKING_ONE = List.of(
+            "souther/compiler/check/AdmissibleReading -> " + OWNER + "#<init>",
+            "souther/compiler/check/StatedByClauses -> " + OWNER + "#<init>",
+            "souther/compiler/check/StatedByClauses$Part -> " + OWNER + "#<init>");
+
+    /**
+     * And every class that settles the place one is filed at.
+     *
+     * <p>The same two, and no third: a site made anywhere else is one this compiler chose rather
+     * than one an author wrote. A leaf is settled where the node is being read; a choice is settled
+     * where the branches are joined, which is the only place the choice an author wrote is known.
+     */
+    private static final List<String> MAKING_A_SITE = List.of(
+            "souther/compiler/check/AdmissibleReading -> " + A_LEAF + "#<init>",
+            "souther/compiler/check/StatedByClauses -> " + A_LEAF + "#<init>",
+            "souther/compiler/check/StatedByClauses$Part -> " + A_CHOICE + "#<init>");
+
+    @Test
+    void everyClassThatSaysARuleIsAnswerableForAPositionIsWrittenDown() {
+        assertEquals(MAKING_ONE, new ArrayList<>(naming(Set.of(OWNER))),
+                "a row added here is a pass answering what a rule is answerable for out of what it"
+                        + " has in hand, which is a place's reasons wherever the asking is not");
+    }
+
+    @Test
+    void andEveryClassThatSettlesWhereOneIsFiledIsWrittenDown() {
+        assertEquals(MAKING_A_SITE, new ArrayList<>(naming(Set.of(A_LEAF, A_CHOICE))),
+                "a site minted where a fact is carried rather than where it is made turns one copy"
+                        + " of a fact into a second fact of the same shape");
+    }
+
+    /**
+     * The walk reads every module's classes.
+     *
+     * <p>Asked of the modules the repository has and not of what a build happened to leave: a module
+     * whose classes are missing is one whose calls this cannot see, and the rows from the rest would
+     * match and this would pass while answering about fewer modules than it names.
+     */
+    @Test
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        List<String> unbuilt = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            if (!Files.isDirectory(classesOf(module)) && hasMainSources(module)) {
+                unbuilt.add(module.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), unbuilt,
+                "a module whose classes are not built is one this walk passes over, and a walk that"
+                        + " passes over a module answers about the rest while saying it answers"
+                        + " about all of them");
+        assertTrue(modulesRead() > 1,
+                "the classes this reads are in more than the one module that declares the fact");
+    }
+
+    /** Every class naming a constructor of one of {@code these}, as the class and what it named. */
+    private static Set<String> naming(Set<String> these) {
+        Set<String> found = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                for (PoolEntry entry : constantPoolOf(each)) {
+                    if (entry instanceof MemberRefEntry member
+                            && these.contains(member.owner().name().stringValue())
+                            && "<init>".equals(member.name().stringValue())) {
+                        found.add(internalName(module, each) + " -> "
+                                + member.owner().name().stringValue() + "#<init>");
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    private static int modulesRead() {
+        int read = 0;
+        for (Path module : REPOSITORY.modules()) {
+            if (!classesUnder(module).isEmpty()) {
+                read++;
+            }
+        }
+        return read;
+    }
+
+    private static Iterable<PoolEntry> constantPoolOf(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled)).constantPool();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The class's own binary name, taken against the directory it was found under rather than off
+     *  the first {@code classes} in the path, which a checkout under one would be. */
+    private static String internalName(Path module, Path compiled) {
+        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
+        return name.substring(0, name.length() - ".class".length());
+    }
+
+    private static Path classesOf(Path module) {
+        return module.resolve("target").resolve("classes");
+    }
+
+    /** Whether the module has main sources to have been built from. A module holding only tests or
+     *  only a pom leaves no classes and is not one this walk is missing. */
+    private static boolean hasMainSources(Path module) {
+        return Files.isDirectory(module.resolve("src").resolve("main").resolve("java"));
+    }
+
+    /** The compiled classes of one module that the compiler is made of. Its own tests are not among
+     *  them: a test makes one to look at it and ships nothing. */
+    private static List<Path> classesUnder(Path module) {
+        Path where = classesOf(module);
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -305,8 +305,8 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      *
      * <p>A machine is made far from here, under the position's allowance, and refused there. What
      * asked for it is this clause, and it is known here and nowhere after — every rule reaching the
-     * position pays into that allowance, so the place cannot say which of them asked (#1341), and
-     * the pattern alone is the same pattern wherever somebody wrote it.
+     * position pays into that allowance, so the place cannot say which of them asked, and the
+     * pattern alone is the same pattern wherever somebody wrote it.
      */
     private PlannedValues<FactSubject> asking(Core e, FactSubject position,
                                               AdmittedPlan.Pattern plan) {

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -14,6 +14,7 @@ import souther.compiler.values.ValueSet;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -311,13 +312,20 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
     private PlannedValues<FactSubject> asking(Core e, FactSubject position,
                                               AdmittedPlan.Pattern plan) {
         asked.computeIfAbsent(e, _ -> new LinkedHashSet<>())
-                .add(new AskedAt(position, plan.plan(), e));
+                .add(new AskedAt(position, plan.plan(), new RuleShortfall.Site.AtALeaf(e)));
         return PlannedValues.at(position, plan);
     }
 
-    /** What was asked for at {@code e}, as it was asked. */
+    /**
+     * What was asked for at {@code e}, as it was asked and in the order it was.
+     *
+     * <p>A set of facts and no order of anybody's, kept in the order they were met all the same:
+     * what is made out of these is published through a projection that reads the order it is given,
+     * so a copy free to reorder would have one compiler publish two documents of one source.
+     */
     Set<AskedAt> askedAt(Core e) {
-        return Set.copyOf(asked.getOrDefault(e, Set.of()));
+        return Collections.unmodifiableSet(
+                new LinkedHashSet<>(asked.getOrDefault(e, Set.of())));
     }
 
     /**
@@ -328,11 +336,16 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * .RuleShortfall}) and are what routes it back here; the third is the written place it is then
      * answerable at. Two clauses writing one pattern about one position ask for one machine and are
      * two of these, which is two rules answerable for one refusal.
+     *
+     * <p>The place is held as the site it will be filed under, so that what makes two of these one
+     * is what makes two facts one. Held as the node instead, the record would compare it as a
+     * value — two clauses of one shape at one source position are equal nodes — and the pair of
+     * them would arrive here as one, while the site they file under tells them apart.
      */
-    record AskedAt(FactSubject position, PatternPlan plan, Core node) {
+    record AskedAt(FactSubject position, PatternPlan plan, RuleShortfall.Site site) {
 
         AskedAt {
-            if (position == null || plan == null || node == null) {
+            if (position == null || plan == null || site == null) {
                 throw new IllegalArgumentException(
                         "a machine is asked for by a clause, for a position");
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -13,6 +13,7 @@ import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -65,6 +66,17 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * are two places in a declaration, and what each of them is about is asked of the one in hand.
      */
     private final Map<Core, StringPredicates.Stated> asStated = new IdentityHashMap<>();
+    /**
+     * What this reading was short of at each clause it gave up on, against the clause.
+     *
+     * <p>By the node itself and by the same rule as the table above: two clauses written the same
+     * way are two places somebody wrote, and a rule is answerable for the one it wrote. Kept as the
+     * decisions are made, so that what a rule is answerable for is never worked out afterwards from
+     * what a position was left holding.
+     */
+    private final Map<Core, List<RuleShortfall>> shortfalls = new IdentityHashMap<>();
+    /** What each clause asked a machine for, against the clause, and by the same rule again. */
+    private final Map<Core, Set<AskedAt>> asked = new IdentityHashMap<>();
     private AdmissibleReading(Terms terms, Map<FactSubject, Type> byName,
                               Symbols symbols, Alternatives alternatives, Allowance<FactSubject> allowed) {
         this.terms = terms;
@@ -184,10 +196,10 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
             // that much less for the meet it does need. So what is said is which machine would
             // answer this rule, and whether one is ever made of it is settled where the position's
             // plan is worked out under its allowance.
-            case StringPredicates.Reading.Accepting it -> PlannedValues.at(position,
+            case StringPredicates.Reading.Accepting it -> asking(e, position,
                     new AdmittedPlan.Pattern(states ? PatternPlan.of(it.accepts())
                             : PatternPlan.notMatching(it.accepts())));
-            case StringPredicates.Reading.PatternNotRead it -> stoppedBy(it.why(), position);
+            case StringPredicates.Reading.PatternNotRead it -> stoppedBy(e, it.why(), position);
             // A rule whose text this could not work out is a rule this did not read, and what that
             // costs is the leaf's to say — over every position the clause names, which is more than
             // this one wherever the text is written out of another.
@@ -209,9 +221,13 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * <p>No {@code default}: a construct the subset learns to stop at is one somebody decides about
      * here, rather than one that quietly takes the answer its neighbours were given.
      */
-    private PlannedValues<FactSubject> stoppedBy(PatternRead.Unsupported why, FactSubject position) {
+    private PlannedValues<FactSubject> stoppedBy(Core e, PatternRead.Unsupported why,
+                                                 FactSubject position) {
         return switch (why) {
-            case NESTED_TOO_DEEPLY -> PlannedValues.unreadable(Set.of(position),
+            // The clause as well as the position. What a rule is answerable for is about the
+            // pattern somebody wrote, and the position is where the reading was left short — read
+            // back off the second, this would be every rule that named the place.
+            case NESTED_TOO_DEEPLY -> shortOf(e, Set.of(position),
                     UnreadReason.PATTERN_TOO_DEEPLY_NESTED);
             case A_GROUP_ABOUT_THE_MATCH,
                  A_BACK_REFERENCE,
@@ -254,8 +270,84 @@ final class AdmissibleReading implements ClauseReading<PlannedValues<FactSubject
      * one path and {@code ==} another, and a relation came out as a form nobody could read.
      */
     private PlannedValues<FactSubject> unreadable(Core e, Denotations at) {
-        return PlannedValues.unreadable(names(e, at), relatesTwoPositions(e, at)
+        return shortOf(e, names(e, at), relatesTwoPositions(e, at)
                 ? UnreadReason.RELATES_TWO_POSITIONS : UnreadReason.FORM_NOT_READ);
+    }
+
+    /**
+     * What {@code e} leaves the positions it names, said twice: to the places, and about the clause.
+     *
+     * <p>Both from the one decision and neither from the other. What a place is left holding is the
+     * reading's answer about the place; what a rule is answerable for is about the thing somebody
+     * wrote, which is the node in hand here and is nowhere in what the places come back with. Read
+     * off the places afterwards, the second is a list of reasons and no clause — every rule reaching
+     * a position pays into its answer, so the place has as many claimants as it has rules.
+     *
+     * <p>Written down against the node rather than returned beside the values, because the fold
+     * carries one answer upward and this is not part of it. What is recorded here is asked for at
+     * the leaf that was read ({@link #shortfallsAt}), which is a handing over and not a second
+     * reading: nothing looks at what the clause came to in order to work out what was decided.
+     */
+    private PlannedValues<FactSubject> shortOf(Core e, Set<FactSubject> named, UnreadReason why) {
+        List<RuleShortfall> mine = shortfalls.computeIfAbsent(e, _ -> new ArrayList<>());
+        RuleShortfall.Site site = new RuleShortfall.Site.AtALeaf(e);
+        named.forEach(each -> {
+            RuleShortfall one = new RuleShortfall(each, why, site);
+            if (!mine.contains(one)) {
+                mine.add(one);
+            }
+        });
+        return PlannedValues.unreadable(named, why);
+    }
+
+    /**
+     * The position held to {@code plan}, with the clause that asked for it written down.
+     *
+     * <p>A machine is made far from here, under the position's allowance, and refused there. What
+     * asked for it is this clause, and it is known here and nowhere after — every rule reaching the
+     * position pays into that allowance, so the place cannot say which of them asked (#1341), and
+     * the pattern alone is the same pattern wherever somebody wrote it.
+     */
+    private PlannedValues<FactSubject> asking(Core e, FactSubject position,
+                                              AdmittedPlan.Pattern plan) {
+        asked.computeIfAbsent(e, _ -> new LinkedHashSet<>())
+                .add(new AskedAt(position, plan.plan(), e));
+        return PlannedValues.at(position, plan);
+    }
+
+    /** What was asked for at {@code e}, as it was asked. */
+    Set<AskedAt> askedAt(Core e) {
+        return Set.copyOf(asked.getOrDefault(e, Set.of()));
+    }
+
+    /**
+     * One machine a clause asked for: the position it is being built for, the pattern it is, and
+     * the clause that asked.
+     *
+     * <p>The first two are what a refusal is about ({@link souther.compiler.values.Unbuilt
+     * .RuleShortfall}) and are what routes it back here; the third is the written place it is then
+     * answerable at. Two clauses writing one pattern about one position ask for one machine and are
+     * two of these, which is two rules answerable for one refusal.
+     */
+    record AskedAt(FactSubject position, PatternPlan plan, Core node) {
+
+        AskedAt {
+            if (position == null || plan == null || node == null) {
+                throw new IllegalArgumentException(
+                        "a machine is asked for by a clause, for a position");
+            }
+        }
+    }
+
+    /**
+     * What the reading decided it was short of at {@code e}, of the rules somebody wrote there.
+     *
+     * <p>Asked at the leaf it was decided at, and answered out of what was written down when the
+     * decision was made. Empty where the reading took the clause in, which is what a leaf nothing
+     * was short of says.
+     */
+    List<RuleShortfall> shortfallsAt(Core e) {
+        return List.copyOf(shortfalls.getOrDefault(e, List.of()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1057,7 +1057,7 @@ public final class FieldDomains {
         // What a rule is answerable for, as the facts it is answerable for. Asked for the reasons
         // alone here, the written places they were decided at would be gone one call before the
         // account that names the rule, and two facts about two clauses would arrive as one.
-        java.util.Set<RuleShortfall> why = took.stoppedBy(rule, named);
+        Set<RuleShortfall> why = took.stoppedBy(rule, named);
         if (!why.isEmpty()) {
             return new RuleAccounting.Why.TheValueReadingSays(why);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1054,7 +1054,10 @@ public final class FieldDomains {
      * name would stand in for an account that is not there.
      */
     private RuleAccounting.Why stoppedBy(RuleRef rule, RuleKey at, List<FactSubject> named) {
-        List<UnreadReason> why = took.stoppedBy(rule, named);
+        // What a rule is answerable for, as the facts it is answerable for. Asked for the reasons
+        // alone here, the written places they were decided at would be gone one call before the
+        // account that names the rule, and two facts about two clauses would arrive as one.
+        java.util.Set<RuleShortfall> why = took.stoppedBy(rule, named);
         if (!why.isEmpty()) {
             return new RuleAccounting.Why.TheValueReadingSays(why);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -92,7 +92,7 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
      *                     what the model admits at a position, made by whoever asked second
      */
     record OfAPart(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
-                   java.util.Set<RuleShortfall> aboutARule,
+                   Set<RuleShortfall> aboutARule,
                    java.util.Map<FactSubject, AdmittedStrings> aboutStrings) {
 
         /** The positions some reading took the whole of this part in at. */

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadByClauses.java
@@ -75,7 +75,11 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
      * branch this declaration has already dropped — and would pay for machines the whole answer
      * never needed to find out.
      *
-     * @param aboutARule what a rule of this part is answerable for, per position
+     * @param aboutARule what a rule of this part is answerable for, each saying the written place
+     *                   the reading decided it at. Not sifted out of what the positions were left
+     *                   holding: a place holds the reasons of every rule that reached it and names
+     *                   none of them, so what came back from sifting it was a list of reasons and
+     *                   no clause
      * @param aboutStrings which strings this part admits at each position it states a rule about.
      *                     Beside the adoptions and not among them: what a part took a position in
      *                     at is what the readings settled, and this is what the clause states — a
@@ -88,8 +92,7 @@ record ReadByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<Fact
      *                     what the model admits at a position, made by whoever asked second
      */
     record OfAPart(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
-                   java.util.Map<FactSubject,
-                           java.util.List<souther.compiler.values.UnreadReason>> aboutARule,
+                   java.util.Set<RuleShortfall> aboutARule,
                    java.util.Map<FactSubject, AdmittedStrings> aboutStrings) {
 
         /** The positions some reading took the whole of this part in at. */

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
@@ -119,8 +119,8 @@ final class ReadingEvidence {
      * <p><b>And only what a rule is answerable for.</b> Everything filed here is filed under a rule,
      * so a reason about no rule may not arrive: an allowance run down by everything a position
      * admits is a fact about the answer, and the same rules in another order would have been built.
-     * Refused rather than dropped, because a caller handing one over has an account of a rule made
-     * out of something that is not about it, and that is worth stopping where it is written.
+     * Nothing is asked here because nothing of the wrong kind can be made: what arrives is refused
+     * where it would be built, which is one fact away from where a caller could have written it.
      */
     void stoppedBy(RuleRef rule, Set<RuleShortfall> read) {
         stopped.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(read);

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
@@ -106,15 +106,15 @@ final class ReadingEvidence {
      * whole what stopped it at a position is asking about the position and hearing whichever rule
      * reached it.
      *
-     * <p><b>What the reading wrote down, and not what it answers when asked about a position.</b>
-     * {@link AdmissibleValues#standing} is the record: a part this reading gave up on, at each
-     * position that part named. {@link AdmissibleValues#whyUnread} is a reading of that record
-     * against the set the alternatives arrived at, and it answers a different question — whether
-     * the set at a position is as narrow as the rules leave it. The two part company exactly where
-     * a choice covers a position: the set is exact and nothing is answerable for it, and the rule
-     * is still one nobody took in. Asked through the second, a rule left standing under alternatives
-     * that cover it came back with no reason at all, and an accounting with the decision from one
-     * question and the reason from the other has a seam to fill.
+     * <p><b>What the reading wrote down where it wrote it, and never a position's answer read
+     * back.</b> What arrives is a {@link RuleShortfall}, made where the reading still had the
+     * written place in hand. {@link AdmissibleValues#standing} answers for the position and is
+     * deliberately not the source of this: it holds the reasons of every rule that reached the
+     * place and names none of them, so an account built out of it is a list of reasons and no
+     * clause. {@link AdmissibleValues#whyUnread} reads that record against the set the alternatives
+     * arrived at and answers a third question — whether the set at a position is as narrow as the
+     * rules leave it — and parts company with both exactly where a choice covers a position: the
+     * set is exact and nothing is answerable for it, and the rule is still one nobody took in.
      *
      * <p><b>And only what a rule is answerable for.</b> Everything filed here is filed under a rule,
      * so a reason about no rule may not arrive: an allowance run down by everything a position

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
@@ -1,13 +1,10 @@
 package souther.compiler.check;
 
 import souther.compiler.values.AdmissibleValues;
-import souther.compiler.values.UnreadReason;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -66,9 +63,18 @@ final class ReadingEvidence {
      *
      * <p>Empty for a rule this reading took in, and empty as well for one it was short of without
      * recording why. The second is what {@link #stoppedBy} answers for.
+     *
+     * <p><b>Facts and not a map of positions to reasons.</b> Each of these says the written place
+     * the reading decided it at as well as the position and the reason, and a map keyed by position
+     * has nowhere to put the third — two choices of one rule each offering an alternative nothing
+     * could read leave one position open, and an author has two of them to look at. Held as reasons
+     * per position they were one, and which of the two a reader was sent to was whichever the walk
+     * met first.
+     *
+     * <p>A set, because nothing here is in an order anybody may read. Which of two an author wrote
+     * first is the source's to say and is asked where a document is written.
      */
-    private final Map<RuleRef, Map<FactSubject, List<UnreadReason>>> stopped =
-            new LinkedHashMap<>();
+    private final Map<RuleRef, Set<RuleShortfall>> stopped = new LinkedHashMap<>();
 
     /** A reading took {@code rule} in at {@code position}. */
     void record(RuleRef rule, FactSubject position) {
@@ -116,19 +122,8 @@ final class ReadingEvidence {
      * Refused rather than dropped, because a caller handing one over has an account of a rule made
      * out of something that is not about it, and that is worth stopping where it is written.
      */
-    void stoppedBy(RuleRef rule, Map<FactSubject, List<UnreadReason>> read) {
-        Map<FactSubject, List<UnreadReason>> here =
-                stopped.computeIfAbsent(rule, _ -> new LinkedHashMap<>());
-        read.forEach((position, why) -> {
-            why.forEach(each -> {
-                if (each.about() != UnreadReason.About.A_RULE) {
-                    throw new IllegalArgumentException(
-                            "a reason about " + each.about() + " is not one a rule is answerable"
-                                    + " for: " + each);
-                }
-            });
-            here.merge(position, why, ReadingEvidence::appended);
-        });
+    void stoppedBy(RuleRef rule, Set<RuleShortfall> read) {
+        stopped.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(read);
     }
 
     /**
@@ -138,24 +133,14 @@ final class ReadingEvidence {
      * under whichever the reading recognised. Empty where this reading recorded nothing of the
      * rule there, which a caller has to answer for rather than fill in from the position.
      */
-    List<UnreadReason> stoppedBy(RuleRef rule, Collection<FactSubject> positions) {
-        Map<FactSubject, List<UnreadReason>> here = stopped.get(rule);
+    Set<RuleShortfall> stoppedBy(RuleRef rule, Collection<FactSubject> positions) {
+        Set<RuleShortfall> here = stopped.get(rule);
         if (here == null) {
-            return List.of();
+            return Set.of();
         }
-        List<UnreadReason> out = new ArrayList<>();
-        for (FactSubject position : positions) {
-            out = appended(out, here.getOrDefault(position, List.of()));
-        }
-        return out;
-    }
-
-    /** The reasons of both, in the order they were met, and each said once. */
-    private static List<UnreadReason> appended(List<UnreadReason> these,
-                                               List<UnreadReason> those) {
-        List<UnreadReason> out = new ArrayList<>(these);
-        those.forEach(each -> {
-            if (!out.contains(each)) {
+        Set<RuleShortfall> out = new LinkedHashSet<>();
+        here.forEach(each -> {
+            if (positions.contains(each.position())) {
                 out.add(each);
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -2,8 +2,10 @@ package souther.compiler.check;
 
 import souther.compiler.values.UnreadReason;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -285,14 +287,13 @@ public final class RuleAccounting {
          * choice among an author's rules, made where the only thing to choose by is which part came
          * first.
          */
-        record TheValueReadingSays(java.util.Set<RuleShortfall> shortfalls) implements Why {
+        record TheValueReadingSays(Set<RuleShortfall> shortfalls) implements Why {
 
             public TheValueReadingSays {
                 if (shortfalls == null || shortfalls.isEmpty()) {
                     throw new IllegalArgumentException("a reading that stopped says why");
                 }
-                shortfalls = java.util.Collections.unmodifiableSet(
-                        new java.util.LinkedHashSet<>(shortfalls));
+                shortfalls = Collections.unmodifiableSet(new LinkedHashSet<>(shortfalls));
             }
 
             /**
@@ -304,7 +305,7 @@ public final class RuleAccounting {
              * reader is sent to would be whichever the walk met first.
              */
             public List<UnreadReason> why() {
-                List<UnreadReason> out = new java.util.ArrayList<>();
+                List<UnreadReason> out = new ArrayList<>();
                 shortfalls.forEach(each -> {
                     if (!out.contains(each.why())) {
                         out.add(each.why());

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -285,13 +285,32 @@ public final class RuleAccounting {
          * choice among an author's rules, made where the only thing to choose by is which part came
          * first.
          */
-        record TheValueReadingSays(List<UnreadReason> why) implements Why {
+        record TheValueReadingSays(java.util.Set<RuleShortfall> shortfalls) implements Why {
 
             public TheValueReadingSays {
-                if (why == null || why.isEmpty()) {
+                if (shortfalls == null || shortfalls.isEmpty()) {
                     throw new IllegalArgumentException("a reading that stopped says why");
                 }
-                why = List.copyOf(why);
+                shortfalls = java.util.Collections.unmodifiableSet(
+                        new java.util.LinkedHashSet<>(shortfalls));
+            }
+
+            /**
+             * The reasons alone, for a reader that has no use for where they were decided.
+             *
+             * <p>The projection out of this and never what is held. Two choices of one rule each
+             * offering an alternative nothing could read leave the position open twice and are two
+             * things an author can look at; asked as reasons they are one, and which of the two a
+             * reader is sent to would be whichever the walk met first.
+             */
+            public List<UnreadReason> why() {
+                List<UnreadReason> out = new java.util.ArrayList<>();
+                shortfalls.forEach(each -> {
+                    if (!out.contains(each.why())) {
+                        out.add(each.why());
+                    }
+                });
+                return List.copyOf(out);
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -258,8 +258,11 @@ public final class RuleAccounting {
          * .ReportedReason}'s. Two vocabularies with a projection between them is what keeps a
          * published word from reaching back into what a reading is allowed to record.
          *
-         * <p>In the order the parts of the clause were met, and each said once: two parts one limit
-         * stopped are one thing for a reader to lift.
+         * <p>Each said once: two parts one limit stopped are one thing for a reader to lift. In no
+         * order anybody may read as the author's — what is carried is a set of facts, and the order
+         * they come out in is the order they were met, which is kept so that one compiler over one
+         * source publishes one document and is asserted as nothing more. Which written place a
+         * reader is sent to first is the source's to say and is settled where a document is written.
          */
         default List<souther.compiler.inputs.BlockReason.AboutARule> stopped() {
             List<souther.compiler.inputs.BlockReason.AboutARule> out = new java.util.ArrayList<>();
@@ -281,11 +284,15 @@ public final class RuleAccounting {
         /**
          * The reading that turns a clause into a set of values.
          *
-         * <p>Everything it was stopped by, in the order the parts of the clause were met. One
-         * position is named by as many parts as the author wrote about it, and two of them stop
-         * this reading in two ways that are lifted by different work — so a single reason here is a
-         * choice among an author's rules, made where the only thing to choose by is which part came
-         * first.
+         * <p>Everything it was stopped by, as facts and not as an order. One position is named by
+         * as many parts as the author wrote about it, and two of them stop this reading in two ways
+         * that are lifted by different work — so a single reason here would be a choice among an
+         * author's rules, and each of these says the written place it was decided at instead.
+         *
+         * <p>The set is held in the order the facts were met, and that order is asserted of
+         * nothing: it is what keeps one compiler over one source publishing one document. What
+         * {@link #why()} answers with is a projection that loses the places, and where a reader is
+         * owed the author's order it is the source that is asked.
          */
         record TheValueReadingSays(Set<RuleShortfall> shortfalls) implements Why {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleShortfall.java
@@ -1,0 +1,93 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.values.UnreadReason;
+
+/**
+ * One thing a rule of the model is answerable for, at one position, written at one place.
+ *
+ * <p>Three and not two. What a reading was short of and where it left the position short are what a
+ * place's own account holds; which written thing it is about is what an account of a rule needs and
+ * is what a place cannot say — every rule reaching a position pays into its answer, so a place has
+ * as many claimants as it has rules and names none of them.
+ *
+ * <p><b>Made where the reading decided, and never read back out of a place.</b> A position's
+ * standing is what it was left holding and is right to hold every reason there is; sifting it for
+ * the ones a rule could be answerable for gives a list of reasons and no rule. So each of these is
+ * made at the point the reading made the decision, where the written thing is still in hand, and
+ * what travels afterwards is this.
+ *
+ * <p>Told apart by all three. The same reason at the same position, decided at two written places,
+ * is two of these — an author has two things to look at, and a carrier that kept one would be
+ * choosing between them by whichever was met first.
+ *
+ * <p>No order. Which of two of these an author wrote first is a fact about the model, and saying it
+ * needs the source rather than the reading; nothing here is in an order anybody may read.
+ *
+ * @param position what the reading was left unable to say the values of
+ * @param why what it was short of, which a rule is answerable for ({@link UnreadReason.About#A_RULE})
+ * @param site the written place the reading decided it at
+ */
+record RuleShortfall(FactSubject position, UnreadReason why, RuleShortfall.Site site) {
+
+    RuleShortfall {
+        if (position == null || why == null || site == null) {
+            throw new IllegalArgumentException(
+                    "a shortfall about a rule says where, what it was, and where it was written");
+        }
+        if (why.about() != UnreadReason.About.A_RULE) {
+            throw new IllegalArgumentException(
+                    "a reason about " + why.about() + " names no rule to be about: " + why);
+        }
+    }
+
+    /**
+     * A written place a reading can be short of something at.
+     *
+     * <p>Two, because two kinds of decision are made about two kinds of thing. A reading gives up on
+     * a clause it has no word for, which is one leaf somebody wrote. A choice offers an alternative
+     * nothing could read, which is one fact about the choice however many positions it reaches and
+     * however many leaves are under it — filed at a leaf, an author would be sent to the branch that
+     * was read.
+     *
+     * <p>What is held is identity and nothing else: two of these are the same written place or are
+     * not. Where they stand relative to each other is the source's to say and is asked nowhere here.
+     */
+    sealed interface Site {
+
+        /** One clause the reading had no word for, as the node it was written as. */
+        record AtALeaf(Core node) implements Site {
+
+            public AtALeaf {
+                if (node == null) {
+                    throw new IllegalArgumentException("a leaf is some node of a clause");
+                }
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                return other instanceof AtALeaf it && node == it.node;
+            }
+
+            @Override
+            public int hashCode() {
+                return System.identityHashCode(node);
+            }
+
+            @Override
+            public String toString() {
+                return "leaf@" + Integer.toHexString(System.identityHashCode(node));
+            }
+        }
+
+        /** One choice an alternative of which nothing could read. */
+        record AtAChoice(ChoiceId id) implements Site {
+
+            public AtAChoice {
+                if (id == null) {
+                    throw new IllegalArgumentException("a choice is some choice of a clause");
+                }
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -63,6 +63,8 @@ sealed interface StatedByClauses {
                 OrderedIntervals<FactSubject> ordered,
                 Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                 Map<FactSubject, StringRestriction> strings,
+                Set<AdmissibleReading.AskedAt> asked,
+                Set<RuleShortfall> ruleShortfalls,
                 Map<Core, Part> parts)
             implements StatedByClauses {
 
@@ -74,8 +76,10 @@ sealed interface StatedByClauses {
         @Override
         public StatedByClauses from(Core e) {
             Map<Core, Part> out = new java.util.IdentityHashMap<>(parts);
-            out.put(e, new Part(byValues, byOrder, values.standing(), strings, values.asked()));
-            return new Said(values, ordered, byValues, byOrder, strings, out);
+            out.put(e, new Part(byValues, byOrder, values.standing(), strings, asked,
+                    ruleShortfalls));
+            return new Said(values, ordered, byValues, byOrder, strings, asked, ruleShortfalls,
+                    out);
         }
     }
 
@@ -91,17 +95,30 @@ sealed interface StatedByClauses {
      * language took it in at, and what it wrote down about the ones it could not. What the part
      * finally admits is not among them — that is the whole value's answer and belongs to the whole.
      *
-     * @param standing what this part's reading recorded about positions it was short of
+     * @param standing what this part's reading recorded about positions it was short of. A
+     *                 position's own account, which is why it holds every reason there is; an
+     *                 account of a rule is not sifted out of it and is {@code ruleShortfalls}
      * @param aboutStrings what this part states about the strings at each position it states a rule
      *                     about. The position is here whether or not the rule was read, because
      *                     which of a position's numbers a rule is written about is settled by the
      *                     call; what the rule leaves is the other half, and a rule this could not
      *                     read has none
+     * @param ruleShortfalls what a rule is answerable for, each saying the written place the
+     *                       reading decided it at. Made where the decision was made and never read
+     *                       back out of {@code standing}: a place holds the reasons of every rule
+     *                       that reached it and names none of them.
+     *
+     *                       <p>Its algebra is the branch's. A branch nobody can be in has none —
+     *                       there is no clause for an author to look at. A branch beside a dead one
+     *                       keeps its own and takes nothing from the other. Two branches somebody
+     *                       can be in have both, together with whatever the choice between them
+     *                       raised
      */
     record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                 Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing,
                 Map<FactSubject, StringRestriction> aboutStrings,
-                java.util.Set<souther.compiler.values.PlannedValues.Asked<FactSubject>> asked) {
+                java.util.Set<AdmissibleReading.AskedAt> asked,
+                Set<RuleShortfall> ruleShortfalls) {
 
         /** The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}. */
         Part inADeadBranch() {
@@ -113,25 +130,29 @@ sealed interface StatedByClauses {
             // What it asked for is kept. A machine refused for a pattern in a branch nobody can be
             // in was still asked for by that pattern, and a part that forgot it would leave the
             // refusal with nothing to be about.
+            // And what a rule is answerable for goes with them, for the same reason: there is no
+            // branch for an author to look at, so there is nothing for a shortfall to send them to.
             return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(), Map.of(),
-                    asked);
+                    asked, Set.of());
         }
 
         /** This part of the branch that stands, beside the same part of one nobody can be in. */
         Part beside(Part gone) {
+            // The standing branch's own, and nothing from the other. What a rule of a branch
+            // nothing satisfies is answerable for is not a rule of this declaration at all.
             return new Part(byValues.beside(gone.byValues()), byOrder.beside(gone.byOrder()),
-                    standing, aboutStrings, both(asked, gone.asked()));
+                    standing, aboutStrings, both(asked, gone.asked()), ruleShortfalls);
         }
 
         /** The same part of two branches, neither of which anybody can be in. */
         Part bothDead(Part other) {
             return new Part(byValues.bothDead(other.byValues()),
                     byOrder.bothDead(other.byOrder()), Map.of(), Map.of(),
-                    both(asked, other.asked()));
+                    both(asked, other.asked()), Set.of());
         }
 
-        /** The same part of two branches somebody can be in. */
-        Part either(Part other) {
+        /** The same part of two branches somebody can be in, under the choice between them. */
+        Part either(ChoiceId choice, Part other) {
             Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
                     ReadByClauses.alsoSaying(standing, other.standing());
             // What an unread alternative does to the reasons is the vocabulary's rule, stated once
@@ -139,26 +160,85 @@ sealed interface StatedByClauses {
             // What this side's copy reached — not what it settled: a position a dead branch
             // settled is an answer, and an unread alternative widens a constraint, not an answer
             // ({@link Adoption#either} makes the same distinction).
+            //
+            // And what a rule is answerable for is said of the choice, beside it and never out of
+            // it. What happened is that this choice offered an alternative nothing could read, so
+            // an author is sent to the choice — filed at a leaf under the branch that was read,
+            // they would be sent to a clause nothing complained of. Made here, where the choice is,
+            // rather than found in the reasons above: those are the place's and name no choice.
+            Set<RuleShortfall> shortfalls = new LinkedHashSet<>(ruleShortfalls);
+            shortfalls.addAll(other.ruleShortfalls());
             if (other.byValues().dropped()) {
                 why = souther.compiler.values.UnreadReason.leftOpen(why, reachedBy(byValues()));
+                leftOpenBy(choice, reachedBy(byValues()), other.ruleShortfalls(), ruleShortfalls,
+                        shortfalls);
             }
             if (byValues().dropped()) {
                 why = souther.compiler.values.UnreadReason.leftOpen(why,
                         reachedBy(other.byValues()));
+                leftOpenBy(choice, reachedBy(other.byValues()), ruleShortfalls,
+                        other.ruleShortfalls(), shortfalls);
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
                     why, StringRestriction.over(aboutStrings, other.aboutStrings(), false),
-                    both(asked, other.asked()));
+                    both(asked, other.asked()), Set.copyOf(shortfalls));
+        }
+
+        /**
+         * What the choice left open at each of {@code these} that {@code unread} does not already
+         * account for, which is one fact about the choice.
+         *
+         * <p>The alternative nothing could read is what leaves these positions open, and at a
+         * position that branch is already answerable for something it is the same shortfall
+         * arriving by another road: {@code n /= 5 || Int.abs(n) >= 2} is one form nothing reads and
+         * not a form and a choice, and counting both would have a reader lift the form and find the
+         * question still there. Where the branch says nothing about the position — the other side
+         * of {@code left /= right || code == "A"} never names {@code code} — the choice is the
+         * first thing to say anything, so it says it.
+         *
+         * <p><b>Asked of what that branch is answerable for and never of what the position holds.</b>
+         * The place holds the reasons of every rule that reached it, so suppressing by it would
+         * make a fact about a rule turn on what a neighbour wrote. The two come to the same answer
+         * today and are two rules; the position's own is {@code UnreadReason.leftOpen}'s.
+         *
+         * <p>And what accounts for the position is what turns on this choice: a shortfall the other
+         * branch holds as well stands whichever way the choice goes, so the branch being unread is
+         * not what left the position open by it. A conjunction distributing over a choice copies
+         * shortfalls made outside it into both branches, and one of those read as this branch's own
+         * would have the choice say nothing where its alternative is the only account there is —
+         * two choices each offering an alternative nothing read are two things to answer, and the
+         * second would arrive only once the first was answered.
+         *
+         * <p>Whole shortfalls, so what an author wrote is part of the comparison and a copy of one
+         * fact is told from two facts of the same shape. Never their reasons: a rule about which
+         * reasons suppress which would be one more place the vocabulary has to be consulted, and a
+         * reason added to it would quietly change what a choice says.
+         */
+        private static void leftOpenBy(ChoiceId choice, Set<FactSubject> these,
+                                       Set<RuleShortfall> unread, Set<RuleShortfall> beside,
+                                       Set<RuleShortfall> out) {
+            these.stream()
+                    .filter(each -> !accountedFor(each, unread, beside))
+                    .forEach(each -> out.add(new RuleShortfall(each,
+                            souther.compiler.values.UnreadReason.ALTERNATIVE_NOT_READ,
+                            new RuleShortfall.Site.AtAChoice(choice))));
+        }
+
+        /** Whether {@code unread} holds an account of {@code at} that {@code beside} does not. */
+        private static boolean accountedFor(FactSubject at, Set<RuleShortfall> unread,
+                                            Set<RuleShortfall> beside) {
+            return unread.stream()
+                    .anyMatch(one -> one.position().equals(at) && !beside.contains(one));
         }
 
         /** What either of them asked for, which is what this part asked for. */
-        private static java.util.Set<souther.compiler.values.PlannedValues.Asked<FactSubject>> both(
-                java.util.Set<souther.compiler.values.PlannedValues.Asked<FactSubject>> these,
-                java.util.Set<souther.compiler.values.PlannedValues.Asked<FactSubject>> those) {
+        private static java.util.Set<AdmissibleReading.AskedAt> both(
+                java.util.Set<AdmissibleReading.AskedAt> these,
+                java.util.Set<AdmissibleReading.AskedAt> those) {
             if (those.isEmpty()) {
                 return these;
             }
-            java.util.Set<souther.compiler.values.PlannedValues.Asked<FactSubject>> out = new LinkedHashSet<>(these);
+            java.util.Set<AdmissibleReading.AskedAt> out = new LinkedHashSet<>(these);
             out.addAll(those);
             return out;
         }
@@ -210,7 +290,7 @@ sealed interface StatedByClauses {
     static StatedByClauses top() {
         return new Said(souther.compiler.values.PlannedValues.top(),
                 OrderedIntervals.top(),
-                Adoption.nothing(), Adoption.nothing(), Map.of(), Map.of());
+                Adoption.nothing(), Adoption.nothing(), Map.of(), Set.of(), Set.of(), Map.of());
     }
 
     /**
@@ -376,6 +456,11 @@ sealed interface StatedByClauses {
                     // about them. Asked of the reading that recognises one, so this is where the
                     // answer enters and the connectives below are what compose it.
                     values.stringRuleIn(e, said, at),
+                    values.askedAt(e),
+                    // And what a rule of this leaf is answerable for, asked of the reading that
+                    // decided it and written down where it decided. Read off what the leaf leaves
+                    // the positions instead, this would be a list of reasons and no clause.
+                    Set.copyOf(values.shortfallsAt(e)),
                     Map.of());
         }
 
@@ -433,6 +518,10 @@ sealed interface StatedByClauses {
                     here.ordered().meet(there.ordered()),
                     here.byValues().both(there.byValues()), here.byOrder().both(there.byOrder()),
                     StringRestriction.over(here.strings(), there.strings(), true),
+                    askedIn(here.asked(), there.asked()),
+                    // What either is answerable for, which a conjunction is answerable for: both
+                    // clauses are the author's and both were read.
+                    shortOf(here.ruleShortfalls(), there.ruleShortfalls()),
                     // The parts of both, since a conjunction is every clause of it holding at once
                     // and each of them is still the part it was.
                     bothParts(here.parts(), there.parts()));
@@ -505,7 +594,10 @@ sealed interface StatedByClauses {
                 // read, which is what admitted the declaration as APART at all.
                 if (alternatives == Alternatives.MERGED
                         && a == Emptiness.NONEMPTY && b == Emptiness.NONEMPTY) {
-                    return live(here, there);
+                    // Merged here and still one choice somebody wrote, which is what an alternative
+                    // nothing could read is a fact about. Given no identity, the fact would have
+                    // nowhere to stand and an author would be sent to a branch that was read.
+                    return live(new ChoiceId(), here, there);
                 }
             }
             // And where whether a branch can be taken is not settled, the question waits — the
@@ -702,7 +794,12 @@ sealed interface StatedByClauses {
             said.parts().forEach((each, part) -> parts.put(each, new PartAccount(
                     part.byValues().unbuiltAt(unbuilt),
                     part.byOrder().unbuiltAt(unbuilt),
-                    aRuleIsAnswerableFor(part, made.made()),
+                    // What the part's own reading decided, and the machines it asked for that were
+                    // refused while the positions were worked out. The second is routed by what the
+                    // refusal says — the pattern and the position it was being built for — to the
+                    // clause that asked for it, and reaches no clause that asked for something else.
+                    shortOf(part.ruleShortfalls(),
+                            askedFor(made.made().aboutARule(), part.asked())),
                     part.aboutStrings())));
             return parts;
         }
@@ -734,7 +831,7 @@ sealed interface StatedByClauses {
                     if (there == Emptiness.EMPTY) {
                         yield beside(keptAs(one, fate.left()), other);
                     }
-                    yield live(keptAs(one, fate.left()), keptAs(other, fate.right()));
+                    yield live(it.id(), keptAs(one, fate.left()), keptAs(other, fate.right()));
                 }
             };
         }
@@ -762,12 +859,18 @@ sealed interface StatedByClauses {
                     // limit its neighbour reached.
                     ReadByClauses.alsoSaying(part.standing(),
                             routed(known.ruleShortfalls(), part, known.answerStanding())),
-                    part.aboutStrings(), part.asked())));
+                    part.aboutStrings(), part.asked(),
+                    // And the same refusal said as what a rule is answerable for, at the clause
+                    // that asked for the machine rather than at the place it was built for.
+                    shortOf(part.ruleShortfalls(),
+                            askedFor(known.ruleShortfalls(), part.asked())))));
             return new Said(read.values().alsoStanding(known.asPositionStanding()), read.ordered(),
-
                     read.byValues().unbuiltAt(known.unbuilt()),
                     read.byOrder().unbuiltAt(known.unbuilt()),
                     read.strings(),
+                    read.asked(),
+                    shortOf(read.ruleShortfalls(),
+                            askedFor(known.ruleShortfalls(), read.asked())),
                     parts);
         }
 
@@ -798,48 +901,6 @@ sealed interface StatedByClauses {
         }
 
         /**
-         * What a rule of one part is answerable for: what its own reading wrote down, and what
-         * working the answer out could not build at a position that part is about.
-         *
-         * <p>The second half comes from what the shortfall says and never from what the part
-         * happens to name. A machine that was too large is the pattern's, and the position it was
-         * being built for is what the spending was arranged by, so a shortfall says both — and a
-         * part is told it where it asked for that machine at that position. Answered by whether
-         * the part names the place, every rule that mentioned it was handed a limit its neighbour
-         * reached; answered by the pattern alone, a rule that wrote it about somewhere else was
-         * handed one that happened elsewhere.
-         *
-         * <p>The first half is the part's own record of its own reading, which is a different
-         * thing from a place's reasons and is why sifting it is right here and nowhere else
-         * ({@code WhatARuleIsAnswerableForIsNotSiftedOutOfAPlace}).
-         */
-        private Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>>
-                aRuleIsAnswerableFor(Part part, souther.compiler.values.Realized<FactSubject> made) {
-            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> out =
-                    new java.util.LinkedHashMap<>();
-            part.standing().forEach((position, why) -> {
-                java.util.List<souther.compiler.values.UnreadReason> mine = why.stream()
-                        .filter(each -> each.about()
-                                == souther.compiler.values.UnreadReason.About.A_RULE)
-                        .toList();
-                if (!mine.isEmpty()) {
-                    out.put(position, mine);
-                }
-            });
-            // And what a machine this part asked for was refused for, which is this part's because
-            // this part asked. Taken by whether the part mentions the position, it was every
-            // part's: an allowance is held per position and every rule reaching one pays into it,
-            // so a rule that named the place was handed a limit its neighbour reached — and an
-            // author reading it went to a clause that reads perfectly well.
-            made.aboutARule().stream()
-                    .filter(each -> part.asked().contains(
-                            new souther.compiler.values.PlannedValues.Asked<>(
-                                    each.at(), each.asked())))
-                    .forEach(each -> out.merge(each.at(),
-                            java.util.List.of(each.why()), ReadByClauses::alsoSaying));
-            return out;
-        }
-
         /**
          * A choice neither branch of which anybody can take.
          *
@@ -862,6 +923,10 @@ sealed interface StatedByClauses {
                     // And what either of them said about the strings goes with them. A run drawn
                     // from a branch nobody can take is a line the model does not draw.
                     Map.of(),
+                    askedIn(here.asked(), there.asked()),
+                    // And nothing a rule is answerable for. Neither branch is one anybody can be
+                    // in, so there is no clause of this declaration for an author to look at.
+                    Set.of(),
                     branchParts(here.parts(), there.parts(), Part::bothDead,
                             Part::inADeadBranch));
         }
@@ -881,20 +946,90 @@ sealed interface StatedByClauses {
                     // The branch that stands, and what the other could not read is not its
                     // business: a rule of a branch nothing satisfies hides no run of this one.
                     alive.strings(),
+                    askedIn(alive.asked(), gone.asked()),
+                    // And what the standing branch is answerable for, which is its own. A rule of
+                    // the branch nobody can be in is not a rule of this declaration.
+                    alive.ruleShortfalls(),
                     branchParts(alive.parts(), gone.parts(), Part::beside,
                             Part::inADeadBranch));
         }
 
-        /** A choice both branches of which somebody can take. */
-        private Said live(Said here, Said there) {
+        /**
+         * A choice both branches of which somebody can take, said of the choice it is.
+         *
+         * <p>Which choice, because that is what an alternative nothing could read is a fact about.
+         * The join knows that a branch was short of a rule and which positions the other promised —
+         * neither of those is a thing an author wrote — and this is where what they wrote is known.
+         */
+        private Said live(ChoiceId choice, Said here, Said there) {
+            Set<RuleShortfall> raised = new LinkedHashSet<>(
+                    shortOf(here.ruleShortfalls(), there.ruleShortfalls()));
+            if (there.byValues().dropped()) {
+                Part.leftOpenBy(choice, Part.reachedBy(here.byValues()),
+                        there.ruleShortfalls(), here.ruleShortfalls(), raised);
+            }
+            if (here.byValues().dropped()) {
+                Part.leftOpenBy(choice, Part.reachedBy(there.byValues()),
+                        here.ruleShortfalls(), there.ruleShortfalls(), raised);
+            }
             return new Said(values.either(here.values(), there.values()),
                     ordered.either(here.ordered(), there.ordered()),
                     here.byValues().either(there.byValues()),
                     here.byOrder().either(there.byOrder()),
                     StringRestriction.over(here.strings(), there.strings(), false),
-                    branchParts(here.parts(), there.parts(), Part::either,
+                    askedIn(here.asked(), there.asked()),
+                    Collections.unmodifiableSet(raised),
+                    branchParts(here.parts(), there.parts(),
+                            (one, other) -> one.either(choice, other),
                             java.util.function.UnaryOperator.identity()));
         }
+    }
+
+    /**
+     * A machine that was refused, said at each clause that asked for it.
+     *
+     * <p>The refusal knows the pattern and the position it was being built for (#1341), and what
+     * asked for that machine there is what a clause wrote. Two clauses writing one pattern about
+     * one position asked for one machine and are two of these — two rules answerable for one
+     * refusal, which is what writing the same clause twice comes to.
+     */
+    private static Set<RuleShortfall> askedFor(
+            Set<souther.compiler.values.Unbuilt.RuleShortfall<FactSubject>> refused,
+            Set<AdmissibleReading.AskedAt> asked) {
+        Set<RuleShortfall> out = new LinkedHashSet<>();
+        refused.forEach(each -> asked.stream()
+                .filter(one -> one.position().equals(each.at()) && one.plan().equals(each.asked()))
+                .forEach(one -> out.add(new RuleShortfall(each.at(), each.why(),
+                        new RuleShortfall.Site.AtALeaf(one.node())))));
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** What either of two readings asked a machine for, which is what both of them asked for. */
+    private static Set<AdmissibleReading.AskedAt> askedIn(Set<AdmissibleReading.AskedAt> these,
+                                                         Set<AdmissibleReading.AskedAt> those) {
+        if (those.isEmpty()) {
+            return these;
+        }
+        Set<AdmissibleReading.AskedAt> out = new LinkedHashSet<>(these);
+        out.addAll(those);
+        return Collections.unmodifiableSet(out);
+    }
+
+    /**
+     * What either of two readings is answerable for, which is what both of them are.
+     *
+     * <p>A union and nothing more. Each of these is one fact about one written place, so two copies
+     * of one are one and two places are two — and nothing here puts them in an order, which is the
+     * source's to say and is asked where a document is written.
+     */
+    private static Set<RuleShortfall> shortOf(Set<RuleShortfall> these,
+                                              Set<RuleShortfall> those) {
+        if (those.isEmpty()) {
+            return these;
+        }
+        Set<RuleShortfall> out = new LinkedHashSet<>(these);
+        out.addAll(those);
+        return Collections.unmodifiableSet(out);
     }
 
     /** The parts of two readings held together, each of them still the part it was. */
@@ -1174,8 +1309,7 @@ sealed interface StatedByClauses {
      * place.
      */
     record PartAccount(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
-                       Map<FactSubject,
-                               java.util.List<souther.compiler.values.UnreadReason>> aboutARule,
+                       Set<RuleShortfall> aboutARule,
                        Map<FactSubject, StringRestriction> aboutStrings) {}
 
     /** What the allowance has left at each of {@code positions}, for holding an account to

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -117,7 +117,7 @@ sealed interface StatedByClauses {
     record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
                 Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing,
                 Map<FactSubject, StringRestriction> aboutStrings,
-                java.util.Set<AdmissibleReading.AskedAt> asked,
+                Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls) {
 
         /** The same part, in a branch nobody can be in — see {@link Adoption#inADeadBranch}. */
@@ -141,14 +141,14 @@ sealed interface StatedByClauses {
             // The standing branch's own, and nothing from the other. What a rule of a branch
             // nothing satisfies is answerable for is not a rule of this declaration at all.
             return new Part(byValues.beside(gone.byValues()), byOrder.beside(gone.byOrder()),
-                    standing, aboutStrings, both(asked, gone.asked()), ruleShortfalls);
+                    standing, aboutStrings, askedIn(asked, gone.asked()), ruleShortfalls);
         }
 
         /** The same part of two branches, neither of which anybody can be in. */
         Part bothDead(Part other) {
             return new Part(byValues.bothDead(other.byValues()),
                     byOrder.bothDead(other.byOrder()), Map.of(), Map.of(),
-                    both(asked, other.asked()), Set.of());
+                    askedIn(asked, other.asked()), Set.of());
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */
@@ -181,7 +181,7 @@ sealed interface StatedByClauses {
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
                     why, StringRestriction.over(aboutStrings, other.aboutStrings(), false),
-                    both(asked, other.asked()), Set.copyOf(shortfalls));
+                    askedIn(asked, other.asked()), Set.copyOf(shortfalls));
         }
 
         /**
@@ -189,12 +189,12 @@ sealed interface StatedByClauses {
          * account for, which is one fact about the choice.
          *
          * <p>The alternative nothing could read is what leaves these positions open, and at a
-         * position that branch is already answerable for something it is the same shortfall
+         * position that branch is answerable for something of its own it is the same shortfall
          * arriving by another road: {@code n /= 5 || Int.abs(n) >= 2} is one form nothing reads and
          * not a form and a choice, and counting both would have a reader lift the form and find the
-         * question still there. Where the branch says nothing about the position — the other side
-         * of {@code left /= right || code == "A"} never names {@code code} — the choice is the
-         * first thing to say anything, so it says it.
+         * question still there. Where the branch says nothing of its own about the position — the
+         * other side of {@code left /= right || code == "A"} never names {@code code} — the choice
+         * is the first thing to say anything, so it says it.
          *
          * <p><b>Asked of what that branch is answerable for and never of what the position holds.</b>
          * The place holds the reasons of every rule that reached it, so suppressing by it would
@@ -229,18 +229,6 @@ sealed interface StatedByClauses {
                                             Set<RuleShortfall> beside) {
             return unread.stream()
                     .anyMatch(one -> one.position().equals(at) && !beside.contains(one));
-        }
-
-        /** What either of them asked for, which is what this part asked for. */
-        private static java.util.Set<AdmissibleReading.AskedAt> both(
-                java.util.Set<AdmissibleReading.AskedAt> these,
-                java.util.Set<AdmissibleReading.AskedAt> those) {
-            if (those.isEmpty()) {
-                return these;
-            }
-            java.util.Set<AdmissibleReading.AskedAt> out = new LinkedHashSet<>(these);
-            out.addAll(those);
-            return out;
         }
 
         /** The positions a rule of this copy reached and did not merely settle: what it
@@ -901,7 +889,6 @@ sealed interface StatedByClauses {
         }
 
         /**
-        /**
          * A choice neither branch of which anybody can take.
          *
          * <p>No one of them speaks for the rest: taking the first to be found impossible out of the
@@ -988,8 +975,8 @@ sealed interface StatedByClauses {
     /**
      * A machine that was refused, said at each clause that asked for it.
      *
-     * <p>The refusal knows the pattern and the position it was being built for (#1341), and what
-     * asked for that machine there is what a clause wrote. Two clauses writing one pattern about
+     * <p>The refusal knows the pattern and the position it was being built for, and what asked for
+     * that machine there is what a clause wrote. Two clauses writing one pattern about
      * one position asked for one machine and are two of these — two rules answerable for one
      * refusal, which is what writing the same clause twice comes to.
      */

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -76,8 +76,7 @@ sealed interface StatedByClauses {
         @Override
         public StatedByClauses from(Core e) {
             Map<Core, Part> out = new java.util.IdentityHashMap<>(parts);
-            out.put(e, new Part(byValues, byOrder, values.standing(), strings, asked,
-                    ruleShortfalls));
+            out.put(e, new Part(byValues, byOrder, strings, asked, ruleShortfalls));
             return new Said(values, ordered, byValues, byOrder, strings, asked, ruleShortfalls,
                     out);
         }
@@ -91,13 +90,13 @@ sealed interface StatedByClauses {
      * that decision never reached — so it answers about a branch the declaration has already
      * dropped, and it pays to find out.
      *
-     * <p>What is here is what a reader of the account needs of a part: which positions each
-     * language took it in at, and what it wrote down about the ones it could not. What the part
-     * finally admits is not among them — that is the whole value's answer and belongs to the whole.
+     * <p>What is here is what a reader of the account needs of a part, and every one of them is a
+     * fact about this written part: how each language took it in, what it says about the strings,
+     * which machines it asked for, and what a rule of it is answerable for. What the part finally
+     * admits is not among them — that is the whole value's answer and belongs to the whole, and so
+     * is what a position was left holding, which is kept once by the carrier that answers for the
+     * position and copied nowhere.
      *
-     * @param standing what this part's reading recorded about positions it was short of. A
-     *                 position's own account, which is why it holds every reason there is; an
-     *                 account of a rule is not sifted out of it and is {@code ruleShortfalls}
      * @param aboutStrings what this part states about the strings at each position it states a rule
      *                     about. The position is here whether or not the rule was read, because
      *                     which of a position's numbers a rule is written about is settled by the
@@ -105,8 +104,8 @@ sealed interface StatedByClauses {
      *                     read has none
      * @param ruleShortfalls what a rule is answerable for, each saying the written place the
      *                       reading decided it at. Made where the decision was made and never read
-     *                       back out of {@code standing}: a place holds the reasons of every rule
-     *                       that reached it and names none of them.
+     *                       back out of what a position was left holding: a place holds the reasons
+     *                       of every rule that reached it and names none of them.
      *
      *                       <p>Its algebra is the branch's. A branch nobody can be in has none —
      *                       there is no clause for an author to look at. A branch beside a dead one
@@ -115,7 +114,6 @@ sealed interface StatedByClauses {
      *                       raised
      */
     record Part(Adoption<FactSubject> byValues, Adoption<FactSubject> byOrder,
-                Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> standing,
                 Map<FactSubject, StringRestriction> aboutStrings,
                 Set<AdmissibleReading.AskedAt> asked,
                 Set<RuleShortfall> ruleShortfalls) {
@@ -132,7 +130,7 @@ sealed interface StatedByClauses {
             // refusal with nothing to be about.
             // And what a rule is answerable for goes with them, for the same reason: there is no
             // branch for an author to look at, so there is nothing for a shortfall to send them to.
-            return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(), Map.of(),
+            return new Part(byValues.inADeadBranch(), byOrder.inADeadBranch(), Map.of(),
                     asked, Set.of());
         }
 
@@ -141,47 +139,40 @@ sealed interface StatedByClauses {
             // The standing branch's own, and nothing from the other. What a rule of a branch
             // nothing satisfies is answerable for is not a rule of this declaration at all.
             return new Part(byValues.beside(gone.byValues()), byOrder.beside(gone.byOrder()),
-                    standing, aboutStrings, askedIn(asked, gone.asked()), ruleShortfalls);
+                    aboutStrings, askedIn(asked, gone.asked()), ruleShortfalls);
         }
 
         /** The same part of two branches, neither of which anybody can be in. */
         Part bothDead(Part other) {
             return new Part(byValues.bothDead(other.byValues()),
-                    byOrder.bothDead(other.byOrder()), Map.of(), Map.of(),
+                    byOrder.bothDead(other.byOrder()), Map.of(),
                     askedIn(asked, other.asked()), Set.of());
         }
 
         /** The same part of two branches somebody can be in, under the choice between them. */
         Part either(ChoiceId choice, Part other) {
-            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> why =
-                    ReadByClauses.alsoSaying(standing, other.standing());
-            // What an unread alternative does to the reasons is the vocabulary's rule, stated once
-            // ({@code UnreadReason.leftOpen}); which positions it happens to is this carrier's.
-            // What this side's copy reached — not what it settled: a position a dead branch
+            // What a rule is answerable for is said of the choice, beside it and never out of it.
+            // What happened is that this choice offered an alternative nothing could read, so an
+            // author is sent to the choice — filed at a leaf under the branch that was read, they
+            // would be sent to a clause nothing complained of. Made here, where the choice is: what
+            // a position was left holding is the position's and names no choice.
+            //
+            // Over what this side's copy reached — not what it settled: a position a dead branch
             // settled is an answer, and an unread alternative widens a constraint, not an answer
             // ({@link Adoption#either} makes the same distinction).
-            //
-            // And what a rule is answerable for is said of the choice, beside it and never out of
-            // it. What happened is that this choice offered an alternative nothing could read, so
-            // an author is sent to the choice — filed at a leaf under the branch that was read,
-            // they would be sent to a clause nothing complained of. Made here, where the choice is,
-            // rather than found in the reasons above: those are the place's and name no choice.
             Set<RuleShortfall> shortfalls = new LinkedHashSet<>(ruleShortfalls);
             shortfalls.addAll(other.ruleShortfalls());
             if (other.byValues().dropped()) {
-                why = souther.compiler.values.UnreadReason.leftOpen(why, reachedBy(byValues()));
                 leftOpenBy(choice, reachedBy(byValues()), other.ruleShortfalls(), ruleShortfalls,
                         shortfalls);
             }
             if (byValues().dropped()) {
-                why = souther.compiler.values.UnreadReason.leftOpen(why,
-                        reachedBy(other.byValues()));
                 leftOpenBy(choice, reachedBy(other.byValues()), ruleShortfalls,
                         other.ruleShortfalls(), shortfalls);
             }
             return new Part(byValues.either(other.byValues()), byOrder.either(other.byOrder()),
-                    why, StringRestriction.over(aboutStrings, other.aboutStrings(), false),
-                    askedIn(asked, other.asked()), Set.copyOf(shortfalls));
+                    StringRestriction.over(aboutStrings, other.aboutStrings(), false),
+                    askedIn(asked, other.asked()), held(shortfalls));
         }
 
         /**
@@ -448,7 +439,7 @@ sealed interface StatedByClauses {
                     // And what a rule of this leaf is answerable for, asked of the reading that
                     // decided it and written down where it decided. Read off what the leaf leaves
                     // the positions instead, this would be a list of reasons and no clause.
-                    Set.copyOf(values.shortfallsAt(e)),
+                    held(values.shortfallsAt(e)),
                     Map.of());
         }
 
@@ -841,15 +832,12 @@ sealed interface StatedByClauses {
             read.parts().forEach((each, part) -> parts.put(each, new Part(
                     part.byValues().unbuiltAt(known.unbuilt()),
                     part.byOrder().unbuiltAt(known.unbuilt()),
-                    // What the answer was short of, to every part of the branch, because every one
-                    // of them waited on it. What a pattern asked for goes to the part that asked
-                    // and to no other: distributed by the place, a rule that named it was handed a
-                    // limit its neighbour reached.
-                    ReadByClauses.alsoSaying(part.standing(),
-                            routed(known.ruleShortfalls(), part, known.answerStanding())),
                     part.aboutStrings(), part.asked(),
-                    // And the same refusal said as what a rule is answerable for, at the clause
-                    // that asked for the machine rather than at the place it was built for.
+                    // What a machine was refused for, said as what a rule is answerable for, at
+                    // the clause that asked for it rather than at the place it was built for. What
+                    // the answer itself was short of is not here: that holds of everything waiting
+                    // on the position and is the position's own, kept by the carrier that answers
+                    // for the position.
                     shortOf(part.ruleShortfalls(),
                             askedFor(known.ruleShortfalls(), part.asked())))));
             return new Said(read.values().alsoStanding(known.asPositionStanding()), read.ordered(),
@@ -860,32 +848,6 @@ sealed interface StatedByClauses {
                     shortOf(read.ruleShortfalls(),
                             askedFor(known.ruleShortfalls(), read.asked())),
                     parts);
-        }
-
-        /**
-         * What a branch's probe found, as much of it as is this part's.
-         *
-         * <p>The answer's half to every part, because every one of them waited on the answer. The
-         * other half by whether this part asked for the machine that was refused — which is a thing
-         * the shortfall says, and not a thing the position it happened at can say. Every rule
-         * reaching a position pays into one allowance, so a place has as many claimants as it has
-         * rules and names none of them.
-         */
-        private static Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>>
-                routed(java.util.Set<souther.compiler.values.Unbuilt
-                        .RuleShortfall<FactSubject>> shortfalls,
-                       Part part,
-                       Map<FactSubject,
-                               java.util.List<souther.compiler.values.UnreadReason>> answered) {
-            Map<FactSubject, java.util.List<souther.compiler.values.UnreadReason>> out =
-                    new java.util.LinkedHashMap<>(answered);
-            shortfalls.stream()
-                    .filter(each -> part.asked().contains(
-                            new souther.compiler.values.PlannedValues.Asked<>(
-                                    each.at(), each.asked())))
-                    .forEach(each -> out.merge(each.at(), java.util.List.of(each.why()),
-                            ReadByClauses::alsoSaying));
-            return out;
         }
 
         /**
@@ -986,9 +948,8 @@ sealed interface StatedByClauses {
         Set<RuleShortfall> out = new LinkedHashSet<>();
         refused.forEach(each -> asked.stream()
                 .filter(one -> one.position().equals(each.at()) && one.plan().equals(each.asked()))
-                .forEach(one -> out.add(new RuleShortfall(each.at(), each.why(),
-                        new RuleShortfall.Site.AtALeaf(one.node())))));
-        return Collections.unmodifiableSet(out);
+                .forEach(one -> out.add(new RuleShortfall(each.at(), each.why(), one.site()))));
+        return held(out);
     }
 
     /** What either of two readings asked a machine for, which is what both of them asked for. */
@@ -1016,7 +977,21 @@ sealed interface StatedByClauses {
         }
         Set<RuleShortfall> out = new LinkedHashSet<>(these);
         out.addAll(those);
-        return Collections.unmodifiableSet(out);
+        return held(out);
+    }
+
+    /**
+     * These facts, as a value nobody can add to.
+     *
+     * <p>The one way one of these sets is finished, and it keeps the order the facts were met in.
+     * That order is no part of what the set means — which written place a reader is sent to first is
+     * the source's to say and is settled where a document is written — but a projection out of the
+     * set does read it ({@code RuleAccounting.Why}), and a copy that reordered would have the same
+     * compiler over the same source publish two documents. {@code Set.copyOf} is such a copy: it
+     * salts the iteration order per run.
+     */
+    private static Set<RuleShortfall> held(java.util.Collection<RuleShortfall> these) {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(these));
     }
 
     /** The parts of two readings held together, each of them still the part it was. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -2,8 +2,11 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
+import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
@@ -175,17 +178,145 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
         StatedByClauses.Part read = new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
                         java.util.Set.of(), false),
-                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of());
+                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), java.util.Set.of());
         StatedByClauses.Part unread = new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
                         true),
                 Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
-                java.util.Set.of());
+                java.util.Set.of(), java.util.Set.of());
+        ChoiceId choice = new ChoiceId();
 
         assertEquals(Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ),
                         CONSTRAINED, List.of(UnreadReason.ALTERNATIVE_NOT_READ)),
-                read.either(unread).standing(),
+                read.either(choice, unread).standing(),
                 "the constraint is left open and the answer stands");
+    }
+
+    /**
+     * And what a rule is answerable for says which choice left it open.
+     *
+     * <p>The place's own account above says the position is open and says nothing about what
+     * anybody wrote — every rule reaching it is in that map. What an author is sent to is this
+     * choice, which is what offered the alternative nothing could read: a leaf under the branch
+     * that was read is a clause nothing complained of.
+     */
+    @Test
+    void whatLeftTheConstraintOpenIsTheChoiceItWasOffered() {
+        StatedByClauses.Part read = new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
+                        java.util.Set.of(), false),
+                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), java.util.Set.of());
+        StatedByClauses.Part unread = new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
+                        true),
+                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
+                java.util.Set.of(), java.util.Set.of());
+        ChoiceId choice = new ChoiceId();
+
+        assertEquals(java.util.Set.of(new RuleShortfall(CONSTRAINED,
+                        UnreadReason.ALTERNATIVE_NOT_READ,
+                        new RuleShortfall.Site.AtAChoice(choice))),
+                read.either(choice, unread).ruleShortfalls(),
+                "an author is sent to the choice that offered the alternative");
+    }
+
+    /**
+     * A shortfall the other branch holds as well is not what this choice left open.
+     *
+     * <p>A conjunction distributing over a choice puts what a rule was short of outside it into
+     * both branches, where it stands whichever way this choice goes. Read as the unread branch's
+     * own account, the alternative an author still has to answer would say nothing — and would say
+     * it once the shortfall standing beside it was answered, which is one round later.
+     */
+    @Test
+    void aShortfallBothBranchesHoldIsNotWhatTheChoiceLeftOpen() {
+        RuleShortfall brought = new RuleShortfall(CONSTRAINED, UnreadReason.ALTERNATIVE_NOT_READ,
+                new RuleShortfall.Site.AtAChoice(new ChoiceId()));
+        ChoiceId choice = new ChoiceId();
+
+        assertEquals(java.util.Set.of(brought, new RuleShortfall(CONSTRAINED,
+                        UnreadReason.ALTERNATIVE_NOT_READ,
+                        new RuleShortfall.Site.AtAChoice(choice))),
+                theBranchRead(java.util.Set.of(brought))
+                        .either(choice, theBranchNothingRead(java.util.Set.of(brought)))
+                        .ruleShortfalls(),
+                "what stands whichever way the choice goes does not account for its alternative"
+                        + " going unread");
+    }
+
+    /** And one only the unread branch holds does account for it. */
+    @Test
+    void aShortfallOnlyTheUnreadBranchHoldsAnswersForThePosition() {
+        RuleShortfall inside = new RuleShortfall(CONSTRAINED, UnreadReason.ALTERNATIVE_NOT_READ,
+                new RuleShortfall.Site.AtAChoice(new ChoiceId()));
+
+        assertEquals(java.util.Set.of(inside),
+                theBranchRead(java.util.Set.of())
+                        .either(new ChoiceId(), theBranchNothingRead(java.util.Set.of(inside)))
+                        .ruleShortfalls(),
+                "answering it settles the position through this branch, which takes the choice's"
+                        + " shortfall with it");
+    }
+
+    /**
+     * And which of the two is not asked of where the shortfall was written.
+     *
+     * <p>A form is one thing an author can lift and a choice is another, and neither tells whether
+     * lifting it is what would leave the branch readable. Asked of the site instead, a site added
+     * later would have this answer written for it a second time.
+     */
+    @Test
+    void andWhichOfTheTwoIsNotAskedOfWhereItWasWritten() {
+        RuleShortfall form = new RuleShortfall(CONSTRAINED, UnreadReason.FORM_NOT_READ,
+                new RuleShortfall.Site.AtALeaf(new Core.Bool(true, Type.BOOL, new SourcePos(1, 1))));
+
+        assertEquals(java.util.Set.of(form),
+                theBranchRead(java.util.Set.of())
+                        .either(new ChoiceId(), theBranchNothingRead(java.util.Set.of(form)))
+                        .ruleShortfalls(),
+                "a form only the unread branch holds accounts for the position");
+        ChoiceId choice = new ChoiceId();
+        assertEquals(java.util.Set.of(form, new RuleShortfall(CONSTRAINED,
+                        UnreadReason.ALTERNATIVE_NOT_READ,
+                        new RuleShortfall.Site.AtAChoice(choice))),
+                theBranchRead(java.util.Set.of(form))
+                        .either(choice, theBranchNothingRead(java.util.Set.of(form)))
+                        .ruleShortfalls(),
+                "and the same form standing in both branches does not");
+    }
+
+    /** A branch that was read, constraining one position and settling another. */
+    private static StatedByClauses.Part theBranchRead(java.util.Set<RuleShortfall> shortfalls) {
+        return new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
+                        java.util.Set.of(), false),
+                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), shortfalls);
+    }
+
+    /** And the alternative beside it that nothing could read. */
+    private static StatedByClauses.Part theBranchNothingRead(
+            java.util.Set<RuleShortfall> shortfalls) {
+        return new StatedByClauses.Part(
+                new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
+                        true),
+                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
+                java.util.Set.of(), shortfalls);
+    }
+
+    /** And two choices leaving one position open are two things an author can look at. */
+    @Test
+    void twoChoicesLeavingOnePositionOpenAreTwo() {
+        ChoiceId one = new ChoiceId();
+        ChoiceId other = new ChoiceId();
+
+        assertEquals(2, java.util.Set.of(
+                        new RuleShortfall(CONSTRAINED, UnreadReason.ALTERNATIVE_NOT_READ,
+                                new RuleShortfall.Site.AtAChoice(one)),
+                        new RuleShortfall(CONSTRAINED, UnreadReason.ALTERNATIVE_NOT_READ,
+                                new RuleShortfall.Site.AtAChoice(other))).size(),
+                "the position is open twice and there are two clauses to look at; held as reasons"
+                        + " at the position they were one, and which of them a reader was sent to"
+                        + " was whichever the walk met first");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -164,60 +164,31 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
     private static final FactSubject UNREAD = FactSubject.of(NAMES.written("unread"));
 
     /**
-     * An unread alternative widens what a branch constrained, and not what a dead branch inside it
-     * settled.
+     * What a rule is answerable for says which choice left the constraint open.
      *
-     * <p>The account's copy of the rule the values join by: a position a dead branch settled holds
-     * an answer — the choice imposes nothing there — and a further alternative, read or not,
-     * imposes nothing extra either ({@code Adoption.either} draws the same line). Written over the
-     * copy's mentions instead, the account held a reason at a settled position that no output
-     * happens to show today, which is a lie waiting for its first reader.
-     */
-    @Test
-    void anUnreadAlternativeWidensAConstraintAndNotAnAnswer() {
-        StatedByClauses.Part read = new StatedByClauses.Part(
-                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
-                        java.util.Set.of(), false),
-                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), java.util.Set.of());
-        StatedByClauses.Part unread = new StatedByClauses.Part(
-                new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
-                        true),
-                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
-                java.util.Set.of(), java.util.Set.of());
-        ChoiceId choice = new ChoiceId();
-
-        assertEquals(Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ),
-                        CONSTRAINED, List.of(UnreadReason.ALTERNATIVE_NOT_READ)),
-                read.either(choice, unread).standing(),
-                "the constraint is left open and the answer stands");
-    }
-
-    /**
-     * And what a rule is answerable for says which choice left it open.
+     * <p>What an author is sent to is this choice, which is what offered the alternative nothing
+     * could read: a leaf under the branch that was read is a clause nothing complained of. The
+     * position's own account is not this and is somewhere else — it says the position is open and
+     * says nothing about what anybody wrote, since every rule reaching it is in it.
      *
-     * <p>The place's own account above says the position is open and says nothing about what
-     * anybody wrote — every rule reaching it is in that map. What an author is sent to is this
-     * choice, which is what offered the alternative nothing could read: a leaf under the branch
-     * that was read is a clause nothing complained of.
+     * <p>And an unread alternative widens what a branch constrained, and not what a dead branch
+     * inside it settled: a position a dead branch settled holds an answer, so the choice imposes
+     * nothing there and a further alternative, read or not, imposes nothing extra either
+     * ({@code Adoption.either} draws the same line). Asked over what the branch mentions instead,
+     * an author would be sent to a choice about a position that is answered.
      */
     @Test
     void whatLeftTheConstraintOpenIsTheChoiceItWasOffered() {
-        StatedByClauses.Part read = new StatedByClauses.Part(
-                new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
-                        java.util.Set.of(), false),
-                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), java.util.Set.of());
-        StatedByClauses.Part unread = new StatedByClauses.Part(
-                new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
-                        true),
-                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
-                java.util.Set.of(), java.util.Set.of());
         ChoiceId choice = new ChoiceId();
 
         assertEquals(java.util.Set.of(new RuleShortfall(CONSTRAINED,
                         UnreadReason.ALTERNATIVE_NOT_READ,
                         new RuleShortfall.Site.AtAChoice(choice))),
-                read.either(choice, unread).ruleShortfalls(),
-                "an author is sent to the choice that offered the alternative");
+                theBranchRead(java.util.Set.of())
+                        .either(choice, theBranchNothingRead(java.util.Set.of()))
+                        .ruleShortfalls(),
+                "an author is sent to the choice that offered the alternative, and to nothing"
+                        + " about the position the branch settled");
     }
 
     /**
@@ -290,7 +261,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
         return new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(CONSTRAINED), java.util.Set.of(SETTLED),
                         java.util.Set.of(), false),
-                Adoption.nothing(), Map.of(), Map.of(), java.util.Set.of(), shortfalls);
+                Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls);
     }
 
     /** And the alternative beside it that nothing could read. */
@@ -299,8 +270,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
         return new StatedByClauses.Part(
                 new Adoption<>(java.util.Set.of(), java.util.Set.of(), java.util.Set.of(UNREAD),
                         true),
-                Adoption.nothing(), Map.of(UNREAD, List.of(UnreadReason.FORM_NOT_READ)), Map.of(),
-                java.util.Set.of(), shortfalls);
+                Adoption.nothing(), Map.of(), java.util.Set.of(), shortfalls);
     }
 
     /** And two choices leaving one position open are two things an author can look at. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
@@ -82,6 +82,18 @@ class AChoiceSaysWhatNothingElseSaidAboutAPositionTest {
                 invariant r = (b == "A" || b == "B") || UNREAD_A
             """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
 
+    /**
+     * Eight clauses about one position that nothing reads, written along one line.
+     *
+     * <p>Enough of them that an order arrived at by hashing would be some other order.
+     */
+    private static final String EIGHT_FORMS_NOTHING_READS = """
+            module demo
+
+            data N = { a: String }
+                invariant r = U && U && U && U && U && U && U && U
+            """.replace("U", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
     /** Where nothing else said anything about the position, the choice says it. */
     @Test
     void aChoiceIsAnswerableWhereItsUnreadAlternativeSaidNothing() {
@@ -131,6 +143,31 @@ class AChoiceSaysWhatNothingElseSaidAboutAPositionTest {
         assertEquals(sitesFor(THE_SAME_THROUGH_ONE_MORE_BRACKET, "b").size(),
                 sitesFor(THE_SAME_BRACKETED_THE_OTHER_WAY, "b").size(),
                 "and has the same number of things to look at");
+    }
+
+    /**
+     * And the facts come out in the order they were met, whatever order that is.
+     *
+     * <p>No order is claimed of them: which written place a reader is sent to first is the source's
+     * to say, and a set of facts says nothing about it. What is held here is that the order does not
+     * come from somewhere else — a projection out of this set is published, so a copy free to
+     * arrange them by hash would have one compiler over one source publish two documents, and which
+     * one an author saw would be the run they happened to make.
+     *
+     * <p>Eight of them because a copy that reorders may leave two or three where they were.
+     */
+    @Test
+    void theFactsComeOutInTheOrderTheyWereMet() {
+        List<Integer> columns = new java.util.ArrayList<>();
+        shortfallsAt(EIGHT_FORMS_NOTHING_READS, "a").forEach(each -> {
+            if (each.site() instanceof RuleShortfall.Site.AtALeaf leaf) {
+                columns.add(leaf.node().pos().column());
+            }
+        });
+
+        assertEquals(8, columns.size(), "one for each clause nothing reads");
+        assertEquals(columns.stream().sorted().toList(), columns,
+                "they were met along the line, and nothing between there and here rearranged them");
     }
 
     /** What a rule of the declaration is answerable for at {@code field}. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceSaysWhatNothingElseSaidAboutAPositionTest.java
@@ -1,0 +1,181 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.UnreadReason;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A choice is answerable for a position its unread alternative said nothing else about.
+ *
+ * <p>What an alternative nothing could read does is leave the positions the other branch promised
+ * open. At a position that branch is already answerable for something, that is the same shortfall
+ * arriving by another road — a form nothing reads is one thing to lift, and a reader told to lift
+ * it and then told about the choice above it would lift the form and find the question still there.
+ * At a position the branch never named, the choice is the first thing to say anything.
+ *
+ * <p><b>Asked of what the branch is answerable for, and never of what the position holds.</b> A
+ * place holds the reasons of every rule that reached it, so a rule suppressed by it would be a fact
+ * about a rule turning on what a neighbour wrote. The position's own account has a rule of its own
+ * that comes to the same answer here, and the two are two rules ({@code UnreadReason.leftOpen}).
+ *
+ * <p>Which choice, because that is what it is a fact about. Filed at a leaf under the branch that
+ * was read, an author would be sent to a clause nothing complained of.
+ */
+class AChoiceSaysWhatNothingElseSaidAboutAPositionTest {
+
+    /**
+     * A branch nothing reads, beside one that promises a position it never names.
+     *
+     * <p>The unread side is about {@code a}; {@code b} is promised by the other side and appears
+     * nowhere in the branch that was not read, so nothing but the choice has anything to say about
+     * why {@code b} is open.
+     */
+    private static final String NOTHING_ELSE_SAID_ABOUT_IT = """
+            module demo
+
+            data N = { a: String, b: String }
+                invariant r = UNREAD_A || b == "A"
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /** And one where the branch nothing reads is about the position itself. */
+    private static final String THE_BRANCH_SAID_IT_ITSELF = """
+            module demo
+
+            data N = { a: String }
+                invariant r = a == "A" || UNREAD_A
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /** Two choices of one rule, each leaving one position open and neither naming it. */
+    private static final String TWO_CHOICES_LEAVE_IT_OPEN = """
+            module demo
+
+            data N = { a: String, b: String, c: String }
+                invariant r =
+                    (UNREAD_A || c == "A") && (UNREAD_B || c == "A")
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"))
+            .replace("UNREAD_B", souther.compiler.ARuleNoReadingTakesIn.about("b"));
+
+    /** The same unreadness under one more bracket, which is one connective and not a tree. */
+    private static final String THE_SAME_THROUGH_ONE_MORE_BRACKET = """
+            module demo
+
+            data N = { a: String, b: String }
+                invariant r = b == "A" || (b == "B" || UNREAD_A)
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /** And the same disjunction bracketed the other way, which says what a bracket is not. */
+    private static final String THE_SAME_BRACKETED_THE_OTHER_WAY = """
+            module demo
+
+            data N = { a: String, b: String }
+                invariant r = (b == "A" || b == "B") || UNREAD_A
+            """.replace("UNREAD_A", souther.compiler.ARuleNoReadingTakesIn.about("a"));
+
+    /** Where nothing else said anything about the position, the choice says it. */
+    @Test
+    void aChoiceIsAnswerableWhereItsUnreadAlternativeSaidNothing() {
+        assertEquals(Set.of(UnreadReason.ALTERNATIVE_NOT_READ),
+                whatARuleIsAnswerableFor(NOTHING_ELSE_SAID_ABOUT_IT, "b"),
+                "the branch that was not read never names this position, so the choice is the"
+                        + " first thing with anything to say about why it is open");
+    }
+
+    /** And where the branch said it itself, the choice adds nothing. */
+    @Test
+    void aChoiceAddsNothingWhereItsUnreadAlternativeSaidItAlready() {
+        assertEquals(Set.of(UnreadReason.FORM_NOT_READ),
+                whatARuleIsAnswerableFor(THE_BRANCH_SAID_IT_ITSELF, "a"),
+                "one form nothing reads is one thing to lift, and the choice above it is the same"
+                        + " shortfall arriving by another road");
+    }
+
+    /** And two choices leaving one position open are two things to look at. */
+    @Test
+    void twoChoicesLeavingOnePositionOpenAreBothAnswerable() {
+        assertEquals(2, sitesFor(TWO_CHOICES_LEAVE_IT_OPEN, "c").size(),
+                "each choice offered an alternative of its own, and an author has both to look"
+                        + " at — held as reasons at the position they were one");
+    }
+
+    /** And one more bracket around the same unreadness is not one more thing to look at. */
+    @Test
+    void oneMoreBracketIsNotOneMoreThingToLookAt() {
+        assertEquals(1, sitesFor(THE_SAME_THROUGH_ONE_MORE_BRACKET, "b").size(),
+                "a choice is one connective and not a tree, so a shortfall that passed through a"
+                        + " bracket on its way up is not a second shortfall");
+    }
+
+    /**
+     * And bracketing the same disjunction the other way says the same thing.
+     *
+     * <p>Which is what a bracket not being a second shortfall comes to: the reasons are of the
+     * choices an author wrote, and {@code ||} means the same thing however it was grouped. Two
+     * choices are still two — what is held here is that grouping alone makes neither.
+     */
+    @Test
+    void theSameDisjunctionGroupedTheOtherWaySaysTheSame() {
+        assertEquals(whatARuleIsAnswerableFor(THE_SAME_THROUGH_ONE_MORE_BRACKET, "b"),
+                whatARuleIsAnswerableFor(THE_SAME_BRACKETED_THE_OTHER_WAY, "b"),
+                "a reader is told the same thing whichever way the author grouped the choice");
+        assertEquals(sitesFor(THE_SAME_THROUGH_ONE_MORE_BRACKET, "b").size(),
+                sitesFor(THE_SAME_BRACKETED_THE_OTHER_WAY, "b").size(),
+                "and has the same number of things to look at");
+    }
+
+    /** What a rule of the declaration is answerable for at {@code field}. */
+    private static Set<UnreadReason> whatARuleIsAnswerableFor(String source, String field) {
+        Set<UnreadReason> out = new LinkedHashSet<>();
+        shortfallsAt(source, field).forEach(each -> out.add(each.why()));
+        return out;
+    }
+
+    /** The written places it is answerable at, which is what tells two of them apart. */
+    private static Set<RuleShortfall.Site> sitesFor(String source, String field) {
+        Set<RuleShortfall.Site> out = new LinkedHashSet<>();
+        shortfallsAt(source, field).forEach(each -> out.add(each.site()));
+        return out;
+    }
+
+    /**
+     * What every question about {@code field} is answerable for, over every rule of the value.
+     *
+     * <p>Keyed by the question and not by the position inside a shortfall: a question is of one rule
+     * at one position, and what is filed under it is that position's. Read the other way, this test
+     * would be reading a place's reasons to find a rule's, which is the thing being closed.
+     */
+    private static Set<RuleShortfall> shortfallsAt(String source, String field) {
+        Set<RuleShortfall> out = new LinkedHashSet<>();
+        read(source).accounting().values().forEach(accounting ->
+                accounting.answers().forEach((owed, outcome) -> {
+                    if (owed.toString().equals(field)
+                            && outcome instanceof RuleAccounting.Outcome.Unaccounted it
+                            && it.why() instanceof RuleAccounting.Why.TheValueReadingSays says) {
+                        out.addAll(says.shortfalls());
+                    }
+                }));
+        return out;
+    }
+
+    private static FieldDomains read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),
+                "the model this reads has to be one somebody could write");
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
+        TypeSymbol.AtModule name = TypeSymbols.declared(new TypeKey(symbols.module(), "N"));
+        return FieldDomains.of(name, RuleReadings.of(compilation, "demo"),
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleIsAnswerableForIsNotSiftedOutOfAPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleIsAnswerableForIsNotSiftedOutOfAPlaceTest.java
@@ -22,12 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * <p>A position says what it was left holding and says it for every reason there is. Sifting those
  * for the ones a rule could be answerable for gives a list of reasons and no rule: an allowance is
  * the position's and every rule reaching it pays in, so what comes back is every rule that named the
- * place, standing in for the one that asked. That is the whole of what #1341 was.
+ * place, standing in for the one that asked.
  *
- * <p>The call site was closed and the sift was left behind — a method on a finished reading that did
- * exactly it, unused and one call away from putting it back. So what is held is the sift itself:
- * naming {@link souther.compiler.values.UnreadReason.About#A_RULE} is how a caller separates the two
- * kinds, and the places entitled to are counted.
+ * <p>Closing a call site leaves the sift behind — a method on a finished reading that does exactly
+ * it, unused and one call away from being put back. So what is held is the sift itself: naming
+ * {@link souther.compiler.values.UnreadReason.About#A_RULE} is how a caller separates the two kinds,
+ * and the places entitled to are counted.
  *
  * <p><b>A tripwire and not a proof.</b> A second sift written inside one of the files below passes
  * this, and so does one written without naming the classification. What it stops is the shape that
@@ -40,15 +40,16 @@ class WhatARuleIsAnswerableForIsNotSiftedOutOfAPlaceTest {
      * Where the two kinds may be told apart, and why each is entitled to.
      *
      * <p>{@code UnreadReason} is the classification itself. {@code Unbuilt} makes the two facts and
-     * refuses a reason of the wrong kind in either. {@code ReadingEvidence} and {@code BlockReason}
+     * refuses a reason of the wrong kind in either. {@code BlockReason} and {@code RuleShortfall}
      * refuse rather than sift: a reason no rule is answerable for is turned away where it would have
-     * been filed under one. {@code StatedByClauses} is the one place a sift is right, and what it
-     * sifts is a part's own record of its own reading — not a place's reasons, which is the
-     * difference this is about.
+     * been filed under one, so what is filed is of the right kind by having been made at all.
+     *
+     * <p>Nowhere reads it to answer with. What a rule is answerable for is made where the asking
+     * is and handed on as {@code RuleShortfall}, and a reading with one in hand has the answer
+     * rather than a place to sift for it.
      */
     private static final Set<String> ENTITLED = Set.of(
-            "UnreadReason.java", "Unbuilt.java", "ReadingEvidence.java", "BlockReason.java",
-            "StatedByClauses.java");
+            "UnreadReason.java", "Unbuilt.java", "BlockReason.java", "RuleShortfall.java");
 
     @Test
     void onlyTheseTellTheTwoKindsApart() throws IOException {


### PR DESCRIPTION
Closes #1352.

A position's standing may explain why the position is wider. It is never
evidence of what a rule is answerable for: a place holds the reasons of
every rule that reached it, so sifting them answers with every rule that
named the place rather than the one that asked.

What a rule was short of is now a value made where the asking is — the
position, a reason of that kind by construction, and the site an author
wrote — carried from the reading through to where the accounting
publishes it. The sift that stood between them is gone, and who may make
one is counted off the compiled classes.

An unread alternative is one of those sites, filed at the choice that
offered it. Whether the choice is a thing an author still has to answer
turns on what the branch that went unread holds and the branch beside it
does not: a shortfall standing in both branches stands whichever way the
choice goes, so it is not the branch being unread that accounts for the
position. That is asked of the whole fact, site included, and never of
where the fact was written — a conjunction distributing over a choice
copies shortfalls into both branches, and two choices each offering an
alternative nothing read remain two things to answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
