### PR TITLE
Read the ranges at the leaves, and settle a choice where both languages are held

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -508,10 +508,12 @@ sealed interface Confinement<A> {
          * <p>Each language is asked what two dead branches leave it, and neither is asked whether
          * they are dead — a language may be perfectly happy with a branch the other refused, and
          * asked through the entry for a choice that stands it would answer for that branch with the
-         * ends it read. The two are not asked alike: the values are taken as leaving nothing first,
-         * which is what stops a position one alternative emptied from being named the reason a
-         * choice nobody can take is empty, and the ranges are not, because what they leave empty
-         * between two branches is already what every alternative leaves empty.
+         * ends it read.
+         *
+         * <p>The values are taken as leaving nothing before they are asked and the ranges are not,
+         * so the two answer differently about which position a dead choice is empty at: the ranges
+         * name the positions every alternative emptied, and the values, having been emptied whole,
+         * name none.
          */
         Planned<A> bothDead(Planned<A> other, Admission<A> shown) {
             return new Planned<>(values.leavingNothing().bothDead(other.values.leavingNothing()),

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -487,8 +487,8 @@ sealed interface Confinement<A> {
          *  nothing has shown the choice empty. */
         Planned<A> either(Planned<A> other, boolean apart) {
             return new Planned<>(
-                    apart ? values.joinApart(other.values) : values.join(other.values),
-                    ordered.join(other.ordered),
+                    apart ? values.joinLiveApart(other.values) : values.joinLive(other.values),
+                    ordered.joinLive(other.ordered),
                     Confinement.both(carriers, other.carriers));
         }
 
@@ -504,10 +504,16 @@ sealed interface Confinement<A> {
          * <p>What the choice was shown by is what both of them were shown by, and where is where
          * both were refused. Neither speaks for the other: alternatives refused at different
          * positions leave a choice no position is why, which is what the proof has to say.
+         *
+         * <p>Each language is told that its branch is one nobody can take before it is asked what
+         * two such branches come to. Which of them showed it is not the question here — a branch
+         * the values refused is a branch the ranges are also nobody's, and a side left as it was
+         * would answer for a dead choice with the ends of a branch that stands.
          */
         Planned<A> bothDead(Planned<A> other, Admission<A> shown) {
             return new Planned<>(values.leavingNothing().bothDead(other.values.leavingNothing()),
-                    ordered.join(other.ordered), Confinement.both(carriers, other.carriers), shown);
+                    ordered.leavingNothing().bothDead(other.ordered.leavingNothing()),
+                    Confinement.both(carriers, other.carriers), shown);
         }
 
         /** This, holding what working it out could not build. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -510,10 +510,12 @@ sealed interface Confinement<A> {
          * asked through the entry for a choice that stands it would answer for that branch with the
          * ends it read.
          *
-         * <p>The values are taken as leaving nothing before they are asked and the ranges are not,
-         * so the two answer differently about which position a dead choice is empty at: the ranges
-         * name the positions every alternative emptied, and the values, having been emptied whole,
-         * name none.
+         * <p>The values are taken as leaving nothing before they are asked and the ranges are not.
+         * A reading that already admits nothing is left as it is, so that is not the difference it
+         * looks like: what a branch another language killed leaves the values is a reading that
+         * holds nothing and names no position, and what a branch the values killed leaves them is
+         * the positions they emptied. Either language names a position only where every alternative
+         * of that language left it empty.
          */
         Planned<A> bothDead(Planned<A> other, Admission<A> shown) {
             return new Planned<>(values.leavingNothing().bothDead(other.values.leavingNothing()),

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -505,14 +505,17 @@ sealed interface Confinement<A> {
          * both were refused. Neither speaks for the other: alternatives refused at different
          * positions leave a choice no position is why, which is what the proof has to say.
          *
-         * <p>Each language is told that its branch is one nobody can take before it is asked what
-         * two such branches come to. Which of them showed it is not the question here — a branch
-         * the values refused is a branch the ranges are also nobody's, and a side left as it was
-         * would answer for a dead choice with the ends of a branch that stands.
+         * <p>Each language is asked what two dead branches leave it, and neither is asked whether
+         * they are dead — a language may be perfectly happy with a branch the other refused, and
+         * asked through the entry for a choice that stands it would answer for that branch with the
+         * ends it read. The two are not asked alike: the values are taken as leaving nothing first,
+         * which is what stops a position one alternative emptied from being named the reason a
+         * choice nobody can take is empty, and the ranges are not, because what they leave empty
+         * between two branches is already what every alternative leaves empty.
          */
         Planned<A> bothDead(Planned<A> other, Admission<A> shown) {
             return new Planned<>(values.leavingNothing().bothDead(other.values.leavingNothing()),
-                    ordered.leavingNothing().bothDead(other.ordered.leavingNothing()),
+                    ordered.bothDead(other.ordered),
                     Confinement.both(carriers, other.carriers), shown);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -19,6 +19,14 @@ import java.util.Map;
  * Which clauses reach a value is settled once, by the walk that gathers them; what each reading
  * makes of a clause is its own.
  *
+ * <p><b>Leaves, and not the connectives over them.</b> What a conjunction or a choice of these
+ * comes to is asked where both languages are held together and where the choices of a declaration
+ * are decided ({@code StatedByClauses}), because a branch nobody can be in is settled by things
+ * neither language holds alone. Answered here as well, that would be a second place deciding what
+ * a choice does to the ranges, and a branch would be dropped only where the ranges were also what
+ * could show it impossible — leaving {@code s < "" || (b == true && b == false)} a choice whose
+ * every branch some language refused and neither refused alone.
+ *
  * <p><b>Why it is not the interval algebra.</b> That one carries one number per position and relates
  * positions to each other by differences, which is worth having and is available only where a model
  * adds and subtracts — so it holds an {@code Int} and a {@code Decimal} and nothing else. This holds
@@ -48,7 +56,7 @@ import java.util.Map;
  * end, and the values a denial leaves are a set rather than a range. Under a denial the two swap
  * places, which is the same rule read once.
  */
-final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject>, Denotations> {
+final class OrderedReading {
 
     private final Terms terms;
     /** What each position's values are ordered on, for the positions that are ordered at all. */
@@ -87,25 +95,6 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
         return carriers;
     }
 
-    @Override
-    public OrderedIntervals<FactSubject> nothingSaid() {
-        return OrderedIntervals.top();
-    }
-
-    @Override
-    public OrderedIntervals<FactSubject> both(OrderedIntervals<FactSubject> one, OrderedIntervals<FactSubject> other) {
-        return one.meet(other);
-    }
-
-    @Override
-    public OrderedIntervals<FactSubject> either(Core writtenAt,
-                                                OrderedIntervals<FactSubject> one,
-                                                OrderedIntervals<FactSubject> other) {
-        // Where two alternatives leave a position is this reading's rule and turns on nothing an
-        // author wrote, so the node the fold hands over is nothing this has a use for.
-        return one.join(other);
-    }
-
     /**
      * A comparison places an end; nothing else here is read.
      *
@@ -114,8 +103,7 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject
      * value sets' answer, and a second account of it kept here would be a second thing to hold in
      * step.
      */
-    @Override
-    public OrderedIntervals<FactSubject> leaf(Core e, boolean positive, Denotations at) {
+    OrderedIntervals<FactSubject> leaf(Core e, boolean positive, Denotations at) {
         return e instanceof Core.Binary bin ? comparison(bin, positive, at) : OrderedIntervals.top();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -607,12 +607,20 @@ sealed interface StatedByClauses {
          * alternative contains, at a position the rules are fine with, and one the refusal would
          * then be written about.
          *
-         * <p>So each side is taken as leaving nothing ({@link AdmissibleValues#leavingNothing},
-         * {@link OrderedIntervals#leavingNothing}) and the languages are joined as they are for any
-         * other choice. What each of them says the choice leaves empty is what <em>every</em>
-         * alternative leaves empty, and where that is no position, the choice admits nothing with
-         * none of them at fault. That is the rule {@link Emptiness.AcrossEveryCase} states for a
-         * sum — what proves it has none is the whole list — arrived at here for the same reason.
+         * <p><b>So which of four a choice is is decided here, and the languages are told the
+         * answer.</b> Every alternative dead is what both of them leave empty
+         * ({@link Confinement.Planned#bothDead}), where each side is first taken as leaving nothing
+         * ({@link AdmissibleValues#leavingNothing}, {@link OrderedIntervals#leavingNothing}); one
+         * alternative dead is the other alternative, which is held already and asks the languages
+         * nothing; both standing is what two readings somebody can be in come to
+         * ({@link Confinement.Planned#either}); and a fate nothing has settled keeps the choice.
+         * What each language is asked is which of those it is realising, and never which of them it
+         * is.
+         *
+         * <p>What every alternative leaves empty is what the dead choice leaves empty, and where
+         * that is no position, the choice admits nothing with none of them at fault. That is the
+         * rule {@link Emptiness.AcrossEveryCase} states for a sum — what proves it has none is the
+         * whole list — arrived at here for the same reason.
          *
          * <p>A choice this settles is settled once and for the whole rule, because it is settled
          * over the alternatives as written and there is one of those however many places

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -607,15 +607,15 @@ sealed interface StatedByClauses {
          * alternative contains, at a position the rules are fine with, and one the refusal would
          * then be written about.
          *
-         * <p><b>So which of four a choice is is decided here, and the languages are told the
+         * <p><b>So which of four a choice is is decided here, and the languages realise the
          * answer.</b> Every alternative dead is what both of them leave empty
-         * ({@link Confinement.Planned#bothDead}), where each side is first taken as leaving nothing
-         * ({@link AdmissibleValues#leavingNothing}, {@link OrderedIntervals#leavingNothing}); one
-         * alternative dead is the other alternative, which is held already and asks the languages
-         * nothing; both standing is what two readings somebody can be in come to
-         * ({@link Confinement.Planned#either}); and a fate nothing has settled keeps the choice.
-         * What each language is asked is which of those it is realising, and never which of them it
-         * is.
+         * ({@link Confinement.Planned#bothDead}); one alternative dead is the other alternative,
+         * which is held already and asks the languages nothing; both standing is what two readings
+         * somebody can be in come to ({@link Confinement.Planned#either}); and a fate nothing has
+         * settled keeps the choice. What each language is asked is which of those it is realising,
+         * and never which of them it is — a language may be perfectly happy with a branch the other
+         * refused, so a language asked to decide would answer about a branch and not about the
+         * choice.
          *
          * <p>What every alternative leaves empty is what the dead choice leaves empty, and where
          * that is no position, the choice admits nothing with none of them at fault. That is the

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedInterval.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedInterval.java
@@ -54,9 +54,14 @@ public record OrderedInterval(Endpoint low, Endpoint high) {
      * touch, and the ends around both admit everything either of them does — which is the safe
      * direction here, since what this decides is that a position has no value.
      *
-     * <p>An empty side contributes nothing. A rule that admits nothing is a choice nobody can take,
-     * so the alternatives that remain are what the choice leaves; hulled in as ends, the empty side
-     * would widen the answer to the other side's ends stretched over a range no value is in.
+     * <p>An empty side contributes no value to the hull, so the hull of one with a non-empty side is
+     * the other side. Hulled as ends instead, an empty range would stretch the answer over values
+     * neither side holds — its ends are places on the order all the same, and nothing lies between
+     * them.
+     *
+     * <p>Whether an alternative is one anybody can take is not asked here. That is about a whole
+     * reading rather than about one position, and is answered where the readings are
+     * ({@link OrderedIntervals#bothDead}).
      */
     public OrderedInterval join(OrderedInterval other) {
         if (holdsNothing()) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedInterval.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedInterval.java
@@ -59,9 +59,10 @@ public record OrderedInterval(Endpoint low, Endpoint high) {
      * neither side holds — its ends are places on the order all the same, and nothing lies between
      * them.
      *
-     * <p>Whether an alternative is one anybody can take is not asked here. That is about a whole
-     * reading rather than about one position, and is answered where the readings are
-     * ({@link OrderedIntervals#bothDead}).
+     * <p>Whether an alternative is one anybody can take is not asked here, and not by
+     * {@link OrderedIntervals} either. That is about a whole reading of a clause, which is more than
+     * the ranges: it is settled where the languages a clause is read in are held together, and what
+     * reaches this is one position of a branch whose fate is known.
      */
     public OrderedInterval join(OrderedInterval other) {
         if (holdsNothing()) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -136,14 +136,18 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
      * positions in both. Where there are none, the choice still admits nothing and no position is at
      * fault, and that is said as itself.
      *
-     * <p>Which alternatives nobody can take is not decided here. That turns on what every language
-     * reading the clause left, and this is called with the answer already in hand — an assertion
-     * because a caller passing something else is this compiler disagreeing with itself rather than
-     * anything a model says.
+     * <p>This realises a decision rather than making one. Which alternatives nobody can take turns
+     * on what every language reading the clause left, and a branch these ranges are perfectly happy
+     * with is one the values may have refused — so what arrives here is each side already told that
+     * nothing satisfies it ({@link #leavingNothing}), and what is asked is what two such sides leave
+     * empty between them.
+     *
+     * <p>Told a side that stands, this would answer that a choice somebody can take admits nothing,
+     * which is the one direction a state deciding emptiness may not move in. What keeps that from
+     * arriving is where the telling is done and not a question asked here: a check beside the call
+     * that normalises the sides is a check of the line above it.
      */
     public OrderedIntervals<A> bothDead(OrderedIntervals<A> other) {
-        assert isBottom() && other.isBottom()
-                : "the ranges of a dead choice are the ranges of two dead alternatives";
         Map<A, OrderedInterval> both = new LinkedHashMap<>();
         for (A position : holdingNothing()) {
             if (other.holdingNothing().contains(position)) {
@@ -167,9 +171,10 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
      *
      * <p>An assertion and not a branch, because a caller passing a side nobody can take is this
      * compiler disagreeing with itself rather than anything a model says. With assertions off the
-     * hull is taken over what the two spoke about, which admits every value either of them did and
-     * more — it loses what one side proved and invents no end, which is the direction this whole
-     * state is only ever allowed to move in.
+     * hull is taken over what the two spoke about, which admits everything either of them did: an
+     * empty range at a position both named contributes nothing to the hull, and a position only the
+     * live side named is left out and so left open. What is lost is what the dead side proved, and
+     * no end is invented — which is the direction this state is only ever allowed to move in.
      */
     public OrderedIntervals<A> joinLive(OrderedIntervals<A> other) {
         assert !isBottom() && !other.isBottom()

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -124,43 +124,56 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
     }
 
     /**
-     * Either reading holding.
+     * A choice no alternative of which anybody can take, said of the ranges.
      *
-     * <p>Over the positions both spoke about, since a position one of them left open is one the two
-     * of them together leave open.
-     *
-     * <p>A side holding nothing is an alternative nobody can take, so the choice is the other one.
-     * Asked of the whole side rather than position by position: a branch with one position empty is
-     * a branch no value satisfies, and hulling its other positions in would widen the answer by ends
-     * no value of the model is ever at.
-     *
-     * <p><b>Both sides holding nothing is a different case.</b> No side speaks for the other there,
-     * so answering with either would settle which position is named by the order the two were
-     * written in. Nor may the two be met: a meet is a conjunction, and the alternatives were never
-     * stated together — {@code (a < "" && b == 0) || (a < "" && b == 1)} met is a {@code b} bounded
-     * at 0 and at 1, which is a contradiction neither alternative contains and a position the rules
-     * are fine with.
+     * <p>No side speaks for the other, so answering with either would settle which position is
+     * named by the order the two were written in. Nor may the two be met: a meet is a conjunction,
+     * and the alternatives were never stated together — {@code (a < "" && b == 0) || (a < "" && b
+     * == 1)} met is a {@code b} bounded at 0 and at 1, which is a contradiction neither alternative
+     * contains and a position the rules are fine with.
      *
      * <p>What the choice leaves empty is what <em>every</em> alternative leaves empty, which is the
      * positions in both. Where there are none, the choice still admits nothing and no position is at
      * fault, and that is said as itself.
+     *
+     * <p>Which alternatives nobody can take is not decided here. That turns on what every language
+     * reading the clause left, and this is called with the answer already in hand — an assertion
+     * because a caller passing something else is this compiler disagreeing with itself rather than
+     * anything a model says.
      */
-    public OrderedIntervals<A> join(OrderedIntervals<A> other) {
-        if (isBottom() && other.isBottom()) {
-            Map<A, OrderedInterval> both = new LinkedHashMap<>();
-            for (A position : holdingNothing()) {
-                if (other.holdingNothing().contains(position)) {
-                    both.put(position, at(position).meet(other.at(position)));
-                }
+    public OrderedIntervals<A> bothDead(OrderedIntervals<A> other) {
+        assert isBottom() && other.isBottom()
+                : "the ranges of a dead choice are the ranges of two dead alternatives";
+        Map<A, OrderedInterval> both = new LinkedHashMap<>();
+        for (A position : holdingNothing()) {
+            if (other.holdingNothing().contains(position)) {
+                both.put(position, at(position).meet(other.at(position)));
             }
-            return new OrderedIntervals<>(both, true);
         }
-        if (isBottom()) {
-            return other;
-        }
-        if (other.isBottom()) {
-            return this;
-        }
+        return new OrderedIntervals<>(both, true);
+    }
+
+    /**
+     * Either reading holding, both alternatives being ones somebody can take.
+     *
+     * <p>Over the positions both spoke about, since a position one of them left open is one the two
+     * of them together leave open.
+     *
+     * <p>Which alternatives those are is not decided here, for the reason {@link #bothDead} gives:
+     * a branch nobody can be in is shown by what every language left, and a choice settled from the
+     * ranges alone would drop a branch no order admits while keeping one no set of values admits.
+     * A choice every alternative of which is dead is {@link #bothDead}, and a choice with one dead
+     * alternative is the other alternative, which the caller holds already.
+     *
+     * <p>An assertion and not a branch, because a caller passing a side nobody can take is this
+     * compiler disagreeing with itself rather than anything a model says. With assertions off the
+     * hull is taken over what the two spoke about, which admits every value either of them did and
+     * more — it loses what one side proved and invents no end, which is the direction this whole
+     * state is only ever allowed to move in.
+     */
+    public OrderedIntervals<A> joinLive(OrderedIntervals<A> other) {
+        assert !isBottom() && !other.isBottom()
+                : "a choice of two live alternatives was asked of " + this + " and " + other;
         Map<A, OrderedInterval> out = new LinkedHashMap<>();
         ranges.forEach((position, range) -> {
             OrderedInterval there = other.ranges.get(position);

--- a/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/OrderedIntervals.java
@@ -136,16 +136,18 @@ public record OrderedIntervals<A>(Map<A, OrderedInterval> ranges, boolean nothin
      * positions in both. Where there are none, the choice still admits nothing and no position is at
      * fault, and that is said as itself.
      *
-     * <p>This realises a decision rather than making one. Which alternatives nobody can take turns
-     * on what every language reading the clause left, and a branch these ranges are perfectly happy
-     * with is one the values may have refused — so what arrives here is each side already told that
-     * nothing satisfies it ({@link #leavingNothing}), and what is asked is what two such sides leave
-     * empty between them.
+     * <p>This realises a decision rather than making one, and it does not ask what it was made of.
+     * Which alternatives nobody can take turns on what every language reading the clause left, and
+     * a branch these ranges are perfectly happy with is one the values may have refused — so what
+     * arrives is the ranges as they were read, of a branch something else settled. What is answered
+     * is what the two of them leave empty between them, and the whole is said to hold nothing
+     * because the choice does, not because these ranges show it.
      *
-     * <p>Told a side that stands, this would answer that a choice somebody can take admits nothing,
-     * which is the one direction a state deciding emptiness may not move in. What keeps that from
-     * arriving is where the telling is done and not a question asked here: a check beside the call
-     * that normalises the sides is a check of the line above it.
+     * <p>Which is why there is no question here about the sides. Asked whether they hold nothing,
+     * this would be deciding what it was called to realise; told a side that stands, it answers
+     * that a choice somebody can take admits nothing, which is the one direction a state deciding
+     * emptiness may not move in. What keeps that from arriving is the caller having settled it,
+     * and there is no reading of a caller that has not.
      */
     public OrderedIntervals<A> bothDead(OrderedIntervals<A> other) {
         Map<A, OrderedInterval> both = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -489,13 +489,14 @@ public sealed interface PlannedValues<A> {
      * answers to one question, and the one made of values alone would drop a branch the order
      * refused and keep one the values did.
      */
-    default PlannedValues<A> join(PlannedValues<A> other) {
+    default PlannedValues<A> joinLive(PlannedValues<A> other) {
         return joinedLive(other, false);
     }
 
     /** Either reading holding, with the alternatives of the two held apart — see
-     *  {@link AdmissibleValues#joinApart}. */
-    default PlannedValues<A> joinApart(PlannedValues<A> other) {
+     *  {@link AdmissibleValues#joinApart}. Both branches are ones somebody can take, by the rule
+     *  {@link #joinLive} states. */
+    default PlannedValues<A> joinLiveApart(PlannedValues<A> other) {
         return joinedLive(other, true);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
@@ -150,13 +150,28 @@ public final class WhatWasCompiled {
     /**
      * Every class that calls {@code method} on {@code on}.
      *
-     * <p>For a rule about who may do something rather than about who may name a type. A call is in
-     * the caller's constant pool whatever it is spelled like at the call site, and a lambda's body
-     * is compiled into the class that wrote it, so a caller cannot get out of this by writing the
-     * call somewhere shorter.
+     * <p>For a rule about who may do something rather than about who may name a type. A lambda's
+     * body is compiled into the class that wrote it, so a caller cannot get out of this by writing
+     * the call somewhere shorter.
+     *
+     * <p><b>Through whatever type it is named.</b> What a call site puts in the constant pool is
+     * the type the receiver was declared as, so a method of an interface called through one of its
+     * implementations is a reference to the implementation. A rule about who may do something is
+     * about the operation and not about the spelling of the variable it was reached through, and a
+     * rule reading only the type it was asked about would be escaped by declaring the receiver one
+     * step down. So the owners are that type and every compiled type that answers it
+     * ({@link #implementing}).
+     *
+     * <p>A type this module did not compile has no implementations to gather, and the walk over
+     * what it did compile finds none — which is the right answer for a rule about this module's own
+     * calls into somebody else's type.
      */
     public static Set<String> callersOf(Class<?> on, String method) {
-        ClassDesc owner = on.describeConstable().orElseThrow();
+        Set<ClassDesc> owners = new LinkedHashSet<>();
+        owners.add(on.describeConstable().orElseThrow());
+        for (String each : implementing(on)) {
+            owners.add(ClassDesc.of(each));
+        }
         Set<String> found = new LinkedHashSet<>();
         for (String each : classes()) {
             ConstantPool pool = parse(each).constantPool();
@@ -168,7 +183,7 @@ public final class WhatWasCompiled {
                     continue;
                 }
                 if (entry instanceof java.lang.classfile.constantpool.MemberRefEntry asCall
-                        && asCall.owner().asSymbol().equals(owner)
+                        && owners.contains(asCall.owner().asSymbol())
                         && asCall.name().stringValue().equals(method)) {
                     found.add(each);
                 }

--- a/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatWasCompiled.java
@@ -12,8 +12,10 @@ import java.lang.constant.ClassDesc;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -232,24 +234,42 @@ public final class WhatWasCompiled {
         return named;
     }
 
+    /**
+     * What each class file holds, read once for however many rules ask about it.
+     *
+     * <p>A rule asks about every class this module compiled, and a suite holds many rules. Read per
+     * question, the same files are parsed again for each of them — which is what a rule about who
+     * calls what does twice over, once for the callers and once for the types the call could be
+     * named through. What is read cannot change while the tests run, since it is what surefire was
+     * handed.
+     */
+    private static final Map<String, ClassModel> READ = new HashMap<>();
+
     /** {@code name} as this module compiled it, or nothing where it is not this module's — the JDK's
      *  own types and anything on the class path, which a rule about this module does not read. */
     private static ClassModel parsedOrNull(String name) {
+        if (READ.containsKey(name)) {
+            return READ.get(name);
+        }
         Path at = CLASSES.resolve(name.replace('.', '/') + ".class");
-        if (!Files.exists(at)) {
-            return null;
-        }
-        try {
-            return ClassFile.of().parse(Files.readAllBytes(at));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        ClassModel read = Files.exists(at) ? parsed(at) : null;
+        READ.put(name, read);
+        return read;
     }
 
     private static ClassModel parse(String name) {
+        ClassModel read = parsedOrNull(name);
+        if (read == null) {
+            throw new UncheckedIOException(new IOException(
+                    CLASSES.resolve(name.replace('.', '/') + ".class") + " is not a class this"
+                            + " module compiled"));
+        }
+        return read;
+    }
+
+    private static ClassModel parsed(Path at) {
         try {
-            return ClassFile.of().parse(
-                    Files.readAllBytes(CLASSES.resolve(name.replace('.', '/') + ".class")));
+            return ClassFile.of().parse(Files.readAllBytes(at));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest.java
@@ -1,0 +1,96 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.Allowance;
+import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.Emptiness;
+import souther.compiler.values.PlannedValues;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a choice nobody can take leaves each language a clause is read in.
+ *
+ * <p>Which alternatives anybody can take is settled over the languages together, and one of them
+ * may have found nothing wrong with a branch the other refused. So a branch is dead while the
+ * ranges of it are ends somebody could be at, and the pair has to say so to both of them: told
+ * only the language that refused it, the other goes on answering for the branch it read while the
+ * pair says nobody is in it.
+ *
+ * <p>The ranges of such a choice reach nothing that reads them — the proof travels beside them and
+ * every reader asks that — so what is checked here is what the next question comes to. Met with a
+ * rule about the same position, ranges left standing rule that rule out, and ranges that were told
+ * do not.
+ */
+class ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest {
+
+    private static final String POSITION = "b";
+
+    private static final Allowance<String> SETS = AsACompilationAllows.forAdmittedValues();
+
+    private static OrderedInterval from(int low, int high) {
+        return new OrderedInterval(Endpoint.inclusive(Count.of(low)),
+                Endpoint.inclusive(Count.of(high)));
+    }
+
+    /** A branch the values refused, whose ranges are ends somebody could be at. */
+    private static Confinement.Planned<String> refusedByItsValues(OrderedInterval range) {
+        return new Confinement.Planned<>(PlannedValues.<String>top().leavingNothing(),
+                OrderedIntervals.at(POSITION, range), Map.of());
+    }
+
+    /**
+     * A choice both alternatives of which the values refused, met afterwards with a rule about the
+     * position their ranges spoke about.
+     *
+     * <p>The rule is one the standing ends of either alternative would rule out, and one that
+     * nothing about a choice nobody can take should have an opinion on.
+     */
+    private Set<String> whatIsLeftEmptyAfterMeeting(OrderedInterval left, OrderedInterval right,
+                                                    OrderedInterval afterwards) {
+        Confinement.Planned<String> dead = refusedByItsValues(left).bothDead(
+                refusedByItsValues(right),
+                Confinement.Admission.left(Emptiness.EMPTY));
+        Confinement.Planned<String> met = dead.meet(new Confinement.Planned<>(
+                PlannedValues.top(), OrderedIntervals.at(POSITION, afterwards), Map.of()));
+        return met.resolve(SETS).holdingNothing();
+    }
+
+    /**
+     * Neither alternative's ends are left answering for the choice.
+     *
+     * <p>The rule met afterwards is one both alternatives' ends exclude. Kept, they make the
+     * position one the rules leave no value at, and the refusal of a declaration is then written
+     * about a position that is nobody's fault — the choice is empty because every alternative of it
+     * is, and no alternative said anything about {@code b} that this rule contradicts.
+     */
+    @Test
+    void theRangesOfADeadChoiceRuleNothingOutAfterwards() {
+        assertEquals(Set.of(), whatIsLeftEmptyAfterMeeting(from(100, 200), from(300, 400),
+                from(1, 2)));
+    }
+
+    /**
+     * And the control: the same rule against a choice whose alternatives stand.
+     *
+     * <p>The ends are the same ones. What differs is that somebody can be in these branches, so
+     * their ranges are theirs to answer with and the rule does contradict them.
+     */
+    @Test
+    void theRangesOfAChoiceSomebodyCanTakeDoRuleItOut() {
+        Confinement.Planned<String> live = new Confinement.Planned<>(
+                PlannedValues.top(), OrderedIntervals.at(POSITION, from(100, 200)), Map.of());
+        Confinement.Planned<String> met = live.meet(new Confinement.Planned<>(
+                PlannedValues.top(), OrderedIntervals.at(POSITION, from(1, 2)), Map.of()));
+
+        assertEquals(Set.of(POSITION), met.resolve(SETS).holdingNothing());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
@@ -1,0 +1,53 @@
+package souther.compiler.check;
+
+import souther.compiler.WhatWasCompiled;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Who may be an algebra over a whole clause tree.
+ *
+ * <p>{@link ClauseReading} is the algebra of the tree: what a leaf says, what a conjunction and a
+ * choice of two readings come to, and the walk that carries the environment down and the answer up.
+ * A reading that interprets only the leaves is not one of these, and typing it as one leaves it
+ * owing the connectives — which is not an empty obligation, because a choice is not compositional
+ * under either language on its own. Where an alternative is one nobody can take turns on what the
+ * values and the ranges left together, so a choice settled inside one language drops the branch that
+ * language could refuse and keeps the branch the other one did.
+ *
+ * <p>That is how the reading of ranges came to carry a second spelling of what a choice does. It
+ * ran nowhere — the whole reading asks it for leaves — and it read as available, under a comment
+ * stating the refuted rule as one in force.
+ *
+ * <p>Read off the compiled classes and not off the source, so an interface put between a reading and
+ * this one arrives here as a row. Read from what this module compiled, so a fold a test builds to
+ * look at the walk is not in the population: such a fold is an algebra of the whole tree and answers
+ * for its own connectives, which is the thing this permits rather than the thing it refuses.
+ */
+class OnlyAFoldOverAWholeClauseTreeIsOneTest {
+
+    /**
+     * The two that read a whole clause tree, and what each of them is.
+     *
+     * <p>{@code StatedByClauses.Reading} is the reading of a declaration's clauses, which is where
+     * both languages are held and where the choices of a rule are decided. {@code ExpansionCost}
+     * counts what a clause would expand to, over the same connectives and by the same walk, which
+     * is why it is this and not a walk of its own.
+     *
+     * <p>A row for a reading of one language — the values, the ranges, or whatever is written next
+     * — is the edge this exists to refuse. Those interpret leaves, and the fold that composes them
+     * is the one above.
+     */
+    private static final Set<String> FOLDS = Set.of(
+            "souther.compiler.check.ExpansionCost",
+            "souther.compiler.check.StatedByClauses$Reading");
+
+    @Test
+    void theOnlyAlgebrasOverAClauseTreeAreTheTwoThatReadOne() {
+        assertEquals(FOLDS, WhatWasCompiled.implementing(ClauseReading.class));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAReadingHoldingBothLanguagesComposesAChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAReadingHoldingBothLanguagesComposesAChoiceTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.check;
+
+import souther.compiler.WhatWasCompiled;
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.PlannedValues;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may compose what a choice leaves, in one language at a time.
+ *
+ * <p>A conjunction is componentwise: what two clauses leave a position is what each language says
+ * they leave it, and a language meeting two of its own readings is answering its own question. A
+ * choice is not. Which alternatives anybody can take is a fact about the whole of what was read —
+ * a branch no order admits beside a branch no set of values admits is a choice with nothing in it,
+ * and neither language alone finds anything wrong with the branch the other one refused.
+ *
+ * <p>So the operations below take an answer rather than work one out. Every alternative dead, and
+ * both alternatives standing, are two proofs the whole state already holds; the component is told
+ * which of them it is realising. One alternative dead asks the components nothing, because what the
+ * choice leaves is the standing alternative, which the holder has in hand.
+ *
+ * <p>That is why these have callers and {@code meet} has none listed: a rule confining the
+ * conjunction would be a rule about arithmetic that is sound wherever it is written.
+ *
+ * <p>Read off the compiled classes. A call is in the caller's constant pool however it is spelled,
+ * and a lambda's body is compiled into the class that wrote it, so this cannot be got out of by
+ * writing the call somewhere shorter.
+ */
+class OnlyAReadingHoldingBothLanguagesComposesAChoiceTest {
+
+    /**
+     * The one place both languages are held while a choice is composed.
+     *
+     * <p>A reading of a declaration's clauses is a pair — which values each position may take, and
+     * where each of them stops — and this is the pair. What decides a branch's fate reads both of
+     * them ({@code Confinement.admission}), and what realises the decision is written here beside
+     * that reading.
+     */
+    private static final String HOLDER = "souther.compiler.check.Confinement$Planned";
+
+    /** What a choice comes to, in one language, once its alternatives' fates are known. */
+    private record ChoiceOperation(Class<?> on, String called) {}
+
+    private static final Set<ChoiceOperation> OF_A_CHOICE = Set.of(
+            new ChoiceOperation(PlannedValues.class, "joinLive"),
+            new ChoiceOperation(PlannedValues.class, "joinLiveApart"),
+            new ChoiceOperation(PlannedValues.class, "bothDead"),
+            new ChoiceOperation(OrderedIntervals.class, "joinLive"),
+            new ChoiceOperation(OrderedIntervals.class, "bothDead"));
+
+    @Test
+    void nothingButTheReadingHoldingBothLanguagesComposesAChoice() {
+        Set<String> elsewhere = new LinkedHashSet<>();
+        for (ChoiceOperation each : OF_A_CHOICE) {
+            for (String caller : WhatWasCompiled.callersOf(each.on(), each.called())) {
+                if (!caller.equals(HOLDER)) {
+                    elsewhere.add(caller + " calls " + each.on().getSimpleName()
+                            + "." + each.called());
+                }
+            }
+        }
+
+        assertEquals(Set.of(), elsewhere,
+                "a choice composed where one language is held is a choice settled by that language");
+    }
+
+    /**
+     * And each of them is reached, so the rule above is about calls that happen.
+     *
+     * <p>A confinement over an operation nobody calls passes whatever the code does. Asked
+     * separately from the rule, so that an operation falling out of use is a finding here and not a
+     * silence there.
+     */
+    @Test
+    void eachOfThemIsWhatTheHolderComposesWith() {
+        for (ChoiceOperation each : OF_A_CHOICE) {
+            assertTrue(WhatWasCompiled.callersOf(each.on(), each.called()).contains(HOLDER),
+                    each.on().getSimpleName() + "." + each.called() + " is composed with");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatOrderedRulesLeaveEachPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatOrderedRulesLeaveEachPositionTest.java
@@ -72,7 +72,7 @@ class WhatOrderedRulesLeaveEachPositionTest {
     @Test
     void aChoiceBetweenTwoRulesLeavesTheEndsAroundBoth() {
         OrderedIntervals<String> either = OrderedIntervals.at(A, from(5, 9))
-                .join(OrderedIntervals.at(A, from(20, 30)));
+                .joinLive(OrderedIntervals.at(A, from(20, 30)));
 
         assertEquals(from(5, 30), either.at(A));
     }
@@ -86,38 +86,17 @@ class WhatOrderedRulesLeaveEachPositionTest {
     @Test
     void aChoiceLeavesAPositionOnlyOneSideBoundedOpen() {
         OrderedIntervals<String> either = OrderedIntervals.at(A, from(5, 9))
-                .join(OrderedIntervals.at(B, from(1, 2)));
+                .joinLive(OrderedIntervals.at(B, from(1, 2)));
 
         assertEquals(OrderedInterval.OPEN, either.at(A));
         assertEquals(OrderedInterval.OPEN, either.at(B));
     }
 
     /**
-     * An alternative that holds nothing is one nobody can take, so the choice is the other one.
-     *
-     * <p>Asked of the whole side and not position by position. A branch with one position empty is
-     * a branch no value satisfies, and hulling its other positions into the answer would widen the
-     * result by ends no value of the model is ever at.
-     */
-    @Test
-    void anAlternativeHoldingNothingLeavesTheChoiceToTheOther() {
-        OrderedIntervals<String> impossible = OrderedIntervals.at(A, above(6))
-                .meet(OrderedIntervals.at(A, below(2)))
-                .meet(OrderedIntervals.at(B, from(100, 200)));
-
-        OrderedIntervals<String> either = impossible.join(OrderedIntervals.at(B, from(1, 2)));
-
-        assertEquals(from(1, 2), either.at(B));
-        assertFalse(either.isBottom());
-    }
-
-    /**
      * A choice both sides of which hold nothing holds nothing, and names what both leave empty.
      *
-     * <p>Where one side can be taken, the other's ranges go with it — nothing satisfies that side,
-     * so what it said narrows nothing. Where neither can be taken, no side speaks for the other,
-     * and the two may not be met either: a meet is a conjunction and the alternatives were never
-     * stated together.
+     * <p>No side speaks for the other, and the two may not be met either: a meet is a conjunction
+     * and the alternatives were never stated together.
      */
     @Test
     void aChoiceWithNothingOnEitherSideNamesWhatBothLeaveEmpty() {
@@ -126,10 +105,10 @@ class WhatOrderedRulesLeaveEachPositionTest {
         OrderedIntervals<String> right = OrderedIntervals.at(B, above(6))
                 .meet(OrderedIntervals.at(B, below(2)));
 
-        assertTrue(left.join(right).isBottom(), "neither side can be taken");
-        assertEquals(Set.of(), left.join(right).holdingNothing(),
+        assertTrue(left.bothDead(right).isBottom(), "neither side can be taken");
+        assertEquals(Set.of(), left.bothDead(right).holdingNothing(),
                 "and no one position is what the choice leaves empty");
-        assertEquals(left.join(right).holdingNothing(), right.join(left).holdingNothing(),
+        assertEquals(left.bothDead(right).holdingNothing(), right.bothDead(left).holdingNothing(),
                 "and the same either way round");
     }
 
@@ -141,8 +120,8 @@ class WhatOrderedRulesLeaveEachPositionTest {
         OrderedIntervals<String> left = empty.meet(OrderedIntervals.at(B, from(0, 0)));
         OrderedIntervals<String> right = empty.meet(OrderedIntervals.at(B, from(1, 1)));
 
-        assertEquals(Set.of(A), left.join(right).holdingNothing());
-        assertEquals(Set.of(A), right.join(left).holdingNothing(), "and either way round");
+        assertEquals(Set.of(A), left.bothDead(right).holdingNothing());
+        assertEquals(Set.of(A), right.bothDead(left).holdingNothing(), "and either way round");
     }
 
     /**
@@ -159,8 +138,8 @@ class WhatOrderedRulesLeaveEachPositionTest {
         OrderedIntervals<String> left = empty.meet(OrderedIntervals.at(B, from(0, 0)));
         OrderedIntervals<String> right = empty.meet(OrderedIntervals.at(B, from(1, 1)));
 
-        assertFalse(left.join(right).holdingNothing().contains(B));
-        assertFalse(right.join(left).holdingNothing().contains(B));
+        assertFalse(left.bothDead(right).holdingNothing().contains(B));
+        assertFalse(right.bothDead(left).holdingNothing().contains(B));
     }
 
     /** A side shown impossible by something outside this holds nothing and names no position. */


### PR DESCRIPTION
Closes #1372.

## What was wrong

`ClauseReading` is the algebra of a whole clause tree — what a leaf says, what a
conjunction and a choice of two readings come to, and the walk that carries the
environment down and the answer up. The reading of ranges interprets only the
leaves of that tree, and was typed as an implementation of the algebra all the
same. That left it owing the connectives, and the only answer it could give to a
choice is the one a choice between two languages refutes.

A choice is not compositional under either projection. Which alternatives anybody
can take turns on what the values and the ranges left together, so a choice
settled inside one language drops the branch that language could refuse and keeps
the branch the other one did — `s < "" || (b == true && b == false)` has a branch
no order admits beside a branch no set of values admits, and each language,
joining alone, finds nothing wrong with the branch the other one refused.

Nothing walked it. What was wrong is that it read as available, under a comment
stating the refuted rule as one in force.

## What this does

The reading of ranges answers for its leaves and says so, as the reading of
admissible values already does. What a conjunction and a choice of its answers
come to is asked where the pair is held.

Composing a choice in one language is realising a decision rather than making
one, and the entry points now say so. What every alternative of a dead choice
leaves empty is `bothDead`; the hull of two alternatives somebody can take is
`joinLive`. A choice with one dead alternative is the alternative that stands,
which the holder of both languages has in hand and asks no language for. The
ranges had all three cases behind one entry and read their own operands for the
fate of a branch; the values had the split already and now carry the precondition
in the name.

Found on the way: a dead choice asked the ranges through the entry for a choice
that stands, and got back the ends of a branch somebody can be in. The proof
travelling beside them hid it from every reader, so what pins it is what the next
question comes to — met with a rule those ends would rule out, ranges answered for
a dead choice leave the position alone and standing ends do not.

The live entry's precondition is an assertion rather than a throw: with
assertions off the hull widens, and widening is the direction this state is only
ever allowed to move in. The corpus and the population were run with the
assertion in place over the undeleted branches, and no path of this compiler
reached them.

The dead entry has no such check, and the asymmetry is the same rule read again.
Its violation invents a bottom — a choice somebody can take, called empty — which
is a narrowing, and a narrowing here refuses a model somebody can write. That is
not a fact to state where it is true by the line above it; what keeps a standing
branch out is the caller that stages the languages, and each language is staged
by what its own operation does rather than to match its neighbour.

## What keeps it there

Two rules read off the compiled classes: who may be an algebra over a clause
tree, and who may compose what a choice leaves in one language. Both were checked
against a reintroduction of the removed reading, which each of them names.

The conjunction is not confined. It is componentwise, so a language meeting two
of its own readings is answering its own question.
