### PR TITLE
Read a signature for what its declaration guarantees

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -158,6 +158,14 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
     }
 
     @Test
+    void aRecordHoldingItsOwnKindIsOpenedOnce() {
+        assertTrue(takes("aRecordThatHoldsItsOwnKind", THE_DERIVED_WORLD),
+                "a record whose component holds another of its own kind is a record that can be"
+                        + " written, and what it holds beside that is read, so a reading arrives at"
+                        + " the second component rather than at the first one for ever");
+    }
+
+    @Test
     void aDeclarationWithNoGenericsIsReadAsOneWithThem() {
         assertTrue(takes("aWorldSpelledOutright", THE_DERIVED_WORLD),
                 "a method with nothing generic about it writes no signature of its own, and its"
@@ -244,6 +252,9 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         record Plain(DerivedSymbols world) {
         }
 
+        record HoldingItsOwnKind(List<HoldingItsOwnKind> more, DerivedSymbols world) {
+        }
+
         <S extends DerivedSymbols> void aBoundThatIsReferredTo(S world) {
         }
 
@@ -281,6 +292,9 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         }
 
         void aComponentWrittenWithoutGenerics(Plain it) {
+        }
+
+        void aRecordThatHoldsItsOwnKind(HoldingItsOwnKind it) {
         }
 
         void aWorldSpelledOutright(DerivedSymbols world) {

--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -219,6 +219,10 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         void fromTheClassesOwnVariable(S world) {
         }
 
+        // The name is its class's again, which is what this one is for: a reading keyed by the
+        // name alone answers with the wrong bound here, and a subject that spelled the two apart
+        // could not say so.
+        @SuppressWarnings("TypeParameterShadowing")
         <S extends ResolvedSymbols> void shadowing(S world) {
         }
     }

--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -1,0 +1,289 @@
+package souther.architecture;
+
+import souther.architecture.WhatASignatureReaches.Scope;
+import souther.compiler.check.DerivedSymbols;
+import souther.compiler.check.ResolvedSymbols;
+import souther.compiler.check.Symbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.MethodSignature;
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reading of a signature answers, held over declarations written here to be read.
+ *
+ * <p>{@link WhatASignatureReaches} is what the rules about a compiled surface are written against,
+ * and the shapes it has to answer for are not shapes this repository writes. Nothing here is
+ * declared with a world arriving through a type variable, which is the whole reason a reading that
+ * could not see one went unnoticed. So the subjects are declared below and read out of this class's
+ * own class file: what javac wrote for a declaration, rather than a signature spelled by hand into
+ * a fixture, which would hold of a grammar this test believed in instead of the one there is.
+ *
+ * <p>Four of these say what the reading means and the rest say that each branch of the two
+ * algebras it walks was walked.
+ */
+class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
+
+    private static final String HERE =
+            "souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest";
+
+    private static final String DECLARATIONS = HERE + "$Declarations";
+
+    private static final String THE_DERIVED_WORLD = internal(DerivedSymbols.class);
+    private static final String THE_RESOLVED_WORLD = internal(ResolvedSymbols.class);
+
+    private static final CompiledClasses COMPILED = CompiledClasses.ofRepository();
+
+    private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
+
+    private static String internal(Class<?> type) {
+        return type.getName().replace('.', '/');
+    }
+
+    /** What the arguments of one declaration below reach, read as a rule reads them. */
+    private static boolean takes(String owner, String method, String wanted) {
+        ClassModel model = COMPILED.read(owner);
+        MethodModel found = model.methods().stream()
+                .filter(each -> each.methodName().equalsString(method))
+                .findFirst().orElseThrow(() -> new AssertionError("no " + method + " in " + owner));
+        MethodSignature signature = found.findAttribute(Attributes.signature())
+                .map(SignatureAttribute::asMethodSignature)
+                .orElseGet(() -> MethodSignature.of(found.methodTypeSymbol()));
+        Scope scope = Scope.of(owner, WhatASignatureReaches.typeParametersOf(model))
+                .and(method, signature.typeParameters());
+        return READING.anyOf(signature.arguments(), scope, Set.of(wanted));
+    }
+
+    private static boolean takes(String method, String wanted) {
+        return takes(DECLARATIONS, method, wanted);
+    }
+
+    @Test
+    void aWorldArrivingThroughAVariableIsTheWorldItsBoundNames() {
+        assertTrue(takes("aBoundThatIsReferredTo", THE_DERIVED_WORLD),
+                "a parameter written as a type variable is read for what its declaration"
+                        + " guarantees, which is what its bound says");
+    }
+
+    @Test
+    void aVariableWithNothingBoundingItReachesNoWorld() {
+        assertFalse(takes("aVariableWithNoBoundOfItsOwn", THE_DERIVED_WORLD),
+                "a variable bounded by nothing guarantees nothing, and a reading that answered"
+                        + " otherwise would be inventing the bound it wanted to find");
+    }
+
+    @Test
+    void aBoundNothingRefersToIsReachedThroughNothing() {
+        assertFalse(takes("aBoundNothingRefersTo", THE_DERIVED_WORLD),
+                "a type parameter is what the variables written in the two halves stand for and is"
+                        + " not itself a place a reading starts, so a bound the declaration never"
+                        + " writes is a bound nothing arrives through");
+    }
+
+    @Test
+    void aVariableIsTheOneDeclaredNearestAndNotTheOneOfTheSameName() {
+        assertTrue(takes(HERE + "$Owned", "shadowing", THE_RESOLVED_WORLD),
+                "a method declaring a variable its class also names is read with its own");
+        assertFalse(takes(HERE + "$Owned", "shadowing", THE_DERIVED_WORLD),
+                "and not with the one it shadows, which a reading keyed by the name alone would"
+                        + " have answered with");
+    }
+
+    @Test
+    void aVariableOfTheClassIsInScopeInItsMethods() {
+        assertTrue(takes(HERE + "$Owned", "fromTheClassesOwnVariable", THE_DERIVED_WORLD),
+                "a class declares type parameters its methods write, so the bindings a reading is"
+                        + " given are the class's with the method's over them");
+    }
+
+    @Test
+    void aVariableBoundedByItselfIsFollowedOnce() {
+        assertFalse(takes("aVariableBoundedByItself", THE_DERIVED_WORLD),
+                "a variable whose bound names it again is ordinary Java, and the closure of a"
+                        + " bound is finite because a binding already followed is not followed"
+                        + " again");
+    }
+
+    @Test
+    void whatBoundsAVariableIsEveryBoundAndNotTheFirst() {
+        assertTrue(takes("aVariableBoundedByInterfaces", HERE + "$AMark"),
+                "a variable bounded by interfaces has no class bound at all, so a reading that"
+                        + " asked only for that one would answer for none of them");
+    }
+
+    @Test
+    void anArrayOfAVariableReachesWhatTheVariableDoes() {
+        assertTrue(takes("anArrayOfTheVariable", THE_DERIVED_WORLD),
+                "an array is what it is an array of");
+    }
+
+    @Test
+    void anArgumentUnderAWildcardIsRead() {
+        assertTrue(takes("anArgumentUnderExtends", THE_DERIVED_WORLD),
+                "a bound written on a wildcard is a type the signature names");
+        assertTrue(takes("anArgumentUnderSuper", THE_DERIVED_WORLD),
+                "and so is one written under a lower wildcard: what is read is which types the"
+                        + " declaration names, not which of them a value could be assigned to");
+        assertFalse(takes("anArgumentThatIsAnything", THE_DERIVED_WORLD),
+                "a wildcard with no bound names nothing");
+    }
+
+    @Test
+    void theTypeAnInnerOneIsWrittenUnderIsRead() {
+        assertTrue(takes("anOuterTypesArgument", THE_DERIVED_WORLD),
+                "a nested type carries the arguments of the type it is nested in, and a reading"
+                        + " that stopped at the inner name would walk past them");
+    }
+
+    @Test
+    void aComponentOfARecordIsReadUnderThatRecordsOwnVariables() {
+        assertTrue(takes("aComponentUnderTheRecordsOwnBound", THE_DERIVED_WORLD),
+                "a record's component is written in the record's variables, so what it reaches is"
+                        + " what that record declared them to be");
+        assertFalse(takes("aRecordThatCannotSeeTheCallersBinding", THE_DERIVED_WORLD),
+                "and never in the caller's: a record is static wherever it is written, so a"
+                        + " reading that kept the scope it arrived with would answer for a binding"
+                        + " the component cannot name");
+    }
+
+    @Test
+    void aDeclarationWithNoGenericsIsReadAsOneWithThem() {
+        assertTrue(takes("aWorldSpelledOutright", THE_DERIVED_WORLD),
+                "a method with nothing generic about it writes no signature of its own, and its"
+                        + " descriptor is read as the signature it is");
+        assertTrue(takes("aComponentWrittenWithoutGenerics", THE_DERIVED_WORLD),
+                "and so is a record component's, so that whether a declaration is generic is"
+                        + " settled before the reading and not inside it");
+    }
+
+    @Test
+    void aVariableBoundNowhereInScopeFailsTheReading() {
+        AssertionError refused = assertThrows(AssertionError.class,
+                () -> takes(HERE + "$Enclosing$Nested", "takesTheEnclosingVariable",
+                        THE_DERIVED_WORLD));
+
+        assertTrue(refused.getMessage().contains("bound nowhere"),
+                "a method of an inner class writes the variables of the class enclosing it, which"
+                        + " are in neither of the two places these bindings come from — and a"
+                        + " reading that cannot say what a variable stands for says so, because"
+                        + " answering that it reaches nothing is how the spelling this reading"
+                        + " replaced went unread: " + refused.getMessage());
+    }
+
+    @Test
+    void aClassOfThisRepositoryThatWasNotBuiltFailsTheReading() {
+        AssertionError refused = assertThrows(AssertionError.class,
+                () -> COMPILED.read("souther/architecture/NothingCompiledThis"));
+
+        assertTrue(refused.getMessage().contains("not built here"),
+                "the same holds of a class whose components a reading has to open and cannot find:"
+                        + " " + refused.getMessage());
+    }
+
+    @Test
+    void theDeclarationsTheseReadingsAreAboutWereRead() {
+        assertEquals(1, COMPILED.read(DECLARATIONS).methods().stream()
+                        .filter(each -> each.methodName().equalsString("aBoundThatIsReferredTo"))
+                        .count(),
+                "the subjects declared here were compiled and found, so a reading that answered"
+                        + " nothing answered about something");
+    }
+
+    /** Something for a variable to be bounded by that is not a class. */
+    interface AMark {
+    }
+
+    /** A class that declares a variable of its own, for the two readings that are about which
+     *  binding a name is. */
+    static class Owned<S extends DerivedSymbols> {
+
+        void fromTheClassesOwnVariable(S world) {
+        }
+
+        <S extends ResolvedSymbols> void shadowing(S world) {
+        }
+    }
+
+    /** A class whose variable a class inside it writes, which is a binding neither the inner
+     *  class's signature nor its method's declares. */
+    static class Enclosing<S extends DerivedSymbols> {
+
+        class Nested {
+
+            void takesTheEnclosingVariable(S world) {
+            }
+        }
+    }
+
+    /**
+     * The subjects.
+     *
+     * <p>Written where javac compiles them rather than spelled as signatures, and reachable from
+     * outside this class so that what is read is a declaration and not a member kept alive for a
+     * reading to find.
+     */
+    static class Declarations {
+
+        record Held<T>(T it) {
+        }
+
+        record Bounded<T extends DerivedSymbols>(T it) {
+        }
+
+        record Plain(DerivedSymbols world) {
+        }
+
+        <S extends DerivedSymbols> void aBoundThatIsReferredTo(S world) {
+        }
+
+        <S> void aVariableWithNoBoundOfItsOwn(S world) {
+        }
+
+        <S extends DerivedSymbols> void aBoundNothingRefersTo(Symbols world) {
+        }
+
+        <S extends DerivedSymbols> void anArrayOfTheVariable(S[] worlds) {
+        }
+
+        <S extends Comparable<S>> void aVariableBoundedByItself(S it) {
+        }
+
+        <S extends Runnable & AMark> void aVariableBoundedByInterfaces(S it) {
+        }
+
+        <S extends DerivedSymbols> void anArgumentUnderExtends(List<? extends S> them) {
+        }
+
+        <S extends DerivedSymbols> void anArgumentUnderSuper(List<? super S> them) {
+        }
+
+        <S extends DerivedSymbols> void anArgumentThatIsAnything(List<?> them) {
+        }
+
+        <S extends DerivedSymbols> void anOuterTypesArgument(Enclosing<S>.Nested it) {
+        }
+
+        void aComponentUnderTheRecordsOwnBound(Bounded<?> it) {
+        }
+
+        <T extends DerivedSymbols> void aRecordThatCannotSeeTheCallersBinding(Held<?> it) {
+        }
+
+        void aComponentWrittenWithoutGenerics(Plain it) {
+        }
+
+        void aWorldSpelledOutright(DerivedSymbols world) {
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -8,7 +8,6 @@ import souther.compiler.check.Symbols;
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.MethodSignature;
 import java.lang.classfile.Signature;
@@ -53,18 +52,26 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         return type.getName().replace('.', '/');
     }
 
-    /** What the arguments of one declaration below reach, read as a rule reads them. */
-    private static boolean takes(String owner, String method, String wanted) {
-        ClassModel model = COMPILED.read(owner);
-        MethodModel found = model.methods().stream()
+    /** One declaration below, read as a rule reads it. */
+    private static MethodSignature signatureOf(String owner, String method) {
+        MethodModel found = COMPILED.read(owner).methods().stream()
                 .filter(each -> each.methodName().equalsString(method))
                 .findFirst().orElseThrow(() -> new AssertionError("no " + method + " in " + owner));
-        MethodSignature signature = found.findAttribute(Attributes.signature())
+        return found.findAttribute(Attributes.signature())
                 .map(SignatureAttribute::asMethodSignature)
                 .orElseGet(() -> MethodSignature.of(found.methodTypeSymbol()));
-        Scope scope = Scope.of(owner, WhatASignatureReaches.typeParametersOf(model))
-                .and(method, signature.typeParameters());
-        return READING.anyOf(signature.arguments(), scope, Set.of(wanted));
+    }
+
+    /** The bindings that declaration is read under: its class's, and its own standing on them. */
+    private static Scope scopeOf(String owner, String method) {
+        return Scope.of(owner, WhatASignatureReaches.typeParametersOf(COMPILED.read(owner)))
+                .and(method, signatureOf(owner, method).typeParameters());
+    }
+
+    /** What the arguments of one declaration below reach. */
+    private static boolean takes(String owner, String method, String wanted) {
+        return READING.anyOf(signatureOf(owner, method).arguments(), scopeOf(owner, method),
+                Set.of(wanted));
     }
 
     private static boolean takes(String method, String wanted) {
@@ -115,6 +122,19 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
                             + " letter binds it for what the method writes, never for what its"
                             + " class already said");
         }
+    }
+
+    @Test
+    void aReportNamesEveryFrameAndWhatDeclaredIt() {
+        String shown = scopeOf(HERE + "$BoundedByItsSibling", "throughTheClassesBound").shown();
+
+        assertTrue(shown.contains(
+                        "$BoundedByItsSibling<B extends " + THE_DERIVED_WORLD + ", A extends B>"),
+                "a frame is named by what declared it and by what it declared, so a report about"
+                        + " a letter says which frame is being spoken of: " + shown);
+        assertTrue(shown.contains("throughTheClassesBound<B extends " + THE_RESOLVED_WORLD + ">"),
+                "and the frame standing on it is named too, or a letter both of them declare is"
+                        + " reported as one: " + shown);
     }
 
     @Test
@@ -211,7 +231,7 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         Signature absent = Signature.of(ClassDesc.of("souther.architecture.NothingCompiledThis"));
 
         AssertionError refused = assertThrows(AssertionError.class, () -> READING.reaches(absent,
-                Scope.of("nothing", List.of()), Set.of(THE_DERIVED_WORLD)));
+                Scope.of(HERE, List.of()), Set.of(THE_DERIVED_WORLD)));
 
         assertTrue(refused.getMessage().contains("not built here"),
                 "the same holds of a class whose components a reading has to open and cannot find,"

--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -43,7 +43,7 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
     private static final String THE_DERIVED_WORLD = internal(DerivedSymbols.class);
     private static final String THE_RESOLVED_WORLD = internal(ResolvedSymbols.class);
 
-    private static final CompiledClasses COMPILED = CompiledClasses.ofRepository();
+    private static final CompiledClasses COMPILED = CompiledClasses.ofEverythingCompiledHere();
 
     private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
 
@@ -197,6 +197,16 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         assertTrue(refused.getMessage().contains("not built here"),
                 "the same holds of a class whose components a reading has to open and cannot find:"
                         + " " + refused.getMessage());
+    }
+
+    @Test
+    void whatIsPublishedIsNotWhatWasCompiledBesideIt() {
+        assertTrue(CompiledClasses.ofEverythingCompiledHere().find(DECLARATIONS).isPresent(),
+                "the subjects declared here are compiled where test output goes, which is the"
+                        + " population this test's readings are about");
+        assertTrue(CompiledClasses.ofWhatThisRepositoryPublishes().find(DECLARATIONS).isEmpty(),
+                "and are not in the one a rule about a compiled surface is about, which is why the"
+                        + " two are named apart rather than searched together");
     }
 
     @Test

