### PR TITLE
Take a proof about an arm by the place, not by an address of one

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
@@ -4,8 +4,6 @@ import souther.compiler.report.AdequacyReport;
 import souther.compiler.query.WeakeningSet;
 import souther.cli.Main;
 import org.junit.jupiter.api.Test;
-import souther.compiler.types.CoverageOrigin;
-
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.observe.MeasurementStatus;
@@ -15,6 +13,7 @@ import souther.compiler.query.ArmCensus;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Weakening;
+import souther.compiler.reach.Reachability;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -310,38 +309,32 @@ class AnArmNothingReachesIsNotOwedARowTest {
     // --- what happens if the proof is wrong -------------------------------------------------------
 
     /**
-     * The probe numbers of the fork's two arms, read off the plan.
+     * The fork's two arms, read off the plan.
      *
-     * <p>Written down rather than read, these were the first two numbers the walk handed out —
-     * which they were only while nothing else in the body was numbered before them. A probe number
-     * is what the emitter and a measurement agree on and it moves whenever the numbering does, so a
-     * test that names one is naming the walk's order and not the arm.
+     * <p>The plan's own sites and not sites built here to stand for them. A site says where a run
+     * through the arm is recorded and which place that is, and the two are one answer the numbering
+     * gave; assembled in a test, the pair would be whatever this test put together and the measures
+     * below would agree with it by construction.
      */
-    private static List<ArmProbe> armProbes() {
+    private static List<CoverageSites.ArmSite> armSites() {
         Compilation compilation = Compilation.ofSource(CAPPED, "Main");
         compilation.answerEverything();
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
-        return checked.plan().arms("classify").stream()
-                .map(CoverageSites.ArmSite::index).toList();
+        return checked.plan().arms("classify");
     }
+
+    private static final List<CoverageSites.ArmSite> ARMS = armSites();
 
     /** The arm nothing reaches — the {@code then} of a guard at 50 no pair can be above. */
-    private static final ArmProbe UNREACHED = armProbes().get(0);
+    private static final CoverageSites.ArmSite UNREACHED_ARM = ARMS.get(0);
 
     /** The arm every run takes. */
-    private static final ArmProbe TAKEN = armProbes().get(1);
+    private static final CoverageSites.ArmSite TAKEN_ARM = ARMS.get(1);
 
-    private static CoverageSites.ArmSite arm(ArmProbe probe) {
-        return new CoverageSites.ArmSite("classify",
-                new souther.compiler.coverage.SourceOutcome.Held(
-                        new souther.compiler.coverage.SourceOutcome.HeldBy.Condition()),
-                null, probe, probe.raw(),
-                new CoverageSites.Obligation("classify",
-                        CoverageOrigin.written("t", probe.raw(),
-                                souther.compiler.types.CoverageConstruct.IF), 0,
-                        souther.compiler.coverage.DecidedBy.THE_DECLARATION));
-    }
+    private static final ArmProbe UNREACHED = UNREACHED_ARM.index();
+
+    private static final ArmProbe TAKEN = TAKEN_ARM.index();
 
     /**
      * The model's own reachability, which proves arm 0 unreachable: nothing at or above 50 is a
@@ -362,7 +355,7 @@ class AnArmNothingReachesIsNotOwedARowTest {
     @Test
     void aProvenArmLeavesTheDenominator() {
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured("b",
-                List.of(arm(UNREACHED), arm(TAKEN)), Set.of(TAKEN),
+                List.of(UNREACHED_ARM, TAKEN_ARM), Set.of(TAKEN),
                 proving().asRunWith(Set.of(TAKEN)), WeakeningSet.none());
 
         assertEquals(List.of(TAKEN), probesOf(measured));
@@ -392,7 +385,7 @@ class AnArmNothingReachesIsNotOwedARowTest {
         // fold the measures read, so what a run does to a proof is decided in one place.
         PathReachability.Answers.AsRun asRun = proving().asRunWith(Set.of(UNREACHED, TAKEN));
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured("b",
-                List.of(arm(UNREACHED), arm(TAKEN)), Set.of(UNREACHED, TAKEN), asRun,
+                List.of(UNREACHED_ARM, TAKEN_ARM), Set.of(UNREACHED, TAKEN), asRun,
                 WeakeningSet.none());
 
         // What a disproved proof bears on is the set of arms and not any one of them. Which arms
@@ -426,7 +419,7 @@ class AnArmNothingReachesIsNotOwedARowTest {
     void andAnArmIsStillAnsweredForBesideADisprovedProof() {
         PathReachability.Answers.AsRun asRun = proving().asRunWith(Set.of(UNREACHED));
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured("b",
-                List.of(arm(UNREACHED), arm(TAKEN)), Set.of(UNREACHED), asRun,
+                List.of(UNREACHED_ARM, TAKEN_ARM), Set.of(UNREACHED), asRun,
                 WeakeningSet.none());
 
         assertEquals(1, measured.arms().covered(), "the row went through the arm it went through");
@@ -445,7 +438,8 @@ class AnArmNothingReachesIsNotOwedARowTest {
 
         assertEquals(Set.of(UNREACHED), asRun.provedWrong(),
                 "a row went through an arm this reading had proven nothing reaches");
-        assertFalse(asRun.answers().nothingArrivesAt(UNREACHED),
+        assertFalse(asRun.answers().at(UNREACHED_ARM.occurrence())
+                        instanceof Reachability.Unreachable,
                 "so nothing about it is proven any more");
         // Both measures read this one object, so what is back for one is back for the other. Said
         // of the arms: what a comparison's outcome was proven to be is not something a row through

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -73,6 +73,12 @@ public final class PathReachability {
          * <p>A place this reading has nothing filed under is one the walk did not get to, which is
          * an answer and not a gap: it is {@link WhyUnsettled.TheWalkDidNotReachIt}, and every
          * consumer treats it as it treats any other unsettled place.
+         *
+         * <p><b>Asked with the place and never with an address of one.</b> A probe says where a run
+         * through an arm is recorded, and which arm that is is the numbering's answer, given where
+         * the number was handed out. Asked here, it would be that correspondence worked out again
+         * by search — over the entries of one reading, which knows of no numbering and could not
+         * tell two arms answering to one probe apart if a walk ever made them.
          */
         public Reachability at(ControlPointId where) {
             Reachability answer = found.get(where);
@@ -153,18 +159,6 @@ public final class PathReachability {
          *  only ever answer "keep everything" can skip on. */
         public boolean provesNothingUnreached() {
             return found.values().stream().noneMatch(Reachability.Unreachable.class::isInstance);
-        }
-
-        /** Whether nothing arrives at the arm recorded at {@code probe}. What every denominator
-         *  takes an arm out by, and the one arm of the answer that takes anything out. */
-        public boolean nothingArrivesAt(ArmProbe probe) {
-            for (Map.Entry<ControlPointId, Reachability> each : found.entrySet()) {
-                if (each.getKey() instanceof ControlPointId.ArmOccurrence arm
-                        && arm.probe().isPresent() && arm.probe().get().equals(probe)) {
-                    return each.getValue() instanceof Reachability.Unreachable;
-                }
-            }
-            return false;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -188,8 +188,9 @@ public final class CoverageSites {
      * words a report writes for one — takes one of these, and a comparison cannot be handed where
      * one is wanted.
      */
-    public record ArmSite(String behavior, SourceOutcome.Arm outcome, Citation at,
-                          ArmProbe index, int ordinal, Obligation obligation) implements Site {
+    public record ArmSite(String behavior, SourceOutcome.Arm outcome,
+                          ControlPointId.ArmOccurrence occurrence, int ordinal,
+                          Obligation obligation) implements Site {
 
         public ArmSite {
             // The pair is what carries the meaning, so the pair is what is checked. Not every
@@ -197,6 +198,32 @@ public final class CoverageSites {
             // a `match` settles no condition — and a walk that put an outcome on the wrong construct
             // is the defect this whole value exists to make impossible.
             OutcomeName.of(obligation.origin().kind(), outcome);
+            if (occurrence == null) {
+                throw new IllegalArgumentException("a site of an arm is the arm's own place, and"
+                        + " this one is being made without it");
+            }
+            if (occurrence.probe().isEmpty()) {
+                throw new IllegalArgumentException("a site is a place a run is recorded at, and "
+                        + occurrence + " is a place nothing records one at");
+            }
+        }
+
+        /**
+         * Where a run through this arm is recorded.
+         *
+         * <p>The occurrence's, because the occurrence is the place and an address is what the
+         * numbering gave the place. Held here as well it would be the same fact written twice, and
+         * a site whose two halves addressed different arms would be a value nothing could refuse.
+         */
+        @Override
+        public ArmProbe index() {
+            return occurrence.probe().orElseThrow();
+        }
+
+        /** Where the fork this is an arm of is, as the occurrence has it. */
+        @Override
+        public Citation at() {
+            return occurrence.at();
         }
     }
 
@@ -525,14 +552,20 @@ public final class CoverageSites {
     private static Plan asPlan(Walked found, SiteNumbering numbering) {
         ComparisonCatalog comparisons = found.comparisons();
         Walk walk = found.walk();
+        // One occurrence per arm the walk made, whoever asks for it. A site of an arm and the arms
+        // of its fork are the same place, and they are the same value: made twice, the two would be
+        // two answers about one arm, and every reader below would be free to have either.
+        IdentityHashMap<DraftArm, ControlPointId.ArmOccurrence> issued = new IdentityHashMap<>();
         List<Site> sites = new ArrayList<>();
         for (DraftSite draft : walk.sites) {
-            sites.add(switch (draft.outcome()) {
-                case SourceOutcome.Arm arm -> new ArmSite(draft.behavior(), arm, draft.at(),
-                        numbering.arm(draft.raw()), draft.ordinal(), draft.obligation());
-                case SourceOutcome.Compared compared -> new ComparisonSite(draft.behavior(),
-                        compared, draft.at(), numbering.comparison(draft.raw()), draft.ordinal(),
-                        draft.obligation());
+            sites.add(switch (draft) {
+                case DraftArmSite arm -> new ArmSite(arm.behavior(), arm.outcome(),
+                        occurrenceOf(arm.arm(), numbering, issued), arm.ordinal(),
+                        arm.obligation());
+                case DraftComparisonSite compared -> new ComparisonSite(compared.behavior(),
+                        compared.outcome(), compared.at(),
+                        numbering.comparison(compared.raw()), compared.ordinal(),
+                        compared.obligation());
             });
         }
         List<GuardRef> guards = new ArrayList<>();
@@ -546,13 +579,12 @@ public final class CoverageSites {
                 byComparison.put(which, numbering.comparison(raw)));
         IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode = new IdentityHashMap<>();
         walk.armsByNode.forEach((node, arms) -> {
-            ControlPointId.ArmOccurrence[] issued =
+            ControlPointId.ArmOccurrence[] here =
                     new ControlPointId.ArmOccurrence[arms.length];
             for (int i = 0; i < arms.length; i++) {
-                issued[i] = new ControlPointId.ArmOccurrence(arms[i].controlId(),
-                        armAt(numbering, arms[i].raw()), arms[i].at(), arms[i].origin());
+                here[i] = occurrenceOf(arms[i], numbering, issued);
             }
-            armsByNode.put(node, issued);
+            armsByNode.put(node, here);
         });
         return new Plan(List.copyOf(sites), List.copyOf(guards), walk.byNode,
                 byComparison, armsByNode, walk.controlByComparison, walk.mayRepeat,
@@ -565,15 +597,53 @@ public final class CoverageSites {
     }
 
     /**
+     * The place {@code draft} is, made once however many readers of it there are.
+     *
+     * <p>Kept by the draft's identity and not by what it holds. Two arms of one shape are two
+     * places, and what is wanted here is the occurrence this draft became rather than the one some
+     * draft equal to it did.
+     */
+    private static ControlPointId.ArmOccurrence occurrenceOf(
+            DraftArm draft, SiteNumbering numbering,
+            IdentityHashMap<DraftArm, ControlPointId.ArmOccurrence> issued) {
+        return issued.computeIfAbsent(draft, each -> new ControlPointId.ArmOccurrence(
+                each.controlId(), armAt(numbering, each.raw()), each.at(), each.origin()));
+    }
+
+    /**
      * One site as the walk has it, before there is a numbering for its number to be a place of.
      *
      * <p>The walk carries numbers because it is what makes the numbering: what a number means is
      * fixed by every place still to be reached and by what the bodies do, so no address of it can
      * exist until the walk is over. The numbers become places once, at {@link #of}, and the
      * places are what everything downstream is handed.
+     *
+     * <p>Two kinds and not one with the arm's half left optional. What a site of an arm has that a
+     * site of a comparison has not is the arm, and a draft carrying one only sometimes would be a
+     * draft whose readers ask whether it is there.
+     *
+     * <p>Nothing is declared here for the two to share. What is made of a draft is made in a switch
+     * over which kind it is, so a name held in common would be a way of reading one without knowing
+     * that — and the parts that go into a site are not the same parts.
      */
-    private record DraftSite(String behavior, SourceOutcome outcome, Citation at, int raw,
-                             int ordinal, Obligation obligation) {}
+    private sealed interface DraftSite {
+    }
+
+    /**
+     * A site of one arm, and the arm it is a site of.
+     *
+     * <p>The two are made in one act, where the arm is, and the arm is carried from it rather
+     * than paired up afterwards by the number they share. A number is what the emitter records at,
+     * and reading it back to find the place a site is about would be that correspondence worked out
+     * again by whoever needed it.
+     */
+    private record DraftArmSite(DraftArm arm, String behavior, SourceOutcome.Arm outcome,
+                                int ordinal, Obligation obligation) implements DraftSite {}
+
+    /** A site of one comparison, which no arm stands at. */
+    private record DraftComparisonSite(String behavior, SourceOutcome.Compared outcome, Citation at,
+                                       int raw, int ordinal, Obligation obligation)
+            implements DraftSite {}
 
     /** One arm as the walk has it: the control point it is, and the number its place was given
      *  where the emitter records one. */
@@ -672,15 +742,27 @@ public final class CoverageSites {
             // The arm is made either way. Whether a run through it can be recorded is the second
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
-            java.util.OptionalInt raw = reachable && answers(arm)
-                    && answering.mayEnter(owner, part)
-                    ? java.util.OptionalInt.of(armSite(outcome, owner, origin, part, decided))
-                    : java.util.OptionalInt.empty();
-            return new DraftArm(controls++, raw,
-                    // The fork's own coordinate, as a site takes it: an arm's body is what lowering
-                    // rewrites and carries whatever position it was built from, so quoting it sends
-                    // an author somewhere else in the file.
-                    Citation.of(owner.pos()), origin);
+            //
+            // The fork's own coordinate, as a site takes it: an arm's body is what lowering
+            // rewrites and carries whatever position it was built from, so quoting it sends an
+            // author somewhere else in the file.
+            Citation at = Citation.of(owner.pos());
+            if (!(reachable && answers(arm) && answering.mayEnter(owner, part))) {
+                return new DraftArm(controls++, java.util.OptionalInt.empty(), at, origin);
+            }
+            // Asked before the place is numbered, so that a tree nothing wrote is refused for being
+            // that rather than for whatever the numbering noticed about it first.
+            written(origin, owner);
+            DraftArm draft = new DraftArm(controls++,
+                    java.util.OptionalInt.of(
+                            numbering.number(new SiteAddress.Arm(places.of(owner), part))),
+                    at, origin);
+            // The site of the arm, holding the arm rather than the number they share. One act, so
+            // there is no moment at which a site exists and which place it is about is still to be
+            // worked out.
+            sites.add(new DraftArmSite(draft, behavior, outcome, ordinal++,
+                    new Obligation(behavior, origin, part, decided)));
+            return draft;
         }
 
         /**
@@ -718,38 +800,11 @@ public final class CoverageSites {
             return answering.at(e);
         }
 
-        /**
-         * One arm, quoted at the fork it belongs to rather than at its own body.
-         *
-         * <p>The fork is written by the author and survives lowering; an arm's body is what lowering
-         * rewrites, and a rewritten node carries whatever position it was built from — which for a
-         * body assembled out of comprehensions and accumulated failures is somewhere else in the file
-         * entirely. An arm quoted at a comment sends the author to the wrong place, and there is
-         * nothing in the position itself to notice that by.
-         *
-         * <p>What the number about to be handed out is an address of is passed in rather than
-         * worked out from the rest: which family a number was issued to is what a reader of the
-         * recording has no other way of telling, and reading it back off the outcome here would be
-         * the numbering deciding it twice.
-         *
-         * @param owner the {@code if}, {@code match} or attempted construction the arm is one of
-         */
-        private int armSite(SourceOutcome.Arm outcome, Core owner, CoverageOrigin origin,
-                            int part, DecidedBy decided) {
-            // Asked before the place is numbered, so that a tree nothing wrote is refused for
-            // being that rather than for whatever the numbering noticed about it first.
-            written(origin, owner);
-            int raw = numbering.number(new SiteAddress.Arm(places.of(owner), part));
-            sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw, ordinal++,
-                    new Obligation(behavior, origin, part, decided)));
-            return raw;
-        }
-
         private int comparisonSite(SourceOutcome.Compared outcome, Core owner,
                                    CoverageOrigin origin, DecidedBy decided) {
             written(origin, owner);
             int raw = numbering.number(new SiteAddress.Comparison(places.of(owner)));
-            sites.add(new DraftSite(behavior, outcome, Citation.of(owner.pos()), raw,
+            sites.add(new DraftComparisonSite(behavior, outcome, Citation.of(owner.pos()), raw,
                     ordinal++, new Obligation(behavior, origin, 0, decided)));
             return raw;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -2,9 +2,10 @@ package souther.compiler.partition;
 
 import souther.compiler.core.Core;
 import souther.compiler.check.PathReachability;
-import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.reach.Reachability;
+import souther.compiler.types.CoverageOrigin;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
@@ -34,9 +35,11 @@ import java.util.Set;
  * is a case the report asks for, and an author reading a gap they cannot fill has at least been told
  * something true about their model.
  *
- * <p>Only guards take an arm away, because only a guard's arm has a reachability proof behind it. A
- * {@code match} arm is left alone here: which cases of a sum can arrive is a different question, and
- * it is asked of the reading of the input ({@link PathReachability}).
+ * <p>Only a condition's arm takes a producer away. A {@code match} arm is left alone here: which
+ * cases of a sum can arrive is a different question, asked of the reading of the position matched
+ * on, and an arm of one taken as a refusal would drop a case of the output for a fact about the
+ * input. Which construct an arm is one of is the origin's answer and not the lowered tree's — an
+ * {@code if} and a {@code guard} are one node by the time this walks.
  */
 public final class ProducedCases {
 
@@ -88,7 +91,7 @@ public final class ProducedCases {
      * value a {@code let} binds — is not what the behavior answers with, and counting it would keep a
      * case owed because the body happened to build one on its way past.
      */
-    private static void walk(Core e, List<ArmProbe> under,
+    private static void walk(Core e, List<ControlPointId.ArmOccurrence> under,
                              CoverageSites.Plan plan,
                              PathReachability.Answers arrives, Set<TypeSymbol> declared, Seen seen) {
         if (seen.anythingUnreadable) {
@@ -126,10 +129,11 @@ public final class ProducedCases {
     }
 
     /** Where one producer puts the case it answers with. */
-    private static void produce(TypeSymbol built, List<ArmProbe> under,
+    private static void produce(TypeSymbol built, List<ControlPointId.ArmOccurrence> under,
                                 PathReachability.Answers arrives,
                                 Set<TypeSymbol> declared, Seen seen) {
-        boolean proven = under.stream().anyMatch(arrives::nothingArrivesAt);
+        boolean proven = under.stream().anyMatch(arm ->
+                arrives.at(arm) instanceof Reachability.Unreachable);
         if (built == null || !declared.contains(built)) {
             // Not a case this can name. Reachable, it could be any of them and nothing is taken away;
             // behind a proven arm it answers nothing and says nothing about any case either.
@@ -143,18 +147,55 @@ public final class ProducedCases {
         }
     }
 
-    /** The arms of an inner fork, added to the ones already above it. An arm with no probe adds
-     * nothing: there is no site for a proof to have been about. */
-    private static List<ArmProbe> beneath(
-            List<ArmProbe> under,
+    /**
+     * The arms of an inner fork that refuse a producer under them, added to the ones already above.
+     *
+     * <p>Whether a run can be recorded in the arm is not among the questions. That is what an arm
+     * is instrumented for, and what this asks is whether anything arrives — a place with no probe
+     * is a place all the same, and the reading answers about it like any other.
+     */
+    private static List<ControlPointId.ArmOccurrence> beneath(
+            List<ControlPointId.ArmOccurrence> under,
             ControlPointId.ArmOccurrence[] arms, int index) {
         if (arms == null || index >= arms.length || arms[index] == null
-                || arms[index].probe().isEmpty()) {
+                || !takesAProducerAway(arms[index])) {
             return under;
         }
-        List<ArmProbe> out = new ArrayList<>(under);
-        out.add(arms[index].probe().get());
+        List<ControlPointId.ArmOccurrence> out = new ArrayList<>(under);
+        out.add(arms[index]);
         return List.copyOf(out);
+    }
+
+    /**
+     * Whether a proof about this arm says anything about what the body can answer with.
+     *
+     * <p>Asked of the construct the author wrote and not of the shape it was lowered to, which is
+     * what {@link CoverageOrigin} carries the construct for. A {@code match} arm is not one of
+     * these: which cases of a sum can arrive is asked of the reading of the input, and an arm of
+     * one taken to refuse a producer would take a case away for a fact about the scrutinee.
+     *
+     * <p>An arm no source wrote takes nothing away either, and an arm carrying nothing that says
+     * what wrote it is one of those. What this walk answers about is what the author's body can
+     * answer with, and a fork nothing wrote is not their construct. Refused rather than answered
+     * for, this would hold a place to more than what makes one: an occurrence names an origin where
+     * it has one, and a reader wanting a construct is a reader that can be told there is none.
+     */
+    private static boolean takesAProducerAway(ControlPointId.ArmOccurrence arm) {
+        CoverageOrigin origin = arm.origin();
+        if (origin == null) {
+            return false;   // nothing here says what wrote it, which is not a construct either
+        }
+        return switch (origin.kind()) {
+            case IF, GUARD, COMPREHENSION -> true;
+            case MATCH, NOT_WRITTEN -> false;
+            // Not an arm of anything. Every arm is one of a fork, and no fork is written as a
+            // comparison — so a value arriving here as one was built by nothing that makes arms,
+            // and either answer about it would be an answer about the author's body made out of
+            // that.
+            case BINARY -> throw new IllegalStateException(
+                    "an arm of " + origin.kind() + " at " + arm.at()
+                            + "; an arm is one of a fork the author wrote");
+        };
     }
 
     private ProducedCases() {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -10,6 +10,7 @@ import souther.compiler.inputs.TermPath;
 import souther.compiler.coverage.ArmProbe;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.SiteNumbering;
+import souther.compiler.reach.Reachability;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.DeadBranchMessage;
 import souther.compiler.diag.msg.ExampleMessage;
@@ -2273,7 +2274,9 @@ public final class Adequacy {
                 List<CoverageSites.ArmSite> all,
                 souther.compiler.check.PathReachability.Answers.AsRun reachable) {
             return all.stream()
-                    .filter(site -> !reachable.answers().nothingArrivesAt(site.index())).toList();
+                    .filter(site -> !(reachable.answers().at(site.occurrence())
+                            instanceof Reachability.Unreachable))
+                    .toList();
         }
 
         /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnArmsSiteAndItsPlaceAreOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnArmsSiteAndItsPlaceAreOneValueTest.java
@@ -1,0 +1,271 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.PathReachability;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.reach.Reachability;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Where a run through an arm is recorded and which arm that is are one value, made once.
+ *
+ * <p>A site of an arm holds the place, and the address it publishes is the place's own. Held beside
+ * it, the address would be the same fact written twice — and a reader given one half would have to
+ * find the other, which over a reading of a body means searching it for whichever entry carries the
+ * address asked about. That search assumes what the numbering guarantees, silently: it reads the
+ * first entry it finds and could not notice two arms answering to one probe.
+ */
+class AnArmsSiteAndItsPlaceAreOneValueTest {
+
+    private static final String MODEL = """
+            module example.arms
+
+            data Count = Int
+                invariant lower = value >= 0
+            data Small
+            data Big
+
+            behavior classify : (c: Count) -> Small | Big
+
+            let classify (c) =
+                if c.value >= 50
+                    then Big
+                    else Small
+
+            example classify
+                | "small" : (Count(1)) -> Small
+            """;
+
+    /**
+     * The site of an arm holds that arm's own place, and holds the very value the fork's arms are
+     * held by.
+     *
+     * <p>Which arm a site is of is taken from the obligation, which says which way through the fork
+     * a row would be owed for. That is the other end of the same act and is not what is under test:
+     * what the finalization could get wrong is the arm a site was paired with, so the expected value
+     * has to be reached by something other than the pairing.
+     *
+     * <p>Identity and not equality. Two occurrences of one arm are equal records, so a second one
+     * made beside the first would answer every question alike until a reader kept one and looked the
+     * other up.
+     */
+    @Test
+    void aSiteHoldsThePlaceOfTheArmItIsASiteOf() {
+        CoverageSites.Plan plan = planOf(MODEL);
+        ControlPointId.ArmOccurrence[] arms = plan.armsByNode().values().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("the model writes a fork"));
+        assertEquals(1, plan.armsByNode().size(),
+                "one fork, so which arms a site is to be found among is not in question");
+
+        List<CoverageSites.ArmSite> sites = plan.sites().stream()
+                .filter(CoverageSites.ArmSite.class::isInstance)
+                .map(CoverageSites.ArmSite.class::cast).toList();
+        assertEquals(arms.length, sites.size(), "every arm of it is a place a run is recorded in");
+        for (CoverageSites.ArmSite site : sites) {
+            assertSame(arms[site.obligation().part()], site.occurrence(),
+                    () -> "the site owed for arm " + site.obligation().part() + " holds "
+                            + site.occurrence() + ", which is not that arm of the fork");
+        }
+    }
+
+    /**
+     * A model whose refused arm answers no value, so the walk numbers no place in it.
+     *
+     * <p>An {@code Active} is never {@code Off}, so the rules prove nothing arrives at that arm; the
+     * arm answers no value, so no run through it could ever be recorded. Both are true of one arm,
+     * which is what makes it the arm this is about.
+     */
+    private static final String SILENT_REFUSED_ARM = """
+            module example.silent
+
+            data On
+            data Off
+            data Pending
+            data Flag = On | Off | Pending
+            data Active = Flag invariant value /= Off
+            data Yes
+
+            behavior pick : (f: Active) -> Yes
+
+            let pick (f) = match f.value with
+                | On      -> Yes
+                | Pending -> Yes
+                | Off     -> unreachable "an Active is never Off"
+
+            example pick
+                | "on" : (Active(On)) -> Yes
+            """;
+
+    /**
+     * A place with no probe carries the proof about it, and the reading answers it.
+     *
+     * <p>The two are independent and were one answer while the question could only be put by probe:
+     * whether a run through an arm can be recorded is what instrumenting it decides, and whether
+     * anything arrives is what the model's rules decide. An arm nobody can record a run in is
+     * exactly the arm a proof about it can never be shown wrong by, which is the arm a reader most
+     * needs the answer for.
+     */
+    @Test
+    void aRealPlaceWithNoProbeCarriesTheProofAboutIt() {
+        PathReachability.Answers answers = arrivalsOf(SILENT_REFUSED_ARM);
+        List<ControlPointId.ArmOccurrence> silent = answers.found().keySet().stream()
+                .filter(ControlPointId.ArmOccurrence.class::isInstance)
+                .map(ControlPointId.ArmOccurrence.class::cast)
+                .filter(arm -> arm.probe().isEmpty()).toList();
+
+        assertEquals(1, silent.size(),
+                () -> "the refused arm answers no value, so it is the arm nothing numbered: "
+                        + answers.found().keySet());
+        assertInstanceOf(Reachability.Unreachable.class, answers.at(silent.get(0)),
+                "and the rules prove nothing arrives at it, which the reading answers about the"
+                        + " place rather than about an address it has not got");
+    }
+
+    /**
+     * A place this reading never filed is unsettled, which is not the same fact as the one above.
+     *
+     * <p>The fail-open direction of {@link PathReachability.Answers#at}: a walk that did not get
+     * somewhere says nothing about it, and every consumer treats that as it treats any other place
+     * the rules settled nothing at.
+     */
+    @Test
+    void aPlaceTheWalkDidNotReachIsUnsettledRatherThanAbsent() {
+        PathReachability.Answers answers = arrivalsOf(MODEL);
+        ControlPointId.ArmOccurrence any = answers.found().keySet().stream()
+                .filter(ControlPointId.ArmOccurrence.class::isInstance)
+                .map(ControlPointId.ArmOccurrence.class::cast)
+                .findFirst().orElseThrow();
+        ControlPointId.ArmOccurrence never = new ControlPointId.ArmOccurrence(
+                Integer.MAX_VALUE, Optional.empty(), any.at(), any.origin());
+
+        assertInstanceOf(Reachability.Unsettled.class, answers.at(never),
+                "a place nothing was filed under is one the walk did not reach");
+    }
+
+    /** What the model's own rules say arrives at each place of {@code model}'s one behavior. */
+    private static PathReachability.Answers arrivalsOf(String model) {
+        Compilation compilation = compiled(model);
+        Map<String, PathReachability.Answers> answers = compilation.db()
+                .ask(new Adequacy.PathReached(compilation.modules().get(0))).value();
+        return answers.values().stream().findFirst()
+                .orElseThrow(() -> new AssertionError("the model under test is measured"));
+    }
+
+    /**
+     * The one thing the reading may be handed a run's own vocabulary for is a correction by a run.
+     *
+     * <p>The whole surface and not the methods anybody remembers, and said as the rule rather than
+     * as a list of the answers it could come back as. A reading asked with an address answers a
+     * question the numbering owns — which arm a number addresses — and it holds no numbering to ask;
+     * what it can be told is what a run lit, and what comes back from that is the corrected reading
+     * ({@link PathReachability.Answers.AsRun}) rather than an answer about any one place.
+     *
+     * <p>Read off the generic signature, since a run's vocabulary reaches this surface inside a
+     * {@code Set} and the erased parameter is nothing but {@code Set}. And read as a family: what
+     * addresses a place a run is recorded at is {@link RunSite}, so a third kind of address added
+     * beside the two is under this rule the day it exists.
+     *
+     * <p>Over this reading's own surface and no further. What a correction hands back holds what a
+     * run lit and is asked about in a run's words rightly — {@code provedWrong()} is a set of
+     * probes, and a reader is free to ask it whether one is in there. The rule is about answering a
+     * question of the model's out of a number, which is what only this class answers.
+     */
+    @Test
+    void theReadingTakesARunsVocabularyOnlyToBeCorrectedByOne() {
+        List<String> asking = new ArrayList<>();
+        for (Method each : PathReachability.Answers.class.getDeclaredMethods()) {
+            if (!Modifier.isPublic(each.getModifiers())) {
+                continue;
+            }
+            for (Type taken : each.getGenericParameterTypes()) {
+                if (namesTheArmsARunLit(taken)) {
+                    if (each.getReturnType() != PathReachability.Answers.AsRun.class) {
+                        asking.add(each.getName() + " takes " + taken + " and answers "
+                                + each.getReturnType().getSimpleName());
+                    }
+                } else if (namesARunsOwnVocabulary(taken)) {
+                    asking.add(each.getName() + " takes " + taken);
+                }
+            }
+        }
+        assertEquals(List.of(), asking,
+                "a number means a place under the numbering that handed it out, and this reading"
+                        + " holds no numbering to ask");
+    }
+
+    /** The probes a run lit, which is the one thing a run tells this reading. */
+    private static boolean namesTheArmsARunLit(Type taken) {
+        return mentions(taken, each -> each == ArmProbe.class);
+    }
+
+    /** Anything else a run is written and read in, which this reading is never asked with. */
+    private static boolean namesARunsOwnVocabulary(Type taken) {
+        return mentions(taken, each -> RunSite.class.isAssignableFrom(each)
+                || each == ComparisonOutcome.class || each == int.class);
+    }
+
+    /**
+     * Whether {@code type} names such a class anywhere in it, past every erasure.
+     *
+     * <p>Each type is read once. A variable can be bounded by something naming itself — {@code <T
+     * extends Comparable<T>>} — and a walk that took the bound again would not come back.
+     */
+    private static boolean mentions(Type type, java.util.function.Predicate<Class<?>> what) {
+        return mentions(type, what, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static boolean mentions(Type type, java.util.function.Predicate<Class<?>> what,
+                                    java.util.Set<Type> read) {
+        if (type != null && !read.add(type)) {
+            return false;
+        }
+        return switch (type) {
+            case Class<?> each -> what.test(each)
+                    || (each.isArray() && mentions(each.getComponentType(), what, read));
+            case ParameterizedType each -> mentions(each.getRawType(), what, read)
+                    || Arrays.stream(each.getActualTypeArguments())
+                            .anyMatch(argument -> mentions(argument, what, read));
+            case GenericArrayType each -> mentions(each.getGenericComponentType(), what, read);
+            case WildcardType each -> Stream.concat(Arrays.stream(each.getUpperBounds()),
+                            Arrays.stream(each.getLowerBounds()))
+                    .anyMatch(bound -> mentions(bound, what, read));
+            case TypeVariable<?> each -> Arrays.stream(each.getBounds())
+                    .anyMatch(bound -> mentions(bound, what, read));
+            case null, default -> false;
+        };
+    }
+
+    private static CoverageSites.Plan planOf(String model) {
+        Compilation compilation = compiled(model);
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        return checked.plan();
+    }
+
+    private static Compilation compiled(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.answerEverything();
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
@@ -245,9 +245,10 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
     /** And a site cannot be made holding one, which is where the two halves are first put together. */
     @Test
     void aSiteCannotHoldAPairTheLanguageDoesNotHave() {
+        CoverageOrigin fork = CoverageOrigin.written("m", 0, CoverageConstruct.COMPREHENSION);
         assertThrows(IllegalArgumentException.class, () -> new CoverageSites.ArmSite("b", built(),
-                null, Numberings.arm(1, 0), 0, new CoverageSites.Obligation("b",
-                        CoverageOrigin.written("m", 0, CoverageConstruct.COMPREHENSION), 0,
+                Numberings.armPlace(0, Numberings.arm(1, 0), fork, null), 0,
+                new CoverageSites.Obligation("b", fork, 0,
                         souther.compiler.coverage.DecidedBy.THE_DECLARATION)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest.java
@@ -45,8 +45,8 @@ class AnUnsettledDecisionIsUncertainHoweverManyPlacesItHasTest {
     private static CoverageSites.ArmSite arm(int index, CoverageOrigin fork, int part,
                                              DecidedBy decided) {
         return new CoverageSites.ArmSite("b",
-                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()), null,
-                PLACES.get(index), index,
+                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()),
+                Numberings.armPlace(index, PLACES.get(index), fork, null), index,
                 new CoverageSites.Obligation("b", fork, part, decided));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/Numberings.java
@@ -1,7 +1,11 @@
 package souther.compiler.coverage;
 
+import souther.compiler.diag.Citation;
+import souther.compiler.types.CoverageOrigin;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A numbering for a fixture that has places in mind and no bodies to walk.
@@ -35,6 +39,24 @@ public final class Numberings {
     /** The arm {@code raw} of a numbering of {@code many} arms. */
     public static ArmProbe arm(int many, int raw) {
         return ofArms(many).arm(raw);
+    }
+
+    /**
+     * The place {@code probe} addresses, as a fixture with no body to walk has it.
+     *
+     * <p>A site of an arm holds the place and takes its address off it, which is the walk's doing
+     * and cannot be had without one. So a fixture writing "the arm numbered 3" says here what that
+     * arm is — the same stand-in the numbers themselves are, and said in one place rather than in
+     * each fixture that needs a site.
+     *
+     * <p>Which place it is comes in rather than being read off the number. A walk hands out control
+     * points and probe numbers from counters of their own and a place is not its address, so a
+     * fixture that let one stand for the other would be writing down a correspondence no numbering
+     * makes.
+     */
+    public static ControlPointId.ArmOccurrence armPlace(int controlId, ArmProbe probe,
+                                                        CoverageOrigin origin, Citation at) {
+        return new ControlPointId.ArmOccurrence(controlId, Optional.of(probe), at, origin);
     }
 
     /** The arms of one numbering, by their numbers, so a fixture holds addresses of one. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
@@ -1,0 +1,248 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.check.PathReachability;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.reach.Reachability;
+import souther.compiler.report.AdequacyReport;
+import souther.compiler.types.CoverageConstruct;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A case is taken out of what a behavior owes for a proof about a condition, and never for one about
+ * a {@code match} arm.
+ *
+ * <p>Which cases of a sum can arrive at an arm is a fact about the position matched on, and what a
+ * body can answer with is a fact about the body. The two met here because both are proofs on the one
+ * reading: an arm of a {@code match} the rules refuse is proven unreachable like any other arm, and
+ * taken as a refusal it drops a case of the <em>output</em> for something established about the
+ * <em>input</em>.
+ *
+ * <p>Which construct an arm belongs to is asked of what wrote it and not of the tree it was lowered
+ * to. A {@code guard} is an {@code if} by then, and a comprehension's condition is a fork nobody
+ * wrote as one.
+ */
+class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
+
+    /**
+     * {@code Off} is a case the rules refuse at {@code f}, and {@code No} is answered with nowhere
+     * else.
+     */
+    private static final String REFUSED_CASE = """
+            module example.refused
+
+            data On
+            data Off
+            data Pending
+            data Flag = On | Off | Pending
+            data Active = Flag invariant value /= Off
+            data Yes
+            data No
+
+            behavior pick : (f: Active) -> Yes | No
+
+            let pick (f) = match f.value with
+                | On      -> Yes
+                | Pending -> Yes
+                | Off     -> No
+
+            example pick
+                | "on" : (Active(On)) -> Yes
+            """;
+
+    /**
+     * The same shape written as a condition: nothing at or above the cap reaches the arm that
+     * answers {@code No}.
+     */
+    private static final String REFUSED_CONDITION = """
+            module example.capped
+
+            data Count = Int
+                invariant lower = value >= 0
+                invariant cap = value <= 10
+            data Yes
+            data No
+
+            behavior pick : (c: Count) -> Yes | No
+
+            let pick (c) =
+                if c.value >= 50
+                    then No
+                    else Yes
+
+            example pick
+                | "small" : (Count(1)) -> Yes
+            """;
+
+    @Test
+    void aRefusedMatchArmLeavesTheCaseItAnswersWithOwed() {
+        assertEquals(Reachability.Unreachable.class,
+                armThatIsRefused(REFUSED_CASE, CoverageConstruct.MATCH).getClass(),
+                "the arm for the case the rules refuse is proven unreachable");
+        assertEquals(Set.of("example.refused.Yes", "example.refused.No"),
+                declaredOutputCasesOf(REFUSED_CASE).stream().map(TypeSymbol::toString)
+                        .collect(Collectors.toSet()),
+                "and the case answered under it is still one this behavior owes a row for");
+    }
+
+    @Test
+    void anArmNothingReachesTakesTheCaseOnlyItAnswersWith() {
+        assertEquals(Reachability.Unreachable.class,
+                armThatIsRefused(REFUSED_CONDITION, CoverageConstruct.IF).getClass(),
+                "the arm the condition cannot come out into is proven unreachable");
+        assertEquals(List.of("example.capped.Yes"), declaredOutputCasesOf(REFUSED_CONDITION).stream()
+                        .map(TypeSymbol::toString).toList(),
+                "and nobody can write a row for what only it answers with");
+    }
+
+    /**
+     * The proof about an arm is read whether or not a run through the arm could be recorded.
+     *
+     * <p>The same compile as above with one thing changed: the arm nothing reaches carries no probe.
+     * Everything else — the fork, the places, the proofs, the body — is what the compiler made, so
+     * what is under test is the walk's answer to instrumentation being absent and nothing else.
+     *
+     * <p>Built rather than found, because no model produces this today: an arm loses its probe when
+     * it answers no value or stands where nothing does, and nothing under such an arm is what the
+     * behavior answers with. That is a fact about the numbering as it stands and not about what this
+     * walk owes — asked by probe, it would go back to answering "nothing is recorded here" to a
+     * question about what arrives.
+     */
+    @Test
+    void aProofIsReadAtAnArmNoRunCouldBeRecordedIn() {
+        Compilation compilation = compiled(REFUSED_CONDITION);
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        Core body = checked.behaviorBodies().get("pick");
+        PathReachability.Answers arrives = compilation.db()
+                .ask(new Adequacy.PathReached(module)).value().get("pick");
+        Set<TypeSymbol> answersWith = casesNamedIn(body);
+
+        ControlPointId.ArmOccurrence refused = arrives.found().entrySet().stream()
+                .filter(each -> each.getValue() instanceof Reachability.Unreachable)
+                .map(Map.Entry::getKey)
+                .filter(ControlPointId.ArmOccurrence.class::isInstance)
+                .map(ControlPointId.ArmOccurrence.class::cast)
+                .findFirst().orElseThrow();
+        assertTrue(refused.probe().isPresent(), "the compiler numbered the arm it proved dead");
+
+        ControlPointId.ArmOccurrence silent = new ControlPointId.ArmOccurrence(
+                refused.controlId(), java.util.Optional.empty(), refused.at(), refused.origin());
+
+        assertEquals(ProducedCases.of(body, checked.plan(), arrives, answersWith),
+                ProducedCases.of(body, planWith(checked.plan(), refused, silent),
+                        arrivalsWith(arrives, refused, silent), answersWith),
+                "what the body can answer with does not turn on where a run could be recorded");
+        assertEquals(List.of("example.capped.Yes"),
+                ProducedCases.of(body, planWith(checked.plan(), refused, silent),
+                                arrivalsWith(arrives, refused, silent), answersWith).stream()
+                        .map(TypeSymbol::toString).toList(),
+                "and the case only the dead arm answers with is still taken away");
+    }
+
+    /**
+     * {@code plan} with {@code now} standing where {@code was} stood, and nothing else moved.
+     *
+     * <p>Matched by what an occurrence is and not by which object it is: a plan derived a second
+     * time from one module holds equal places rather than the same ones, and the reading this is
+     * held against was made against a derivation of its own.
+     */
+    private static CoverageSites.Plan planWith(CoverageSites.Plan plan,
+                                               ControlPointId.ArmOccurrence was,
+                                               ControlPointId.ArmOccurrence now) {
+        IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> arms = new IdentityHashMap<>();
+        plan.armsByNode().forEach((node, held) -> {
+            ControlPointId.ArmOccurrence[] out = held.clone();
+            for (int at = 0; at < out.length; at++) {
+                if (out[at].equals(was)) {
+                    out[at] = now;
+                }
+            }
+            arms.put(node, out);
+        });
+        return new CoverageSites.Plan(plan.sites(), plan.guards(), plan.byNode(),
+                plan.byComparison(), arms, plan.controlByComparison(), plan.mayRepeat(),
+                plan.forkByNode(), plan.comparisons(), plan.numbering());
+    }
+
+    /** The same answers, filed under {@code now} where they were filed under {@code was}. */
+    private static PathReachability.Answers arrivalsWith(PathReachability.Answers answers,
+                                                         ControlPointId.ArmOccurrence was,
+                                                         ControlPointId.ArmOccurrence now) {
+        Map<ControlPointId, Reachability> found = new LinkedHashMap<>();
+        answers.found().forEach((where, said) -> found.put(where.equals(was) ? now : where, said));
+        return new PathReachability.Answers(found, answers.arriving());
+    }
+
+    /**
+     * Every case named anywhere in {@code body}, which for this fixture is the pair its signature
+     * declares.
+     *
+     * <p>Wider than what a measure is handed, and enough here: what the two calls below are
+     * compared on is the one set, and the body of this model builds nothing that is not one of its
+     * output's cases. A body that did would want the declared cases, which are the signature's to
+     * say and not this walk's.
+     */
+    private static Set<TypeSymbol> casesNamedIn(Core body) {
+        Set<TypeSymbol> out = new LinkedHashSet<>();
+        gather(body, out);
+        return out;
+    }
+
+    private static void gather(Core e, Set<TypeSymbol> out) {
+        if (e == null) {
+            return;
+        }
+        switch (e) {
+            case Core.UnitValue value -> out.add(value.data());
+            case Core.Construct built -> out.add(built.typeName());
+            default -> { }
+        }
+        Core.forEachChild(e, child -> gather(child, out));
+    }
+
+    /** What the reading says about the one arm of {@code kind} it proves nothing arrives at. */
+    private static Reachability armThatIsRefused(String model, CoverageConstruct kind) {
+        Compilation compilation = compiled(model);
+        Map<String, PathReachability.Answers> answers = compilation.db()
+                .ask(new Adequacy.PathReached(compilation.modules().get(0))).value();
+        return answers.get("pick").found().entrySet().stream()
+                .filter(each -> each.getKey() instanceof ControlPointId.ArmOccurrence arm
+                        && arm.origin().kind() == kind)
+                .map(Map.Entry::getValue)
+                .filter(Reachability.Unreachable.class::isInstance)
+                .findFirst().orElseThrow(() ->
+                        new AssertionError("no arm of a " + kind + " is proven unreachable"));
+    }
+
+    /** The cases of the output this behavior is measured against. */
+    private static Set<TypeSymbol> declaredOutputCasesOf(String model) {
+        AdequacyReport report = AdequacyReport.of(compiled(model));
+        return report.modules().get(0).behaviors().stream()
+                .filter(behavior -> behavior.name().equals("pick"))
+                .findFirst().orElseThrow()
+                .evidence().signature().output().declared();
+    }
+
+    private static Compilation compiled(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.answerEverything();
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AGapIsRefusedOverByWhatSettledItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AGapIsRefusedOverByWhatSettledItTest.java
@@ -49,8 +49,9 @@ class AGapIsRefusedOverByWhatSettledItTest {
     private static CoverageSites.ArmSite arm(CoverageOrigin fork, int index, DecidedBy decided) {
         return new CoverageSites.ArmSite("b",
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()),
-                Citation.of(new SourcePos(1, 1, new SourceId("0"))),
-                PLACES.get(index), index,
+                Numberings.armPlace(index, PLACES.get(index), fork,
+                        Citation.of(new SourcePos(1, 1, new SourceId("0")))),
+                index,
                 new CoverageSites.Obligation("b", fork, index, decided));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatWasObservedDecidesWhatAReportMayNameTest.java
@@ -48,9 +48,10 @@ class WhatWasObservedDecidesWhatAReportMayNameTest {
     private static CoverageSites.ArmSite arm(CoverageOrigin fork, int index, DecidedBy decided) {
         return new CoverageSites.ArmSite("b",
                 new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition()),
-                souther.compiler.diag.Citation.of(new souther.compiler.diag.SourcePos(1, 1,
-                        new souther.compiler.source.SourceId("0"))),
-                PLACES.get(index), index,
+                Numberings.armPlace(index, PLACES.get(index), fork,
+                        souther.compiler.diag.Citation.of(new souther.compiler.diag.SourcePos(1, 1,
+                                new souther.compiler.source.SourceId("0")))),
+                index,
                 new CoverageSites.Obligation("b", fork, index, decided));
     }
 


### PR DESCRIPTION
Closes #1360.

`PathReachability.Answers` holds what arrives at each place of a body, keyed by the place. A measure that had a site of an arm and wanted what arrives there had only the probe, so it searched the reading for whichever entry carried that address and answered with the first it reached. The function it was reproducing belongs to the numbering, which hands a number to a place once; the search assumed that without saying so, and nothing in it could tell two arms answering to one probe apart.

The site of an arm now holds the place its fork's arms are held by. Both halves are minted in one act, where the arm is, and the occurrence is made once and shared between the site and the arms of the fork — so the address a site publishes is the place's own rather than the same fact written beside it, and there is no second half left to disagree. The reading is asked with the place, the reverse lookup is gone, and a check over the whole surface of `Answers` holds it to being asked that way.

Which arms a producer is refused behind is now asked of the construct the author wrote rather than of the shape it was lowered to. An arm of a `match` is not one of them: which cases of a sum can arrive is a fact about the position matched on, and read as a refusal it took a case of the output away for something established about the input. The class doc said so already; the mechanism stopped agreeing when the arms of a `match` came to carry a proof.

Whether a run can be recorded in an arm is no longer asked at all. That is what instrumentation answers, and a place with no probe is a place the reading answers about like any other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)