### PR TITLE
Ask for the rules that govern a declaration by name, in one representation

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -1,0 +1,320 @@
+package souther.architecture;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.DerivedSymbols;
+import souther.compiler.check.ExpandedClauseLookup;
+import souther.compiler.check.Symbols;
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.RecordComponent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How a caller asks for the rules that govern a declaration.
+ *
+ * <p>Which declarations govern one — its own and every one a spread reaches — is a walk over the
+ * declarations, and it is {@code TypeOps}' walk. Two things are held of its surface, and they are
+ * two because what they are about is two.
+ *
+ * <p><b>The walk is given a name and reads the declarations itself.</b> A caller that passed a
+ * declaration node beside the world would be deciding the representation of the declaration asked
+ * about while the world decided the ones under it, and nothing either of them held would say the
+ * two were the same reading.
+ *
+ * <p><b>What a clause states is read from whatever owns that representation.</b> The settled form is
+ * the derived world's, so a walk that answers with one takes {@link DerivedSymbols} and not the
+ * reader that does not name a stage. The expanded form is
+ * {@code ExpandedClauseLookup}'s — one question, one input, no node to fall back on — and that
+ * interface holds its own answer; a rule here that demanded the derived world of it as well would
+ * be reporting a walk that is already closed, by a stronger arrangement than this one.
+ *
+ * <p>What this does not hold is that no walk of the kind can be written anywhere else. A class
+ * reaching the declarations itself could compose its own, and no reading of a signature would say
+ * so. The first line against that is which methods are reachable at all, and this is the second.
+ */
+class HowARuleThatGovernsADeclarationIsAskedForTest {
+
+    private static final String A_CLAUSE = internal(Hir.InvariantClause.class);
+    private static final String A_DECLARATION = internal(Hir.Def.class);
+    private static final String THE_DERIVED_WORLD = internal(DerivedSymbols.class);
+    private static final String THE_LOOKUP = internal(ExpandedClauseLookup.class);
+
+    /** The declaration worlds, read off the sealed interface rather than listed: a world added to it
+     *  is one a walk could be handed, and these rules have to see it arrive. */
+    private static final Set<String> THE_WORLDS = worlds();
+
+    private static final Pattern NAMES_A_TYPE = Pattern.compile("L([^;<]+)[;<]");
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    private static Set<String> worlds() {
+        Set<String> out = new LinkedHashSet<>();
+        out.add(internal(Symbols.class));
+        for (Class<?> each : Symbols.class.getPermittedSubclasses()) {
+            out.add(internal(each));
+        }
+        return out;
+    }
+
+    /** Every declaration node, read off the sealed interface for the same reason. */
+    private static Set<String> declarationNodes() {
+        Set<String> out = new LinkedHashSet<>();
+        out.add(A_DECLARATION);
+        for (Class<?> each : Hir.Def.class.getPermittedSubclasses()) {
+            out.add(internal(each));
+        }
+        return out;
+    }
+
+    private static String internal(Class<?> type) {
+        return type.getName().replace('.', '/');
+    }
+
+    /** One method as these rules read it. Split at the parameters' close, because which half a type
+     *  is named in is what is being asked: a walk is handed a world and answers with clauses. */
+    private record Read(String name, String takes, String answersWith) {
+
+        String shown() {
+            return name + "(" + takes + ")" + answersWith;
+        }
+    }
+
+    /**
+     * The methods another class can ask this one for.
+     *
+     * <p>Not the public ones. What these rules are about is what a caller elsewhere may reach, and a
+     * package-private method is reachable by every class beside it — the walk that answers with the
+     * settled form is one of those, so a reading of the public surface alone would be a rule about a
+     * set its own subject is not in. A private method is the class's own business and is held by
+     * what its neighbours here do with it, which is a thing to read rather than to check.
+     */
+    private static List<Read> reachableMethods() {
+        List<Read> out = new ArrayList<>();
+        for (MethodModel method : typeOps().methods()) {
+            if (method.flags().has(AccessFlag.PRIVATE) || method.flags().has(AccessFlag.SYNTHETIC)
+                    || method.methodName().stringValue().startsWith("<")) {
+                continue;
+            }
+            // The generic signature where there is one. A clause reached through a list, an
+            // `Optional`, a map value or a record is a clause a caller gets, and the containers
+            // erase to something naming no clause at all — so a rule read off the descriptor would
+            // hold of exactly the shape nobody writes.
+            String signature = method.findAttribute(Attributes.signature())
+                    .map(each -> each.signature().stringValue())
+                    .orElseGet(() -> method.methodType().stringValue());
+            int closed = signature.lastIndexOf(')');
+            out.add(new Read(method.methodName().stringValue(),
+                    signature.substring(signature.indexOf('(') + 1, closed),
+                    signature.substring(closed + 1)));
+        }
+        return out;
+    }
+
+    /** The walks: what answers with a rule of a declaration, in either representation. */
+    private static List<Read> walksOverWhatGoverns() {
+        List<Read> found = new ArrayList<>();
+        for (Read method : reachableMethods()) {
+            if (reachesAClause(method.answersWith()) && reachesOneOf(method.takes(), THE_WORLDS)) {
+                found.add(method);
+            }
+        }
+        return found;
+    }
+
+    @Test
+    void aWalkOverWhatGovernsIsGivenANameAndNotADeclaration() {
+        List<String> handedANode = new ArrayList<>();
+        for (Read walk : walksOverWhatGoverns()) {
+            if (reachesADeclaration(walk.takes())) {
+                handedANode.add(walk.shown());
+            }
+        }
+
+        assertEquals(List.of(), handedANode,
+                "a walk over what governs a declaration reads the declarations from the world it"
+                        + " was handed, so that the one asked about and the ones a spread reaches"
+                        + " are one reading");
+    }
+
+    @Test
+    void aWalkThatAnswersWithTheSettledFormTakesTheDerivedWorld() {
+        List<String> loose = new ArrayList<>();
+        for (Read walk : walksOverWhatGoverns()) {
+            // What the expanded form states is the lookup's to answer, and it holds that itself.
+            if (reachesOneOf(walk.takes(), Set.of(THE_LOOKUP))) {
+                continue;
+            }
+            if (!reachesOneOf(walk.takes(), Set.of(THE_DERIVED_WORLD))) {
+                loose.add(walk.shown());
+            }
+        }
+
+        assertEquals(List.of(), loose,
+                "the settled form of a clause is the derived world's, so a walk that answers with"
+                        + " one says which world it read");
+    }
+
+    /**
+     * And each rule above is about something.
+     *
+     * <p>Held for the two representations apart, because the rules are. The settled walk is the one
+     * the derived world's rule is about and the expanded walks are the ones it passes over, so a
+     * count of both together is a count that stays right while either goes to nothing — which is how
+     * a rule comes to hold of an empty set and say so to nobody.
+     */
+    @Test
+    void thereAreWalksOfEachKind() {
+        List<String> settled = new ArrayList<>();
+        List<String> expanded = new ArrayList<>();
+        for (Read walk : walksOverWhatGoverns()) {
+            (reachesOneOf(walk.takes(), Set.of(THE_LOOKUP)) ? expanded : settled).add(walk.shown());
+        }
+
+        assertFalse(settled.isEmpty(),
+                "a walk here answers with the settled form, which is what the derived world's rule"
+                        + " is about");
+        assertFalse(expanded.isEmpty(),
+                "a walk here answers with the expanded form, which that rule passes over because"
+                        + " the lookup holds it");
+    }
+
+    /**
+     * And a walk is found through what its answer is made of, not through what its answer is called.
+     *
+     * <p>The walks here answer with a value that names no clause: what a caller gets the clauses out
+     * of is a record the answer holds. A reading that took the types written in the signature would
+     * find none of them, and {@link #thereAreWalksOfEachKind} would be failing for that reason
+     * rather than saying there is no walk — so this is held on its own.
+     */
+    @Test
+    void aClauseInsideWhatAWalkAnswersWithIsOneThisReads() {
+        List<String> namingNoClause = new ArrayList<>();
+        for (Read walk : walksOverWhatGoverns()) {
+            if (!walk.answersWith().contains(A_CLAUSE)) {
+                namingNoClause.add(walk.shown());
+            }
+        }
+
+        assertFalse(namingNoClause.isEmpty(),
+                "a walk here answers with something that names no clause and holds one, which is"
+                        + " what makes following a record the thing to do");
+    }
+
+    /** Held so the readings above are over the members that class writes and not over a class file
+     *  that was not found: a scan of nothing reports nothing loose. */
+    @Test
+    void theClassTheseRulesAreAboutWasRead() {
+        assertTrue(reachableMethods().size() > 1,
+                "the class these rules are about was read and has a public surface");
+    }
+
+    /**
+     * Whether what {@code signature} describes reaches a clause: it names one, or it names a record
+     * that holds one.
+     *
+     * <p>Held over what a type is made of and not over what it is called. A record carrying a clause
+     * hands its caller the clause, and a rule that read only the types written in the signature
+     * would be answered by wrapping a walk's answer in a record — one line, and no word about the
+     * reading having changed.
+     */
+    private static boolean reachesAClause(String signature) {
+        return reachesOneOf(signature, Set.of(A_CLAUSE));
+    }
+
+    /**
+     * Whether what {@code signature} describes reaches a declaration node.
+     *
+     * <p>Read the way the answer is read, and for the reason the answer is: a pair of a name and the
+     * declaration under it, wrapped in a record, is the same thing to be handed as the two written
+     * side by side. This is not a shape nobody writes — it is what a newtype layer was, and closing
+     * it is half of what this file is about.
+     */
+    private static boolean reachesADeclaration(String signature) {
+        return reachesOneOf(signature, declarationNodes());
+    }
+
+    private static boolean reachesOneOf(String signature, Set<String> wanted) {
+        Matcher named = NAMES_A_TYPE.matcher(signature);
+        while (named.find()) {
+            if (reaches(named.group(1), wanted, new LinkedHashSet<>())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean reaches(String type, Set<String> wanted, Set<String> seen) {
+        if (wanted.contains(type)) {
+            return true;
+        }
+        if (!type.startsWith("souther/") || !seen.add(type)) {
+            return false;
+        }
+        Class<?> loaded;
+        try {
+            loaded = Class.forName(type.replace('/', '.'), false,
+                    HowARuleThatGovernsADeclarationIsAskedForTest.class.getClassLoader());
+        } catch (ClassNotFoundException _) {
+            return false;
+        }
+        if (!loaded.isRecord()) {
+            return false;
+        }
+        for (RecordComponent component : loaded.getRecordComponents()) {
+            String generic = component.getGenericSignature();
+            Matcher named = NAMES_A_TYPE.matcher(
+                    generic != null ? generic : component.getType().descriptorString());
+            while (named.find()) {
+                if (reaches(named.group(1), wanted, seen)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The compiled class these rules read, found through the repository.
+     *
+     * <p>Not through {@code java.class.path}. What a module is handed there is the reactor's to
+     * decide and it is not the same in every build — a module built beside this one arrives as its
+     * {@code target/classes}, and one already packaged arrives as a jar — so a walk over the entries
+     * is a walk over something that answers differently depending on which goal was run. What these
+     * rules are about is the compiled surface of a class of this repository, and the repository is
+     * where that is.
+     */
+    private static ClassModel typeOps() {
+        for (Path module : REPOSITORY.modules()) {
+            Path compiled = module.resolve("target").resolve("classes")
+                    .resolve("souther/compiler/check/TypeOps.class");
+            if (Files.isRegularFile(compiled)) {
+                try {
+                    return ClassFile.of().parse(Files.readAllBytes(compiled));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+        throw new AssertionError("the class these rules are about was not built here");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
@@ -134,8 +134,8 @@ final class CardinalityTransfer {
         if (contradiction.isPresent()) {
             return Cardinality.none(contradiction.get());
         }
-        OccurrenceCounts counts = OccurrenceCounts.of(named, data, source, policy, granted);
-        OccurrenceValues values = OccurrenceValues.of(named, data, source, policy, granted);
+        OccurrenceCounts counts = OccurrenceCounts.of(named, source, policy, granted);
+        OccurrenceValues values = OccurrenceValues.of(named, source, policy, granted);
         Map<String, Type> fields = TypeOps.fieldTypes(data, source.symbols());
         if (data.newtype()) {
             // A newtype is one value under a name, so its value sits where it sits: the rules written

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -32,7 +32,7 @@ final class Clauses {
 
     private final Symbols symbols;
     private final ExpandedClauseLookup expandedClauses;
-    private final Map<Hir.Data, Map<String, Type>> fields = new HashMap<>();
+    private final Map<TypeSymbol.AtModule, Map<String, Type>> fields = new HashMap<>();
     private final Map<TypeSymbol.AtModule, Map<String, BindingId>> bindings =
             new HashMap<>();
     /** Remembered per declaration, not per clause: a clause an include brings in is one expression
@@ -65,17 +65,18 @@ final class Clauses {
 
     /** Every rule that applies to {@code named}, in the expanded representation, with whether every
      * one of them was reached. */
-    ExpandedRules of(TypeSymbol.AtModule named, Hir.Data data) {
+    ExpandedRules of(TypeSymbol.AtModule named) {
         return effective.computeIfAbsent(named, name ->
-                TypeOps.expandedInvariants(name, data, symbols, expandedClauses));
+                TypeOps.expandedInvariants(name, symbols, expandedClauses));
     }
 
     private final Map<TypeSymbol.AtModule, List<TypeOps.Declared>> declaredClauses =
             new HashMap<>();
 
-    /** What {@code data}'s fields are. */
-    Map<String, Type> fieldsOf(Hir.Data data) {
-        return fields.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
+    /** What {@code named}'s fields are, read from this reading's own world for the reason
+     *  {@link #declarationOf} gives. */
+    Map<String, Type> fieldsOf(TypeSymbol.AtModule named) {
+        return fields.computeIfAbsent(named, name -> TypeOps.fieldTypes(declarationOf(name), symbols));
     }
 
     /**
@@ -86,8 +87,23 @@ final class Clauses {
      * of: two modules may declare one spelling, and a reader with both in sight would otherwise have
      * them answer alike.
      */
-    Map<String, BindingId> bindingsOf(TypeSymbol.AtModule named, Hir.Data data) {
+    Map<String, BindingId> bindingsOf(TypeSymbol.AtModule named) {
         return bindings.computeIfAbsent(named, name -> TypeOps.fieldBindings(name, symbols));
+    }
+
+    /**
+     * The declaration {@code named} is, read from the world this reading was made against.
+     *
+     * <p>Read here and not taken from a caller. What a clause states is read in a representation,
+     * and so is what the declaration it is written on holds; handed a node, this would type a clause
+     * of one reading against the fields of another, and nothing it held would say so.
+     */
+    private Hir.Data declarationOf(TypeSymbol.AtModule named) {
+        if (symbols.declaredNode(named) instanceof Hir.Data data) {
+            return data;
+        }
+        throw new IllegalArgumentException(
+                "`" + named.name() + "` is not a product this reading's world declares");
     }
 
     /**
@@ -99,12 +115,15 @@ final class Clauses {
      * not, and it never was — the elaborator does not answer null of its own accord, so every one of
      * those was an exception caught here and dropped.
      */
-    TypedClause typed(ClauseAsExpanded clause, TypeSymbol.AtModule named, Hir.Data data) {
+    TypedClause typed(ClauseAsExpanded clause, TypeSymbol.AtModule named) {
         return typed.computeIfAbsent(named, _ -> new IdentityHashMap<>())
                 .computeIfAbsent(clause.read(), _ -> SecondaryClauseReading.of(clause,
-                        () -> new SecondaryClauseReading.Over(
-                                DataChecker.fieldScope(named, data, symbols),
-                                CheckContext.of(symbols).forData(data).forDischarge()),
+                        () -> {
+                            Hir.Data data = declarationOf(named);
+                            return new SecondaryClauseReading.Over(
+                                    DataChecker.fieldScope(named, data, symbols),
+                                    CheckContext.of(symbols).forData(data).forDischarge());
+                        },
                         "typing a clause of " + named));
     }
 
@@ -116,16 +135,16 @@ final class Clauses {
      * that is not there, and the clause is left to the run-time check rather than read against
      * nothing.
      */
-    Core statedAt(ClauseAsExpanded clause, TypeSymbol.AtModule named, Hir.Data data,
+    Core statedAt(ClauseAsExpanded clause, TypeSymbol.AtModule named,
                   Map<BindingId, Core> given) {
         // Fail-open: a clause with no form leaves its run-time check standing, whichever way the
         // form went missing. Which of the two it was matters to a reader that publishes a sentence
         // about the clause, and this is not one.
-        Core stated = typed(clause, named, data).orNull();
+        Core stated = typed(clause, named).orNull();
         if (stated == null) {
             return null;
         }
-        return given.keySet().containsAll(fieldsRead(stated, named, data))
+        return given.keySet().containsAll(fieldsRead(stated, named))
                 ? substituted(stated, given) : null;
     }
 
@@ -137,11 +156,11 @@ final class Clauses {
      * it owes where one is being built are the same clauses read the same way, and they differ only
      * in what the fields are given — a read of each field, or the value each is being handed.
      */
-    StatedClauses statedAt(TypeSymbol.AtModule named, Hir.Data data, Map<BindingId, Core> given) {
+    StatedClauses statedAt(TypeSymbol.AtModule named, Map<BindingId, Core> given) {
         List<Stated> stated = new ArrayList<>();
         List<RuleRef.Invariant> lost = new ArrayList<>();
-        for (TypeOps.Declared inv : declared(named, data)) {
-            Core one = statedAt(inv.asExpanded(), named, data, given);
+        for (TypeOps.Declared inv : declared(named)) {
+            Core one = statedAt(inv.asExpanded(), named, given);
             if (one != null) {
                 stated.add(new Stated(Clause.of(inv), one));
             } else {
@@ -193,15 +212,15 @@ final class Clauses {
     record Stated(Clause clause, Core expr) {}
 
     /** Every clause of {@code named}, each with the declaration that wrote it. */
-    List<TypeOps.Declared> declared(TypeSymbol.AtModule named, Hir.Data data) {
-        return declaredClauses.computeIfAbsent(named, name -> of(name, data).reached());
+    List<TypeOps.Declared> declared(TypeSymbol.AtModule named) {
+        return declaredClauses.computeIfAbsent(named, name -> of(name).reached());
     }
 
     /** Which of {@code data}'s own fields {@code clause} reads, remembered: a clause is read at every
      * construction of its type, and what it reads does not change between them. */
-    private Set<BindingId> fieldsRead(Core clause, TypeSymbol.AtModule named, Hir.Data data) {
+    private Set<BindingId> fieldsRead(Core clause, TypeSymbol.AtModule named) {
         return readsFields.computeIfAbsent(clause, read -> {
-            Set<BindingId> declared = new HashSet<>(bindingsOf(named, data).values());
+            Set<BindingId> declared = new HashSet<>(bindingsOf(named).values());
             Set<BindingId> found = new HashSet<>();
             readsOf(read, binding -> {
                 if (declared.contains(binding)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -81,9 +81,9 @@ public final class DataChecker {
         TypeChecker.forEachChild(e, c -> collectConstChecks(c, symbols, out));
     }
 
-    public static boolean isInvariantBearing(TypeSymbol typeName, Symbols symbols) {
-        return typeName != null && symbols.declaredNode(typeName) instanceof Hir.Data d
-                && !TypeOps.settledInvariants(d, symbols).isEmpty();
+    public static boolean isInvariantBearing(TypeSymbol.AtModule typeName, Symbols symbols) {
+        return typeName != null
+                && !TypeOps.invariantHeadersGoverning(typeName, symbols).isEmpty();
     }
 
     /**
@@ -94,7 +94,7 @@ public final class DataChecker {
      */
     private static void checkClauseNames(Hir.Data data, Symbols symbols) {
         Set<String> seen = new HashSet<>();
-        for (Hir.InvariantClause clause : TypeOps.settledInvariants(data, symbols)) {
+        for (InvariantHeader clause : TypeOps.invariantHeadersGoverning(data.declares(), symbols)) {
             String name = clause.name().orElse(null);
             if (name != null && !seen.add(name)) {
                 throw CompileException.of(Diagnostic

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredClauses.java
@@ -94,19 +94,18 @@ public final class DeclaredClauses {
     }
 
     private static List<Conjunct> writtenOn(TypeSymbol wears, RuleReadingSource source) {
-        // The declaration the name was written by, read here. A name a module wrote is one this
-        // finds a data for; a caller handed the body instead would be holding a declaration for a
-        // question that is this one's, and could read the position's structure back out of it.
-        if (!(wears instanceof TypeSymbol.AtModule named)
-                || !(source.symbols().declaredNode(named) instanceof Hir.Data data)) {
+        // A name a module wrote is the only one there are rules of to read: what the language
+        // declares carries none. Which declaration that name is, and what it states, are the walk's
+        // to read from the world and the lookup it holds.
+        if (!(wears instanceof TypeSymbol.AtModule named)) {
             return List.of();
         }
         List<Conjunct> out = new ArrayList<>();
         // The clauses with the declaration each was written on, which is what names the line
         // (ADR-0090). Read flat, every clause a spread brought in was named after the type that
         // spread it, and two clauses of one declaration were one rule.
-        for (TypeOps.Declared declared : TypeOps.declaredExpanded(
-                named, data, source.symbols(), source.invariants()).reached()) {
+        for (TypeOps.Declared declared : TypeOps.expandedInvariants(
+                named, source.symbols(), source.invariants()).reached()) {
             RuleRef.Invariant rule = new RuleRef.Invariant(Clause.Ref.of(declared));
             int conjunct = -1;
             for (Hir.Expr each : ClauseHelpers.conjunctsOf(declared.clause().expr())) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredTypeEvidence.java
@@ -149,8 +149,8 @@ public record DeclaredTypeEvidence(FieldRead read,
      */
     public boolean heldToARule(Type type) {
         return type instanceof Type.Ref(TypeSymbol named)
-                && symbols().declaredNode(named) instanceof Hir.Data data
-                && !TypeOps.settledInvariants(data, symbols()).isEmpty();
+                && named instanceof TypeSymbol.AtModule declared
+                && !TypeOps.invariantHeadersGoverning(declared, symbols()).isEmpty();
     }
 
     /** The body a name stands for, where it names a value of this reading's own. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -1562,15 +1562,14 @@ public final class Elaborator {
      *
      * <p>Nothing is checked for the {@code else e} form: it already answers any failure.
      */
-    private static void checkArmsAnswerClauses(Hir.IfConstructed ic, TypeSymbol typeName, Symbols symbols) {
+    private static void checkArmsAnswerClauses(Hir.IfConstructed ic, TypeSymbol.AtModule typeName,
+                                               Symbols symbols) {
         if (!ic.mapsClauses()) {
             return;
         }
-        List<Hir.InvariantClause> clauses = symbols.declaredNode(typeName) instanceof Hir.Data data
-                ? TypeOps.settledInvariants(data, symbols) : List.of();
         LinkedHashSet<String> named = new LinkedHashSet<>();
         boolean unnamed = false;
-        for (Hir.InvariantClause clause : clauses) {
+        for (InvariantHeader clause : TypeOps.invariantHeadersGoverning(typeName, symbols)) {
             if (clause.name().isPresent()) {
                 named.add(clause.name().get());
             } else {

--- a/souther-compiler/src/main/java/souther/compiler/check/ExecutableInvariants.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExecutableInvariants.java
@@ -27,6 +27,12 @@ import java.util.Map;
  * ({@link TypeOps#fieldBindings}). So the unit is the data being built and not the declaration a
  * clause was written on: an answer keyed by where a clause was written would be short exactly the
  * clauses a construction has to satisfy.
+ *
+ * <p>And every one of them comes out of one derived world. What a clause states depends on the
+ * representation its declaration is read in — a helper the declaring module expanded is still a
+ * call in the form resolution left, under a name that means nothing where this stands — while what
+ * a clause is called and where it was written do not. This is the reading that runs, so it is the
+ * settled form it wants, and the world it asks is the one that has it.
  */
 public final class ExecutableInvariants {
 
@@ -35,11 +41,18 @@ public final class ExecutableInvariants {
     /**
      * {@code data} as it is built and checked.
      *
+     * <p>{@code data} says which declaration values are being built of, and decides nothing about
+     * how any declaration is read: the rules that govern it — its own and every one a spread brings
+     * in — are read through {@code symbols}, this one included. A node is what a caller of this
+     * already holds, and what would go wrong if it decided the reading is that the declaration
+     * asked about would be at whichever stage the caller was at and the ones under it at whichever
+     * the world reads.
+     *
      * @param helpers the signatures of the recursive helpers a clause may reach — the same table the
      *     body check reads, because a clause naming a total helper names the same one a body does
      * @throws CompileException where a clause is not a condition
      */
-    public static ValueShape of(Hir.Data data, Symbols symbols, Map<String, Type> helpers) {
+    public static ValueShape of(Hir.Data data, DerivedSymbols symbols, Map<String, Type> helpers) {
         Map<String, Type> types = TypeOps.fieldTypes(data, symbols);
         Map<String, BindingId> bindings =
                 TypeOps.fieldBindings(data.declares(), symbols);
@@ -53,7 +66,7 @@ public final class ExecutableInvariants {
         Scope reading = DataChecker.fieldScope(data.declares(), data, symbols).reaching(helpers);
         CheckContext ctx = CheckContext.executableInvariant(symbols, data);
         List<ValueShape.Invariant> invariants = new ArrayList<>();
-        for (Hir.InvariantClause clause : TypeOps.settledInvariants(data, symbols)) {
+        for (Hir.InvariantClause clause : TypeOps.settledClausesGoverning(data.declares(), symbols)) {
             // Desugared first, the way a body is: a clause writing a comprehension states the same
             // condition as the `if` it is derived from, and one of the two reaching the check and
             // the other reaching what runs is the shape this exists to stop.

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -364,7 +364,7 @@ public final class FieldDomains {
         // answers were being given away by treating it as a value with nothing to say.
         READINGS.incrementAndGet();
         InvariantChecker.Seeded seeded =
-                InvariantChecker.seedFields(named, data, source, policy, settled, reach);
+                InvariantChecker.seedFields(named, source, policy, settled, reach);
         Map<RuleKey, NumericDomain.Bounds> out = new LinkedHashMap<>();
         seeded.atoms().forEach((field, atom) -> {
             // The value itself is at no name of its own, and its range is the one thing not worth
@@ -1446,7 +1446,7 @@ public final class FieldDomains {
     public static boolean mayHoldNothingAt(TypeSymbol.AtModule named, Hir.Data data, RuleKey path,
                                            RuleReadingSource source, ReadingPolicy policy) {
         // A count is never below none, so leaving it no room above none is leaving it at none.
-        return OccurrenceCounts.of(named, data, source, policy).mayHoldAtMost(path, 0);
+        return OccurrenceCounts.of(named, source, policy).mayHoldAtMost(path, 0);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -293,7 +293,7 @@ public final class InvariantChecker {
      * in the representation the check reads.
      */
     public static ClauseDischarge capabilityOf(ClausesForDischarge.ClauseReading clause,
-                                               TypeSymbol.AtModule named, Hir.Data data,
+                                               TypeSymbol.AtModule named,
                                                RuleReadingSource source, ReadingPolicy policy) {
         InvariantChecker c =
                 new InvariantChecker(source.symbols(), source.invariants(), policy);
@@ -303,10 +303,10 @@ public final class InvariantChecker {
         // seeded of them — what a clause owes is the question, and answering it here would be
         // assuming it.
         return c.capabilityOf(clause,
-                _ -> c.clauses.typed(clause.asExpanded(), named, data),
-                Denotations.none().locations(c.clauses.bindingsOf(named, data).values(),
+                _ -> c.clauses.typed(clause.asExpanded(), named),
+                Denotations.none().locations(c.clauses.bindingsOf(named).values(),
                         c.terms::placeSubject, c.terms::placeTerm),
-                data.name());
+                named.name());
     }
 
     /**
@@ -561,9 +561,9 @@ public final class InvariantChecker {
      * nothing about, which is the same answer as a declaration with no rules — so nothing about the
      * declaration throws. {@link Terms.OneTermTwoKinds} is not about the declaration, and nothing
      * below here catches it. */
-    static Seeded seedFields(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy) {
-        return seedFields(named, data, source, policy, Map.of());
+        return seedFields(named, source, policy, Map.of());
     }
 
     /**
@@ -573,9 +573,9 @@ public final class InvariantChecker {
      * field is one more assertion into it — so what comes back is the range each remaining field can
      * still take, which is where a row completing that assignment has to look.
      */
-    static Seeded seedFields(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled) {
-        return seedFields(named, data, source, policy, settled, Reach.EVERYTHING);
+        return seedFields(named, source, policy, settled, Reach.EVERYTHING);
     }
 
     /**
@@ -588,13 +588,17 @@ public final class InvariantChecker {
      * declaration was holding. Supposing a declaration has values is the other thing {@code reach}
      * says, and it is not that one — see {@link Reach}.
      */
-    static Seeded seedFields(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    static Seeded seedFields(TypeSymbol.AtModule named, RuleReadingSource source,
                              ReadingPolicy policy, Map<NumberAt<RuleKey>, Count> settled,
                              Reach reach) {
         Symbols symbols = source.symbols();
         InvariantChecker c = new InvariantChecker(symbols, source.invariants(), policy);
-        Map<String, Type> fields = c.clauses.fieldsOf(data);
-        Map<String, BindingId> bindings = c.clauses.bindingsOf(named, data);
+        // A newtype's value is the same location as the newtype, so it is at no name of its own and
+        // its fields are the first step there is. Read from the world rather than off a node handed
+        // in, and turned into a name here, where the names a rule may write are decided.
+        boolean atTheValue = DeclaredTypeEvidence.isNewtype(named, symbols);
+        Map<String, Type> fields = c.clauses.fieldsOf(named);
+        Map<String, BindingId> bindings = c.clauses.bindingsOf(named);
         Denotations at = Denotations.none()
                 .locations(bindings.values(), c.terms::placeSubject, c.terms::placeTerm);
         Known k = Known.top();
@@ -658,7 +662,7 @@ public final class InvariantChecker {
         // missing from this reading is the position, since a clause of this declaration can
         // name any position of it.
         boolean skipped = false;
-        ExpandedRules rules = c.clauses.of(named, data);
+        ExpandedRules rules = c.clauses.of(named);
         if (!opened && !rules.reached().isEmpty()) {
             gathering.missed(RuleKey.THE_VALUE, new RulesMissed.PositionNotOpened());
         }
@@ -671,7 +675,7 @@ public final class InvariantChecker {
             gathering.missed(RuleKey.THE_VALUE, new RulesMissed.ClausesNotExpanded());
         }
         for (TypeOps.Declared declared :
-                opened ? c.clauses.declared(named, data) : List.<TypeOps.Declared>of()) {
+                opened ? c.clauses.declared(named) : List.<TypeOps.Declared>of()) {
             // Where this clause becomes a rule of the model something can be attributed to.
             // Everything below carries the origin as it is: what is written down here is read
             // back by a report, and a reader handed the clause reference instead would have to
@@ -682,7 +686,7 @@ public final class InvariantChecker {
                 skipped = true;
                 continue;
             }
-            Core stated = c.clauses.typed(declared.asExpanded(), named, data).orNull();
+            Core stated = c.clauses.typed(declared.asExpanded(), named).orNull();
             if (stated == null) {
                 read = false;
                 gathering.missed(RuleKey.THE_VALUE, new RulesMissed.ClauseNotTyped());
@@ -719,7 +723,7 @@ public final class InvariantChecker {
                 // Every position: this is the reading a boundary is derived from, and a rule
                 // the construction must satisfy is a rule wherever in the value it sits.
                 k = c.engine.seedAt(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
-                        data.newtype() ? RuleKey.THE_VALUE : RuleKey.of(field.getKey()),
+                        atTheValue ? RuleKey.THE_VALUE : RuleKey.of(field.getKey()),
                         k, at, new GuaranteeWalk.Extent.EveryName(), gathering, reach);
             }
         }
@@ -735,7 +739,7 @@ public final class InvariantChecker {
                 // position of a record inside a newtype was filed one step deeper than anything
                 // asks for.
                 c.name(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
-                        data.newtype() ? RuleKey.THE_VALUE : RuleKey.of(field.getKey()),
+                        atTheValue ? RuleKey.THE_VALUE : RuleKey.of(field.getKey()),
                         type, at, symbols, 1, atoms, typeAt, held, keys);
             }
         }
@@ -942,7 +946,7 @@ public final class InvariantChecker {
         Core inner = value;
         Type worn = type;
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
-            Type under = TypeOps.fieldTypes(layer.data(), symbols).get("value");
+            Type under = TypeOps.newtypeInner(layer.named(), symbols);
             if (under == null) {
                 break;
             }
@@ -3078,7 +3082,7 @@ public final class InvariantChecker {
      * value and not a choice of arms.
      */
     private Judgment verdictOf(Core.Construct nd, Hir.Data type, Known k, Denotations at) {
-        Map<String, BindingId> fields = clauses.bindingsOf(nd.typeName(), type);
+        Map<String, BindingId> fields = clauses.bindingsOf(nd.typeName());
         Map<BindingId, Core> given = new HashMap<>();
         for (Core.FieldValue fv : nd.values()) {
             BindingId field = fields.get(fv.field());
@@ -3090,7 +3094,7 @@ public final class InvariantChecker {
             Core written = terms.writtenValue(fv.value(), at);
             given.put(field, written != null ? written : fv.value());
         }
-        return verdictOf(nd.typeName(), type, given, k, at, !constantlyBuilt(type, nd));
+        return verdictOf(nd.typeName(), given, k, at, !constantlyBuilt(type, nd));
     }
 
     /** Which of the values a construction hands over is not one a clause may be read against
@@ -3169,7 +3173,7 @@ public final class InvariantChecker {
 
     /** The discharge verdict for a construction of {@code type} whose fields are being given
      * {@code given}. */
-    private Judgment verdictOf(TypeSymbol.AtModule named, Hir.Data type, Map<BindingId, Core> given, Known k,
+    private Judgment verdictOf(TypeSymbol.AtModule named, Map<BindingId, Core> given, Known k,
                                Denotations at, boolean decidesFalse) {
         // What the construction hands over that no clause may be read against. A clause naming one of
         // them is left to the run-time check, and one that is decided outright is still decided: what
@@ -3198,7 +3202,7 @@ public final class InvariantChecker {
         // The clauses that state something here, and not whether they are all of them: a clause
         // stating nothing readable at this construction is one the run-time check stands for, which
         // is what `unreadable` below already carries for the ones that were read.
-        for (Clauses.Stated stated : clauses.statedAt(named, type, given).clauses()) {
+        for (Clauses.Stated stated : clauses.statedAt(named, given).clauses()) {
             Predicates.Owed o = predicates.obligations(stated.expr(), k, at, unnamed, decidesFalse);
             unreadable |= o.unreadable();
             for (Predicates.Part eachOne : o.parts()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantHeader.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantHeader.java
@@ -1,0 +1,33 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.SourcePos;
+
+import java.util.Optional;
+
+/**
+ * What a rule that governs a declaration is called, and where its author wrote it.
+ *
+ * <p>A clause without what it states. The name and the position are what every representation of a
+ * declaration agrees on: resolution settles which clauses there are, what each is called and where
+ * it stands, and the only thing that makes one afterwards is
+ * {@link souther.compiler.ast.Hir.InvariantClause#with}, which replaces the expression and carries
+ * the name and the position across. Nothing below adds a clause, drops one, or moves one. So a
+ * reader that wants these can read them off whichever representation it is holding, and a reader
+ * that wants what the clause states cannot — which is why the expression is not here.
+ *
+ * <p>Held to those two. Which declaration a rule was written on, and which of that declaration's
+ * rules it is, are answered by {@link TypeOps.Declared} for the readers that ask; put here they
+ * would be two more things every representation had to agree about for no reader that asks.
+ *
+ * @param name  what the author called the rule, or nothing where they wrote none
+ * @param pos   where the clause was written
+ */
+public record InvariantHeader(Optional<String> name, SourcePos pos) {
+
+    public InvariantHeader {
+        if (name == null || pos == null) {
+            throw new IllegalArgumentException("a rule has a name it may not have been given, and a"
+                    + " place it was written");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
@@ -23,10 +23,17 @@ import java.util.Map;
  * </ul>
  *
  * <p>What is <em>not</em> settled is what a declaration takes in by a spread. A clause of the type
- * spread from is still that type's, and which clauses apply to a declaration is composed on demand
- * by {@link TypeOps#settledInvariants} walking {@code includes()}. A reader that took this state to
- * mean the spreads had been flattened into each declaration would find a declaration's own clauses
- * where it expected every clause that governs it.
+ * spread from is still that type's, and which clauses govern a declaration is composed on demand by
+ * the walks of {@link TypeOps} following {@code includes()}. A reader that took this state to mean
+ * the spreads had been flattened into each declaration would find a declaration's own clauses where
+ * it expected every clause that governs it.
+ *
+ * <p>Those walks reach every declaration through a world and none through a node handed to them, and
+ * what each of them states is read from whatever owns that representation: the settled form from the
+ * derived world, where this rung's work is what a declaration is read as, and the expanded form from
+ * {@link ExpandedClauseLookup}. What turns on neither is what a rule is called and where it stands
+ * ({@link InvariantHeader}), which resolution settles and {@link Hir.InvariantClause#with} carries
+ * across every rewrite below.
  *
  * <p>The name is the part a reader cannot see for itself. A clause that has been expanded reads like
  * one the author wrote that way, and what this says is that nothing in it is left to expand. A pass

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.CountDomain;
 import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.LinearForm;
@@ -49,9 +48,9 @@ public final class OccurrenceCounts {
      * up to how many values the element has, and each of those is the same reading of the same
      * clauses.
      */
-    public static OccurrenceCounts of(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    public static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
                                        ReadingPolicy policy) {
-        return of(named, data, source, policy, _ -> false);
+        return of(named, source, policy, _ -> false);
     }
 
     /**
@@ -61,11 +60,11 @@ public final class OccurrenceCounts {
      * rules are what say it has none — its own, and the ones under whatever it wraps — so supposing
      * it has a value is not reading it at all.
      */
-    static OccurrenceCounts of(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    static OccurrenceCounts of(TypeSymbol.AtModule named, RuleReadingSource source,
                                  ReadingPolicy policy,
                                  java.util.function.Predicate<TypeSymbol> granted) {
         return new OccurrenceCounts(
-                InvariantChecker.seedFields(named, data, source, policy, java.util.Map.of(),
+                InvariantChecker.seedFields(named, source, policy, java.util.Map.of(),
                         InvariantChecker.Reach.stoppingAt(granted)));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
@@ -39,10 +38,10 @@ public final class OccurrenceValues {
         this.seeded = seeded;
     }
 
-    /** What {@code data}, declared as {@code named}, leaves the values at each of its names. */
-    public static OccurrenceValues of(TypeSymbol.AtModule named, Hir.Data data,
+    /** What the declaration {@code named} is leaves the values at each of its names. */
+    public static OccurrenceValues of(TypeSymbol.AtModule named,
                                       RuleReadingSource source, ReadingPolicy policy) {
-        return of(named, data, source, policy, _ -> false);
+        return of(named, source, policy, _ -> false);
     }
 
     /**
@@ -52,11 +51,11 @@ public final class OccurrenceValues {
      * rules are what say it has none — its own, and the ones under whatever it wraps — so supposing
      * it has a value is not reading it at all.
      */
-    static OccurrenceValues of(TypeSymbol.AtModule named, Hir.Data data, RuleReadingSource source,
+    static OccurrenceValues of(TypeSymbol.AtModule named, RuleReadingSource source,
                                  ReadingPolicy policy,
                                  java.util.function.Predicate<TypeSymbol> granted) {
         return new OccurrenceValues(
-                InvariantChecker.seedFields(named, data, source, policy, java.util.Map.of(),
+                InvariantChecker.seedFields(named, source, policy, java.util.Map.of(),
                         InvariantChecker.Reach.stoppingAt(granted)));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -418,7 +418,7 @@ public final class TypeCardinality {
             if (!(def instanceof Hir.Data data) || !(name instanceof TypeSymbol.AtModule at)) {
                 return;
             }
-            OccurrenceCounts held = OccurrenceCounts.of(at, data, source, policy);
+            OccurrenceCounts held = OccurrenceCounts.of(at, source, policy);
             for (RuleKey path : data.newtype() ? Set.of(RuleKey.THE_VALUE)
                     : TypeOps.fieldTypes(data, symbols).keySet().stream()
                             .map(RuleKey::of).collect(java.util.stream.Collectors.toSet())) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -89,14 +89,14 @@ final class TypeGuarantees {
         Set<Object> already = new HashSet<>();
         for (ValueReading.Owner owner : written.owners()) {
             Map<BindingId, Core> given = new HashMap<>();
-            clauses.bindingsOf(owner.named(), owner.data()).forEach((name, binding) -> {
+            clauses.bindingsOf(owner.named()).forEach((name, binding) -> {
                 Core value = values.get(name);
                 if (value != null) {
                     given.put(binding, value);
                 }
             });
             Clauses.StatedClauses stated =
-                    clauses.statedAt(owner.named(), owner.data(), given);
+                    clauses.statedAt(owner.named(), given);
             for (Clauses.Stated one : stated.clauses()) {
                 if (already.add(one.clause().ref())) {
                     here.add(read(one, denotations, withoutParts));
@@ -135,7 +135,7 @@ final class TypeGuarantees {
     private boolean beyond(Type type, ValueReading here, Set<Object> stated) {
         ValueReading there = ValueReading.of(type, symbols);
         for (ValueReading.Owner owner : there.owners()) {
-            for (TypeOps.Declared each : clauses.declared(owner.named(), owner.data())) {
+            for (TypeOps.Declared each : clauses.declared(owner.named())) {
                 if (!stated.contains(Clause.of(each).ref())) {
                     return true;
                 }
@@ -208,7 +208,7 @@ final class TypeGuarantees {
             return false;
         }
         for (ValueReading.Owner owner : written.owners()) {
-            if (!clauses.declared(owner.named(), owner.data()).isEmpty()) {
+            if (!clauses.declared(owner.named()).isEmpty()) {
                 return true;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1186,8 +1186,8 @@ public final class TypeOps {
      */
     static ValueReading.Owner writingFields(TypeSymbol name, Symbols symbols) {
         return name instanceof TypeSymbol.AtModule at
-                && symbols.declaredNode(at) instanceof Hir.Data data
-                ? new ValueReading.Owner(at, data) : null;
+                && symbols.declaredNode(at) instanceof Hir.Data
+                ? new ValueReading.Owner(at) : null;
     }
 
     /** Every data reachable from {@code data} through spreads, transitively — the set two cases are
@@ -1208,18 +1208,61 @@ public final class TypeOps {
     }
 
     /**
-     * All invariant clauses that apply to a data, in the order a failure is decided by: the clauses of
-     * the data it spreads first, then its own, each in the order it is written.
+     * What each rule that governs a declaration is called and where it was written, in the order a
+     * failure is decided by: the rules of what it spreads first, then its own, each in the order it
+     * is written.
      *
-     * <p>A clause keeps the name it was declared with wherever it arrives from, so a spread carries not
-     * only the rule but what an attempt on the spreading type calls it.
+     * <p>The part of a clause that does not turn on the representation the declaration is read in.
+     * Resolution settles which clauses a declaration has, what each is called and where it stands;
+     * after it, the only thing that makes one is {@link Hir.InvariantClause#with}, which replaces the
+     * expression and carries the name and the position across, and no representation below adds a
+     * clause, drops one, or reorders them. So this is well defined in every representation, and a
+     * reader may ask it of whichever world it holds.
+     *
+     * <p>What a clause states is not here, and that is what this answer is for: what a rule states is
+     * owned by the representation it is read in, and nothing can reach it through this.
      */
-    public static List<Hir.InvariantClause> settledInvariants(Hir.Data data, Symbols symbols) {
+    public static List<InvariantHeader> invariantHeadersGoverning(
+            TypeSymbol.AtModule named, Symbols symbols) {
+        List<InvariantHeader> headers = new ArrayList<>();
+        for (Hir.InvariantClause clause : settledClauses(named, symbols)) {
+            headers.add(new InvariantHeader(clause.name(), clause.pos()));
+        }
+        return headers;
+    }
+
+    /**
+     * The rules that govern {@code named}, as they were settled: what the declaring module made of
+     * each clause once the helpers it names were expanded into it.
+     *
+     * <p>Not public, and there is one reader. What a clause states is owned by the representation it
+     * is read in — the settled form by the derived world, the expanded one by
+     * {@link ExpandedClauseLookup} — so a way of asking for it that anyone could reach is a way of
+     * asking for one representation and being answered in whichever the caller's world happened to
+     * be at.
+     *
+     * <p>Every declaration is read from {@code symbols}: the one asked about and every one a spread
+     * reaches. Handed a node beside the world, the declaration asked about would be at whichever
+     * stage the caller was holding and the ones under it at whichever stage the world reads.
+     */
+    static List<Hir.InvariantClause> settledClausesGoverning(
+            TypeSymbol.AtModule named, DerivedSymbols symbols) {
+        return settledClauses(named, symbols);
+    }
+
+    /** The same for a reader that wants only what every representation agrees on, which is why this
+     *  takes any world. Private, so the world a clause's body is read from stays said by the method
+     *  a caller names. */
+    private static List<Hir.InvariantClause> settledClauses(
+            TypeSymbol.AtModule named, Symbols symbols) {
+        if (!(symbols.declaredNode(named) instanceof Hir.Data data)) {
+            return List.of();
+        }
         List<Hir.InvariantClause> invs = new ArrayList<>();
         for (Hir.Name inc : data.includes()) {
-            Hir.Data spread = spreadTarget(inc, symbols);
-            if (spread != null) {
-                invs.addAll(settledInvariants(spread, symbols));
+            if (inc.answered() instanceof Hir.Name.Denoting denoting
+                    && denoting.type() instanceof TypeSymbol.AtModule spread) {
+                invs.addAll(settledClauses(spread, symbols));
             }
         }
         invs.addAll(data.invariants());
@@ -1236,8 +1279,12 @@ public final class TypeOps {
      * another source of clauses is a walk somebody can hand the wrong one.
      */
     public static ExpandedRules expandedInvariants(
-            TypeSymbol.AtModule named, Hir.Data data, Symbols symbols, ExpandedClauseLookup form) {
-        return declaredExpanded(named, data, symbols, form);
+            TypeSymbol.AtModule named, Symbols symbols, ExpandedClauseLookup form) {
+        if (form == null) {
+            throw new IllegalArgumentException(
+                    "reading a declaration's clauses takes somewhere to read them from");
+        }
+        return governedBy(named, symbols, form);
     }
 
     /**
@@ -1245,8 +1292,7 @@ public final class TypeOps {
      *
      * <p>A clause reaching a type through a spread is that type's to hold and the other type's to
      * have written, and a reader told which clause failed on a data that declares none of its own is
-     * told about a declaration they would not find. {@code declaredOn} is null where the walk was
-     * not given a name to start from.
+     * told about a declaration they would not find.
      *
      * <p>{@code ordinal} is which of {@code declaredOn}'s own clauses this is, counted where that
      * declaration writes them and not where this walk happened to reach it. Two spreads of one type
@@ -1282,42 +1328,53 @@ public final class TypeOps {
      * and that is the sentence the whole of #1312 was about — shared through a clause-source
      * parameter, it is one edit away from being a choice again.
      *
-     * <p>{@code named} is what the walk reached this declaration by. A spread whose name is not a
-     * module's declaration contributes nothing and costs nothing: no module wrote it, so there is no
-     * expansion of it to be short of.
+     * <p>{@code named} is the declaration being read, and the only way in. Which declarations the
+     * walk visits is {@code symbols}' to answer and what each of them states is {@code form}'s: two
+     * authorities with two questions, and neither is asked the other's. Handed a node as well, which
+     * declarations are reached would come from the caller for the one asked about and from the world
+     * for the ones under it — and the two need not be the same reading.
+     *
+     * <p>A spread whose name is not a module's declaration contributes nothing and costs nothing: no
+     * module wrote it, so there is no expansion of it to be short of.
+     *
+     * <p>A declaration this world cannot read is rules not reached and not rules there are none of.
+     * What a declaration takes in is written on it, so a walk that could not read it did not walk
+     * what it spreads — and the two authorities settle that between them: something declares it or
+     * nothing does, which is {@code form}'s to say, and it can be read here or it cannot, which is
+     * the world's. Only where nothing declares it at all are there no spreads to be short of.
      */
-    public static ExpandedRules declaredExpanded(
-            TypeSymbol.AtModule named, Hir.Data data, Symbols symbols, ExpandedClauseLookup form) {
-        if (form == null) {
-            throw new IllegalArgumentException(
-                    "reading a declaration's clauses takes somewhere to read them from");
-        }
-        ExpandedRules found = new ExpandedRules(List.of(), true);
-        for (Hir.Name inc : data.includes()) {
-            Hir.Data id = spreadTarget(inc, symbols);
-            if (id != null) {
-                found = found.and(declaredExpanded(
-                        inc.answered().type() instanceof TypeSymbol.AtModule at ? at : null,
-                        id, symbols, form));
+    private static ExpandedRules governedBy(
+            TypeSymbol.AtModule named, Symbols symbols, ExpandedClauseLookup form) {
+        ExpandedClauseResult stated = form.of(named.key());
+        Hir.Def declared = symbols.declaredNode(named);
+        ExpandedRules found = new ExpandedRules(List.of(),
+                declared != null || stated instanceof ExpandedClauseResult.NotDeclared);
+        if (declared instanceof Hir.Data data) {
+            for (Hir.Name inc : data.includes()) {
+                if (inc.answered() instanceof Hir.Name.Denoting denoting
+                        && denoting.type() instanceof TypeSymbol.AtModule spread) {
+                    found = found.and(governedBy(spread, symbols, form));
+                }
             }
         }
-        return found.and(ownClausesOf(named, form));
+        return found.and(rulesOf(named, stated));
     }
 
     /**
-     * What {@code form} answers for {@code named} alone, as rules.
+     * What the lookup answered for {@code named} alone, as rules.
      *
      * <p>An answer this could not be given is carried as a rule not reached rather than as no rule.
      * They are the same empty list and opposite facts: a declaration that states nothing holds every
      * value its type does, and one whose clauses nobody worked out holds whatever its author wrote.
      * A reading handed the second as the first says a position admits everything and says nothing
      * about not having looked.
+     *
+     * <p>Handed the answer rather than the lookup, because the walk above reads the same answer to
+     * decide something else — whether a declaration nothing here can read is one nothing declares.
+     * Asked twice, the two questions could be answered by two.
      */
-    private static ExpandedRules ownClausesOf(TypeSymbol.AtModule named, ExpandedClauseLookup form) {
-        if (named == null) {
-            return new ExpandedRules(List.of(), true);
-        }
-        return switch (form.of(named.key())) {
+    private static ExpandedRules rulesOf(TypeSymbol.AtModule named, ExpandedClauseResult stated) {
+        return switch (stated) {
             case ExpandedClauseResult.Found(ExpandedClauses clauses) -> {
                 List<Declared> out = new ArrayList<>();
                 for (int ordinal = 0; ordinal < clauses.clauses().size(); ordinal++) {
@@ -1590,7 +1647,7 @@ public final class TypeOps {
         Type at = t;
         while (isSingleValueNewtype(at, symbols) && worn.add(((Type.Ref) at).name())) {
             Hir.Data data = (Hir.Data) symbols.declaredNode(((Type.Ref) at).name());
-            layers.add(new Layer(((Type.Ref) at).name(), data));
+            layers.add(new Layer(((Type.Ref) at).name()));
             Type inner = fieldTypes(data, symbols).get("value");
             if (inner == null) {
                 break;
@@ -1604,13 +1661,16 @@ public final class TypeOps {
     public record NewtypeSpine(List<Layer> layers, Type terminal) {}
 
     /**
-     * One name a value wears, and the declaration it is written by.
+     * One name a value wears.
      *
-     * <p>Kept together because a rule is read at a layer and reported by the declaration that wrote
-     * it — a failure names a clause of a type, and dropping which type that was leaves a diagnostic
-     * with nothing to point at.
+     * <p>The name and nothing under it. A rule is read at a layer and reported by the declaration
+     * that wrote it, and the name is what says which that is — so a reader with the name has what a
+     * diagnostic needs and asks the world it is reading in for the rest. The declaration was carried
+     * here as well, and a reader holding one holds the clauses written on it, in whichever
+     * representation this walk's world happened to be at; what a rule states is asked for by naming
+     * the representation it is read in, and this walk names none.
      */
-    public record Layer(TypeSymbol named, Hir.Data data) {}
+    public record Layer(TypeSymbol named) {}
 
     /**
      * The names wrapped round a value of {@code t}, outermost first.

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueGuarantees.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain.Bounds;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -54,7 +53,7 @@ public final class ValueGuarantees {
         Map<RuleKey, Bounds> guaranteed = new LinkedHashMap<>();
         for (ValueReading.Owner owner : owners) {
             InvariantChecker.Seeded seeded =
-                    seededOf(owner.named(), owner.data(), source, policy);
+                    seededOf(owner.named(), source, policy);
             if (seeded == null) {
                 // All of them or none, which is what leaves a value unbounded rather than bounded
                 // by half of what the declarations say.
@@ -76,9 +75,9 @@ public final class ValueGuarantees {
     /** The reading of {@code named}, or null where it fell over. A reading that fell over is one
      * this says nothing from, which leaves a value unbounded rather than bounded by half of what
      * a declaration says. */
-    private static InvariantChecker.Seeded seededOf(TypeSymbol.AtModule named, Hir.Data data,
+    private static InvariantChecker.Seeded seededOf(TypeSymbol.AtModule named,
                                                     RuleReadingSource source, ReadingPolicy policy) {
-        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, data, source, policy);
+        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, source, policy);
         return seeded.everyClauseRead() && !seeded.constraints().isBottom() ? seeded : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueReading.java
@@ -38,7 +38,7 @@ sealed interface ValueReading {
 
     /** A declaration whose clauses hold of every value standing here, and the name it was reached
      *  by — which is what a clause of it resolves its fields against. */
-    record Owner(TypeSymbol.AtModule named, Hir.Data data) {}
+    record Owner(TypeSymbol.AtModule named) {}
 
     /** The declaration standing here, which a walk files what it has entered under and a reader
      *  supposing values names, or null where no declaration stands here. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -940,7 +940,7 @@ final class BodyGen {
             Hir.Data owner = (Hir.Data) symbols.declaredNode(nd.typeName());
             Map<String, Type> flds = fieldTypes(owner);
             ClassDesc cdType = cd(nd.typeName());
-            TypeSymbol built = nd.typeName();
+            TypeSymbol.AtModule built = nd.typeName();
             // A type of another module is built through its checked entry: `new` reaches a constructor
             // that is not public, and the checked entry is the declared path either way.
             if (DataChecker.isInvariantBearing(built, symbols) || symbols.scope().isForeign(built)) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -719,7 +719,7 @@ final class CodecGen {
      * between a boundary that holds and one that quietly does not.
      */
     private List<Hir.InvariantClause> dischargeForm(Hir.Data data) {
-        return TypeOps.expandedInvariants(data.declares(), data, symbols,
+        return TypeOps.expandedInvariants(data.declares(), symbols,
                 ctx.dischargeInvariants()).whole()
                 .orElseThrow(() -> new RulesWereNotAllRead(data.declares().name()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -25,6 +25,7 @@ import souther.compiler.check.Lower;
 import souther.compiler.check.ReqSig;
 import souther.compiler.check.Sig;
 import souther.compiler.check.DerivedSymbols;
+import souther.compiler.check.InvariantHeader;
 import souther.compiler.check.TypeOps;
 import souther.compiler.core.EnsuresEnforcement;
 import souther.compiler.codegen.Backend;
@@ -618,28 +619,19 @@ public final class Output {
                     writtenValue(check.value()), clausesOf(db, check), check.pos());
         }
 
-        /** What the type is declared to hold of its values, in declaration order, or none where the
-         *  declaring module cannot be read here. */
+        /** What the type is declared to hold of its values, in declaration order — the names, which
+         *  are what a report of a constant that broke one quotes, and which every representation of
+         *  the declaration agrees on. None where the declaring module has no scope here, which is a
+         *  module this compilation does not have rather than one whose clauses could not be read. */
         private static List<ConstantConstruction.Clause> clausesOf(Db db,
                 DataChecker.ConstCheck check) {
-            Answer<souther.compiler.check.Prepared> declaring =
-                    db.ask(new Shapes.Prepared(check.type().module()));
             Answer<DerivedSymbols> scope = Names.derivedSymbols(db, check.type().module());
-            if (!declaring.present() || !scope.present()) {
-                return List.of();
-            }
-            List<Hir.InvariantClause> clauses = null;
-            for (souther.compiler.check.Derived.Def declared : declaring.value().defs()) {
-                if (declared instanceof souther.compiler.check.Derived.Data data
-                        && data.declaration().node().name().equals(check.type().name())) {
-                    clauses = TypeOps.settledInvariants(data.declaration().node(), scope.value());
-                }
-            }
-            if (clauses == null) {
+            if (!scope.present()) {
                 return List.of();
             }
             List<ConstantConstruction.Clause> named = new ArrayList<>();
-            for (Hir.InvariantClause clause : clauses) {
+            for (InvariantHeader clause
+                    : TypeOps.invariantHeadersGoverning(check.type(), scope.value())) {
                 named.add(new ConstantConstruction.Clause(clause.name()));
             }
             return named;

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -59,7 +59,7 @@ public final class Shapes {
      *
      * <p>Which clauses govern a declaration is a separate question and is not answered here:
      * a clause of a type this one spreads stays that type's, and
-     * {@link souther.compiler.check.TypeOps#settledInvariants} composes them where one is asked
+     * {@link souther.compiler.check.TypeOps#expandedInvariants} composes them where one is asked
      * for.
      *
      * <p>Settling substitutes what the modules this one imports publish to it, as lowering a body
@@ -491,7 +491,7 @@ public final class Shapes {
                     for (Hir.InvariantClause declared : data.invariants()) {
                         for (ClausesForDischarge.ClauseReading written
                                 : declaring.conjunctsOf(declared.expr(), new BindingOwner.OfData(named))) {
-                            clauses.add(InvariantChecker.capabilityOf(written, named, data,
+                            clauses.add(InvariantChecker.capabilityOf(written, named,
                                     reading.value(),
                                     db.ask(new Front.Reading()).value()).named(declared.name()));
                         }

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -111,7 +111,7 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
             Compilation c = compiled(reached);
 
             assertEquals(Map.of("lo", new BindingId(declaring, 0), "hi", new BindingId(declaring, 1)),
-                    readBy(c, "demo").bindingsOf(RANGE, range(c)),
+                    readBy(c, "demo").bindingsOf(RANGE),
                     "reached " + reached + ": a field is bound by the declaration that wrote it");
         }
     }
@@ -132,9 +132,9 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
             Hir.Expr clause = range.invariants().get(0).expr();
 
             ClauseAsExpanded read = new ClauseAsExpanded(clause, CallsLeftStanding.NONE);
-            Core athome = readBy(c, "up").typed(read, RANGE, range).orNull();
+            Core athome = readBy(c, "up").typed(read, RANGE).orNull();
             assertNotNull(athome, "the declaring module reads its own rule");
-            assertEquals(athome, readBy(c, "demo").typed(read, RANGE, range).orNull(),
+            assertEquals(athome, readBy(c, "demo").typed(read, RANGE).orNull(),
                     "reached " + reached + ": one rule, read the same either side of the boundary");
         }
     }
@@ -182,10 +182,8 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
         Clauses read = readBy(c, "demo");
 
         TypeSymbol.AtModule ours = TypeSymbols.declared(new TypeKey("demo", "Range"));
-        Hir.Data mine = (Hir.Data) c.db().ask(new Names.ResolvedDeclaration(ours.key())).value();
-
-        assertTrue(Collections.disjoint(read.bindingsOf(RANGE, range(c)).values(),
-                        read.bindingsOf(ours, mine).values()),
+        assertTrue(Collections.disjoint(read.bindingsOf(RANGE).values(),
+                        read.bindingsOf(ours).values()),
                 "two declarations of `Range` bind two sets of fields");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -119,8 +119,8 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
                     continue;
                 }
                 TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey(module, data.name()));
-                for (TypeOps.Declared each : clauses.of(named, data).reached()) {
-                    assertNotNull(clauses.typed(each.asExpanded(), named, data),
+                for (TypeOps.Declared each : clauses.of(named).reached()) {
+                    assertNotNull(clauses.typed(each.asExpanded(), named),
                             "`" + data.name() + "` declares a clause this check could not type:\n"
                                     + source);
                     read++;

--- a/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Scopes;
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -20,15 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class HowManyValuesAPositionHasIsNotHowMuchItHoldsTest {
 
-    private static Hir.Data data(Compilation compilation, String name) {
-        for (Hir.Def def : compilation.module("demo").defs().stream().map(each -> each.declaration().node()).toList()) {
-            if (def instanceof Hir.Data found && found.name().equals(name)) {
-                return found;
-            }
-        }
-        throw new IllegalArgumentException("no such declaration: " + name);
-    }
-
     private static Cardinality valuesAt(String source, String name, RuleKey path) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
@@ -40,7 +30,7 @@ class HowManyValuesAPositionHasIsNotHowMuchItHoldsTest {
                 "the model this reads has to be one somebody could write");
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return OccurrenceValues.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)),
-                data(compilation, name), RuleReadings.of(compilation, "demo"),
+                RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
                 .wholeValuesAt(path);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Scopes;
-import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -28,15 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class UnsupportedInformationNeverShrinksTheModelSetTest {
 
-    private static Hir.Data data(Compilation compilation, String name) {
-        for (Hir.Def def : compilation.module("demo").defs().stream().map(each -> each.declaration().node()).toList()) {
-            if (def instanceof Hir.Data found && found.name().equals(name)) {
-                return found;
-            }
-        }
-        throw new IllegalArgumentException("no such declaration: " + name);
-    }
-
     private static FieldDomains domainsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
@@ -51,7 +41,7 @@ class UnsupportedInformationNeverShrinksTheModelSetTest {
         compilation.answerEverything();
         Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return OccurrenceCounts.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)),
-                data(compilation, name), RuleReadings.of(compilation, "demo"),
+                RuleReadings.of(compilation, "demo"),
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatFallsOpenIsWhatSomebodyNamedALimitTest.java
@@ -193,7 +193,7 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
     void whatAClauseIsReadOverIsWorkedOutInsideTheReading() {
         Compilation c = answered(STANDING);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("demo", "制限木"));
-        TypeOps.Declared clause = expandedClauseOf(c, named, declarationOf(c, named));
+        TypeOps.Declared clause = expandedClauseOf(c, named);
         List<GaveUp> gaveUp = new ArrayList<>();
         InvariantChecker.GAVE_UP = gaveUp;
         try {
@@ -269,7 +269,7 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         Compilation c = answered(TWO_STANDING);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("demo", "制限木"));
         Hir.Data data = declarationOf(c, named);
-        TypeOps.Declared clause = expandedClauseOf(c, named, data);
+        TypeOps.Declared clause = expandedClauseOf(c, named);
         Supplier<SecondaryClauseReading.Over> over =
                 () -> new SecondaryClauseReading.Over(
                         DataChecker.fieldScope(named, data, symbolsOf(c)),
@@ -300,7 +300,7 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         Compilation c = answered(STANDING);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("demo", "制限木"));
         Hir.Data data = declarationOf(c, named);
-        TypeOps.Declared clause = expandedClauseOf(c, named, data);
+        TypeOps.Declared clause = expandedClauseOf(c, named);
         java.util.function.Supplier<SecondaryClauseReading.Over> over =
                 () -> new SecondaryClauseReading.Over(
                         DataChecker.fieldScope(named, data, symbolsOf(c)),
@@ -325,9 +325,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
     void anExpansionSaysWhatItLeftStanding() {
         Compilation c = answered(STANDING);
         TypeSymbol.AtModule named = TypeSymbols.declared(new TypeKey("demo", "制限木"));
-        Hir.Data data = declarationOf(c, named);
 
-        assertFalse(expandedClauseOf(c, named, data).standing().leftNothing(),
+        assertFalse(expandedClauseOf(c, named).standing().leftNothing(),
                 "the recursive helper the clause names is left standing");
     }
 
@@ -353,9 +352,8 @@ class WhatFallsOpenIsWhatSomebodyNamedALimitTest {
         return data;
     }
 
-    private static TypeOps.Declared expandedClauseOf(Compilation c, TypeSymbol.AtModule named,
-                                                     Hir.Data data) {
-        List<TypeOps.Declared> reached = TypeOps.expandedInvariants(named, data, symbolsOf(c),
+    private static TypeOps.Declared expandedClauseOf(Compilation c, TypeSymbol.AtModule named) {
+        List<TypeOps.Declared> reached = TypeOps.expandedInvariants(named, symbolsOf(c),
                 lookupOf(c)).reached();
         assertEquals(1, reached.size(), () -> named + " writes the one clause this reads");
         return reached.get(0);

--- a/souther-compiler/src/test/java/souther/compiler/query/AnInheritedRuleRunsAsItsOwnModuleSettledItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnInheritedRuleRunsAsItsOwnModuleSettledItTest.java
@@ -1,0 +1,127 @@
+package souther.compiler.query;
+
+import souther.compiler.core.ValueShape;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A rule a spread brings in from another module runs as the module that wrote it settled it.
+ *
+ * <p>What a clause states is settled per module: a helper the clause names is expanded into it. A
+ * module publishes the type and not every definition its rules are written over, so a reader handed
+ * the clause as resolution left it is handed a name that means nothing where it stands — and the
+ * reading that runs would be elaborating something no author wrote.
+ *
+ * <p>Held at the reading that runs, because that is the consumer of the settled form: what a value
+ * is checked against when it is built. The other representation a clause has is read from
+ * {@code ExpandedClauseLookup}, which answers by declaration and cannot be handed a node.
+ *
+ * <p>Compared against what the declaring module's own reading runs, rather than against a shape.
+ * What is being held is that a rule is its declaration's wherever it is read, not that today's
+ * expansion comes out one particular way.
+ *
+ * <p><b>What this pins is behaviour that already holds, and it is written down for that reason.</b>
+ * Reading a declaration from a world at the wrong stage breaks every reader of it, this module's
+ * own included, so no degradation of the world tells the two apart — which is to say the ownership
+ * here is not held up by anything a run can observe. What holds it is the shape of the walk: the
+ * declarations it reaches come from one world and what they state comes from one owner, and that is
+ * held where it can be, over the surface rather than over a run.
+ */
+class AnInheritedRuleRunsAsItsOwnModuleSettledItTest {
+
+    private static final TypeSymbol.AtModule THE_SPREAD =
+            TypeSymbols.declared(new TypeKey("wrote", "Base"));
+
+    private static final TypeSymbol.AtModule THE_TAKER =
+            TypeSymbols.declared(new TypeKey("reads", "Wider"));
+
+    /** The rule is written over a definition of this module, which the module does not publish. */
+    private static final String DECLARING = """
+            module wrote exposing ( Base )
+
+            let floor = 0
+
+            data Base = { n: Int }
+                invariant atLeast = n >= floor
+            """;
+
+    /** Takes the rule in with the fields, so what it holds of a value is the other module's. */
+    private static final String READING = """
+            module reads
+
+            import wrote ( Base )
+
+            data Wider = { ...Base, m: Int }
+            """;
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofSources(List.of(DECLARING, READING), ModulePath.EMPTY);
+        c.answerEverything();
+        assertEquals(List.of(), c.db().allReports(), "the workspace compiles to begin with");
+        return c;
+    }
+
+    /** What the reading that runs holds a value of {@code named} to. */
+    private static List<ValueShape.Invariant> runsAgainst(Compilation c,
+                                                          TypeSymbol.AtModule named) {
+        Answer<Map<TypeSymbol.AtModule, ValueShape>> shapes =
+                c.db().ask(new Shapes.ValueShapes(named.module()));
+        assertNotNull(shapes.value(), () -> named.module() + " has a reading that runs");
+        ValueShape shape = shapes.value().get(named);
+        assertNotNull(shape, () -> named + " is read there");
+        return shape.invariants();
+    }
+
+    @Test
+    void aRuleTakenInFromAnotherModuleRunsAsThatModuleSettledIt() {
+        Compilation c = compiled();
+
+        List<ValueShape.Invariant> wrote = runsAgainst(c, THE_SPREAD);
+        assertFalse(wrote.isEmpty(), "the declaration under test states a rule");
+
+        assertEquals(wrote.toString(), runsAgainst(c, THE_TAKER).toString(),
+                "the rule a spread brings in is the one its own module settled");
+    }
+
+    /**
+     * And the settling rewrites that rule, which is what makes the check above say something.
+     *
+     * <p>Were the clause left alone — the bound written out, the definition it names exposed — every
+     * reading of it would agree and the check above would hold of a compiler that never settled
+     * anything.
+     */
+    @Test
+    void theRuleUnderTestIsOneTheSettlingRewrites() {
+        Compilation c = compiled();
+
+        Answer<souther.compiler.check.Normalized.Def> settled =
+                c.db().ask(new Shapes.NormalizedDef(THE_SPREAD.key()));
+        Answer<souther.compiler.ast.Hir.Def> resolved =
+                c.db().ask(new Names.ResolvedDeclaration(THE_SPREAD.key()));
+        assertNotNull(settled.value(), "the declaration under test is normalized");
+        assertNotNull(resolved.value(), "the declaration under test is resolved");
+
+        assertFalse(clausesOf(settled.value().node()).equals(clausesOf(resolved.value())),
+                "the rule under test is one the settling rewrites");
+    }
+
+    private static String clausesOf(souther.compiler.ast.Hir.Def def) {
+        StringBuilder out = new StringBuilder();
+        for (souther.compiler.ast.Hir.InvariantClause clause
+                : ((souther.compiler.ast.Hir.Data) def).invariants()) {
+            out.append(clause.expr()).append('\n');
+        }
+        return out.toString();
+    }
+}


### PR DESCRIPTION
Closes #1334.

Which rules govern a declaration — its own, and every one a spread reaches — is a walk over the declarations. Both walks took a declaration node beside the world they would read the rest from, so which representation the declaration asked about was in came from the caller and which the ones under it were in came from the world, and nothing either of them held said the two were one reading. `settledInvariants` said in its name which representation it answered in while its arguments carried none.

They take the name now, and read every declaration they reach from the world. The world says which declarations govern which; what each of them states is read from whatever owns that representation. The expanded form is `ExpandedClauseLookup`'s, which already answers by declaration and can be handed no node. The settled form is the derived world's, where a helper the declaring module wrote has been expanded into the clause that names it, and the walk that answers with one says so in its parameter.

What turns on neither is what a rule is called and where its author wrote it. Resolution settles those and `InvariantClause#with` carries them across every rewrite below, so `InvariantHeader` is well defined in every representation and the readers that want only those take it. What a clause states cannot be reached through it.

The same shape went with the walks wherever a declaration node was carried beside the world that would be asked about it: the memo in `Clauses`, the search in `Output`, the declaration a newtype layer handed out.

## What holds it

Over the surface, because a run cannot tell the difference. Reading a declaration from a world at the wrong stage breaks every reader of it, the declaring module's own included, so no degradation separates a walk that owns its representation from one that is handed it. What the surface holds is the two sentences above, read off the compiled class: no walk here is given both a name and a declaration, and one that answers with the settled form says which world it read. The reading follows a record that carries a walk's answer, so wrapping the answer says nothing about the reading having changed. Both rules were checked against a walk of each shape that breaks them.

Beside that, what a run does hold is written down as the behaviour it is: a rule a spread brings in from another module runs as the module that wrote it settled it, compared against that module's own reading rather than against the shape of today's expansion.

## Measured rather than assumed

This branch was rebuilt on the current `develop` after measuring there. An earlier version of it also moved the analysis reading to the derived world, on evidence taken before `ExpandedClauseLookup` landed; measured again on `develop`, the reading of a foreign declaration through that path is answered by the lookup and no resolved world reaches it, so that part is not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)