--- a/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/ASignatureIsReadForWhatItsDeclarationGuaranteesTest.java
@@ -11,7 +11,9 @@ import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.MethodSignature;
+import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.Set;
 
@@ -98,6 +100,21 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         assertFalse(takes(HERE + "$Owned", "shadowing", THE_DERIVED_WORLD),
                 "and not with the one it shadows, which a reading keyed by the name alone would"
                         + " have answered with");
+    }
+
+    @Test
+    void aBoundIsReadWhereItsVariableWasDeclared() {
+        for (String owner : List.of(HERE + "$BoundedByItsSibling",
+                HERE + "$BoundedThroughAnArgument")) {
+            assertTrue(takes(owner, "throughTheClassesBound", THE_DERIVED_WORLD),
+                    owner + ": a variable bounded by another of its class stands for what that one"
+                            + " was declared to be, and where that name was declared is where the"
+                            + " bound is read");
+            assertFalse(takes(owner, "throughTheClassesBound", THE_RESOLVED_WORLD),
+                    owner + ": and not where the variable was written — a method naming the same"
+                            + " letter binds it for what the method writes, never for what its"
+                            + " class already said");
+        }
     }
 
     @Test
@@ -191,12 +208,15 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
 
     @Test
     void aClassOfThisRepositoryThatWasNotBuiltFailsTheReading() {
-        AssertionError refused = assertThrows(AssertionError.class,
-                () -> COMPILED.read("souther/architecture/NothingCompiledThis"));
+        Signature absent = Signature.of(ClassDesc.of("souther.architecture.NothingCompiledThis"));
+
+        AssertionError refused = assertThrows(AssertionError.class, () -> READING.reaches(absent,
+                Scope.of("nothing", List.of()), Set.of(THE_DERIVED_WORLD)));
 
         assertTrue(refused.getMessage().contains("not built here"),
-                "the same holds of a class whose components a reading has to open and cannot find:"
-                        + " " + refused.getMessage());
+                "the same holds of a class whose components a reading has to open and cannot find,"
+                        + " and it is the reading that has to say so rather than the lookup under"
+                        + " it: " + refused.getMessage());
     }
 
     @Test
