### PR TITLE
Read a denial between two positions

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -248,31 +248,36 @@ final class AdmissibleReading {
             read = sided(b.right(), b.left(), states, at);
         }
         if (read == null) {
-            read = holdingAsOne(b, states, at);
+            read = relating(b, states, at);
         }
         return read != null ? read : unreadable(b, at);
     }
 
     /**
-     * The two positions a comparison holds as one value, or null where it holds none.
+     * What a comparison between two positions states about the pair, or null where it is not one.
      *
-     * <p>Only where the comparison states that they are equal. Which that is has been settled
-     * already — {@code states} is what the comparison claims once the denials it stands under have
-     * been counted — so {@code p /= r} and {@code !(p == r)} arrive here alike and are not this: a
-     * denial removes the diagonal from a product rather than making one side of it, which is not
-     * something this reading can hold.
+     * <p>Two rules and one reading of them. An equality says the two are one side of the product;
+     * a denial says no one value stands at both, which makes no side and is held beside the product
+     * ({@code Apartness}). Which of the two it is has been settled already — {@code states} is what
+     * the comparison claims once the denials it stands under have been counted — so {@code p /= r}
+     * and {@code !(p == r)} arrive here alike and are read as the same rule.
      *
-     * <p>And only between two positions. A position compared with itself says nothing, and a
-     * comparison naming one position and something this could not read is not a rule about a pair.
+     * <p>Read here and not given up on. Left as a rule that reached no reading, what the rules
+     * stated about {@code p} and what they stated about {@code r} stayed two facts about two
+     * places, and a declaration whose positions cannot differ was admitted.
+     *
+     * <p>Only between two positions. A comparison of a position with itself is a rule about one
+     * position and is left where every rule this does not read is left, and a comparison naming one
+     * position and something this could not read is not a rule about a pair either.
      */
