### PR TITLE
Work a population out once for the class that asks three questions of it

### DIFF
--- a/souther-bench/src/test/java/souther/bench/CorpusTest.java
+++ b/souther-bench/src/test/java/souther/bench/CorpusTest.java
@@ -1,5 +1,6 @@
 package souther.bench;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,19 @@ class CorpusTest {
 
     private static synchronized Compilation compiled(Corpus corpus) {
         return COMPILED.computeIfAbsent(corpus, Corpus::compile);
+    }
+
+    /**
+     * And given back when the class is done with them.
+     *
+     * <p>A fork runs its classes one after another and keeps the JVM, so what is held statically is
+     * held for every class after this one as well. What is kept here is two answered compilations of
+     * models the size somebody writes, with their classes materialised — a floor under the heap that
+     * the rest of this module's tests would be running above for a saving that is this class's.
+     */
+    @AfterAll
+    static void released() {
+        COMPILED.clear();
     }
 
     @Test

--- a/souther-bench/src/test/java/souther/bench/CorpusTest.java
+++ b/souther-bench/src/test/java/souther/bench/CorpusTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Compilation;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -21,10 +24,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("population")
 class CorpusTest {
 
+    /**
+     * Each corpus compiled once for the class.
+     *
+     * <p>Three questions are asked of the same compiles and none of them changes one, so a compile
+     * per question is the same answer worked out again — and a corpus is the size someone writes,
+     * so working it out again is most of what this class costs.
+     */
+    private static final Map<Corpus, Compilation> COMPILED = new LinkedHashMap<>();
+
+    private static synchronized Compilation compiled(Corpus corpus) {
+        return COMPILED.computeIfAbsent(corpus, Corpus::compile);
+    }
+
     @Test
     void everyCorpusCompiles() {
         for (Corpus corpus : Corpus.all()) {
-            corpus.check(corpus.compile());
+            corpus.check(compiled(corpus));
         }
     }
 
@@ -49,8 +65,7 @@ class CorpusTest {
             if (corpus.sources().size() < 2) {
                 continue;
             }
-            Compilation compilation = corpus.compile();
-            if (compilation.modules().size() >= 2) {
+            if (compiled(corpus).modules().size() >= 2) {
                 return;
             }
         }
@@ -65,7 +80,7 @@ class CorpusTest {
     void aCorpusOfOneSourceNamesOneModule() {
         for (Corpus corpus : Corpus.all()) {
             if (corpus.sources().size() == 1) {
-                assertTrue(corpus.compile().modules().size() == 1,
+                assertTrue(compiled(corpus).modules().size() == 1,
                         () -> corpus + " is one source and names several modules");
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
@@ -89,14 +89,24 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
     /** The same three rules in every order, and one answer between them. */
     @Test
     void everyOrderOfTheSameRulesLeavesTheSameAnswer() {
-        AdmissibleSet first = admitted(RULES, ORDERS.get(0));
+        AdmissibleSet first = sameInEveryOrder(RULES);
 
-        for (List<Integer> order : ORDERS) {
-            assertEquals(first, admitted(RULES, order),
-                    "the values and the account of them, written as " + order);
-        }
         assertEquals(AdmissibleSet.READ_IN_FULL, first.completeness(),
                 "and every one of them is read in full, since no product of patterns is built");
+    }
+
+    /** What {@code rules} admit, which every order of them comes to. Each order is read once:
+     *  reading it is building two machines, and the first order read twice is one machine too many. */
+    private static AdmissibleSet sameInEveryOrder(List<String> rules) {
+        AdmissibleSet first = null;
+        for (List<Integer> order : ORDERS) {
+            AdmissibleSet each = admitted(rules, order);
+            if (first == null) {
+                first = each;
+            }
+            assertEquals(first, each, "the values and the account of them, written as " + order);
+        }
+        return first;
     }
 
     /**
@@ -113,12 +123,8 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
      */
     @Test
     void theSameHoldsWhereEveryRuleIsAPattern() {
-        AdmissibleSet first = admitted(ALL_PATTERNS, ORDERS.get(0));
+        AdmissibleSet first = sameInEveryOrder(ALL_PATTERNS);
 
-        for (List<Integer> order : ORDERS) {
-            assertEquals(first, admitted(ALL_PATTERNS, order),
-                    "the values and the account of them, written as " + order);
-        }
         assertEquals(AdmissibleSet.READ_IN_FULL, first.completeness(),
                 "and the small one is met first, so nothing large is built");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
@@ -99,8 +99,10 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
      * What {@code rules} admit, which every order of them comes to.
      *
      * <p>The first order is what the rest are held against, so it is read before the loop and the
-     * loop is over the other five. Read inside it as well, the first comparison would be a value
-     * against itself, which asserts nothing and costs the two machines that reading an order is.
+     * loop is over the other five. Read inside the loop as well it would be read twice, and what
+     * the two readings of it are held against each other for is that one order comes out the same
+     * way twice — which is a claim about a compile repeating itself and not about where the rules
+     * are written. That is what is given up here, for the two machines a reading of an order costs.
      */
     private static AdmissibleSet sameInEveryOrder(List<String> rules) {
         AdmissibleSet first = admitted(rules, ORDERS.getFirst());

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest.java
@@ -95,16 +95,19 @@ class WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest {
                 "and every one of them is read in full, since no product of patterns is built");
     }
 
-    /** What {@code rules} admit, which every order of them comes to. Each order is read once:
-     *  reading it is building two machines, and the first order read twice is one machine too many. */
+    /**
+     * What {@code rules} admit, which every order of them comes to.
+     *
+     * <p>The first order is what the rest are held against, so it is read before the loop and the
+     * loop is over the other five. Read inside it as well, the first comparison would be a value
+     * against itself, which asserts nothing and costs the two machines that reading an order is.
+     */
     private static AdmissibleSet sameInEveryOrder(List<String> rules) {
-        AdmissibleSet first = null;
-        for (List<Integer> order : ORDERS) {
-            AdmissibleSet each = admitted(rules, order);
-            if (first == null) {
-                first = each;
-            }
-            assertEquals(first, each, "the values and the account of them, written as " + order);
+        AdmissibleSet first = admitted(rules, ORDERS.getFirst());
+
+        for (List<Integer> order : ORDERS.subList(1, ORDERS.size())) {
+            assertEquals(first, admitted(rules, order),
+                    "the values and the account of them, written as " + order);
         }
         return first;
     }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
@@ -51,7 +51,7 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
     @Test
     void aReadingThatStoppedIsCarriedByThePositionItStoppedAt() throws Exception {
         TreeSet<String> met = new TreeSet<>();
-        for (InputDomain read : everyReading()) {
+        for (InputDomain read : EVERY_READING) {
             for (Position each : read.positions()) {
                 if (each.rulesWithoutALine().stream()
                         .noneMatch(one -> one.why() instanceof BlockReason.RuleReadingStopped)) {
@@ -72,7 +72,7 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
     @Test
     void andSoIsOneWhoseRuleNothingClassified() throws Exception {
         TreeSet<String> met = new TreeSet<>();
-        for (InputDomain read : everyReading()) {
+        for (InputDomain read : EVERY_READING) {
             for (Position each : read.positions()) {
                 if (each.unansweredQuestions().stream()
                         .noneMatch(StandingQuestion.Unclassified.class::isInstance)) {
@@ -120,13 +120,21 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
                 () -> "and nothing is short of the position's rules: " + at.reading());
     }
 
-    /** The reading of every behavior of every model this repository carries. */
+    /**
+     * The reading of every behavior of every model this repository carries.
+     *
+     * <p>Read once for the class, as the models are compiled once for the JVM: two questions here
+     * walk the same readings and neither changes one, so reading them per question is the same
+     * work over — and reading the population is most of what this class costs.
+     */
+    private static final List<InputDomain> EVERY_READING = everyReading();
+
     private static List<InputDomain> everyReading() {
         List<InputDomain> out = new ArrayList<>();
         for (Compilation compilation : RepositoryModels.all()) {
             readings(compilation, out);
         }
-        return out;
+        return List.copyOf(out);
     }
 
     private static void readings(Compilation compilation, List<InputDomain> out) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
@@ -51,7 +51,7 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
     @Test
     void aReadingThatStoppedIsCarriedByThePositionItStoppedAt() throws Exception {
         TreeSet<String> met = new TreeSet<>();
-        for (InputDomain read : EVERY_READING) {
+        for (InputDomain read : everyReading()) {
             for (Position each : read.positions()) {
                 if (each.rulesWithoutALine().stream()
                         .noneMatch(one -> one.why() instanceof BlockReason.RuleReadingStopped)) {
@@ -72,7 +72,7 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
     @Test
     void andSoIsOneWhoseRuleNothingClassified() throws Exception {
         TreeSet<String> met = new TreeSet<>();
-        for (InputDomain read : EVERY_READING) {
+        for (InputDomain read : everyReading()) {
             for (Position each : read.positions()) {
                 if (each.unansweredQuestions().stream()
                         .noneMatch(StandingQuestion.Unclassified.class::isInstance)) {
@@ -120,21 +120,31 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
                 () -> "and nothing is short of the position's rules: " + at.reading());
     }
 
+    /** The readings, once they have been made. */
+    private static List<InputDomain> everyReading;
+
     /**
      * The reading of every behavior of every model this repository carries.
      *
      * <p>Read once for the class, as the models are compiled once for the JVM: two questions here
      * walk the same readings and neither changes one, so reading them per question is the same
      * work over — and reading the population is most of what this class costs.
+     *
+     * <p>Read when one of them asks, and not while the class is initialised. What this population
+     * failing to be read looks like is the regression this class is about, and a class that could
+     * not initialise reports it as an initialiser that threw on every method — including the one
+     * below that reads none of this and is what says the other two are answerable.
      */
-    private static final List<InputDomain> EVERY_READING = everyReading();
-
-    private static List<InputDomain> everyReading() {
+    private static synchronized List<InputDomain> everyReading() {
+        if (everyReading != null) {
+            return everyReading;
+        }
         List<InputDomain> out = new ArrayList<>();
         for (Compilation compilation : RepositoryModels.all()) {
             readings(compilation, out);
         }
-        return List.copyOf(out);
+        everyReading = List.copyOf(out);
+        return everyReading;
     }
 
     private static void readings(Compilation compilation, List<InputDomain> out) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +146,19 @@ class APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest {
         }
         everyReading = List.copyOf(out);
         return everyReading;
+    }
+
+    /**
+     * And given back when the class is done with them.
+     *
+     * <p>A fork keeps its JVM, so what is held statically is held for every class after this one.
+     * Less than what a corpus's compiles come to — the compilations these are read from are
+     * {@link RepositoryModels}' and stay whatever this does — but the readings themselves are this
+     * class's, and it is the class that wanted them.
+     */
+    @AfterAll
+    static void released() {
+        everyReading = null;
     }
 
     private static void readings(Compilation compilation, List<InputDomain> out) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.inputs;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -208,13 +209,37 @@ class NoRuleIsPlacedWhereNothingAccountsForItTest {
         return out;
     }
 
-    /** The rules of every value every reading of this repository's models opens. */
-    private static List<PlacedRules> everyValueRead() {
+    /** The rules of every value the models open, once they have been read. */
+    private static List<PlacedRules> everyValueRead;
+
+    /**
+     * The rules of every value every reading of this repository's models opens.
+     *
+     * <p>Read once for the class. Two questions here walk these and neither changes one, so
+     * reading them per question is the same work over — and the models are compiled once for the
+     * JVM already, which is the same arrangement one step further down.
+     *
+     * <p>Read when a question asks rather than while the class is initialised: a population that
+     * cannot be read is what this class is about, and an initialiser that threw reports it on every
+     * method at once and names no cause.
+     */
+    private static synchronized List<PlacedRules> everyValueRead() {
+        if (everyValueRead != null) {
+            return everyValueRead;
+        }
         List<PlacedRules> out = new ArrayList<>();
         for (Compilation compilation : ASKED_ABOUT) {
             valuesRead(compilation, out);
         }
-        return out;
+        everyValueRead = List.copyOf(out);
+        return everyValueRead;
+    }
+
+    /** And given back when the class is done with them, as the readings of a corpus are: a fork
+     *  keeps its JVM, so what is held statically is held for every class after this one. */
+    @AfterAll
+    static void released() {
+        everyValueRead = null;
     }
 
     private static void valuesRead(Compilation compilation, List<PlacedRules> out) {


### PR DESCRIPTION
## What

Four classes worked the same thing out more than once, and none of their questions changes what it reads. Each now reads it once for the class — when a question asks, rather than while the class is initialised — and gives it back when the class is done.

- `CorpusTest` compiled every bench corpus per question.
- `APositionARuleWasNotReadAtDoesNotReadAsOneEveryRuleWasReadAtTest` made the reading of every behavior of every repository model per question.
- `NoRuleIsPlacedWhereNothingAccountsForItTest` held the compilations for the class and read the values of every one of them again per question.
- `WhatARuleCostsDoesNotTurnOnWhereItIsWrittenTest` read the order the other orders are held against a second time inside the loop.

## Why

Measured from the surefire records of a population-included run: the first three are among the longest classes of the nightly, and the fourth is the longest of a pull request's run. What each costs is the population it reads, so reading it once is what there is to save; the rest of what they do is the question itself.

The saving is measured by running the four classes in one JVM against the same four on `develop`, interleaved and repeated, because the same class varies by half again between whole runs on a machine somebody else is also using.

## What is given up

The last of them read one order twice, and holding the two readings against each other says that a compile of one order repeats itself. That is a claim about the compile rather than about where the rules are written, and it goes with the second reading. What the loop still holds is the class's own subject: the answer and the account of it do not turn on the order the rules were written in.

## Read when a question asks

Not while the class is initialised. A population that cannot be read is the regression these classes are about, and an initialiser that threw reports it as a failure of every method at once — including the ones that read none of it and are what say the others are answerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