@@ -234,6 +254,24 @@ class ASignatureIsReadForWhatItsDeclarationGuaranteesTest {
         // could not say so.
         @SuppressWarnings("TypeParameterShadowing")
         <S extends ResolvedSymbols> void shadowing(S world) {
+        }
+    }
+
+    /** A class whose second variable is bounded by its first, with a method that names the first
+     *  again. What the second stands for is settled where it was declared. */
+    static class BoundedByItsSibling<B extends DerivedSymbols, A extends B> {
+
+        @SuppressWarnings("TypeParameterShadowing")
+        <B extends ResolvedSymbols> void throughTheClassesBound(A world) {
+        }
+    }
+
+    /** The same, with the bound reaching its sibling through a type argument and the sibling
+     *  declared after the variable that names it. */
+    static class BoundedThroughAnArgument<A extends List<B>, B extends DerivedSymbols> {
+
+        @SuppressWarnings("TypeParameterShadowing")
+        <B extends ResolvedSymbols> void throughTheClassesBound(A world) {
         }
     }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
@@ -69,10 +69,13 @@ final class CompiledClasses {
     }
 
     private Optional<ClassModel> parse(String internalName) {
-        for (Path module : repository.modules()) {
-            Path target = module.resolve("target");
-            for (String output : outputs) {
-                Path compiled = target.resolve(output).resolve(internalName + ".class");
+        // Outputs outermost, because the order they are named in is an order between them: a class
+        // this repository publishes answers about that name wherever a module beside it also
+        // compiled one.
+        for (String output : outputs) {
+            for (Path module : repository.modules()) {
+                Path compiled = module.resolve("target").resolve(output)
+                        .resolve(internalName + ".class");
                 if (Files.isRegularFile(compiled)) {
                     try {
                         return Optional.of(ClassFile.of().parse(Files.readAllBytes(compiled)));

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
@@ -1,0 +1,73 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The class files this repository built, found through the repository.
+ *
+ * <p>Not through {@code java.class.path}. What a module is handed there is the reactor's to decide
+ * and it is not the same in every build — a module built beside this one arrives as its
+ * {@code target/classes}, and one already packaged arrives as a jar — so a walk over the entries is
+ * a walk over something that answers differently depending on which goal was run. What a rule here
+ * is about is the compiled surface of a class of this repository, and the repository is where that
+ * is.
+ *
+ * <p>Test output is searched beside main output, because the subjects a reading's own test declares
+ * to be read are compiled there.
+ *
+ * <p>A name this cannot find is not a class that reaches nothing. It is a question this cannot
+ * answer, and it says so rather than answering.
+ */
+final class CompiledClasses {
+
+    private final RepositoryLayout repository;
+
+    private final Map<String, Optional<ClassModel>> read = new HashMap<>();
+
+    private CompiledClasses(RepositoryLayout repository) {
+        this.repository = repository;
+    }
+
+    static CompiledClasses ofRepository() {
+        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory());
+    }
+
+    /** The class {@code internalName} names, or nothing where this repository built no such file. */
+    Optional<ClassModel> find(String internalName) {
+        return read.computeIfAbsent(internalName, this::parse);
+    }
+
+    /** The class {@code internalName} names, where failing to find one fails the reading. */
+    ClassModel read(String internalName) {
+        return find(internalName).orElseThrow(() -> new AssertionError(
+                "the class " + internalName.replace('/', '.') + " was not built here, so what a"
+                        + " signature naming it reaches is a question this cannot answer"));
+    }
+
+    private Optional<ClassModel> parse(String internalName) {
+        for (Path module : repository.modules()) {
+            Path target = module.resolve("target");
+            for (String output : new String[] {"classes", "test-classes"}) {
+                Path compiled = target.resolve(output).resolve(internalName + ".class");
+                if (Files.isRegularFile(compiled)) {
+                    try {
+                        return Optional.of(ClassFile.of().parse(Files.readAllBytes(compiled)));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/CompiledClasses.java
@@ -9,6 +9,7 @@ import java.lang.classfile.ClassModel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,8 +23,11 @@ import java.util.Optional;
  * is about is the compiled surface of a class of this repository, and the repository is where that
  * is.
  *
- * <p>Test output is searched beside main output, because the subjects a reading's own test declares
- * to be read are compiled there.
+ * <p>Which output is searched is the caller's to name, because the two questions asked here are
+ * about two populations. A rule about what a class of this repository offers its callers is about
+ * what the repository publishes, and a class compiled beside a test is not that. A test that
+ * declares its own subjects to be read is asking about those, and they are compiled where test
+ * output goes. One lookup answering both would be answering each with the other's population.
  *
  * <p>A name this cannot find is not a class that reaches nothing. It is a question this cannot
  * answer, and it says so rather than answering.
@@ -32,14 +36,24 @@ final class CompiledClasses {
 
     private final RepositoryLayout repository;
 
+    private final List<String> outputs;
+
     private final Map<String, Optional<ClassModel>> read = new HashMap<>();
 
-    private CompiledClasses(RepositoryLayout repository) {
+    private CompiledClasses(RepositoryLayout repository, List<String> outputs) {
         this.repository = repository;
+        this.outputs = outputs;
     }
 
-    static CompiledClasses ofRepository() {
-        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory());
+    /** What this repository publishes: the compiled surface a caller elsewhere reaches. */
+    static CompiledClasses ofWhatThisRepositoryPublishes() {
+        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory(), List.of("classes"));
+    }
+
+    /** That and what was compiled beside it, which is where a test's own subjects are. */
+    static CompiledClasses ofEverythingCompiledHere() {
+        return new CompiledClasses(RepositoryLayout.ofWorkingDirectory(),
+                List.of("classes", "test-classes"));
     }
 
     /** The class {@code internalName} names, or nothing where this repository built no such file. */
@@ -57,7 +71,7 @@ final class CompiledClasses {
     private Optional<ClassModel> parse(String internalName) {
         for (Path module : repository.modules()) {
             Path target = module.resolve("target");
-            for (String output : new String[] {"classes", "test-classes"}) {
+            for (String output : outputs) {
                 Path compiled = target.resolve(output).resolve(internalName + ".class");
                 if (Files.isRegularFile(compiled)) {
                     try {

--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -13,7 +13,6 @@ import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.MethodSignature;
-import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
@@ -104,7 +103,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
      * half. They are what the variables the two halves write stand for, and a rule that started a
      * reading at them would find a bound the method never uses.
      */
-    private record Read(String name, MethodSignature signature, Scope scope) {
+    private record Read(MethodSignature signature, Scope scope) {
 
         boolean takesOneOf(Set<String> wanted) {
             return READING.anyOf(signature.arguments(), scope, wanted);
@@ -123,34 +122,9 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
          * type parameter is is settled by the reading, not by whether a reader can see it.
          */
         String shown() {
-            String enclosing = scope.under().map(Read::shown).orElse("");
-            String declared = signature.typeParameters().isEmpty() ? ""
-                    : signature.typeParameters().stream().map(Read::shown)
-                            .collect(Collectors.joining(", ", "<", ">"));
             String takes = signature.arguments().stream().map(Signatures::shown)
                     .collect(Collectors.joining(", "));
-            return enclosing + name + declared + "(" + takes + "): "
-                    + Signatures.shown(signature.result());
-        }
-
-        /** The frames under a method's own, each as what declared it and what it declared. */
-        private static String shown(Scope enclosing) {
-            StringBuilder out = new StringBuilder();
-            for (Scope frame : enclosing.frames()) {
-                if (!frame.declared().isEmpty()) {
-                    out.append(frame.owner()).append(frame.declared().values().stream()
-                            .map(Read::shown).collect(Collectors.joining(", ", "<", ">")))
-                            .append('.');
-                }
-            }
-            return out.toString();
-        }
-
-        private static String shown(Signature.TypeParam declared) {
-            List<Signature.RefTypeSig> bounds = WhatASignatureReaches.boundsOf(declared);
-            return bounds.isEmpty() ? declared.identifier()
-                    : declared.identifier() + " extends " + bounds.stream().map(Signatures::shown)
-                            .collect(Collectors.joining(" & "));
+            return scope.shown() + "(" + takes + "): " + Signatures.shown(signature.result());
         }
     }
 
@@ -179,8 +153,9 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
             MethodSignature signature = method.findAttribute(Attributes.signature())
                     .map(SignatureAttribute::asMethodSignature)
                     .orElseGet(() -> MethodSignature.of(method.methodTypeSymbol()));
-            String name = method.methodName().stringValue();
-            out.add(new Read(name, signature, ofTheClass.and(name, signature.typeParameters())));
+            // The method's own frame is named for it, which is where a report gets the name from.
+            out.add(new Read(signature, ofTheClass.and(method.methodName().stringValue(),
+                    signature.typeParameters())));
         }
         return out;
     }

--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -65,7 +65,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
     private static final String THE_LOOKUP = internal(ExpandedClauseLookup.class);
 
     /** The declaration worlds, read off the sealed interface rather than listed: a world added to it
-     *  is one a walk could be handed, and these rules have to see it arrive. */
+     *  is one a walk can be declared to take, and these rules have to see it arrive. */
     private static final Set<String> THE_WORLDS = worlds();
 
     private static final CompiledClasses COMPILED =
@@ -114,15 +114,36 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
             return READING.reaches(signature.result(), scope, wanted);
         }
 
-        /** As a failure names it: the type parameters shown, because a reader of a report about
-         *  {@code S} has to see what {@code S} was declared to be, and not read as roots. */
+        /**
+         * As a failure names it.
+         *
+         * <p>Every frame the method stands in, and not only its own: a report about {@code S} has
+         * to say what {@code S} was declared to be, and a method writing a letter its class
+         * declared is answered for by the class. Shown and not read as roots — which of the two a
+         * type parameter is is settled by the reading, not by whether a reader can see it.
+         */
         String shown() {
+            String enclosing = scope.under().map(Read::shown).orElse("");
             String declared = signature.typeParameters().isEmpty() ? ""
                     : signature.typeParameters().stream().map(Read::shown)
-                            .collect(Collectors.joining(", ", "<", "> "));
+                            .collect(Collectors.joining(", ", "<", ">"));
             String takes = signature.arguments().stream().map(Signatures::shown)
                     .collect(Collectors.joining(", "));
-            return declared + name + "(" + takes + "): " + Signatures.shown(signature.result());
+            return enclosing + name + declared + "(" + takes + "): "
+                    + Signatures.shown(signature.result());
+        }
+
+        /** The frames under a method's own, each as what declared it and what it declared. */
+        private static String shown(Scope enclosing) {
+            StringBuilder out = new StringBuilder();
+            for (Scope frame : enclosing.frames()) {
+                if (!frame.declared().isEmpty()) {
+                    out.append(frame.owner()).append(frame.declared().values().stream()
+                            .map(Read::shown).collect(Collectors.joining(", ", "<", ">")))
+                            .append('.');
+                }
+            }
+            return out.toString();
         }
 
         private static String shown(Signature.TypeParam declared) {

--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -1,29 +1,26 @@
 package souther.architecture;
 
+import souther.architecture.WhatASignatureReaches.Scope;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.ExpandedClauseLookup;
 import souther.compiler.check.Symbols;
-import souther.test.RepositoryLayout;
+import souther.test.Signatures;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.classfile.Attributes;
-import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.MethodModel;
+import java.lang.classfile.MethodSignature;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.reflect.AccessFlag;
-import java.lang.reflect.RecordComponent;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,11 +45,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * interface holds its own answer; a rule here that demanded the derived world of it as well would
  * be reporting a walk that is already closed, by a stronger arrangement than this one.
  *
+ * <p>Both are read through {@link WhatASignatureReaches}, so that what a walk is handed is read for
+ * what the declaration guarantees rather than for how it was written. A world wrapped in a record,
+ * named through a type variable's bound, or written as the argument of a container is the world the
+ * caller has to have, and a rule that read only the types spelled beside the parameters would be
+ * answered by any of those rewrites.
+ *
  * <p>What this does not hold is that no walk of the kind can be written anywhere else. A class
  * reaching the declarations itself could compose its own, and no reading of a signature would say
  * so. The first line against that is which methods are reachable at all, and this is the second.
  */
 class HowARuleThatGovernsADeclarationIsAskedForTest {
+
+    private static final String TYPE_OPS = "souther/compiler/check/TypeOps";
 
     private static final String A_CLAUSE = internal(Hir.InvariantClause.class);
     private static final String A_DECLARATION = internal(Hir.Def.class);
@@ -63,9 +68,9 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
      *  is one a walk could be handed, and these rules have to see it arrive. */
     private static final Set<String> THE_WORLDS = worlds();
 
-    private static final Pattern NAMES_A_TYPE = Pattern.compile("L([^;<]+)[;<]");
+    private static final CompiledClasses COMPILED = CompiledClasses.ofRepository();
 
-    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+    private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
 
     private static Set<String> worlds() {
         Set<String> out = new LinkedHashSet<>();
@@ -90,12 +95,40 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
         return type.getName().replace('.', '/');
     }
 
-    /** One method as these rules read it. Split at the parameters' close, because which half a type
-     *  is named in is what is being asked: a walk is handed a world and answers with clauses. */
-    private record Read(String name, String takes, String answersWith) {
+    /**
+     * One method as these rules read it.
+     *
+     * <p>The arguments and the answer apart, because which half a type is named in is what is being
+     * asked: a walk is handed a world and answers with clauses. The type parameters are neither
+     * half. They are what the variables the two halves write stand for, and a rule that started a
+     * reading at them would find a bound the method never uses.
+     */
+    private record Read(String name, MethodSignature signature, Scope scope) {
 
+        boolean takesOneOf(Set<String> wanted) {
+            return READING.anyOf(signature.arguments(), scope, wanted);
+        }
+
+        boolean answersWithOneOf(Set<String> wanted) {
+            return READING.reaches(signature.result(), scope, wanted);
+        }
+
+        /** As a failure names it: the type parameters shown, because a reader of a report about
+         *  {@code S} has to see what {@code S} was declared to be, and not read as roots. */
         String shown() {
-            return name + "(" + takes + ")" + answersWith;
+            String declared = signature.typeParameters().isEmpty() ? ""
+                    : signature.typeParameters().stream().map(Read::shown)
+                            .collect(Collectors.joining(", ", "<", "> "));
+            String takes = signature.arguments().stream().map(Signatures::shown)
+                    .collect(Collectors.joining(", "));
+            return declared + name + "(" + takes + "): " + Signatures.shown(signature.result());
+        }
+
+        private static String shown(Signature.TypeParam declared) {
+            List<Signature.RefTypeSig> bounds = WhatASignatureReaches.boundsOf(declared);
+            return bounds.isEmpty() ? declared.identifier()
+                    : declared.identifier() + " extends " + bounds.stream().map(Signatures::shown)
+                            .collect(Collectors.joining(" & "));
         }
     }
 
@@ -109,23 +142,23 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
      * what its neighbours here do with it, which is a thing to read rather than to check.
      */
     private static List<Read> reachableMethods() {
+        ClassModel typeOps = COMPILED.read(TYPE_OPS);
+        Scope ofTheClass = Scope.of(TYPE_OPS, WhatASignatureReaches.typeParametersOf(typeOps));
         List<Read> out = new ArrayList<>();
-        for (MethodModel method : typeOps().methods()) {
+        for (MethodModel method : typeOps.methods()) {
             if (method.flags().has(AccessFlag.PRIVATE) || method.flags().has(AccessFlag.SYNTHETIC)
                     || method.methodName().stringValue().startsWith("<")) {
                 continue;
             }
-            // The generic signature where there is one. A clause reached through a list, an
-            // `Optional`, a map value or a record is a clause a caller gets, and the containers
-            // erase to something naming no clause at all — so a rule read off the descriptor would
-            // hold of exactly the shape nobody writes.
-            String signature = method.findAttribute(Attributes.signature())
-                    .map(each -> each.signature().stringValue())
-                    .orElseGet(() -> method.methodType().stringValue());
-            int closed = signature.lastIndexOf(')');
-            out.add(new Read(method.methodName().stringValue(),
-                    signature.substring(signature.indexOf('(') + 1, closed),
-                    signature.substring(closed + 1)));
+            // The generic signature where there is one, and the descriptor read as one where there
+            // is not. A clause reached through a list, an `Optional`, a map value or a record is a
+            // clause a caller gets, and the containers erase to something naming no clause at all —
+            // so a rule read off the descriptor alone would hold of exactly the shape nobody writes.
+            MethodSignature signature = method.findAttribute(Attributes.signature())
+                    .map(SignatureAttribute::asMethodSignature)
+                    .orElseGet(() -> MethodSignature.of(method.methodTypeSymbol()));
+            String name = method.methodName().stringValue();
+            out.add(new Read(name, signature, ofTheClass.and(name, signature.typeParameters())));
         }
         return out;
     }
@@ -134,7 +167,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
     private static List<Read> walksOverWhatGoverns() {
         List<Read> found = new ArrayList<>();
         for (Read method : reachableMethods()) {
-            if (reachesAClause(method.answersWith()) && reachesOneOf(method.takes(), THE_WORLDS)) {
+            if (method.answersWithOneOf(Set.of(A_CLAUSE)) && method.takesOneOf(THE_WORLDS)) {
                 found.add(method);
             }
         }
@@ -145,7 +178,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
     void aWalkOverWhatGovernsIsGivenANameAndNotADeclaration() {
         List<String> handedANode = new ArrayList<>();
         for (Read walk : walksOverWhatGoverns()) {
-            if (reachesADeclaration(walk.takes())) {
+            if (walk.takesOneOf(declarationNodes())) {
                 handedANode.add(walk.shown());
             }
         }
@@ -161,10 +194,10 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
         List<String> loose = new ArrayList<>();
         for (Read walk : walksOverWhatGoverns()) {
             // What the expanded form states is the lookup's to answer, and it holds that itself.
-            if (reachesOneOf(walk.takes(), Set.of(THE_LOOKUP))) {
+            if (walk.takesOneOf(Set.of(THE_LOOKUP))) {
                 continue;
             }
-            if (!reachesOneOf(walk.takes(), Set.of(THE_DERIVED_WORLD))) {
+            if (!walk.takesOneOf(Set.of(THE_DERIVED_WORLD))) {
                 loose.add(walk.shown());
             }
         }
@@ -187,7 +220,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
         List<String> settled = new ArrayList<>();
         List<String> expanded = new ArrayList<>();
         for (Read walk : walksOverWhatGoverns()) {
-            (reachesOneOf(walk.takes(), Set.of(THE_LOOKUP)) ? expanded : settled).add(walk.shown());
+            (walk.takesOneOf(Set.of(THE_LOOKUP)) ? expanded : settled).add(walk.shown());
         }
 
         assertFalse(settled.isEmpty(),
@@ -210,7 +243,7 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
     void aClauseInsideWhatAWalkAnswersWithIsOneThisReads() {
         List<String> namingNoClause = new ArrayList<>();
         for (Read walk : walksOverWhatGoverns()) {
-            if (!walk.answersWith().contains(A_CLAUSE)) {
+            if (!walk.signature().result().signatureString().contains(A_CLAUSE)) {
                 namingNoClause.add(walk.shown());
             }
         }
@@ -226,95 +259,5 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
     void theClassTheseRulesAreAboutWasRead() {
         assertTrue(reachableMethods().size() > 1,
                 "the class these rules are about was read and has a public surface");
-    }
-
-    /**
-     * Whether what {@code signature} describes reaches a clause: it names one, or it names a record
-     * that holds one.
-     *
-     * <p>Held over what a type is made of and not over what it is called. A record carrying a clause
-     * hands its caller the clause, and a rule that read only the types written in the signature
-     * would be answered by wrapping a walk's answer in a record — one line, and no word about the
-     * reading having changed.
-     */
-    private static boolean reachesAClause(String signature) {
-        return reachesOneOf(signature, Set.of(A_CLAUSE));
-    }
-
-    /**
-     * Whether what {@code signature} describes reaches a declaration node.
-     *
-     * <p>Read the way the answer is read, and for the reason the answer is: a pair of a name and the
-     * declaration under it, wrapped in a record, is the same thing to be handed as the two written
-     * side by side. This is not a shape nobody writes — it is what a newtype layer was, and closing
-     * it is half of what this file is about.
-     */
-    private static boolean reachesADeclaration(String signature) {
-        return reachesOneOf(signature, declarationNodes());
-    }
-
-    private static boolean reachesOneOf(String signature, Set<String> wanted) {
-        Matcher named = NAMES_A_TYPE.matcher(signature);
-        while (named.find()) {
-            if (reaches(named.group(1), wanted, new LinkedHashSet<>())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean reaches(String type, Set<String> wanted, Set<String> seen) {
-        if (wanted.contains(type)) {
-            return true;
-        }
-        if (!type.startsWith("souther/") || !seen.add(type)) {
-            return false;
-        }
-        Class<?> loaded;
-        try {
-            loaded = Class.forName(type.replace('/', '.'), false,
-                    HowARuleThatGovernsADeclarationIsAskedForTest.class.getClassLoader());
-        } catch (ClassNotFoundException _) {
-            return false;
-        }
-        if (!loaded.isRecord()) {
-            return false;
-        }
-        for (RecordComponent component : loaded.getRecordComponents()) {
-            String generic = component.getGenericSignature();
-            Matcher named = NAMES_A_TYPE.matcher(
-                    generic != null ? generic : component.getType().descriptorString());
-            while (named.find()) {
-                if (reaches(named.group(1), wanted, seen)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * The compiled class these rules read, found through the repository.
-     *
-     * <p>Not through {@code java.class.path}. What a module is handed there is the reactor's to
-     * decide and it is not the same in every build — a module built beside this one arrives as its
-     * {@code target/classes}, and one already packaged arrives as a jar — so a walk over the entries
-     * is a walk over something that answers differently depending on which goal was run. What these
-     * rules are about is the compiled surface of a class of this repository, and the repository is
-     * where that is.
-     */
-    private static ClassModel typeOps() {
-        for (Path module : REPOSITORY.modules()) {
-            Path compiled = module.resolve("target").resolve("classes")
-                    .resolve("souther/compiler/check/TypeOps.class");
-            if (Files.isRegularFile(compiled)) {
-                try {
-                    return ClassFile.of().parse(Files.readAllBytes(compiled));
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }
-        }
-        throw new AssertionError("the class these rules are about was not built here");
     }
 }

--- a/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/HowARuleThatGovernsADeclarationIsAskedForTest.java
@@ -68,7 +68,8 @@ class HowARuleThatGovernsADeclarationIsAskedForTest {
      *  is one a walk could be handed, and these rules have to see it arrive. */
     private static final Set<String> THE_WORLDS = worlds();
 
-    private static final CompiledClasses COMPILED = CompiledClasses.ofRepository();
+    private static final CompiledClasses COMPILED =
+            CompiledClasses.ofWhatThisRepositoryPublishes();
 
     private static final WhatASignatureReaches READING = new WhatASignatureReaches(COMPILED);
 

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
@@ -1,0 +1,230 @@
+package souther.architecture;
+
+import souther.test.Signatures;
+
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.ClassSignature;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.RecordAttribute;
+import java.lang.classfile.attribute.RecordComponentInfo;
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * What the types a signature is written in reach.
+ *
+ * <p>The closure read from the roots it is given: the types the signature names, the declared upper
+ * bounds of the type variables it refers to, and the components of the records it arrives at. A rule
+ * about a surface is written against this so that it holds of what a caller can be handed rather
+ * than of how the handing was spelled — a clause inside a record is a clause the caller gets, and a
+ * world named through a variable is the world the declaration guarantees.
+ *
+ * <p><b>A bound is read because it is what the declaration guarantees, not because it says what the
+ * argument will be.</b> {@code <S extends Symbols>} may be given a derived world and this reading
+ * does not say so; what it says is that {@code Symbols} is what every use of {@code S} is warranted
+ * to be. That is the same answer to both of the questions a rule asks — whether a world could arrive
+ * here at all, and whether the one that arrives is the derived one — so one reading serves both, and
+ * a walk bounded only by {@code Symbols} stays loose under the rule that wants the derived world.
+ *
+ * <p><b>A type parameter is an environment and not a root.</b> A bound is followed when the variable
+ * it belongs to is referred to from a root, and not before: a method declaring
+ * {@code <S extends DerivedSymbols>} and never writing {@code S} reaches nothing through it.
+ *
+ * <p><b>What this cannot resolve, it does not call unreachable.</b> A type variable with no binding
+ * in scope and a class of this repository with no class file are both questions this reading cannot
+ * answer, and both fail it. Answering {@code false} there is the shape of the defect this reading
+ * replaced: a spelling nobody had thought of went unread and was reported as reaching nothing.
+ *
+ * <p>What it does not do is recover what a signature threw away. A raw type, or a parameter written
+ * as {@code Object}, names nothing this can follow, and no reading of the signature will say what
+ * flows through it. Nor does it substitute the arguments at a use into the components of the record
+ * they parameterize: an argument is written where the record is used and is already read there, and
+ * a bound is the only thing a signature refers to without spelling it. A question about which
+ * component becomes which type would need that substitution and is not one this answers.
+ */
+final class WhatASignatureReaches {
+
+    private static final String OF_THIS_REPOSITORY = "souther/";
+
+    private final CompiledClasses compiled;
+
+    WhatASignatureReaches(CompiledClasses compiled) {
+        this.compiled = compiled;
+    }
+
+    /** Whether any of {@code roots}, read in {@code scope}, reaches one of {@code wanted}. */
+    boolean anyOf(List<Signature> roots, Scope scope, Set<String> wanted) {
+        Walk walk = new Walk(wanted);
+        for (Signature root : roots) {
+            if (walk.reaches(root, scope)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Whether {@code root}, read in {@code scope}, reaches one of {@code wanted}. */
+    boolean reaches(Signature root, Scope scope, Set<String> wanted) {
+        return anyOf(List.of(root), scope, wanted);
+    }
+
+    /** The signature of one record component, generic or not, as this reading takes it. */
+    static Signature componentSignature(RecordComponentInfo component) {
+        return component.findAttribute(Attributes.signature())
+                .map(SignatureAttribute::asTypeSignature)
+                .orElseGet(() -> Signature.of(component.descriptorSymbol()));
+    }
+
+    /** What a type parameter declares its variable to be: the class bound where there is one, and
+     *  the interface bounds, which is where a variable bounded only by interfaces says so. */
+    static List<Signature.RefTypeSig> boundsOf(Signature.TypeParam declared) {
+        List<Signature.RefTypeSig> out =
+                new ArrayList<>(declared.classBound().map(List::of).orElse(List.of()));
+        out.addAll(declared.interfaceBounds());
+        return out;
+    }
+
+    /** The type parameters a class declares, none where it declares no signature of its own. */
+    static List<Signature.TypeParam> typeParametersOf(ClassModel owner) {
+        return owner.findAttribute(Attributes.signature())
+                .map(SignatureAttribute::asClassSignature)
+                .map(ClassSignature::typeParameters)
+                .orElse(List.of());
+    }
+
+    /** One reading, holding what it has already been through. */
+    private final class Walk {
+
+        private final Set<String> wanted;
+
+        /** The records already opened. Their components were read under their own scope, which is
+         *  the same one however this arrived at them, so a second visit answers nothing new. */
+        private final Set<String> opened = new LinkedHashSet<>();
+
+        /** The bindings already followed, which is a different loop from the one above: a variable
+         *  bounded by its own type is ordinary Java, and the closure of a bound is finite. */
+        private final Set<Scope.Binding> followed = new LinkedHashSet<>();
+
+        private Walk(Set<String> wanted) {
+            this.wanted = wanted;
+        }
+
+        private boolean reaches(Signature type, Scope scope) {
+            return switch (type) {
+                case Signature.BaseTypeSig _ -> false;
+                case Signature.ArrayTypeSig array -> reaches(array.componentSignature(), scope);
+                case Signature.TypeVarSig variable -> reachesThroughBounds(variable, scope);
+                case Signature.ClassTypeSig named -> reachesThroughClass(named, scope);
+            };
+        }
+
+        private boolean reachesThroughArgument(Signature.TypeArg argument, Scope scope) {
+            return switch (argument) {
+                case Signature.TypeArg.Unbounded _ -> false;
+                case Signature.TypeArg.Bounded bounded -> reaches(bounded.boundType(), scope);
+            };
+        }
+
+        private boolean reachesThroughBounds(Signature.TypeVarSig variable, Scope scope) {
+            Scope.Binding binding = scope.bindingOf(variable.identifier());
+            if (!followed.add(binding)) {
+                return false;
+            }
+            for (Signature.RefTypeSig bound : binding.bounds()) {
+                if (reaches(bound, scope)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean reachesThroughClass(Signature.ClassTypeSig named, Scope scope) {
+            String name = Signatures.named(named);
+            if (wanted.contains(name)) {
+                return true;
+            }
+            for (Signature.TypeArg argument : named.typeArgs()) {
+                if (reachesThroughArgument(argument, scope)) {
+                    return true;
+                }
+            }
+            Optional<Signature.ClassTypeSig> outer = named.outerType();
+            if (outer.isPresent() && reachesThroughClass(outer.get(), scope)) {
+                return true;
+            }
+            return reachesThroughComponents(name);
+        }
+
+        private boolean reachesThroughComponents(String named) {
+            // A class of another repository holds nothing of this one, so there is no record of
+            // theirs to open. Which is a definition and not an absence: what a name of theirs
+            // reaches was answered by the arguments written beside it.
+            if (!named.startsWith(OF_THIS_REPOSITORY) || !opened.add(named)) {
+                return false;
+            }
+            ClassModel owner = compiled.read(named);
+            Optional<RecordAttribute> components = owner.findAttribute(Attributes.record());
+            if (components.isEmpty()) {
+                return false;
+            }
+            // Replaced and not layered: a record is static wherever it is written, so the variables
+            // a component names are its own and never the ones in scope where it was reached.
+            Scope inside = Scope.of(named, typeParametersOf(owner));
+            for (RecordComponentInfo component : components.get().components()) {
+                if (reaches(componentSignature(component), inside)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * What the type variables in scope stand for.
+     *
+     * <p>Built by whoever holds a signature, because which bindings are in scope is a fact about
+     * where the signature was written and not one the signature carries: a method's own parameters
+     * over the ones its class declares, and a name declared in both is the method's.
+     */
+    record Scope(Map<String, Binding> bindings) {
+
+        static Scope of(String owner, List<Signature.TypeParam> declared) {
+            return new Scope(Map.of()).and(owner, declared);
+        }
+
+        /** This scope with {@code declared} over it, where a repeated name is the newer binding. */
+        Scope and(String owner, List<Signature.TypeParam> declared) {
+            Map<String, Binding> out = new LinkedHashMap<>(bindings);
+            for (Signature.TypeParam each : declared) {
+                out.put(each.identifier(), new Binding(owner, each.identifier(), each));
+            }
+            return new Scope(out);
+        }
+
+        Binding bindingOf(String identifier) {
+            Binding found = bindings.get(identifier);
+            if (found == null) {
+                throw new AssertionError("the type variable " + identifier + " is bound nowhere this"
+                        + " reading was given, so what it stands for is a question this cannot"
+                        + " answer; the scope holds " + bindings.keySet());
+            }
+            return found;
+        }
+
+        /** One type variable, told apart by what declared it: a method may name a variable its own
+         *  class also names, and the two are two. */
+        record Binding(String owner, String identifier, Signature.TypeParam declared) {
+
+            List<Signature.RefTypeSig> bounds() {
+                return boundsOf(declared);
+            }
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
@@ -86,7 +86,7 @@ final class WhatASignatureReaches {
 
     /** What a type parameter declares its variable to be: the class bound where there is one, and
      *  the interface bounds, which is where a variable bounded only by interfaces says so. */
-    static List<Signature.RefTypeSig> boundsOf(Signature.TypeParam declared) {
+    private static List<Signature.RefTypeSig> boundsOf(Signature.TypeParam declared) {
         List<Signature.RefTypeSig> out =
                 new ArrayList<>(declared.classBound().map(List::of).orElse(List.of()));
         out.addAll(declared.interfaceBounds());
@@ -111,7 +111,9 @@ final class WhatASignatureReaches {
         private final Set<String> opened = new LinkedHashSet<>();
 
         /** The bindings already followed, which is a different loop from the one above: a variable
-         *  bounded by its own type is ordinary Java, and the closure of a bound is finite. */
+         *  bounded by its own type is ordinary Java, and the closure of a bound is finite. The
+         *  binding alone is the key because a binding settles the frame its bound is read in, so
+         *  there is no second reading of one to miss. */
         private final Set<Scope.Binding> followed = new LinkedHashSet<>();
 
         private Walk(Set<String> wanted) {
@@ -248,6 +250,36 @@ final class WhatASignatureReaches {
                 out.addAll(frame.declared().keySet());
             }
             return out;
+        }
+
+        /**
+         * These frames as a report names them: what declared each, and what each declared.
+         *
+         * <p>Here because the frames are. A report about {@code S} says what {@code S} was declared
+         * to be, and where two frames declare that letter it says which of them is being spoken of;
+         * a reader that held only the innermost would name one of the two and call it the answer.
+         */
+        String shown() {
+            List<String> named = new ArrayList<>();
+            for (Scope frame : frames()) {
+                named.add(frame.owner() + frame.shownDeclared());
+            }
+            return String.join(".", named);
+        }
+
+        /** What this frame alone declared, or nothing where it declares no variable. */
+        String shownDeclared() {
+            if (declared.isEmpty()) {
+                return "";
+            }
+            List<String> each = new ArrayList<>();
+            for (Signature.TypeParam parameter : declared.values()) {
+                List<Signature.RefTypeSig> bounds = boundsOf(parameter);
+                each.add(bounds.isEmpty() ? parameter.identifier()
+                        : parameter.identifier() + " extends " + String.join(" & ",
+                                bounds.stream().map(Signatures::shown).toList()));
+            }
+            return "<" + String.join(", ", each) + ">";
         }
 
         /** A variable's binding beside the frame it was declared in, which is where its bound is

--- a/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhatASignatureReaches.java
@@ -29,8 +29,10 @@ import java.util.Set;
  * <p><b>A bound is read because it is what the declaration guarantees, not because it says what the
  * argument will be.</b> {@code <S extends Symbols>} may be given a derived world and this reading
  * does not say so; what it says is that {@code Symbols} is what every use of {@code S} is warranted
- * to be. That is the same answer to both of the questions a rule asks — whether a world could arrive
- * here at all, and whether the one that arrives is the derived one — so one reading serves both, and
+ * to be. That is the same answer to both of the questions a rule asks — whether the declaration
+ * guarantees a world arrives here at all, and whether the one it guarantees is the derived one, a
+ * question about what is written and never about what a run could pass — so one reading serves both,
+ * and
  * a walk bounded only by {@code Symbols} stays loose under the rule that wants the derived world.
  *
  * <p><b>A type parameter is an environment and not a root.</b> A bound is followed when the variable
@@ -133,12 +135,14 @@ final class WhatASignatureReaches {
         }
 
         private boolean reachesThroughBounds(Signature.TypeVarSig variable, Scope scope) {
-            Scope.Binding binding = scope.bindingOf(variable.identifier());
-            if (!followed.add(binding)) {
+            Scope.Resolved resolved = scope.bindingOf(variable.identifier());
+            if (!followed.add(resolved.binding())) {
                 return false;
             }
-            for (Signature.RefTypeSig bound : binding.bounds()) {
-                if (reaches(bound, scope)) {
+            // In the frame that declared it, never the one it was written in: what a bound names is
+            // read where the bound was written.
+            for (Signature.RefTypeSig bound : resolved.binding().bounds()) {
+                if (reaches(bound, resolved.declaredIn())) {
                     return true;
                 }
             }
@@ -189,33 +193,66 @@ final class WhatASignatureReaches {
     /**
      * What the type variables in scope stand for.
      *
+     * <p>A frame for each declaration that binds any — the class's, and the method's standing on
+     * it — kept as a chain and not as one map. A binding is two things at once: which parameter a
+     * name is, and the world that parameter's own bound is written in. A method naming a letter its
+     * class also names binds it for what the method writes, while what the class declared under
+     * that letter goes on standing for what its own frame says; one map keyed by the name holds the
+     * first of those and loses the second, and a bound read in the wrong frame answers with another
+     * variable's declaration.
+     *
      * <p>Built by whoever holds a signature, because which bindings are in scope is a fact about
-     * where the signature was written and not one the signature carries: a method's own parameters
-     * over the ones its class declares, and a name declared in both is the method's.
+     * where the signature was written and not one the signature carries.
      */
-    record Scope(Map<String, Binding> bindings) {
+    record Scope(String owner, Map<String, Signature.TypeParam> declared, Optional<Scope> under) {
 
         static Scope of(String owner, List<Signature.TypeParam> declared) {
-            return new Scope(Map.of()).and(owner, declared);
+            return new Scope(owner, byName(declared), Optional.empty());
         }
 
-        /** This scope with {@code declared} over it, where a repeated name is the newer binding. */
+        /** This scope with a frame over it, which is where a repeated name is bound from here. */
         Scope and(String owner, List<Signature.TypeParam> declared) {
-            Map<String, Binding> out = new LinkedHashMap<>(bindings);
-            for (Signature.TypeParam each : declared) {
-                out.put(each.identifier(), new Binding(owner, each.identifier(), each));
-            }
-            return new Scope(out);
+            return new Scope(owner, byName(declared), Optional.of(this));
         }
 
-        Binding bindingOf(String identifier) {
-            Binding found = bindings.get(identifier);
-            if (found == null) {
-                throw new AssertionError("the type variable " + identifier + " is bound nowhere this"
-                        + " reading was given, so what it stands for is a question this cannot"
-                        + " answer; the scope holds " + bindings.keySet());
+        private static Map<String, Signature.TypeParam> byName(List<Signature.TypeParam> declared) {
+            Map<String, Signature.TypeParam> out = new LinkedHashMap<>();
+            for (Signature.TypeParam each : declared) {
+                out.put(each.identifier(), each);
             }
-            return found;
+            return out;
+        }
+
+        /** The frames this stands on, outermost first, this one last. */
+        List<Scope> frames() {
+            List<Scope> out = new ArrayList<>(under.map(Scope::frames).orElse(List.of()));
+            out.add(this);
+            return out;
+        }
+
+        /** The binding {@code identifier} names here, and the frame that declared it. */
+        Resolved bindingOf(String identifier) {
+            Signature.TypeParam found = declared.get(identifier);
+            if (found != null) {
+                return new Resolved(new Binding(owner, identifier, found), this);
+            }
+            return under.map(frame -> frame.bindingOf(identifier))
+                    .orElseThrow(() -> new AssertionError("the type variable " + identifier
+                            + " is bound nowhere this reading was given, so what it stands for is a"
+                            + " question this cannot answer; the scope holds " + names()));
+        }
+
+        private List<String> names() {
+            List<String> out = new ArrayList<>();
+            for (Scope frame : frames()) {
+                out.addAll(frame.declared().keySet());
+            }
+            return out;
+        }
+
+        /** A variable's binding beside the frame it was declared in, which is where its bound is
+         *  read: that frame's own names, and the ones it stands on. */
+        record Resolved(Binding binding, Scope declaredIn) {
         }
 
         /** One type variable, told apart by what declared it: a method may name a variable its own


### PR DESCRIPTION
Closes #1369.

The rules about the walk over what governs a declaration read a method's
signature for the names written in it. A type variable names no class, so a
world arriving as one — or an answer reached through a variable's bound — was
read as reaching nothing, and a walk written that way was governed by neither
rule. The reading also split the signature at the parameters and dropped the
front, which is where the bounds are declared.

`WhatASignatureReaches` reads the signature as the grammar it is. It walks the
`java.lang.classfile` signature algebras with no default arm, so which forms
there are to answer for is settled by the JDK rather than guessed: a class type
reaches through its arguments, its outer type and, when it is a record of this
repository, its components; an array reaches through what it is an array of; a
type variable reaches through what its declaration bounds it by.

A bound is read because it is what every use of the variable is warranted to
be. That is the same answer to both questions the rules ask — whether a world
could arrive at all, and whether the one that arrives is the derived one — so a
walk bounded only by the reader that names no stage is now reported loose
rather than passed over. Type parameters are the environment the two halves are
read in and are not themselves read, so a bound nothing refers to reaches
nothing. A record is entered under its own variables.

What the reading cannot resolve it does not call unreachable. A variable bound
nowhere in scope and a class of this repository with no class file both fail
the reading, because answering that they reach nothing is the shape of the
defect being closed here.

What it does not do is recover what a signature threw away: a raw type or a
parameter written as `Object` names nothing to follow, and no reading of a
signature will say what flows through it.

The subjects the reading is held over are declared in its own test and read out
of the class file javac wrote for them, because nothing in this repository is
written with a world arriving through a variable — which is why a reading that
could not see one went unnoticed. The walks the rules report over the subject
class are the ones they reported before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)