### PR TITLE
Prove an assertion where the state it guards is held

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -731,11 +731,16 @@ sealed interface Confinement<A> {
             //
             // Said once, and what stands here until it is said is what nothing read leaves. Saying
             // it twice is this compiler disagreeing with itself rather than anything a model says,
-            // which is why it is an assertion. With assertions off it stays conservative: the
-            // values are built again from top, so the first reading can only be forgotten, while
-            // the ranges and the carriers are met with what the second brings rather than replaced
-            // by it, and neither invents an end nobody read. The state moves only toward admitting
-            // more, which is the direction this reading is allowed to move in.
+            // which is why it is an assertion. With assertions off what is lost is knowledge and
+            // nothing kept is untrue. Only the values forget: they are built again from top, so
+            // the first reading goes. The ranges are met, the carrier table takes the later answer
+            // where both name a position, and an emptiness either of them proved stays proved —
+            // each of those keeps what a reading said rather than working something out across
+            // the two. That they may be kept together is the one thing this rests on: a reading
+            // arriving here is a true reading of one world, so what two of them say of a position
+            // they both name holds of it either way. What the state stops being is the conjunction
+            // it says it is, since the values no longer answer for the reading the rest of it
+            // still carries.
             assert !values.hasReadings()
                     : "the values of a state are read once, and these were read over " + values;
             return new Conjoined<>(

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -730,9 +730,12 @@ sealed interface Confinement<A> {
             // reader builds out of it is more of the same answer at the same positions.
             //
             // Said once, and what stands here until it is said is what nothing read leaves. Saying
-            // it twice would keep the second reading and drop the first without a word. An
-            // assertion because a throw would be caught by the fail-open around the reading and
-            // leave it silently dropped.
+            // it twice is this compiler disagreeing with itself rather than anything a model says,
+            // which is why it is an assertion. With assertions off it stays conservative: the
+            // values are built again from top, so the first reading can only be forgotten, while
+            // the ranges and the carriers are met with what the second brings rather than replaced
+            // by it, and neither invents an end nobody read. The state moves only toward admitting
+            // more, which is the direction this reading is allowed to move in.
             assert !values.hasReadings()
                     : "the values of a state are read once, and these were read over " + values;
             return new Conjoined<>(

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -731,18 +731,19 @@ sealed interface Confinement<A> {
             //
             // Said once, and what stands here until it is said is what nothing read leaves. Saying
             // it twice is this compiler disagreeing with itself rather than anything a model says,
-            // which is why it is an assertion. With assertions off what is lost is knowledge and
-            // nothing kept is untrue. Only the values forget: they are built again from top, so
-            // the first reading goes. The ranges are met, the carrier table takes the later answer
-            // where both name a position, and an emptiness either of them proved stays proved —
-            // each of those keeps what a reading said rather than working something out across
-            // the two. That they may be kept together is the one thing this rests on: a reading
-            // arriving here is a true reading of one world, so what two of them say of a position
-            // they both name holds of it either way. What the state stops being is the conjunction
-            // it says it is, since the values no longer answer for the reading the rest of it
-            // still carries.
-            assert !values.hasReadings()
-                    : "the values of a state are read once, and these were read over " + values;
+            // which is why it is an assertion. With assertions off the second reading is left out
+            // and what was already read stands, so the failure cannot make an answer more precise
+            // or say anything no reading said — whatever the second reading is. Settled here, in
+            // one line, rather than out of what each part of a state does with a reading met over
+            // another: the values would forget the first, the ranges would keep both, and the
+            // carrier of a position both name would be the later of the two. None of those is the
+            // same direction, and a reason resting on all three would be as good as the next edit
+            // to any of them.
+            if (values.hasReadings()) {
+                assert false : "the values of a state are read once, and these were read over "
+                        + values;
+                return this;
+            }
             return new Conjoined<>(
                     ConjoinedAdmissibleValues.of(
                             AdmissibleValues.<A>top().meet(read.values(), sets), sets),

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -289,8 +289,7 @@ public final class ConjoinedAdmissibleValues<A> {
         // One answer is being built, so one composer is spending for it. Two readings that were put
         // together by different composers are two answers, and meeting them would charge a position
         // of one against the allowance of the other. An assertion because it is a fact about how
-        // this compiler reads a declaration rather than about any model — see
-        // `Confinement.Conjoined.taking`, which holds the same kind of thing the same way.
+        // this compiler reads a declaration rather than about any model.
         assert sets == other.sets
                 : "two readings put together by different composers are two answers";
         List<AdmissibleValues<A>> both = new ArrayList<>(factors);


### PR DESCRIPTION
Closes #1380.

`Confinement.Conjoined.taking` argued for its assertion by saying what would
happen to a throw: the fail-open around the reading would catch it and drop it
without a word. That fail-open is gone — the discharge check falls open on the
limits it names and on nothing else, and a failure nobody named a limit stops
the compile. A reader taking the sentence at face value would write the next
such decision against a mechanism that is not there.

The premise was the wrong shape even while it held. The readings that reach this
method answer to more than one boundary, each with its own policy about what it
may swallow, so what a throw comes to here was never one answer. What a check may
swallow is settled where a limit is made; nothing outside that boundary should
carry the answer as a premise of its own.

The decision itself stands, and the reason it should have been written against is
beside it twice already: an assertion because the failure is this compiler
disagreeing with itself rather than anything a model says, and because the
un-asserted behaviour states nothing untrue.

The second half is now something this method does rather than something a reader
works out. A taking over a state that already holds a reading answers with the
state it was given, so what stands cannot be more precise than what was read and
cannot say what no reading said, whatever the second reading is. Argued from the
parts instead, it would rest on three operations that do not agree: the values
forget the first reading, the ranges keep both, and the carrier of a position both
name is whichever arrived later. A reason resting on all three is worth as much as
the next edit to any of them, which is the shape this issue was about.

This is not a fail-open policy and does not touch the boundary that owns one. It
is one method saying what it does with a call it refuses, which is nothing.

I reviewed the production assertions and the exception-handling references around
them. No other assertion justification depended on a caller's catch policy.

## `ConjoinedAdmissibleValues.meet`

Its assertion pointed here as holding the same kind of thing the same way. It does
not. With assertions off, a crossing of composers splits: the purse in hand pays
for positions of the other reading and gives up sooner, which widens; and a block
the other allowance had given up on is not spent in this one, so an exact answer
is built that nobody paid for. Nothing false is stated either way — what is lost
is the bound the budget puts on a reading, not soundness.

So the behaviour and the assertion are left alone, and only the reference is cut.
Its own first half stays as it stands. Filling in an assertions-off argument there
would be stating something that has not been shown. That belongs to an issue of
its own: admissible values can regain precision when values built under different
allowance histories are composed.

No test. What the assertion guards is a path no reachable call takes, and the
answer it now gives there is the state it was handed. Pinning that would need the
class loaded with assertions off, which is more machinery than the property is
worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
