### PR TITLE
Name the evidence a rule states, and refuse an import that takes a name the package declares

### DIFF
--- a/souther-architecture-test/pom.xml
+++ b/souther-architecture-test/pom.xml
@@ -14,11 +14,12 @@
     <name>Souther Architecture Tests</name>
 
     <description>
-        Holds the checks whose population is the compiled output of the whole reactor, and nothing
-        else. A check that reads compiled classes sees what has been built when it runs, so where it
-        lives is what it measures: one living in the module it is about reads that module and passes
-        over every module built after it, saying nothing about them while looking as though it did.
-        A check that a module can answer on its own belongs in that module.
+        Holds the checks whose population is the whole reactor, and nothing else — its compiled
+        output, or its sources where the fact a check is about is written in them rather than kept
+        in a class file. A check that reads compiled classes sees what has been built when it runs,
+        so where it lives is what it measures: one living in the module it is about reads that
+        module and passes over every module built after it, saying nothing about them while looking
+        as though it did. A check that a module can answer on its own belongs in that module.
 
         The reactor had no such place. This is one: it depends on every other module and nothing
         depends on it, so Maven builds it last and every module's classes are there when its tests

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -1,0 +1,235 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name a package declares means that name inside the package.
+ *
+ * <p>Two packages may call two things by one name. A word that fits one bounded context fits
+ * another, and asking every such pair to give one of them up would be a rule about the words rather
+ * than about what they say — {@code Ordered} in a partition and {@code Ordered} in a query are two
+ * answers to two questions, and nothing is clearer for one of them being renamed.
+ *
+ * <p>What is refused is one file rebinding the name. A single-type import wins over the package a
+ * compilation unit is in, so
+ *
+ * <pre>
+ * package a;
+ * import b.X;
+ * </pre>
+ *
+ * leaves the bare {@code X} in that file meaning {@code b.X} while the package around it declares
+ * one of its own. A reader who knows where they are has to find the import before they know which
+ * question they are looking at, a search for either finds both, and javac says nothing — the file
+ * compiles and the two names are the same word.
+ *
+ * <p>The escape is to write the foreign type out where it is used. It is longer, and the length is
+ * the point: such a file is holding two things one word names, and it says which it means at each
+ * place it means one.
+ *
+ * <p><b>Only a non-static single-type import.</b> That is the whole of what this reads, so it is the
+ * whole of what the rule claims. Java introduces names other ways — a static import, a nested type
+ * reached through its owner — and each is a question of its own; a sentence here about what a bare
+ * name always means would be wider than the reading under it.
+ */
+class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * Every source this repository holds, and not its main sources alone.
+     *
+     * <p>The reversal is the same wherever it is written. A test in {@code souther.compiler.partition}
+     * importing a {@code query} type of the same name reads exactly as wrongly as a class beside it
+     * would, and the tests are where most of the reading happens.
+     */
+    @Test
+    void noSourceRebindsANameItsOwnPackageDeclares() {
+        List<Unit> units = parsed(REPOSITORY.filesUnderSourceTrees(".java"));
+        assertTrue(units.size() > 1000,
+                "this reads the repository's sources, and it read " + units.size());
+
+        assertEquals(List.of(), rebindings(units),
+                "a file whose package declares this name and which imports another package's:"
+                        + " inside it the bare name means the other one, and nothing says so."
+                        + " Drop the import and write the foreign type out where it is used");
+    }
+
+    /**
+     * And what the rule holds and does not, on sources written to be either.
+     *
+     * <p>Here rather than by naming the pairs the repository happens to hold. That two packages both
+     * declare {@code Ordered} is true today and is not something a check should hold them to, and a
+     * fixture that named it would be this test asking for the duplication to stay.
+     */
+    @Test
+    void aNameTheOwnPackageDoesNotDeclareIsImportedFreely() {
+        String bringsIn = "package p; import q.A; class C { A a; }";
+        String leavesAlone = "package p; class C { q.A a; }";
+        String another = "package p; import q.B; class C { B b; }";
+
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.A"),
+                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                        "q/A.java", "package q; class A {}",
+                        "q/B.java", "package q; class B {}",
+                        "p/C.java", bringsIn))),
+                "the name is the package's own and the import takes it");
+
+        assertEquals(List.of(),
+                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                        "q/A.java", "package q; class A {}",
+                        "p/C.java", leavesAlone))),
+                "the foreign type written out takes no name");
+
+        assertEquals(List.of(),
+                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                        "q/A.java", "package q; class A {}",
+                        "q/B.java", "package q; class B {}",
+                        "p/C.java", another))),
+                "a name p declares nothing by is a name nothing here is about");
+    }
+
+    /** One compilation unit, as much of it as this question is about. */
+    private record Unit(String where, String pkg, Set<String> declares, List<String> imports) {}
+
+    /**
+     * The rebindings among {@code units}, each said as the file, the name and what it was taken to.
+     *
+     * <p>Sorted, so that what a failure lists is the same on every machine and reads as a list of
+     * places to go rather than as whatever order a walk happened to have.
+     */
+    private static List<String> rebindings(List<Unit> units) {
+        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
+        for (Unit unit : units) {
+            declaredBy.computeIfAbsent(unit.pkg(), _ -> new LinkedHashSet<>())
+                    .addAll(unit.declares());
+        }
+        Set<String> found = new TreeSet<>();
+        for (Unit unit : units) {
+            Set<String> own = declaredBy.getOrDefault(unit.pkg(), Set.of());
+            for (String imported : unit.imports()) {
+                int dot = imported.lastIndexOf('.');
+                String name = dot < 0 ? imported : imported.substring(dot + 1);
+                String from = dot < 0 ? "" : imported.substring(0, dot);
+                // A same-package import binds the name it already had, so nothing means anything
+                // different for it being written. Whether it should be written at all is another
+                // rule's question.
+                if (!from.equals(unit.pkg()) && own.contains(name)) {
+                    found.add(unit.where() + " rebinds `" + name + "`, which " + unit.pkg()
+                            + " declares, to " + imported);
+                }
+            }
+        }
+        return List.copyOf(found);
+    }
+
+    /** The sources at {@code paths}, named by their path under the repository root. */
+    private static List<Unit> parsed(List<Path> paths) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager files =
+                     compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)) {
+            return read(compiler, files.getJavaFileObjectsFromPaths(paths),
+                    at -> REPOSITORY.root().relativize(Path.of(at)).toString());
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+    }
+
+    /** The same, of sources written here, named by the key they were written under. */
+    private static List<Unit> parsedFrom(Map<String, String> sources) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        List<JavaFileObject> written = new ArrayList<>();
+        sources.forEach((named, text) -> written.add(new Written(named, text)));
+        // What a written source is called is the path of the URI it was given, which is that key
+        // under the root every URI needs.
+        return read(compiler, written, at -> at.startsWith("/") ? at.substring(1) : at);
+    }
+
+    /**
+     * What each source says about its package, its top-level types and its imports.
+     *
+     * <p>Parsed and not compiled. Every part of the question is written in the file — which package
+     * it declares, which names it declares in that package, which types it imports by name — so
+     * nothing here needs a symbol resolved, a classpath, or the rest of the repository to be built.
+     */
+    private static List<Unit> read(JavaCompiler compiler, Iterable<? extends JavaFileObject> sources,
+                                   java.util.function.UnaryOperator<String> naming) {
+        JavacTask task = (JavacTask) compiler.getTask(null, null, diagnostic -> { },
+                List.of("-proc:none"), null, sources);
+        List<Unit> out = new ArrayList<>();
+        try {
+            for (CompilationUnitTree unit : task.parse()) {
+                Set<String> declares = new LinkedHashSet<>();
+                for (Tree declared : unit.getTypeDecls()) {
+                    // A stray `;` among the declarations is not one. Every top-level type is a
+                    // class, an interface, a record or an enum, and a `ClassTree` is what the
+                    // parser calls all four.
+                    if (declared instanceof ClassTree it) {
+                        declares.add(it.getSimpleName().toString());
+                    }
+                }
+                List<String> imports = new ArrayList<>();
+                for (ImportTree each : unit.getImports()) {
+                    String named = each.getQualifiedIdentifier().toString();
+                    // A static import brings in a member and an on-demand import brings in no name
+                    // at all until something is written; neither is what this is about, and the
+                    // class doc says so rather than this quietly covering them.
+                    if (!each.isStatic() && !named.endsWith(".*")) {
+                        imports.add(named);
+                    }
+                }
+                out.add(new Unit(naming.apply(unit.getSourceFile().getName()),
+                        unit.getPackageName() == null ? "" : unit.getPackageName().toString(),
+                        declares, imports));
+            }
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+        return List.copyOf(out);
+    }
+
+    /** A source written here rather than read from the repository. */
+    private static final class Written extends SimpleJavaFileObject {
+
+        private final String text;
+
+        private Written(String named, String text) {
+            super(URI.create("string:///" + named), Kind.SOURCE);
+            this.text = text;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return text;
+        }
+    }
+}

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -118,6 +118,31 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 "a name p declares nothing by is a name nothing here is about");
     }
 
+    /**
+     * The package an import comes from is the type's owner, and not the package it is written in.
+     *
+     * <p>A nested type is imported through whatever holds it, so an import from the file's own
+     * package can still take the name: {@code import p.Outer.A} inside {@code p} leaves the bare
+     * {@code A} meaning the nested one while {@code p} declares its own. What changes nothing is an
+     * import of the very type the package declares — the name already meant that.
+     */
+    @Test
+    void anImportFromTheOwnPackageTakesTheNameWhereItNamesSomethingElse() {
+        Map<String, String> declared = Map.of("p/A.java", "package p; class A {}",
+                "p/Outer.java", "package p; class Outer { static class A {} }");
+
+        Map<String, String> throughAnOwner = new LinkedHashMap<>(declared);
+        throughAnOwner.put("p/C.java", "package p; import p.Outer.A; class C { A a; }");
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to p.Outer.A"),
+                rebindings(parsedFrom(throughAnOwner)),
+                "the owner is another type, so the name is taken");
+
+        Map<String, String> theSameType = new LinkedHashMap<>(declared);
+        theSameType.put("p/C.java", "package p; import p.A; class C { A a; }");
+        assertEquals(List.of(), rebindings(parsedFrom(theSameType)),
+                "the import names what the package declares, and the name already meant it");
+    }
+
     /** One compilation unit, as much of it as this question is about. */
     private record Unit(String where, String pkg, Set<String> declares, List<String> imports) {}
 

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -13,6 +13,7 @@ import com.sun.source.util.Trees;
 
 import org.junit.jupiter.api.Test;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
@@ -83,6 +84,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * source can see it, so it declares nothing a bare name in a main source could otherwise have
  * meant. So the main sources answer for every source, and a test source's own root answers for it
  * besides.
+ *
+ * <p>Every module's main sources, and not the ones a module is built against. Which of them a
+ * compilation actually sees is its dependencies' business, and this does not read them — so a
+ * package split across two modules that do not depend on each other would be answered here as one
+ * package. What that costs is a name reported as taken where a compilation could not have taken
+ * it, which is a thing to look at rather than one to pass over, and the packages this repository
+ * splits are all along one chain of dependencies.
+ *
+ * <p><b>What this cannot answer, it says.</b> The question is written as a source in the package
+ * and read against the classes this test runs against, which are the modules' main classes. An
+ * owner that is not among them — a test class of another module, a library another module keeps to
+ * itself — leaves the question unanswered, and a source in no package leaves it unasked; both are
+ * listed. Neither is a rebinding and neither is the absence of one.
  */
 class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
 
@@ -117,6 +131,22 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 "a static import whose simple name a package here declares, taken from an owner"
                         + " this repository does not declare: whether it binds a member type is"
                         + " that owner's answer and nothing here has it");
+    }
+
+    /**
+     * And nothing this repository declares is called what the question's own source is called.
+     *
+     * <p>The question is written as a class in the package it is about, so a package declaring a
+     * type of that name would have the two collide and the question would not compile. Held here
+     * rather than left to whoever reads a failure about a source that looks nothing like the rule.
+     */
+    @Test
+    void nothingIsCalledWhatTheQuestionsOwnSourceIsCalled() {
+        assertEquals(List.of(), repositorySources().stream()
+                        .filter(each -> each.declares().contains(ASKED))
+                        .map(Unit::where).toList(),
+                "a type called `" + ASKED + "`, which is what the source written to ask what a name"
+                        + " means is called: rename either");
     }
 
     /**
@@ -273,6 +303,23 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
     }
 
     /**
+     * And the compiler this asks is reading this repository's own classes.
+     *
+     * <p>The one thing a run over the sources cannot show. Every static import it has to ask about
+     * is one whose name a package here declares, and there are none — so a reading that resolved
+     * nothing at all would report no rebinding and no unanswered import, and pass. This asks about
+     * a type this repository declares and nothing else does, so a classpath that had gone empty
+     * says so here rather than in a silence somewhere else.
+     */
+    @Test
+    void theCompilerThisAsksIsReadingThisRepositorysClasses() {
+        assertEquals("souther.compiler.partition.RuleEvidence.Divides",
+                repositoryMeanings().meaningOf("souther.architecture", "Divides",
+                        new Import("souther.compiler.partition.RuleEvidence.Divides", true)),
+                "a member type of this repository, reached through the classes this runs against");
+    }
+
+    /**
      * And what a name comes to mean is the compiler's answer, over types nothing here wrote.
      *
      * <p>Beside the fixtures, which pin what the rule does with each answer. This pins the answer
@@ -296,6 +343,35 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
         assertNull(meanings.meaningOf("p", "SimpleEntry",
                         new Import("nothing.declares.This.SimpleEntry", true)),
                 "and an owner nothing resolves is neither of those");
+    }
+
+    /**
+     * A name the package declares where only its tests do is answered like any other.
+     *
+     * <p>The question is asked by writing a source, and what that source is read against is the
+     * classes this test runs against — which hold a module's main classes and not its tests. So the
+     * package's own type is written into the question rather than looked for: the caller has
+     * already established there is one, and what the question needs of it is that the name has
+     * something to mean where the import does not take it.
+     *
+     * <p>Left to be found, a test class importing a field of the same name as a type beside it
+     * would come back unanswered, and the rule would be asking that the type be visible to this
+     * check as well as declared — which is not the rule.
+     */
+    @Test
+    void aTypeOnlyATestRootDeclaresIsStillWhatTheNameMeans() {
+        Map<String, String> owner = Map.of("q/Outer.java",
+                "package q; public class Outer { public static int A = 1; }");
+        Map<String, String> beside = Map.of("p/A.java", "package p; class A {}",
+                "p/C.java", "package p; import static q.Outer.A; class C { A type; int value = A; }");
+
+        Found found = read(inRoots(Map.of("main", owner), Map.of("test", beside)),
+                meaningsIn(owner));
+
+        assertEquals(List.of(), found.rebindings(),
+                "the field takes no type name, and the package's own type is what `A` means");
+        assertEquals(List.of(), found.unanswered(),
+                "and nothing about it went unanswered for the type being a test class");
     }
 
     /** And an owner nothing here declares is one the check says it cannot answer about. */
@@ -432,6 +508,14 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 // formed. A static import names whichever member the owner has by that name, and
                 // only an accessible static member type of them binds a type name, so what the
                 // bare name comes to mean is asked rather than worked out.