-    private PlannedValues<FactSubject> holdingAsOne(Core.Binary b, boolean states, Denotations at) {
-        if (!states) {
-            return null;
-        }
+    private PlannedValues<FactSubject> relating(Core.Binary b, boolean states, Denotations at) {
         FactSubject here = positionIn(b.left(), at);
         FactSubject there = positionIn(b.right(), at);
-        return here == null || there == null || here.equals(there)
-                ? null : PlannedValues.holdingAsOne(here, there);
+        if (here == null || there == null || here.equals(there)) {
+            return null;
+        }
+        return states ? PlannedValues.holdingAsOne(here, there)
+                : PlannedValues.heldApart(here, there);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -876,6 +876,25 @@ public sealed interface Carrier {
         };
     }
 
+    /**
+     * The same, of a block whose positions may be on no order at all.
+     *
+     * <p>Here rather than at the caller, because a block on no order is a case of the question and
+     * not a case of who is asking. Such a block has no range for its values to be met with, so a
+     * set naming them is the whole of what it holds; every other shape is one only an order can say
+     * the values of, since what a written set leaves out is every value there is. Answered where a
+     * caller happens to notice the absence, that caller would be deciding what a value and an order
+     * come to, which is what this type is for — and the second answer would count differently from
+     * this one the first time either changed.
+     */
+    static Admits leftAt(Carrier carrier, ValueSet set, OrderedInterval range, int atMost) {
+        if (carrier != null) {
+            return carrier.valuesShared(set, range, atMost);
+        }
+        return set instanceof ValueSet.Finite it ? Admits.of(it.values(), atMost)
+                : new Admits.NotKnown();
+    }
+
     /** Which of {@code values} lie inside {@code range}, unknown where one of them is not a value
      *  this order places at all. */
     private Admits named(java.util.Set<Value> values, OrderedInterval range, int atMost) {
@@ -886,13 +905,10 @@ public sealed interface Carrier {
                 return new Admits.NotKnown();
             }
             if (range.admits(at)) {
-                if (out.size() == atMost) {
-                    return new Admits.MoreThanCounted();
-                }
                 out.add(each);
             }
         }
-        return new Admits.These(out);
+        return Admits.of(out, atMost);
     }
 
     /** Which values {@code range} holds that {@code excluded} does not name, where they are few
@@ -916,11 +932,11 @@ public sealed interface Carrier {
             if (value == null) {
                 return new Admits.NotKnown();
             }
-            if (!away.contains(value) && out.add(value) && out.size() > atMost) {
-                return new Admits.MoreThanCounted();
+            if (!away.contains(value)) {
+                out.add(value);
             }
         }
-        return new Admits.These(out);
+        return Admits.of(out, atMost);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -19,11 +19,13 @@ import souther.compiler.regex.Meter;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
+import souther.compiler.values.Admits;
 import souther.compiler.values.Emptiness;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -837,6 +839,103 @@ public sealed interface Carrier {
                     ? Emptiness.NONEMPTY : somethingNotExcluded(it.excluded(), range);
             case ValueSet.Matching it -> this instanceof Text
                     ? stringsInside(it.language(), range, meter) : Emptiness.UNDECIDED;
+        };
+    }
+
+    /**
+     * Which values this order holds inside {@code range} that {@code set} admits.
+     *
+     * <p>{@link #meets} answering with the values rather than with whether there are any, for a
+     * reader relating one position to another. Whether a denial between two blocks leaves anything
+     * turns on which values each of them is left and not on whether it is left some, so the
+     * question a relation asks is this one — and it is here, beside the answer about one position,
+     * because a set and a range are put together in one place or in two that come to disagree.
+     *
+     * <p>Three answers, and the middle one is what keeps a relation cheap. A block left more values
+     * than a caller will count is one that never runs out for want of a value to take, so a reader
+     * relating a handful of blocks may stop counting rather than enumerate an order — and a block
+     * this cannot say the values of is a block a relation says nothing about, which is what every
+     * widening here is.
+     *
+     * @param atMost how many values a caller will count. Its own and not this order's: how many
+     *               there have to be before the answer stops mattering is a question about what the
+     *               caller is relating
+     */
+    default Admits valuesShared(ValueSet set, OrderedInterval range, int atMost) {
+        OrderedInterval held = extent().meet(range);
+        if (held.holdsNothing()) {
+            return new Admits.These(Set.of());
+        }
+        return switch (set) {
+            case ValueSet.Finite it -> named(it.values(), held, atMost);
+            case ValueSet.Cofinite it -> placed(held, it.excluded(), atMost);
+            // A language is a description of a machine rather than the set it comes to, and
+            // building one to relate two positions would spend a position's allowance on a question
+            // about a pair.
+            case ValueSet.Matching _ -> new Admits.NotKnown();
+        };
+    }
+
+    /** Which of {@code values} lie inside {@code range}, unknown where one of them is not a value
+     *  this order places at all. */
+    private Admits named(java.util.Set<Value> values, OrderedInterval range, int atMost) {
+        Set<Value> out = new LinkedHashSet<>();
+        for (Value each : values) {
+            Place at = placeOf(each);
+            if (at == null) {
+                return new Admits.NotKnown();
+            }
+            if (range.admits(at)) {
+                if (out.size() == atMost) {
+                    return new Admits.MoreThanCounted();
+                }
+                out.add(each);
+            }
+        }
+        return new Admits.These(out);
+    }
+
+    /** Which values {@code range} holds that {@code excluded} does not name, where they are few
+     *  enough to write down. */
+    private Admits placed(OrderedInterval range, Set<Value> excluded, int atMost) {
+        List<Place> held = firstPlacesIn(range, atMost + excluded.size() + 1);
+        if (held == null) {
+            return new Admits.MoreThanCounted();
+        }
+        Set<Value> away = new LinkedHashSet<>();
+        for (Value each : excluded) {
+            Place at = placeOf(each);
+            if (at == null) {
+                return new Admits.NotKnown();
+            }
+            away.add(valueAt(at));
+        }
+        Set<Value> out = new LinkedHashSet<>();
+        for (Place at : held) {
+            Value value = valueAt(at);
+            if (value == null) {
+                return new Admits.NotKnown();
+            }
+            if (!away.contains(value) && out.add(value) && out.size() > atMost) {
+                return new Admits.MoreThanCounted();
+            }
+        }
+        return new Admits.These(out);
+    }
+
+    /**
+     * The value at a place on this order, or null where this order has no way of writing one down.
+     *
+     * <p>{@link #placeOf} the other way round, and here for the reason that one is: a value and
+     * where it sits are the same fact said twice, and the crossing between them is the carrier's.
+     * The temporal carriers place no written value, so nothing here writes one back.
+     */
+    private Value valueAt(Place at) {
+        return switch (this) {
+            case Whole _, Dense _ -> Value.number(Count.number(at).at());
+            case Text _ -> Value.text(((souther.compiler.numeric.Text) at).at());
+            case Ordinal it -> Value.of(it.caseAt(at));
+            case Days _, Seconds _, SecondsOfDay _, Nanos _ -> null;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -370,16 +370,8 @@ sealed interface Confinement<A> {
     /** Which values {@code block} is left, where {@code sits} puts its positions. */
     private static <A> Admits admits(Map<A, Carrier> carriers, Function<A, OrderedInterval> sits,
                                      Sameness.Block<A> block, ValueSet set, int atMost) {
-        Carrier carrier = null;
-        OrderedInterval within = OrderedInterval.OPEN;
-        for (A position : block.members()) {
-            Carrier here = carriers.get(position);
-            if (here != null) {
-                carrier = here;
-            }
-            within = within.meet(sits.apply(position));
-        }
-        return Carrier.leftAt(carrier, set, within, atMost);
+        Placed placed = placedAt(carriers, sits, block);
+        return Carrier.leftAt(placed.carrier(), set, placed.within(), atMost);
     }
 
     /** The two questions one walk over the alternatives is asked: what each block leaves, and what
@@ -422,21 +414,34 @@ sealed interface Confinement<A> {
     private static <A> Emptiness answered(Map<A, Carrier> carriers,
                                           Function<A, OrderedInterval> sits, Meter meter,
                                           Sameness.Block<A> block, ValueSet set) {
-        // What the block is ordered on, and where it stops. Positions an alternative holds as
-        // one value have one value between them, so the range that value is in is every one of
-        // their ranges at once — asked of one member, {@code p == r && p < d1 && r > d2} would
-        // be answered against half of what the rules say and the pair would come back holding
-        // something.
+        Placed placed = placedAt(carriers, sits, block);
+        return placed.carrier() == null ? Emptiness.NONEMPTY
+                : placed.carrier().meets(set, placed.within(), meter);
+    }
+
+    /**
+     * What a block is ordered on and where its positions leave it.
+     *
+     * <p>Worked out once, because two questions are asked of a block against it — whether it admits
+     * anything, and what a denial between it and another comes to — and both need the same two
+     * facts. Written at each of them, the assertion below is on one and the other answers a block
+     * this compiler is wrong about without saying so.
+     *
+     * <p>The range is every one of the positions' at once. Positions an alternative holds as one
+     * value have one value between them, so asking one member would answer {@code p == r && p < d1
+     * && r > d2} against half of what the rules say and the pair would come back holding something.
+     */
+    private static <A> Placed placedAt(Map<A, Carrier> carriers, Function<A, OrderedInterval> sits,
+                                       Sameness.Block<A> block) {
         Carrier carrier = null;
         OrderedInterval within = OrderedInterval.OPEN;
         for (A position : block.members()) {
             Carrier here = carriers.get(position);
-            // One carrier, and an assertion because it is about this compiler rather than
-            // about any model: a rule holding two positions as one value is one an equality
-            // between them typed, and an equality types only where the two are of one type. A
-            // block whose members disagreed would be answered by whichever of them the
-            // members happen to be read in the order of, which is a fact about how they are
-            // spelled.
+            // One carrier, and an assertion because it is about this compiler rather than about any
+            // model: a rule holding two positions as one value is one an equality between them
+            // typed, and an equality types only where the two are of one type. A block whose
+            // members disagreed would be answered by whichever of them the members happen to be
+            // read in the order of, which is a fact about how they are spelled.
             assert carrier == null || here == null || carrier.equals(here)
                     : "positions held as one value are ordered on " + carrier + " and " + here;
             if (here != null) {
@@ -444,8 +449,12 @@ sealed interface Confinement<A> {
             }
             within = within.meet(sits.apply(position));
         }
-        return carrier == null ? Emptiness.NONEMPTY : carrier.meets(set, within, meter);
+        return new Placed(carrier, within);
     }
+
+    /** A block's order and the range its positions leave it, the order being null where nothing
+     *  orders it. */
+    record Placed(Carrier carrier, OrderedInterval within) {}
 
     /** Whether anything outside these readings places a position of {@code block}. */
     private static <A> boolean places(Sameness.Block<A> block,
@@ -532,7 +541,7 @@ sealed interface Confinement<A> {
                     // against the values its blocks are left, and those are descriptions here. The
                     // walk says so of each alternative that carries one.
                     (asked, _) -> values.anyAlternativeAdmits(asked),
-                    (asked, _) -> Refusal.atEachOf(values.refusedInEveryAlternativeAt(asked)),
+                    (asked, _) -> values.refusedInEveryAlternativeAt(asked),
                     values.emptiedBlocks());
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -379,15 +379,7 @@ sealed interface Confinement<A> {
             }
             within = within.meet(sits.apply(position));
         }
-        if (carrier != null) {
-            return carrier.valuesShared(set, within, atMost);
-        }
-        // A position on no order has no range for its values to be met with, so a set naming them
-        // is the whole of what it holds. Every other shape is one only an order can say the values
-        // of — what a written set leaves out is every value there is, and how many that is is the
-        // carrier's answer.
-        return set instanceof ValueSet.Finite it && it.values().size() <= atMost
-                ? new Admits.These(it.values()) : new Admits.NotKnown();
+        return Carrier.leftAt(carrier, set, within, atMost);
     }
 
     /** The two questions one walk over the alternatives is asked: what each block leaves, and what
@@ -536,15 +528,11 @@ sealed interface Confinement<A> {
         @Override
         public Admission<A> admission(PositionEnvelope.Restrictions<A> outside) {
             return shown != null ? shown : Confinement.admission(ordered, carriers, outside,
-                    // A description is not a set, so what a denial between two blocks comes to is
-                    // not something this side can work out — and a relation carried by an
-                    // alternative is a relation nothing here has read. Said as undecided rather
-                    // than as something standing, which is what every question this side puts off
-                    // is said as.
-                    (asked, _) -> values.anyAlternativeAdmits(asked)
-                            .met(values.anyDenialRead() ? Emptiness.UNDECIDED : Emptiness.NONEMPTY),
-                    (asked, _) -> new Refusal.AtEachOf<>(
-                            values.refusedInEveryAlternativeAt(asked)),
+                    // The relation is not asked on this side: what a denial comes to is settled
+                    // against the values its blocks are left, and those are descriptions here. The
+                    // walk says so of each alternative that carries one.
+                    (asked, _) -> values.anyAlternativeAdmits(asked),
+                    (asked, _) -> Refusal.atEachOf(values.refusedInEveryAlternativeAt(asked)),
                     values.emptiedBlocks());
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -247,7 +247,7 @@ sealed interface Confinement<A> {
                                       PositionEnvelope.Restrictions<A> outside,
                                       Admitting<A> admitting,
                                       Refusing<A> refused,
-                                      Set<Sameness.Block<A>> heldAsOneAndEmptied) {
+                                      Refusal<A> alreadyShown) {
         // The ends holding a position nothing, which is that reading's own answer whatever else
         // places the position: a reading left with no range at all names none, and where it names
         // one, that is where the lack is.
@@ -339,14 +339,15 @@ sealed interface Confinement<A> {
         // it, since a proof that consults no range is one no placing of a position took part in.
         if (admitting.of((_, _) -> Emptiness.NONEMPTY,
                 relating(carriers, _ -> OrderedInterval.OPEN)) == Emptiness.EMPTY) {
-            // With the places where what the values were left nothing at is a value several
-            // positions share. Each of them holds something on its own, so the general answer —
-            // that the values admit nothing — is true and says less than what was shown.
-            return heldAsOneAndEmptied.isEmpty()
-                    ? new Admission<>(Emptiness.EMPTY, EmptyBy.VALUES, new Refusal.Nowhere<>(),
-                            Shown.BY_THE_READINGS)
-                    : Admission.eachOf(Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_AS_ONE,
-                            heldAsOneAndEmptied, Shown.BY_THE_READINGS);
+            // With where the reading was refused, where that is nearer than the general answer.
+            // Each of those places holds something on its own, so "the values admit nothing" is
+            // true of the declaration and says less than what was shown — and which of the two
+            // nearer sentences it is is the refusal's to say and not a second reading of it.
+            return new Admission<>(Emptiness.EMPTY, switch (alreadyShown) {
+                case Refusal.Nowhere<A> _ -> EmptyBy.VALUES;
+                case Refusal.AtEachOf<A> _ -> EmptyBy.POSITIONS_HELD_AS_ONE;
+                case Refusal.OfThemTogether<A> _ -> EmptyBy.POSITIONS_HELD_APART;
+            }, alreadyShown, Shown.BY_THE_READINGS);
         }
         return new Admission<>(Emptiness.EMPTY, EmptyBy.SET_AND_RANGE, where, how);
     }
@@ -542,7 +543,7 @@ sealed interface Confinement<A> {
                     // walk says so of each alternative that carries one.
                     (asked, _) -> values.anyAlternativeAdmits(asked),
                     (asked, _) -> values.refusedInEveryAlternativeAt(asked),
-                    values.emptiedBlocks());
+                    values.refusedBy());
         }
 
         /**
@@ -693,7 +694,7 @@ sealed interface Confinement<A> {
             Admission<A> said = Confinement.admission(ordered, carriers, outside,
                     made.values()::anyAlternativeAdmits,
                     made.values()::refusedInEveryAlternativeAt,
-                    made.values().emptiedBlocks());
+                    made.values().refusedBy());
             // A position nobody could build is one what stands there is wider than the rules, so a
             // pair the ranges did not refuse may still hold nothing. Settled empty is settled all
             // the same: a narrower reading refuses no less.
@@ -758,7 +759,7 @@ sealed interface Confinement<A> {
         public Admission<A> admission(PositionEnvelope.Restrictions<A> outside) {
             return shown != null ? shown : Confinement.admission(ordered, carriers, outside,
                     values::anyAlternativeAdmits, values::refusedInEveryAlternativeAt,
-                    values.emptiedBlocks());
+                    values.refusedBy());
         }
 
         /** The positions the order leaves no value at. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -9,8 +9,11 @@ import souther.compiler.values.Allowance;
 import souther.compiler.values.AskedOfEachBlock;
 import souther.compiler.values.ConjoinedAdmissibleValues;
 import souther.compiler.values.Emptiness;
+import souther.compiler.values.Admits;
+import souther.compiler.values.AskedOfARelation;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realized;
+import souther.compiler.values.Refusal;
 import souther.compiler.values.Sameness;
 import souther.compiler.values.ValueSet;
 
@@ -107,35 +110,32 @@ sealed interface Confinement<A> {
      *            That word names which of the two readings left the pair nothing, and where the
      *            answer needed a restriction from outside, neither of them did
      *
-     * @param at   the blocks every alternative was refused at, empty where no one of them is why.
-     *             Read of {@link EmptyBy#SET_AND_RANGE}, {@link EmptyBy#ORDER} and
-     *             {@link EmptyBy#POSITIONS_HELD_AS_ONE}.
-     *
-     *             <p>Blocks and not the positions they are of. What was refused is the one value a
-     *             block holds, and each of its positions may be left something on its own — taken
-     *             apart here, a pair whose ranges share nothing would be reported at whichever of
-     *             them is declared first, whose own rules are fine with what they leave it. Two
-     *             blocks refused are two of these and stay two: their positions put in one set say
-     *             the rules hold all of them as one value, which no rule states, and a choice
-     *             between two dead branches would intersect those sets and claim a lack about
-     *             whatever the two happened to share
+     * @param site where the lack is, and whether it is a lack at each of some blocks or a lack
+     *             about several of them together — see {@link Refusal}
      */
-    record Admission<A>(Emptiness emptiness, EmptyBy by, Set<Sameness.Block<A>> at, Shown how) {
+    record Admission<A>(Emptiness emptiness, EmptyBy by, Refusal<A> site, Shown how) {
 
-        public Admission {
-            at = Set.copyOf(at);
+        /** The blocks the lack is about, for a reader that only has to name places. */
+        Set<Sameness.Block<A>> at() {
+            return site.blocks();
         }
 
         /** The same, where what was refused is places rather than values several of them share. */
         static <A> Admission<A> at(Emptiness emptiness, EmptyBy by, Set<A> positions, Shown how) {
             Set<Sameness.Block<A>> blocks = new LinkedHashSet<>();
             positions.forEach(each -> blocks.add(Sameness.Block.of(each)));
-            return new Admission<>(emptiness, by, blocks, how);
+            return new Admission<>(emptiness, by, new Refusal.AtEachOf<>(blocks), how);
+        }
+
+        /** The same, at each of these blocks. */
+        static <A> Admission<A> eachOf(Emptiness emptiness, EmptyBy by,
+                                       Set<Sameness.Block<A>> blocks, Shown how) {
+            return new Admission<>(emptiness, by, new Refusal.AtEachOf<>(blocks), how);
         }
 
         /** Something may satisfy the pair, so nothing emptied it. */
         static <A> Admission<A> left(Emptiness emptiness) {
-            return new Admission<>(emptiness, EmptyBy.NOTHING_SHOWN, Set.of(),
+            return new Admission<>(emptiness, EmptyBy.NOTHING_SHOWN, new Refusal.Nowhere<>(),
                     Shown.BY_THE_READINGS);
         }
 
@@ -159,18 +159,18 @@ sealed interface Confinement<A> {
          * were written in.
          */
         static <A> Admission<A> bothShown(Admission<A> one, Admission<A> other) {
-            Set<Sameness.Block<A>> both = new LinkedHashSet<>(one.at);
-            both.retainAll(other.at);
             // And shown by the readings alone only where both of them were, which is the rule
             // however these two were shown. Nothing hands a branch's fate a restriction from
             // outside today ({@link StatedByClauses.Reading}), so both of these are the readings'
             // own; said the other way, this would be a fact about the pair that neither half is.
             return new Admission<>(Emptiness.EMPTY,
-                    one.by == other.by ? one.by : EmptyBy.RULES_TOGETHER, both,
+                    one.by == other.by ? one.by : EmptyBy.RULES_TOGETHER,
+                    Refusal.shownByBoth(one.site, other.site),
                     one.byTheReadings() && other.byTheReadings()
                             ? Shown.BY_THE_READINGS : Shown.ONCE_THE_POSITIONS_ARE_PLACED);
         }
     }
+
 
     /**
      * What an emptiness was shown by: these two readings, or these two asked with what stands
@@ -208,6 +208,16 @@ sealed interface Confinement<A> {
          */
         POSITIONS_HELD_AS_ONE,
 
+        /**
+         * Positions the rules state to hold different values are left no way of differing.
+         *
+         * <p>Not a lack at any of them, which is what tells it from every other arm here. Each of
+         * those blocks is left values of its own and what has nothing is an assignment to all of
+         * them at once — so the proof is about them together, and what it is read off is the
+         * argument that refused them rather than a set of places.
+         */
+        POSITIONS_HELD_APART,
+
         /** Some position's order holds no value, whatever the values admit. */
         ORDER,
 
@@ -235,8 +245,8 @@ sealed interface Confinement<A> {
      */
     static <A> Admission<A> admission(OrderedIntervals<A> ordered, Map<A, Carrier> carriers,
                                       PositionEnvelope.Restrictions<A> outside,
-                                      Function<AskedOfEachBlock<A>, Emptiness> admitting,
-                                      Function<AskedOfEachBlock<A>, Set<Sameness.Block<A>>> refused,
+                                      Admitting<A> admitting,
+                                      Refusing<A> refused,
                                       Set<Sameness.Block<A>> heldAsOneAndEmptied) {
         // The ends holding a position nothing, which is that reading's own answer whatever else
         // places the position: a reading left with no range at all names none, and where it names
@@ -253,6 +263,14 @@ sealed interface Confinement<A> {
         AskedOfEachBlock<A> byTheReadings = asking(carriers, ordered::at, meter);
         AskedOfEachBlock<A> narrowed = asking(carriers, position ->
                 ordered.at(position).meet(outside.at(position).interval()), meter);
+        // What a relation between two blocks comes to, which is settled against what each of them
+        // is left once everything placing its positions has been met with it. Built here for the
+        // same reason the question above is: the values and the ranges are put together in one
+        // place, and a relation read against the values alone would answer one way for a block
+        // pinned to one value by a written value and another for a block pinned to one by its ends.
+        AskedOfARelation<A> relating = relating(carriers, position ->
+                ordered.at(position).meet(outside.at(position).interval()));
+        AskedOfARelation<A> byTheReadingsRelating = relating(carriers, ordered::at);
         // And a block nothing outside places is the question above and not another one, so it is
         // answered once however many askings reach it. That is what lets the two share a meter: a
         // machine a question builds is built for the block it is about, and asking about the same
@@ -265,7 +283,7 @@ sealed interface Confinement<A> {
         // One walk, and it is asked where the positions are: what a reading leaves is what it
         // leaves once everything that places its positions has been met with it, and a walk per
         // asking would be an alternative visited twice by two questions that have to agree.
-        Emptiness said = admitting.apply(placed);
+        Emptiness said = admitting.of(placed, relating);
         if (said != Emptiness.EMPTY) {
             // And a position with nowhere to be once everything placing it is met, which is a lack
             // the alternatives never hear about: a position no alternative names is not one they
@@ -291,22 +309,14 @@ sealed interface Confinement<A> {
         // where they do, that is what an author is told — read off the walk that was answered, a
         // pair whose own set and range share no value would be reported against bounds derived
         // somewhere else, which is true and is not what they wrote.
-        Shown how = outside.saysNothing() || admitting.apply(byTheReadings) == Emptiness.EMPTY
+        Shown how = outside.saysNothing()
+                || admitting.of(byTheReadings, byTheReadingsRelating) == Emptiness.EMPTY
                 ? Shown.BY_THE_READINGS : Shown.ONCE_THE_POSITIONS_ARE_PLACED;
         // The values holding no alternative at all is the values' own answer, and asking anything
         // of the ranges would not have changed it. Told apart here rather than by a second reader
         // reassembling the same three facts — and said to be the readings' whichever asking reached
         // it, since a proof that consults no range is one no placing of a position took part in.
-        if (admitting.apply((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY) {
-            // With the places where what the values were left nothing at is a value several
-            // positions share. Each of them holds something on its own, so the general answer —
-            // that the values admit nothing — is true and says less than what was shown.
-            return heldAsOneAndEmptied.isEmpty()
-                    ? new Admission<>(Emptiness.EMPTY, EmptyBy.VALUES, Set.of(),
-                            Shown.BY_THE_READINGS)
-                    : new Admission<>(Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_AS_ONE,
-                            heldAsOneAndEmptied, Shown.BY_THE_READINGS);
-        }
+        //
         // The blocks it was asked at, which is what the question was about. A block of several
         // positions is refused as one value and not as each of them: {@code p == r && p < "b" && r
         // > "y"} leaves each position a range with something in it, and what has nothing is the
@@ -314,8 +324,83 @@ sealed interface Confinement<A> {
         //
         // Asked of the question that showed it, so that the blocks named are the ones refused by
         // what the proof says refused them.
-        return new Admission<>(Emptiness.EMPTY, EmptyBy.SET_AND_RANGE,
-                refused.apply(how == Shown.BY_THE_READINGS ? byTheReadings : placed), how);
+        Refusal<A> where = how == Shown.BY_THE_READINGS
+                ? refused.of(byTheReadings, byTheReadingsRelating)
+                : refused.of(placed, relating);
+        // A lack about several blocks together, which is nearer than either of the answers below
+        // and is not one of them: each of those blocks is left values of its own, and what has
+        // nothing is an assignment to all of them at once.
+        if (where instanceof Refusal.OfThemTogether) {
+            return new Admission<>(Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_APART, where, how);
+        }
+        // The values holding no alternative at all is the values' own answer, and asking anything
+        // of the ranges would not have changed it. Told apart here rather than by a second reader
+        // reassembling the same three facts — and said to be the readings' whichever asking reached
+        // it, since a proof that consults no range is one no placing of a position took part in.
+        if (admitting.of((_, _) -> Emptiness.NONEMPTY,
+                relating(carriers, _ -> OrderedInterval.OPEN)) == Emptiness.EMPTY) {
+            // With the places where what the values were left nothing at is a value several
+            // positions share. Each of them holds something on its own, so the general answer —
+            // that the values admit nothing — is true and says less than what was shown.
+            return heldAsOneAndEmptied.isEmpty()
+                    ? new Admission<>(Emptiness.EMPTY, EmptyBy.VALUES, new Refusal.Nowhere<>(),
+                            Shown.BY_THE_READINGS)
+                    : Admission.eachOf(Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_AS_ONE,
+                            heldAsOneAndEmptied, Shown.BY_THE_READINGS);
+        }
+        return new Admission<>(Emptiness.EMPTY, EmptyBy.SET_AND_RANGE, where, how);
+    }
+
+    /**
+     * What the denials between an alternative's blocks come to, where {@code sits} puts its
+     * positions.
+     *
+     * <p>The relation asked against what each of its blocks is left, which is the values that
+     * block admits met with where its positions sit. Which is why it is built beside the question
+     * about one block rather than inside the reading that holds the relation: the reading holds
+     * the values and nothing else, and a denial settled against those alone would answer one way
+     * for a block a written value pins and another for a block its ends pin.
+     */
+    private static <A> AskedOfARelation<A> relating(Map<A, Carrier> carriers,
+                                                    Function<A, OrderedInterval> sits) {
+        return (apart, product) -> apart.reduce((block, atMost) ->
+                admits(carriers, sits, block, product.get(block), atMost));
+    }
+
+    /** Which values {@code block} is left, where {@code sits} puts its positions. */
+    private static <A> Admits admits(Map<A, Carrier> carriers, Function<A, OrderedInterval> sits,
+                                     Sameness.Block<A> block, ValueSet set, int atMost) {
+        Carrier carrier = null;
+        OrderedInterval within = OrderedInterval.OPEN;
+        for (A position : block.members()) {
+            Carrier here = carriers.get(position);
+            if (here != null) {
+                carrier = here;
+            }
+            within = within.meet(sits.apply(position));
+        }
+        if (carrier != null) {
+            return carrier.valuesShared(set, within, atMost);
+        }
+        // A position on no order has no range for its values to be met with, so a set naming them
+        // is the whole of what it holds. Every other shape is one only an order can say the values
+        // of — what a written set leaves out is every value there is, and how many that is is the
+        // carrier's answer.
+        return set instanceof ValueSet.Finite it && it.values().size() <= atMost
+                ? new Admits.These(it.values()) : new Admits.NotKnown();
+    }
+
+    /** The two questions one walk over the alternatives is asked: what each block leaves, and what
+     *  the denials between them come to. */
+    @FunctionalInterface
+    interface Admitting<A> {
+        Emptiness of(AskedOfEachBlock<A> blocks, AskedOfARelation<A> relation);
+    }
+
+    /** The same two questions, asked to write down where a reading was left nothing. */
+    @FunctionalInterface
+    interface Refusing<A> {
+        Refusal<A> of(AskedOfEachBlock<A> blocks, AskedOfARelation<A> relation);
     }
 
     /**
@@ -451,7 +536,15 @@ sealed interface Confinement<A> {
         @Override
         public Admission<A> admission(PositionEnvelope.Restrictions<A> outside) {
             return shown != null ? shown : Confinement.admission(ordered, carriers, outside,
-                    values::anyAlternativeAdmits, values::refusedInEveryAlternativeAt,
+                    // A description is not a set, so what a denial between two blocks comes to is
+                    // not something this side can work out — and a relation carried by an
+                    // alternative is a relation nothing here has read. Said as undecided rather
+                    // than as something standing, which is what every question this side puts off
+                    // is said as.
+                    (asked, _) -> values.anyAlternativeAdmits(asked)
+                            .met(values.anyDenialRead() ? Emptiness.UNDECIDED : Emptiness.NONEMPTY),
+                    (asked, _) -> new Refusal.AtEachOf<>(
+                            values.refusedInEveryAlternativeAt(asked)),
                     values.emptiedBlocks());
         }
 
@@ -692,12 +785,9 @@ sealed interface Confinement<A> {
         <B> Conjoined<B> renamed(Function<A, B> naming) {
             Map<B, Carrier> out = new LinkedHashMap<>();
             carriers.forEach((position, carrier) -> out.put(naming.apply(position), carrier));
-            Set<Sameness.Block<B>> at = new LinkedHashSet<>();
-            if (shown != null) {
-                shown.at().forEach(block -> at.add(block.renamed(naming)));
-            }
             Admission<B> said = shown == null ? null
-                    : new Admission<>(shown.emptiness(), shown.by(), at, shown.how());
+                    : new Admission<>(shown.emptiness(), shown.by(),
+                            shown.site().renamed(naming), shown.how());
             return new Conjoined<>(values.renamed(naming), ordered.renamed(naming), out, said);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -7,6 +7,7 @@ import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.ConjoinedAdmissibleValues;
+import souther.compiler.values.Refusal;
 
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
@@ -286,10 +287,20 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
             case ORDER -> new Emptiness.EmptyOrderedInterval();
             case SET_AND_RANGE -> new Emptiness.NoAllowedValueInRange();
             case POSITIONS_HELD_AS_ONE -> new Emptiness.NoCommonValueForEqualPositions();
+            case POSITIONS_HELD_APART -> new Emptiness.NoDistinctValuesForPositionsHeldApart();
             case NOTHING_SHOWN, VALUES, RULES_TOGETHER -> null;
         } : new Emptiness.NoAllowedValueWithinRequiredBounds();
         if (said == null) {
             return Optional.ofNullable(why);
+        }
+        // Positions stated to differ, which is a lack about all of them at once and at none of
+        // them. Said as its own place rather than through the one below: that one names the block
+        // whose positions are one value, and these positions are not one value — read through it,
+        // a proof would say the rules hold them as one, which is what they state they are not.
+        if (shown.site() instanceof Refusal.OfThemTogether<A> it) {
+            List<Emptiness.AtAField.Where> apart = declaredIn(it.why().blocks(), positions);
+            return Optional.of(apart.size() < 2 ? Emptiness.preferred(why, said)
+                    : Emptiness.preferred(why, new Emptiness.AtPositionsHeldApart(apart, said)));
         }
         // One block of the proof is named, and it is named as what it is: a place where it is one
         // position, and the positions together where it is several.
@@ -354,6 +365,38 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
         List<Emptiness.AtAField.Where> out = new ArrayList<>();
         positions.forEach((position, place) -> {
             if (named.holds(position)) {
+                out.add(place);
+            }
+        });
+        return out;
+    }
+
+    /**
+     * Where the value declares the positions of every one of {@code blocks}, in that order.
+     *
+     * <p>All of them and not one, which is what parts this from {@link #nearestBlock}. A lack about
+     * blocks together is one lack about all of them, so every place it names is part of the
+     * sentence; there is no choosing between them, and dropping one would say the rules refuse
+     * fewer positions than they do.
+     *
+     * <p>Empty where the value declares none of one of those positions, which is a lack about
+     * subjects it does not name. What can be said then is what the general proof says.
+     */
+    private static <A> List<Emptiness.AtAField.Where> declaredIn(
+            Set<souther.compiler.values.Sameness.Block<A>> blocks,
+            SequencedMap<A, Emptiness.AtAField.Where> positions) {
+        Set<A> named = new java.util.LinkedHashSet<>();
+        for (souther.compiler.values.Sameness.Block<A> block : blocks) {
+            for (A member : block.members()) {
+                if (!positions.containsKey(member)) {
+                    return List.of();
+                }
+                named.add(member);
+            }
+        }
+        List<Emptiness.AtAField.Where> out = new ArrayList<>();
+        positions.forEach((position, place) -> {
+            if (named.contains(position)) {
                 out.add(place);
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -8,6 +8,7 @@ import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.ConjoinedAdmissibleValues;
 import souther.compiler.values.Refusal;
+import souther.compiler.values.RelationalWitness;
 
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
@@ -287,7 +288,13 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
             case ORDER -> new Emptiness.EmptyOrderedInterval();
             case SET_AND_RANGE -> new Emptiness.NoAllowedValueInRange();
             case POSITIONS_HELD_AS_ONE -> new Emptiness.NoCommonValueForEqualPositions();
-            case POSITIONS_HELD_APART -> new Emptiness.NoDistinctValuesForPositionsHeldApart();
+            // Which of the arguments a relation refuses by is the witness's to say, and the two are
+            // two sentences: one is about how many values there are and the other about nothing of
+            // the kind.
+            case POSITIONS_HELD_APART -> shown.site() instanceof Refusal.OfThemTogether<A> it
+                    && it.why() instanceof RelationalWitness.ABlockApartFromItself
+                    ? new Emptiness.PositionsHeldAsOneAreHeldApart()
+                    : new Emptiness.NoDistinctValuesForPositionsHeldApart();
             case NOTHING_SHOWN, VALUES, RULES_TOGETHER -> null;
         } : new Emptiness.NoAllowedValueWithinRequiredBounds();
         if (said == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -547,7 +547,8 @@ public final class DataChecker {
                      Emptiness.TheNameHasNone _, Emptiness.NoBaseInComponent _,
                      Emptiness.AtAField _, Emptiness.AtEqualPositions _,
                      Emptiness.AtPositionsHeldApart _,
-                     Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
+                     Emptiness.NoDistinctValuesForPositionsHeldApart _,
+                     Emptiness.PositionsHeldAsOneAreHeldApart _ ->
                         at.say(new DataMessage.ItsRulesCannotAllHold(data));
             };
             // The places together, the same way, and a sentence of its own: these positions are
@@ -557,6 +558,12 @@ public final class DataChecker {
             case Emptiness.AtPositionsHeldApart it -> switch (it.under()) {
                 case Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
                         at.say(new DataMessage.NoValuesTheseCanAllDifferIn(
+                                data, written(it.where())));
+                // And the two rules where what refuses is reading them: one value is not two,
+                // whatever those positions may hold. An author told there were too few values
+                // would go looking for more, and there is no number of them that would do.
+                case Emptiness.PositionsHeldAsOneAreHeldApart _ ->
+                        at.say(new DataMessage.TheseAreHeldAsOneValueAndStatedToDiffer(
                                 data, written(it.where())));
                 // Every other proof, named rather than gathered under a default, for the reason
                 // the arm above gives. None of them reaches here today: this place is written
@@ -582,7 +589,8 @@ public final class DataChecker {
             // block to name, what is carried is the general form instead. Being exhaustive over the
             // proofs is what makes the next one a build that stops here.
             case Emptiness.NoCommonValueForEqualPositions _,
-                 Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
+                 Emptiness.NoDistinctValuesForPositionsHeldApart _,
+                 Emptiness.PositionsHeldAsOneAreHeldApart _ ->
                     at.say(new DataMessage.ItsRulesCannotAllHold(data));
             case Emptiness.ConflictingRules _, Emptiness.EmptyNumericInterval _ ->
                     at.say(new DataMessage.ItsRulesCannotAllHold(data));

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -545,7 +545,32 @@ public final class DataChecker {
                      Emptiness.SetRequiresTooManyDistinctValues _,
                      Emptiness.NonEmptyCollectionWithNoElement _, Emptiness.AcrossEveryCase _,
                      Emptiness.TheNameHasNone _, Emptiness.NoBaseInComponent _,
-                     Emptiness.AtAField _, Emptiness.AtEqualPositions _ ->
+                     Emptiness.AtAField _, Emptiness.AtEqualPositions _,
+                     Emptiness.AtPositionsHeldApart _,
+                     Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
+                        at.say(new DataMessage.ItsRulesCannotAllHold(data));
+            };
+            // The places together, the same way, and a sentence of its own: these positions are
+            // stated to differ and there is no way for them to. Said as what they cannot all
+            // differ in rather than as a value they cannot all hold, which is the rule turned
+            // round and is what the places beside them do hold.
+            case Emptiness.AtPositionsHeldApart it -> switch (it.under()) {
+                case Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
+                        at.say(new DataMessage.NoValuesTheseCanAllDifferIn(
+                                data, written(it.where())));
+                // Every other proof, named rather than gathered under a default, for the reason
+                // the arm above gives. None of them reaches here today: this place is written
+                // only under the proof above it.
+                case Emptiness.ConflictingRules _, Emptiness.EmptyNumericInterval _,
+                     Emptiness.EmptyOrderedInterval _, Emptiness.NoAllowedCollectionSize _,
+                     Emptiness.SetRequiresTooManyDistinctValues _,
+                     Emptiness.NonEmptyCollectionWithNoElement _, Emptiness.AcrossEveryCase _,
+                     Emptiness.TheNameHasNone _, Emptiness.NoBaseInComponent _,
+                     Emptiness.NoAllowedValueInRange _,
+                     Emptiness.NoAllowedValueWithinRequiredBounds _,
+                     Emptiness.NoCommonValueForEqualPositions _,
+                     Emptiness.AtAField _, Emptiness.AtEqualPositions _,
+                     Emptiness.AtPositionsHeldApart _ ->
                         at.say(new DataMessage.ItsRulesCannotAllHold(data));
             };
             case Emptiness.NoBaseInComponent it -> {
@@ -556,7 +581,8 @@ public final class DataChecker {
             // made only inside the one that says which positions it is about, and where there is no
             // block to name, what is carried is the general form instead. Being exhaustive over the
             // proofs is what makes the next one a build that stops here.
-            case Emptiness.NoCommonValueForEqualPositions _ ->
+            case Emptiness.NoCommonValueForEqualPositions _,
+                 Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
                     at.say(new DataMessage.ItsRulesCannotAllHold(data));
             case Emptiness.ConflictingRules _, Emptiness.EmptyNumericInterval _ ->
                     at.say(new DataMessage.ItsRulesCannotAllHold(data));

--- a/souther-compiler/src/main/java/souther/compiler/check/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Emptiness.java
@@ -151,6 +151,17 @@ public sealed interface Emptiness {
     record NoDistinctValuesForPositionsHeldApart() implements Emptiness {}
 
     /**
+     * Positions the rules hold as one value are also stated to differ.
+     *
+     * <p>Refused by reading the two rules and against no value: whatever those positions may hold,
+     * one value is not two. Beside {@link NoDistinctValuesForPositionsHeldApart} rather than said
+     * as it, because that one is about how many values there are and this one is about nothing of
+     * the kind — an author told there were too few would go looking for more, and there is no
+     * number of them that would do.
+     */
+    record PositionsHeldAsOneAreHeldApart() implements Emptiness {}
+
+    /**
      * A set is asked to hold more values that differ than there are of what it holds.
      *
      * <p>One number and not two. What was compared is whether the rules admit any size this small,
@@ -355,7 +366,8 @@ public sealed interface Emptiness {
             case ConflictingRules _, EmptyOrderedInterval _, NoAllowedValueInRange _,
                  NoAllowedValueWithinRequiredBounds _,
                  NoCommonValueForEqualPositions _,
-                 NoDistinctValuesForPositionsHeldApart _ -> Nearness.DIRECT;
+                 NoDistinctValuesForPositionsHeldApart _,
+                 PositionsHeldAsOneAreHeldApart _ -> Nearness.DIRECT;
             case EmptyNumericInterval _, SetRequiresTooManyDistinctValues _,
                  NoAllowedCollectionSize _ -> Nearness.STRUCTURAL;
             case TheNameHasNone _, NoBaseInComponent _ -> Nearness.PROPAGATED;

--- a/souther-compiler/src/main/java/souther/compiler/check/Emptiness.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Emptiness.java
@@ -136,6 +136,21 @@ public sealed interface Emptiness {
     record NoCommonValueForEqualPositions() implements Emptiness {}
 
     /**
+     * Positions the rules state to hold different values are left no way of differing.
+     *
+     * <p>The other half of what a rule between two positions can say, and the same shape of lack:
+     * each of them is left values of its own, and what has nothing is an assignment to all of them
+     * at once. So it is said of the positions together, and a sentence naming one would send an
+     * author after a rule that place is fine with.
+     *
+     * <p><b>Not {@link NoCommonValueForEqualPositions} with the rule turned round.</b> That one is
+     * a lack at one place — the value several positions are — and this one is a lack at no place.
+     * A reader shown the first is shown where to look; a reader shown this is shown which rules
+     * cannot hold between them.
+     */
+    record NoDistinctValuesForPositionsHeldApart() implements Emptiness {}
+
+    /**
      * A set is asked to hold more values that differ than there are of what it holds.
      *
      * <p>One number and not two. What was compared is whether the rules admit any size this small,
@@ -252,6 +267,28 @@ public sealed interface Emptiness {
     }
 
     /**
+     * Several positions of the declaration are stated to differ, and cannot all be told apart.
+     *
+     * <p>{@link AtEqualPositions} for the rule the other way round, and a different sentence rather
+     * than the same one about different places. Those positions hold one value between them and
+     * this value has none; these positions hold a value each and there are not enough values to go
+     * round. A reader shown the first goes to the value they share, and there is nowhere for a
+     * reader of this to go but to the rules between them.
+     *
+     * @param where the places, in the order the value declares them
+     */
+    record AtPositionsHeldApart(List<AtAField.Where> where, Emptiness under) implements Emptiness {
+
+        public AtPositionsHeldApart {
+            where = List.copyOf(where);
+            if (where.size() < 2) {
+                throw new IllegalArgumentException(
+                        "positions stated to differ are more than one position");
+            }
+        }
+    }
+
+    /**
      * Every case of a sum, or every member of a union, has no value.
      *
      * <p>All of them and not one of them. A sum has a value wherever any case does, so what proves it
@@ -317,12 +354,14 @@ public sealed interface Emptiness {
             // the rules contradicting, with the place and the reason filled in.
             case ConflictingRules _, EmptyOrderedInterval _, NoAllowedValueInRange _,
                  NoAllowedValueWithinRequiredBounds _,
-                 NoCommonValueForEqualPositions _ -> Nearness.DIRECT;
+                 NoCommonValueForEqualPositions _,
+                 NoDistinctValuesForPositionsHeldApart _ -> Nearness.DIRECT;
             case EmptyNumericInterval _, SetRequiresTooManyDistinctValues _,
                  NoAllowedCollectionSize _ -> Nearness.STRUCTURAL;
             case TheNameHasNone _, NoBaseInComponent _ -> Nearness.PROPAGATED;
             case AtAField at -> at.under().category();
             case AtEqualPositions at -> at.under().category();
+            case AtPositionsHeldApart at -> at.under().category();
             case NonEmptyCollectionWithNoElement held -> held.element().category();
             // As far off as its furthest case: the sum has none because all of them have none, so a
             // proof reaching another declaration is a proof this one reaches it too.

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -321,6 +321,7 @@ public final class TypeCardinality {
                  Emptiness.EmptyOrderedInterval _, Emptiness.NoAllowedValueInRange _,
                  Emptiness.NoAllowedValueWithinRequiredBounds _,
                  Emptiness.NoCommonValueForEqualPositions _,
+                 Emptiness.NoDistinctValuesForPositionsHeldApart _,
                  Emptiness.SetRequiresTooManyDistinctValues _,
                  Emptiness.NoAllowedCollectionSize _ -> true;
             case Emptiness.TheNameHasNone it ->
@@ -332,6 +333,7 @@ public final class TypeCardinality {
             case Emptiness.NoBaseInComponent _ -> false;
             case Emptiness.AtAField it -> restsOn(it.under(), within, shown);
             case Emptiness.AtEqualPositions it -> restsOn(it.under(), within, shown);
+            case Emptiness.AtPositionsHeldApart it -> restsOn(it.under(), within, shown);
             case Emptiness.NonEmptyCollectionWithNoElement it ->
                     restsOn(it.element(), within, shown);
             case Emptiness.AcrossEveryCase it ->

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -322,6 +322,7 @@ public final class TypeCardinality {
                  Emptiness.NoAllowedValueWithinRequiredBounds _,
                  Emptiness.NoCommonValueForEqualPositions _,
                  Emptiness.NoDistinctValuesForPositionsHeldApart _,
+                 Emptiness.PositionsHeldAsOneAreHeldApart _,
                  Emptiness.SetRequiresTooManyDistinctValues _,
                  Emptiness.NoAllowedCollectionSize _ -> true;
             case Emptiness.TheNameHasNone it ->

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -205,7 +205,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
          */
         final class Alternatives<A> implements Held<A> {
 
-            private final Set<Box<A>> boxes;
+            private final Set<Alternative<A>> boxes;
             /**
              * Which positions every alternative holds as one value, which is the coordinate this
              * reading answers a position in.
@@ -221,7 +221,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
              *  everywhere else here. */
             private final Map<Sameness.Block<A>, ValueSet> across;
 
-            private Alternatives(Set<Box<A>> boxes, Sameness<A> commonSameness,
+            private Alternatives(Set<Alternative<A>> boxes, Sameness<A> commonSameness,
                                  Map<Sameness.Block<A>, ValueSet> across) {
                 if (boxes.isEmpty()) {
                     throw new IllegalArgumentException("a reading holding no alternative is Nothing");
@@ -232,7 +232,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             }
 
             /** One alternative, which holds at each of its blocks what it says there. */
-            public static <A> Alternatives<A> of(Box<A> box) {
+            public static <A> Alternatives<A> of(Alternative<A> box) {
                 return new Alternatives<>(Set.of(box), box.sameness(), box.at());
             }
 
@@ -243,9 +243,9 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
 
             /** What every alternative holds as one, which is what a reading can say of a position
              *  it holds several alternatives of. */
-            static <A> Sameness<A> commonTo(Collection<Box<A>> boxes) {
+            static <A> Sameness<A> commonTo(Collection<Alternative<A>> boxes) {
                 Sameness<A> out = null;
-                for (Box<A> box : boxes) {
+                for (Alternative<A> box : boxes) {
                     out = out == null ? box.sameness() : out.common(box.sameness());
                 }
                 return out == null ? Sameness.discrete() : out;
@@ -259,7 +259,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
              * join, and a join of two languages is a machine — worked out from the sets after they
              * were built, it would be a machine nobody had described and nobody had counted.
              */
-            static <A> Alternatives<A> of(Set<Box<A>> boxes, Sameness<A> commonSameness,
+            static <A> Alternatives<A> of(Set<Alternative<A>> boxes, Sameness<A> commonSameness,
                                           Map<Sameness.Block<A>, ValueSet> across) {
                 return new Alternatives<>(boxes, commonSameness, across);
             }
@@ -280,7 +280,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
              * equality, the coordinate the union answers in is the finer one they agree on, and
              * that machine is its own.
              */
-            static <A> Made<A> of(Set<Box<A>> boxes, Allowance<A> sets) {
+            static <A> Made<A> of(Set<Alternative<A>> boxes, Allowance<A> sets) {
                 Sameness<A> common = commonTo(boxes);
                 Map<Sameness.Block<A>, ValueSet> across = new LinkedHashMap<>();
                 Set<Sameness.Block<A>> gaveUp = new LinkedHashSet<>();
@@ -313,7 +313,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             /** The alternatives, and the blocks the exact answer across them was not built at. */
             record Made<A>(Alternatives<A> held, Set<Sameness.Block<A>> gaveUp) {}
 
-            public Set<Box<A>> boxes() {
+            public Set<Alternative<A>> boxes() {
                 return boxes;
             }
 
@@ -325,7 +325,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
 
             /** The same alternatives under other names, which moves no value and builds nothing. */
             <B> Alternatives<B> renamed(java.util.function.Function<A, B> naming) {
-                Set<Box<B>> renamed = new LinkedHashSet<>();
+                Set<Alternative<B>> renamed = new LinkedHashSet<>();
                 boxes.forEach(box -> renamed.add(box.renamed(naming)));
                 Map<Sameness.Block<B>, ValueSet> out = new LinkedHashMap<>();
                 across.forEach((block, set) -> out.put(block.renamed(naming), set));
@@ -431,10 +431,15 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
          * <p>Said as one plan over every part rather than folded two at a time
          * ({@link Allowance#meeting}), so that a block gathering three sets costs one number
          * whichever order the equalities that made it were written in.
+         *
+         * <p>{@code heldAsOne} is handed in and not worked out here, because what the two of them
+         * are a product over is not settled by their sides alone: a denial beside them names blocks
+         * as well ({@link Alternative#sameness}). Asked of the sides, a side and a denial of one
+         * conjunction would be filed a step apart.
          */
-        Map<Sameness.Block<A>, ValueSet> narrowedWith(Box<A> other, Allowance<A> sets,
+        Map<Sameness.Block<A>, ValueSet> narrowedWith(Box<A> other, Sameness<A> heldAsOne,
+                                                      Allowance<A> sets,
                                                       Set<Sameness.Block<A>> gaveUp) {
-            Sameness<A> heldAsOne = sameness().meet(other.sameness());
             Map<Sameness.Block<A>, List<ValueSet>> parts = new LinkedHashMap<>();
             gathering(at, heldAsOne, parts);
             gathering(other.at, heldAsOne, parts);
@@ -468,6 +473,126 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             Map<Sameness.Block<B>, ValueSet> out = new LinkedHashMap<>();
             at.forEach((block, set) -> out.put(block.renamed(naming), set));
             return new Box<>(out);
+        }
+    }
+
+    /**
+     * One alternative: a product over its blocks, and which of those blocks are stated to differ.
+     *
+     * <p>Two kinds of rule and one alternative. What each block may hold on its own is a product
+     * and is {@link Box}; what a denial between two of them says is not a side of any product, so
+     * it is beside it ({@link Apartness}) and the two together are what a value has to satisfy. A
+     * value stands in this where it stands in the product and no two blocks the relation names hold
+     * one value.
+     *
+     * <p><b>Which is why the relation is not in the box.</b> A box is every combination of its
+     * sides standing, and a reader may take one side's value without asking about another's. A
+     * denial makes some of those combinations stand for nothing, and a reader that could not see it
+     * would go on reading the box as the set of what satisfies the rules.
+     *
+     * <p>The blocks this is a product over are its sides' and the relation's together. A denial
+     * between two positions nothing else narrowed says nothing about what either admits, so the
+     * product holds no side for them — and the alternative is still one whose answer at those
+     * positions the relation speaks about.
+     *
+     * @param product what each block may hold, every combination of them standing
+     * @param apart which of those blocks are stated to hold different values
+     */
+    public record Alternative<A>(Box<A> product, Apartness<A> apart) {
+
+        /** One alternative that states no denial. */
+        public static <A> Alternative<A> of(Box<A> product) {
+            return new Alternative<>(product, Apartness.nothing());
+        }
+
+        /** One alternative over positions that are each their own block, stating no denial. */
+        public static <A> Alternative<A> at(Map<A, ValueSet> said) {
+            return of(Box.at(said));
+        }
+
+        /** What each block may hold, a block this says nothing about being left out. */
+        public Map<Sameness.Block<A>, ValueSet> at() {
+            return product.at();
+        }
+
+        /**
+         * Which positions this alternative holds as one value, over its sides and its relation
+         * alike.
+         *
+         * <p>Read off what it holds rather than kept beside it, which is what keeps the two from
+         * disagreeing: a relation stored as a second account of the blocks would have to be moved
+         * whenever the sides were, and the alternative would be a product over one thing and a
+         * relation over another.
+         */
+        public Sameness<A> sameness() {
+            Set<Sameness.Block<A>> named = new LinkedHashSet<>(product.at().keySet());
+            named.addAll(apart.blocks());
+            return Sameness.of(named);
+        }
+
+        ValueSet get(Sameness.Block<A> block) {
+            return product.get(block);
+        }
+
+        /** What stands at {@code position}, which is what the block it is on holds. */
+        ValueSet get(A position) {
+            return get(sameness().blockOf(position));
+        }
+
+        /** Every position this alternative says anything about, by narrowing it or by relating
+         *  it. */
+        Set<A> positions() {
+            Set<A> out = new LinkedHashSet<>(product.positions());
+            apart.blocks().forEach(block -> out.addAll(block.members()));
+            return out;
+        }
+
+        /**
+         * Both alternatives holding at once.
+         *
+         * <p>{@link Box#narrowedWith}'s rule, and the relation carried onto the blocks that rule
+         * leaves. The equalities of the two are conjoined and closed first, so a denial stated of
+         * blocks either side was a product over is a denial of whatever those blocks are part of
+         * here — and where the two ends land on one block, the conjunction says a value differs
+         * from itself and nothing satisfies it.
+         *
+         * <p>Carried here and not by whoever meets two of them, because the blocks the sides are
+         * filed under and the blocks the relation names are the same blocks: moved separately, the
+         * two would be filed under coordinates a step apart and {@link Sameness#filing} would
+         * refuse whichever of them was moved second.
+         */
+        Met<A> narrowedWith(Alternative<A> other, Allowance<A> sets,
+                            Set<Sameness.Block<A>> gaveUp) {
+            Sameness<A> heldAsOne = sameness().meet(other.sameness());
+            return new Met<>(product.narrowedWith(other.product, heldAsOne, sets, gaveUp),
+                    apart.and(other.apart).filedIn(heldAsOne));
+        }
+
+        /** What a conjunction of two alternatives came to, before anything asks whether a value
+         *  stands in it. */
+        record Met<A>(Map<Sameness.Block<A>, ValueSet> at, Apartness<A> apart) {
+
+            /** Whether nothing stands in it, which is a side left no value or a block stated to
+             *  differ from itself. */
+            boolean standsForNothing() {
+                return at.values().stream().anyMatch(ValueSet::isEmpty)
+                        || apart.holdsABlockApartFromItself();
+            }
+
+            /** The alternative it is, which a caller asks for only where something stands in it. */
+            Alternative<A> alternative() {
+                return new Alternative<>(new Box<>(at), apart);
+            }
+        }
+
+        /** The same alternative under other names, which moves no value and builds nothing. */
+        <B> Alternative<B> renamed(java.util.function.Function<A, B> naming) {
+            return new Alternative<>(product.renamed(naming), apart.renamed(naming));
+        }
+
+        @Override
+        public String toString() {
+            return apart.isEmpty() ? product.toString() : product + " with " + apart;
         }
     }
 
@@ -936,7 +1061,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked) {
         if (held instanceof Held.Alternatives<A> it) {
             Emptiness any = Emptiness.EMPTY;
-            for (Box<A> box : it.boxes()) {
+            for (Alternative<A> box : it.boxes()) {
                 Emptiness stands = Emptiness.NONEMPTY;
                 for (Map.Entry<Sameness.Block<A>, ValueSet> each : box.at().entrySet()) {
                     stands = stands.met(asked.of(each.getKey(), each.getValue()));
@@ -976,7 +1101,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             return Set.of();
         }
         Set<Sameness.Block<A>> everywhere = null;
-        for (Box<A> box : it.boxes()) {
+        for (Alternative<A> box : it.boxes()) {
             Set<Sameness.Block<A>> here = new LinkedHashSet<>();
             // The block and not its positions. What was refused is the one value those positions
             // share, and each of them may be left something on its own — taken apart here, the
@@ -1230,16 +1355,16 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             emptied.addAll(other.emptiedBlocks());
             return new Held.Nothing<>(emptied);
         }
-        Set<Box<A>> live = new LinkedHashSet<>();
+        Set<Alternative<A>> live = new LinkedHashSet<>();
         Set<Sameness.Block<A>> emptied = null;
-        for (Box<A> here : alternatives()) {
-            for (Box<A> there : other.alternatives()) {
-                Map<Sameness.Block<A>, ValueSet> both = here.narrowedWith(there, sets, gaveUp);
-                if (both.values().stream().noneMatch(ValueSet::isEmpty)) {
-                    live.add(new Box<>(both));
+        for (Alternative<A> here : alternatives()) {
+            for (Alternative<A> there : other.alternatives()) {
+                Alternative.Met<A> both = here.narrowedWith(there, sets, gaveUp);
+                if (!both.standsForNothing()) {
+                    live.add(both.alternative());
                     continue;
                 }
-                emptied = alsoEmptied(emptied, both);
+                emptied = alsoEmptied(emptied, both.at());
             }
         }
         if (live.isEmpty()) {
@@ -1435,8 +1560,28 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             out.put(block, made.set());
         }
         // Live by construction: a join of two sets is empty only where both are, and neither side
-        // is bottom here.
-        return one(new Box<>(out));
+        // is bottom here. What it states of two blocks is what every alternative of both states of
+        // them — a denial one branch reads is not the choice's, the same way an equality is not.
+        return one(new Alternative<>(new Box<>(out),
+                apartInEveryAlternative(heldAsOne)
+                        .commonWith(other.apartInEveryAlternative(heldAsOne), heldAsOne)));
+    }
+
+    /**
+     * What every alternative of this reading states to differ, said at {@code finer}.
+     *
+     * <p>Every one of them and not any: an alternative is one somebody may be in, so a denial one
+     * of them states is a rule a value satisfying another need not meet. Read at the blocks the
+     * caller answers in, because that is where the answer is filed — a denial stated where two
+     * positions were one value says as much of each of them where they are two.
+     */
+    private Apartness<A> apartInEveryAlternative(Sameness<A> finer) {
+        Apartness<A> out = null;
+        for (Alternative<A> box : alternatives()) {
+            out = out == null ? box.apart().readAt(finer)
+                    : out.commonWith(box.apart(), finer);
+        }
+        return out == null ? Apartness.nothing() : out;
     }
 
     /**
@@ -1447,7 +1592,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     private Held<A> apart(AdmissibleValues<A> other, Allowance<A> sets,
                           Set<Sameness.Block<A>> gaveUp) {
-        Set<Box<A>> boxes = new LinkedHashSet<>(alternatives());
+        Set<Alternative<A>> boxes = new LinkedHashSet<>(alternatives());
         boxes.addAll(other.alternatives());
         Held.Alternatives.Made<A> made = Held.Alternatives.of(boxes, sets);
         gaveUp.addAll(made.gaveUp());
@@ -1481,7 +1626,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /** The alternatives this holds, which a reading that admits nothing has none of. */
-    private Set<Box<A>> alternatives() {
+    private Set<Alternative<A>> alternatives() {
         return held instanceof Held.Alternatives<A> it ? it.boxes() : Set.of();
     }
 
@@ -1510,8 +1655,14 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
 
     /** One alternative, which is what most readings hold. Nothing is put together, so what each
      *  position holds across the alternatives is what the one of them says. */
-    private static <A> Held<A> one(Box<A> box) {
+    private static <A> Held<A> one(Alternative<A> box) {
         return Held.Alternatives.of(box);
+    }
+
+    /** One alternative that states no denial, which is what every reading of a single rule holds
+     *  but the one that read a denial. */
+    private static <A> Held<A> one(Box<A> box) {
+        return one(Alternative.of(box));
     }
 
     /** Either side holding at each position, which is what both spoke about: a position one of

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -402,7 +402,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             return Sameness.of(at.keySet());
         }
 
-        ValueSet get(Sameness.Block<A> block) {
+        /** What this says stands at {@code block}, which is every value where it says nothing. */
+        public ValueSet get(Sameness.Block<A> block) {
             return at.getOrDefault(block, ValueSet.ANY);
         }
 
@@ -895,6 +896,34 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /**
+     * Two positions said to hold different values, which is what a denial between them states.
+     *
+     * <p>Narrowing neither, the way an equality narrows neither: what a denial says is that no one
+     * value stands at both, which is a relation between two sides of the product rather than a
+     * statement about either. So it is held beside the product ({@link Apartness}) and what it
+     * comes to is worked out where the values each side is left are in hand.
+     *
+     * <p><b>And guaranteeing nothing at either of them.</b> What is guaranteed is a lower bound —
+     * these values are admitted whatever else is read — and no value can be shown admitted at one
+     * of two positions held apart without an assignment for the other. Over a carrier of one value
+     * a denial admits nothing at all, so a guarantee of every value would be false of a model
+     * somebody can write. Said here rather than wherever a denial is met with something, because
+     * meeting a guarantee with nothing leaves nothing: every conjunction this rule reaches has it
+     * without a second rule saying so, and a choice beside it keeps what its other branch
+     * guarantees, which is right — a value satisfying that branch is under no denial.
+     */
+    public static <A> AdmissibleValues<A> heldApart(A here, A there) {
+        Sameness.Block<A> one = Sameness.Block.of(here);
+        Sameness.Block<A> other = Sameness.Block.of(there);
+        Map<Sameness.Block<A>, ValueSet> promised = new LinkedHashMap<>();
+        promised.put(one, ValueSet.NONE);
+        promised.put(other, ValueSet.NONE);
+        return new AdmissibleValues<>(
+                one(new Alternative<>(new Box<>(Map.of()), Apartness.of(here, there))),
+                Map.of(), Standing.nothing(), promised, ValueSet.ANY, true, Set.of(), Set.of());
+    }
+
+    /**
      * A rule this could not read, which says nothing about any position and spoils the ones it
      * names.
      *
@@ -1058,7 +1087,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * reading is settled empty only where every alternative is, since one nobody worked out may yet
      * hold something.
      */
-    public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked) {
+    public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked, AskedOfARelation<A> relating) {
         if (held instanceof Held.Alternatives<A> it) {
             Emptiness any = Emptiness.EMPTY;
             for (Alternative<A> box : it.boxes()) {
@@ -1068,6 +1097,12 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
                     if (stands == Emptiness.EMPTY) {
                         break;
                     }
+                }
+                // And what its denials come to, asked after the blocks and not before. An
+                // alternative already refused at a block is one no relation has to be read for,
+                // and reading it first would spend on every alternative what one question settled.
+                if (stands != Emptiness.EMPTY) {
+                    stands = stands.met(relating.of(box.apart(), box.product()).emptiness());
                 }
                 any = any.joined(stands);
                 if (any == Emptiness.NONEMPTY) {
@@ -1096,34 +1131,49 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * What it cannot do is disagree with that answer about anything a reader acts on: what comes
      * back is somewhere to name, and none of them is the general form.
      */
-    public Set<Sameness.Block<A>> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked) {
+    public Refusal<A> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked,
+                                                  AskedOfARelation<A> relating) {
         if (!(held instanceof Held.Alternatives<A> it)) {
-            return Set.of();
+            return new Refusal.Nowhere<>();
         }
-        Set<Sameness.Block<A>> everywhere = null;
+        Refusal<A> everywhere = null;
         for (Alternative<A> box : it.boxes()) {
-            Set<Sameness.Block<A>> here = new LinkedHashSet<>();
-            // The block and not its positions. What was refused is the one value those positions
-            // share, and each of them may be left something on its own — taken apart here, the
-            // proof would say a lack is at a place whose own rules are fine with it.
-            box.at().forEach((block, set) -> {
-                if (asked.of(block, set) == Emptiness.EMPTY) {
-                    here.add(block);
-                }
-            });
-            if (here.isEmpty()) {
-                return Set.of();
+            Refusal<A> here = refusalIn(box, asked, relating);
+            if (here.isNowhere()) {
+                return new Refusal.Nowhere<>();
             }
-            if (everywhere == null) {
-                everywhere = here;
-            } else {
-                everywhere.retainAll(here);
-                if (everywhere.isEmpty()) {
-                    return Set.of();
-                }
+            everywhere = everywhere == null ? here : Refusal.shownByBoth(everywhere, here);
+            if (everywhere.isNowhere()) {
+                return new Refusal.Nowhere<>();
             }
         }
-        return everywhere == null ? Set.of() : Collections.unmodifiableSet(everywhere);
+        return everywhere == null ? new Refusal.Nowhere<>() : everywhere;
+    }
+
+    /**
+     * Where one alternative was refused, which is at its blocks or about several of them together.
+     *
+     * <p>The blocks first, because a lack at a block is the nearer answer: it names a place whose
+     * own rules leave it nothing, where a lack about several of them names no such place. An
+     * alternative refused both ways is refused at the blocks, and the relation is what is left to
+     * say where no block has nothing on its own.
+     */
+    private Refusal<A> refusalIn(Alternative<A> box, AskedOfEachBlock<A> asked,
+                                 AskedOfARelation<A> relating) {
+        Set<Sameness.Block<A>> here = new LinkedHashSet<>();
+        // The block and not its positions. What was refused is the one value those positions
+        // share, and each of them may be left something on its own — taken apart here, the
+        // proof would say a lack is at a place whose own rules are fine with it.
+        box.at().forEach((block, set) -> {
+            if (asked.of(block, set) == Emptiness.EMPTY) {
+                here.add(block);
+            }
+        });
+        if (!here.isEmpty()) {
+            return new Refusal.AtEachOf<>(here);
+        }
+        return relating.of(box.apart(), box.product()) instanceof Apartness.Reduction.Nothing<A> it
+                ? new Refusal.OfThemTogether<>(it.why()) : new Refusal.Nowhere<>();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -196,7 +196,13 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         }
 
         /**
-         * The alternatives the rules leave, none of which admits nothing.
+         * The alternatives the rules leave, no side of which admits nothing.
+         *
+         * <p>No side, and not none of which admits nothing. An alternative whose denials state a
+         * value to differ from itself admits nothing and is one of these all the same: what says so
+         * is the relation it carries, and it is read where a relation is read. Dropped where the
+         * sides are put together, the rules that emptied it would be gone and a reader asking why
+         * would be told the general answer.
          *
          * <p>A set and not a sequence: what is held is their union, so the same alternative written
          * twice is one alternative and the order two of them were met in is not part of the answer.
@@ -573,11 +579,18 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
          *  stands in it. */
         record Met<A>(Map<Sameness.Block<A>, ValueSet> at, Apartness<A> apart) {
 
-            /** Whether nothing stands in it, which is a side left no value or a block stated to
-             *  differ from itself. */
+            /**
+             * Whether a side of it is left no value, which is what makes it no alternative.
+             *
+             * <p>A side and not the relation. A conjunction that puts two blocks together makes a
+             * denial between them a value stated to differ from itself, and nothing satisfies that
+             * — but it is a fact the relation states rather than a product with an empty side, and
+             * what states it is still there to be read. Dropped here, the alternative would go and
+             * the rules that emptied it would go with it, and a reader asking why would be told
+             * that the values admit nothing.
+             */
             boolean standsForNothing() {
-                return at.values().stream().anyMatch(ValueSet::isEmpty)
-                        || apart.holdsABlockApartFromItself();
+                return at.values().stream().anyMatch(ValueSet::isEmpty);
             }
 
             /** The alternative it is, which a caller asks for only where something stands in it. */

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -178,20 +178,20 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
          *                value and leave that value nothing, while each of them on its own is left
          *                something
          */
-        record Nothing<A>(Set<Sameness.Block<A>> emptied) implements Held<A> {
+        record Nothing<A>(Refusal<A> shown) implements Held<A> {
 
             public Nothing {
-                emptied = Collections.unmodifiableSet(new LinkedHashSet<>(emptied));
-                if (emptied.stream().anyMatch(Sameness.Block::isOne)) {
+                if (shown instanceof Refusal.AtEachOf<A> it
+                        && it.blocks().stream().anyMatch(Sameness.Block::isOne)) {
                     throw new IllegalArgumentException(
                             "a lone position left no value is what the positions' own rules say,"
                                     + " and is not a lack the block is answerable for");
                 }
             }
 
-            /** Nothing satisfies the rules, and no block of several positions is why. */
+            /** Nothing satisfies the rules, and nothing here says where. */
             public Nothing() {
-                this(Set.of());
+                this(new Refusal.Nowhere<>());
             }
         }
 
@@ -580,22 +580,36 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         record Met<A>(Map<Sameness.Block<A>, ValueSet> at, Apartness<A> apart) {
 
             /**
-             * Whether a side of it is left no value, which is what makes it no alternative.
+             * The alternative this is, or where nothing stands in it.
              *
-             * <p>A side and not the relation. A conjunction that puts two blocks together makes a
-             * denial between them a value stated to differ from itself, and nothing satisfies that
-             * — but it is a fact the relation states rather than a product with an empty side, and
-             * what states it is still there to be read. Dropped here, the alternative would go and
-             * the rules that emptied it would go with it, and a reader asking why would be told
-             * that the values admit nothing.
+             * <p>Two ways for a conjunction of two alternatives to stand for nothing, and both of
+             * them are answered here. A side may be left no value, which is a product with an empty
+             * side and no alternative at all; and the denials may state a value to differ from
+             * itself, which nothing satisfies whatever the sides hold.
+             *
+             * <p><b>Answered here and not by keeping it and reading it later.</b> An alternative
+             * standing for nothing is not a member of a union — a choice between it and something
+             * else is that something else — so keeping it would make the union hold what its
+             * alternatives do not, and a reading of it say that it admits what none of them does.
+             * What is carried out instead is why, since that is knowable only here.
              */
-            boolean standsForNothing() {
-                return at.values().stream().anyMatch(ValueSet::isEmpty);
-            }
-
-            /** The alternative it is, which a caller asks for only where something stands in it. */
-            Alternative<A> alternative() {
-                return new Alternative<>(new Box<>(at), apart);
+            Held<A> stands() {
+                Set<Sameness.Block<A>> emptied = new LinkedHashSet<>();
+                at.forEach((block, set) -> {
+                    if (!block.isOne() && set.isEmpty()) {
+                        emptied.add(block);
+                    }
+                });
+                if (at.values().stream().anyMatch(ValueSet::isEmpty)) {
+                    return new Held.Nothing<>(Refusal.atEachOf(emptied));
+                }
+                for (Apartness.Edge<A> edge : apart.edges()) {
+                    if (edge.isOfOneBlock()) {
+                        return new Held.Nothing<>(new Refusal.OfThemTogether<>(
+                                new RelationalWitness.ABlockApartFromItself<>(edge.one())));
+                    }
+                }
+                return Held.Alternatives.of(new Alternative<>(new Box<>(at), apart));
             }
         }
 
@@ -1065,15 +1079,15 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /**
-     * The blocks of more than one position the rules left no value, where that is what emptied
-     * this reading.
+     * Where this reading was refused, where it holds nothing.
      *
-     * <p>Empty where the reading holds something, and empty where what emptied it is a position's
-     * own rules rather than what several of them share. Read here rather than worked out from what
-     * survived: nothing survived.
+     * <p>Nowhere in particular where the reading holds something, and nowhere where what emptied it
+     * is a position's own rules rather than something several of them are answerable for. Read here
+     * rather than worked out from what survived: nothing survived, and what refused an alternative
+     * is knowable only while it is being refused.
      */
-    public Set<Sameness.Block<A>> emptiedBlocks() {
-        return held instanceof Held.Nothing<A> it ? it.emptied() : Set.of();
+    public Refusal<A> refusedBy() {
+        return held instanceof Held.Nothing<A> it ? it.shown() : new Refusal.Nowhere<>();
     }
 
     /**
@@ -1248,7 +1262,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      */
     public <B> AdmissibleValues<B> renamed(java.util.function.Function<A, B> naming) {
         Held<B> renamedHeld = switch (held) {
-            case Held.Nothing<A> it -> new Held.Nothing<B>(renamedNames(it.emptied(), naming));
+            case Held.Nothing<A> it -> new Held.Nothing<B>(it.shown().renamed(naming));
             case Held.Alternatives<A> alternatives -> alternatives.renamed(naming);
         };
         return new AdmissibleValues<>(renamedHeld, renamedKeys(perPosition, naming),
@@ -1414,24 +1428,24 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             // Emptied by whatever emptied the side that was empty. A conjunction with a side
             // nothing satisfies is empty for that side's reason, and working it out again from
             // what is left would find nothing left to work it out from.
-            Set<Sameness.Block<A>> emptied = new LinkedHashSet<>(emptiedBlocks());
-            emptied.addAll(other.emptiedBlocks());
-            return new Held.Nothing<>(emptied);
+            return new Held.Nothing<>(Refusal.eitherShown(refusedBy(), other.refusedBy()));
         }
         Set<Alternative<A>> live = new LinkedHashSet<>();
-        Set<Sameness.Block<A>> emptied = null;
+        // What every dropped pair was refused by, and not what any of them was. A pair may be
+        // dropped for a reason of its own, so what the conjunction holds nothing by is what all of
+        // them agree on — the rule a choice between two dead branches is put together by.
+        Refusal<A> dropped = null;
         for (Alternative<A> here : alternatives()) {
             for (Alternative<A> there : other.alternatives()) {
-                Alternative.Met<A> both = here.narrowedWith(there, sets, gaveUp);
-                if (!both.standsForNothing()) {
-                    live.add(both.alternative());
-                    continue;
+                switch (here.narrowedWith(there, sets, gaveUp).stands()) {
+                    case Held.Alternatives<A> it -> live.addAll(it.boxes());
+                    case Held.Nothing<A> it -> dropped = dropped == null ? it.shown()
+                            : Refusal.shownByBoth(dropped, it.shown());
                 }
-                emptied = alsoEmptied(emptied, both.at());
             }
         }
         if (live.isEmpty()) {
-            return new Held.Nothing<>(emptied == null ? Set.of() : emptied);
+            return new Held.Nothing<>(dropped == null ? new Refusal.Nowhere<>() : dropped);
         }
         Held.Alternatives.Made<A> made = Held.Alternatives.of(live, sets);
         gaveUp.addAll(made.gaveUp());
@@ -1523,9 +1537,9 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
             // Emptied by what emptied both. A block one branch was left nothing at is one the
             // other may stand at, so what the choice is left nothing at is what neither of them
             // has a value for — the same rule the rest of a dead choice is put together by.
-            Set<Sameness.Block<A>> emptied = new LinkedHashSet<>(emptiedBlocks());
-            emptied.retainAll(other.emptiedBlocks());
-            return new AdmissibleValues<>(new Held.Nothing<>(emptied), emptyInBoth(other),
+            return new AdmissibleValues<>(
+                    new Held.Nothing<>(Refusal.shownByBoth(refusedBy(), other.refusedBy())),
+                    emptyInBoth(other),
                     standing.and(other.standing),
                     Map.of(), ValueSet.NONE, true,
                     eachApart(both(tangled, other.tangled)),
@@ -1662,31 +1676,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         return made.held();
     }
 
-    /**
-     * The blocks of several positions one dropped alternative was left no value at, kept beside
-     * what every other dropped alternative was.
-     *
-     * <p>What every one of them was left nothing at, and not what any of them was. An alternative
-     * may be dropped for a reason of its own, so a block named by one of them is not why the
-     * reading holds nothing — the same rule a choice between two dead branches is put together by.
-     *
-     * @param so what the alternatives before this one were left nothing at, or null where this is
-     *           the first of them
-     */
-    static <A> Set<Sameness.Block<A>> alsoEmptied(Set<Sameness.Block<A>> so,
-                                                  Map<Sameness.Block<A>, ValueSet> dropped) {
-        Set<Sameness.Block<A>> here = new LinkedHashSet<>();
-        dropped.forEach((block, set) -> {
-            if (!block.isOne() && set.isEmpty()) {
-                here.add(block);
-            }
-        });
-        if (so == null) {
-            return here;
-        }
-        so.retainAll(here);
-        return so;
-    }
 
     /** The alternatives this holds, which a reading that admits nothing has none of. */
     private Set<Alternative<A>> alternatives() {

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -165,18 +165,23 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
          * alternatives cannot answer it, because a conjunction drops the pairs nothing stands in
          * and what a dropped pair was going to say about a position leaves with it.
          *
-         * @param emptied the blocks of more than one position that were left no value, where that
-         *                is what emptied the reading. Carried and not worked out again: an
-         *                alternative is dropped where a side of it admits nothing, and the side is
-         *                gone with it — asked afterwards, the answer would be that the values admit
-         *                nothing, which is true and is the general form of what was shown.
+         * @param shown where the reading was refused, where anything answerable for it is.
+         *              Carried and not worked out again: an alternative is dropped where nothing
+         *              stands in it, and what refused it is gone with it — asked afterwards, the
+         *              answer would be that the values admit nothing, which is true and is the
+         *              general form of what was shown.
          *
-         *                <p>Only blocks of several positions. A lone position left no value is
-         *                what {@link AdmissibleValues#perPosition} already answers, and a second
-         *                account of it here would be the same fact in two spellings. What is new is
-         *                a lack no position has on its own: the rules hold these positions as one
-         *                value and leave that value nothing, while each of them on its own is left
-         *                something
+         *              <p>A lack at blocks is only ever at blocks of several positions. A lone
+         *              position left no value is what {@link AdmissibleValues#perPosition} already
+         *              answers, and a second account of it here would be the same fact in two
+         *              spellings. What is new is a lack no position has on its own: the rules hold
+         *              these positions as one value and leave that value nothing, while each of
+         *              them on its own is left something.
+         *
+         *              <p>A lack about blocks together carries no such rule, and names blocks of
+         *              one position wherever the rules relate two positions nothing else holds as
+         *              one. It is not a lack at either of them — each is left values of its own —
+         *              so nothing here is a second account of what a position's own rules say
          */
         record Nothing<A>(Refusal<A> shown) implements Held<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -854,7 +854,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
 
     /** Nothing read and nothing missed, which is what a reading starts from. */
     public static <A> AdmissibleValues<A> top() {
-        return new AdmissibleValues<>(one(Box.at(Map.of())), Map.of(), Standing.nothing(),
+        return new AdmissibleValues<>(one(Alternative.at(Map.of())), Map.of(), Standing.nothing(),
                 Map.of(), ValueSet.ANY, true, Set.of(), Set.of());
     }
 
@@ -901,7 +901,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     /** One position said to admit {@code set}, and nothing missed. */
     public static <A> AdmissibleValues<A> at(A atom, ValueSet set) {
         Map<A, ValueSet> said = Map.of(atom, set);
-        return new AdmissibleValues<>(set.isEmpty() ? new Held.Nothing<>() : one(Box.at(said)),
+        return new AdmissibleValues<>(
+                set.isEmpty() ? new Held.Nothing<>() : one(Alternative.at(said)),
                 said, Standing.nothing(), Map.of(Sameness.Block.of(atom), set),
                 ValueSet.ANY, true, Set.of(), Set.of());
     }
@@ -922,7 +923,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         // one: it shapes the relation without touching what any position admits. Left out, a
         // choice between two equalities would be a union of two relations that no product holds
         // and would say it lost nothing, since what it reads to decide that is this key set.
-        return new AdmissibleValues<>(one(new Box<>(Map.of(block, ValueSet.ANY))), Map.of(),
+        return new AdmissibleValues<>(
+                one(Alternative.of(new Box<>(Map.of(block, ValueSet.ANY)))), Map.of(),
                 Standing.nothing(), Map.of(block, ValueSet.ANY), ValueSet.ANY, true,
                 Set.of(), Set.of());
     }
@@ -971,7 +973,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         // Nothing is guaranteed anywhere, and at the positions it does not name as much as at the
         // ones it does: what a rule this has no word for admits is not known, so a choice offering
         // it as an alternative is offering nothing that can be counted on.
-        return new AdmissibleValues<>(one(Box.at(Map.of())), Map.of(),
+        return new AdmissibleValues<>(one(Alternative.at(Map.of())), Map.of(),
                 Standing.of(named, why), Map.of(),
                 ValueSet.NONE, true, Set.of(), Set.of());
     }
@@ -1658,12 +1660,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * positions were one value says as much of each of them where they are two.
      */
     private Apartness<A> apartInEveryAlternative(Sameness<A> finer) {
-        Apartness<A> out = null;
-        for (Alternative<A> box : alternatives()) {
-            out = out == null ? box.apart().readAt(finer)
-                    : out.commonWith(box.apart(), finer);
-        }
-        return out == null ? Apartness.nothing() : out;
+        return Apartness.commonTo(alternatives().stream().map(Alternative::apart).toList(), finer);
     }
 
     /**
@@ -1716,11 +1713,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         return Held.Alternatives.of(box);
     }
 
-    /** One alternative that states no denial, which is what every reading of a single rule holds
-     *  but the one that read a denial. */
-    private static <A> Held<A> one(Box<A> box) {
-        return one(Alternative.of(box));
-    }
 
     /** Either side holding at each position, which is what both spoke about: a position one of
      *  them says nothing about is one a value satisfying that side may hold anything at. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Admits.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Admits.java
@@ -37,6 +37,18 @@ public sealed interface Admits {
     /** More values than the caller said it would count, which is as many as it needs. */
     record MoreThanCounted() implements Admits {}
 
+    /**
+     * These values, or that there are more of them than {@code atMost}.
+     *
+     * <p>The one place the bound is applied. Whoever works out which values a block is left counts
+     * them as it goes and has to decide where to stop, and that decision written at each of those
+     * places is the same rule spelled three ways — one stopping at the bound, one past it, one
+     * calling the answer unknown. What "more than were counted" means belongs to this word.
+     */
+    static Admits of(Set<Value> values, int atMost) {
+        return values.size() > atMost ? new MoreThanCounted() : new These(values);
+    }
+
     /** Not something the reading that was asked can write down. */
     record NotKnown() implements Admits {}
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Admits.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Admits.java
@@ -1,0 +1,64 @@
+package souther.compiler.values;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Which values one block of an alternative is left, for a reader relating it to another.
+ *
+ * <p>Three answers and not a set, because the two that are not a set are what let a relation be
+ * decided without enumerating an order. Whether a denial between two blocks leaves anything turns
+ * on which values each of them holds; a block holding more of them than the relation has blocks
+ * never runs out, and a block whose values nothing here can write down is one the relation says
+ * nothing about.
+ *
+ * <p><b>{@link MoreThanCounted} is not a set and not a refusal to answer.</b> It is the answer that
+ * there are more values here than the caller said it would count — which is what a reader deciding
+ * a relation between a handful of blocks needs, since such a block can always be given a value no
+ * other took. Read as {@link NotKnown}, a relation over strings would be undecidable; read as a
+ * set, it would be counted and the count would be wrong.
+ */
+public sealed interface Admits {
+
+    /** These values and no others. */
+    record These(Set<Value> values) implements Admits {
+
+        public These {
+            values = Collections.unmodifiableSet(new LinkedHashSet<>(values));
+        }
+
+        /** The one value this is, or null where it is not one value. */
+        public Value only() {
+            return values.size() == 1 ? values.iterator().next() : null;
+        }
+    }
+
+    /** More values than the caller said it would count, which is as many as it needs. */
+    record MoreThanCounted() implements Admits {}
+
+    /** Not something the reading that was asked can write down. */
+    record NotKnown() implements Admits {}
+
+    /** This without {@code value}, which is what a block held apart from one holding only that
+     *  value is left. Taking one value from more than were counted leaves more than were counted
+     *  less one, which is still more than none. */
+    default Admits without(Value value) {
+        if (!(this instanceof These it) || !it.values().contains(value)) {
+            return this;
+        }
+        Set<Value> out = new LinkedHashSet<>(it.values());
+        out.remove(value);
+        return new These(out);
+    }
+
+    /** Whether this is settled to be no value at all. */
+    default boolean isNone() {
+        return this instanceof These it && it.values().isEmpty();
+    }
+
+    /** Whether which values these are is written down, which is what a count can be taken of. */
+    default boolean isCounted() {
+        return this instanceof These;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -338,15 +338,19 @@ public final class Apartness<A> {
      * for.
      */
     private RelationalWitness<A> takingWhatOneValueBlocksHold(Map<Sameness.Block<A>, Admits> left) {
+        // The blocks and not the entries, because taking a value away writes back into the map this
+        // is walking. Which blocks there are does not change while it runs — a reduction takes
+        // values away and never adds a block — so the list is made once.
+        List<Sameness.Block<A>> named = new ArrayList<>(left.keySet());
         boolean moved = true;
         while (moved) {
             moved = false;
-            for (Map.Entry<Sameness.Block<A>, Admits> each : left.entrySet()) {
-                Value only = each.getValue() instanceof Admits.These it ? it.only() : null;
+            for (Sameness.Block<A> block : named) {
+                Value only = left.get(block) instanceof Admits.These it ? it.only() : null;
                 if (only == null) {
                     continue;
                 }
-                for (Sameness.Block<A> next : apartFrom(each.getKey())) {
+                for (Sameness.Block<A> next : apartFrom(block)) {
                     Admits was = left.get(next);
                     Admits now = was.without(only);
                     if (now.equals(was)) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -217,6 +217,12 @@ public final class Apartness<A> {
      * relates all three and states nothing of {@code p} and {@code r}, so two values are enough;
      * read as one set of three, it would be refused over a carrier of two and no rule says so.
      *
+     * <p><b>Only the ones nothing can be added to.</b> A set of blocks all stated to differ is
+     * refused by there being fewer values between them than there are blocks, and a set inside one
+     * of these is refused only where this one is: a value apiece for the larger set is a value
+     * apiece for every part of it. So the parts are covered by the whole and emitting them as well
+     * is the same question asked again — once per subset, which is as many as there are subsets.
+     *
      * <p>Bounded by {@code most}, and by refusing rather than by answering with less: how many of
      * these there are is not something the rules bound, and a reading that stopped partway would
      * decide a declaration by how far it happened to get. A relation too large to walk is one this
@@ -232,39 +238,58 @@ public final class Apartness<A> {
             apart.computeIfAbsent(edge.other(), _ -> new LinkedHashSet<>()).add(edge.one());
         }
         List<Set<Sameness.Block<A>>> found = new ArrayList<>();
-        List<Sameness.Block<A>> named = new ArrayList<>(apart.keySet());
-        for (Sameness.Block<A> block : named) {
-            grow(new LinkedHashSet<>(Set.of(block)), apart.get(block), apart, found, most);
-            if (found.size() > most) {
-                return List.of();
-            }
+        grow(new LinkedHashSet<>(), new LinkedHashSet<>(apart.keySet()), new LinkedHashSet<>(),
+                apart, found, most);
+        if (found.size() > most) {
+            return List.of();
         }
         found.sort(Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
         return found;
     }
 
-    /** Every set {@code sofar} grows into by taking blocks every one of its members is apart
-     *  from. */
+    /**
+     * Every set {@code sofar} grows into that nothing can be added to, each reached once.
+     *
+     * <p>{@code may} is what can still be added and {@code taken} is what was tried and set aside.
+     * A set is one nothing can be added to where both are empty; where {@code taken} holds
+     * something, every set this branch could reach was reached already through that block, and
+     * walking on would find the same sets by another road. Without it a set of {@code k} blocks is
+     * found once for every order its blocks can be taken in, and each of those is the same question
+     * asked again.
+     *
+     * @param sofar the blocks taken so far, all stated to differ from each other
+     * @param may the blocks every one of those is stated to differ from
+     * @param taken those of them already set aside, which some earlier branch has covered
+     */
     private void grow(Set<Sameness.Block<A>> sofar, Set<Sameness.Block<A>> may,
+                      Set<Sameness.Block<A>> taken,
                       Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart,
                       List<Set<Sameness.Block<A>>> found, int most) {
         if (found.size() > most) {
             return;
         }
-        if (sofar.size() > 1) {
-            found.add(Collections.unmodifiableSet(new LinkedHashSet<>(sofar)));
-        }
-        for (Sameness.Block<A> next : may) {
-            Set<Sameness.Block<A>> grown = new LinkedHashSet<>(sofar);
-            if (!grown.add(next)) {
-                continue;
+        if (may.isEmpty()) {
+            if (taken.isEmpty() && sofar.size() > 1) {
+                found.add(Collections.unmodifiableSet(new LinkedHashSet<>(sofar)));
             }
-            Set<Sameness.Block<A>> still = new LinkedHashSet<>(may);
-            still.retainAll(apart.getOrDefault(next, Set.of()));
-            grow(grown, still, apart, found, most);
+            return;
+        }
+        Set<Sameness.Block<A>> left = new LinkedHashSet<>(may);
+        Set<Sameness.Block<A>> aside = new LinkedHashSet<>(taken);
+        for (Sameness.Block<A> next : may) {
+            Set<Sameness.Block<A>> apartFromNext = apart.getOrDefault(next, Set.of());
+            Set<Sameness.Block<A>> grown = new LinkedHashSet<>(sofar);
+            grown.add(next);
+            Set<Sameness.Block<A>> still = new LinkedHashSet<>(left);
+            still.retainAll(apartFromNext);
+            Set<Sameness.Block<A>> covered = new LinkedHashSet<>(aside);
+            covered.retainAll(apartFromNext);
+            grow(grown, still, covered, apart, found, most);
             if (found.size() > most) {
                 return;
             }
+            left.remove(next);
+            aside.add(next);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -583,14 +583,6 @@ public final class Apartness<A> {
      */
     public record Edge<A>(Sameness.Block<A> one, Sameness.Block<A> other) {
 
-        public Edge {
-            if (String.valueOf(one).compareTo(String.valueOf(other)) > 0) {
-                Sameness.Block<A> swapped = one;
-                one = other;
-                other = swapped;
-            }
-        }
-
         /** Whether both ends are one block, which is a value stated to differ from itself. */
         public boolean isOfOneBlock() {
             return one.equals(other);
@@ -601,9 +593,35 @@ public final class Apartness<A> {
             return new Edge<>(one.renamed(naming), other.renamed(naming));
         }
 
+        /**
+         * The same pair whichever end was written first.
+         *
+         * <p>Said here and not by putting the ends in an order when one is made. An order over the
+         * blocks would have to come from something, and what there is to order them by is how they
+         * are spelled — so two blocks that render alike would be one end, and this rule would be
+         * about a rendering rather than about the blocks. What makes the pair unordered is that it
+         * is a pair, which is what this says.
+         */
+        @Override
+        public boolean equals(Object said) {
+            return said instanceof Edge<?> it
+                    && ((one.equals(it.one) && other.equals(it.other))
+                            || (one.equals(it.other) && other.equals(it.one)));
+        }
+
+        @Override
+        public int hashCode() {
+            return one.hashCode() + other.hashCode();
+        }
+
+        /** The two ends, written in one order whichever way round they were stated. Which end is
+         *  written first is a fact about the reading and not about the rule, so it is settled here
+         *  and nowhere the rule is compared. */
         @Override
         public String toString() {
-            return one + " /= " + other;
+            String mine = String.valueOf(one);
+            String theirs = String.valueOf(other);
+            return mine.compareTo(theirs) <= 0 ? mine + " /= " + theirs : theirs + " /= " + mine;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -33,6 +33,16 @@ import java.util.function.Function;
  */
 public final class Apartness<A> {
 
+    /**
+     * How many sets of blocks all stated to differ this will look at before it stops.
+     *
+     * <p>A stated limit and not a figure anything derives. How many such sets a relation has is not
+     * bounded by how many rules were written, and a reduction that walked all of them would make
+     * what a declaration costs turn on a shape nothing else here charges for. Reaching it is this
+     * saying nothing, which is what it says of every relation it has no argument for.
+     */
+    private static final int SETS_LOOKED_AT = 4096;
+
     /** In the order they were stated, so that what is written out of a reading comes out the same
      *  on two compiles of one model. */
     private final Set<Edge<A>> edges;
@@ -255,6 +265,260 @@ public final class Apartness<A> {
             if (found.size() > most) {
                 return;
             }
+        }
+    }
+
+    /**
+     * What these denials come to, against what each block they name is left.
+     *
+     * <p>Three answers, and the two that are not "nothing stands here" are two different things. An
+     * assignment found is a value for every block that no denial refuses, which is what makes
+     * {@link Reduction.Standing} a claim rather than a failure to refuse; anything else is
+     * {@link Reduction.NotKnown}, which says that this reduction did not settle it and never that
+     * something stands.
+     *
+     * <p><b>What it can refuse, in the order it tries.</b> A block stated to differ from itself is
+     * read off the rule. A block whose neighbours each hold one value loses those values, and where
+     * that leaves it none, nothing stands — run to a fixpoint, because a block cut down to one
+     * value cuts down its own neighbours. And a set of blocks each stated to differ from every
+     * other needs a value apiece, so where there are fewer values between them than there are
+     * blocks, nothing stands.
+     *
+     * <p><b>What it cannot.</b> Which values a general relation leaves is a colouring, and this is
+     * not one: {@code a /= b && b /= c && c /= d && d /= e && e /= a} over two values is refused by
+     * no pair and by no set of blocks that are all apart, and this says nothing about it. That is a
+     * widening like every other here — the relation is carried whole, and what a later reduction
+     * shows is shown of what is already held.
+     *
+     * @param admitting what each block is left, which is a question about a block and a range and
+     *                  belongs to whoever holds both
+     */
+    public Reduction<A> reduce(WhatABlockAdmits<A> admitting) {
+        if (isEmpty()) {
+            return new Reduction.Standing<>();
+        }
+        // How many values a block has to hold before it never runs out, which is how many blocks
+        // there are: its neighbours take fewer values than that between them, so one is left.
+        int atMost = blocks().size();
+        for (Edge<A> edge : edges) {
+            if (edge.isOfOneBlock()) {
+                return new Reduction.Nothing<>(
+                        new RelationalWitness.ABlockApartFromItself<>(edge.one()));
+            }
+        }
+        Map<Sameness.Block<A>, Admits> left = new LinkedHashMap<>();
+        for (Sameness.Block<A> block : blocks()) {
+            left.put(block, admitting.of(block, atMost));
+        }
+        RelationalWitness<A> why = takingWhatOneValueBlocksHold(left);
+        if (why == null) {
+            why = counting(left);
+        }
+        if (why != null) {
+            return new Reduction.Nothing<>(why);
+        }
+        return assignable(left, atMost) ? new Reduction.Standing<>() : new Reduction.NotKnown<>();
+    }
+
+    /**
+     * Every block's values less the ones its one-valued neighbours take, to a fixpoint, and why
+     * where that leaves one of them nothing.
+     *
+     * <p>To a fixpoint because taking values away makes more one-valued blocks: a block left two
+     * values one of which a neighbour holds is left one, and what it then holds is taken from its
+     * own neighbours. Run once, where the answer lay two steps in would turn on the order the rules
+     * were written.
+     */
+    private RelationalWitness<A> takingWhatOneValueBlocksHold(Map<Sameness.Block<A>, Admits> left) {
+        boolean moved = true;
+        while (moved) {
+            moved = false;
+            for (Map.Entry<Sameness.Block<A>, Admits> each : left.entrySet()) {
+                Value only = each.getValue() instanceof Admits.These it ? it.only() : null;
+                if (only == null) {
+                    continue;
+                }
+                for (Sameness.Block<A> next : apartFrom(each.getKey())) {
+                    Admits was = left.get(next);
+                    Admits now = was.without(only);
+                    if (now.equals(was)) {
+                        continue;
+                    }
+                    left.put(next, now);
+                    moved = true;
+                    if (now.isNone()) {
+                        return new RelationalWitness.NoValueLeftBetweenThem<>(next,
+                                oneValued(apartFrom(next), left));
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Which of {@code these} hold one value, which are the blocks that took the values away. */
+    private Set<Sameness.Block<A>> oneValued(Set<Sameness.Block<A>> these,
+                                             Map<Sameness.Block<A>, Admits> left) {
+        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
+        these.forEach(block -> {
+            if (left.get(block) instanceof Admits.These it && it.only() != null) {
+                out.add(block);
+            }
+        });
+        return out;
+    }
+
+    /**
+     * Why a set of blocks all stated to differ has fewer values between them than there are of
+     * them, or null where none has.
+     *
+     * <p>Asked of the blocks whose values are written down and of no others. A block holding more
+     * values than a caller counted never runs out, and a block this cannot say the values of is one
+     * nothing is known about — dropped from the set either way, which leaves a smaller set, and a
+     * shortage shown of fewer blocks is a shortage.
+     */
+    private RelationalWitness<A> counting(Map<Sameness.Block<A>, Admits> left) {
+        for (Set<Sameness.Block<A>> apart : everyPairwiseApartSet(SETS_LOOKED_AT)) {
+            Map<Sameness.Block<A>, Set<Value>> counted = new LinkedHashMap<>();
+            apart.forEach(block -> {
+                if (left.get(block) instanceof Admits.These it) {
+                    counted.put(block, it.values());
+                }
+            });
+            if (counted.size() < 2) {
+                continue;
+            }
+            RelationalWitness<A> why = shortage(counted);
+            if (why != null) {
+                return why;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Which of {@code counted} cannot all be given a value no other takes, or null where they can.
+     *
+     * <p>A value apiece and no two the same, which is a matching between the blocks and the values.
+     * Where one is found, the blocks are satisfiable together; where the search for one runs out at
+     * a block, what it reached is a set of blocks and every value any of them holds — one fewer
+     * value than there are blocks, which is what the shortage is.
+     */
+    private RelationalWitness<A> shortage(Map<Sameness.Block<A>, Set<Value>> counted) {
+        Map<Value, Sameness.Block<A>> taken = new LinkedHashMap<>();
+        for (Sameness.Block<A> block : counted.keySet()) {
+            Set<Value> reached = new LinkedHashSet<>();
+            if (given(block, counted, taken, reached)) {
+                continue;
+            }
+            Set<Sameness.Block<A>> blocks = new LinkedHashSet<>();
+            blocks.add(block);
+            reached.forEach(value -> blocks.add(taken.get(value)));
+            return new RelationalWitness.TooFewValuesBetweenThem<>(blocks, reached);
+        }
+        return null;
+    }
+
+    /** Whether {@code block} can be given a value, moving the blocks already holding one along. */
+    private boolean given(Sameness.Block<A> block, Map<Sameness.Block<A>, Set<Value>> counted,
+                          Map<Value, Sameness.Block<A>> taken, Set<Value> reached) {
+        for (Value value : counted.get(block)) {
+            if (!reached.add(value)) {
+                continue;
+            }
+            Sameness.Block<A> holder = taken.get(value);
+            if (holder == null || given(holder, counted, taken, reached)) {
+                taken.put(value, block);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether every block can be given a value no block it is stated to differ from takes.
+     *
+     * <p>Taken in the order the blocks were named, which is enough to show an assignment and not
+     * enough to show there is none: a run that fails here is one this says nothing about. A block
+     * holding more values than the whole relation has blocks is given one of them without naming
+     * it — its neighbours take fewer values than it holds, so one is free.
+     */
+    private boolean assignable(Map<Sameness.Block<A>, Admits> left, int atMost) {
+        if (atMost < left.size()) {
+            return false;
+        }
+        Map<Sameness.Block<A>, Object> given = new LinkedHashMap<>();
+        for (Map.Entry<Sameness.Block<A>, Admits> each : left.entrySet()) {
+            Set<Object> away = new LinkedHashSet<>();
+            apartFrom(each.getKey()).forEach(next -> {
+                Object held = given.get(next);
+                if (held != null) {
+                    away.add(held);
+                }
+            });
+            switch (each.getValue()) {
+                case Admits.These it -> {
+                    Value free = it.values().stream().filter(one -> !away.contains(one))
+                            .findFirst().orElse(null);
+                    if (free == null) {
+                        return false;
+                    }
+                    given.put(each.getKey(), free);
+                }
+                // More values than there are blocks, so more than its neighbours can have taken.
+                case Admits.MoreThanCounted _ -> given.put(each.getKey(), new Object());
+                case Admits.NotKnown _ -> {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * What one block of an alternative is left, asked by a relation reading it.
+     *
+     * <p>The bound is handed over and not the asked reader's own. How many values a block has to
+     * hold before a relation stops caring is how many blocks the relation has, which is a fact
+     * about the relation — worked out on the other side, it would be the same rule written where
+     * nothing keeps the two in step.
+     *
+     * @param <A> what a position is called
+     */
+    @FunctionalInterface
+    public interface WhatABlockAdmits<A> {
+
+        /**
+         * Which values {@code block} is left.
+         *
+         * @param atMost how many values are worth counting, which is how many blocks the relation
+         *               asking has: a block holding more than that never runs out of values its
+         *               neighbours have not taken
+         */
+        Admits of(Sameness.Block<A> block, int atMost);
+    }
+
+    /** What a relation was found to come to, against what its blocks are left. */
+    public sealed interface Reduction<A> {
+
+        /** Every block can be given a value no block it is stated to differ from takes. */
+        record Standing<A>() implements Reduction<A> {}
+
+        /** Neither shown, which is what this reduction says of every relation it has no argument
+         *  for. */
+        record NotKnown<A>() implements Reduction<A> {}
+
+        /** Nothing satisfies the denials, and why. */
+        record Nothing<A>(RelationalWitness<A> why) implements Reduction<A> {}
+
+        /** What this comes to where a reader wants the three answers a reading gives about one
+         *  block. */
+        default Emptiness emptiness() {
+            return switch (this) {
+                case Standing<A> _ -> Emptiness.NONEMPTY;
+                case NotKnown<A> _ -> Emptiness.UNDECIDED;
+                case Nothing<A> _ -> Emptiness.EMPTY;
+            };
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -324,10 +324,18 @@ public final class Apartness<A> {
      * Every block's values less the ones its one-valued neighbours take, to a fixpoint, and why
      * where that leaves one of them nothing.
      *
-     * <p>To a fixpoint because taking values away makes more one-valued blocks: a block left two
-     * values one of which a neighbour holds is left one, and what it then holds is taken from its
-     * own neighbours. Run once, where the answer lay two steps in would turn on the order the rules
-     * were written.
+     * <p>Until nothing moves, because taking values away makes more one-valued blocks: a block left
+     * two values one of which a neighbour holds is left one, and what it then holds is taken from
+     * its own neighbours.
+     *
+     * <p><b>No model here needs the second round.</b> A sweep takes the blocks in the order the
+     * denials were stated and writes what it finds as it goes, so a chain running that way is
+     * followed to its end within one sweep — and a refusal by taking values away is a chain from a
+     * block left one value, which is the only shape this argument refuses. What a second round can
+     * still do is tighten a set the count below then reads. It is here for that and because a
+     * single sweep would make the answer turn on the order the denials happen to be stated in;
+     * measured, removing it leaves the whole suite green, so nothing yet holds it to what it is
+     * for.
      */
     private RelationalWitness<A> takingWhatOneValueBlocksHold(Map<Sameness.Block<A>, Admits> left) {
         boolean moved = true;

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -1,0 +1,308 @@
+package souther.compiler.values;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Which blocks of one alternative are stated to hold different values.
+ *
+ * <p>Beside the product and not a side of it. An equality between two positions says the two are
+ * one subject, which is a congruence and can be what a product is indexed by ({@link Sameness}); a
+ * denial says neither position is the other's, which removes the diagonal from a product of two
+ * sides and makes no side. So it is held here, as a relation over the blocks the alternative is a
+ * product over, and what it comes to is worked out where the values each of those blocks is left
+ * are in hand.
+ *
+ * <p><b>Blocks and not positions.</b> An alternative holding {@code p} and {@code q} as one value
+ * has one answer between them, so a denial reaching either of them is a denial about that one
+ * answer. Held between positions, {@code p == q && q /= r} would be a rule about {@code q} that
+ * nothing said of {@code p}, and the two would disagree about a value they are one of.
+ *
+ * <p>Exact. Nothing here is widened or given up on: what an alternative was told is what it holds,
+ * and how much of it a reader can decide is that reader's own limit. So a graph this cannot be
+ * reduced by is still a graph it carries, and a reduction learned later reads what is already here.
+ *
+ * @param <A> what a position is called
+ */
+public final class Apartness<A> {
+
+    /** In the order they were stated, so that what is written out of a reading comes out the same
+     *  on two compiles of one model. */
+    private final Set<Edge<A>> edges;
+
+    private Apartness(Set<Edge<A>> edges) {
+        this.edges = Collections.unmodifiableSet(new LinkedHashSet<>(edges));
+    }
+
+    /** No two blocks stated to differ, which is what an alternative that read no denial holds. */
+    public static <A> Apartness<A> nothing() {
+        return new Apartness<>(Set.of());
+    }
+
+    /** The two positions stated to hold different values, each on the block it is its own of. */
+    public static <A> Apartness<A> of(A one, A other) {
+        return new Apartness<>(Set.of(new Edge<>(Sameness.Block.of(one), Sameness.Block.of(other))));
+    }
+
+    /** Whether nothing is stated to differ from anything. */
+    public boolean isEmpty() {
+        return edges.isEmpty();
+    }
+
+    /** Every pair stated to differ. */
+    public Set<Edge<A>> edges() {
+        return edges;
+    }
+
+    /** Every block some pair names, which is what an alternative is a product over beyond what its
+     *  own sides say. */
+    public Set<Sameness.Block<A>> blocks() {
+        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
+        edges.forEach(edge -> {
+            out.add(edge.one());
+            out.add(edge.other());
+        });
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** The blocks {@code block} is stated to differ from. */
+    public Set<Sameness.Block<A>> apartFrom(Sameness.Block<A> block) {
+        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
+        edges.forEach(edge -> {
+            if (edge.one().equals(block)) {
+                out.add(edge.other());
+            } else if (edge.other().equals(block)) {
+                out.add(edge.one());
+            }
+        });
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** Whether some pair states a block differs from itself, which nothing satisfies. */
+    public boolean holdsABlockApartFromItself() {
+        return edges.stream().anyMatch(Edge::isOfOneBlock);
+    }
+
+    /**
+     * Both alternatives' denials, filed under the blocks {@code heldAsOne} holds.
+     *
+     * <p>The union pushed forward and not the union. A conjunction leaves a coarser relation — an
+     * equality read beside these puts two blocks together — so a pair stated of the blocks either
+     * side was a product over is a pair of whatever those blocks are part of here. Left where they
+     * were, a denial would name a block this alternative does not answer in, which is what
+     * {@link Sameness#filing} refuses.
+     *
+     * <p>A pair both of whose ends land on one block is kept and not dropped. What it says is that
+     * a value differs from itself, which nothing satisfies — read as a pair to discard, the
+     * alternative would go on standing and the rules that emptied it would be gone.
+     */
+    public Apartness<A> filedIn(Sameness<A> heldAsOne) {
+        Set<Edge<A>> out = new LinkedHashSet<>();
+        for (Edge<A> edge : edges) {
+            out.add(new Edge<>(under(edge.one(), heldAsOne), under(edge.other(), heldAsOne)));
+        }
+        return new Apartness<>(out);
+    }
+
+    /** Both of them, before anything says what blocks the two together are a product over. */
+    public Apartness<A> and(Apartness<A> other) {
+        if (other.isEmpty()) {
+            return this;
+        }
+        if (isEmpty()) {
+            return other;
+        }
+        Set<Edge<A>> out = new LinkedHashSet<>(edges);
+        out.addAll(other.edges);
+        return new Apartness<>(out);
+    }
+
+    /**
+     * What both alternatives state, over the blocks a choice between them leaves.
+     *
+     * <p>Read at {@code finer}, which is what the two agree a block is ({@link Sameness#common}).
+     * A pair one alternative states of a block the other holds apart is still a pair of everything
+     * that block is made of there — {@code p == q} beside {@code p /= r} says {@code q /= r} as
+     * well — so each pair is pulled back onto the finer blocks its ends are made of before the two
+     * are compared. Compared where they were stated, one alternative's coarser pair would match
+     * nothing on the other side and a denial both of them state would be lost.
+     *
+     * <p>What is left is what both hold, because a choice states what neither branch denies only
+     * where both branches deny it.
+     */
+    public Apartness<A> commonWith(Apartness<A> other, Sameness<A> finer) {
+        if (isEmpty() || other.isEmpty()) {
+            return nothing();
+        }
+        Set<Edge<A>> mine = pulledBackTo(finer);
+        Set<Edge<A>> theirs = other.pulledBackTo(finer);
+        Set<Edge<A>> out = new LinkedHashSet<>(mine);
+        out.retainAll(theirs);
+        return new Apartness<>(out);
+    }
+
+    /**
+     * The same relation, said of the finer blocks {@code finer} cuts its ends into.
+     *
+     * <p>For a reader taking a relation stated where two positions were one value into a reading
+     * that does not hold them as one. What a pair said of a block says of everything that block is
+     * made of, so nothing is lost and nothing is invented — and a pair left where it was would name
+     * a block the reading below does not answer in.
+     */
+    public Apartness<A> readAt(Sameness<A> finer) {
+        return isEmpty() ? this : new Apartness<>(pulledBackTo(finer));
+    }
+
+    /** Every pair this states, said of the finer blocks each of its ends is made of. */
+    private Set<Edge<A>> pulledBackTo(Sameness<A> finer) {
+        Set<Edge<A>> out = new LinkedHashSet<>();
+        for (Edge<A> edge : edges) {
+            for (Sameness.Block<A> one : partsOf(edge.one(), finer)) {
+                for (Sameness.Block<A> other : partsOf(edge.other(), finer)) {
+                    out.add(new Edge<>(one, other));
+                }
+            }
+        }
+        return out;
+    }
+
+    /** The blocks {@code finer} cuts {@code block} into, which is {@code block} itself where it
+     *  cuts it nowhere. */
+    private static <A> Set<Sameness.Block<A>> partsOf(Sameness.Block<A> block, Sameness<A> finer) {
+        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
+        block.members().forEach(each -> out.add(finer.blockOf(each)));
+        return out;
+    }
+
+    /** The same relation between the same blocks, under the names {@code naming} gives their
+     *  positions. */
+    public <B> Apartness<B> renamed(Function<A, B> naming) {
+        Set<Edge<B>> out = new LinkedHashSet<>();
+        edges.forEach(edge -> out.add(edge.renamed(naming)));
+        return new Apartness<>(out);
+    }
+
+    /** The block {@code block} is part of here, asked of any of its positions: a block is inside
+     *  one block of a coarser relation, so which member is asked does not decide the answer. */
+    private static <A> Sameness.Block<A> under(Sameness.Block<A> block, Sameness<A> heldAsOne) {
+        return heldAsOne.blockOf(block.members().iterator().next());
+    }
+
+    /**
+     * Every set of blocks this states to differ from each other, largest first.
+     *
+     * <p>What a counting reduction is asked of. A set whose blocks are all stated apart from each
+     * other needs a value each and no two the same, so how many values there are between them
+     * decides whether anything stands — and a set some pair of which this says nothing about needs
+     * no such thing, since two blocks nothing holds apart may hold one value.
+     *
+     * <p>Which is why the answer is not the parts the relation falls into. {@code p /= q && q /= r}
+     * relates all three and states nothing of {@code p} and {@code r}, so two values are enough;
+     * read as one set of three, it would be refused over a carrier of two and no rule says so.
+     *
+     * <p>Bounded by {@code most}, and by refusing rather than by answering with less: how many of
+     * these there are is not something the rules bound, and a reading that stopped partway would
+     * decide a declaration by how far it happened to get. A relation too large to walk is one this
+     * says nothing about, which is what it says about every relation it has no reduction for.
+     */
+    public List<Set<Sameness.Block<A>>> everyPairwiseApartSet(int most) {
+        Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
+        for (Edge<A> edge : edges) {
+            if (edge.isOfOneBlock()) {
+                continue;
+            }
+            apart.computeIfAbsent(edge.one(), _ -> new LinkedHashSet<>()).add(edge.other());
+            apart.computeIfAbsent(edge.other(), _ -> new LinkedHashSet<>()).add(edge.one());
+        }
+        List<Set<Sameness.Block<A>>> found = new ArrayList<>();
+        List<Sameness.Block<A>> named = new ArrayList<>(apart.keySet());
+        for (Sameness.Block<A> block : named) {
+            grow(new LinkedHashSet<>(Set.of(block)), apart.get(block), apart, found, most);
+            if (found.size() > most) {
+                return List.of();
+            }
+        }
+        found.sort(Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
+        return found;
+    }
+
+    /** Every set {@code sofar} grows into by taking blocks every one of its members is apart
+     *  from. */
+    private void grow(Set<Sameness.Block<A>> sofar, Set<Sameness.Block<A>> may,
+                      Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart,
+                      List<Set<Sameness.Block<A>>> found, int most) {
+        if (found.size() > most) {
+            return;
+        }
+        if (sofar.size() > 1) {
+            found.add(Collections.unmodifiableSet(new LinkedHashSet<>(sofar)));
+        }
+        for (Sameness.Block<A> next : may) {
+            Set<Sameness.Block<A>> grown = new LinkedHashSet<>(sofar);
+            if (!grown.add(next)) {
+                continue;
+            }
+            Set<Sameness.Block<A>> still = new LinkedHashSet<>(may);
+            still.retainAll(apart.getOrDefault(next, Set.of()));
+            grow(grown, still, apart, found, most);
+            if (found.size() > most) {
+                return;
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Apartness<?> it && edges.equals(it.edges);
+    }
+
+    @Override
+    public int hashCode() {
+        return edges.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return edges.toString();
+    }
+
+    /**
+     * Two blocks stated to hold different values.
+     *
+     * <p>Unordered: {@code p /= q} and {@code q /= p} are one rule, so the two ends are put in one
+     * order whichever way round they were written and the pair is equal to itself written the
+     * other way. Compared by its ends and by nothing else, so a rule stated twice is stated once.
+     */
+    public record Edge<A>(Sameness.Block<A> one, Sameness.Block<A> other) {
+
+        public Edge {
+            if (String.valueOf(one).compareTo(String.valueOf(other)) > 0) {
+                Sameness.Block<A> swapped = one;
+                one = other;
+                other = swapped;
+            }
+        }
+
+        /** Whether both ends are one block, which is a value stated to differ from itself. */
+        public boolean isOfOneBlock() {
+            return one.equals(other);
+        }
+
+        /** The same pair between the blocks {@code naming} calls these. */
+        public <B> Edge<B> renamed(Function<A, B> naming) {
+            return new Edge<>(one.renamed(naming), other.renamed(naming));
+        }
+
+        @Override
+        public String toString() {
+            return one + " /= " + other;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -34,12 +34,18 @@ import java.util.function.Function;
 public final class Apartness<A> {
 
     /**
-     * How many sets of blocks all stated to differ this will look at before it stops.
+     * How many sets of blocks this will look at before it stops.
      *
-     * <p>A stated limit and not a figure anything derives. How many such sets a relation has is not
-     * bounded by how many rules were written, and a reduction that walked all of them would make
-     * what a declaration costs turn on a shape nothing else here charges for. Reaching it is this
-     * saying nothing, which is what it says of every relation it has no argument for.
+     * <p>Looked at and not found. How many sets a relation has does not say how much work finding
+     * them is: a relation whose blocks are all stated to differ has one such set and as many ways
+     * of reaching it as anyone likes, so a bound on the answers is no bound on the walk. What is
+     * counted is every set the walk stands on, whether or not it turns out to be one nothing can be
+     * added to.
+     *
+     * <p>A stated limit and not a figure anything derives. How much work a relation is worth is not
+     * bounded by how many rules were written, and a reduction that walked all of it would make what
+     * a declaration costs turn on a shape nothing else here charges for. Reaching it is this saying
+     * nothing, which is what it says of every relation it has no argument for.
      */
     private static final int SETS_LOOKED_AT = 4096;
 
@@ -237,14 +243,53 @@ public final class Apartness<A> {
             apart.computeIfAbsent(edge.one(), _ -> new LinkedHashSet<>()).add(edge.other());
             apart.computeIfAbsent(edge.other(), _ -> new LinkedHashSet<>()).add(edge.one());
         }
-        List<Set<Sameness.Block<A>>> found = new ArrayList<>();
+        Walk<A> walk = new Walk<>(most);
         grow(new LinkedHashSet<>(), new LinkedHashSet<>(apart.keySet()), new LinkedHashSet<>(),
-                apart, found, most);
-        if (found.size() > most) {
+                apart, walk);
+        if (walk.spent()) {
             return List.of();
         }
-        found.sort(Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
-        return found;
+        walk.found().sort(
+                Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
+        return walk.found();
+    }
+
+    /**
+     * What a walk over the sets has found and what it has spent finding it.
+     *
+     * <p>Both, because the second is what the bound is on. How many sets there are does not say how
+     * much work finding them is — a relation whose blocks are all stated to differ has one set and
+     * a search that looks at every way to reach it — so a bound on the answers is no bound at all,
+     * and the walk that ran into it would be the walk nobody was counting.
+     */
+    private static final class Walk<A> {
+
+        private final List<Set<Sameness.Block<A>>> found = new ArrayList<>();
+        private final int most;
+        private int steps;
+
+        private Walk(int most) {
+            this.most = most;
+        }
+
+        List<Set<Sameness.Block<A>>> found() {
+            return found;
+        }
+
+        /** Whether this has looked at as much as it is allowed to. */
+        boolean spent() {
+            return steps > most || found.size() > most;
+        }
+
+        /** One more set looked at, whether or not it turned out to be one nothing can be added
+         *  to. */
+        void looked() {
+            steps++;
+        }
+
+        void add(Set<Sameness.Block<A>> these) {
+            found.add(Collections.unmodifiableSet(new LinkedHashSet<>(these)));
+        }
     }
 
     /**
@@ -263,20 +308,31 @@ public final class Apartness<A> {
      */
     private void grow(Set<Sameness.Block<A>> sofar, Set<Sameness.Block<A>> may,
                       Set<Sameness.Block<A>> taken,
-                      Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart,
-                      List<Set<Sameness.Block<A>>> found, int most) {
-        if (found.size() > most) {
+                      Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart, Walk<A> walk) {
+        walk.looked();
+        if (walk.spent()) {
             return;
         }
         if (may.isEmpty()) {
             if (taken.isEmpty() && sofar.size() > 1) {
-                found.add(Collections.unmodifiableSet(new LinkedHashSet<>(sofar)));
+                walk.add(sofar);
             }
             return;
         }
+        // The blocks one of them is not stated to differ from, and no others. Every set nothing can
+        // be added to holds that one or something it does not differ from, so the rest are reached
+        // through those — and a relation whose blocks are all stated to differ has one such set and
+        // one way in, where taking each of them in turn is a way in for every block there is.
+        Set<Sameness.Block<A>> around = apart.getOrDefault(pivot(may, taken, apart), Set.of());
+        List<Sameness.Block<A>> ways = new ArrayList<>();
+        may.forEach(each -> {
+            if (!around.contains(each)) {
+                ways.add(each);
+            }
+        });
         Set<Sameness.Block<A>> left = new LinkedHashSet<>(may);
         Set<Sameness.Block<A>> aside = new LinkedHashSet<>(taken);
-        for (Sameness.Block<A> next : may) {
+        for (Sameness.Block<A> next : ways) {
             Set<Sameness.Block<A>> apartFromNext = apart.getOrDefault(next, Set.of());
             Set<Sameness.Block<A>> grown = new LinkedHashSet<>(sofar);
             grown.add(next);
@@ -284,13 +340,37 @@ public final class Apartness<A> {
             still.retainAll(apartFromNext);
             Set<Sameness.Block<A>> covered = new LinkedHashSet<>(aside);
             covered.retainAll(apartFromNext);
-            grow(grown, still, covered, apart, found, most);
-            if (found.size() > most) {
+            grow(grown, still, covered, apart, walk);
+            if (walk.spent()) {
                 return;
             }
             left.remove(next);
             aside.add(next);
         }
+    }
+
+    /** Whichever of the blocks still in play is stated to differ from most of what may be added,
+     *  which is what leaves the fewest ways in. */
+    private Sameness.Block<A> pivot(Set<Sameness.Block<A>> may, Set<Sameness.Block<A>> taken,
+                                    Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart) {
+        Sameness.Block<A> best = null;
+        int most = -1;
+        for (Set<Sameness.Block<A>> these : List.of(may, taken)) {
+            for (Sameness.Block<A> each : these) {
+                Set<Sameness.Block<A>> around = apart.getOrDefault(each, Set.of());
+                int reach = 0;
+                for (Sameness.Block<A> one : may) {
+                    if (around.contains(one)) {
+                        reach++;
+                    }
+                }
+                if (reach > most) {
+                    most = reach;
+                    best = each;
+                }
+            }
+        }
+        return best;
     }
 
     /**
@@ -473,43 +553,28 @@ public final class Apartness<A> {
     }
 
     /**
-     * Whether every block can be given a value no block it is stated to differ from takes.
+     * Whether every block can be given a value no block it is stated to differ from takes, shown by
+     * an argument that does not depend on which block is taken first.
      *
-     * <p>Taken in the order the blocks were named, which is enough to show an assignment and not
-     * enough to show there is none: a run that fails here is one this says nothing about. A block
-     * holding more values than the whole relation has blocks is given one of them without naming
-     * it — its neighbours take fewer values than it holds, so one is free.
+     * <p><b>And by no other.</b> An assignment found by taking the blocks in some order is an
+     * assignment, but which orders find one is not a fact about the relation: two writings of one
+     * rule are one relation, and a reading that stood on the order they were stated in would answer
+     * a model one way written this way round and another written the other. So what is claimed here
+     * is the one thing every order shows.
+     *
+     * <p>What that leaves is a relation whose blocks each hold more values than the relation has
+     * blocks. Anything else is {@link Reduction.NotKnown}, which is what this says of every relation
+     * it has no argument for — a satisfiable one included.
      */
     private boolean assignable(Map<Sameness.Block<A>, Admits> left, int atMost) {
-        if (atMost < left.size()) {
-            return false;
-        }
-        Map<Sameness.Block<A>, Object> given = new LinkedHashMap<>();
-        for (Map.Entry<Sameness.Block<A>, Admits> each : left.entrySet()) {
-            Set<Object> away = new LinkedHashSet<>();
-            apartFrom(each.getKey()).forEach(next -> {
-                Object held = given.get(next);
-                if (held != null) {
-                    away.add(held);
-                }
-            });
-            switch (each.getValue()) {
-                case Admits.These it -> {
-                    Value free = it.values().stream().filter(one -> !away.contains(one))
-                            .findFirst().orElse(null);
-                    if (free == null) {
-                        return false;
-                    }
-                    given.put(each.getKey(), free);
-                }
-                // More values than there are blocks, so more than its neighbours can have taken.
-                case Admits.MoreThanCounted _ -> given.put(each.getKey(), new Object());
-                case Admits.NotKnown _ -> {
-                    return false;
-                }
-            }
-        }
-        return true;
+        // Every block holding more values than there are blocks, so each of them can be given one
+        // no other took whatever order they are taken in. Which is the whole of what is claimed
+        // here: taking them in an order and giving each the first value its neighbours have not
+        // taken finds an assignment for some relations and not for others, and which it is turns on
+        // the order the denials were stated in — so a relation would stand written one way and be
+        // undecided written the other, and the two are one relation.
+        return atMost >= left.size()
+                && left.values().stream().allMatch(each -> each instanceof Admits.MoreThanCounted);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -1,6 +1,7 @@
 package souther.compiler.values;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -174,6 +175,29 @@ public final class Apartness<A> {
      */
     public Apartness<A> readAt(Sameness<A> finer) {
         return isEmpty() ? this : new Apartness<>(pulledBackTo(finer));
+    }
+
+    /**
+     * What every one of these relations states, at the blocks {@code finer} holds.
+     *
+     * <p>What a choice between several alternatives states, read once. A denial one of them states
+     * is not the choice's, so what survives is what they all state — and it survives at the blocks
+     * the choice answers in, which are the finer ones the alternatives agree on.
+     *
+     * <p>Here rather than at each reader. A reading whose values are still descriptions and one
+     * whose values are sets both merge their alternatives into one product, and both have to carry
+     * this across it; written at each, the one that is added later carries nothing and the choice
+     * quietly forgets a rule both branches state.
+     *
+     * <p>Nothing where there are none of them. A reading holding no alternative states no denial,
+     * which is what a reading holding nothing does.
+     */
+    public static <A> Apartness<A> commonTo(Collection<Apartness<A>> these, Sameness<A> finer) {
+        Apartness<A> out = null;
+        for (Apartness<A> each : these) {
+            out = out == null ? each.readAt(finer) : out.commonWith(each, finer);
+        }
+        return out == null ? nothing() : out;
     }
 
     /** Every pair this states, said of the finer blocks each of its ends is made of. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -367,6 +367,13 @@ public final class Apartness<A> {
         // is walking. Which blocks there are does not change while it runs — a reduction takes
         // values away and never adds a block — so the list is made once.
         List<Sameness.Block<A>> named = new ArrayList<>(left.keySet());
+        // What each block's answer rests on, which begins as the block's own rules and grows by
+        // whatever forced a value out of it. Carried and not read back off the map at the end: a
+        // block holding one value there may hold it because a rule said so or because three
+        // removals left it that, and which of those it was is the difference between a lack about
+        // two blocks and a lack about four.
+        Map<Sameness.Block<A>, Set<Sameness.Block<A>>> restsOn = new LinkedHashMap<>();
+        named.forEach(block -> restsOn.put(block, new LinkedHashSet<>(Set.of(block))));
         boolean moved = true;
         while (moved) {
             moved = false;
@@ -382,10 +389,14 @@ public final class Apartness<A> {
                         continue;
                     }
                     left.put(next, now);
+                    // What took the value away is that {@code block} holds only it, which rests on
+                    // whatever left it holding only that.
+                    restsOn.get(next).addAll(restsOn.get(block));
                     moved = true;
                     if (now.isNone()) {
-                        return new RelationalWitness.NoValueLeftBetweenThem<>(next,
-                                oneValued(apartFrom(next), left));
+                        Set<Sameness.Block<A>> by = new LinkedHashSet<>(restsOn.get(next));
+                        by.remove(next);
+                        return new RelationalWitness.NoValueLeftBetweenThem<>(next, by);
                     }
                 }
             }
@@ -393,17 +404,6 @@ public final class Apartness<A> {
         return null;
     }
 
-    /** Which of {@code these} hold one value, which are the blocks that took the values away. */
-    private Set<Sameness.Block<A>> oneValued(Set<Sameness.Block<A>> these,
-                                             Map<Sameness.Block<A>, Admits> left) {
-        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
-        these.forEach(block -> {
-            if (left.get(block) instanceof Admits.These it && it.only() != null) {
-                out.add(block);
-            }
-        });
-        return out;
-    }
 
     /**
      * Why a set of blocks all stated to differ has fewer values between them than there are of

--- a/souther-compiler/src/main/java/souther/compiler/values/AskedOfARelation.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AskedOfARelation.java
@@ -1,0 +1,33 @@
+package souther.compiler.values;
+
+/**
+ * What the denials between one alternative's blocks come to, for a reader that has to ask it of
+ * every alternative.
+ *
+ * <p>Beside {@link AskedOfEachBlock} and not instead of it. That one is a question about a block,
+ * and every reading below it answers about one block — so a relation between two of them cannot be
+ * asked that way, and widening the question until it could would make every reader of a block
+ * answer for a pair. This is the other question the same walk is asked, and the walk asks the cheap
+ * one first: an alternative some block is already refused at is one no relation has to be read for.
+ *
+ * <p><b>Asked of the whole alternative and answered before the blocks are.</b> A denial is settled
+ * against what its blocks are left, and what one is left is not known until everything placing its
+ * positions has been met with it — so the reader that answers this is the one holding the ranges
+ * and the restrictions, and what it is handed is the relation and what the alternative says its
+ * blocks hold.
+ *
+ * @param <A> what a position is called
+ */
+@FunctionalInterface
+public interface AskedOfARelation<A> {
+
+    /**
+     * What {@code apart} comes to, where {@code product} is what the alternative says each of its
+     * blocks holds.
+     *
+     * @param apart which of the alternative's blocks are stated to hold different values
+     * @param product what the alternative says each block holds, before anything outside it has
+     *                been met with that
+     */
+    Apartness.Reduction<A> of(Apartness<A> apart, AdmissibleValues.Box<A> product);
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -179,10 +179,10 @@ public final class ConjoinedAdmissibleValues<A> {
      * <p>Nothing read is every value at every position, which stands whatever is asked — the
      * question is one about which values a rule leaves, and no rule left any.
      */
-    public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked) {
+    public Emptiness anyAlternativeAdmits(AskedOfEachBlock<A> asked, AskedOfARelation<A> relating) {
         Emptiness stands = Emptiness.NONEMPTY;
         for (AdmissibleValues<A> each : factors) {
-            stands = stands.met(each.anyAlternativeAdmits(asked));
+            stands = stands.met(each.anyAlternativeAdmits(asked, relating));
             if (stands == Emptiness.EMPTY) {
                 return stands;
             }
@@ -198,10 +198,27 @@ public final class ConjoinedAdmissibleValues<A> {
      * that position is — and a position every alternative of its own factor is refused at is one
      * every alternative of the conjunction is refused at.
      */
-    public Set<Sameness.Block<A>> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked) {
-        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
-        factors.forEach(each -> out.addAll(each.refusedInEveryAlternativeAt(asked)));
-        return Collections.unmodifiableSet(out);
+    public Refusal<A> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked,
+                                                  AskedOfARelation<A> relating) {
+        Set<Sameness.Block<A>> blocks = new LinkedHashSet<>();
+        Refusal<A> together = null;
+        for (AdmissibleValues<A> each : factors) {
+            switch (each.refusedInEveryAlternativeAt(asked, relating)) {
+                case Refusal.AtEachOf<A> it -> blocks.addAll(it.blocks());
+                // The first of them, which is the first in the order the readings arrived and so
+                // the order the rules were written. Every factor refused is refused of the
+                // conjunction, so each of these is true of it and naming one is naming one of
+                // several true things; put together, two lacks about two sets of blocks would say
+                // that no assignment to all of them stands, which neither factor showed.
+                case Refusal.OfThemTogether<A> it -> together =
+                        together == null ? it : together;
+                case Refusal.Nowhere<A> _ -> { }
+            }
+        }
+        if (!blocks.isEmpty()) {
+            return new Refusal.AtEachOf<>(blocks);
+        }
+        return together == null ? new Refusal.Nowhere<>() : together;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -270,12 +270,20 @@ public final class ConjoinedAdmissibleValues<A> {
         return names == null ? Sameness.Block.of(subject) : names.blockOf(subject);
     }
 
-    /** The blocks of several positions the rules left no value, over every reading held here —
-     *  see {@link AdmissibleValues#emptiedBlocks}. */
-    public Set<Sameness.Block<A>> emptiedBlocks() {
-        Set<Sameness.Block<A>> out = new LinkedHashSet<>();
-        factors.forEach(each -> out.addAll(each.emptiedBlocks()));
-        return Collections.unmodifiableSet(out);
+    /**
+     * Where a factor was refused, over every reading held here — see
+     * {@link AdmissibleValues#refusedBy}.
+     *
+     * <p>Every factor refused is refused of the conjunction, so what is put together is what each
+     * of them was refused by ({@link Refusal#eitherShown}) and not what they agree on. The factors
+     * name disjoint vocabularies, so two lacks at blocks are a lack at all of them.
+     */
+    public Refusal<A> refusedBy() {
+        Refusal<A> out = null;
+        for (AdmissibleValues<A> each : factors) {
+            out = out == null ? each.refusedBy() : Refusal.eitherShown(out, each.refusedBy());
+        }
+        return out == null ? new Refusal.Nowhere<>() : out;
     }
 
     /** Every subject any factor names. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlanOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlanOrder.java
@@ -150,6 +150,10 @@ final class PlanOrder {
      *
      * <p>A set of boxes and not a sequence: the alternatives are a union, so each is written out and
      * the writings are sorted. What each box holds is written by position, for the same reason.
+     *
+     * <p>Both halves of an alternative, because both are what it says. Two alternatives whose sides
+     * agree and whose denials do not are two alternatives, and written by their sides alone they
+     * would come out alike — which puts the readings back in the order they happened to arrive in.
      */
     static void written(AdmissibleValues.Held<?> held, StringBuilder out) {
         switch (held) {
@@ -160,12 +164,26 @@ final class PlanOrder {
                         .map(box -> {
                             StringBuilder one = new StringBuilder();
                             written(box.at(), one);
+                            written(box.apart(), one);
                             return one.toString();
                         })
                         .sorted()
                         .forEach(each -> out.append(each).append(';'));
             }
         }
+    }
+
+    /**
+     * Which blocks an alternative states to differ, written out in one order whatever order they
+     * were stated in.
+     *
+     * <p>Sorted, for the reason the alternatives are: a relation is a set of pairs, so the same
+     * rules written two ways are one relation and have to come out as one writing.
+     */
+    private static void written(Apartness<?> apart, StringBuilder out) {
+        out.append(apart.edges().size()).append(';');
+        apart.edges().stream().map(String::valueOf).sorted()
+                .forEach(each -> out.append(each).append(';'));
     }
 
     private static long states(java.util.Collection<ValueSet> sets) {

--- a/souther-compiler/src/main/java/souther/compiler/values/PlanOrder.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlanOrder.java
@@ -182,6 +182,7 @@ final class PlanOrder {
      */
     private static void written(Apartness<?> apart, StringBuilder out) {
         out.append(apart.edges().size()).append(';');
+        tellApart(apart.blocks());
         apart.edges().stream().map(String::valueOf).sorted()
                 .forEach(each -> out.append(each).append(';'));
     }
@@ -212,10 +213,7 @@ final class PlanOrder {
      */
     static void written(java.util.Map<?, ValueSet> at, StringBuilder out) {
         out.append(at.size()).append(';');
-        java.util.List<String> named = at.keySet().stream().map(String::valueOf).toList();
-        assert java.util.Set.copyOf(named).size() == at.size()
-                : "two positions of one reading are written alike, so an order over readings is not"
-                        + " one: " + named;
+        tellApart(at.keySet());
         at.entrySet().stream()
                 .map(each -> {
                     StringBuilder one = new StringBuilder(String.valueOf(each.getKey()));
@@ -225,6 +223,21 @@ final class PlanOrder {
                 })
                 .sorted()
                 .forEach(each -> out.append(each).append(';'));
+    }
+
+    /**
+     * That what a reading is filed under tells its subjects apart, wherever they are written out.
+     *
+     * <p>Here rather than at the map above, which is one of the places a reading's subjects are
+     * written and not the only one: a relation names blocks no side of the product holds, so a
+     * reading whose subjects collide there would be written out past the one check that exists to
+     * catch it. The rule is about writing subjects down, so it is asked wherever that happens.
+     */
+    private static void tellApart(java.util.Collection<?> these) {
+        java.util.List<String> named = these.stream().map(String::valueOf).toList();
+        assert java.util.Set.copyOf(named).size() == java.util.Set.copyOf(these).size()
+                : "two subjects of one reading are written alike, so an order over readings is not"
+                        + " one: " + named;
     }
 
     static void write(ValueSet set, StringBuilder out) {

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -34,13 +34,87 @@ sealed interface PlannedHeld<A> {
      * a join of two descriptions is a description, so there is nothing to pay for and nothing to
      * decide.
      */
-    record Alternatives<A>(Set<Box<A>> boxes) implements PlannedHeld<A> {
+    record Alternatives<A>(Set<Alternative<A>> boxes) implements PlannedHeld<A> {
 
         public Alternatives {
             if (boxes.isEmpty()) {
                 throw new IllegalArgumentException("a reading holding no alternative is Nothing");
             }
             boxes = Collections.unmodifiableSet(new LinkedHashSet<>(boxes));
+        }
+    }
+
+    /**
+     * One alternative while its values are still descriptions: a product over its blocks, and
+     * which of those blocks are stated to differ.
+     *
+     * <p>{@link AdmissibleValues.Alternative}'s two halves over descriptions rather than sets. The
+     * relation is exact either side of {@link PlannedValues#resolve} — a denial is a denial whether
+     * or not anybody has worked out what the blocks it names admit — so what changes across that
+     * line is the product and not this.
+     *
+     * @param product what each block is described as holding
+     * @param apart which of those blocks are stated to hold different values
+     */
+    record Alternative<A>(Box<A> product, Apartness<A> apart) {
+
+        /** One alternative that states no denial. */
+        static <A> Alternative<A> of(Box<A> product) {
+            return new Alternative<>(product, Apartness.nothing());
+        }
+
+        /** One alternative over positions that are each their own block, stating no denial. */
+        static <A> Alternative<A> at(Map<A, AdmittedPlan> said) {
+            return of(Box.at(said));
+        }
+
+        /** What each block is described as holding. */
+        Map<Sameness.Block<A>, AdmittedPlan> at() {
+            return product.at();
+        }
+
+        /** Which positions this alternative holds as one value, over its sides and its relation
+         *  alike — see {@link AdmissibleValues.Alternative#sameness}. */
+        Sameness<A> sameness() {
+            Set<Sameness.Block<A>> named = new LinkedHashSet<>(product.at().keySet());
+            named.addAll(apart.blocks());
+            return Sameness.of(named);
+        }
+
+        AdmittedPlan get(Sameness.Block<A> block) {
+            return product.get(block);
+        }
+
+        /** What is described at {@code position}, which is what the block it is on describes. */
+        AdmittedPlan get(A position) {
+            return get(sameness().blockOf(position));
+        }
+
+        /** Every position this alternative says anything about, by describing it or by relating
+         *  it. */
+        Set<A> positions() {
+            Set<A> out = new LinkedHashSet<>(product.positions());
+            apart.blocks().forEach(block -> out.addAll(block.members()));
+            return out;
+        }
+
+        /** Both alternatives holding at once, over what the two of them hold as one value —
+         *  see {@link AdmissibleValues.Alternative#narrowedWith}. */
+        Alternative<A> meet(Alternative<A> other) {
+            Sameness<A> heldAsOne = sameness().meet(other.sameness());
+            return new Alternative<>(product.meet(other.product, heldAsOne),
+                    apart.and(other.apart).filedIn(heldAsOne));
+        }
+
+        /** Whether the rules of this alternative state that a value differs from itself, which
+         *  nothing satisfies. */
+        boolean standsForNothing() {
+            return apart.holdsABlockApartFromItself();
+        }
+
+        @Override
+        public String toString() {
+            return apart.isEmpty() ? product.toString() : product + " with " + apart;
         }
     }
 
@@ -108,8 +182,7 @@ sealed interface PlannedHeld<A> {
          * is every description that reached the positions it holds. Nothing is built, so nothing is
          * charged and nothing can be refused.
          */
-        Box<A> meet(Box<A> other) {
-            Sameness<A> heldAsOne = sameness().meet(other.sameness());
+        Box<A> meet(Box<A> other, Sameness<A> heldAsOne) {
             Map<Sameness.Block<A>, List<AdmittedPlan>> parts = new LinkedHashMap<>();
             gathering(at, heldAsOne, parts);
             gathering(other.at, heldAsOne, parts);
@@ -130,7 +203,12 @@ sealed interface PlannedHeld<A> {
     }
 
     /** One alternative, which is what most readings hold. */
-    static <A> PlannedHeld<A> one(Box<A> box) {
+    static <A> PlannedHeld<A> one(Alternative<A> box) {
         return new Alternatives<>(Set.of(box));
+    }
+
+    /** One alternative that states no denial. */
+    static <A> PlannedHeld<A> one(Box<A> box) {
+        return one(Alternative.of(box));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -106,12 +106,6 @@ sealed interface PlannedHeld<A> {
                     apart.and(other.apart).filedIn(heldAsOne));
         }
 
-        /** Whether the rules of this alternative state that a value differs from itself, which
-         *  nothing satisfies. */
-        boolean standsForNothing() {
-            return apart.holdsABlockApartFromItself();
-        }
-
         @Override
         public String toString() {
             return apart.isEmpty() ? product.toString() : product + " with " + apart;

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedHeld.java
@@ -201,8 +201,4 @@ sealed interface PlannedHeld<A> {
         return new Alternatives<>(Set.of(box));
     }
 
-    /** One alternative that states no denial. */
-    static <A> PlannedHeld<A> one(Box<A> box) {
-        return one(Alternative.of(box));
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -160,13 +160,17 @@ public sealed interface PlannedValues<A> {
                                 break;
                             }
                         }
-                        // And what its denials come to, which on this side of {@link #resolve} is
-                        // nothing: they are settled against the values each block is left, and
-                        // those are descriptions here. Said of the alternative that holds them and
-                        // not of the reading, which is the grain the question is asked at — an
-                        // alternative beside one carrying a denial stands on its own rules.
+                        // And what its denials come to. A block stated to differ from itself is
+                        // settled by reading the rule and needs no values, so it is settled here;
+                        // everything else a denial says is settled against the values its blocks
+                        // are left, and those are descriptions on this side of {@link #resolve}.
+                        //
+                        // Said of the alternative that holds them and not of the reading, which is
+                        // the grain the question is asked at — an alternative beside one carrying a
+                        // denial stands on its own rules.
                         if (stands != Emptiness.EMPTY && !box.apart().isEmpty()) {
-                            stands = Emptiness.UNDECIDED;
+                            stands = box.apart().holdsABlockApartFromItself()
+                                    ? Emptiness.EMPTY : Emptiness.UNDECIDED;
                         }
                         any = any.joined(stands);
                         if (any == Emptiness.NONEMPTY) {
@@ -188,33 +192,56 @@ public sealed interface PlannedValues<A> {
      * whose description this could not ask about is not one of them — it was not refused, it was not
      * asked.
      */
-    default Set<Sameness.Block<A>> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked) {
+    default Refusal<A> refusedInEveryAlternativeAt(AskedOfEachBlock<A> asked) {
         if (!(this instanceof Settled<A> it
                 && it.held() instanceof PlannedHeld.Alternatives<A> boxes)) {
-            return Set.of();
+            return new Refusal.Nowhere<>();
         }
-        Set<Sameness.Block<A>> everywhere = null;
+        Refusal<A> everywhere = null;
         for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
-            Set<Sameness.Block<A>> here = new LinkedHashSet<>();
-            // The block and not its positions — see {@link AdmissibleValues}.
-            box.at().forEach((block, plan) -> {
-                if (askedOf(block, plan, asked) == Emptiness.EMPTY) {
-                    here.add(block);
-                }
-            });
-            if (here.isEmpty()) {
-                return Set.of();
+            Refusal<A> here = refusalIn(box, asked);
+            if (here.isNowhere()) {
+                return new Refusal.Nowhere<>();
             }
-            if (everywhere == null) {
-                everywhere = here;
-            } else {
-                everywhere.retainAll(here);
-                if (everywhere.isEmpty()) {
-                    return Set.of();
-                }
+            everywhere = everywhere == null ? here : Refusal.shownByBoth(everywhere, here);
+            if (everywhere.isNowhere()) {
+                return new Refusal.Nowhere<>();
             }
         }
-        return everywhere == null ? Set.of() : Collections.unmodifiableSet(everywhere);
+        return everywhere == null ? new Refusal.Nowhere<>() : everywhere;
+    }
+
+    /**
+     * Where one alternative was refused, out of the descriptions alone.
+     *
+     * <p>The blocks first and the relation after, as
+     * {@link AdmissibleValues#refusedInEveryAlternativeAt} does. What this side can say of a
+     * relation is what needs no values: a block stated to differ from itself is refused by reading
+     * the rule, and everything else a denial says waits for the sets.
+     *
+     * <p>Said here and not left to the reading below it. What an alternative was refused by is only
+     * knowable while it is being refused, so an answer that dropped the alternative and worked out
+     * afterwards why the reading holds nothing would find the general form.
+     */
+    private static <A> Refusal<A> refusalIn(PlannedHeld.Alternative<A> box,
+                                            AskedOfEachBlock<A> asked) {
+        Set<Sameness.Block<A>> here = new LinkedHashSet<>();
+        // The block and not its positions — see {@link AdmissibleValues}.
+        box.at().forEach((block, plan) -> {
+            if (askedOf(block, plan, asked) == Emptiness.EMPTY) {
+                here.add(block);
+            }
+        });
+        if (!here.isEmpty()) {
+            return new Refusal.AtEachOf<>(here);
+        }
+        for (Apartness.Edge<A> edge : box.apart().edges()) {
+            if (edge.isOfOneBlock()) {
+                return new Refusal.OfThemTogether<>(
+                        new RelationalWitness.ABlockApartFromItself<>(edge.one()));
+            }
+        }
+        return new Refusal.Nowhere<>();
     }
 
     /** What one block's description comes to under the question, waiting where a machine would
@@ -443,15 +470,7 @@ public sealed interface PlannedValues<A> {
         Set<PlannedHeld.Alternative<A>> live = new LinkedHashSet<>();
         for (PlannedHeld.Alternative<A> one : alternatives(here)) {
             for (PlannedHeld.Alternative<A> two : alternatives(there)) {
-                // A conjunction whose denials put a block apart from itself is one nothing
-                // satisfies, and it is dropped where every other alternative nothing stands in is.
-                // Which is as much as this side of {@link #resolve} can say: whether the sets a
-                // description comes to leave anything is the question that is put off, and whether
-                // a value differs from itself is not.
-                PlannedHeld.Alternative<A> both = one.meet(two);
-                if (!both.standsForNothing()) {
-                    live.add(both);
-                }
+                live.add(one.meet(two));
             }
         }
         return live.isEmpty() ? new PlannedHeld.Nothing<>()

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -95,6 +95,20 @@ public sealed interface PlannedValues<A> {
     }
 
     /**
+     * Two positions said to hold different values — see {@link AdmissibleValues#heldApart}.
+     */
+    static <A> PlannedValues<A> heldApart(A here, A there) {
+        Map<Sameness.Block<A>, AdmittedPlan> promised = new LinkedHashMap<>();
+        promised.put(Sameness.Block.of(here), AdmittedPlan.NONE);
+        promised.put(Sameness.Block.of(there), AdmittedPlan.NONE);
+        return new Settled<>(
+                PlannedHeld.one(new PlannedHeld.Alternative<>(
+                        new PlannedHeld.Box<>(Map.of()), Apartness.of(here, there))),
+                Map.of(), Standing.nothing(), promised, AdmittedPlan.ANY, true,
+                Set.of(), Set.of());
+    }
+
+    /**
      * A rule this could not read, which says nothing about any position and spoils the ones it
      * names — see {@link AdmissibleValues#unreadable}.
      */
@@ -301,6 +315,20 @@ public sealed interface PlannedValues<A> {
             }
         }
         return everywhere == null ? Set.of() : Collections.unmodifiableSet(everywhere);
+    }
+
+    /**
+     * Whether some alternative states two of its blocks to hold different values.
+     *
+     * <p>Asked and not answered. What a denial comes to is settled against the values its blocks
+     * are left, and on this side of {@link #resolve} those are descriptions — so a reading holding
+     * one has a rule nothing here has read, and a caller told nothing about it would take the
+     * answer about the sides for the answer about the alternative.
+     */
+    default boolean anyDenialRead() {
+        return this instanceof Settled<A> it
+                && it.held() instanceof PlannedHeld.Alternatives<A> boxes
+                && boxes.boxes().stream().anyMatch(box -> !box.apart().isEmpty());
     }
 
     /** What every alternative holds as one value. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -160,6 +160,14 @@ public sealed interface PlannedValues<A> {
                                 break;
                             }
                         }
+                        // And what its denials come to, which on this side of {@link #resolve} is
+                        // nothing: they are settled against the values each block is left, and
+                        // those are descriptions here. Said of the alternative that holds them and
+                        // not of the reading, which is the grain the question is asked at — an
+                        // alternative beside one carrying a denial stands on its own rules.
+                        if (stands != Emptiness.EMPTY && !box.apart().isEmpty()) {
+                            stands = Emptiness.UNDECIDED;
+                        }
                         any = any.joined(stands);
                         if (any == Emptiness.NONEMPTY) {
                             yield any;
@@ -315,20 +323,6 @@ public sealed interface PlannedValues<A> {
             }
         }
         return everywhere == null ? Set.of() : Collections.unmodifiableSet(everywhere);
-    }
-
-    /**
-     * Whether some alternative states two of its blocks to hold different values.
-     *
-     * <p>Asked and not answered. What a denial comes to is settled against the values its blocks
-     * are left, and on this side of {@link #resolve} those are descriptions — so a reading holding
-     * one has a rule nothing here has read, and a caller told nothing about it would take the
-     * answer about the sides for the answer about the alternative.
-     */
-    default boolean anyDenialRead() {
-        return this instanceof Settled<A> it
-                && it.held() instanceof PlannedHeld.Alternatives<A> boxes
-                && boxes.boxes().stream().anyMatch(box -> !box.apart().isEmpty());
     }
 
     /** What every alternative holds as one value. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -327,12 +327,12 @@ public sealed interface PlannedValues<A> {
      * <p>Every alternative and not one of them, the same way a dead choice is put together: a
      * block one alternative is left nothing at is one another may stand at.
      */
-    default Set<Sameness.Block<A>> emptiedBlocks() {
+    default Refusal<A> refusedBy() {
         if (!(this instanceof Settled<A> it
                 && it.held() instanceof PlannedHeld.Alternatives<A> boxes)) {
-            return Set.of();
+            return new Refusal.Nowhere<>();
         }
-        Set<Sameness.Block<A>> everywhere = null;
+        Refusal<A> everywhere = null;
         for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             Set<Sameness.Block<A>> here = new LinkedHashSet<>();
             box.at().forEach((block, plan) -> {
@@ -340,16 +340,13 @@ public sealed interface PlannedValues<A> {
                     here.add(block);
                 }
             });
-            if (everywhere == null) {
-                everywhere = here;
-            } else {
-                everywhere.retainAll(here);
-            }
-            if (everywhere.isEmpty()) {
-                return Set.of();
+            Refusal<A> said = Refusal.atEachOf(here);
+            everywhere = everywhere == null ? said : Refusal.shownByBoth(everywhere, said);
+            if (everywhere.isNowhere()) {
+                return new Refusal.Nowhere<>();
             }
         }
-        return everywhere == null ? Set.of() : Collections.unmodifiableSet(everywhere);
+        return everywhere == null ? new Refusal.Nowhere<>() : everywhere;
     }
 
     /** What every alternative holds as one value. */
@@ -817,22 +814,26 @@ public sealed interface PlannedValues<A> {
                                                              Allowance<A> by, Unbuilt<A> gaveUp) {
         Set<AdmissibleValues.Alternative<A>> live = new LinkedHashSet<>();
         Set<PlannedHeld.Alternative<A>> standing = new LinkedHashSet<>();
-        Set<Sameness.Block<A>> emptied = null;
+        Refusal<A> dropped = null;
         for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
-            Map<Sameness.Block<A>, ValueSet> at = builtIn(box, by, gaveUp);
-            if (at.values().stream().noneMatch(ValueSet::isEmpty)) {
-                // The relation crosses unchanged. What a denial says is about the blocks and not
-                // about what they were described as holding, so building the descriptions is not
-                // where it could be lost or gained.
-                live.add(new AdmissibleValues.Alternative<>(
-                        new AdmissibleValues.Box<>(at), box.apart()));
-                standing.add(box);
-                continue;
+            // The relation crosses unchanged. What a denial says is about the blocks and not about
+            // what they were described as holding, so building the descriptions is not where it
+            // could be lost or gained — and whether anything stands in the alternative is asked the
+            // one way it is asked wherever two of them are put together.
+            AdmissibleValues.Held<A> said = new AdmissibleValues.Alternative.Met<>(
+                    builtIn(box, by, gaveUp), box.apart()).stands();
+            switch (said) {
+                case AdmissibleValues.Held.Alternatives<A> it -> {
+                    live.addAll(it.boxes());
+                    standing.add(box);
+                }
+                case AdmissibleValues.Held.Nothing<A> it -> dropped = dropped == null ? it.shown()
+                        : Refusal.shownByBoth(dropped, it.shown());
             }
-            emptied = AdmissibleValues.alsoEmptied(emptied, at);
         }
         if (live.isEmpty()) {
-            return new AdmissibleValues.Held.Nothing<>(emptied == null ? Set.of() : emptied);
+            return new AdmissibleValues.Held.Nothing<>(
+                    dropped == null ? new Refusal.Nowhere<>() : dropped);
         }
         // What each block the alternatives agree on holds across the ones that stand, described
         // first and built once. Read off the sets instead, a join of two languages would be a

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -67,7 +67,7 @@ public sealed interface PlannedValues<A> {
 
     /** Nothing read and nothing missed, which is what a reading starts from. */
     static <A> PlannedValues<A> top() {
-        return new Settled<>(PlannedHeld.one(PlannedHeld.Box.at(Map.of())), Map.of(),
+        return new Settled<>(PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
                 Standing.nothing(), Map.of(), AdmittedPlan.ANY, true, Set.of(), Set.of());
     }
 
@@ -76,7 +76,7 @@ public sealed interface PlannedValues<A> {
         Map<A, AdmittedPlan> said = Map.of(atom, plan);
         return new Settled<>(
                 plan instanceof AdmittedPlan.Nothing ? new PlannedHeld.Nothing<>()
-                        : PlannedHeld.one(PlannedHeld.Box.at(said)),
+                        : PlannedHeld.one(PlannedHeld.Alternative.at(said)),
                 said, Standing.nothing(), Map.of(Sameness.Block.of(atom), plan),
                 AdmittedPlan.ANY, true, Set.of(), Set.of());
     }
@@ -89,7 +89,8 @@ public sealed interface PlannedValues<A> {
         // Promised at the block, though it narrows nothing there — see
         // {@link AdmissibleValues#holdingAsOne}.
         return new Settled<>(
-                PlannedHeld.one(new PlannedHeld.Box<>(Map.of(block, AdmittedPlan.ANY))),
+                PlannedHeld.one(PlannedHeld.Alternative.of(
+                        new PlannedHeld.Box<>(Map.of(block, AdmittedPlan.ANY)))),
                 Map.of(), Standing.nothing(), Map.of(block, AdmittedPlan.ANY),
                 AdmittedPlan.ANY, true, Set.of(), Set.of());
     }
@@ -113,7 +114,7 @@ public sealed interface PlannedValues<A> {
      * names — see {@link AdmissibleValues#unreadable}.
      */
     static <A> PlannedValues<A> unreadable(Set<A> named, UnreadReason why) {
-        return new Settled<>(PlannedHeld.one(PlannedHeld.Box.at(Map.of())), Map.of(),
+        return new Settled<>(PlannedHeld.one(PlannedHeld.Alternative.at(Map.of())), Map.of(),
                 Standing.of(named, why), Map.of(), AdmittedPlan.NONE, true, Set.of(),
                 Set.of());
     }
@@ -631,7 +632,20 @@ public sealed interface PlannedValues<A> {
             }
             out.put(block, AdmittedPlan.joining(List.of(across(here, member), theirs)));
         }
-        return PlannedHeld.one(new PlannedHeld.Box<>(out));
+        // And what every alternative of both states to differ, which the choice states as well.
+        // Merging a union into the smallest product containing it widens what the blocks hold; it
+        // does not licence forgetting a rule both branches wrote, and a denial dropped here is one
+        // no equality read beside the choice can be refused against.
+        return PlannedHeld.one(new PlannedHeld.Alternative<>(new PlannedHeld.Box<>(out),
+                Apartness.commonTo(List.of(apartInEveryAlternative(here, heldAsOne),
+                        apartInEveryAlternative(there, heldAsOne)), heldAsOne)));
+    }
+
+    /** What every alternative of one reading states to differ, said at {@code finer} — see
+     *  {@link Apartness#commonTo}. */
+    private static <A> Apartness<A> apartInEveryAlternative(Settled<A> of, Sameness<A> finer) {
+        return Apartness.commonTo(
+                alternatives(of).stream().map(PlannedHeld.Alternative::apart).toList(), finer);
     }
 
     /** Either side holding at each position, which is what both spoke about. */

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -137,7 +137,7 @@ public sealed interface PlannedValues<A> {
                 case PlannedHeld.Nothing<A> _ -> Emptiness.EMPTY;
                 case PlannedHeld.Alternatives<A> boxes -> {
                     Emptiness any = Emptiness.EMPTY;
-                    for (PlannedHeld.Box<A> box : boxes.boxes()) {
+                    for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
                         Emptiness stands = Emptiness.NONEMPTY;
                         for (Map.Entry<Sameness.Block<A>, AdmittedPlan> each
                                 : box.at().entrySet()) {
@@ -172,7 +172,7 @@ public sealed interface PlannedValues<A> {
             return Set.of();
         }
         Set<Sameness.Block<A>> everywhere = null;
-        for (PlannedHeld.Box<A> box : boxes.boxes()) {
+        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             Set<Sameness.Block<A>> here = new LinkedHashSet<>();
             // The block and not its positions — see {@link AdmissibleValues}.
             box.at().forEach((block, plan) -> {
@@ -284,7 +284,7 @@ public sealed interface PlannedValues<A> {
             return Set.of();
         }
         Set<Sameness.Block<A>> everywhere = null;
-        for (PlannedHeld.Box<A> box : boxes.boxes()) {
+        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             Set<Sameness.Block<A>> here = new LinkedHashSet<>();
             box.at().forEach((block, plan) -> {
                 if (!block.isOne() && plan instanceof AdmittedPlan.Nothing) {
@@ -306,7 +306,7 @@ public sealed interface PlannedValues<A> {
     /** What every alternative holds as one value. */
     private static <A> Sameness<A> commonTo(PlannedHeld.Alternatives<A> boxes) {
         Sameness<A> out = null;
-        for (PlannedHeld.Box<A> box : boxes.boxes()) {
+        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             out = out == null ? box.sameness() : out.common(box.sameness());
         }
         return out == null ? Sameness.discrete() : out;
@@ -418,17 +418,25 @@ public sealed interface PlannedValues<A> {
                 || there.held() instanceof PlannedHeld.Nothing) {
             return new PlannedHeld.Nothing<>();
         }
-        Set<PlannedHeld.Box<A>> live = new LinkedHashSet<>();
-        for (PlannedHeld.Box<A> one : alternatives(here)) {
-            for (PlannedHeld.Box<A> two : alternatives(there)) {
-                live.add(one.meet(two));
+        Set<PlannedHeld.Alternative<A>> live = new LinkedHashSet<>();
+        for (PlannedHeld.Alternative<A> one : alternatives(here)) {
+            for (PlannedHeld.Alternative<A> two : alternatives(there)) {
+                // A conjunction whose denials put a block apart from itself is one nothing
+                // satisfies, and it is dropped where every other alternative nothing stands in is.
+                // Which is as much as this side of {@link #resolve} can say: whether the sets a
+                // description comes to leave anything is the question that is put off, and whether
+                // a value differs from itself is not.
+                PlannedHeld.Alternative<A> both = one.meet(two);
+                if (!both.standsForNothing()) {
+                    live.add(both);
+                }
             }
         }
         return live.isEmpty() ? new PlannedHeld.Nothing<>()
                 : new PlannedHeld.Alternatives<>(live);
     }
 
-    private static <A> Set<PlannedHeld.Box<A>> alternatives(Settled<A> of) {
+    private static <A> Set<PlannedHeld.Alternative<A>> alternatives(Settled<A> of) {
         return of.held() instanceof PlannedHeld.Alternatives<A> it ? it.boxes() : Set.of();
     }
 
@@ -558,7 +566,7 @@ public sealed interface PlannedValues<A> {
 
     /** The alternatives of both, which is what the choice leaves where they are held apart. */
     private static <A> PlannedHeld<A> apart(Settled<A> here, Settled<A> there) {
-        Set<PlannedHeld.Box<A>> boxes = new LinkedHashSet<>(alternatives(here));
+        Set<PlannedHeld.Alternative<A>> boxes = new LinkedHashSet<>(alternatives(here));
         boxes.addAll(alternatives(there));
         return new PlannedHeld.Alternatives<>(boxes);
     }
@@ -766,13 +774,17 @@ public sealed interface PlannedValues<A> {
      */
     private static <A> AdmissibleValues.Held<A> alternatives(PlannedHeld.Alternatives<A> boxes,
                                                              Allowance<A> by, Unbuilt<A> gaveUp) {
-        Set<AdmissibleValues.Box<A>> live = new LinkedHashSet<>();
-        Set<PlannedHeld.Box<A>> standing = new LinkedHashSet<>();
+        Set<AdmissibleValues.Alternative<A>> live = new LinkedHashSet<>();
+        Set<PlannedHeld.Alternative<A>> standing = new LinkedHashSet<>();
         Set<Sameness.Block<A>> emptied = null;
-        for (PlannedHeld.Box<A> box : boxes.boxes()) {
+        for (PlannedHeld.Alternative<A> box : boxes.boxes()) {
             Map<Sameness.Block<A>, ValueSet> at = builtIn(box, by, gaveUp);
             if (at.values().stream().noneMatch(ValueSet::isEmpty)) {
-                live.add(new AdmissibleValues.Box<>(at));
+                // The relation crosses unchanged. What a denial says is about the blocks and not
+                // about what they were described as holding, so building the descriptions is not
+                // where it could be lost or gained.
+                live.add(new AdmissibleValues.Alternative<>(
+                        new AdmissibleValues.Box<>(at), box.apart()));
                 standing.add(box);
                 continue;
             }
@@ -804,7 +816,7 @@ public sealed interface PlannedValues<A> {
 
     /** One alternative's descriptions as the sets they come to, each built under its own block's
      *  allowance. */
-    private static <A> Map<Sameness.Block<A>, ValueSet> builtIn(PlannedHeld.Box<A> box,
+    private static <A> Map<Sameness.Block<A>, ValueSet> builtIn(PlannedHeld.Alternative<A> box,
                                                                 Allowance<A> by,
                                                                 Unbuilt<A> gaveUp) {
         Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
@@ -1,0 +1,91 @@
+package souther.compiler.values;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Where a reading was left nothing, and what kind of lack it is.
+ *
+ * <p><b>Two quantifiers and not one set of blocks.</b> A lack at each of some blocks says of every
+ * one of them that it holds nothing; a lack about several of them together says that no assignment
+ * to all of them stands, while each of them is left values of its own. Held as one set, a reader
+ * putting two lacks together intersects them — which is what the first kind means and is an
+ * invention for the second, since two collective lacks over sets that overlap have shown nothing
+ * about what the two happened to share.
+ *
+ * <p>So the two are told apart by being two, and a reader that has to put two of them together is
+ * made to say what it means by it ({@link #shownByBoth}).
+ *
+ * @param <A> what a position is called
+ */
+public sealed interface Refusal<A> {
+
+    /** Nowhere in particular, which is where a lack no block is answerable for is. */
+    record Nowhere<A>() implements Refusal<A> {}
+
+    /** Each of these blocks is left nothing. */
+    record AtEachOf<A>(Set<Sameness.Block<A>> blocks) implements Refusal<A> {
+
+        public AtEachOf {
+            blocks = Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
+        }
+    }
+
+    /**
+     * No assignment to these blocks together stands, and what showed it.
+     *
+     * <p>The whole argument and not the blocks alone, because what a report may say about them
+     * turns on which argument refused them: a value stated to differ from itself and a set of
+     * blocks with fewer values between them than there are blocks are two sentences.
+     */
+    record OfThemTogether<A>(RelationalWitness<A> why) implements Refusal<A> {}
+
+    /** The blocks the lack is about, for a reader that only has to name places. */
+    default Set<Sameness.Block<A>> blocks() {
+        return switch (this) {
+            case Nowhere<A> _ -> Set.of();
+            case AtEachOf<A> it -> it.blocks();
+            case OfThemTogether<A> it -> it.why().blocks();
+        };
+    }
+
+    /** Whether nothing here names a place. */
+    default boolean isNowhere() {
+        return this instanceof Nowhere || blocks().isEmpty();
+    }
+
+    /** The same lack about the blocks {@code naming} calls these. */
+    default <B> Refusal<B> renamed(Function<A, B> naming) {
+        return switch (this) {
+            case Nowhere<A> _ -> new Nowhere<>();
+            case AtEachOf<A> it -> {
+                Set<Sameness.Block<B>> out = new LinkedHashSet<>();
+                it.blocks().forEach(block -> out.add(block.renamed(naming)));
+                yield new AtEachOf<>(out);
+            }
+            case OfThemTogether<A> it -> new OfThemTogether<>(it.why().renamed(naming));
+        };
+    }
+
+    /**
+     * Where two readings both left nothing were both refused.
+     *
+     * <p>The blocks each was refused at, kept where both were refused there. A block one of them
+     * stands at is not one the pair has nothing at, so what can be said is what they agree on —
+     * and where they agree on none, what was shown is about the whole product and no block is why.
+     *
+     * <p><b>And nothing kept where either is a lack about blocks together, unless the two are the
+     * same lack.</b> Such a lack is not a lack at each of its blocks, so intersecting it with
+     * anything answers a question neither reading was asked.
+     */
+    static <A> Refusal<A> shownByBoth(Refusal<A> one, Refusal<A> other) {
+        if (one instanceof AtEachOf<A> mine && other instanceof AtEachOf<A> theirs) {
+            Set<Sameness.Block<A>> both = new LinkedHashSet<>(mine.blocks());
+            both.retainAll(theirs.blocks());
+            return new AtEachOf<>(both);
+        }
+        return one.equals(other) ? one : new Nowhere<>();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
@@ -25,12 +25,28 @@ public sealed interface Refusal<A> {
     /** Nowhere in particular, which is where a lack no block is answerable for is. */
     record Nowhere<A>() implements Refusal<A> {}
 
-    /** Each of these blocks is left nothing. */
+    /**
+     * Each of these blocks is left nothing.
+     *
+     * <p>Never none of them: a lack at no block is a lack nowhere, which is the case beside this
+     * one. Refused here rather than read as {@link Nowhere} by whoever holds one, so that "no block
+     * is why" has one spelling — held as two, a reader has to ask both, and the one that forgets
+     * reports a lack at nowhere in particular as a lack somewhere.
+     */
     record AtEachOf<A>(Set<Sameness.Block<A>> blocks) implements Refusal<A> {
 
         public AtEachOf {
             blocks = Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
+            if (blocks.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a lack at no block is a lack nowhere, which is Nowhere");
+            }
         }
+    }
+
+    /** A lack at each of {@code blocks}, which is nowhere where they are none. */
+    static <A> Refusal<A> atEachOf(Set<Sameness.Block<A>> blocks) {
+        return blocks.isEmpty() ? new Nowhere<>() : new AtEachOf<>(blocks);
     }
 
     /**
@@ -53,7 +69,7 @@ public sealed interface Refusal<A> {
 
     /** Whether nothing here names a place. */
     default boolean isNowhere() {
-        return this instanceof Nowhere || blocks().isEmpty();
+        return this instanceof Nowhere;
     }
 
     /** The same lack about the blocks {@code naming} calls these. */
@@ -84,7 +100,7 @@ public sealed interface Refusal<A> {
         if (one instanceof AtEachOf<A> mine && other instanceof AtEachOf<A> theirs) {
             Set<Sameness.Block<A>> both = new LinkedHashSet<>(mine.blocks());
             both.retainAll(theirs.blocks());
-            return new AtEachOf<>(both);
+            return atEachOf(both);
         }
         return one.equals(other) ? one : new Nowhere<>();
     }

--- a/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Refusal.java
@@ -86,7 +86,34 @@ public sealed interface Refusal<A> {
     }
 
     /**
-     * Where two readings both left nothing were both refused.
+     * Where a conjunction with a side that holds nothing was refused.
+     *
+     * <p>A different question from {@link #shownByBoth}, and the answer is different. There, two
+     * readings of one set of rules both hold nothing and what can be said is what they agree on;
+     * here, a conjunction is refused because a side of it is, and where both sides are, both
+     * reasons are true of it. So two lacks at blocks are a lack at all of them.
+     *
+     * <p>A lack about blocks together is not put together with anything, and two of them that are
+     * not one lack leave nothing. Both are true of the conjunction, and naming one of them would be
+     * naming whichever side the caller wrote first — which is a fact about the writing.
+     */
+    static <A> Refusal<A> eitherShown(Refusal<A> one, Refusal<A> other) {
+        if (one.isNowhere()) {
+            return other;
+        }
+        if (other.isNowhere()) {
+            return one;
+        }
+        if (one instanceof AtEachOf<A> mine && other instanceof AtEachOf<A> theirs) {
+            Set<Sameness.Block<A>> both = new LinkedHashSet<>(mine.blocks());
+            both.addAll(theirs.blocks());
+            return new AtEachOf<>(both);
+        }
+        return one.equals(other) ? one : new Nowhere<>();
+    }
+
+    /**
+     * Where two readings that both left nothing were both refused.
      *
      * <p>The blocks each was refused at, kept where both were refused there. A block one of them
      * stands at is not one the pair has nothing at, so what can be said is what they agree on —

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
@@ -1,0 +1,107 @@
+package souther.compiler.values;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Why the denials between an alternative's blocks leave nothing.
+ *
+ * <p>A lack about several blocks together and not about any of them. Each of the blocks named here
+ * is left values of its own; what has nothing is an assignment to all of them at once, so a proof
+ * naming one of them would send an author to a place whose own rules are fine with what they leave
+ * it.
+ *
+ * <p><b>Not one shape, because it is not one argument.</b> A block stated to differ from itself is
+ * refused by reading the rule; a block left no value by its neighbours is refused by taking values
+ * away; a set of blocks with fewer values between them than there are blocks is refused by counting.
+ * Held as the counting one alone, the first two would be reported as a shortage of values that no
+ * count was taken of — and a reduction learned later is a case added here rather than a sentence
+ * somebody has to rewrite.
+ *
+ * @param <A> what a position is called
+ */
+public sealed interface RelationalWitness<A> {
+
+    /** Every block the lack is about, which is what a report has to name to say what has nothing. */
+    Set<Sameness.Block<A>> blocks();
+
+    /** The same argument about the blocks {@code naming} calls these. */
+    default <B> RelationalWitness<B> renamed(java.util.function.Function<A, B> naming) {
+        return switch (this) {
+            case ABlockApartFromItself<A> it ->
+                    new ABlockApartFromItself<>(it.block().renamed(naming));
+            case NoValueLeftBetweenThem<A> it -> {
+                Set<Sameness.Block<B>> by = new LinkedHashSet<>();
+                it.by().forEach(block -> by.add(block.renamed(naming)));
+                yield new NoValueLeftBetweenThem<>(it.block().renamed(naming), by);
+            }
+            case TooFewValuesBetweenThem<A> it -> {
+                Set<Sameness.Block<B>> blocks = new LinkedHashSet<>();
+                it.blocks().forEach(block -> blocks.add(block.renamed(naming)));
+                yield new TooFewValuesBetweenThem<>(blocks, it.available());
+            }
+        };
+    }
+
+    /**
+     * The rules hold two positions as one value and state that they differ.
+     *
+     * <p>One block and a lack about it all the same: what has nothing is the value those positions
+     * are, and each of them is left everything on its own.
+     */
+    record ABlockApartFromItself<A>(Sameness.Block<A> block) implements RelationalWitness<A> {
+
+        @Override
+        public Set<Sameness.Block<A>> blocks() {
+            return Set.of(block);
+        }
+    }
+
+    /**
+     * A block whose neighbours take every value it was left.
+     *
+     * @param block the block left nothing
+     * @param by the blocks holding one value each, whose values are the ones taken
+     */
+    record NoValueLeftBetweenThem<A>(Sameness.Block<A> block,
+                                     Set<Sameness.Block<A>> by) implements RelationalWitness<A> {
+
+        public NoValueLeftBetweenThem {
+            by = Collections.unmodifiableSet(new LinkedHashSet<>(by));
+        }
+
+        @Override
+        public Set<Sameness.Block<A>> blocks() {
+            Set<Sameness.Block<A>> out = new LinkedHashSet<>();
+            out.add(block);
+            out.addAll(by);
+            return Collections.unmodifiableSet(out);
+        }
+    }
+
+    /**
+     * Blocks stated to differ from each other, with fewer values between them than there are of
+     * them.
+     *
+     * <p>Every one of them needs a value no other takes, and {@code available} is every value any
+     * of them may hold — so a value each is more than the rules leave. The blocks are pairwise
+     * apart and not merely related: {@code p /= q && q /= r} relates three and states nothing of
+     * {@code p} and {@code r}, so two values are enough for it and this is not what it comes to.
+     *
+     * @param blocks the blocks, each stated to differ from every other
+     * @param available every value any of them may hold
+     */
+    record TooFewValuesBetweenThem<A>(Set<Sameness.Block<A>> blocks,
+                                      Set<Value> available) implements RelationalWitness<A> {
+
+        public TooFewValuesBetweenThem {
+            blocks = Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
+            available = Collections.unmodifiableSet(new LinkedHashSet<>(available));
+            if (available.size() >= blocks.size()) {
+                throw new IllegalArgumentException("blocks stated to differ are refused by there"
+                        + " being fewer values than blocks, and " + blocks + " have " + available);
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
@@ -61,8 +61,22 @@ public sealed interface RelationalWitness<A> {
     /**
      * A block whose neighbours take every value it was left.
      *
+     * <p><b>Every block the argument rests on, and not the ones that took the last values.</b> A
+     * neighbour holding one value may hold it because a rule said so or because its own neighbours
+     * left it that, and the second kind is not a reason on its own — {@code q} left at one value by
+     * {@code p} takes that value from {@code r}, and {@code q} with {@code r} alone is satisfiable.
+     * Named as the neighbours in hand, this would say a lack is about two blocks where nothing is
+     * refused until three of them are read, which is a sentence sending an author to a pair whose
+     * own rules are fine.
+     *
+     * <p>Which is also what makes two of these comparable. {@link Refusal#shownByBoth} keeps a
+     * collective lack where two readings show the same one, and that is only sound where the
+     * witness is the whole argument — two lacks reached through different blocks are two lacks, and
+     * they say so by naming them.
+     *
      * @param block the block left nothing
-     * @param by the blocks holding one value each, whose values are the ones taken
+     * @param by every other block the argument rests on, which is what forced the values out of it
+     *           and what forced those in turn
      */
     record NoValueLeftBetweenThem<A>(Sameness.Block<A> block,
                                      Set<Sameness.Block<A>> by) implements RelationalWitness<A> {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -280,6 +280,7 @@ data.its-rules-cannot-all-hold=data `{data}` cannot be constructed: its rules ca
 data.nothing-is-left-for-that-position-to-hold=data `{data}` cannot be constructed: the rules leave `{at}` nothing to hold.
 data.no-value-its-rules-allow-is-in-that-range=data `{data}` cannot be constructed: no value the rules allow `{at}` is inside the range they leave it.
 data.no-value-these-can-all-hold=data `{data}` cannot be constructed: the rules hold {at} as one value, and leave no value all of them can hold.
+data.no-values-these-can-all-differ-in=data `{data}` cannot be constructed: the rules state {at} to hold different values, and leave too few values for all of them to differ.
 data.no-value-these-allow-is-in-the-range-they-share=data `{data}` cannot be constructed: the rules hold {at} as one value, and no value they allow it is inside the range they leave it.
 data.no-value-its-rules-allow-is-within-the-bounds-they-require=data `{data}` cannot be constructed: no value the rules allow `{at}` is within the bounds they require it to be within.
 data.no-value-these-allow-is-within-the-bounds-they-require=data `{data}` cannot be constructed: the rules hold {at} as one value, and no value they allow it is within the bounds they require it to be within.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -281,6 +281,7 @@ data.nothing-is-left-for-that-position-to-hold=data `{data}` cannot be construct
 data.no-value-its-rules-allow-is-in-that-range=data `{data}` cannot be constructed: no value the rules allow `{at}` is inside the range they leave it.
 data.no-value-these-can-all-hold=data `{data}` cannot be constructed: the rules hold {at} as one value, and leave no value all of them can hold.
 data.no-values-these-can-all-differ-in=data `{data}` cannot be constructed: the rules state {at} to hold different values, and leave too few values for all of them to differ.
+data.these-are-held-as-one-value-and-stated-to-differ=data `{data}` cannot be constructed: the rules hold {at} as one value and state that they differ.
 data.no-value-these-allow-is-in-the-range-they-share=data `{data}` cannot be constructed: the rules hold {at} as one value, and no value they allow it is inside the range they leave it.
 data.no-value-its-rules-allow-is-within-the-bounds-they-require=data `{data}` cannot be constructed: no value the rules allow `{at}` is within the bounds they require it to be within.
 data.no-value-these-allow-is-within-the-bounds-they-require=data `{data}` cannot be constructed: the rules hold {at} as one value, and no value they allow it is within the bounds they require it to be within.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -276,6 +276,7 @@ data.nothing-is-left-for-that-position-to-hold=data `{data}` は構築できま�
 data.no-value-its-rules-allow-is-in-that-range=data `{data}` は構築できません。規則が `{at}` に許した値のうち、規則が残した範囲に入るものがありません。
 data.no-value-these-can-all-hold=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そのすべてが持てる値がありません。
 data.no-values-these-can-all-differ-in=data `{data}` は構築できません。規則は {at} が互いに異なる値を持つと述べていますが、すべてを異ならせるだけの値がありません。
+data.these-are-held-as-one-value-and-stated-to-differ=data `{data}` は構築できません。規則は {at} を1つの値として扱いながら、互いに異なるとも述べています。
 data.no-value-these-allow-is-in-the-range-they-share=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そこに許した値のうち、規則が残した範囲に入るものがありません。
 data.no-value-its-rules-allow-is-within-the-bounds-they-require=data `{data}` は構築できません。規則が `{at}` に許した値のうち、規則が `{at}` に要求する範囲に入るものがありません。
 data.no-value-these-allow-is-within-the-bounds-they-require=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そこに許した値のうち、規則が要求する範囲に入るものがありません。

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -275,6 +275,7 @@ data.its-rules-cannot-all-hold=data `{data}` は構築できません。規則�
 data.nothing-is-left-for-that-position-to-hold=data `{data}` は構築できません。規則が `{at}` に持てる値を1つも残していません。
 data.no-value-its-rules-allow-is-in-that-range=data `{data}` は構築できません。規則が `{at}` に許した値のうち、規則が残した範囲に入るものがありません。
 data.no-value-these-can-all-hold=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そのすべてが持てる値がありません。
+data.no-values-these-can-all-differ-in=data `{data}` は構築できません。規則は {at} が互いに異なる値を持つと述べていますが、すべてを異ならせるだけの値がありません。
 data.no-value-these-allow-is-in-the-range-they-share=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そこに許した値のうち、規則が残した範囲に入るものがありません。
 data.no-value-its-rules-allow-is-within-the-bounds-they-require=data `{data}` は構築できません。規則が `{at}` に許した値のうち、規則が `{at}` に要求する範囲に入るものがありません。
 data.no-value-these-allow-is-within-the-bounds-they-require=data `{data}` は構築できません。規則は {at} を1つの値として扱っており、そこに許した値のうち、規則が要求する範囲に入るものがありません。

--- a/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
@@ -70,9 +70,9 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
     /**
      * A claim nothing settles.
      *
-     * <p>{@code f /= g} refuses pairs and no value of {@code f} on its own, and it is a rule this
-     * compiler does not take into what a position may hold — so nothing here says whether an
-     * {@code Off} arrives, and the case keeps what it was owed.
+     * <p>The rule about {@code f} is stated as an alternative to one this compiler does not take
+     * into what a position may hold, so {@code f} is left open by a branch that never named it —
+     * nothing here says whether an {@code Off} arrives, and the case keeps what it was owed.
      */
     private static final String UNPROVEN = """
             module example.probe
@@ -81,7 +81,7 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
             data Off
             data Pending
             data Flag = On | Off | Pending
-            data T = { f: Flag, g: Flag } invariant f /= g
+            data T = { f: Flag, g: String } invariant either = UNREAD_G || f == On
             data Answer = Int
 
             behavior pick : (t: T) -> Answer
@@ -93,8 +93,8 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
                 | Off     -> unreachable "the probe never passes Off"
 
             example pick
-                | "on" : (T { f = On, g = Off }) -> Answer(1)
-            """;
+                | "on" : (T { f = On, g = "x" }) -> Answer(1)
+            """.replace("UNREAD_G", ARuleNoReadingTakesIn.about("g"));
 
     private static Compilation measured(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
@@ -974,7 +974,7 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
     void theArmUnderTheForkIsStillNotAnArm() {
         CompileException refused = org.junit.jupiter.api.Assertions.assertThrows(
                 CompileException.class, () -> Compiler.compile(UNPROVEN + """
-                            | "off" : (T { f = Off, g = On }) -> Answer(0)
+                            | "off" : (T { f = Off, g = "x" }) -> Answer(0)
                         """));
 
         assertEquals("E1911", refused.diagnostics().get(0).code(), refused.getMessage());

--- a/souther-compiler/src/test/java/souther/compiler/AStandingQuestionSaysWhatItStandsForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AStandingQuestionSaysWhatItStandsForTest.java
@@ -111,7 +111,7 @@ class AStandingQuestionSaysWhatItStandsForTest {
     /**
      * Two parts of one clause stopped in two ways, and the line says both.
      *
-     * <p>{@code a /= b} relates the position to another, which this reading recognised and has no
+     * <p>{@code a < b} relates the position to another, which this reading recognised and has no
      * set of one position's values for; the other is a form it does not take apart.
      * The two are lifted by different work, so an author told only one of them lifts it and finds
      * the question still standing.
@@ -129,7 +129,7 @@ class AStandingQuestionSaysWhatItStandsForTest {
                         module probe.two
 
                         data Pair = { a: String, b: String }
-                            invariant both = a /= b && UNREAD_A
+                            invariant both = a < b && UNREAD_A
 
                         behavior read : (p: Pair) -> Ok
                         """), "invariant Pair (both)"));
@@ -142,7 +142,7 @@ class AStandingQuestionSaysWhatItStandsForTest {
                         module probe.two
 
                         data Pair = { a: String, b: String }
-                            invariant both = UNREAD_A && a /= b
+                            invariant both = UNREAD_A && a < b
 
                         behavior read : (p: Pair) -> Ok
                         """), "invariant Pair (both)"),
@@ -254,7 +254,7 @@ class AStandingQuestionSaysWhatItStandsForTest {
                         module probe.two
 
                         data Pair = { a: String, b: String }
-                            invariant both = a /= b && UNREAD_A
+                            invariant both = a < b && UNREAD_A
 
                         behavior read : (p: Pair) -> Ok
                         """));
@@ -264,7 +264,7 @@ class AStandingQuestionSaysWhatItStandsForTest {
                         module probe.two
 
                         data Pair = { a: String, b: String }
-                            invariant both = UNREAD_A && a /= b
+                            invariant both = UNREAD_A && a < b
 
                         behavior read : (p: Pair) -> Ok
                         """),

--- a/souther-compiler/src/test/java/souther/compiler/CompileUnreachableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileUnreachableTest.java
@@ -100,16 +100,17 @@ class CompileUnreachableTest {
         // The position holds an Int, which is a long on the JVM, so the abort has to leave the stack
         // in the shape the arm beside it leaves: a verified method, not one the verifier rejects.
         //
-        // Matched on a field of a pair whose rule relates its two fields. The premise is one nothing
-        // here settles (spec §unreachable-is-for-what-the-model-rules-out), which is what leaves a
-        // `B` both writable at the boundary and able to reach the abort.
+        // Matched on a field of a pair one of whose rules is stated as an alternative to a rule
+        // nothing here reads. The premise is one nothing here settles (spec
+        // §unreachable-is-for-what-the-model-rules-out), which is what leaves a `B` both writable
+        // at the boundary and able to reach the abort.
         String module = """
                 module demo
 
                 data A
                 data B
                 data AB = A | B
-                data Pair = { l: AB, r: AB } invariant l /= r
+                data Pair = { l: AB, s: String } invariant either = UNREAD_S || l == A
                 data Out = Int
 
                 behavior run : (v: Pair) -> Out constructs Out
@@ -119,15 +120,15 @@ class CompileUnreachableTest {
                         | A -> 1
                         | B -> unreachable "a B never reaches this rule"
                 )
-                """;
+                """.replace("UNREAD_S", ARuleNoReadingTakesIn.about("s"));
         BytesClassLoader loader = new BytesClassLoader(Compiler.compile(module), getClass().getClassLoader());
         Object impl = Emitted.behavior(loader, "demo", "run").getConstructor().newInstance();
 
         assertEquals(1L, Codecs.encode(loader, "demo.Out", Codecs.apply(impl,
-                Codecs.decoded(loader, "demo.Pair", java.util.Map.of("l", "A", "r", "B")))));
+                Codecs.decoded(loader, "demo.Pair", java.util.Map.of("l", "A", "s", "x")))));
         UnreachableReached aborted = assertThrows(UnreachableReached.class,
                 () -> Codecs.apply(impl, Codecs.decoded(loader, "demo.Pair",
-                        java.util.Map.of("l", "B", "r", "A"))));
+                        java.util.Map.of("l", "B", "s", "x"))));
         assertTrue(aborted.getMessage().contains("a B never reaches this rule"), aborted.getMessage());
     }
 
@@ -206,14 +207,15 @@ class CompileUnreachableTest {
     @Test
     void anUnreachableBoundByALetAborts() throws Throwable {
         // Nothing states a type here, so the binding takes the one thing `unreachable` has: no value.
-        // The premise is one nothing settles, as above, which is what keeps the `B` writable.
+        // The premise is one nothing settles, as above — an alternative to a rule nothing here
+        // reads — which is what keeps the `B` writable.
         String module = """
                 module demo
 
                 data A
                 data B
                 data AB = A | B
-                data Pair = { l: AB, r: AB } invariant l /= r
+                data Pair = { l: AB, s: String } invariant either = UNREAD_S || l == A
                 data Out = Int
 
                 behavior run : (v: Pair) -> Out constructs Out
@@ -224,15 +226,15 @@ class CompileUnreachableTest {
                         | B -> unreachable "a B never reaches this rule"
                     Out(n)
                 }
-                """;
+                """.replace("UNREAD_S", ARuleNoReadingTakesIn.about("s"));
         BytesClassLoader loader = new BytesClassLoader(Compiler.compile(module), getClass().getClassLoader());
         Object impl = Emitted.behavior(loader, "demo", "run").getConstructor().newInstance();
 
         assertEquals(1L, Codecs.encode(loader, "demo.Out", Codecs.apply(impl,
-                Codecs.decoded(loader, "demo.Pair", java.util.Map.of("l", "A", "r", "B")))));
+                Codecs.decoded(loader, "demo.Pair", java.util.Map.of("l", "A", "s", "x")))));
         assertThrows(UnreachableReached.class,
                 () -> Codecs.apply(impl, Codecs.decoded(loader, "demo.Pair",
-                        java.util.Map.of("l", "B", "r", "A"))));
+                        java.util.Map.of("l", "B", "s", "x"))));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/ADenialBetweenTwoPositionsIsHeldBesideTheProductTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADenialBetweenTwoPositionsIsHeldBesideTheProductTest.java
@@ -1,0 +1,222 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Located;
+import souther.compiler.diag.msg.DataMessage;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A denial between two positions, held beside the product the alternatives are over.
+ *
+ * <p>An equality between two positions is a congruence and can be what a product is indexed by: the
+ * two become one side of it, and a rule about either is a rule about both. A denial is not one. It
+ * removes the diagonal from a product of two sides and makes no side, so it reaches no coordinate —
+ * and left there, what the rules stated about {@code p} and what they stated about {@code r} stayed
+ * two facts about two places, and a declaration whose positions cannot differ was admitted.
+ *
+ * <p>What is asserted here is that it reaches a reading, that the reading is the same whatever the
+ * positions are of, and that what it comes to is worked out from what each of the positions is left
+ * rather than from the rule alone.
+ *
+ * <p>Each refusal is written beside the nearest model that does have a value. A reading that held
+ * the positions apart and left them nothing would refuse both, and what is asserted would be that
+ * something was refused rather than that the denial was read.
+ */
+class ADenialBetweenTwoPositionsIsHeldBesideTheProductTest {
+
+    private static final String STAGE = """
+            module demo
+
+            data Ready
+            data Done
+            data Stage = Ready | Done
+
+            """;
+
+    private static List<String> saidOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(Located::diagnostic)
+                .map(each -> each.said().getClass().getSimpleName())
+                .toList();
+    }
+
+    private static void refuses(String source) {
+        assertEquals(List.of("NoValuesTheseCanAllDifferIn"), saidOf(source),
+                "no value of this can be written");
+    }
+
+    private static void admits(String source) {
+        assertEquals(List.of(), saidOf(source), "a value of this can be written");
+    }
+
+    /** The places a refusal names, as it writes them. */
+    private static String named(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(Located::diagnostic)
+                .map(each -> each.said())
+                .filter(DataMessage.NoValuesTheseCanAllDifferIn.class::isInstance)
+                .map(each -> ((DataMessage.NoValuesTheseCanAllDifferIn) each).at())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("nothing said which places cannot differ"));
+    }
+
+    /**
+     * Two positions of a sum, each left the one value, and said to differ.
+     *
+     * <p>Each clause about one position is read. What was not read is the one relating them, and
+     * with it read there is no value {@code p} can take that {@code r} does not.
+     */
+    @Test
+    void twoPositionsOfASumHeldApartAreLeftNoWayOfDiffering() {
+        refuses(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant no = p /= r && p == Ready && r == Ready
+                """);
+    }
+
+    /** And the same rules leaving them different values are admitted, so what refuses is the pair
+     *  of facts and not the denial. */
+    @Test
+    void andTheSameDenialOverRulesThatLeaveRoomIsAdmitted() {
+        admits(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant ok = p /= r && p == Ready && r == Done
+                """);
+    }
+
+    /** A denial nothing else narrows leaves both positions everything and refuses nothing. */
+    @Test
+    void aDenialOnItsOwnRefusesNothing() {
+        admits(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant apart = p /= r
+                """);
+    }
+
+    /** A string is a carrier the numbers do not hold, and is read the same way. */
+    @Test
+    void twoStringPositionsHeldApartAreReadTheSameWay() {
+        refuses("""
+                module demo
+
+                data Pair = { p: String, r: String }
+                    invariant no = p /= r && p == "A" && r == "A"
+                """);
+    }
+
+    /**
+     * And where one of them is left its one value by its ends rather than by a written value.
+     *
+     * <p>What a denial comes to is settled against what each position is left, which is its values
+     * met with where its order stops. Read against the values alone, {@code r} would come back
+     * admitting every string and the pair would be admitted — the same rule refused one way when an
+     * author wrote it as an equality and another when they wrote it as two bounds.
+     */
+    @Test
+    void andWhereTheOneValueIsLeftByTheEndsRatherThanByAWrittenValue() {
+        refuses("""
+                module demo
+
+                data Pair = { p: String, r: String }
+                    invariant no = p /= r && p == "b" && r >= "b" && r <= "b"
+                """);
+    }
+
+    /** A position of two values is one the numbers do not hold either, and is read the same way. */
+    @Test
+    void twoTruthValuedPositionsHeldApartAreReadTheSameWay() {
+        refuses("""
+                module demo
+
+                data Pair = { p: Bool, r: Bool }
+                    invariant no = p /= r && p == true && r == true
+                """);
+    }
+
+    /**
+     * An {@code Int} is beside them, because two readings answering one clause is not two meanings
+     * of it.
+     *
+     * <p>The numbers hold a denial between two of them as a hole in a sum, and this reading holds
+     * it as a relation between two blocks. Both are right and the answer has to be the same.
+     */
+    @Test
+    void andAnIntIsRefusedTheSameWayTheNumbersRefuseIt() {
+        refuses("""
+                module demo
+
+                data Pair = { p: Int, r: Int }
+                    invariant no = p /= r && p == 1 && r == 1
+                """);
+    }
+
+    /**
+     * Three positions each stated to differ from the others, over a carrier of two values.
+     *
+     * <p>Refused by counting and by no pair: every pair of them can differ, and the three of them
+     * need a value each. So what the reading answers is how many values the positions it relates
+     * can take between them.
+     */
+    @Test
+    void threePositionsAllHeldApartOverTwoValuesAreRefusedByCounting() {
+        refuses(STAGE + """
+                data Trio = { p: Stage, q: Stage, r: Stage }
+                    invariant no = p /= q && q /= r && r /= p
+                """);
+    }
+
+    /**
+     * And a chain of the same length is not, which is what tells the counting rule from the parts
+     * the relation falls into.
+     *
+     * <p>{@code p /= q && q /= r} relates all three and states nothing of {@code p} and {@code r},
+     * so two values are enough: {@code p} and {@code r} may be {@code Ready} with {@code q}
+     * {@code Done}. A reading that counted the blocks a relation reaches rather than the blocks all
+     * stated to differ would refuse this, and no rule of the model says so.
+     */
+    @Test
+    void andAChainOfThreeOverTwoValuesStands() {
+        admits(STAGE + """
+                data Trio = { p: Stage, q: Stage, r: Stage }
+                    invariant ok = p /= q && q /= r
+                """);
+    }
+
+    /**
+     * Positions the rules hold as one value and state to differ.
+     *
+     * <p>A conjunction puts the two blocks together, and the denial between them becomes a value
+     * stated to differ from itself. Read against what the blocks hold, there is nothing to read:
+     * the rule refuses whatever they were left.
+     */
+    @Test
+    void twoPositionsHeldAsOneAndApartAreRefusedWhateverTheyHold() {
+        assertEquals(List.of("ItsRulesCannotAllHold"), saidOf(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant no = p == r && p /= r
+                """), "no value of this can be written");
+    }
+
+    /** The refusal names the positions together, since each of them is left values of its own. */
+    @Test
+    void theRefusalNamesThePositionsTogether() {
+        String source = STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant no = p /= r && p == Ready && r == Ready
+                """;
+
+        refuses(source);
+        assertEquals("`p`, `r`", named(source));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ADenialBetweenTwoPositionsIsHeldBesideTheProductTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADenialBetweenTwoPositionsIsHeldBesideTheProductTest.java
@@ -197,12 +197,13 @@ class ADenialBetweenTwoPositionsIsHeldBesideTheProductTest {
      * Positions the rules hold as one value and state to differ.
      *
      * <p>A conjunction puts the two blocks together, and the denial between them becomes a value
-     * stated to differ from itself. Read against what the blocks hold, there is nothing to read:
-     * the rule refuses whatever they were left.
+     * stated to differ from itself. Refused against no value at all — one value is not two,
+     * whatever those positions may hold — which is why it is said as its own sentence and not as
+     * there being too few values for them to differ. There is no number of values that would do.
      */
     @Test
     void twoPositionsHeldAsOneAndApartAreRefusedWhateverTheyHold() {
-        assertEquals(List.of("ItsRulesCannotAllHold"), saidOf(STAGE + """
+        assertEquals(List.of("TheseAreHeldAsOneValueAndStatedToDiffer"), saidOf(STAGE + """
                 data Pair = { p: Stage, r: Stage }
                     invariant no = p == r && p /= r
                 """), "no value of this can be written");

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -145,12 +145,14 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
         Confinement.Admission<FactSubject> one = new Confinement.Admission<>(
                 souther.compiler.values.Emptiness.EMPTY,
                 Confinement.EmptyBy.POSITIONS_HELD_AS_ONE,
-                Set.of(souther.compiler.values.Sameness.of(P, Q).joining(Q, R).blockOf(P)),
+                new souther.compiler.values.Refusal.AtEachOf<>(
+                        Set.of(souther.compiler.values.Sameness.of(P, Q).joining(Q, R).blockOf(P))),
                 Confinement.Shown.BY_THE_READINGS);
         Confinement.Admission<FactSubject> other = new Confinement.Admission<>(
                 souther.compiler.values.Emptiness.EMPTY,
                 Confinement.EmptyBy.POSITIONS_HELD_AS_ONE,
-                Set.of(souther.compiler.values.Sameness.of(P, Q).joining(Q, S).blockOf(P)),
+                new souther.compiler.values.Refusal.AtEachOf<>(
+                        Set.of(souther.compiler.values.Sameness.of(P, Q).joining(Q, S).blockOf(P))),
                 Confinement.Shown.BY_THE_READINGS);
 
         assertTrue(Confinement.Admission.bothShown(one, other).at().isEmpty(),

--- a/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProofNamesOneBlockAndNotAllOfThemTest.java
@@ -89,7 +89,7 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
         AdmissibleValues<FactSubject> both =
                 emptiedAt(R, S, sets).meet(emptiedAt(P, Q, sets), sets);
-        assertEquals(2, both.emptiedBlocks().size(), "or this measures one block twice");
+        assertEquals(2, both.refusedBy().blocks().size(), "or this measures one block twice");
 
         ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
                 .takingRead(Confinement.Worked.of(both, OrderedIntervals.top(), Map.of()), sets);
@@ -118,7 +118,7 @@ class AProofNamesOneBlockAndNotAllOfThemTest {
             AdmissibleValues<FactSubject> other = emptiedAt(P, Q, sets);
             AdmissibleValues<FactSubject> both = reversed
                     ? other.meet(one, sets) : one.meet(other, sets);
-            assertEquals(2, both.emptiedBlocks().size(), "or the two witnesses are not both here");
+            assertEquals(2, both.refusedBy().blocks().size(), "or the two witnesses are not both here");
 
             ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
                     .takingRead(Confinement.Worked.of(both, OrderedIntervals.top(), Map.of()),

--- a/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
@@ -88,6 +88,7 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
             case Emptiness.NoCommonValueForEqualPositions _ -> "no value they can all hold";
             case Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
                     "no values they can all differ in";
+            case Emptiness.PositionsHeldAsOneAreHeldApart _ -> "one value stated to differ";
             case Emptiness.SetRequiresTooManyDistinctValues it -> "a set over at most " + it.available();
             case Emptiness.NoAllowedCollectionSize _ -> "no size";
         };

--- a/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
@@ -81,7 +81,13 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
             case Emptiness.NoAllowedValueInRange _ -> "no allowed value in the range";
             case Emptiness.NoAllowedValueWithinRequiredBounds _ ->
                     "no allowed value within the bounds required";
+            case Emptiness.AtPositionsHeldApart it -> it.where().stream().map(each -> switch (each) {
+                case Emptiness.AtAField.Where.TheValueItself _ -> "value";
+                case Emptiness.AtAField.Where.In(String spelled) -> spelled;
+            }).toList() + " " + shape(it.under());
             case Emptiness.NoCommonValueForEqualPositions _ -> "no value they can all hold";
+            case Emptiness.NoDistinctValuesForPositionsHeldApart _ ->
+                    "no values they can all differ in";
             case Emptiness.SetRequiresTooManyDistinctValues it -> "a set over at most " + it.available();
             case Emptiness.NoAllowedCollectionSize _ -> "no size";
         };

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest.java
@@ -243,17 +243,19 @@ class AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest {
     }
 
     /**
-     * A denial between two positions is not this and is not read.
+     * A denial between two positions is not this and is held elsewhere.
      *
-     * <p>An equality says the two are one side of the product. A denial takes the diagonal out of
-     * a product, which is not a product — so it reaches no reading here, and this model is one
-     * nothing refuses.
+     * <p>An equality says the two are one side of the product; a denial takes the diagonal out of
+     * one, which makes no side. So it is held beside the product rather than as what the product is
+     * over, and what it comes to is
+     * {@code ADenialBetweenTwoPositionsIsHeldBesideTheProductTest}'s. What is pinned here is that
+     * the two are not one rule read two ways: this equality holds where that denial does not.
      */
     @Test
-    void aDenialBetweenTwoPositionsIsNotHeld() {
+    void aDenialBetweenTwoPositionsIsNotThisRuleTurnedRound() {
         admits(STAGE + """
                 data Pair = { p: Stage, r: Stage }
-                    invariant no = p /= r && p == Ready && r == Ready
+                    invariant ok = p /= r && p == Ready && r == Done
                 """);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest.java
@@ -242,20 +242,4 @@ class AnEqualityBetweenTwoPositionsIsHeldByTheValuesTest {
         assertEquals("`p`, `q`", named(source));
     }
 
-    /**
-     * A denial between two positions is not this and is held elsewhere.
-     *
-     * <p>An equality says the two are one side of the product; a denial takes the diagonal out of
-     * one, which makes no side. So it is held beside the product rather than as what the product is
-     * over, and what it comes to is
-     * {@code ADenialBetweenTwoPositionsIsHeldBesideTheProductTest}'s. What is pinned here is that
-     * the two are not one rule read two ways: this equality holds where that denial does not.
-     */
-    @Test
-    void aDenialBetweenTwoPositionsIsNotThisRuleTurnedRound() {
-        admits(STAGE + """
-                data Pair = { p: Stage, r: Stage }
-                    invariant ok = p /= r && p == Ready && r == Done
-                """);
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
@@ -39,7 +39,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
             module demo
 
             data N = { a: String, b: String }
-                invariant both = a /= b && UNREAD_A
+                invariant both = a < b && UNREAD_A
             """.replace("UNREAD_A", UNREAD_A);
 
     /** The two written the other way round, which is the same clause. */
@@ -47,7 +47,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
             module demo
 
             data N = { a: String, b: String }
-                invariant both = UNREAD_A && a /= b
+                invariant both = UNREAD_A && a < b
             """.replace("UNREAD_A", UNREAD_A);
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -451,6 +451,31 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
     }
 
     /**
+     * And a denial between two positions is not one of them either, because it is read.
+     *
+     * <p>The reason above is about a rule this reading recognised and could not turn into a set of
+     * one position's values. A denial is one it takes in — as a relation beside the product rather
+     * than as a set — so nothing about it went unread, and a position it names is one this reading
+     * speaks for. Left standing, the accounting would say the model draws a distinction this could
+     * not follow, and an author would be sent to a rule that was read in full.
+     *
+     * <p>What the positions hold is still every value. A denial narrows neither of them on its own,
+     * which is what parts being read from being narrowed.
+     */
+    @Test
+    void andADenialBetweenTwoPositionsIsReadRatherThanStoodOn() {
+        FieldDomains read = of("""
+                module demo
+
+                data Pair = { left: String, right: String }
+                    invariant differ = left /= right
+                """, "Pair");
+
+        wholly(ValueSet.ANY, read, "left");
+        wholly(ValueSet.ANY, read, "right");
+    }
+
+    /**
      * A position compared with itself is related to nothing, and is not said to be.
      *
      * <p>Two operands and one position. The reading recognises the comparison and finds a position

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -257,7 +257,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
      * And what such a position is told is that an alternative took it back, whatever the unread
      * branch was about.
      *
-     * <p>{@code left /= right} relates two positions and {@code code} is neither of them, so the
+     * <p>{@code left < right} relates two positions and {@code code} is neither of them, so the
      * reason the branch stopped is not a reason about {@code code}. Lent across, a report would
      * tell an author that a rule compares {@code code} with another position, and no rule does.
      *
@@ -273,7 +273,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 module demo
 
                 data Triple = { left: String, right: String, code: String }
-                    invariant either = left /= right || code == "A"
+                    invariant either = left < right || code == "A"
                 """, "Triple");
 
         asFarAsRead(ValueSet.ANY, UnreadReason.ALTERNATIVE_NOT_READ, read, "code");
@@ -323,7 +323,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
      *
      * <p>{@code a == 5} admits every {@code b}, so the choice does and nothing about {@code b} went
      * unread — while that alternative stands. {@code a == 7} refuses every value it admits, and what
-     * is left is {@code a /= b} with {@code a} at 7, which is a rule this cannot read about a
+     * is left is {@code a < b} with {@code a} at 7, which is a rule this cannot read about a
      * {@code b} that is now not every value. A reading that had struck the rule off where the
      * choice was read would answer that the model leaves {@code b} every value and that this was
      * read in full.
@@ -334,7 +334,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 module demo
 
                 data R = { a: Int, b: Int }
-                    invariant one = a == 5 || a /= b
+                    invariant one = a == 5 || a < b
                     invariant two = a == 7
                 """, "R");
 
@@ -417,11 +417,15 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
     /**
      * A rule relating two positions is told apart from one written in a form this cannot read.
      *
-     * <p>Both leave the positions open and neither is the other. Nothing about {@code left /= right}
+     * <p>Both leave the positions open and neither is the other. Nothing about {@code left < right}
      * was beyond this reading — both sides were recognised, and what it says is a fact about the
      * pair, which a set of one position's values is not. A regex over one of them is a form this
      * reading does not take apart, which is a fact about the reading and is lifted by different
      * work.
+     *
+     * <p>An ordering and not a denial, which is the relation this reading now holds: a denial
+     * between two positions is read, and what it leaves them is a relation beside the product
+     * rather than a rule that reached nothing.
      *
      * <p>Told apart where the reading gave up, since that is the only place both sides are still in
      * hand. Recovered afterwards from the spoiled positions alone, the two would be one answer.
@@ -432,7 +436,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 module demo
 
                 data Pair = { left: String, right: String }
-                    invariant differ = left /= right
+                    invariant differ = left < right
                 """, "Pair");
         asFarAsRead(ValueSet.ANY, UnreadReason.RELATES_TWO_POSITIONS, related, "left");
         asFarAsRead(ValueSet.ANY, UnreadReason.RELATES_TWO_POSITIONS, related, "right");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
@@ -202,6 +202,32 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
     }
 
     /**
+     * And a denial between two positions raises nothing either, though a reading takes it in.
+     *
+     * <p>Two questions with one name between them. Whether a reading can hold what a rule says and
+     * whether a rule raises a question about one position are different things: the values now hold
+     * {@code p /= q} as a relation between two blocks, and it still divides neither of them, so
+     * there is nothing here for a measure of coverage to go and check.
+     *
+     * <p>Which is why the two are not kept in step. A capability gained on one side is not a reason
+     * to move the other, and this is what says so.
+     */
+    @Test
+    void andSoDoesADenialAReadingTakesIn() {
+        Required.Irrelevant said = assertInstanceOf(Required.Irrelevant.class,
+                only(raisedBy("""
+                        module example.booking
+
+                        data Pair = { p: Int, q: Int }
+                            invariant differ = p /= q
+                        """, "Pair"), "differ"),
+                "a rule about a pair raises no question about one position");
+
+        assertEquals(Set.of(Required.Because.IT_RELATES_TWO_POSITIONS), said.because());
+        assertEquals(Set.of(), said.obligations());
+    }
+
+    /**
      * A conjunction is one rule, and raises what its parts raise together.
      *
      * <p>The relational half takes nothing away. Written as a first-wins answer, whichever conjunct

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Located;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a relation between positions comes to, and what it does not turn on.
+ *
+ * <p>A relation is a set of pairs and a pair is unordered, so the same rules written another way
+ * are the same rules. What is asserted here is that: which side of a denial an author wrote first,
+ * which order the clauses are in, and how a conjunction was bracketed all leave one answer.
+ *
+ * <p>And what it does turn on. A denial one branch of a choice states is not the choice's, and a
+ * conjunction that puts two blocks together carries the denials onto the blocks it leaves — both of
+ * which are rules about where a relation is filed rather than about what it says.
+ */
+class WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest {
+
+    private static final String STAGE = """
+            module demo
+
+            data Ready
+            data Done
+            data Stage = Ready | Done
+
+            """;
+
+    private static List<String> saidOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(Located::diagnostic)
+                .map(each -> each.said().getClass().getSimpleName())
+                .toList();
+    }
+
+    private static void refuses(String rule) {
+        assertEquals(List.of("NoValuesTheseCanAllDifferIn"), saidOf(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant no = RULE
+                """.replace("RULE", rule)), rule);
+    }
+
+    private static void admits(String source) {
+        assertEquals(List.of(), saidOf(source), "a value of this can be written");
+    }
+
+    /** A pair is unordered, so a denial written either way round is one rule. */
+    @Test
+    void aDenialIsTheSameRuleWrittenEitherWayRound() {
+        refuses("p /= r && p == Ready && r == Ready");
+        refuses("r /= p && p == Ready && r == Ready");
+    }
+
+    /** And the clauses of a conjunction are met in whatever order they are written. */
+    @Test
+    void andTheClausesAreMetInWhateverOrderTheyAreWritten() {
+        refuses("p /= r && p == Ready && r == Ready");
+        refuses("p == Ready && p /= r && r == Ready");
+        refuses("p == Ready && r == Ready && p /= r");
+        refuses("r == Ready && p /= r && p == Ready");
+    }
+
+    /** And wherever the brackets fall, since a conjunction of a conjunction is a conjunction. */
+    @Test
+    void andWhereverTheBracketsFall() {
+        refuses("(p /= r && p == Ready) && r == Ready");
+        refuses("p /= r && (p == Ready && r == Ready)");
+        refuses("(p /= r) && (p == Ready) && (r == Ready)");
+    }
+
+    /**
+     * A denial one alternative states is not the choice's.
+     *
+     * <p>The first branch is one nobody can be in and the second is one anybody can, so the choice
+     * stands. Lent across, the denial would refuse the branch beside it and a choice would hold a
+     * rule neither alternative states.
+     */
+    @Test
+    void aDenialOneBranchStatesIsNotLentToTheBranchBesideIt() {
+        admits(STAGE + """
+                data Pair = { p: Stage, r: Stage }
+                    invariant either = (p /= r && p == Ready && r == Ready)
+                        || (p == Ready && r == Ready)
+                """);
+    }
+
+    /**
+     * A denial reaching a block a later equality widens is a denial about the block it leaves.
+     *
+     * <p>{@code q /= r} is stated of {@code q} on its own, and {@code p == q} makes {@code p} and
+     * {@code q} one value — so the denial is between that block and {@code r}, and the rules
+     * leaving both of them {@code Ready} leave the pair nothing. Left where it was stated, the
+     * denial would name a block the conjunction does not answer in and would reach nothing.
+     */
+    @Test
+    void aDenialIsCarriedOntoTheBlocksAConjunctionLeaves() {
+        assertEquals(List.of("NoValuesTheseCanAllDifferIn"), saidOf(STAGE + """
+                data Trio = { p: Stage, q: Stage, r: Stage }
+                    invariant no = p == q && q /= r && p == Ready && r == Ready
+                """), "the denial is between the block p and q are and r");
+    }
+
+    /** And the same rules leaving the block and {@code r} different values are admitted. */
+    @Test
+    void andTheSameRulesLeavingThemDifferentValuesAreAdmitted() {
+        admits(STAGE + """
+                data Trio = { p: Stage, q: Stage, r: Stage }
+                    invariant ok = p == q && q /= r && p == Ready && r == Done
+                """);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -37,9 +37,24 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         return (block, _) -> new Admits.These(these.getOrDefault(block, Set.of(A, B)));
     }
 
-    /** A pair is unordered, so a rule written either way round is one rule. */
+    /**
+     * A pair is unordered, so a rule written either way round is one rule.
+     *
+     * <p>By being a pair and not by putting its ends in an order. An order over the blocks would
+     * have to come from how they are spelled, and then two blocks that render alike would be one
+     * end — so what is asserted is the equality itself, which is what the reading below it is
+     * filed and deduplicated by.
+     */
     @Test
     void aPairIsUnorderedAndIsOneRuleWrittenEitherWayRound() {
+        Apartness.Edge<String> one = new Apartness.Edge<>(P, R);
+        Apartness.Edge<String> back = new Apartness.Edge<>(R, P);
+
+        assertEquals(one, back);
+        assertEquals(one.hashCode(), back.hashCode(), "and equal pairs hash alike");
+        assertEquals(String.valueOf(one), String.valueOf(back),
+                "and are written out the same way, whichever end was stated first");
+
         assertEquals(Apartness.of("p", "r"), Apartness.of("r", "p"));
         assertEquals(1, Apartness.of("p", "r").and(Apartness.of("r", "p")).edges().size(),
                 "one rule stated twice is stated once");
@@ -147,6 +162,34 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         }
         assertEquals(R, left.block());
         assertEquals(Set.of(Q), left.by(), "the neighbour whose one value took the last of them");
+    }
+
+    /**
+     * A conjunction that makes a denial into a value stated to differ from itself keeps the
+     * alternative, and the relation is what refuses it.
+     *
+     * <p>Dropped where the sides are put together, the rules that emptied it would be gone with it
+     * — and a reader asking why the declaration holds nothing would be told the general answer,
+     * which is that the values admit nothing. What an alternative was refused by is only knowable
+     * while it is being refused, so the argument is made where the argument is read.
+     */
+    @Test
+    void aConjunctionThatEmptiesAnAlternativeByItsRelationSaysSo() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+        AdmissibleValues<String> both = AdmissibleValues.<String>holdingAsOne("p", "r")
+                .meet(AdmissibleValues.heldApart("p", "r"), sets);
+
+        // Nothing is asked of what the block holds: a value stated to differ from itself is refused
+        // by reading the rule, which is why this is settled before any value is.
+        Refusal<String> why = both.refusedInEveryAlternativeAt(
+                (_, _) -> Emptiness.NONEMPTY,
+                (apart, _) -> apart.reduce((_, _) -> new Admits.NotKnown()));
+
+        if (!(why instanceof Refusal.OfThemTogether<String> together)) {
+            throw new AssertionError("refused by what its blocks are held as: " + why);
+        }
+        assertInstanceOf(RelationalWitness.ABlockApartFromItself.class, together.why());
+        assertEquals(Set.of(Sameness.of("p", "r").blockOf("p")), together.blocks());
     }
 
     /** What a reduction that refused was refused by. */

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -2,6 +2,7 @@ package souther.compiler.values;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -152,6 +153,27 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     private static RelationalWitness<String> refusedBy(Apartness.Reduction<String> said) {
         assertInstanceOf(Apartness.Reduction.Nothing.class, said);
         return ((Apartness.Reduction.Nothing<String>) said).why();
+    }
+
+    /**
+     * The sets a count is taken of are the ones nothing can be added to, each of them once.
+     *
+     * <p>A set inside one of these is refused only where the whole is, so emitting the parts as
+     * well is the same question asked once per subset — and a set reached by taking its blocks in
+     * another order is that same set again. Both show up as a count taken more often than there are
+     * answers, which is what the bound on how many sets this will look at then runs into.
+     */
+    @Test
+    void theSetsCountedAreTheOnesNothingCanBeAddedTo() {
+        Apartness<String> triangle = Apartness.of("p", "q")
+                .and(Apartness.of("q", "r")).and(Apartness.of("r", "p"));
+
+        assertEquals(List.of(Set.of(P, Q, R)), triangle.everyPairwiseApartSet(64),
+                "one set, and not every part of it nor every order its blocks come in");
+
+        Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
+        assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everyPairwiseApartSet(64),
+                "and a chain is two of them, neither of which the other holds");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -154,6 +154,30 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         return ((Apartness.Reduction.Nothing<String>) said).why();
     }
 
+    /**
+     * A cycle of five over two values is refused by no pair and by no set of blocks all stated to
+     * differ, and this says nothing about it.
+     *
+     * <p>Nothing satisfies it — a cycle of odd length needs three values — and no argument this
+     * reduction has reaches it: no block is left one value, so nothing is taken away; and every set
+     * of blocks all stated to differ here is a pair, which two values are enough for. Deciding it
+     * is colouring a graph, which is a different question from the one this answers.
+     *
+     * <p>Written down as the boundary and not as a gap to be closed here. What this holds is the
+     * whole relation, so a reduction that can colour is one added beside these rather than a
+     * rewrite of what they leave — and a reading that answered {@link Apartness.Reduction.Standing}
+     * would be claiming an assignment it has not got.
+     */
+    @Test
+    void aCycleOfFiveOverTwoValuesIsPastWhatThisReductionShows() {
+        Apartness<String> cycle = Apartness.of("a", "b")
+                .and(Apartness.of("b", "c")).and(Apartness.of("c", "d"))
+                .and(Apartness.of("d", "e")).and(Apartness.of("e", "a"));
+
+        assertInstanceOf(Apartness.Reduction.NotKnown.class, cycle.reduce(holding(
+                java.util.Map.of())), "nothing satisfies it, and no argument here reaches it");
+    }
+
     /** A block this cannot say the values of is one the relation says nothing about. */
     @Test
     void aBlockWhoseValuesAreNotKnownIsOneTheRelationSaysNothingAbout() {

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -1,0 +1,179 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a relation between blocks holds, and how it moves when the blocks do.
+ *
+ * <p>The blocks an alternative is a product over are settled by what it holds, and a conjunction
+ * leaves coarser ones while a choice leaves finer ones. So a relation stated of the blocks either
+ * side was over has to arrive at the blocks the operation leaves, and in the direction that
+ * operation goes: pushed forward under a conjunction, pulled back under a choice.
+ *
+ * <p>Asked here rather than through a model because what a model can show is which declarations are
+ * refused, and these are rules about where an answer is filed. Two of them are only visible as a
+ * refusal that fails to happen.
+ */
+class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
+
+    private static final Sameness.Block<String> P = Sameness.Block.of("p");
+    private static final Sameness.Block<String> Q = Sameness.Block.of("q");
+    private static final Sameness.Block<String> R = Sameness.Block.of("r");
+
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    /** What a block admits, for a reduction that has to be asked. */
+    private static Apartness.WhatABlockAdmits<String> holding(
+            java.util.Map<Sameness.Block<String>, Set<Value>> these) {
+        return (block, _) -> new Admits.These(these.getOrDefault(block, Set.of(A, B)));
+    }
+
+    /** A pair is unordered, so a rule written either way round is one rule. */
+    @Test
+    void aPairIsUnorderedAndIsOneRuleWrittenEitherWayRound() {
+        assertEquals(Apartness.of("p", "r"), Apartness.of("r", "p"));
+        assertEquals(1, Apartness.of("p", "r").and(Apartness.of("r", "p")).edges().size(),
+                "one rule stated twice is stated once");
+    }
+
+    /**
+     * A conjunction that holds two blocks as one carries a denial onto the block it leaves.
+     *
+     * <p>{@code q /= r} stated of {@code q} on its own is a denial between {@code r} and whatever
+     * {@code q} is part of once {@code p == q} is read. Left where it was stated, it would name a
+     * block the conjunction does not answer in.
+     */
+    @Test
+    void aConjunctionCarriesADenialOntoTheBlockItLeaves() {
+        Sameness<String> heldAsOne = Sameness.of("p", "q");
+        Sameness.Block<String> both = heldAsOne.blockOf("p");
+
+        Apartness<String> filed = Apartness.of("q", "r").filedIn(heldAsOne);
+
+        assertEquals(Set.of(both, R), filed.blocks());
+        assertEquals(Set.of(both), filed.apartFrom(R));
+    }
+
+    /** And where both ends land on one block, the rules state that a value differs from itself. */
+    @Test
+    void andWhereBothEndsLandOnOneBlockAValueIsStatedToDifferFromItself() {
+        Apartness<String> filed = Apartness.of("p", "q").filedIn(Sameness.of("p", "q"));
+
+        assertTrue(filed.holdsABlockApartFromItself());
+        assertInstanceOf(RelationalWitness.ABlockApartFromItself.class,
+                refusedBy(filed.reduce(holding(java.util.Map.of()))));
+    }
+
+    /**
+     * A choice keeps what both alternatives state, read at the finer blocks it answers in.
+     *
+     * <p>One alternative holds {@code p} and {@code q} as one value and states that block apart
+     * from {@code r}; the other states {@code p /= r} and {@code q /= r} of the two positions
+     * separately. The choice holds neither {@code p} nor {@code q} as one with anything, and what
+     * both alternatives state of them is that each differs from {@code r}.
+     *
+     * <p>Compared where they were stated, the coarser pair would match neither of the finer ones
+     * and a denial both alternatives state would be lost.
+     */
+    @Test
+    void aChoiceKeepsWhatBothAlternativesStateAtTheFinerBlocks() {
+        Sameness<String> coarser = Sameness.of("p", "q");
+        Apartness<String> one = Apartness.of("p", "r").filedIn(coarser);
+        Apartness<String> other = Apartness.of("p", "r").and(Apartness.of("q", "r"));
+
+        Apartness<String> both = one.commonWith(other, Sameness.discrete());
+
+        assertEquals(Set.of(Sameness.Block.of("p"), Sameness.Block.of("q"), R), both.blocks());
+        assertEquals(Set.of(P, Q), both.apartFrom(R));
+    }
+
+    /** And a denial only one alternative states is not the choice's. */
+    @Test
+    void andADenialOnlyOneAlternativeStatesIsNotTheChoices() {
+        assertTrue(Apartness.of("p", "r")
+                .commonWith(Apartness.of("q", "r"), Sameness.discrete()).isEmpty());
+    }
+
+    /**
+     * Blocks all stated to differ, counted; blocks merely related, not.
+     *
+     * <p>{@code p /= q && q /= r && r /= p} needs a value each over two values and nothing
+     * satisfies it. {@code p /= q && q /= r} states nothing of {@code p} and {@code r}, so two
+     * values are enough — and a reduction counting what a relation reaches rather than what it
+     * states to differ would refuse a model no rule refuses.
+     */
+    @Test
+    void blocksAllStatedToDifferAreCountedAndBlocksMerelyRelatedAreNot() {
+        Apartness<String> triangle = Apartness.of("p", "q")
+                .and(Apartness.of("q", "r")).and(Apartness.of("r", "p"));
+        Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
+
+        RelationalWitness<String> why = refusedBy(triangle.reduce(holding(java.util.Map.of())));
+        if (!(why instanceof RelationalWitness.TooFewValuesBetweenThem<String> few)) {
+            throw new AssertionError("refused by counting, and said so: " + why);
+        }
+        assertEquals(Set.of(P, Q, R), few.blocks());
+        assertEquals(Set.of(A, B), few.available());
+
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                chain.reduce(holding(java.util.Map.of())));
+    }
+
+    /**
+     * A block whose neighbours hold one value each loses those values, to a fixpoint.
+     *
+     * <p>{@code p} at {@code A} takes {@code A} from {@code q}, which leaves {@code q} at {@code B}
+     * — and that takes {@code B} from {@code r}, which is left nothing. Run once, the second step
+     * would not happen and the rules would be admitted.
+     */
+    @Test
+    void takingWhatOneValuedBlocksHoldRunsToAFixpoint() {
+        Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
+
+        RelationalWitness<String> why = refusedBy(chain.reduce(holding(java.util.Map.of(
+                P, Set.of(A), Q, Set.of(A, B), R, Set.of(B)))));
+
+        if (!(why instanceof RelationalWitness.NoValueLeftBetweenThem<String> left)) {
+            throw new AssertionError("refused by taking values away, and said so: " + why);
+        }
+        assertEquals(R, left.block());
+        assertEquals(Set.of(Q), left.by(), "the neighbour whose one value took the last of them");
+    }
+
+    /** What a reduction that refused was refused by. */
+    private static RelationalWitness<String> refusedBy(Apartness.Reduction<String> said) {
+        assertInstanceOf(Apartness.Reduction.Nothing.class, said);
+        return ((Apartness.Reduction.Nothing<String>) said).why();
+    }
+
+    /** A block this cannot say the values of is one the relation says nothing about. */
+    @Test
+    void aBlockWhoseValuesAreNotKnownIsOneTheRelationSaysNothingAbout() {
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                Apartness.of("p", "r").reduce((_, _) -> new Admits.NotKnown()));
+    }
+
+    /** And a block holding more values than the relation has blocks never runs out. */
+    @Test
+    void andABlockHoldingMoreValuesThanThereAreBlocksNeverRunsOut() {
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                Apartness.of("p", "r").reduce((_, _) -> new Admits.MoreThanCounted()));
+    }
+
+    /** A relation nothing stated is one nothing refuses. */
+    @Test
+    void aRelationNothingStatedRefusesNothing() {
+        assertTrue(Apartness.<String>nothing().isEmpty());
+        assertFalse(Apartness.<String>nothing().holdsABlockApartFromItself());
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                Apartness.<String>nothing().reduce((_, _) -> new Admits.NotKnown()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -128,14 +128,14 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     }
 
     /**
-     * A block whose neighbours hold one value each loses those values, to a fixpoint.
+     * A block whose neighbours hold one value each loses those values, along the whole chain.
      *
      * <p>{@code p} at {@code A} takes {@code A} from {@code q}, which leaves {@code q} at {@code B}
-     * — and that takes {@code B} from {@code r}, which is left nothing. Run once, the second step
-     * would not happen and the rules would be admitted.
+     * — and that takes {@code B} from {@code r}, which is left nothing. Two steps and not one, so a
+     * reading that took only what the blocks held when it started would admit this.
      */
     @Test
-    void takingWhatOneValuedBlocksHoldRunsToAFixpoint() {
+    void takingWhatOneValuedBlocksHoldFollowsTheWholeChain() {
         Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
 
         RelationalWitness<String> why = refusedBy(chain.reduce(holding(java.util.Map.of(

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -112,6 +112,34 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertEquals(Set.of(P, Q), both.apartFrom(R));
     }
 
+    /**
+     * A choice merged into one product keeps what every alternative states.
+     *
+     * <p>Merging a union into the smallest product containing it widens what the blocks hold. It
+     * does not licence forgetting a rule both branches wrote — and a denial dropped there is one no
+     * equality read beside the choice can be refused against, so a declaration nothing satisfies
+     * comes back admitted.
+     *
+     * <p>Asked of the reading whose values are still descriptions as well as of the one whose
+     * values are sets. Both merge, both have to carry it, and which of the two a compilation takes
+     * is settled by how large the choice is rather than by anything a model says.
+     */
+    @Test
+    void aChoiceMergedIntoOneProductKeepsWhatEveryAlternativeStates() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+
+        AdmissibleValues<String> merged = AdmissibleValues.<String>heldApart("p", "r")
+                .join(AdmissibleValues.heldApart("p", "r"), sets);
+        assertTrue(merged.meet(AdmissibleValues.holdingAsOne("p", "r"), sets).isBottom(),
+                "the choice states it, so an equality read beside it refuses");
+
+        PlannedValues<String> planned = PlannedValues.<String>heldApart("p", "r")
+                .join(PlannedValues.heldApart("p", "r"));
+        assertTrue(planned.meet(PlannedValues.holdingAsOne("p", "r"))
+                        .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
+                "and the same of a reading whose values are still descriptions");
+    }
+
     /** And a denial only one alternative states is not the choice's. */
     @Test
     void andADenialOnlyOneAlternativeStatesIsNotTheChoices() {

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -161,7 +162,37 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
             throw new AssertionError("refused by taking values away, and said so: " + why);
         }
         assertEquals(R, left.block());
-        assertEquals(Set.of(Q), left.by(), "the neighbour whose one value took the last of them");
+        // And the argument is every block it rests on. {@code q} took the last value from {@code r}
+        // and holds one value only because {@code p} does — so {@code q} with {@code r} alone is
+        // satisfiable, and a witness naming those two would say a lack is at a pair whose own rules
+        // are fine with what they leave it.
+        assertEquals(Set.of(P, Q), left.by(),
+                "every block the argument rests on, and not the one that took the last value");
+        assertEquals(Set.of(P, Q, R), left.blocks());
+    }
+
+    /**
+     * And a lack reached through other blocks is another lack, whatever it ends at.
+     *
+     * <p>Two chains ending at the same block, taking the same values away, resting on different
+     * rules: one runs through {@code q} and the other through {@code s}. Named by where they end,
+     * the two would be one lack — and a choice between readings holding them would keep it and say
+     * that those blocks together admit nothing, which neither of them showed of them.
+     */
+    @Test
+    void andALackReachedThroughOtherBlocksIsAnotherLack() {
+        RelationalWitness<String> one = refusedBy(
+                Apartness.of("p", "q").and(Apartness.of("q", "r")).reduce(holding(java.util.Map.of(
+                        P, Set.of(A), Q, Set.of(A, B), R, Set.of(B)))));
+        RelationalWitness<String> other = refusedBy(
+                Apartness.of("p", "s").and(Apartness.of("s", "r")).reduce(holding(java.util.Map.of(
+                        P, Set.of(A), Sameness.Block.of("s"), Set.of(A, B), R, Set.of(B)))));
+
+        assertNotEquals(one, other, "two arguments over different blocks are two arguments");
+        assertInstanceOf(Refusal.Nowhere.class,
+                Refusal.shownByBoth(new Refusal.OfThemTogether<>(one),
+                        new Refusal.OfThemTogether<>(other)),
+                "so a choice between readings holding them keeps neither");
     }
 
     /**
@@ -217,6 +248,31 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
         assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everyPairwiseApartSet(64),
                 "and a chain is two of them, neither of which the other holds");
+    }
+
+    /**
+     * And seven blocks all stated to differ over two values are refused, like three of them.
+     *
+     * <p>Beside the cycle below, and the two together are what part the incompleteness this reading
+     * means from one it would have by accident. Seven blocks all apart is the same argument three
+     * of them are refused by and nothing harder; a reading that reached it by walking every part of
+     * the set, or the set once per order its blocks come in, would run out of what it allows itself
+     * to look at and say nothing — and the shape it went quiet on would be the easy one.
+     */
+    @Test
+    void andSevenBlocksAllStatedToDifferOverTwoValuesAreRefusedLikeThree() {
+        Apartness<String> all = Apartness.nothing();
+        List<String> named = List.of("a", "b", "c", "d", "e", "f", "g");
+        for (int one = 0; one < named.size(); one++) {
+            for (int other = one + 1; other < named.size(); other++) {
+                all = all.and(Apartness.of(named.get(one), named.get(other)));
+            }
+        }
+
+        assertEquals(1, all.everyPairwiseApartSet(64).size(),
+                "one set, and not every part of it nor every order its blocks come in");
+        assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
+                refusedBy(all.reduce(holding(java.util.Map.of()))));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -140,8 +140,33 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertEquals(Set.of(P, Q, R), few.blocks());
         assertEquals(Set.of(A, B), few.available());
 
-        assertInstanceOf(Apartness.Reduction.Standing.class,
+        // And the chain is not refused. Whether it is said to stand is a different question: a
+        // value apiece exists for it and no argument here shows one, which is what
+        // {@link Apartness.Reduction.NotKnown} says.
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
                 chain.reduce(holding(java.util.Map.of())));
+    }
+
+    /**
+     * An assignment is claimed only where every order of the blocks shows one.
+     *
+     * <p>The same relation over the same values, stated two ways round. Both leave every block more
+     * values than the relation has blocks, so each of them can be given one no other took whatever
+     * order they are taken in — and a reading that took the blocks in the order the denials were
+     * stated in would answer one of these and not the other, which is a fact about the writing.
+     */
+    @Test
+    void whetherAnAssignmentIsClaimedDoesNotTurnOnHowTheDenialsWereStated() {
+        Apartness<String> one = Apartness.of("p", "q")
+                .and(Apartness.of("p", "r")).and(Apartness.of("q", "r"));
+        Apartness<String> back = Apartness.of("q", "r")
+                .and(Apartness.of("p", "r")).and(Apartness.of("p", "q"));
+
+        assertEquals(one, back, "one relation, written two ways");
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                one.reduce((_, _) -> new Admits.MoreThanCounted()));
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                back.reduce((_, _) -> new Admits.MoreThanCounted()));
     }
 
     /**
@@ -196,31 +221,50 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     }
 
     /**
-     * A conjunction that makes a denial into a value stated to differ from itself keeps the
-     * alternative, and the relation is what refuses it.
+     * A conjunction that makes a denial into a value stated to differ from itself holds nothing,
+     * and says what by.
      *
-     * <p>Dropped where the sides are put together, the rules that emptied it would be gone with it
-     * — and a reader asking why the declaration holds nothing would be told the general answer,
-     * which is that the values admit nothing. What an alternative was refused by is only knowable
-     * while it is being refused, so the argument is made where the argument is read.
+     * <p>Nothing stands in such an alternative, so it is no member of a union — a choice between it
+     * and something else is that something else. Kept as one so that its argument could be read
+     * later, the union would hold what its alternatives do not and a reading of it would say the
+     * declaration admits what none of them does.
+     *
+     * <p>So the argument leaves with it. What refused an alternative is knowable only while it is
+     * being refused, and it is carried out rather than worked out again from what is left.
      */
     @Test
-    void aConjunctionThatEmptiesAnAlternativeByItsRelationSaysSo() {
+    void aConjunctionEmptiedByItsRelationHoldsNothingAndSaysWhat() {
         Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
         AdmissibleValues<String> both = AdmissibleValues.<String>holdingAsOne("p", "r")
                 .meet(AdmissibleValues.heldApart("p", "r"), sets);
 
-        // Nothing is asked of what the block holds: a value stated to differ from itself is refused
-        // by reading the rule, which is why this is settled before any value is.
-        Refusal<String> why = both.refusedInEveryAlternativeAt(
-                (_, _) -> Emptiness.NONEMPTY,
-                (apart, _) -> apart.reduce((_, _) -> new Admits.NotKnown()));
+        assertTrue(both.isBottom(), "no value of these rules can be written");
 
-        if (!(why instanceof Refusal.OfThemTogether<String> together)) {
-            throw new AssertionError("refused by what its blocks are held as: " + why);
+        if (!(both.refusedBy() instanceof Refusal.OfThemTogether<String> together)) {
+            throw new AssertionError("refused by what its blocks are held as: " + both.refusedBy());
         }
         assertInstanceOf(RelationalWitness.ABlockApartFromItself.class, together.why());
         assertEquals(Set.of(Sameness.of("p", "r").blockOf("p")), together.blocks());
+    }
+
+    /**
+     * And a choice between it and an alternative somebody can take is that alternative.
+     *
+     * <p>A union with an empty member is the union of the rest, so what the choice leaves at
+     * {@code p} is what the branch anybody can take leaves it. Kept as a member, the dead branch
+     * says nothing about {@code p} — nothing narrowed it there — and the choice would come back
+     * admitting every value.
+     */
+    @Test
+    void andAChoiceBetweenItAndSomethingStandingIsThatSomething() {
+        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+        AdmissibleValues<String> dead = AdmissibleValues.<String>holdingAsOne("p", "r")
+                .meet(AdmissibleValues.heldApart("p", "r"), sets);
+
+        assertEquals(ValueSet.just(A),
+                dead.joinApart(AdmissibleValues.at("p", ValueSet.just(A)), sets).at("p"));
+        assertEquals(ValueSet.just(A),
+                AdmissibleValues.at("p", ValueSet.just(A)).joinApart(dead, sets).at("p"));
     }
 
     /** What a reduction that refused was refused by. */

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -134,7 +134,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
                 "the choice states it, so an equality read beside it refuses");
 
         PlannedValues<String> planned = PlannedValues.<String>heldApart("p", "r")
-                .join(PlannedValues.heldApart("p", "r"));
+                .joinLive(PlannedValues.heldApart("p", "r"));
         assertTrue(planned.meet(PlannedValues.holdingAsOne("p", "r"))
                         .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
                 "and the same of a reading whose values are still descriptions");

--- a/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest.java
@@ -1,0 +1,68 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Two readings both left nothing, put together.
+ *
+ * <p>A lack at each of some blocks says of every one of them that it holds nothing, so two of them
+ * agree about the blocks they both name. A lack about several blocks together says that no
+ * assignment to all of them stands, while each of them is left values of its own — and two of those
+ * over sets that overlap have shown nothing about the overlap. Held as one set of blocks, the
+ * second would be intersected like the first and a proof would claim a lack neither reading showed.
+ */
+class ALackAboutBlocksTogetherIsNotALackAtEachOfThemTest {
+
+    private static final Sameness.Block<String> P = Sameness.Block.of("p");
+    private static final Sameness.Block<String> Q = Sameness.Block.of("q");
+    private static final Sameness.Block<String> R = Sameness.Block.of("r");
+
+    private static Refusal<String> together(Sameness.Block<String> one,
+                                            Sameness.Block<String> other) {
+        return new Refusal.OfThemTogether<>(new RelationalWitness.TooFewValuesBetweenThem<>(
+                Set.of(one, other), Set.of(Value.text("A"))));
+    }
+
+    /** Two lacks at blocks are one lack at the blocks both of them name. */
+    @Test
+    void twoLacksAtBlocksKeepWhatBothOfThemName() {
+        Refusal<String> both = Refusal.shownByBoth(
+                new Refusal.AtEachOf<>(Set.of(P, Q)), new Refusal.AtEachOf<>(Set.of(Q, R)));
+
+        assertEquals(Set.of(Q), assertInstanceOf(Refusal.AtEachOf.class, both).blocks());
+    }
+
+    /**
+     * And two lacks about blocks together over sets that overlap keep nothing.
+     *
+     * <p>Neither of them says that {@code q} holds nothing — each says that its own blocks cannot
+     * all be told apart, and {@code q} is left values of its own in both. Intersected, the answer
+     * would be that the rules leave {@code q} nothing, which is a sentence neither reading showed.
+     */
+    @Test
+    void andTwoLacksAboutBlocksTogetherKeepNothingOfWhatTheyShare() {
+        Refusal<String> both = Refusal.shownByBoth(together(P, Q), together(Q, R));
+
+        assertInstanceOf(Refusal.Nowhere.class, both);
+    }
+
+    /** Two of them that are the same lack are that lack, since both readings showed the one thing. */
+    @Test
+    void andTwoOfThemThatAreOneLackAreThatLack() {
+        assertEquals(together(P, Q), Refusal.shownByBoth(together(P, Q), together(P, Q)));
+    }
+
+    /** A lack about blocks together and a lack at blocks are not one another, whatever they name. */
+    @Test
+    void andALackAtBlocksSaysNothingAboutALackAboutThemTogether() {
+        assertInstanceOf(Refusal.Nowhere.class,
+                Refusal.shownByBoth(together(P, Q), new Refusal.AtEachOf<>(Set.of(P, Q))));
+        assertInstanceOf(Refusal.Nowhere.class,
+                Refusal.shownByBoth(new Refusal.AtEachOf<>(Set.of(P, Q)), together(P, Q)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
@@ -97,7 +97,7 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
 
         assertTrue(reading.isBottom());
         assertEquals(Set.of(Set.of("p", "r")),
-                reading.emptiedBlocks().stream().map(Sameness.Block::members)
+                reading.refusedBy().blocks().stream().map(Sameness.Block::members)
                         .collect(java.util.stream.Collectors.toSet()));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryPartOfAReadingIsAValueTest.java
@@ -102,7 +102,8 @@ class EveryPartOfAReadingIsAValueTest {
         }
         if (type == AdmissibleValues.Held.class) {
             return new Sample(AdmissibleValues.Held.Alternatives.of(
-                    new AdmissibleValues.Box<String>(Map.of())), List.of());
+                    AdmissibleValues.Alternative.of(
+                            new AdmissibleValues.Box<String>(Map.of()))), List.of());
         }
         // A position, which this reading is generic over. What one is is the caller's; that two of
         // them are not the same one is all this needs.
@@ -217,12 +218,12 @@ class EveryPartOfAReadingIsAValueTest {
         assertEquals(Set.of(Sameness.Block.of("a")), box.at().keySet(),
                 "what was said is what was said then");
 
-        Set<AdmissibleValues.Box<String>> boxes = new LinkedHashSet<>();
-        boxes.add(box);
+        Set<AdmissibleValues.Alternative<String>> boxes = new LinkedHashSet<>();
+        boxes.add(AdmissibleValues.Alternative.of(box));
         AdmissibleValues.Held.Alternatives<String> held =
                 AdmissibleValues.Held.Alternatives.of(boxes, AsACompilationAllows.forAdmittedValues()).held();
 
-        boxes.add(AdmissibleValues.Box.at(Map.of("b", ValueSet.ANY)));
+        boxes.add(AdmissibleValues.Alternative.at(Map.of("b", ValueSet.ANY)));
         assertEquals(1, held.boxes().size(), "the alternatives are the ones it was made of");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -55,7 +55,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
 
         assertEquals(twoAlternatives("a", "b").at("a"), both.at("a"));
         assertEquals(twoAlternatives("c", "d").at("d"), both.at("d"));
-        assertEquals(Emptiness.NONEMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY));
+        assertEquals(Emptiness.NONEMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY,
+                (_, _) -> new Apartness.Reduction.Standing<>()));
     }
 
     /**
@@ -94,7 +95,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
                                 AdmissibleValues.at("c", just("x"))
                                         .meet(AdmissibleValues.at("c", just("y")), SETS), SETS));
 
-        assertEquals(Emptiness.EMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY));
+        assertEquals(Emptiness.EMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY,
+                (_, _) -> new Apartness.Reduction.Standing<>()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAPositionHoldsAcrossAlternativesDoesNotFollowHowTheyWereFilledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAPositionHoldsAcrossAlternativesDoesNotFollowHowTheyWereFilledTest.java
@@ -38,8 +38,8 @@ class WhatAPositionHoldsAcrossAlternativesDoesNotFollowHowTheyWereFilledTest {
     }
 
     /** One alternative, holding {@code set} at the one position there is. */
-    private static AdmissibleValues.Box<String> box(ValueSet set) {
-        return AdmissibleValues.Box.at(Map.of("here", set));
+    private static AdmissibleValues.Alternative<String> box(ValueSet set) {
+        return AdmissibleValues.Alternative.at(Map.of("here", set));
     }
 
     /**
@@ -49,7 +49,7 @@ class WhatAPositionHoldsAcrossAlternativesDoesNotFollowHowTheyWereFilledTest {
      * small one first is a join with a written value, and one that meets the two large ones first is
      * a machine of their sum.
      */
-    private static List<AdmissibleValues.Box<String>> three() {
+    private static List<AdmissibleValues.Alternative<String>> three() {
         return List.of(box(matching("x|a{300}")), box(matching("x|b{300}")),
                 box(ValueSet.just(Value.text("x"))));
     }
@@ -62,8 +62,8 @@ class WhatAPositionHoldsAcrossAlternativesDoesNotFollowHowTheyWereFilledTest {
         int spent = -1;
         for (List<Integer> order : List.of(List.of(0, 1, 2), List.of(0, 2, 1), List.of(1, 0, 2),
                 List.of(1, 2, 0), List.of(2, 0, 1), List.of(2, 1, 0))) {
-            List<AdmissibleValues.Box<String>> boxes = three();
-            Set<AdmissibleValues.Box<String>> filled = new LinkedHashSet<>();
+            List<AdmissibleValues.Alternative<String>> boxes = three();
+            Set<AdmissibleValues.Alternative<String>> filled = new LinkedHashSet<>();
             order.forEach(each -> filled.add(boxes.get(each)));
 
             Allowance<String> by = AsACompilationAllows.forAdmittedValues();

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
@@ -83,6 +83,11 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
                         says(VALUE, A).meet(says(OTHER, A), SETS)
                                 .join(says(VALUE, B).meet(says(OTHER, B), SETS), SETS)
                                 .meet(says(VALUE, A), SETS)),
+                made("heldApart", AdmissibleValues.heldApart(VALUE, OTHER)),
+                made("meet with heldApart",
+                        says(VALUE, A).meet(AdmissibleValues.heldApart(VALUE, OTHER), SETS)),
+                made("join with heldApart",
+                        says(VALUE, A).join(AdmissibleValues.heldApart(VALUE, OTHER), SETS)),
                 made("join nested under a join",
                         says(VALUE, A).join(says(VALUE, B)
                                 .join(unreadable(Set.of(VALUE)), SETS).alsoOpenedAt(Set.of(VALUE)),
@@ -105,6 +110,36 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
             assertEquals(ValueSet.NONE, state.guaranteedAt(atom),
                     () -> "at " + atom + " of a reading that admits nothing");
         }
+    }
+
+    /**
+     * A position held apart from another is guaranteed nothing, and one beside it keeps what it had.
+     *
+     * <p>A guarantee is a lower approximation: these values stand there whatever else is read. No
+     * value can be shown to stand at one of two positions held apart without an assignment for the
+     * other — over a carrier of one value a denial admits nothing at all — so the honest guarantee
+     * at both of them is none. What the rules leave them is still every value, which is the upper
+     * approximation and a different question.
+     *
+     * <p>Said where the rule is read rather than wherever a denial is met with something. Meeting a
+     * guarantee with nothing leaves nothing, so every conjunction the rule reaches has it without a
+     * second rule saying so — and a choice beside it keeps what its other branch guarantees, which
+     * is right, because a value satisfying that branch is under no denial.
+     */
+    @Test
+    void aPositionHeldApartFromAnotherIsGuaranteedNothing() {
+        AdmissibleValues<String> apart = AdmissibleValues.heldApart(VALUE, OTHER);
+
+        assertEquals(ValueSet.NONE, apart.guaranteedAt(VALUE));
+        assertEquals(ValueSet.NONE, apart.guaranteedAt(OTHER));
+        assertEquals(ValueSet.ANY, apart.at(VALUE), "and the rules leave it every value");
+
+        assertEquals(ValueSet.NONE,
+                says(VALUE, A).meet(apart, SETS).guaranteedAt(VALUE),
+                "a conjunction the rule reaches guarantees nothing there");
+        assertEquals(ValueSet.just(A),
+                says(VALUE, A).join(apart, SETS).guaranteedAt(VALUE),
+                "and a branch beside it keeps what it guarantees on its own");
     }
 
     static Stream<Arguments> admittingNothing() {

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/DataMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/DataMessage.java
@@ -118,6 +118,17 @@ public sealed interface DataMessage extends Message {
     record NoValueTheseCanAllHold(String data, String at) implements DataMessage, Reported {}
 
     /**
+     * Positions the rules state to hold different values cannot all differ.
+     *
+     * <p>The rule the other way round from {@link NoValueTheseCanAllHold}, and a sentence of its
+     * own rather than that one with the places changed. There the places are one value and it has
+     * none; here each of them holds a value and there are not enough values for them all to differ
+     * — so an author sent to look for a value they share would find one and be none the wiser.
+     */
+    @Code(DiagnosticCode.E1013)
+    record NoValuesTheseCanAllDifferIn(String data, String at) implements DataMessage, Reported {}
+
+    /**
      * The values positions held as one value are allowed and the range they share have none in
      * common.
      *

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/DataMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/DataMessage.java
@@ -129,6 +129,17 @@ public sealed interface DataMessage extends Message {
     record NoValuesTheseCanAllDifferIn(String data, String at) implements DataMessage, Reported {}
 
     /**
+     * Positions the rules hold as one value are also stated to differ.
+     *
+     * <p>Beside {@link NoValuesTheseCanAllDifferIn} and not it. That one says there are too few
+     * values for these to differ, which sends an author to look for more; here there is no number
+     * of values that would do, because one value is not two whatever it is.
+     */
+    @Code(DiagnosticCode.E1013)
+    record TheseAreHeldAsOneValueAndStatedToDiffer(String data, String at)
+            implements DataMessage, Reported {}
+
+    /**
      * The values positions held as one value are allowed and the range they share have none in
      * common.
      *


### PR DESCRIPTION
Closes #1364.

An equality between two positions is a congruence, so it can be what a
product is indexed by — which is what #1350 made it. A denial is not one:
it removes the diagonal from a product of two sides and makes no side. So
it reached no reading, and what the rules stated about one position and
what they stated about the other stayed two facts about two places.

## What holds it

An alternative is now a product and a relation beside it. The product is
unchanged — every combination of its sides standing — and the relation
says which of its blocks are stated to hold different values. The blocks
an alternative is over are read off both, so a denial between two
positions nothing else narrows is still a rule about blocks the
alternative answers in.

The relation owns where it is filed. A conjunction pushes it onto the
blocks it leaves, so a denial and a side of one alternative are never
filed a step apart; a choice pulls it back onto the finer blocks it
answers in and keeps what every alternative states. Where both ends of a
pair land on one block, the rules state that a value differs from itself.

## What it comes to

Settled where the values a block is left are in hand, which is where a
set of values and a range on an order are already put together — so a
position pinned to one value by its ends is read like one pinned by a
written value. The walk that owns the alternatives asks the cheap
question first: an alternative already refused at a block is one no
relation has to be read for.

Three arguments, each named by what it shows: a value stated to differ
from itself, a block whose neighbours take every value it was left, and
blocks all stated to differ with fewer values between them than there are
blocks. A chain is not a set of blocks all stated to differ and is
admitted. A cycle of odd length is refused by none of the three, and that
is written down as the boundary rather than closed here — the relation is
carried whole, so a reduction that can colour is one added beside these.

## What had to move with it

A lack about blocks together is not a lack at each of them. Where a
refusal is is now two shapes, and a reader putting two of them together
has to say what it means by it: two collective lacks over sets that
overlap have shown nothing about the overlap.

A position held apart from another is guaranteed nothing, since no value
is shown to stand at one of them without an assignment for the other.

A rule this reading takes in is not one it stopped on, so a denial no
longer stands as a rule relating two positions; an ordering between two
of them still does. What a rule raises about one position is a different
question with the same name, and it is unchanged — a denial divides
neither position, so it raises nothing there either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)