+                if (each.isStatic() && unit.pkg().isEmpty()) {
+                    // Nothing can be asked about a source in no package: the question is written as
+                    // a source in the package, and there is none to write it in. Said rather than
+                    // decided, for the reason an owner nothing resolves is.
+                    unanswered.add(unit.where() + " imports `" + each.name()
+                            + "` and is in no package, which nothing here can ask about");
+                    continue;
+                }
                 String means = each.isStatic()
                         ? meanings.meaningOf(unit.pkg(), each.name(), each) : each.spelled();
                 if (means == null) {
@@ -621,11 +705,22 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      * source would be given, arrived at by the same resolution.
      */
     private static NameMeanings meaningsOver(List<JavaFileObject> also) {
+        Set<String> alreadyWritten = declaredIn(also);
         return (pkg, name, importing) -> {
             List<JavaFileObject> sources = new ArrayList<>(also);
-            sources.add(new Written("probe", "Probe.java", "package " + pkg + "; "
+            // The package's own type, where these sources do not already hold one. The caller has
+            // established that the package declares this name, and the probe needs it declared to
+            // have something to mean where the import does not take it. What it is declared as does
+            // not matter: the answer is its qualified name either way, and a real one on the
+            // classpath is the same name as this. Added where a source here already declares it,
+            // the two would be one type declared twice.
+            if (!alreadyWritten.contains(pkg + "." + name)) {
+                sources.add(new Written("asking", pkg.replace('.', '/') + "/" + name + ".java",
+                        "package " + pkg + "; class " + name + " {}"));
+            }
+            sources.add(new Written("asking", ASKED + ".java", "package " + pkg + "; "
                     + (importing.isStatic() ? "import static " : "import ") + importing.spelled()
-                    + "; class Probe { " + name + " field; }"));
+                    + "; class " + ASKED + " { " + name + " field; }"));
             JavacTask task = (JavacTask) compiler().getTask(null, null, diagnostic -> { },
                     List.of("-proc:none"), null, sources);
             List<CompilationUnitTree> units = new ArrayList<>();
@@ -640,20 +735,58 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
             }
             Trees trees = Trees.instance(task);
             for (CompilationUnitTree unit : units) {
-                if (!unit.getSourceFile().toUri().toString().endsWith("/Probe.java")) {
+                if (!unit.getSourceFile().toUri().toString().endsWith("/" + ASKED + ".java")) {
                     continue;
                 }
-                ClassTree probe = (ClassTree) unit.getTypeDecls().getFirst();
-                Tree written = probe.getMembers().stream()
+                ClassTree asked = (ClassTree) unit.getTypeDecls().getFirst();
+                Tree written = asked.getMembers().stream()
                         .filter(VariableTree.class::isInstance).map(VariableTree.class::cast)
                         .findFirst().orElseThrow().getType();
-                return trees.getElement(TreePath.getPath(unit, written))
-                        instanceof TypeElement it ? it.getQualifiedName().toString() : null;
+                Element means = trees.getElement(TreePath.getPath(unit, written));
+                if (!(means instanceof TypeElement it)) {
+                    throw new IllegalStateException("the source written to ask what `" + name
+                            + "` means in " + pkg + " left it meaning " + means
+                            + ", though the package declares a type by that name");
+                }
+                return it.getQualifiedName().toString();
             }
             throw new IllegalStateException("the source written to ask what `" + name
                     + "` means in " + pkg + " did not come back");
         };
     }
+
+    /**
+     * What the sources handed to a probe declare, as qualified names.
+     *
+     * <p>Read rather than worked out from where a source sits, because that is the question: the
+     * probe declares the package's own type only where these do not, and a name matched on a path
+     * would be this deciding it by how a file happens to be called.
+     */
+    private static Set<String> declaredIn(List<JavaFileObject> sources) {
+        if (sources.isEmpty()) {
+            return Set.of();
+        }
+        JavacTask task = (JavacTask) compiler().getTask(null, null, diagnostic -> { },
+                List.of("-proc:none"), null, sources);
+        Set<String> out = new LinkedHashSet<>();
+        try {
+            for (CompilationUnitTree unit : task.parse()) {
+                String pkg = unit.getPackageName() == null ? "" : unit.getPackageName() + ".";
+                for (Tree declared : unit.getTypeDecls()) {
+                    if (declared instanceof ClassTree it) {
+                        out.add(pkg + it.getSimpleName());
+                    }
+                }
+            }
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+        return Set.copyOf(out);
+    }
+
+    /** What the source written to ask the question is called. Not a name any package here declares
+     *  — one that did would have the question's own class collide with the type it asks about. */
+    private static final String ASKED = "WhatTheNameMeansHere";
 
     /** What the names of this repository's compiled classes mean, which is what its sources are
      *  read against. */

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -10,6 +10,9 @@ import com.sun.source.util.JavacTask;
 
 import org.junit.jupiter.api.Test;
 
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
@@ -30,6 +33,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -61,10 +65,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p><b>Whichever of the two ways the import is spelled.</b> {@code import static b.Outer.X} binds
  * {@code X} to a member type and shadows the package's own just as {@code import b.X} does, so the
  * rule is about what an import binds and not about the keyword in front of it. Which of them a
- * static import binds is asked rather than assumed: the owner is looked up among the types this
- * repository declares, and a name it declares no member type by is a field or a method, which is a
- * different namespace and takes nothing. An owner this repository does not declare cannot be
- * answered here at all, and those are listed rather than let through
+ * static import binds is the owner's answer, and it is asked of the compiler
+ * ({@link MemberTypes}): the members of a type are the ones it inherits as well as the ones it
+ * declares, so no reading of the owner's source text answers this. An owner nothing here resolves
+ * is a third answer and is listed rather than let through
  * ({@link #everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout}).
  *
  * <p>An on-demand import is not one of these. {@code import b.*} and {@code import static b.Outer.*}
@@ -91,7 +95,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void noSourceRebindsANameItsOwnPackageDeclares() {
-        assertEquals(List.of(), read(repositorySources()).rebindings(),
+        assertEquals(List.of(), read(repositorySources(), repositoryMembers()).rebindings(),
                 "a file whose package declares this name and which imports another package's:"
                         + " inside it the bare name means the other one, and nothing says so."
                         + " Drop the import and write the foreign type out where it is used");
@@ -107,7 +111,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout() {
-        assertEquals(List.of(), read(repositorySources()).unanswered(),
+        assertEquals(List.of(), read(repositorySources(), repositoryMembers()).unanswered(),
                 "a static import whose simple name a package here declares, taken from an owner"
                         + " this repository does not declare: whether it binds a member type is"
                         + " that owner's answer and nothing here has it");
@@ -218,14 +222,55 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 "an on-demand import is below the package's own members and rebinds nothing");
     }
 
+    /**
+     * A member type the owner inherits is one a static import binds, and takes the name.
+     *
+     * <p>The case a reading of the owner's source text cannot answer. {@code Child} declares
+     * nothing, and {@code import static q.Child.A} binds {@code Base}'s {@code A} all the same —
+     * so a check that looked for the declaration inside {@code Child} would find none, call it a
+     * field or a method, and let the rebinding through.
+     */
+    @Test
+    void aStaticImportOfAnInheritedMemberTypeTakesTheName() {
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.Child.A"),
+                rebindingsIn(Map.of(
+                        "q/Base.java", "package q; public class Base { public static class A {} }",
+                        "q/Child.java", "package q; public class Child extends Base {}",
+                        "p/A.java", "package p; class A {}",
+                        "p/C.java", "package p; import static q.Child.A; class C { A a; }")),
+                "the owner has the member type by inheriting it, and the import binds it");
+    }
+
+    /**
+     * And what a static import binds is the compiler's answer, over types nothing here wrote.
+     *
+     * <p>Beside the fixtures, which pin what the rule does with each of the three answers. This
+     * pins the answers themselves against a type this repository does not own and cannot edit:
+     * {@code HashMap} has {@code SimpleEntry} by inheriting it from {@code AbstractMap}, and its
+     * own body says nothing about it.
+     */
+    @Test
+    void whatAnOwnerHasByANameIsAskedOfTheCompiler() {
+        MemberTypes members = repositoryMembers();
+
+        assertEquals(Boolean.TRUE, members.bindsATypeNamed("java.util.AbstractMap", "SimpleEntry"),
+                "a member type the owner declares");
+        assertEquals(Boolean.TRUE, members.bindsATypeNamed("java.util.HashMap", "SimpleEntry"),
+                "and one it inherits, which no reading of its own text finds");
+        assertEquals(Boolean.FALSE, members.bindsATypeNamed("java.util.HashMap", "size"),
+                "a method is a different namespace and takes no type name");
+        assertNull(members.bindsATypeNamed("nothing.declares.This", "A"),
+                "and an owner nothing resolves is neither of those");
+    }
+
     /** And an owner nothing here declares is one the check says it cannot answer about. */
     @Test
     void aStaticImportFromAnOwnerThisDoesNotDeclareIsSaidToBeUnanswered() {
-        Found found = read(written(Map.of("p/A.java", "package p; class A {}",
-                "p/C.java", "package p; import static x.Elsewhere.A; class C { A a; }")));
+        Found found = ofWritten(Map.of("p/A.java", "package p; class A {}",
+                "p/C.java", "package p; import static x.Elsewhere.A; class C { A a; }"));
 
         assertEquals(List.of(), found.rebindings(), "nothing here says what it binds");
-        assertEquals(List.of("p/C.java imports `A` from x.Elsewhere, which this does not declare"),
+        assertEquals(List.of("p/C.java imports `A` from x.Elsewhere, which nothing here resolves"),
                 found.unanswered(), "so the import is named rather than let through");
     }
 
@@ -244,11 +289,13 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 "p/C.java", "package p; import q.A; class C { A a; }");
 
         assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.A"),
-                read(inRoots(Map.of("main", declaresA), Map.of("test", takesIt))).rebindings(),
+                read(inRoots(Map.of("main", declaresA), Map.of("test", takesIt)),
+                        membersOf(merged(declaresA, takesIt))).rebindings(),
                 "the test root resolves against the main sources of the package");
 
         assertEquals(List.of(),
-                read(inRoots(Map.of("main", takesIt), Map.of("test", declaresA))).rebindings(),
+                read(inRoots(Map.of("main", takesIt), Map.of("test", declaresA)),
+                        membersOf(merged(declaresA, takesIt))).rebindings(),
                 "a class declared only under a test root shadows nothing in a main source");
     }
 
@@ -273,7 +320,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
 
     /** One compilation unit, as much of it as this question is about. */
     private record Unit(String where, String pkg, String root, boolean isMain,
-                        Set<String> declares, Set<String> types, List<Import> imports) {}
+                        Set<String> declares, List<Import> imports) {}
 
     /** One single import, which binds a name whatever the keyword in front of it is. */
     private record Import(String spelled, boolean isStatic) {
@@ -315,12 +362,10 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      * <p>Sorted, so that what a failure lists is the same on every machine and reads as a list of
      * places to go rather than as whatever order a walk happened to have.
      */
-    private static Found read(List<Unit> units) {
+    private static Found read(List<Unit> units, MemberTypes members) {
         Map<String, Set<String>> byMain = new LinkedHashMap<>();
         Map<String, Map<String, Set<String>>> byTestRoot = new LinkedHashMap<>();
-        Set<String> types = new LinkedHashSet<>();
         for (Unit unit : units) {
-            types.addAll(unit.types());
             if (unit.isMain()) {
                 byMain.computeIfAbsent(unit.pkg(), _ -> new LinkedHashSet<>())
                         .addAll(unit.declares());
@@ -348,12 +393,16 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 if (!each.isStatic() && each.owner().equals(unit.pkg())) {
                     continue;
                 }
-                if (!each.isStatic() || types.contains(each.spelled())) {
+                // A plain single import names a type by being one. A static import names whichever
+                // member the owner has by that name, so the owner is asked.
+                Boolean binds = each.isStatic()
+                        ? members.bindsATypeNamed(each.owner(), each.name()) : Boolean.TRUE;
+                if (Boolean.TRUE.equals(binds)) {
                     found.add(unit.where() + " rebinds `" + each.name() + "`, which " + unit.pkg()
                             + " declares, to " + each.spelled());
-                } else if (!types.contains(each.owner())) {
+                } else if (binds == null) {
                     unanswered.add(unit.where() + " imports `" + each.name() + "` from "
-                            + each.owner() + ", which this does not declare");
+                            + each.owner() + ", which nothing here resolves");
                 }
             }
         }
@@ -411,7 +460,12 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
     /** The rebindings among sources written here, for a case that has nothing to say about
      *  roots. */
     private static List<String> rebindingsIn(Map<String, String> sources) {
-        return read(written(sources)).rebindings();
+        return ofWritten(sources).rebindings();
+    }
+
+    /** What reading sources written here comes to, resolved against those same sources. */
+    private static Found ofWritten(Map<String, String> sources) {
+        return read(written(sources), membersOf(sources));
     }
 
     /**
@@ -473,17 +527,15 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 }
                 String pkg = unit.getPackageName() == null ? "" : unit.getPackageName().toString();
                 Set<String> declares = new LinkedHashSet<>();
-                Set<String> types = new LinkedHashSet<>();
                 for (Tree declared : unit.getTypeDecls()) {
                     // A stray `;` among the declarations is not one. Every top-level type is a
                     // class, an interface, a record or an enum, and a `ClassTree` is what the
                     // parser calls all four.
                     if (declared instanceof ClassTree it) {
                         declares.add(it.getSimpleName().toString());
-                        gather(it, pkg.isEmpty() ? "" : pkg + ".", types);
                     }
                 }
-                out.add(new Unit(came.where(), pkg, root.named(), root.isMain(), declares, types,
+                out.add(new Unit(came.where(), pkg, root.named(), root.isMain(), declares,
                         importsOf(unit)));
             }
         } catch (IOException unreadable) {
@@ -497,16 +549,68 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
         return out;
     }
 
-    /** Every type {@code declared} holds, itself and whatever is nested in it, under {@code owner}
-     *  — which is what says whether a static import of a name binds a type. */
-    private static void gather(ClassTree declared, String owner, Set<String> types) {
-        String named = owner + declared.getSimpleName();
-        types.add(named);
-        for (Tree member : declared.getMembers()) {
-            if (member instanceof ClassTree it) {
-                gather(it, named + ".", types);
+    /**
+     * Whether a static import of {@code name} from {@code owner} binds a type.
+     *
+     * <p>Three answers. What a static import brings in is whichever member the owner has by that
+     * name, and a member type shadows the package's own where a field or a method does not — so the
+     * two have to be told apart, and an owner nothing can resolve is a third thing rather than
+     * either of them.
+     *
+     * <p><b>Asked of the compiler and never of the owner's source text.</b> The members of a type
+     * include the ones it inherits, so a class whose own body declares nothing can still be the
+     * owner of a member type: {@code java.util.HashMap} has {@code SimpleEntry} because
+     * {@code AbstractMap} declares it, and no reading of {@code HashMap}'s text says so. Answered
+     * by walking declarations, this would be Java's member lookup written a second time here —
+     * superclasses, interfaces, hiding, accessibility — and the second copy is the one that gets a
+     * case wrong and reports a pass.
+     */
+    private interface MemberTypes {
+
+        /** {@code TRUE} where the owner has a member type of that name, {@code FALSE} where what it
+         *  has by that name is not a type, and null where the owner is not resolvable here. */
+        Boolean bindsATypeNamed(String owner, String name);
+    }
+
+    /** The compiler's own answer, over whatever {@code elements} can reach. */
+    private static MemberTypes memberTypesOf(Elements elements) {
+        return (owner, name) -> {
+            TypeElement it = elements.getTypeElement(owner);
+            if (it == null) {
+                return null;
             }
+            return ElementFilter.typesIn(elements.getAllMembers(it)).stream()
+                    .anyMatch(each -> each.getSimpleName().contentEquals(name));
+        };
+    }
+
+    /**
+     * What the classes this test runs against declare.
+     *
+     * <p>This module depends on every other, so the owners a repository source imports from are on
+     * the classpath along with the libraries beside them. An owner that is not — a test class of
+     * another module, which nothing depends on — comes back unresolvable and is said to be.
+     */
+    private static MemberTypes repositoryMembers() {
+        return memberTypesOf(((JavacTask) compiler().getTask(null, null, diagnostic -> { },
+                List.of("-proc:none"), null, List.of())).getElements());
+    }
+
+    /** The same, of types written here rather than compiled. */
+    private static MemberTypes membersOf(Map<String, String> sources) {
+        List<JavaFileObject> written = new ArrayList<>();
+        sources.forEach((at, text) -> written.add(new Written("main", at, text)));
+        JavacTask task = (JavacTask) compiler().getTask(null, null, diagnostic -> { },
+                List.of("-proc:none"), null, written);
+        try {
+            // Entered and attributed, because a member of a type is known once the type is. What
+            // the sources here fail to resolve is not this question — a fixture may import from an
+            // owner nobody declares, which is one of the three answers.
+            task.analyze();
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
         }
+        return memberTypesOf(task.getElements());
     }
 
     /**
@@ -547,6 +651,14 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
     /** What this repository calls a path, which is where it sits under the root. */
     private static String named(Path at) {
         return REPOSITORY.root().relativize(at).toString();
+    }
+
+    /** Two sets of sources as one, for a case that hands the same texts to two readings. */
+    private static Map<String, String> merged(Map<String, String> these,
+                                              Map<String, String> those) {
+        Map<String, String> out = new LinkedHashMap<>(these);
+        out.putAll(those);
+        return out;
     }
 
     /** A source written here rather than read from the repository. */

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -10,6 +10,7 @@ import com.sun.source.util.JavacTask;
 
 import org.junit.jupiter.api.Test;
 
+import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
@@ -29,6 +30,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -39,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * than about what they say — {@code Ordered} in a partition and {@code Ordered} in a query are two
  * answers to two questions, and nothing is clearer for one of them being renamed.
  *
- * <p>What is refused is one file rebinding the name. A single-type import wins over the package a
+ * <p>What is refused is one file rebinding the name. A single import wins over the package a
  * compilation unit is in, so
  *
  * <pre>
@@ -56,10 +58,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the point: such a file is holding two things one word names, and it says which it means at each
  * place it means one.
  *
- * <p><b>Only a non-static single-type import.</b> That is the whole of what this reads, so it is the
- * whole of what the rule claims. Java introduces names other ways — a static import, a nested type
- * reached through its owner — and each is a question of its own; a sentence here about what a bare
- * name always means would be wider than the reading under it.
+ * <p><b>Whichever of the two ways the import is spelled.</b> {@code import static b.Outer.X} binds
+ * {@code X} to a member type and shadows the package's own just as {@code import b.X} does, so the
+ * rule is about what an import binds and not about the keyword in front of it. Which of them a
+ * static import binds is asked rather than assumed: the owner is looked up among the types this
+ * repository declares, and a name it declares no member type by is a field or a method, which is a
+ * different namespace and takes nothing. An owner this repository does not declare cannot be
+ * answered here at all, and those are listed rather than let through
+ * ({@link #everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout}).
+ *
+ * <p>An on-demand import is not one of these. {@code import b.*} and {@code import static b.Outer.*}
+ * are lower in precedence than the package's own members, so the bare name goes on meaning what the
+ * package declares and nothing is rebound.
+ *
+ * <p><b>Which names a package declares is asked of the sources that compile with it.</b> A package
+ * may be split across modules, and a name declared in another module's main sources is as much a
+ * member of the package as one beside it. A test source is not: it is compiled apart, no main
+ * source can see it, so it declares nothing a bare name in a main source could otherwise have
+ * meant. So the main sources answer for every source, and a test source's own root answers for it
+ * besides.
  */
 class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
 
@@ -74,18 +91,50 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void noSourceRebindsANameItsOwnPackageDeclares() {
-        List<Unit> units = parsed(REPOSITORY.filesUnderSourceTrees(".java"));
-        assertTrue(units.size() > 1000,
-                "this reads the repository's sources, and it read " + units.size());
-
-        assertEquals(List.of(), rebindings(units),
+        assertEquals(List.of(), read(repositorySources()).rebindings(),
                 "a file whose package declares this name and which imports another package's:"
                         + " inside it the bare name means the other one, and nothing says so."
                         + " Drop the import and write the foreign type out where it is used");
     }
 
     /**
-     * And what the rule holds and does not, on sources written to be either.
+     * And every static import that could have taken a name is one this could answer about.
+     *
+     * <p>Beside the rule rather than inside it. Whether such an import binds a type is the owner's
+     * answer, and an owner outside this repository has none here — reported as no rebinding, the
+     * check would be passing over exactly the case it cannot see, and reported as one it would be
+     * refusing an import on the strength of not knowing what it names.
+     */
+    @Test
+    void everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout() {
+        assertEquals(List.of(), read(repositorySources()).unanswered(),
+                "a static import whose simple name a package here declares, taken from an owner"
+                        + " this repository does not declare: whether it binds a member type is"
+                        + " that owner's answer and nothing here has it");
+    }
+
+    /**
+     * And the roots this read are every place the repository keeps a Java source.
+     *
+     * <p>The population's own control. What is read is a root at a time, because that is what
+     * decides which names a source resolves against; a source somewhere no root covers would be
+     * passed over, and this check would go on reporting a pass about the rest.
+     */
+    @Test
+    void everyJavaSourceUnderASourceTreeIsUnderOneOfTheRootsRead() {
+        Set<String> read = new TreeSet<>();
+        for (Root root : roots()) {
+            root.sources().forEach(each -> read.add(named(each)));
+        }
+        Set<String> held = new TreeSet<>();
+        REPOSITORY.filesUnderSourceTrees(".java").forEach(each -> held.add(named(each)));
+
+        assertEquals(List.copyOf(held), List.copyOf(read),
+                "a Java source the roots do not cover is one this passes over");
+    }
+
+    /**
+     * What the rule holds and does not, on sources written to be either.
      *
      * <p>Here rather than by naming the pairs the repository happens to hold. That two packages both
      * declare {@code Ordered} is true today and is not something a check should hold them to, and a
@@ -93,28 +142,24 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void aNameTheOwnPackageDoesNotDeclareIsImportedFreely() {
-        String bringsIn = "package p; import q.A; class C { A a; }";
-        String leavesAlone = "package p; class C { q.A a; }";
-        String another = "package p; import q.B; class C { B b; }";
-
         assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.A"),
-                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                rebindingsIn(Map.of("p/A.java", "package p; class A {}",
                         "q/A.java", "package q; class A {}",
                         "q/B.java", "package q; class B {}",
-                        "p/C.java", bringsIn))),
+                        "p/C.java", "package p; import q.A; class C { A a; }")),
                 "the name is the package's own and the import takes it");
 
         assertEquals(List.of(),
-                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                rebindingsIn(Map.of("p/A.java", "package p; class A {}",
                         "q/A.java", "package q; class A {}",
-                        "p/C.java", leavesAlone))),
+                        "p/C.java", "package p; class C { q.A a; }")),
                 "the foreign type written out takes no name");
 
         assertEquals(List.of(),
-                rebindings(parsedFrom(Map.of("p/A.java", "package p; class A {}",
+                rebindingsIn(Map.of("p/A.java", "package p; class A {}",
                         "q/A.java", "package q; class A {}",
                         "q/B.java", "package q; class B {}",
-                        "p/C.java", another))),
+                        "p/C.java", "package p; import q.B; class C { B b; }")),
                 "a name p declares nothing by is a name nothing here is about");
     }
 
@@ -134,107 +179,223 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
         Map<String, String> throughAnOwner = new LinkedHashMap<>(declared);
         throughAnOwner.put("p/C.java", "package p; import p.Outer.A; class C { A a; }");
         assertEquals(List.of("p/C.java rebinds `A`, which p declares, to p.Outer.A"),
-                rebindings(parsedFrom(throughAnOwner)),
-                "the owner is another type, so the name is taken");
+                rebindingsIn(throughAnOwner), "the owner is another type, so the name is taken");
 
         Map<String, String> theSameType = new LinkedHashMap<>(declared);
         theSameType.put("p/C.java", "package p; import p.A; class C { A a; }");
-        assertEquals(List.of(), rebindings(parsedFrom(theSameType)),
+        assertEquals(List.of(), rebindingsIn(theSameType),
                 "the import names what the package declares, and the name already meant it");
     }
 
+    /**
+     * A static import takes the name where it binds a member type, and not where it binds a member.
+     *
+     * <p>The three answers the owner gives. A member type shadows the package's own name exactly as
+     * a plain import does; a field or a method is a different namespace and shadows nothing; and an
+     * owner this repository does not declare is one nothing here can ask, which is said rather than
+     * decided either way.
+     */
+    @Test
+    void aStaticImportTakesTheNameWhereWhatItBindsIsAType() {
+        Map<String, String> owner = Map.of("p/A.java", "package p; class A {}",
+                "q/Outer.java",
+                "package q; class Outer { static class A {} static int B; static void C() {} }");
+
+        Map<String, String> aType = new LinkedHashMap<>(owner);
+        aType.put("p/C.java", "package p; import static q.Outer.A; class C { A a; }");
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.Outer.A"),
+                rebindingsIn(aType), "a member type takes the name, however the import is spelled");
+
+        Map<String, String> aMember = new LinkedHashMap<>(owner);
+        aMember.put("p/B.java", "package p; class B {}");
+        aMember.put("p/C.java", "package p; import static q.Outer.B; class C { B b; }");
+        assertEquals(List.of(), rebindingsIn(aMember),
+                "a field is a different namespace and takes no type name");
+
+        Map<String, String> onDemand = new LinkedHashMap<>(owner);
+        onDemand.put("p/C.java", "package p; import static q.Outer.*; class C { A a; }");
+        assertEquals(List.of(), rebindingsIn(onDemand),
+                "an on-demand import is below the package's own members and rebinds nothing");
+    }
+
+    /** And an owner nothing here declares is one the check says it cannot answer about. */
+    @Test
+    void aStaticImportFromAnOwnerThisDoesNotDeclareIsSaidToBeUnanswered() {
+        Found found = read(written(Map.of("p/A.java", "package p; class A {}",
+                "p/C.java", "package p; import static x.Elsewhere.A; class C { A a; }")));
+
+        assertEquals(List.of(), found.rebindings(), "nothing here says what it binds");
+        assertEquals(List.of("p/C.java imports `A` from x.Elsewhere, which this does not declare"),
+                found.unanswered(), "so the import is named rather than let through");
+    }
+
+    /**
+     * A name written under one root resolves against the main sources of its package and against
+     * its own root, and against no other root's tests.
+     *
+     * <p>Both directions, because only one of them is a rule. A test source sees the main classes
+     * beside it, so a main class does take the name there; a main source sees no test class, and a
+     * rule that took one to shadow would say a bare name in it means something it cannot mean.
+     */
+    @Test
+    void aMainSourceDoesNotResolveAgainstTheTestsBesideIt() {
+        Map<String, String> declaresA = Map.of("p/A.java", "package p; class A {}");
+        Map<String, String> takesIt = Map.of("q/A.java", "package q; class A {}",
+                "p/C.java", "package p; import q.A; class C { A a; }");
+
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.A"),
+                read(inRoots(Map.of("main", declaresA), Map.of("test", takesIt))).rebindings(),
+                "the test root resolves against the main sources of the package");
+
+        assertEquals(List.of(),
+                read(inRoots(Map.of("main", takesIt), Map.of("test", declaresA))).rebindings(),
+                "a class declared only under a test root shadows nothing in a main source");
+    }
+
+    /**
+     * A source this cannot parse is refused, and not read as one that declares nothing.
+     *
+     * <p>The parser recovers what it can and hands back a unit either way, so a file it choked on
+     * contributes no declaration and no import — which reads exactly like a file that rebinds
+     * nothing. What this check is worth is that it cannot pass quietly, and a source it never read
+     * is the one way it could.
+     */
+    @Test
+    void aSourceThisCannotParseIsRefusedRatherThanReadAsEmpty() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> written(Map.of("p/A.java", "package p; class A {}",
+                        "p/C.java", "package p; class C { import q.A; ((( }")));
+
+        assertTrue(refused.getMessage().contains("p/C.java"),
+                "the file is named, so a reader is told which source went unread: "
+                        + refused.getMessage());
+    }
+
     /** One compilation unit, as much of it as this question is about. */
-    private record Unit(String where, String pkg, Set<String> declares, List<String> imports) {}
+    private record Unit(String where, String pkg, String root, boolean isMain,
+                        Set<String> declares, Set<String> types, List<Import> imports) {}
+
+    /** One single import, which binds a name whatever the keyword in front of it is. */
+    private record Import(String spelled, boolean isStatic) {
+
+        String name() {
+            return spelled.substring(spelled.lastIndexOf('.') + 1);
+        }
+
+        String owner() {
+            int dot = spelled.lastIndexOf('.');
+            return dot < 0 ? "" : spelled.substring(0, dot);
+        }
+    }
+
+    /** One source root, whether it holds a module's main sources, and what is under it. */
+    private record Root(String named, boolean isMain, List<Path> sources) {}
+
+    /** A source handed to the parser, under the name whoever handed it over calls it. */
+    private record Named(JavaFileObject source, String where) {}
+
+    /**
+     * What reading the sources came to: the names an import took, and the imports nothing here
+     * could answer about.
+     *
+     * <p>Two lists and not one. An import this cannot resolve is not an import that binds nothing —
+     * folded into either answer, the check would either pass over what it cannot see or refuse an
+     * import for not being understood.
+     */
+    private record Found(List<String> rebindings, List<String> unanswered) {}
 
     /**
      * The rebindings among {@code units}, each said as the file, the name and what it was taken to.
      *
+     * <p>What a name resolves against is where the source is compiled and not where the walk found
+     * it: every main source of a package answers for the package, wherever in the reactor it is,
+     * and a test source's own root answers for it besides. A test class of another root is nothing
+     * a source here can see, so it declares no name a bare one could otherwise have meant.
+     *
      * <p>Sorted, so that what a failure lists is the same on every machine and reads as a list of
      * places to go rather than as whatever order a walk happened to have.
      */
-    private static List<String> rebindings(List<Unit> units) {
-        Map<String, Set<String>> declaredBy = new LinkedHashMap<>();
+    private static Found read(List<Unit> units) {
+        Map<String, Set<String>> byMain = new LinkedHashMap<>();
+        Map<String, Map<String, Set<String>>> byTestRoot = new LinkedHashMap<>();
+        Set<String> types = new LinkedHashSet<>();
         for (Unit unit : units) {
-            declaredBy.computeIfAbsent(unit.pkg(), _ -> new LinkedHashSet<>())
-                    .addAll(unit.declares());
+            types.addAll(unit.types());
+            if (unit.isMain()) {
+                byMain.computeIfAbsent(unit.pkg(), _ -> new LinkedHashSet<>())
+                        .addAll(unit.declares());
+            } else {
+                byTestRoot.computeIfAbsent(unit.root(), _ -> new LinkedHashMap<>())
+                        .computeIfAbsent(unit.pkg(), _ -> new LinkedHashSet<>())
+                        .addAll(unit.declares());
+            }
         }
         Set<String> found = new TreeSet<>();
+        Set<String> unanswered = new TreeSet<>();
         for (Unit unit : units) {
-            Set<String> own = declaredBy.getOrDefault(unit.pkg(), Set.of());
-            for (String imported : unit.imports()) {
-                int dot = imported.lastIndexOf('.');
-                String name = dot < 0 ? imported : imported.substring(dot + 1);
-                String from = dot < 0 ? "" : imported.substring(0, dot);
+            Set<String> own = new LinkedHashSet<>(byMain.getOrDefault(unit.pkg(), Set.of()));
+            if (!unit.isMain()) {
+                own.addAll(byTestRoot.getOrDefault(unit.root(), Map.of())
+                        .getOrDefault(unit.pkg(), Set.of()));
+            }
+            for (Import each : unit.imports()) {
+                if (!own.contains(each.name())) {
+                    continue;
+                }
                 // A same-package import binds the name it already had, so nothing means anything
                 // different for it being written. Whether it should be written at all is another
                 // rule's question.
-                if (!from.equals(unit.pkg()) && own.contains(name)) {
-                    found.add(unit.where() + " rebinds `" + name + "`, which " + unit.pkg()
-                            + " declares, to " + imported);
+                if (!each.isStatic() && each.owner().equals(unit.pkg())) {
+                    continue;
+                }
+                if (!each.isStatic() || types.contains(each.spelled())) {
+                    found.add(unit.where() + " rebinds `" + each.name() + "`, which " + unit.pkg()
+                            + " declares, to " + each.spelled());
+                } else if (!types.contains(each.owner())) {
+                    unanswered.add(unit.where() + " imports `" + each.name() + "` from "
+                            + each.owner() + ", which this does not declare");
                 }
             }
         }
-        return List.copyOf(found);
-    }
-
-    /** The sources at {@code paths}, named by their path under the repository root. */
-    private static List<Unit> parsed(List<Path> paths) {
-        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        try (StandardJavaFileManager files =
-                     compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)) {
-            return read(compiler, files.getJavaFileObjectsFromPaths(paths),
-                    at -> REPOSITORY.root().relativize(Path.of(at)).toString());
-        } catch (IOException unreadable) {
-            throw new UncheckedIOException(unreadable);
-        }
-    }
-
-    /** The same, of sources written here, named by the key they were written under. */
-    private static List<Unit> parsedFrom(Map<String, String> sources) {
-        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        List<JavaFileObject> written = new ArrayList<>();
-        sources.forEach((named, text) -> written.add(new Written(named, text)));
-        // What a written source is called is the path of the URI it was given, which is that key
-        // under the root every URI needs.
-        return read(compiler, written, at -> at.startsWith("/") ? at.substring(1) : at);
+        return new Found(List.copyOf(found), List.copyOf(unanswered));
     }
 
     /**
-     * What each source says about its package, its top-level types and its imports.
+     * Every source root this repository has, and whether it holds a module's main sources.
      *
-     * <p>Parsed and not compiled. Every part of the question is written in the file — which package
-     * it declares, which names it declares in that package, which types it imports by name — so
-     * nothing here needs a symbol resolved, a classpath, or the rest of the repository to be built.
+     * <p>Which directory is which root is the repository's answer ({@link RepositoryLayout}) and
+     * never a reading of a path: worked out here, whether a source is a test source would be a
+     * spelling this file agreed with by having been written the same way.
      */
-    private static List<Unit> read(JavaCompiler compiler, Iterable<? extends JavaFileObject> sources,
-                                   java.util.function.UnaryOperator<String> naming) {
-        JavacTask task = (JavacTask) compiler.getTask(null, null, diagnostic -> { },
-                List.of("-proc:none"), null, sources);
+    private static List<Root> roots() {
+        List<Root> out = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            Path main = REPOSITORY.javaTreeOf(module, "main");
+            Path test = REPOSITORY.javaTreeOf(module, "test");
+            if (main != null) {
+                out.add(new Root(named(main), true, sourcesUnder(main)));
+            }
+            if (test != null) {
+                out.add(new Root(named(test), false, sourcesUnder(test)));
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** The sources this repository holds, read a root at a time. */
+    private static List<Unit> repositorySources() {
         List<Unit> out = new ArrayList<>();
-        try {
-            for (CompilationUnitTree unit : task.parse()) {
-                Set<String> declares = new LinkedHashSet<>();
-                for (Tree declared : unit.getTypeDecls()) {
-                    // A stray `;` among the declarations is not one. Every top-level type is a
-                    // class, an interface, a record or an enum, and a `ClassTree` is what the
-                    // parser calls all four.
-                    if (declared instanceof ClassTree it) {
-                        declares.add(it.getSimpleName().toString());
-                    }
+        JavaCompiler compiler = compiler();
+        try (StandardJavaFileManager files =
+                     compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)) {
+            for (Root root : roots()) {
+                Map<URI, Named> named = new LinkedHashMap<>();
+                for (Path at : root.sources()) {
+                    JavaFileObject source =
+                            files.getJavaFileObjectsFromPaths(List.of(at)).iterator().next();
+                    named.put(source.toUri(), new Named(source, named(at)));
                 }
-                List<String> imports = new ArrayList<>();
-                for (ImportTree each : unit.getImports()) {
-                    String named = each.getQualifiedIdentifier().toString();
-                    // A static import brings in a member and an on-demand import brings in no name
-                    // at all until something is written; neither is what this is about, and the
-                    // class doc says so rather than this quietly covering them.
-                    if (!each.isStatic() && !named.endsWith(".*")) {
-                        imports.add(named);
-                    }
-                }
-                out.add(new Unit(naming.apply(unit.getSourceFile().getName()),
-                        unit.getPackageName() == null ? "" : unit.getPackageName().toString(),
-                        declares, imports));
+                out.addAll(parse(compiler, named, root));
             }
         } catch (IOException unreadable) {
             throw new UncheckedIOException(unreadable);
@@ -242,13 +403,159 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
         return List.copyOf(out);
     }
 
+    /** Sources written here, all under one main root. */
+    private static List<Unit> written(Map<String, String> sources) {
+        return inRoots(Map.of("main", sources));
+    }
+
+    /** The rebindings among sources written here, for a case that has nothing to say about
+     *  roots. */
+    private static List<String> rebindingsIn(Map<String, String> sources) {
+        return read(written(sources)).rebindings();
+    }
+
+    /**
+     * The same, under roots of their own. A root called {@code main} holds main sources and
+     * anything else holds a module's tests, which is the one distinction the rule draws.
+     */
+    @SafeVarargs
+    private static List<Unit> inRoots(Map<String, Map<String, String>>... roots) {
+        JavaCompiler compiler = compiler();
+        List<Unit> out = new ArrayList<>();
+        for (Map<String, Map<String, String>> root : roots) {
+            root.forEach((named, sources) -> {
+                Map<URI, Named> given = new LinkedHashMap<>();
+                sources.forEach((at, text) -> {
+                    JavaFileObject source = new Written(named, at, text);
+                    given.put(source.toUri(), new Named(source, at));
+                });
+                out.addAll(parse(compiler, given, new Root(named, "main".equals(named), List.of())));
+            });
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * What each source says about its package, the types it declares and the names it imports.
+     *
+     * <p>Parsed and not compiled. Every part of the question is written in the file — which package
+     * it declares, which types it declares in it, which names it imports — so nothing here needs a
+     * symbol resolved, a classpath, or the rest of the repository to be built.
+     *
+     * <p>What each source is called comes from {@code named}, which is the caller that handed it
+     * over. Read back off the file object, a name would be whatever spelling the compiler kept of a
+     * path or a URI, and every caller would be undoing a different one. Looked up by the URI,
+     * because the compilation unit need not carry the very object it was handed and does carry
+     * where it came from.
+     *
+     * <p>A source the parser could not read is refused rather than taken for one that declares
+     * nothing. The parser recovers what it can and hands back a unit either way, so a file it
+     * choked on would contribute no declaration and no import — and this check would report a pass
+     * over sources it never read.
+     */
+    private static List<Unit> parse(JavaCompiler compiler, Map<URI, Named> named, Root root) {
+        List<String> refused = new ArrayList<>();
+        JavacTask task = (JavacTask) compiler.getTask(null, null, diagnostic -> {
+            if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
+                refused.add(diagnostic.getSource() == null ? diagnostic.getMessage(null)
+                        : named.get(diagnostic.getSource().toUri()).where()
+                                + ": " + diagnostic.getMessage(null));
+            }
+        }, List.of("-proc:none"), null, named.values().stream().map(Named::source).toList());
+        List<Unit> out = new ArrayList<>();
+        try {
+            for (CompilationUnitTree unit : task.parse()) {
+                Named came = named.get(unit.getSourceFile().toUri());
+                if (came == null) {
+                    throw new IllegalStateException(
+                            "a compilation unit came back from " + unit.getSourceFile().toUri()
+                                    + ", which nothing here handed over");
+                }
+                String pkg = unit.getPackageName() == null ? "" : unit.getPackageName().toString();
+                Set<String> declares = new LinkedHashSet<>();
+                Set<String> types = new LinkedHashSet<>();
+                for (Tree declared : unit.getTypeDecls()) {
+                    // A stray `;` among the declarations is not one. Every top-level type is a
+                    // class, an interface, a record or an enum, and a `ClassTree` is what the
+                    // parser calls all four.
+                    if (declared instanceof ClassTree it) {
+                        declares.add(it.getSimpleName().toString());
+                        gather(it, pkg.isEmpty() ? "" : pkg + ".", types);
+                    }
+                }
+                out.add(new Unit(came.where(), pkg, root.named(), root.isMain(), declares, types,
+                        importsOf(unit)));
+            }
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+        if (!refused.isEmpty()) {
+            throw new IllegalStateException("sources this could not parse, which contribute no"
+                    + " declaration and no import and would leave this reporting a pass over"
+                    + " them: " + refused);
+        }
+        return out;
+    }
+
+    /** Every type {@code declared} holds, itself and whatever is nested in it, under {@code owner}
+     *  — which is what says whether a static import of a name binds a type. */
+    private static void gather(ClassTree declared, String owner, Set<String> types) {
+        String named = owner + declared.getSimpleName();
+        types.add(named);
+        for (Tree member : declared.getMembers()) {
+            if (member instanceof ClassTree it) {
+                gather(it, named + ".", types);
+            }
+        }
+    }
+
+    /**
+     * The single imports of one source, static and not.
+     *
+     * <p>An on-demand import is left out and is not an omission: it is lower in precedence than the
+     * members of the package a source is in, so the bare name goes on meaning what the package
+     * declares and there is nothing here to refuse.
+     */
+    private static List<Import> importsOf(CompilationUnitTree unit) {
+        List<Import> out = new ArrayList<>();
+        for (ImportTree each : unit.getImports()) {
+            String spelled = each.getQualifiedIdentifier().toString();
+            if (!spelled.endsWith(".*")) {
+                out.add(new Import(spelled, each.isStatic()));
+            }
+        }
+        return out;
+    }
+
+    /** The compiler this parses with, which a JRE does not have. */
+    private static JavaCompiler compiler() {
+        JavaCompiler found = ToolProvider.getSystemJavaCompiler();
+        if (found == null) {
+            throw new IllegalStateException("this reads sources with the system Java compiler and"
+                    + " this runtime has none: run the tests on a JDK");
+        }
+        return found;
+    }
+
+    /** The {@code .java} under one root, sorted, which is how the walk of a source tree hands
+     *  them over. */
+    private static List<Path> sourcesUnder(Path root) {
+        return REPOSITORY.filesUnderSourceTrees(".java").stream()
+                .filter(each -> each.startsWith(root)).toList();
+    }
+
+    /** What this repository calls a path, which is where it sits under the root. */
+    private static String named(Path at) {
+        return REPOSITORY.root().relativize(at).toString();
+    }
+
     /** A source written here rather than read from the repository. */
     private static final class Written extends SimpleJavaFileObject {
 
         private final String text;
 
-        private Written(String named, String text) {
-            super(URI.create("string:///" + named), Kind.SOURCE);
+        private Written(String root, String named, String text) {
+            super(URI.create("string:///" + root + "/" + named), Kind.SOURCE);
             this.text = text;
         }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest.java
@@ -6,13 +6,14 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
 
 import org.junit.jupiter.api.Test;
 
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
@@ -64,11 +65,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p><b>Whichever of the two ways the import is spelled.</b> {@code import static b.Outer.X} binds
  * {@code X} to a member type and shadows the package's own just as {@code import b.X} does, so the
- * rule is about what an import binds and not about the keyword in front of it. Which of them a
- * static import binds is the owner's answer, and it is asked of the compiler
- * ({@link MemberTypes}): the members of a type are the ones it inherits as well as the ones it
- * declares, so no reading of the owner's source text answers this. An owner nothing here resolves
- * is a third answer and is listed rather than let through
+ * rule is about what an import binds and not about the keyword in front of it. A static import
+ * brings in the accessible static members the owner has by that name, which is not the same as the
+ * members it has: a member class that is not static binds nothing, and neither does one the
+ * importing source may not reach. So what is asked is what the bare name comes to mean where the
+ * import is written, and the whole of the answer is the compiler's ({@link NameMeanings}). An
+ * owner nothing here resolves is a third answer and is listed rather than let through
  * ({@link #everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout}).
  *
  * <p>An on-demand import is not one of these. {@code import b.*} and {@code import static b.Outer.*}
@@ -95,7 +97,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void noSourceRebindsANameItsOwnPackageDeclares() {
-        assertEquals(List.of(), read(repositorySources(), repositoryMembers()).rebindings(),
+        assertEquals(List.of(), read(repositorySources(), repositoryMeanings()).rebindings(),
                 "a file whose package declares this name and which imports another package's:"
                         + " inside it the bare name means the other one, and nothing says so."
                         + " Drop the import and write the foreign type out where it is used");
@@ -111,7 +113,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      */
     @Test
     void everyStaticImportThatCouldTakeANameIsOneThisCanAnswerAbout() {
-        assertEquals(List.of(), read(repositorySources(), repositoryMembers()).unanswered(),
+        assertEquals(List.of(), read(repositorySources(), repositoryMeanings()).unanswered(),
                 "a static import whose simple name a package here declares, taken from an owner"
                         + " this repository does not declare: whether it binds a member type is"
                         + " that owner's answer and nothing here has it");
@@ -194,16 +196,16 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
     /**
      * A static import takes the name where it binds a member type, and not where it binds a member.
      *
-     * <p>The three answers the owner gives. A member type shadows the package's own name exactly as
-     * a plain import does; a field or a method is a different namespace and shadows nothing; and an
-     * owner this repository does not declare is one nothing here can ask, which is said rather than
-     * decided either way.
+     * <p>A member type the import brings in shadows the package's own name exactly as a plain
+     * import does; a field or a method is a different namespace and shadows nothing.
      */
     @Test
     void aStaticImportTakesTheNameWhereWhatItBindsIsAType() {
-        Map<String, String> owner = Map.of("p/A.java", "package p; class A {}",
-                "q/Outer.java",
-                "package q; class Outer { static class A {} static int B; static void C() {} }");
+        // Reachable from `p`, because a static import of what a source may not reach binds
+        // nothing and would be asking this about a program that does not compile.
+        Map<String, String> owner = Map.of("p/A.java", "package p; public class A {}",
+                "q/Outer.java", "package q; public class Outer { public static class A {}"
+                        + " public static int B; public static void C() {} }");
 
         Map<String, String> aType = new LinkedHashMap<>(owner);
         aType.put("p/C.java", "package p; import static q.Outer.A; class C { A a; }");
@@ -211,7 +213,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 rebindingsIn(aType), "a member type takes the name, however the import is spelled");
 
         Map<String, String> aMember = new LinkedHashMap<>(owner);
-        aMember.put("p/B.java", "package p; class B {}");
+        aMember.put("p/B.java", "package p; public class B {}");
         aMember.put("p/C.java", "package p; import static q.Outer.B; class C { B b; }");
         assertEquals(List.of(), rebindingsIn(aMember),
                 "a field is a different namespace and takes no type name");
@@ -228,38 +230,71 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      * <p>The case a reading of the owner's source text cannot answer. {@code Child} declares
      * nothing, and {@code import static q.Child.A} binds {@code Base}'s {@code A} all the same —
      * so a check that looked for the declaration inside {@code Child} would find none, call it a
-     * field or a method, and let the rebinding through.
+     * field or a method, and let the rebinding through. What is named is the type the name comes to
+     * mean, which is where it is declared and not the way the import reached it.
      */
     @Test
     void aStaticImportOfAnInheritedMemberTypeTakesTheName() {
-        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.Child.A"),
+        assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.Base.A"),
                 rebindingsIn(Map.of(
                         "q/Base.java", "package q; public class Base { public static class A {} }",
                         "q/Child.java", "package q; public class Child extends Base {}",
-                        "p/A.java", "package p; class A {}",
+                        "p/A.java", "package p; public class A {}",
                         "p/C.java", "package p; import static q.Child.A; class C { A a; }")),
                 "the owner has the member type by inheriting it, and the import binds it");
     }
 
     /**
-     * And what a static import binds is the compiler's answer, over types nothing here wrote.
+     * A member the import does not bring in takes no name, though the owner has one by that name.
      *
-     * <p>Beside the fixtures, which pin what the rule does with each of the three answers. This
-     * pins the answers themselves against a type this repository does not own and cannot edit:
-     * {@code HashMap} has {@code SimpleEntry} by inheriting it from {@code AbstractMap}, and its
-     * own body says nothing about it.
+     * <p>The two ways "the owner has a member type called this" is not "the import binds a type
+     * called this". A member class that is not static is no part of what a static import brings in,
+     * and neither is one the importing source may not reach — in both, what the import does bring
+     * in is the field beside it, and the bare name goes on meaning the package's own type. Refused
+     * on the strength of the member existing, each would be a source held to a name it never took.
      */
     @Test
-    void whatAnOwnerHasByANameIsAskedOfTheCompiler() {
-        MemberTypes members = repositoryMembers();
+    void aMemberTheImportDoesNotBringInTakesNoName() {
+        assertEquals(List.of(),
+                rebindingsIn(Map.of("p/A.java", "package p; public class A {}",
+                        "q/Outer.java", "package q; public class Outer {"
+                                + " public class A {} public static int A = 1; }",
+                        "p/C.java", "package p; import static q.Outer.A;"
+                                + " class C { A type; int value = A; }")),
+                "a member class that is not static is not what a static import brings in");
 
-        assertEquals(Boolean.TRUE, members.bindsATypeNamed("java.util.AbstractMap", "SimpleEntry"),
-                "a member type the owner declares");
-        assertEquals(Boolean.TRUE, members.bindsATypeNamed("java.util.HashMap", "SimpleEntry"),
-                "and one it inherits, which no reading of its own text finds");
-        assertEquals(Boolean.FALSE, members.bindsATypeNamed("java.util.HashMap", "size"),
-                "a method is a different namespace and takes no type name");
-        assertNull(members.bindsATypeNamed("nothing.declares.This", "A"),
+        assertEquals(List.of(),
+                rebindingsIn(Map.of("p/A.java", "package p; public class A {}",
+                        "q/Outer.java", "package q; public class Outer {"
+                                + " private static class A {} public static int A = 1; }",
+                        "p/C.java", "package p; import static q.Outer.A;"
+                                + " class C { A type; int value = A; }")),
+                "and neither is a member type the importing source may not reach");
+    }
+
+    /**
+     * And what a name comes to mean is the compiler's answer, over types nothing here wrote.
+     *
+     * <p>Beside the fixtures, which pin what the rule does with each answer. This pins the answer
+     * itself against a type this repository does not own and cannot edit: {@code HashMap} has
+     * {@code SimpleEntry} by inheriting it from {@code AbstractMap}, and its own body says nothing
+     * about it.
+     */
+    @Test
+    void whatANameMeansIsAskedOfTheCompiler() {
+        NameMeanings meanings =
+                meaningsIn(Map.of("p/SimpleEntry.java", "package p; public class SimpleEntry {}"));
+
+        assertEquals("java.util.AbstractMap.SimpleEntry",
+                meanings.meaningOf("p", "SimpleEntry",
+                        new Import("java.util.HashMap.SimpleEntry", true)),
+                "a member type reached through a supertype, which no reading of HashMap finds");
+        assertEquals("p.SimpleEntry",
+                meanings.meaningOf("p", "SimpleEntry",
+                        new Import("java.util.HashMap.entrySet", true)),
+                "a method leaves the package's own type meaning the name");
+        assertNull(meanings.meaningOf("p", "SimpleEntry",
+                        new Import("nothing.declares.This.SimpleEntry", true)),
                 "and an owner nothing resolves is neither of those");
     }
 
@@ -290,12 +325,12 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
 
         assertEquals(List.of("p/C.java rebinds `A`, which p declares, to q.A"),
                 read(inRoots(Map.of("main", declaresA), Map.of("test", takesIt)),
-                        membersOf(merged(declaresA, takesIt))).rebindings(),
+                        meaningsIn(merged(declaresA, takesIt))).rebindings(),
                 "the test root resolves against the main sources of the package");
 
         assertEquals(List.of(),
                 read(inRoots(Map.of("main", takesIt), Map.of("test", declaresA)),
-                        membersOf(merged(declaresA, takesIt))).rebindings(),
+                        meaningsIn(merged(declaresA, takesIt))).rebindings(),
                 "a class declared only under a test root shadows nothing in a main source");
     }
 
@@ -362,7 +397,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
      * <p>Sorted, so that what a failure lists is the same on every machine and reads as a list of
      * places to go rather than as whatever order a walk happened to have.
      */
-    private static Found read(List<Unit> units, MemberTypes members) {
+    private static Found read(List<Unit> units, NameMeanings meanings) {
         Map<String, Set<String>> byMain = new LinkedHashMap<>();
         Map<String, Map<String, Set<String>>> byTestRoot = new LinkedHashMap<>();
         for (Unit unit : units) {
@@ -393,16 +428,18 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
                 if (!each.isStatic() && each.owner().equals(unit.pkg())) {
                     continue;
                 }
-                // A plain single import names a type by being one. A static import names whichever
-                // member the owner has by that name, so the owner is asked.
-                Boolean binds = each.isStatic()
-                        ? members.bindsATypeNamed(each.owner(), each.name()) : Boolean.TRUE;
-                if (Boolean.TRUE.equals(binds)) {
-                    found.add(unit.where() + " rebinds `" + each.name() + "`, which " + unit.pkg()
-                            + " declares, to " + each.spelled());
-                } else if (binds == null) {
+                // A plain single import names a type by being one — that is what makes it well
+                // formed. A static import names whichever member the owner has by that name, and
+                // only an accessible static member type of them binds a type name, so what the
+                // bare name comes to mean is asked rather than worked out.
+                String means = each.isStatic()
+                        ? meanings.meaningOf(unit.pkg(), each.name(), each) : each.spelled();
+                if (means == null) {
                     unanswered.add(unit.where() + " imports `" + each.name() + "` from "
                             + each.owner() + ", which nothing here resolves");
+                } else if (!means.equals(unit.pkg() + "." + each.name())) {
+                    found.add(unit.where() + " rebinds `" + each.name() + "`, which " + unit.pkg()
+                            + " declares, to " + means);
                 }
             }
         }
@@ -465,7 +502,7 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
 
     /** What reading sources written here comes to, resolved against those same sources. */
     private static Found ofWritten(Map<String, String> sources) {
-        return read(written(sources), membersOf(sources));
+        return read(written(sources), meaningsIn(sources));
     }
 
     /**
@@ -550,67 +587,85 @@ class AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest {
     }
 
     /**
-     * Whether a static import of {@code name} from {@code owner} binds a type.
+     * What a bare name comes to mean in a package once an import is written there.
      *
-     * <p>Three answers. What a static import brings in is whichever member the owner has by that
-     * name, and a member type shadows the package's own where a field or a method does not — so the
-     * two have to be told apart, and an owner nothing can resolve is a third thing rather than
-     * either of them.
+     * <p><b>The question the rule asks, and not one beside it.</b> Whether the owner has a member
+     * of that name is a different question: a single static import brings in the accessible static
+     * members, so a member class that is not static binds nothing, and neither does one the
+     * importing source may not reach. Either of those, read as "the owner has a member type", is a
+     * source refused for a name it never took.
      *
-     * <p><b>Asked of the compiler and never of the owner's source text.</b> The members of a type
-     * include the ones it inherits, so a class whose own body declares nothing can still be the
-     * owner of a member type: {@code java.util.HashMap} has {@code SimpleEntry} because
-     * {@code AbstractMap} declares it, and no reading of {@code HashMap}'s text says so. Answered
-     * by walking declarations, this would be Java's member lookup written a second time here —
-     * superclasses, interfaces, hiding, accessibility — and the second copy is the one that gets a
-     * case wrong and reports a pass.
+     * <p>So what is asked is what the name means where the import is written, and every part of
+     * the answer — static, accessible, inherited, hidden — is the compiler's. Assembled from
+     * conditions here, this would be Java's import resolution written a second time, and the second
+     * copy is the one that has a case wrong and reports a pass.
      */
-    private interface MemberTypes {
+    private interface NameMeanings {
 
-        /** {@code TRUE} where the owner has a member type of that name, {@code FALSE} where what it
-         *  has by that name is not a type, and null where the owner is not resolvable here. */
-        Boolean bindsATypeNamed(String owner, String name);
-    }
-
-    /** The compiler's own answer, over whatever {@code elements} can reach. */
-    private static MemberTypes memberTypesOf(Elements elements) {
-        return (owner, name) -> {
-            TypeElement it = elements.getTypeElement(owner);
-            if (it == null) {
-                return null;
-            }
-            return ElementFilter.typesIn(elements.getAllMembers(it)).stream()
-                    .anyMatch(each -> each.getSimpleName().contentEquals(name));
-        };
+        /**
+         * The type a bare {@code name} denotes in a source of {@code pkg} that writes
+         * {@code importing}, or null where nothing here resolves it.
+         *
+         * <p>Null two ways and they are one answer: the owner is not on what this reads, or the
+         * package's own type is not either. Both are this being unable to say, which is neither
+         * "the name was taken" nor "it was not".
+         */
+        String meaningOf(String pkg, String name, Import importing);
     }
 
     /**
-     * What the classes this test runs against declare.
+     * The compiler's answer, over the classes this test runs against and {@code also}.
      *
-     * <p>This module depends on every other, so the owners a repository source imports from are on
-     * the classpath along with the libraries beside them. An owner that is not — a test class of
-     * another module, which nothing depends on — comes back unresolvable and is said to be.
+     * <p>Asked by writing the one source that asks it: a class in the package, with the import
+     * above it and the name used as a type. What that name resolves to is what a reader of the real
+     * source would be given, arrived at by the same resolution.
      */
-    private static MemberTypes repositoryMembers() {
-        return memberTypesOf(((JavacTask) compiler().getTask(null, null, diagnostic -> { },
-                List.of("-proc:none"), null, List.of())).getElements());
+    private static NameMeanings meaningsOver(List<JavaFileObject> also) {
+        return (pkg, name, importing) -> {
+            List<JavaFileObject> sources = new ArrayList<>(also);
+            sources.add(new Written("probe", "Probe.java", "package " + pkg + "; "
+                    + (importing.isStatic() ? "import static " : "import ") + importing.spelled()
+                    + "; class Probe { " + name + " field; }"));
+            JavacTask task = (JavacTask) compiler().getTask(null, null, diagnostic -> { },
+                    List.of("-proc:none"), null, sources);
+            List<CompilationUnitTree> units = new ArrayList<>();
+            try {
+                task.parse().forEach(units::add);
+                task.analyze();
+            } catch (IOException unreadable) {
+                throw new UncheckedIOException(unreadable);
+            }
+            if (task.getElements().getTypeElement(importing.owner()) == null) {
+                return null;   // the owner is not something this reads, so it says nothing
+            }
+            Trees trees = Trees.instance(task);
+            for (CompilationUnitTree unit : units) {
+                if (!unit.getSourceFile().toUri().toString().endsWith("/Probe.java")) {
+                    continue;
+                }
+                ClassTree probe = (ClassTree) unit.getTypeDecls().getFirst();
+                Tree written = probe.getMembers().stream()
+                        .filter(VariableTree.class::isInstance).map(VariableTree.class::cast)
+                        .findFirst().orElseThrow().getType();
+                return trees.getElement(TreePath.getPath(unit, written))
+                        instanceof TypeElement it ? it.getQualifiedName().toString() : null;
+            }
+            throw new IllegalStateException("the source written to ask what `" + name
+                    + "` means in " + pkg + " did not come back");
+        };
     }
 
-    /** The same, of types written here rather than compiled. */
-    private static MemberTypes membersOf(Map<String, String> sources) {
+    /** What the names of this repository's compiled classes mean, which is what its sources are
+     *  read against. */
+    private static NameMeanings repositoryMeanings() {
+        return meaningsOver(List.of());
+    }
+
+    /** The same, over types written here rather than compiled. */
+    private static NameMeanings meaningsIn(Map<String, String> sources) {
         List<JavaFileObject> written = new ArrayList<>();
         sources.forEach((at, text) -> written.add(new Written("main", at, text)));
-        JavacTask task = (JavacTask) compiler().getTask(null, null, diagnostic -> { },
-                List.of("-proc:none"), null, written);
-        try {
-            // Entered and attributed, because a member of a type is known once the type is. What
-            // the sources here fail to resolve is not this question — a fixture may import from an
-            // owner nobody declares, which is one of the three answers.
-            task.analyze();
-        } catch (IOException unreadable) {
-            throw new UncheckedIOException(unreadable);
-        }
-        return memberTypesOf(task.getElements());
+        return meaningsOver(written);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
-import souther.compiler.check.BehaviorContract.Clause;
 import souther.compiler.check.BehaviorContract.Rule;
 import souther.compiler.check.BehaviorContract.RuleId;
 import souther.compiler.core.Contract;
@@ -156,7 +155,7 @@ public final class BehaviorChecker {
         // one pass — what a rule states is which case it applies to and what holds there, and every
         // refusal here is this not having been able to read that — so an arm that fails contributes
         // no rule and stops nothing else.
-        List<Clause> clauses = new ArrayList<>();
+        List<BehaviorContract.Clause> clauses = new ArrayList<>();
         int armOrdinal = 0;
         for (int c = 0; c < behavior.ensures().size(); c++) {
             Hir.EnsuresClause written = behavior.ensures().get(c);
@@ -167,7 +166,8 @@ public final class BehaviorChecker {
                 collect(found, () -> rules.addAll(
                         read(behavior, arm, answer, symbols, owner, params.size(), clauseIndex, ordinal)));
             }
-            clauses.add(new Clause(written.name(), rules, written.pos(), written.region()));
+            clauses.add(new BehaviorContract.Clause(written.name(), rules, written.pos(),
+                    written.region()));
         }
         return new Reading(new BehaviorContract(name, params, sig.outputType(), clauses), found);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -20,7 +20,6 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 import souther.compiler.values.Admits;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -821,24 +820,24 @@ public sealed interface Carrier {
      * is one position's, so that a carrier added later answers what a carrier has to answer and not
      * what a reading does.
      *
-     * <p>{@link Emptiness#UNDECIDED} where this order cannot say. A pattern over a carrier that is
+     * <p>{@link souther.compiler.values.Emptiness#UNDECIDED} where this order cannot say. A pattern over a carrier that is
      * not the strings is a set belonging to no position of this order rather than one this refuses,
      * and a machine the allowance will not pay for is a question that waits — neither of them is a
      * value being ruled out.
      *
      * @param meter what may be built to answer, where answering takes a machine
      */
-    default Emptiness meets(ValueSet set, OrderedInterval range, Meter meter) {
+    default souther.compiler.values.Emptiness meets(ValueSet set, OrderedInterval range, Meter meter) {
         if (range.holdsNothing()) {
-            return Emptiness.EMPTY;
+            return souther.compiler.values.Emptiness.EMPTY;
         }
         return switch (set) {
             case ValueSet.Finite it -> anyOf(it.values(), range);
             // Every value of the order is admitted, and the range holds one.
             case ValueSet.Cofinite it -> it.excluded().isEmpty()
-                    ? Emptiness.NONEMPTY : somethingNotExcluded(it.excluded(), range);
+                    ? souther.compiler.values.Emptiness.NONEMPTY : somethingNotExcluded(it.excluded(), range);
             case ValueSet.Matching it -> this instanceof Text
-                    ? stringsInside(it.language(), range, meter) : Emptiness.UNDECIDED;
+                    ? stringsInside(it.language(), range, meter) : souther.compiler.values.Emptiness.UNDECIDED;
         };
     }
 
@@ -957,17 +956,17 @@ public sealed interface Carrier {
 
     /** Whether one of {@code values} is inside {@code range}, undecided where a value of the set is
      *  not one this order places at all. */
-    private Emptiness anyOf(java.util.Set<Value> values, OrderedInterval range) {
+    private souther.compiler.values.Emptiness anyOf(java.util.Set<Value> values, OrderedInterval range) {
         boolean placed = true;
         for (Value each : values) {
             Place at = placeOf(each);
             if (at == null) {
                 placed = false;
             } else if (range.admits(at)) {
-                return Emptiness.NONEMPTY;
+                return souther.compiler.values.Emptiness.NONEMPTY;
             }
         }
-        return placed ? Emptiness.EMPTY : Emptiness.UNDECIDED;
+        return placed ? souther.compiler.values.Emptiness.EMPTY : souther.compiler.values.Emptiness.UNDECIDED;
     }
 
     /**
@@ -977,10 +976,10 @@ public sealed interface Carrier {
      * excluded: a range holding more than that holds one of them whatever the exclusions are, and
      * counting further would be enumerating an order to answer a question about a handful of values.
      */
-    private Emptiness somethingNotExcluded(Set<Value> excluded, OrderedInterval range) {
+    private souther.compiler.values.Emptiness somethingNotExcluded(Set<Value> excluded, OrderedInterval range) {
         List<Place> held = firstPlacesIn(range, excluded.size() + 1);
         if (held == null) {
-            return Emptiness.NONEMPTY;
+            return souther.compiler.values.Emptiness.NONEMPTY;
         }
         List<Place> away = new ArrayList<>(excluded.size());
         excluded.forEach(each -> {
@@ -991,10 +990,10 @@ public sealed interface Carrier {
         });
         for (Place each : held) {
             if (away.stream().noneMatch(each::sameAs)) {
-                return Emptiness.NONEMPTY;
+                return souther.compiler.values.Emptiness.NONEMPTY;
             }
         }
-        return Emptiness.EMPTY;
+        return souther.compiler.values.Emptiness.EMPTY;
     }
 
     /**
@@ -1057,7 +1056,7 @@ public sealed interface Carrier {
      * or they do not. Said as a projection of the language onto the ends instead, a rule whose
      * strings are not one stretch of the order would have no ends to be compared with.
      */
-    private Emptiness stringsInside(Language language, OrderedInterval range, Meter meter) {
+    private souther.compiler.values.Emptiness stringsInside(Language language, OrderedInterval range, Meter meter) {
         OrderedInterval held = extent().meet(range);
         Language inside = language;
         if (held.high() != null) {
@@ -1075,9 +1074,9 @@ public sealed interface Carrier {
             inside = above == null ? null : inside.and(above, meter);
         }
         if (inside == null) {
-            return Emptiness.UNDECIDED;
+            return souther.compiler.values.Emptiness.UNDECIDED;
         }
-        return inside.isEmpty() ? Emptiness.EMPTY : Emptiness.NONEMPTY;
+        return inside.isEmpty() ? souther.compiler.values.Emptiness.EMPTY : souther.compiler.values.Emptiness.NONEMPTY;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/CheckedDeclarations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CheckedDeclarations.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.ValueShape;
 import souther.compiler.observe.Composed;
-import souther.compiler.observe.Declarations;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -24,7 +23,7 @@ import java.util.Map;
  * declaration this reading cannot reach at all, and one it reaches that the check settled nothing
  * about. Neither is a data with no fields.
  */
-public final class CheckedDeclarations implements Declarations {
+public final class CheckedDeclarations implements souther.compiler.observe.Declarations {
 
     /** What each declaration was checked to be, asked for by the declaration's own identity. */
     public interface Shapes {

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -8,7 +8,6 @@ import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AskedOfEachBlock;
 import souther.compiler.values.ConjoinedAdmissibleValues;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.Admits;
 import souther.compiler.values.AskedOfARelation;
 import souther.compiler.values.PlannedValues;
@@ -43,8 +42,8 @@ import java.util.function.Function;
  *
  * <p><b>Nothing is admitted where the ranges refuse every alternative, and something is admitted
  * only where they were asked.</b> That asymmetry is the whole of what went wrong. Either half
- * holding nothing leaves the pair nothing, so {@link Emptiness#EMPTY} is sound from either of them;
- * {@link Emptiness#NONEMPTY} is a claim about the pair and can only come out of the walk that was
+ * holding nothing leaves the pair nothing, so {@link souther.compiler.values.Emptiness#EMPTY} is sound from either of them;
+ * {@link souther.compiler.values.Emptiness#NONEMPTY} is a claim about the pair and can only come out of the walk that was
  * handed the ranges. A reading that answered it from the values alone settled a branch as one
  * somebody can be in before anything asked where its positions stop.
  *
@@ -81,13 +80,13 @@ sealed interface Confinement<A> {
     }
 
     /** Whether anything satisfies both readings. */
-    default Emptiness admits() {
+    default souther.compiler.values.Emptiness admits() {
         return admission().emptiness();
     }
 
     /** Whether it is settled that nothing does. */
     default boolean holdsNothing() {
-        return admits() == Emptiness.EMPTY;
+        return admits() == souther.compiler.values.Emptiness.EMPTY;
     }
 
     /**
@@ -113,7 +112,7 @@ sealed interface Confinement<A> {
      * @param site where the lack is, and whether it is a lack at each of some blocks or a lack
      *             about several of them together — see {@link Refusal}
      */
-    record Admission<A>(Emptiness emptiness, EmptyBy by, Refusal<A> site, Shown how) {
+    record Admission<A>(souther.compiler.values.Emptiness emptiness, EmptyBy by, Refusal<A> site, Shown how) {
 
         /** The blocks the lack is about, for a reader that only has to name places. */
         Set<Sameness.Block<A>> at() {
@@ -121,27 +120,27 @@ sealed interface Confinement<A> {
         }
 
         /** The same, where what was refused is places rather than values several of them share. */
-        static <A> Admission<A> at(Emptiness emptiness, EmptyBy by, Set<A> positions, Shown how) {
+        static <A> Admission<A> at(souther.compiler.values.Emptiness emptiness, EmptyBy by, Set<A> positions, Shown how) {
             Set<Sameness.Block<A>> blocks = new LinkedHashSet<>();
             positions.forEach(each -> blocks.add(Sameness.Block.of(each)));
             return new Admission<>(emptiness, by, new Refusal.AtEachOf<>(blocks), how);
         }
 
         /** The same, at each of these blocks. */
-        static <A> Admission<A> eachOf(Emptiness emptiness, EmptyBy by,
+        static <A> Admission<A> eachOf(souther.compiler.values.Emptiness emptiness, EmptyBy by,
                                        Set<Sameness.Block<A>> blocks, Shown how) {
             return new Admission<>(emptiness, by, new Refusal.AtEachOf<>(blocks), how);
         }
 
         /** Something may satisfy the pair, so nothing emptied it. */
-        static <A> Admission<A> left(Emptiness emptiness) {
+        static <A> Admission<A> left(souther.compiler.values.Emptiness emptiness) {
             return new Admission<>(emptiness, EmptyBy.NOTHING_SHOWN, new Refusal.Nowhere<>(),
                     Shown.BY_THE_READINGS);
         }
 
         /** Whether it is settled that nothing satisfies what was asked. */
         boolean holdsNothing() {
-            return emptiness == Emptiness.EMPTY;
+            return emptiness == souther.compiler.values.Emptiness.EMPTY;
         }
 
         /** Whether these two readings are the whole of what showed it. */
@@ -163,7 +162,7 @@ sealed interface Confinement<A> {
             // however these two were shown. Nothing hands a branch's fate a restriction from
             // outside today ({@link StatedByClauses.Reading}), so both of these are the readings'
             // own; said the other way, this would be a fact about the pair that neither half is.
-            return new Admission<>(Emptiness.EMPTY,
+            return new Admission<>(souther.compiler.values.Emptiness.EMPTY,
                     one.by == other.by ? one.by : EmptyBy.RULES_TOGETHER,
                     Refusal.shownByBoth(one.site, other.site),
                     one.byTheReadings() && other.byTheReadings()
@@ -236,7 +235,7 @@ sealed interface Confinement<A> {
      * The one implementation of the question, whatever the values are held as.
      *
      * <p>The ranges reach every position of every alternative, so what comes back is about the pair
-     * — which is what makes {@link Emptiness#NONEMPTY} sayable at all. A holder whose values are
+     * — which is what makes {@link souther.compiler.values.Emptiness#NONEMPTY} sayable at all. A holder whose values are
      * still descriptions answers as much of it as needs no machine and leaves the rest open; a
      * holder whose values are sets answers all of it.
      *
@@ -252,7 +251,7 @@ sealed interface Confinement<A> {
         // places the position: a reading left with no range at all names none, and where it names
         // one, that is where the lack is.
         if (ordered.isBottom()) {
-            return Admission.at(Emptiness.EMPTY, EmptyBy.ORDER, ordered.holdingNothing(),
+            return Admission.at(souther.compiler.values.Emptiness.EMPTY, EmptyBy.ORDER, ordered.holdingNothing(),
                     Shown.BY_THE_READINGS);
         }
         // A meter of this asking, spent on every question asked in it. What may be built to decide
@@ -283,8 +282,8 @@ sealed interface Confinement<A> {
         // One walk, and it is asked where the positions are: what a reading leaves is what it
         // leaves once everything that places its positions has been met with it, and a walk per
         // asking would be an alternative visited twice by two questions that have to agree.
-        Emptiness said = admitting.of(placed, relating);
-        if (said != Emptiness.EMPTY) {
+        souther.compiler.values.Emptiness said = admitting.of(placed, relating);
+        if (said != souther.compiler.values.Emptiness.EMPTY) {
             // And a position with nowhere to be once everything placing it is met, which is a lack
             // the alternatives never hear about: a position no alternative names is not one they
             // are asked about, so where what is required of it does not reach where its own ends
@@ -301,7 +300,7 @@ sealed interface Confinement<A> {
                 }
             });
             return nowhere.isEmpty() ? Admission.left(said)
-                    : Admission.at(Emptiness.EMPTY, EmptyBy.ORDER, nowhere,
+                    : Admission.at(souther.compiler.values.Emptiness.EMPTY, EmptyBy.ORDER, nowhere,
                             Shown.ONCE_THE_POSITIONS_ARE_PLACED);
         }
         // What showed it, which is a second question and is asked where a proof is written rather
@@ -310,7 +309,7 @@ sealed interface Confinement<A> {
         // pair whose own set and range share no value would be reported against bounds derived
         // somewhere else, which is true and is not what they wrote.
         Shown how = outside.saysNothing()
-                || admitting.of(byTheReadings, byTheReadingsRelating) == Emptiness.EMPTY
+                || admitting.of(byTheReadings, byTheReadingsRelating) == souther.compiler.values.Emptiness.EMPTY
                 ? Shown.BY_THE_READINGS : Shown.ONCE_THE_POSITIONS_ARE_PLACED;
         // The values holding no alternative at all is the values' own answer, and asking anything
         // of the ranges would not have changed it. Told apart here rather than by a second reader
@@ -331,25 +330,25 @@ sealed interface Confinement<A> {
         // and is not one of them: each of those blocks is left values of its own, and what has
         // nothing is an assignment to all of them at once.
         if (where instanceof Refusal.OfThemTogether) {
-            return new Admission<>(Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_APART, where, how);
+            return new Admission<>(souther.compiler.values.Emptiness.EMPTY, EmptyBy.POSITIONS_HELD_APART, where, how);
         }
         // The values holding no alternative at all is the values' own answer, and asking anything
         // of the ranges would not have changed it. Told apart here rather than by a second reader
         // reassembling the same three facts — and said to be the readings' whichever asking reached
         // it, since a proof that consults no range is one no placing of a position took part in.
-        if (admitting.of((_, _) -> Emptiness.NONEMPTY,
-                relating(carriers, _ -> OrderedInterval.OPEN)) == Emptiness.EMPTY) {
+        if (admitting.of((_, _) -> souther.compiler.values.Emptiness.NONEMPTY,
+                relating(carriers, _ -> OrderedInterval.OPEN)) == souther.compiler.values.Emptiness.EMPTY) {
             // With where the reading was refused, where that is nearer than the general answer.
             // Each of those places holds something on its own, so "the values admit nothing" is
             // true of the declaration and says less than what was shown — and which of the two
             // nearer sentences it is is the refusal's to say and not a second reading of it.
-            return new Admission<>(Emptiness.EMPTY, switch (alreadyShown) {
+            return new Admission<>(souther.compiler.values.Emptiness.EMPTY, switch (alreadyShown) {
                 case Refusal.Nowhere<A> _ -> EmptyBy.VALUES;
                 case Refusal.AtEachOf<A> _ -> EmptyBy.POSITIONS_HELD_AS_ONE;
                 case Refusal.OfThemTogether<A> _ -> EmptyBy.POSITIONS_HELD_APART;
             }, alreadyShown, Shown.BY_THE_READINGS);
         }
-        return new Admission<>(Emptiness.EMPTY, EmptyBy.SET_AND_RANGE, where, how);
+        return new Admission<>(souther.compiler.values.Emptiness.EMPTY, EmptyBy.SET_AND_RANGE, where, how);
     }
 
     /**
@@ -379,7 +378,7 @@ sealed interface Confinement<A> {
      *  the denials between them come to. */
     @FunctionalInterface
     interface Admitting<A> {
-        Emptiness of(AskedOfEachBlock<A> blocks, AskedOfARelation<A> relation);
+        souther.compiler.values.Emptiness of(AskedOfEachBlock<A> blocks, AskedOfARelation<A> relation);
     }
 
     /** The same two questions, asked to write down where a reading was left nothing. */
@@ -405,18 +404,18 @@ sealed interface Confinement<A> {
         // about the very blocks the walk that reached it did — by the set in hand and not by what
         // a set is equal to, since two sets that are equal are two answers only if somebody built
         // them twice.
-        Map<Sameness.Block<A>, Map<ValueSet, Emptiness>> asked = new LinkedHashMap<>();
+        Map<Sameness.Block<A>, Map<ValueSet, souther.compiler.values.Emptiness>> asked = new LinkedHashMap<>();
         return (block, set) -> asked
                 .computeIfAbsent(block, _ -> new IdentityHashMap<>())
                 .computeIfAbsent(set, it -> answered(carriers, sits, meter, block, it));
     }
 
     /** Whether {@code block} admits anything where {@code sits} puts its positions. */
-    private static <A> Emptiness answered(Map<A, Carrier> carriers,
+    private static <A> souther.compiler.values.Emptiness answered(Map<A, Carrier> carriers,
                                           Function<A, OrderedInterval> sits, Meter meter,
                                           Sameness.Block<A> block, ValueSet set) {
         Placed placed = placedAt(carriers, sits, block);
-        return placed.carrier() == null ? Emptiness.NONEMPTY
+        return placed.carrier() == null ? souther.compiler.values.Emptiness.NONEMPTY
                 : placed.carrier().meets(set, placed.within(), meter);
     }
 
@@ -465,10 +464,10 @@ sealed interface Confinement<A> {
 
     /** What showed a conjunction of two readings empty, where either of them was. */
     static <A> Admission<A> eitherShown(Admission<A> one, Admission<A> other) {
-        if (one.emptiness() != Emptiness.EMPTY) {
-            return other.emptiness() == Emptiness.EMPTY ? other : null;
+        if (one.emptiness() != souther.compiler.values.Emptiness.EMPTY) {
+            return other.emptiness() == souther.compiler.values.Emptiness.EMPTY ? other : null;
         }
-        return other.emptiness() == Emptiness.EMPTY ? Admission.bothShown(one, other) : one;
+        return other.emptiness() == souther.compiler.values.Emptiness.EMPTY ? Admission.bothShown(one, other) : one;
     }
 
     /** What each position is ordered on, both tables put together. */
@@ -553,12 +552,12 @@ sealed interface Confinement<A> {
          * together. What it may spend is the answer's own allowance, so what is asked is what is
          * established and a branch nothing established is kept.
          */
-        Emptiness alreadyEstablished(Allowance<A> by) {
-            Emptiness said = admits();
-            if (said != Emptiness.UNDECIDED) {
+        souther.compiler.values.Emptiness alreadyEstablished(Allowance<A> by) {
+            souther.compiler.values.Emptiness said = admits();
+            if (said != souther.compiler.values.Emptiness.UNDECIDED) {
                 return said;
             }
-            return values.holdsNothingAsBuilt(by) ? Emptiness.EMPTY : Emptiness.UNDECIDED;
+            return values.holdsNothingAsBuilt(by) ? souther.compiler.values.Emptiness.EMPTY : souther.compiler.values.Emptiness.UNDECIDED;
         }
 
         /**
@@ -698,8 +697,8 @@ sealed interface Confinement<A> {
             // A position nobody could build is one what stands there is wider than the rules, so a
             // pair the ranges did not refuse may still hold nothing. Settled empty is settled all
             // the same: a narrower reading refuses no less.
-            return said.emptiness() == Emptiness.NONEMPTY && !made.unbuilt().isEmpty()
-                    ? Admission.left(Emptiness.UNDECIDED) : said;
+            return said.emptiness() == souther.compiler.values.Emptiness.NONEMPTY && !made.unbuilt().isEmpty()
+                    ? Admission.left(souther.compiler.values.Emptiness.UNDECIDED) : said;
         }
 
         /** The positions the order leaves no value at, for a reader writing down where. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Settlement.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.Realized;
 import souther.compiler.values.UnreadReason;
 
@@ -27,7 +26,7 @@ import java.util.TreeSet;
  * inside the left of {@code A} is refined by {@code A}'s left, and the same branch inside the right
  * by {@code A}'s right. What the written branch's author can act on is the whole declaration's
  * answer: nobody can be in it only if nobody can be in it anywhere it stands. So the sides join over
- * occurrences by {@link Emptiness#joined}, which is associative, commutative and idempotent — and
+ * occurrences by {@link souther.compiler.values.Emptiness#joined}, which is associative, commutative and idempotent — and
  * so is every other component of a side ({@link Sided#alsoSeen}), so the order the copies are met
  * in, and how the conjunctions were bracketed, cannot reach the answer.
  *
@@ -59,7 +58,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
      * <p>{@code standing} and {@code unbuilt} carry what probing the occurrences could not build,
      * for the one case the account needs it: a branch kept without being shown live is kept with
      * the reason nobody knows, or the account would call a position open where the truth is that
-     * nothing looked. Read only where the aggregate stays {@link Emptiness#UNDECIDED}; a branch
+     * nothing looked. Read only where the aggregate stays {@link souther.compiler.values.Emptiness#UNDECIDED}; a branch
      * shown live somewhere needs no excuse, and a branch dead everywhere takes its reasons with it.
      *
      * <p><b>Two halves and not one map, because they are routed and not distributed alike.</b> What
@@ -79,7 +78,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
                  Set<FactSubject> unbuilt) {
 
         /** Whether anything satisfies this branch, as far as its occurrences settled it. */
-        Emptiness emptiness() {
+        souther.compiler.values.Emptiness emptiness() {
             return shown.emptiness();
         }
 
@@ -127,7 +126,7 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
          *
          * <p>Associative, commutative and idempotent in every component, which is what lets the
          * class doc promise that the order the copies are met in cannot reach the answer:
-         * {@link Emptiness#joined} is, a set union is, and the reasons are joined as a set and then
+         * {@link souther.compiler.values.Emptiness#joined} is, a set union is, and the reasons are joined as a set and then
          * said in the vocabulary's declared order — kept in the order the occurrences were met,
          * they would be said in a neighbouring clause's order.
          */
@@ -148,8 +147,8 @@ record Settlement(Confinement.Worked<FactSubject> confinement,
             // And what showed the branch empty, where both occurrences of it are. Where they were
             // shown by different things, or refused at different positions, neither speaks for the
             // branch — which is the same rule a choice of two dead branches is under.
-            Emptiness said = emptiness().joined(other.emptiness());
-            Confinement.Admission<FactSubject> both = said == Emptiness.EMPTY
+            souther.compiler.values.Emptiness said = emptiness().joined(other.emptiness());
+            Confinement.Admission<FactSubject> both = said == souther.compiler.values.Emptiness.EMPTY
                     ? Confinement.Admission.bothShown(shown, other.shown)
                     : Confinement.Admission.left(said);
             return new Sided(both, why, java.util.Collections.unmodifiableSet(asked), gaveUp);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -6,7 +6,6 @@ import souther.compiler.types.Type;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Realizations;
 import souther.compiler.values.Realized;
@@ -650,8 +649,8 @@ sealed interface StatedByClauses {
                     && other instanceof StatedTogether.Said there) {
                 Confinement.Admission<FactSubject> mine = here.confinement().admission();
                 Confinement.Admission<FactSubject> theirs = there.confinement().admission();
-                Emptiness a = mine.emptiness();
-                Emptiness b = theirs.emptiness();
+                souther.compiler.values.Emptiness a = mine.emptiness();
+                souther.compiler.values.Emptiness b = theirs.emptiness();
                 // A branch the descriptions already show empty is decided here whichever way the
                 // declaration holds its choices. The answer is definitive — a description empty
                 // before anything is built admits nothing however the other clauses refine it —
@@ -659,16 +658,16 @@ sealed interface StatedByClauses {
                 // so nothing a deferral waits for can reach a different decision. Deferred anyway,
                 // the dead branch would widen the met-together tree for nothing.
                 //
-                if (a == Emptiness.EMPTY && b == Emptiness.EMPTY) {
+                if (a == souther.compiler.values.Emptiness.EMPTY && b == souther.compiler.values.Emptiness.EMPTY) {
                     decided.put(choice.id(), settled(mine, theirs));
                     return new StatedTogether.Said(here.confinement().bothDead(there.confinement(),
                             Confinement.Admission.bothShown(mine, theirs)));
                 }
-                if (a == Emptiness.EMPTY) {
+                if (a == souther.compiler.values.Emptiness.EMPTY) {
                     decided.put(choice.id(), settled(mine, theirs));
                     return other;
                 }
-                if (b == Emptiness.EMPTY) {
+                if (b == souther.compiler.values.Emptiness.EMPTY) {
                     decided.put(choice.id(), settled(mine, theirs));
                     return one;
                 }
@@ -679,7 +678,7 @@ sealed interface StatedByClauses {
                 // deferral costs was counted over the whole declaration before any clause was
                 // read, which is what admitted the declaration as APART at all.
                 if (alternatives == Alternatives.MERGED
-                        && a == Emptiness.NONEMPTY && b == Emptiness.NONEMPTY) {
+                        && a == souther.compiler.values.Emptiness.NONEMPTY && b == souther.compiler.values.Emptiness.NONEMPTY) {
                     decided.put(choice.id(), settled(mine, theirs));
                     return new StatedTogether.Said(
                             either(here.confinement(), there.confinement()));
@@ -748,16 +747,16 @@ sealed interface StatedByClauses {
          */
         private StatedTogether.Said decided(StatedTogether.Said one, Settlement.Sided here,
                                             StatedTogether.Said other, Settlement.Sided there) {
-            if (here.emptiness() == Emptiness.EMPTY && there.emptiness() == Emptiness.EMPTY) {
+            if (here.emptiness() == souther.compiler.values.Emptiness.EMPTY && there.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
                 // The rule for a choice nobody can take, named rather than arrived at: a join is
                 // what two branches somebody can take come to, and neither of these is one.
                 return new StatedTogether.Said(one.confinement().bothDead(other.confinement(),
                         Confinement.Admission.bothShown(here.shown(), there.shown())));
             }
-            if (here.emptiness() == Emptiness.EMPTY) {
+            if (here.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
                 return keptTogether(other, there);
             }
-            if (there.emptiness() == Emptiness.EMPTY) {
+            if (there.emptiness() == souther.compiler.values.Emptiness.EMPTY) {
                 return keptTogether(one, here);
             }
             StatedTogether.Said left = keptTogether(one, here);
@@ -775,7 +774,7 @@ sealed interface StatedByClauses {
          */
         private StatedTogether.Said keptTogether(StatedTogether.Said read,
                                                  Settlement.Sided known) {
-            if (known.emptiness() != Emptiness.UNDECIDED) {
+            if (known.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
                 return read;
             }
             return new StatedTogether.Said(
@@ -798,7 +797,7 @@ sealed interface StatedByClauses {
         private Settlement.Sided probed(StatedTogether.Said read,
                                         Allowance<FactSubject> by) {
             Confinement.Admission<FactSubject> said = read.confinement().admission();
-            if (said.emptiness() != Emptiness.UNDECIDED) {
+            if (said.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
                 return Settlement.Sided.settledAs(said);
             }
             // Worked out, the descriptions become sets and every alternative can be asked where its
@@ -806,7 +805,7 @@ sealed interface StatedByClauses {
             // what a pattern comes to.
             Confinement.Worked<FactSubject> worked = read.confinement().resolve(by);
             Confinement.Admission<FactSubject> admitted = worked.admission();
-            if (admitted.emptiness() != Emptiness.UNDECIDED) {
+            if (admitted.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
                 return Settlement.Sided.settledAs(admitted);
             }
             Realized<FactSubject> made = worked.made();
@@ -818,7 +817,7 @@ sealed interface StatedByClauses {
                     new LinkedHashMap<>();
             made.aboutTheAnswer().forEach(each -> answered.merge(each.at(),
                     List.of(each.why()), ReadByClauses::alsoSaying));
-            return new Settlement.Sided(Confinement.Admission.left(Emptiness.UNDECIDED), answered,
+            return new Settlement.Sided(Confinement.Admission.left(souther.compiler.values.Emptiness.UNDECIDED), answered,
                     made.aboutARule(), made.unbuilt());
         }
 
@@ -889,7 +888,7 @@ sealed interface StatedByClauses {
          */
         private static boolean nobodyIsIn(StatedTogether.Said branch,
                                           Allowance<FactSubject> by) {
-            return branch.confinement().alreadyEstablished(by) == Emptiness.EMPTY;
+            return branch.confinement().alreadyEstablished(by) == souther.compiler.values.Emptiness.EMPTY;
         }
 
         /**
@@ -979,15 +978,15 @@ sealed interface StatedByClauses {
                         throw new IllegalStateException(
                                 "a choice of a rule was never met in the settled reading");
                     }
-                    Emptiness here = fate.left().emptiness();
-                    Emptiness there = fate.right().emptiness();
-                    if (here == Emptiness.EMPTY && there == Emptiness.EMPTY) {
+                    souther.compiler.values.Emptiness here = fate.left().emptiness();
+                    souther.compiler.values.Emptiness there = fate.right().emptiness();
+                    if (here == souther.compiler.values.Emptiness.EMPTY && there == souther.compiler.values.Emptiness.EMPTY) {
                         yield one.bothDead(other);
                     }
-                    if (here == Emptiness.EMPTY) {
+                    if (here == souther.compiler.values.Emptiness.EMPTY) {
                         yield keptAs(other, fate.right()).beside(one);
                     }
-                    if (there == Emptiness.EMPTY) {
+                    if (there == souther.compiler.values.Emptiness.EMPTY) {
                         yield keptAs(one, fate.left()).beside(other);
                     }
                     // Here, where both branches have their fate. What an alternative nothing could
@@ -1015,7 +1014,7 @@ sealed interface StatedByClauses {
          * taken in until this is applied.
          */
         private Taken keptAs(Taken read, Settlement.Sided known) {
-            if (known.emptiness() != Emptiness.UNDECIDED) {
+            if (known.emptiness() != souther.compiler.values.Emptiness.UNDECIDED) {
                 return read;
             }
             return read.mapped(part -> new Part(

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -64,7 +64,7 @@ import java.util.List;
  *                short of the lines that have no value
  */
 public record Axis(AxisId id, NumericTerm.FromOnePosition term,
-                   List<PartitionClass> classes, List<PartitionEvidenceOrigin> divides,
+                   List<PartitionClass> classes, List<RuleEvidenceOrigin> divides,
                    List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
 
     public Axis {
@@ -146,7 +146,7 @@ public record Axis(AxisId id, NumericTerm.FromOnePosition term,
      * a reader rebuilding a measure it already has.
      */
     public static Axis of(String behavior, NumericTerm.FromOnePosition term,
-                          List<PartitionClass> classes, List<PartitionEvidenceOrigin> divides,
+                          List<PartitionClass> classes, List<RuleEvidenceOrigin> divides,
                           List<Cut> cuts, List<Parting> parted, NarrowedBounds narrowed) {
         return new Axis(AxisId.of(behavior, term), term, classes, divides, cuts, parted, narrowed);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -88,7 +88,7 @@ public final class BehaviorSetStatements {
      *                position is one of these: it is about that value, and a denominator held open
      *                by it would be held open by a rule that never reached the position
      */
-    public record Read(List<PartitionEvidence> statements, List<ClassingBlocker> blocked,
+    public record Read(List<RuleEvidence> statements, List<ClassingBlocker> blocked,
                        List<RuleWithoutALine> saying) {
 
         public Read {
@@ -178,7 +178,7 @@ public final class BehaviorSetStatements {
         Map<NumericTerm.FromOnePosition, Realizations> answers = new LinkedHashMap<>();
         byTerm.forEach((term, plans) ->
                 answers.put(term, allowance.realizeAll(purseOf(term), plans)));
-        List<PartitionEvidence> statements = new ArrayList<>();
+        List<RuleEvidence> statements = new ArrayList<>();
         for (Asked each : asked) {
             state(each, answers.get(each.term()), statements, blocked);
         }
@@ -272,13 +272,13 @@ public final class BehaviorSetStatements {
      * is a question about the position's values and is asked where they are known.
      */
     private static void state(Asked each, Realizations answer,
-                              List<PartitionEvidence> statements, List<ClassingBlocker> blocked) {
+                              List<RuleEvidence> statements, List<ClassingBlocker> blocked) {
         if (!(answer instanceof Realizations.Exact built)) {
             blocked.add(new ClassingBlocker(each.term(), each.by(),
                     new BlockReason.BehaviorDistinctionsTooCostly()));
             return;
         }
-        statements.add(new PartitionEvidence.BySet(new SetStatement(each.term(),
+        statements.add(new RuleEvidence.BySet(new SetStatement(each.term(),
                 built.of(each.whenTrue()), built.of(each.whenFalse()), each.states(), each.by())));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Classing.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Classing.java
@@ -85,12 +85,12 @@ final class Classing {
      * classes are written in the day a set rule was written beside it, and the classes it already
      * had would be rewritten under a rule that says nothing about them.
      */
-    static Vocabulary vocabularyOf(List<PartitionEvidence> mine, Carrier carrier) {
+    static Vocabulary vocabularyOf(List<RuleEvidence> mine, Carrier carrier) {
         boolean sets = true;
         boolean lines = true;
-        for (PartitionEvidence each : mine) {
+        for (RuleEvidence each : mine) {
             sets &= asASet(each, carrier) != null;
-            lines &= !(each instanceof PartitionEvidence.BySet);
+            lines &= !(each instanceof RuleEvidence.BySet);
         }
         if (lines) {
             return Vocabulary.ON_AN_ORDER;
@@ -107,11 +107,11 @@ final class Classing {
      * has no such writing, and neither has a value singled out of anything but a string — a run of
      * values is not a set this compiler holds, and saying so is what keeps the two apart.
      */
-    private static AsASet asASet(PartitionEvidence evidence, Carrier carrier) {
+    private static AsASet asASet(RuleEvidence evidence, Carrier carrier) {
         return switch (evidence) {
-            case PartitionEvidence.BySet(SetStatement it) ->
+            case RuleEvidence.BySet(SetStatement it) ->
                     new AsASet(it.whenTrue(), it.whenFalse(), it.statement());
-            case PartitionEvidence.Singles(GuardThresholds.Guards.Singled it) -> {
+            case RuleEvidence.Singles(GuardThresholds.Guards.Singled it) -> {
                 if (!(carrier instanceof Carrier.Text) || !(it.value() instanceof Text text)) {
                     yield null;
                 }
@@ -120,7 +120,7 @@ final class Classing {
                         new ValueSet.Cofinite(Set.of(one)),
                         new PredicateStatement.Equalling(text.at()));
             }
-            case PartitionEvidence.Divides _ -> null;
+            case RuleEvidence.Divides _ -> null;
         };
     }
 
@@ -155,16 +155,16 @@ final class Classing {
         }
 
         /** The rules the classes were made out of. */
-        List<PartitionEvidence> dividing() {
+        List<RuleEvidence> dividing() {
             return of(Outcome.DIVIDED);
         }
 
         /** And the rules the classes were not composed out of, because there are none. */
-        List<PartitionEvidence> notComposed() {
+        List<RuleEvidence> notComposed() {
             return of(Outcome.NOT_COMPOSED);
         }
 
-        private List<PartitionEvidence> of(Outcome outcome) {
+        private List<RuleEvidence> of(Outcome outcome) {
             return forEach.stream().filter(each -> each.outcome() == outcome)
                     .map(Disposed::what).toList();
         }
@@ -204,7 +204,7 @@ final class Classing {
     }
 
     /** One rule of a position and what became of it. */
-    record Disposed(PartitionEvidence what, Outcome outcome,
+    record Disposed(RuleEvidence what, Outcome outcome,
                     BlockReason.RuleWithoutLineReason why) {
 
         Disposed {
@@ -263,7 +263,7 @@ final class Classing {
      * @param writing what a row would carry for a value of this position, or null where nothing
      *                here composes one
      */
-    static Result of(NumericTerm.FromOnePosition term, List<PartitionEvidence> mine,
+    static Result of(NumericTerm.FromOnePosition term, List<RuleEvidence> mine,
                      List<ClassingBlocker> blocked, Carrier carrier, ValueSet admits,
                      Allowance<NumericTerm.FromOnePosition> allowance,
                      Function<Place, FixtureTemplate> writing) {
@@ -273,9 +273,9 @@ final class Classing {
         // one that states none must not be in the population that chooses a vocabulary or composes
         // a class. Left in, a rule that divides nothing would put the position's classes in one
         // algebra or the other, and would stand in every label the classes carry.
-        List<PartitionEvidence> active = new ArrayList<>();
+        List<RuleEvidence> active = new ArrayList<>();
         List<Disposed> told = new ArrayList<>();
-        for (PartitionEvidence each : mine) {
+        for (RuleEvidence each : mine) {
             // Only a rule read as a set of the strings is asked. A line and a value singled out are
             // settled where they were read — the reader that makes one has already held it to what
             // the position may take — and what a rule of the strings names is every string there
@@ -284,7 +284,7 @@ final class Classing {
             // Asked of all of them, a value singled out of a string would buy machines out of the
             // allowance for what a behavior tells apart, and a model that only writes equalities
             // could lose its classes to a limit meant for something else.
-            if (!(each instanceof PartitionEvidence.BySet set)) {
+            if (!(each instanceof RuleEvidence.BySet set)) {
                 active.add(each);
                 continue;   // filled in below, once it is known whether the classes took it up
             }
@@ -346,10 +346,10 @@ final class Classing {
      * are said to be that rather than left out. Left out, a reader cannot tell a rule this decided
      * nothing about from one it forgot — and the account that follows is the reader.
      */
-    private static List<Disposed> filled(List<PartitionEvidence> mine, List<Disposed> told,
+    private static List<Disposed> filled(List<RuleEvidence> mine, List<Disposed> told,
                                          Outcome otherwise) {
         List<Disposed> out = new ArrayList<>();
-        for (PartitionEvidence each : mine) {
+        for (RuleEvidence each : mine) {
             Disposed already = told.stream().filter(one -> one.what().equals(each))
                     .findFirst().orElse(null);
             out.add(already != null ? already : new Disposed(each, otherwise, null));
@@ -368,17 +368,17 @@ final class Classing {
      * <p>Written here so that the places that say "no classes" say it the same way: one of them
      * keeping its own list is one of them able to leave a rule out.
      */
-    private static Result notComposed(List<PartitionEvidence> mine, List<Disposed> told,
+    private static Result notComposed(List<RuleEvidence> mine, List<Disposed> told,
                                       BlockReason.RuleWithoutLineReason why) {
         List<Disposed> out = new ArrayList<>();
-        for (PartitionEvidence each : mine) {
+        for (RuleEvidence each : mine) {
             Disposed already = told.stream().filter(one -> one.what().equals(each))
                     .findFirst().orElse(null);
             if (already != null && already.outcome() == Outcome.TOLD_NOTHING_APART) {
                 out.add(already);
             } else {
                 out.add(new Disposed(each,
-                        each instanceof PartitionEvidence.BySet
+                        each instanceof RuleEvidence.BySet
                                 ? Outcome.NOT_COMPOSED : Outcome.LEFT_TO_THE_WALK, null));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClassingBlocker.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClassingBlocker.java
@@ -13,7 +13,7 @@ import souther.compiler.inputs.RuleWithoutALine;
  * a partition the model does not draw — and the ones that did not come out have to be present where
  * that decision is made, or the decision is made over the successes.
  *
- * <p><b>Not a piece of evidence</b> ({@link PartitionEvidence}). That is what a rule of the model
+ * <p><b>Not a piece of evidence</b> ({@link RuleEvidence}). That is what a rule of the model
  * was read to say about how a position's values are divided, and this rule was not read to say
  * anything: what it carries is that this compiler did not get there. Put among the evidence, an
  * account would owe a measure for it and a reader would be told the model divides a position in a

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -76,7 +76,7 @@ public final class EnsuresThresholds {
      *                is a sentence about the model, and the model says otherwise in its own
      *                declaration
      */
-    public record Clauses(List<PartitionEvidence> evidence,
+    public record Clauses(List<RuleEvidence> evidence,
                           List<LineDrawn> between, RulesWithNoLine noLine) {
 
         public static final Clauses NONE =
@@ -90,12 +90,12 @@ public final class EnsuresThresholds {
         /** The lines, read off what the walk said. Not a list of their own, for the reason
          *  {@link GuardThresholds.Guards#thresholds} is not one. */
         public List<Threshold> thresholds() {
-            return PartitionEvidence.linesIn(evidence);
+            return RuleEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<GuardThresholds.Guards.Singled> singled() {
-            return PartitionEvidence.pointsIn(evidence);
+            return RuleEvidence.pointsIn(evidence);
         }
     }
 
@@ -173,7 +173,7 @@ public final class EnsuresThresholds {
 
     /** What the walk has found so far, and the behavior a line between two positions is named
      *  after. Together because they are filled together and are one answer. */
-    private record Drawn(String behavior, List<PartitionEvidence> evidence,
+    private record Drawn(String behavior, List<RuleEvidence> evidence,
                          List<LineDrawn> between,
                          RulesWithNoLine.Gathered noLine) {}
 
@@ -244,13 +244,13 @@ public final class EnsuresThresholds {
                     // falls and not the value beside it.
                     case ComparisonClaim.Singled _ -> {
                         if (at.value() != null) {
-                            out.evidence().add(new PartitionEvidence.Singles(
+                            out.evidence().add(new RuleEvidence.Singles(
                                     new GuardThresholds.Guards.Singled(
                                             at.position(), at.value(), origin)));
                         }
                     }
                     case ComparisonClaim.Cut order ->
-                            out.evidence().add(new PartitionEvidence.Divides(
+                            out.evidence().add(new RuleEvidence.Divides(
                                     new Threshold(at.position(), at.cutting().seam(),
                                             order.valueBelongs(), origin)));
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EvidenceAccount.java
@@ -83,7 +83,7 @@ final class EvidenceAccount {
 
     /** One piece of evidence and what became of it, held together so that holding the stage to a
      *  {@link Disposition.Measured} can ask the evidence what it should have left behind. */
-    private record Answered(PartitionEvidence what, Disposition how) {}
+    private record Answered(RuleEvidence what, Disposition how) {}
 
     /**
      * The distinctions this stage was told it did not get, and whether each was acted on.
@@ -100,15 +100,15 @@ final class EvidenceAccount {
      */
     private final Map<ClassingBlocker, Boolean> blockers = new LinkedHashMap<>();
 
-    private final Map<PartitionEvidence.FiledEvidenceId, PartitionEvidence> owed = new LinkedHashMap<>();
-    private final Map<PartitionEvidence.FiledEvidenceId, Answered> answered = new LinkedHashMap<>();
+    private final Map<RuleEvidence.FiledEvidenceId, RuleEvidence> owed = new LinkedHashMap<>();
+    private final Map<RuleEvidence.FiledEvidenceId, Answered> answered = new LinkedHashMap<>();
 
     /**
      * The evidence this stage was handed, and the one thing about it this has to establish rather
      * than assume.
      *
      * <p><b>That the identity tells the pieces apart.</b> Everything below counts by
-     * {@link PartitionEvidence#id}, so two pieces sharing one is one entry here — and then the piece that
+     * {@link RuleEvidence#id}, so two pieces sharing one is one entry here — and then the piece that
      * went missing is the one the other answered for. An account whose denominator is short before
      * any work happens reports a complete measure over evidence it never held, which is the sentence
      * this whole type exists to refuse.
@@ -120,10 +120,10 @@ final class EvidenceAccount {
      * <p>The same piece handed over twice is one piece. What that would say about the stage is
      * nothing, and nothing here counts arrivals.
      */
-    EvidenceAccount(List<PartitionEvidence> evidence, List<ClassingBlocker> blocked) {
+    EvidenceAccount(List<RuleEvidence> evidence, List<ClassingBlocker> blocked) {
         blocked.forEach(each -> blockers.put(each, false));
-        for (PartitionEvidence each : evidence) {
-            PartitionEvidence already = owed.put(each.id(), each);
+        for (RuleEvidence each : evidence) {
+            RuleEvidence already = owed.put(each.id(), each);
             if (already != null && !already.equals(each)) {
                 throw new IllegalStateException("two pieces of evidence are called " + each.id()
                         + ": " + already + " and " + each
@@ -132,11 +132,11 @@ final class EvidenceAccount {
         }
     }
 
-    void disposedOf(PartitionEvidence what, Disposition how) {
+    void disposedOf(RuleEvidence what, Disposition how) {
         // Held against what was handed over rather than against whatever else was disposed of. The
         // identity is one to one over the input, so a piece arriving here under an id belonging to
         // another is a piece this stage was never given.
-        PartitionEvidence given = owed.get(what.id());
+        RuleEvidence given = owed.get(what.id());
         if (given != null && !given.equals(what)) {
             throw new IllegalStateException("this stage disposed of " + what
                     + " under the name of " + given);
@@ -148,7 +148,7 @@ final class EvidenceAccount {
         }
     }
 
-    void measured(PartitionEvidence what, AxisId at) {
+    void measured(RuleEvidence what, AxisId at) {
         disposedOf(what, new Disposition.Measured(at));
     }
 
@@ -201,29 +201,29 @@ final class EvidenceAccount {
 
     /** Whether {@code axis} carries what {@code evidence} draws, asked in that evidence's own
      *  terms. */
-    private static boolean carries(Axis axis, PartitionEvidence evidence) {
+    private static boolean carries(Axis axis, RuleEvidence evidence) {
         return switch (evidence) {
             // A set told from the rest is carried by the classes and by nothing below them: there
             // is no cut it is an origin of and no parting it is an alternative in. So what says the
             // axis carries it is that the classes were composed out of it, which the axis records
             // beside them — read off the classes instead, the question would be whether one set is
             // inside another, and that is a machine nobody paid for.
-            case PartitionEvidence.BySet set -> axis.divides().contains(set.by());
+            case RuleEvidence.BySet set -> axis.divides().contains(set.by());
             // A line the position has no value beside is not a cut of it. It parts the values all
             // the same, and where it parts them is what carries the rule — as the authored line,
             // which is the key that side keeps.
-            case PartitionEvidence.Divides(Threshold line) when line.value() == null ->
+            case RuleEvidence.Divides(Threshold line) when line.value() == null ->
                     axis.parted().stream().anyMatch(each ->
                             each.alternatives().contains(line.origin().authoredLine()));
             // And one it has a value beside is a cut, as is a value singled out: a rule that
             // singles nothing out is not one of those, so there is always a value here.
-            case PartitionEvidence.Divides it ->
+            case RuleEvidence.Divides it ->
                     axis.cuts().stream().anyMatch(each -> each.origins().contains(it.by()));
             // A cut where the classes are runs of values, and the classes themselves where they
             // are sets: one value singled out of a string is a set of that value, so what carries
             // it is whichever vocabulary the position's classes came out in. Asked of the cuts
             // alone, a position whose classes composed it would be reported as having lost it.
-            case PartitionEvidence.Singles it ->
+            case RuleEvidence.Singles it ->
                     axis.divides().contains(it.by())
                             || axis.cuts().stream()
                                     .anyMatch(each -> each.origins().contains(it.by()));
@@ -232,7 +232,7 @@ final class EvidenceAccount {
 
     /** That this stage said what became of everything it was handed. */
     private void everyPieceWasDisposedOf() {
-        List<PartitionEvidence.FiledEvidenceId> lost = owed.keySet().stream()
+        List<RuleEvidence.FiledEvidenceId> lost = owed.keySet().stream()
                 .filter(each -> !answered.containsKey(each)).toList();
         if (!lost.isEmpty()) {
             throw new IllegalStateException(
@@ -240,7 +240,7 @@ final class EvidenceAccount {
                             + " — a measure reported as complete over evidence that went missing"
                             + " is what this account exists to refuse");
         }
-        List<PartitionEvidence.FiledEvidenceId> strangers = answered.keySet().stream()
+        List<RuleEvidence.FiledEvidenceId> strangers = answered.keySet().stream()
                 .filter(each -> !owed.containsKey(each)).toList();
         if (!strangers.isEmpty()) {
             throw new IllegalStateException(

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -70,7 +70,7 @@ public final class GuardThresholds {
      * {@code c} on the low side and are two different rules about it — so it is read where the
      * operator is still in hand, and which values arrive is asked of the reading of the whole body.
      */
-    public record Guards(List<PartitionEvidence> evidence,
+    public record Guards(List<RuleEvidence> evidence,
                          RulesWithNoLine noLine,
                          List<LineDrawn> between,
                          ReachingCuts reaching) {
@@ -86,12 +86,12 @@ public final class GuardThresholds {
         /** The lines, read off what the walk said. Not a list of their own: the walk met these and
          *  the values it singled out in one order, and holding two lists loses it. */
         public List<Threshold> thresholds() {
-            return PartitionEvidence.linesIn(evidence);
+            return RuleEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<Singled> singled() {
-            return PartitionEvidence.pointsIn(evidence);
+            return RuleEvidence.pointsIn(evidence);
         }
 
         /**
@@ -147,7 +147,7 @@ public final class GuardThresholds {
                             souther.compiler.check.ElementBindings elements,
                             souther.compiler.check.PathReachability.Answers arrives) {
         InputDomain inputs = read.domain();
-        List<PartitionEvidence> found = new ArrayList<>();
+        List<RuleEvidence> found = new ArrayList<>();
         RulesWithNoLine.Gathered withoutALine = new RulesWithNoLine.Gathered();
         List<LineDrawn> between = new ArrayList<>();
         // One reading of the body, and everything below is that reading asked something. Where a
@@ -422,7 +422,7 @@ public final class GuardThresholds {
     private static void lineAt(ComparisonCatalog.Catalogued each,
                                CoverageSites.Plan plan,
                                ComparisonAssessment read,
-                               List<PartitionEvidence> out,
+                               List<RuleEvidence> out,
                                List<LineDrawn> between,
                                RulesWithNoLine.Gathered withoutALine) {
         publish(each, read, withoutALine);
@@ -442,11 +442,11 @@ public final class GuardThresholds {
                     // here — the position is divided all the same, and what divides it is the line.
                     case ComparisonClaim.Singled _ -> {
                         if (at.value() != null) {
-                            out.add(new PartitionEvidence.Singles(
+                            out.add(new RuleEvidence.Singles(
                                     new Guards.Singled(at.position(), at.value(), origin)));
                         }
                     }
-                    case ComparisonClaim.Cut order -> out.add(new PartitionEvidence.Divides(
+                    case ComparisonClaim.Cut order -> out.add(new RuleEvidence.Divides(
                             new Threshold(at.position(), at.cutting().seam(),
                                     order.valueBelongs(), origin)));
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -4,7 +4,6 @@ import souther.compiler.check.ComparisonClaim;
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.numeric.Towards;
-import souther.compiler.reading.Condition;
 import souther.compiler.reading.Factor;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.Outcome;
@@ -370,9 +369,9 @@ public final class InteractionCells {
     }
 
     /** What {@code holds} leaves open, or null where any of it narrows nothing or narrows it away. */
-    private static Cell narrowedBy(List<Condition> holds, List<Axis> axes) {
+    private static Cell narrowedBy(List<souther.compiler.reading.Condition> holds, List<Axis> axes) {
         Cell cell = Cell.anything(axes);
-        for (Condition each : holds) {
+        for (souther.compiler.reading.Condition each : holds) {
             Cell said = admittedBy(each, axes);
             if (said == null) {
                 return null;
@@ -395,9 +394,9 @@ public final class InteractionCells {
     }
 
     /** Which classes {@code condition} leaves its position, or null where it names none. */
-    private static Cell admittedBy(Condition condition, List<Axis> axes) {
+    private static Cell admittedBy(souther.compiler.reading.Condition condition, List<Axis> axes) {
         switch (condition) {
-            case Condition.Case one -> {
+            case souther.compiler.reading.Condition.Case one -> {
                 int axis = axisAt(axes, one.at());
                 if (axis < 0) {
                     return null;
@@ -410,7 +409,7 @@ public final class InteractionCells {
                 }
                 return null;
             }
-            case Condition.Side one -> {
+            case souther.compiler.reading.Condition.Side one -> {
                 int axis = axisOf(axes, one.at());
                 if (axis < 0) {
                     return null;
@@ -449,7 +448,7 @@ public final class InteractionCells {
                 return wantedIsUp ? only(axes, axis, edge, last) : only(axes, axis, 0, edge);
             }
             // A fork this reading could not name a position for narrows nothing.
-            case Condition.Arm ignored -> {
+            case souther.compiler.reading.Condition.Arm ignored -> {
                 return null;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -18,8 +18,8 @@ import java.util.List;
  * the rule placed on the values either side of what it wrote, which of its lines this is, which
  * point a row against it stands at, what a declaration is owed for it. So a rule that divides a
  * position without drawing a line is not one of these — it is the other kind of reading a piece of
- * partition evidence carries ({@link PredicateOrigin}), and what the two share is identity alone
- * ({@link PartitionEvidenceOrigin}). Named for neither, this type was one a predicate looked as
+ * rule evidence carries ({@link PredicateOrigin}), and what the two share is identity alone
+ * ({@link RuleEvidenceOrigin}). Named for neither, this type was one a predicate looked as
  * though it belonged in, and putting one here would have made the line's answers total over a
  * reading that has no line.
  *
@@ -40,7 +40,7 @@ import java.util.List;
  * they merge into one partition while staying separate obligations. Reaching the boundary through one
  * guard says nothing about the other.
  */
-public sealed interface LineOrigin extends PartitionEvidenceOrigin {
+public sealed interface LineOrigin extends RuleEvidenceOrigin {
 
     /**
      * A clause of a {@code data}'s invariant, as the clause it is.

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -56,7 +56,7 @@ public final class LinesWhereTheyFall {
      * place nobody meant and a reason nobody established. So it comes back as a finding naming the
      * rule, and a reader is told what actually happened to it.
      */
-    public record Filed(List<PartitionEvidence> evidence, List<ClassingBlocker> blocked,
+    public record Filed(List<RuleEvidence> evidence, List<ClassingBlocker> blocked,
                         List<LineDrawn> between,
                         RulesWithNoLine notPlaced) {
 
@@ -69,27 +69,27 @@ public final class LinesWhereTheyFall {
         /** The lines, for a reader that wants only those. Read off the one list and not kept
          *  beside it. */
         public List<Threshold> thresholds() {
-            return PartitionEvidence.linesIn(evidence);
+            return RuleEvidence.linesIn(evidence);
         }
 
         /** The values singled out, likewise. */
         public List<GuardThresholds.Guards.Singled> singled() {
-            return PartitionEvidence.pointsIn(evidence);
+            return RuleEvidence.pointsIn(evidence);
         }
     }
 
     /** Every measurement where its name was filed, and the lines this had nowhere to put. */
-    public static Filed of(InputReading read, List<PartitionEvidence> evidence,
+    public static Filed of(InputReading read, List<RuleEvidence> evidence,
                            List<ClassingBlocker> blocked, List<LineDrawn> between) {
         InputDomain inputs = read.domain();
         Symbols symbols = read.symbols();
-        List<PartitionEvidence> out = new ArrayList<>();
+        List<RuleEvidence> out = new ArrayList<>();
         List<LineDrawn> outBetween = new ArrayList<>();
         RulesWithNoLine.Gathered notPlaced = new RulesWithNoLine.Gathered();
         // One pass in the order the rules were read, so what comes out is in that order too. A pass
         // per kind of thing a rule can say puts every range before every equality, whatever order a
         // body wrote them in, and every reader downstream takes the numbers in that order.
-        for (PartitionEvidence each : evidence) {
+        for (RuleEvidence each : evidence) {
             // Every number the name stands at, filed together. Filing is one rule to as many
             // positions as its name reaches, so a piece put out one part at a time can leave the
             // others behind — and the account that runs after this begins with what comes out of
@@ -134,7 +134,7 @@ public final class LinesWhereTheyFall {
      * so a move that left the number answered by no single place would be this compiler
      * contradicting the reading that produced the evidence.
      */
-    private static PartitionEvidence measuredAt(PartitionEvidence evidence, NumericTerm at) {
+    private static RuleEvidence measuredAt(RuleEvidence evidence, NumericTerm at) {
         NumericTerm.FromOnePosition here = at.atOnePosition();
         if (here == null) {
             throw new IllegalStateException(
@@ -142,15 +142,15 @@ public final class LinesWhereTheyFall {
                             + "`, which no single position answers");
         }
         return switch (evidence) {
-            case PartitionEvidence.Divides(Threshold line) ->
-                    new PartitionEvidence.Divides(thresholdAt(line, here));
-            case PartitionEvidence.Singles(GuardThresholds.Guards.Singled point) ->
-                    new PartitionEvidence.Singles(singledAt(point, here));
+            case RuleEvidence.Divides(Threshold line) ->
+                    new RuleEvidence.Divides(thresholdAt(line, here));
+            case RuleEvidence.Singles(GuardThresholds.Guards.Singled point) ->
+                    new RuleEvidence.Singles(singledAt(point, here));
             // The values are the position's own, so moving the division moves where it is measured
             // and nothing else. What each side holds was worked out where the rule was read, and a
             // filing that worked them out again would be a second answer about one rule.
-            case PartitionEvidence.BySet(SetStatement division) ->
-                    new PartitionEvidence.BySet(new SetStatement(here, division.whenTrue(),
+            case RuleEvidence.BySet(SetStatement division) ->
+                    new RuleEvidence.BySet(new SetStatement(here, division.whenTrue(),
                             division.whenFalse(), division.statement(), division.origin()));
         };
     }
@@ -251,7 +251,7 @@ public final class LinesWhereTheyFall {
      */
     private static WhereTheNameStands standingOf(InputDomain inputs, NumericTerm term,
                                                  Symbols symbols,
-                                                 PartitionEvidenceOrigin origin) {
+                                                 RuleEvidenceOrigin origin) {
         TermPath path = term.subjectPath();
         if (inputs.at(path) != null) {
             return new WhereTheNameStands.AsWritten(term);

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -129,17 +129,17 @@ public final class LinesWhereTheyFall {
     /**
      * The same piece of evidence, measured at {@code at}.
      *
-     * <p>Evidence divides a position, so the number it moved to answers one. What a name is filed
-     * at is a field of a value and a term is taken at it the way it was taken where it was written,
-     * so a move that left the number answered by no single place would be this compiler
-     * contradicting the reading that produced the evidence.
+     * <p>What a rule states is about one position's values, so the number it moved to answers one.
+     * What a name is filed at is a field of a value and a term is taken at it the way it was taken
+     * where it was written, so a move that left the number answered by no single place would be
+     * this compiler contradicting the reading that produced the evidence.
      */
     private static RuleEvidence measuredAt(RuleEvidence evidence, NumericTerm at) {
         NumericTerm.FromOnePosition here = at.atOnePosition();
         if (here == null) {
             throw new IllegalStateException(
-                    "`" + evidence.at() + "` divides a position and was filed at `" + at
-                            + "`, which no single position answers");
+                    "`" + evidence.at() + "` is what a rule states about one position and was filed"
+                            + " at `" + at + "`, which no single position answers");
         }
         return switch (evidence) {
             case RuleEvidence.Divides(Threshold line) ->

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -516,13 +516,13 @@ public final class Partitions {
      * are in the order an author wrote them.
      */
     private static List<NumericTerm.FromOnePosition> numbersMeasuring(
-            PositionMeasurements at, List<PartitionEvidence> evidence,
+            PositionMeasurements at, List<RuleEvidence> evidence,
             List<ClassingBlocker> blocked, EvidenceAccount account) {
         TermPath path = at.position().path();
-        List<PartitionEvidence> here = evidence.stream()
+        List<RuleEvidence> here = evidence.stream()
                 .filter(each -> each.at().position().equals(path)).toList();
         List<NumericTerm.FromOnePosition> numbers = new ArrayList<>();
-        for (PartitionEvidence each : here) {
+        for (RuleEvidence each : here) {
             if (!numbers.contains(each.at())) {
                 numbers.add(each.at());
             }
@@ -558,7 +558,7 @@ public final class Partitions {
      * route through this would be a second answer to what a rule about a number comes to.
      */
     private static BodyCutInspection measureAt(List<Axis> out, PositionMeasurements at, Axis axis,
-                                  NumericTerm.FromOnePosition term, List<PartitionEvidence> evidence,
+                                  NumericTerm.FromOnePosition term, List<RuleEvidence> evidence,
                                   List<ClassingBlocker> blocked,
                                   Quantities reading, RuleReadingSource ruleSource,
                                   ReadingPolicy policy,
@@ -571,10 +571,10 @@ public final class Partitions {
         // evidence said to be measured here and the measure it was measured at are one name.
         AxisId id = AxisId.of(behavior, term);
         Type type = at.position().type();
-        List<PartitionEvidence> mine = evidence.stream()
+        List<RuleEvidence> mine = evidence.stream()
                 .filter(each -> each.at().equals(term)).toList();
-        List<Threshold> here = PartitionEvidence.linesIn(mine);
-        List<GuardThresholds.Guards.Singled> points = PartitionEvidence.pointsIn(mine);
+        List<Threshold> here = RuleEvidence.linesIn(mine);
+        List<GuardThresholds.Guards.Singled> points = RuleEvidence.pointsIn(mine);
         // What this term's values can be, which is the type's bound already narrowed by whatever
         // the record it sits in says about it. Reading the type again here would put a threshold
         // back inside a range the record has no values in.
@@ -606,7 +606,7 @@ public final class Partitions {
                 // axis they are on; a line and a value singled out are measured by the walk below,
                 // which is where what they leave is worked out.
                 case DIVIDED -> {
-                    if (each.what() instanceof PartitionEvidence.BySet) {
+                    if (each.what() instanceof RuleEvidence.BySet) {
                         account.measured(each.what(), id);
                     }
                 }
@@ -631,13 +631,13 @@ public final class Partitions {
         // The answer's own population, and not what is left after taking the rest away. Subtracted
         // here, the same question is answered twice — and the day the two subtract differently the
         // classes are composed out of one list and recorded as composed out of another.
-        List<PartitionEvidence> dividing = answered.dividing();
+        List<RuleEvidence> dividing = answered.dividing();
         // And what the walk below still reads, which is not the same list. Only the classes turn on
         // whether they composed: where they did not, the lines a rule drew are still lines and the
         // places it parts the position are still places, so the walk runs over everything that
         // reached here but the rules proved to tell nothing apart — those state nothing, and a line
         // read off one would be a line the model does not draw.
-        List<PartitionEvidence> taken = answered.forEach().stream()
+        List<RuleEvidence> taken = answered.forEach().stream()
                 .filter(each -> each.outcome() == Classing.Outcome.LEFT_TO_THE_WALK
                         || each.outcome() == Classing.Outcome.DIVIDED)
                 .map(Classing.Disposed::what).toList();
@@ -669,7 +669,7 @@ public final class Partitions {
         // what a reader is told is assembled once, after every position has been measured, so a
         // finding kept here would be one nobody reads.
         if (made.why() != null && blocked.isEmpty()) {
-            PartitionEvidence.statementsIn(answered.notComposed())
+            RuleEvidence.statementsIn(answered.notComposed())
                     .forEach(each -> found.add(RuleWithoutALine.of(each.origin().rule(),
                             each.origin().cited(),
                             new FilingCoordinate.AtPosition(term.position()), made.why())));
@@ -682,7 +682,7 @@ public final class Partitions {
             // Nothing orders this position, so its classes are the values singled out and
             // everything else. Ranges here would ask the rows for a distinction between the two
             // sides of a value the behavior treats alike.
-            taken.stream().filter(each -> !(each instanceof PartitionEvidence.BySet))
+            taken.stream().filter(each -> !(each instanceof RuleEvidence.BySet))
                     .forEach(each -> account.measured(each, id));
             return made(out, at, behavior, term,
                     made.classesFor(axis, () -> singledClasses(points, term, type, reading,
@@ -703,11 +703,11 @@ public final class Partitions {
         // which is the thing being fixed here happening again one field over. The end the
         // position stops short of is outside it as much as anything past it is.
         List<Threshold> reachable = new ArrayList<>();
-        for (PartitionEvidence each : taken) {
-            if (each instanceof PartitionEvidence.BySet) {
+        for (RuleEvidence each : taken) {
+            if (each instanceof RuleEvidence.BySet) {
                 continue;   // already answered for above, as a class the vocabularies will not hold
             }
-            if (!(each instanceof PartitionEvidence.Divides(Threshold line))) {
+            if (!(each instanceof RuleEvidence.Divides(Threshold line))) {
                 // A value singled out beside an ordering. The model has drawn the further
                 // distinction itself, so the value is one more line among the ranges and it is
                 // merged with them below.
@@ -772,7 +772,7 @@ public final class Partitions {
     private static BodyCutInspection made(List<Axis> out, PositionMeasurements at, String behavior,
                                           NumericTerm.FromOnePosition term,
                                           List<PartitionClass> classes,
-                                          List<PartitionEvidenceOrigin> divides, List<Cut> cuts,
+                                          List<RuleEvidenceOrigin> divides, List<Cut> cuts,
                                           List<Parting> parted, NarrowedBounds narrowed,
                                           BodyCutInspection drew, RulesWithNoLine rules) {
         if (classes.isEmpty() && cuts.isEmpty() && parted.isEmpty()) {
@@ -819,7 +819,7 @@ public final class Partitions {
      *                  a place on the order and a set class has no answer to where it lies
      * @param why       what stopped the classes, or null where nothing did
      */
-    private record Composition(List<PartitionClass> classes, List<PartitionEvidenceOrigin> divides,
+    private record Composition(List<PartitionClass> classes, List<RuleEvidenceOrigin> divides,
                                boolean keepsCuts, BlockReason.RuleWithoutLineReason why) {
 
         /** The order is the vocabulary, so the run of classes the caller works out is the answer. */
@@ -852,8 +852,8 @@ public final class Partitions {
     }
 
     /** Which rules the classes were composed out of, which is every distinction that went in. */
-    private static List<PartitionEvidenceOrigin> composedFrom(List<PartitionEvidence> mine) {
-        return mine.stream().map(PartitionEvidence::by).toList();
+    private static List<RuleEvidenceOrigin> composedFrom(List<RuleEvidence> mine) {
+        return mine.stream().map(RuleEvidence::by).toList();
     }
 
     /** The lines already cut on the number, of which there are none where nothing measured it. */
@@ -969,9 +969,9 @@ public final class Partitions {
                                        List<LineDrawn> between,
                                        ReachingCuts reaching,
                                        Allowance<NumericTerm.FromOnePosition> allowance) {
-        List<PartitionEvidence> evidence = new ArrayList<>();
-        thresholds.forEach(each -> evidence.add(new PartitionEvidence.Divides(each)));
-        singled.forEach(each -> evidence.add(new PartitionEvidence.Singles(each)));
+        List<RuleEvidence> evidence = new ArrayList<>();
+        thresholds.forEach(each -> evidence.add(new RuleEvidence.Divides(each)));
+        singled.forEach(each -> evidence.add(new RuleEvidence.Singles(each)));
         // Nothing here tells a set of the position's values from the rest, so nothing composes one
         // and the allowance for composing them is never asked for a machine. It is still handed in
         // rather than made: an allowance is what a compilation's grant becomes, and one made here
@@ -992,7 +992,7 @@ public final class Partitions {
      */
     public static Partitioning withEvidence(Partitioning base,
                                             Quantities reading,
-                                            List<PartitionEvidence> evidence,
+                                            List<RuleEvidence> evidence,
                                             List<ClassingBlocker> blocked,
                                             Allowance<NumericTerm.FromOnePosition> allowance,
                                             RuleReadingSource ruleSource, ReadingPolicy policy,

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
@@ -29,7 +29,7 @@ import souther.compiler.check.RuleRef;
  */
 public record PredicateOrigin(RuleRef.Predicate rule, PredicateOccurrence occurrence,
                               RuleCitation.WrittenAt written)
-        implements PartitionEvidenceOrigin {
+        implements RuleEvidenceOrigin {
 
     public PredicateOrigin {
         if (rule == null || occurrence == null || written == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -4,7 +4,6 @@ import souther.compiler.core.Core;
 import souther.compiler.check.PathReachability;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.reach.Reachability;
 import souther.compiler.types.SourceConstructOrigin;
 import souther.compiler.types.TypeSymbol;
 
@@ -133,7 +132,7 @@ public final class ProducedCases {
                                 PathReachability.Answers arrives,
                                 Set<TypeSymbol> declared, Seen seen) {
         boolean proven = under.stream().anyMatch(arm ->
-                arrives.at(arm) instanceof Reachability.Unreachable);
+                arrives.at(arm) instanceof souther.compiler.reach.Reachability.Unreachable);
         if (built == null || !declared.contains(built)) {
             // Not a case this can name. Reachable, it could be any of them and nothing is taken away;
             // behind a proven arm it answers nothing and says nothing about any case either.

--- a/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidence.java
@@ -30,14 +30,14 @@ import souther.compiler.inputs.NumericTerm;
  * filed at each of those positions, and what the partition is owed is each of them. The identity of
  * a filed one is {@link #id}, which is that expansion's answer and not this reading's.
  */
-public sealed interface PartitionEvidence {
+public sealed interface RuleEvidence {
 
     /** The position this is about, which one position answers: evidence divides a position, and
      *  something no single place answers divides none. */
     NumericTerm.FromOnePosition at();
 
     /** The rule that said it, and which reading of it this is. */
-    PartitionEvidenceOrigin by();
+    RuleEvidenceOrigin by();
 
     /**
      * What tells one filed piece of evidence from another, once it has been filed.
@@ -52,7 +52,7 @@ public sealed interface PartitionEvidence {
     }
 
     /** Where a run of the position's values ends and the next begins. */
-    record Divides(Threshold line) implements PartitionEvidence {
+    record Divides(Threshold line) implements RuleEvidence {
 
         @Override
         public NumericTerm.FromOnePosition at() {
@@ -72,7 +72,7 @@ public sealed interface PartitionEvidence {
      * distinguishes is the value from every other value, and reading it as a place to cut would put
      * a distinction between the two sides into a partition the model never drew.
      */
-    record Singles(GuardThresholds.Guards.Singled point) implements PartitionEvidence {
+    record Singles(GuardThresholds.Guards.Singled point) implements RuleEvidence {
 
         @Override
         public NumericTerm.FromOnePosition at() {
@@ -93,7 +93,7 @@ public sealed interface PartitionEvidence {
      * of anything. Read as a line it would be a cut at a value the model never named, and read as a
      * single value it would be one value standing for a set.
      */
-    record BySet(SetStatement states) implements PartitionEvidence {
+    record BySet(SetStatement states) implements RuleEvidence {
 
         @Override
         public NumericTerm.FromOnePosition at() {
@@ -108,7 +108,7 @@ public sealed interface PartitionEvidence {
 
     /** What one filed piece of evidence is called: the rule that said it and the position it was
      *  filed at. Not a count of how many times anything reached it. */
-    record FiledEvidenceId(PartitionEvidenceOrigin by, NumericTerm.FromOnePosition at) {}
+    record FiledEvidenceId(RuleEvidenceOrigin by, NumericTerm.FromOnePosition at) {}
 
     /**
      * The lines among {@code evidence}, for a reader that wants only those.
@@ -116,20 +116,20 @@ public sealed interface PartitionEvidence {
      * <p>Here and not at each holder of a list. Four of them wanted the same two projections and
      * each wrote its own, which is four places to answer the day a third variant is written.
      */
-    static java.util.List<Threshold> linesIn(java.util.List<PartitionEvidence> evidence) {
+    static java.util.List<Threshold> linesIn(java.util.List<RuleEvidence> evidence) {
         return evidence.stream().filter(Divides.class::isInstance)
                 .map(each -> ((Divides) each).line()).toList();
     }
 
     /** The values singled out among {@code evidence}, likewise. */
     static java.util.List<GuardThresholds.Guards.Singled> pointsIn(
-            java.util.List<PartitionEvidence> evidence) {
+            java.util.List<RuleEvidence> evidence) {
         return evidence.stream().filter(Singles.class::isInstance)
                 .map(each -> ((Singles) each).point()).toList();
     }
 
     /** What the rules state as sets among {@code evidence}, likewise. */
-    static java.util.List<SetStatement> statementsIn(java.util.List<PartitionEvidence> evidence) {
+    static java.util.List<SetStatement> statementsIn(java.util.List<RuleEvidence> evidence) {
         return evidence.stream().filter(BySet.class::isInstance)
                 .map(each -> ((BySet) each).states()).toList();
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidence.java
@@ -32,8 +32,15 @@ import souther.compiler.inputs.NumericTerm;
  */
 public sealed interface RuleEvidence {
 
-    /** The position this is about, which one position answers: evidence divides a position, and
-     *  something no single place answers divides none. */
+    /**
+     * The position whose values the rule says something about.
+     *
+     * <p>One position and not several, because that is what a statement of this kind has a subject
+     * at: what the rule states is true of the values standing at one place, and a rule relating two
+     * places states nothing about either one's values on its own. Whether the position holds values
+     * on both sides of what is said — whether it is divided by it — is a fact about those values and
+     * is settled where they are known ({@link Classing}).
+     */
     NumericTerm.FromOnePosition at();
 
     /** The rule that said it, and which reading of it this is. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidenceOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RuleEvidenceOrigin.java
@@ -30,7 +30,7 @@ import souther.compiler.check.RuleRef;
  * which each kind holds its own answer to — so an account keyed by {@link #rule()} would close on
  * the first reading everything the rest were owed.
  */
-public sealed interface PartitionEvidenceOrigin permits LineOrigin, PredicateOrigin {
+public sealed interface RuleEvidenceOrigin permits LineOrigin, PredicateOrigin {
 
     /**
      * Which rule of the model this is a reading of.

--- a/souther-compiler/src/main/java/souther/compiler/query/Compositions.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compositions.java
@@ -6,7 +6,6 @@ import souther.compiler.check.PipelineSigs;
 import souther.compiler.check.Sig;
 import souther.compiler.check.DerivedSymbols;
 import souther.compiler.check.Unanswerable;
-import souther.compiler.core.Composition;
 import souther.compiler.types.ValueName;
 
 import java.util.LinkedHashMap;
@@ -29,7 +28,7 @@ public final class Compositions {
     private Compositions() {}
 
     /** Every composed behavior this module declares, by the name it is reached by. */
-    public record Of(String name) implements Key<Map<ValueName.Behavior, Composition>> {
+    public record Of(String name) implements Key<Map<ValueName.Behavior, souther.compiler.core.Composition>> {
 
         @Override
         public String module() {
@@ -37,7 +36,7 @@ public final class Compositions {
         }
 
         @Override
-        public Answer<Map<ValueName.Behavior, Composition>> compute(Db db) {
+        public Answer<Map<ValueName.Behavior, souther.compiler.core.Composition>> compute(Db db) {
             Answer<Lower.Lowered> lowering = db.ask(new Bodies.Lowering(name));
             Answer<Map<ValueName.Behavior, Sig>> sigs = db.ask(new Bodies.Reachable(name));
             Answer<DerivedSymbols> scope = Names.derivedSymbols(db, name);
@@ -46,7 +45,7 @@ public final class Compositions {
             }
             Hir.Module module = lowering.value().lowered();
             Map<ValueName.Behavior, List<Hir.Var>> stages = PipelineSigs.pipelineStages(module);
-            Map<ValueName.Behavior, Composition> out = new LinkedHashMap<>();
+            Map<ValueName.Behavior, souther.compiler.core.Composition> out = new LinkedHashMap<>();
             for (Hir.BehaviorDef behavior : module.behaviors()) {
                 if (behavior instanceof Hir.PipeBehavior pipe) {
                     try {

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest.java
@@ -6,7 +6,6 @@ import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.PlannedValues;
 
 import org.junit.jupiter.api.Test;
@@ -58,7 +57,7 @@ class ADeadChoiceLeavesNoLanguageAnsweringForABranchThatStandsTest {
                                                     OrderedInterval afterwards) {
         Confinement.Planned<String> dead = refusedByItsValues(left).bothDead(
                 refusedByItsValues(right),
-                Confinement.Admission.left(Emptiness.EMPTY));
+                Confinement.Admission.left(souther.compiler.values.Emptiness.EMPTY));
         Confinement.Planned<String> met = dead.meet(new Confinement.Planned<>(
                 PlannedValues.top(), OrderedIntervals.at(POSITION, afterwards), Map.of()));
         return met.resolve(SETS).holdingNothing();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest.java
@@ -7,7 +7,6 @@ import souther.compiler.regex.Meter;
 import souther.compiler.regex.PatternPlan;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.ValueSet;
 
 import java.io.File;
@@ -106,9 +105,9 @@ class WhatDecidesWhetherAValueExistsHoldsBothLanguagesTest {
                 "a carrier this could not make is one the answer below is not asked of");
         for (Carrier each : carriers) {
             Meter meter = PatternPlan.Budget.OF_WHAT_A_SET_AND_A_RANGE_SHARE.meter();
-            assertEquals(Emptiness.NONEMPTY, each.meets(ValueSet.ANY, each.extent(), meter),
+            assertEquals(souther.compiler.values.Emptiness.NONEMPTY, each.meets(ValueSet.ANY, each.extent(), meter),
                     each + " holds values, and every one of them is admitted");
-            assertEquals(Emptiness.EMPTY, each.meets(ValueSet.NONE, each.extent(), meter),
+            assertEquals(souther.compiler.values.Emptiness.EMPTY, each.meets(ValueSet.NONE, each.extent(), meter),
                     each + " holds no value a rule admitting none allows");
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest.java
@@ -8,7 +8,6 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
-import souther.compiler.reach.Reachability;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.TypeSymbol;
@@ -92,7 +91,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
 
     @Test
     void aRefusedMatchArmLeavesTheCaseItAnswersWithOwed() {
-        assertEquals(Reachability.Unreachable.class,
+        assertEquals(souther.compiler.reach.Reachability.Unreachable.class,
                 armThatIsRefused(REFUSED_CASE, SourceConstruct.MATCH).getClass(),
                 "the arm for the case the rules refuse is proven unreachable");
         assertEquals(Set.of("example.refused.Yes", "example.refused.No"),
@@ -103,7 +102,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
 
     @Test
     void anArmNothingReachesTakesTheCaseOnlyItAnswersWith() {
-        assertEquals(Reachability.Unreachable.class,
+        assertEquals(souther.compiler.reach.Reachability.Unreachable.class,
                 armThatIsRefused(REFUSED_CONDITION, SourceConstruct.IF).getClass(),
                 "the arm the condition cannot come out into is proven unreachable");
         assertEquals(List.of("example.capped.Yes"), declaredOutputCasesOf(REFUSED_CONDITION).stream()
@@ -135,7 +134,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
         Set<TypeSymbol> answersWith = casesNamedIn(body);
 
         ControlPointId.ArmOccurrence refused = arrives.found().entrySet().stream()
-                .filter(each -> each.getValue() instanceof Reachability.Unreachable)
+                .filter(each -> each.getValue() instanceof souther.compiler.reach.Reachability.Unreachable)
                 .map(Map.Entry::getKey)
                 .filter(ControlPointId.ArmOccurrence.class::isInstance)
                 .map(ControlPointId.ArmOccurrence.class::cast)
@@ -185,7 +184,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
     private static PathReachability.Answers arrivalsWith(PathReachability.Answers answers,
                                                          ControlPointId.ArmOccurrence was,
                                                          ControlPointId.ArmOccurrence now) {
-        Map<ControlPointId, Reachability> found = new LinkedHashMap<>();
+        Map<ControlPointId, souther.compiler.reach.Reachability> found = new LinkedHashMap<>();
         answers.found().forEach((where, said) -> found.put(where.equals(was) ? now : where, said));
         return new PathReachability.Answers(found, answers.arriving());
     }
@@ -218,7 +217,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
     }
 
     /** What the reading says about the one arm of {@code kind} it proves nothing arrives at. */
-    private static Reachability armThatIsRefused(String model, SourceConstruct kind) {
+    private static souther.compiler.reach.Reachability armThatIsRefused(String model, SourceConstruct kind) {
         Compilation compilation = compiled(model);
         Map<String, PathReachability.Answers> answers = compilation.db()
                 .ask(new Adequacy.PathReached(compilation.modules().get(0))).value();
@@ -226,7 +225,7 @@ class AProofAboutAMatchArmSaysNothingAboutWhatIsAnsweredWithTest {
                 .filter(each -> each.getKey() instanceof ControlPointId.ArmOccurrence arm
                         && arm.origin().kind() == kind)
                 .map(Map.Entry::getValue)
-                .filter(Reachability.Unreachable.class::isInstance)
+                .filter(souther.compiler.reach.Reachability.Unreachable.class::isInstance)
                 .findFirst().orElseThrow(() ->
                         new AssertionError("no arm of a " + kind + " is proven unreachable"));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -46,8 +46,8 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
      */
     @Test
     void twoPiecesOfEvidenceUnderOneNameAreRefusedWhereTheyAreHandedOver() {
-        PartitionEvidence one = dividing("10");
-        PartitionEvidence other = dividing("20");
+        RuleEvidence one = dividing("10");
+        RuleEvidence other = dividing("20");
         assertEquals(one.id(), other.id(), "the same rule and the same number");
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
@@ -65,7 +65,7 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
      */
     @Test
     void onePieceHandedOverTwiceIsOnePiece() {
-        PartitionEvidence one = dividing("10");
+        RuleEvidence one = dividing("10");
 
         EvidenceAccount account = new EvidenceAccount(List.of(one, one), List.of());
         account.measured(one, new AxisId("f", AT.toString()));
@@ -87,8 +87,8 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
         assertTrue(refused.getMessage().contains("under the name of"), refused.getMessage());
     }
 
-    private static PartitionEvidence dividing(String at) {
-        return new PartitionEvidence.Divides(new Threshold(AT,
+    private static RuleEvidence dividing(String at) {
+        return new RuleEvidence.Divides(new Threshold(AT,
                 Seam.of(LevelSpace.onACarrier(new Carrier.Whole()),
                         new Level.OnACarrier(new Carrier.Whole(),
                                 new Count(new java.math.BigDecimal(at))),

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest.java
@@ -86,7 +86,7 @@ class WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest {
 
         assertEquals(List.of(), read.blocked(), "both rules divide the position");
         assertEquals(2, read.statements().size(), "and each of them is a division of it");
-        assertEquals(1, read.statements().stream().map(PartitionEvidence::at).distinct().count(),
+        assertEquals(1, read.statements().stream().map(RuleEvidence::at).distinct().count(),
                 "of the one position both are written about");
     }
 
@@ -133,7 +133,7 @@ class WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest {
 
         assertEquals(List.of(), read.blocked(), "both rules divide the position");
         assertEquals(2, read.statements().size(), "and each of them is a division of it");
-        assertEquals(1, read.statements().stream().map(PartitionEvidence::at).distinct().count(),
+        assertEquals(1, read.statements().stream().map(RuleEvidence::at).distinct().count(),
                 "of the one position both are written about");
     }
 
@@ -291,7 +291,7 @@ class WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest {
                 // A position whose own declarations leave it a language, which is what an
                 // `invariant String.matches(...)` leaves. Meeting a rule with it is machine work,
                 // and that is the work this allowance cannot afford.
-                ((PartitionEvidence.BySet) read.statements().get(0)).states().whenTrue(),
+                ((RuleEvidence.BySet) read.statements().get(0)).states().whenTrue(),
                 spent, place -> null);
 
         assertInstanceOf(Classing.Classed.NotComposed.class, answered.classed(),
@@ -304,7 +304,7 @@ class WhatABehaviorsRuleAboutItsStringsDividesAPositionIntoTest {
     /** The one division the model under test states. */
     private static SetStatement divisionIn(BehaviorSetStatements.Read read) {
         assertEquals(1, read.statements().size(), "the model under test states one division");
-        return ((PartitionEvidence.BySet) read.statements().get(0)).states();
+        return ((RuleEvidence.BySet) read.statements().get(0)).states();
     }
 
     private static BehaviorSetStatements.Read readingsOf(String behavior) {

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -139,13 +139,32 @@ public final class RepositoryLayout {
     public List<Path> mainTrees(String kind) {
         List<Path> out = new ArrayList<>();
         for (Path module : modules) {
-            Path tree = module.resolve("src").resolve("main").resolve(kind);
-            if (Files.isDirectory(tree)) {
+            Path tree = treeOf(module, "main", kind);
+            if (tree != null) {
                 out.add(tree);
             }
         }
         out.sort(Path::compareTo);
         return List.copyOf(out);
+    }
+
+    /**
+     * The {@code src/<phase>/java} of {@code module}, or null where it has none.
+     *
+     * <p>The roots the compiler is handed apart, which is what a check that reads sources for what
+     * a name means has to keep apart too. A name written in a test source resolves against that
+     * module's test root and its main root; one written in a main source resolves against the main
+     * root alone, whatever the tests beside it declare. Read off a path instead, which root a
+     * source is under is worked out by whoever asks and the answer is a spelling.
+     */
+    public Path javaTreeOf(Path module, String phase) {
+        return treeOf(module, phase, "java");
+    }
+
+    /** Where a module keeps one kind of source, or null where it keeps none of that kind. */
+    private static Path treeOf(Path module, String phase, String kind) {
+        Path tree = module.resolve("src").resolve(phase).resolve(kind);
+        return Files.isDirectory(tree) ? tree : null;
     }
 
     /**


### PR DESCRIPTION
Closes #1378.

`partition.PartitionEvidence` and `query.PartitionEvidence` answered two questions under one word. The first is one thing a rule of the model states about a position's values; the second is what a behavior's rows reach of the distinctions its model draws. Neither is a projection of the other.

## The name

The query name stays. It is one of the measures a `BehaviorEvidence` holds, beside the signature's and the branch's, and `Partition` is the word that tells those apart. On the other side `Partition` is the package the type sits in and says nothing more, while `Evidence` is the vocabulary its neighbours are written in — an origin, an account, a disposition of one piece. So:

    partition.PartitionEvidence       -> RuleEvidence
    partition.PartitionEvidenceOrigin -> RuleEvidenceOrigin

## What kept it from being noticed

`SameNameButDifferent` refuses a compilation unit that means two things by one name, and the way out it leaves is a fully qualified name at the use. There is a second way out that it does not see: a single import wins over the package a file is in, so a file in `partition` could import the `query` type and every bare `PartitionEvidence` in it meant the opposite of what the package said. The file compiles, a search for either finds both, and nothing says which question the reader is looking at. That is where most of these files were.

Sharing a simple name is not itself the defect — two bounded contexts may both have an `Ordered`, and renaming one of them makes nothing clearer. Rebinding the name inside a file is, so that is what is refused now:

> A single import must not take a simple type name declared by the compilation unit's package.

`AnImportedTypeDoesNotTakeANameDeclaredByThePackageTest` holds it. There is no allowlist. The escape is to write the foreign type out where it is used, which the sources that were doing this now do.

## What the rule is careful about

**Both spellings of an import.** `import static b.Outer.X` binds `X` to a member type and shadows the package's own exactly as `import b.X` does, so the rule is about what an import binds rather than about the keyword in front of it. An on-demand import binds nothing that outranks the package's own members and is left out.

**What the name comes to mean is the compiler's answer.** A static import brings in the accessible static members the owner has by that name, which is not the same as the members it has: a member class that is not static binds nothing, and neither does one the importing source may not reach. Nor is it enough to look for a member type and add `static` — what is left is accessibility, which is a fact about the source doing the importing. So the question is asked where the import is written: the one source that asks it is written, and what the name resolves to is the answer. Static, accessible, inherited, hidden — every part of it is the compiler's, and none of it is restated in the check. An owner nothing resolves is a third answer, listed rather than let through.

**Which names a package declares depends on where a source is compiled.** A package may be split across modules, and a name in another module's main sources is as much a member of the package as one beside it; a test source is not, because it is compiled apart and no main source can see it.

**A source the parser cannot read is refused**, since it would otherwise contribute no declaration and no import and read exactly like a source that rebinds nothing. And the roots read are checked against the sources the repository holds, so a source no root covers is not passed over.

## What it found

`BehaviorChecker` took `Clause` from `BehaviorContract` while its own package declares a different `Clause` — nobody had reported it. A second turned up in develop while this branch was catching up, which is the kind it exists for.

Its predicate is pinned on sources written for it rather than on the pairs the repository happens to hold today, so nothing here holds an existing duplication in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
