### PR TITLE
Take the purse an answer is built out of at the composition

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
@@ -120,9 +120,11 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
      * The methods of {@code owner} a caller can reach whose signature mentions an allowance, by
      * name.
      *
-     * <p>What a caller can reach, because the rule is about what may be asked of the value. A
-     * private helper of one of these is part of how that operation is written and reaches no purse
-     * a caller did not hand over.
+     * <p>What a caller can reach, because the rule is about which of a value's questions come with
+     * a purse. A private helper is part of how one of them is written and spends what that
+     * operation was handed; what it must not do is make an allowance of its own, and that is a
+     * different rule with a walk of its own
+     * ({@code WhoMayBuildALanguageAboutAPositionTest} counts every making and every asking).
      */
     private static List<String> namingAnAllowance(String owner) {
         TreeSet<String> out = new TreeSet<>();

--- a/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
@@ -14,8 +15,14 @@ import java.lang.reflect.AccessFlag;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,18 +37,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * purses to be charged to, so which of them pays, and with it how exactly the composition comes out,
  * is settled by which side the call was written on rather than by anything either reading says.
  *
- * <p>So the holders are written down, and every one of them is somewhere an answer is under
- * construction:
+ * <p>So everywhere one can be reached from is written down, and every one of them is a reading that
+ * has not finished answering or something holding one.
  *
- * <pre>
- *     AdmissibleReading         reads one declaration's clauses into the sets they leave
- *     PlacedRules               reads one value's rules at the paths its positions have
- *     InvariantChecker$Seeded   one such reading part-built, for a reader that finishes it
- * </pre>
+ * <p><b>Reached from and not held in.</b> What a reader can spend is what it can reach, so a purse
+ * put in a carrier that several readers keep is a purse those readers have. Asked one field deep,
+ * the carrier would be the only row and the readers keeping it would hold an allowance with nothing
+ * saying so — which is what this walk missed while the rule was being written, and is why it is
+ * transitive.
  *
- * <p>Read off the compiled classes, so a record component is a row here as readily as a field: the
- * two are one thing to a reader that can spend what it finds. A row that is new is a finding —
- * either an answer is being built somewhere new, or a purse has moved into a value.
+ * <p>Read off the compiled classes, so a record component is a row as readily as a field: the two
+ * are one thing to a reader that can spend what it finds. A row that is new is a finding — either a
+ * reading is being made somewhere new, or an answer has taken a purse on.
  */
 class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
 
@@ -51,11 +58,28 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
-    /** Every production class that holds one, which is every place an answer is being built. */
+    /**
+     * Every production class an allowance can be reached from, which is every reading still
+     * answering and everything holding one.
+     *
+     * <p>Two of them are the readers. {@code AdmissibleReading} turns one declaration's clauses into
+     * the sets they leave; {@code PlacedRules} answers what the rules leave a value's positions and
+     * builds the sets as they are asked for, so it is a reading that has not finished. The rest hold
+     * one of those and reach the purse through it.
+     *
+     * <p>What is not here is the list's point. A reading's published answers —
+     * {@code AdmissibleValues}, {@code ConjoinedAdmissibleValues}, {@code ConstraintState}, and the
+     * seeded reading a later reader keeps — carry sets and no way to buy another, so two of them met
+     * have no purse of their own to be composed under.
+     */
     private static final List<String> HOLDING_AN_ALLOWANCE = List.of(
             "souther/compiler/check/AdmissibleReading",
-            "souther/compiler/check/InvariantChecker$Seeded",
-            "souther/compiler/inputs/PlacedRules");
+            "souther/compiler/check/StatedByClauses$Reading",
+            "souther/compiler/inputs/OpenedRules",
+            "souther/compiler/inputs/PlacedRules",
+            "souther/compiler/inputs/PlacedRules$Reaching",
+            "souther/compiler/inputs/ReadQuantities",
+            "souther/compiler/inputs/ReadRegion");
 
     /**
      * And what a conjunction of readings names one for.
@@ -101,20 +125,103 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
                         + " finding nothing at all");
     }
 
-    /** Every class with a field of that type, which is a record component as well. */
-    private static List<String> holdingAnAllowance() {
-        TreeSet<String> out = new TreeSet<>();
+    /**
+     * And it sees the two ways a purse is held without being spelled at the holder.
+     *
+     * <p>The row above is a class with a field of that type, which the plainest walk finds. These
+     * two are what a plain walk misses: a holder that reaches one through what it holds, and a
+     * declared type the erasure throws away. Left unasked, both lists would match a walk that had
+     * quietly stopped looking for either.
+     */
+    @Test
+    void andItSeesAPurseHeldThroughAnotherAndOneInsideAContainer() {
+        assertEquals(List.of(), fieldTypesOf("souther/compiler/inputs/OpenedRules").stream()
+                        .filter(ALLOWANCE::equals).toList(),
+                "this one names no allowance of its own");
+        assertTrue(holdingAnAllowance().contains("souther/compiler/inputs/OpenedRules"),
+                "and it holds a reading that has one, so it can spend what that reading has —"
+                        + " a walk that stops at the first field cannot say so");
+
+        assertTrue(typesIn("Ljava/util/List<L" + ALLOWANCE + "<TA;>;>;").contains(ALLOWANCE),
+                "a purse inside a collection is a purse; the erasure leaves `java/util/List` and"
+                        + " the declaration is where it is still named");
+    }
+
+    /** Every type named by a field of {@code owner}, for asking what it names of itself. */
+    private static Set<String> fieldTypesOf(String owner) {
+        Set<String> out = new LinkedHashSet<>();
         for (Path module : REPOSITORY.modules()) {
             for (Path each : classesUnder(module)) {
-                for (FieldModel field : classOf(each).fields()) {
-                    if (field.fieldType().stringValue().equals("L" + ALLOWANCE + ";")) {
-                        out.add(internalName(module, each));
-                    }
+                if (internalName(module, each).equals(owner)) {
+                    classOf(each).fields().forEach(field -> out.addAll(typesIn(declared(field))));
                 }
             }
         }
-        return new ArrayList<>(out);
+        return out;
     }
+
+    /**
+     * Every class that can reach an allowance through what it holds.
+     *
+     * <p><b>Through what it holds and not only in it.</b> A class holding a value that holds one has
+     * the purse: what a reader of it can spend is what it can reach, however many fields away that
+     * is. Read one field deep, a purse moved into a carrier several readers keep would be a row for
+     * the carrier alone, and the readers keeping it would be holding an allowance with nothing
+     * saying so — which is what happened while this rule was being written.
+     *
+     * <p><b>And what a field says of itself, not what the erasure left.</b> A field of {@code
+     * List<Allowance>} is a field of {@code List}, so the type is gone from the descriptor and reads
+     * here as no allowance at all. The declared type is in the signature where there is one, and
+     * that is what is asked.
+     */
+    private static List<String> holdingAnAllowance() {
+        Map<String, Set<String>> holds = new LinkedHashMap<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                Set<String> reaching = new LinkedHashSet<>();
+                for (FieldModel field : classOf(each).fields()) {
+                    reaching.addAll(typesIn(declared(field)));
+                }
+                holds.put(internalName(module, each), reaching);
+            }
+        }
+        // What reaches an allowance, and then what reaches that, until nothing new arrives.
+        Set<String> reaches = new TreeSet<>(Set.of(ALLOWANCE));
+        boolean growing = true;
+        while (growing) {
+            growing = false;
+            for (Map.Entry<String, Set<String>> each : holds.entrySet()) {
+                if (!reaches.contains(each.getKey())
+                        && each.getValue().stream().anyMatch(reaches::contains)) {
+                    reaches.add(each.getKey());
+                    growing = true;
+                }
+            }
+        }
+        reaches.remove(ALLOWANCE);
+        return new ArrayList<>(reaches);
+    }
+
+    /** What a field says its type is: the signature where the declaration has one, and the
+     *  descriptor where it does not. */
+    private static String declared(FieldModel field) {
+        return field.findAttribute(Attributes.signature())
+                .map(each -> each.signature().stringValue())
+                .orElseGet(() -> field.fieldType().stringValue());
+    }
+
+    /** Every class named anywhere in a descriptor or signature, arguments of a generic type
+     *  included. */
+    private static Set<String> typesIn(String descriptor) {
+        Set<String> out = new LinkedHashSet<>();
+        Matcher found = NAMED.matcher(descriptor);
+        while (found.find()) {
+            out.add(found.group(1));
+        }
+        return out;
+    }
+
+    private static final Pattern NAMED = Pattern.compile("L([^;<>]+)[;<]");
 
     /**
      * The methods of {@code owner} a caller can reach whose signature mentions an allowance, by
@@ -130,18 +237,31 @@ class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
         TreeSet<String> out = new TreeSet<>();
         for (Path module : REPOSITORY.modules()) {
             for (Path each : classesUnder(module)) {
-                if (!internalName(module, each).equals(owner)) {
+                String here = internalName(module, each);
+                // The type and everything declared inside it. What may be asked of a conjunction
+                // includes what its own nested types offer, and one of those taking a purse is the
+                // same capability under another name.
+                if (!here.equals(owner) && !here.startsWith(owner + "$")) {
                     continue;
                 }
+                String within = here.equals(owner) ? "" : here.substring(owner.length() + 1) + ".";
                 for (MethodModel method : classOf(each).methods()) {
                     if (!method.flags().has(AccessFlag.PRIVATE)
-                            && method.methodType().stringValue().contains("L" + ALLOWANCE + ";")) {
-                        out.add(method.methodName().stringValue());
+                            && typesIn(declared(method)).contains(ALLOWANCE)) {
+                        out.add(within + method.methodName().stringValue());
                     }
                 }
             }
         }
         return new ArrayList<>(out);
+    }
+
+    /** What a method says its signature is: the declaration where it has one, and the descriptor
+     *  where it does not — so an allowance inside a generic type is still named. */
+    private static String declared(MethodModel method) {
+        return method.findAttribute(Attributes.signature())
+                .map(each -> each.signature().stringValue())
+                .orElseGet(() -> method.methodType().stringValue());
     }
 
     private static ClassModel classOf(Path compiled) {

--- a/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest.java
@@ -1,0 +1,175 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.MethodModel;
+import java.lang.reflect.AccessFlag;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who holds an allowance, and where an operation says which answer is paying.
+ *
+ * <p>An {@link souther.compiler.values.Allowance} is what one answer being built may spend. Held by
+ * something that is building one, it is that answer's own account of itself. Held by a value that
+ * answers, it is a fact about no reading in the value — and a composition of two such values has two
+ * purses to be charged to, so which of them pays, and with it how exactly the composition comes out,
+ * is settled by which side the call was written on rather than by anything either reading says.
+ *
+ * <p>So the holders are written down, and every one of them is somewhere an answer is under
+ * construction:
+ *
+ * <pre>
+ *     AdmissibleReading         reads one declaration's clauses into the sets they leave
+ *     PlacedRules               reads one value's rules at the paths its positions have
+ *     InvariantChecker$Seeded   one such reading part-built, for a reader that finishes it
+ * </pre>
+ *
+ * <p>Read off the compiled classes, so a record component is a row here as readily as a field: the
+ * two are one thing to a reader that can spend what it finds. A row that is new is a finding —
+ * either an answer is being built somewhere new, or a purse has moved into a value.
+ */
+class AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest {
+
+    private static final String ALLOWANCE = "souther/compiler/values/Allowance";
+
+    private static final String CONJUNCTION = "souther/compiler/values/ConjoinedAdmissibleValues";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** Every production class that holds one, which is every place an answer is being built. */
+    private static final List<String> HOLDING_AN_ALLOWANCE = List.of(
+            "souther/compiler/check/AdmissibleReading",
+            "souther/compiler/check/InvariantChecker$Seeded",
+            "souther/compiler/inputs/PlacedRules");
+
+    /**
+     * And what a conjunction of readings names one for.
+     *
+     * <p>{@link souther.compiler.values.ConjoinedAdmissibleValues} is the value the rule above is
+     * about: two of them are met, so a purse it held would be the one the meet spent. It holds none,
+     * and the allowance reaches it as the argument of the one operation that may build — the meet of
+     * two readings over a shared vocabulary, which comes to a set neither of them holds.
+     *
+     * <p>Every other operation of it reads what is already there, and a second name in this row is
+     * one of those having grown a way to spend. A getter is a row too, since what it hands back is
+     * the purse itself.
+     */
+    private static final List<String> NAMING_AN_ALLOWANCE = List.of("meet");
+
+    @Test
+    void everyHolderOfAnAllowanceIsBuildingAnAnswer() {
+        assertEquals(HOLDING_AN_ALLOWANCE, holdingAnAllowance(),
+                "an allowance is what one answer being built may spend, so it is held by whoever is"
+                        + " building one: held by a value that answers, a composition of two of them"
+                        + " has two purses and picks by which side the call was written on");
+    }
+
+    @Test
+    void andAConjunctionNamesOneOnlyWhereItComposes() {
+        assertEquals(NAMING_AN_ALLOWANCE, namingAnAllowance(CONJUNCTION),
+                "a conjunction is composed under the caller's allowance and holds none of its own:"
+                        + " another operation naming one is either a second place that spends or a"
+                        + " purse handed back for somebody else to spend");
+    }
+
+    /**
+     * And the walk sees a holder that is there.
+     *
+     * <p>Matched on a descriptor nothing has, both lists would be empty and equal to an empty
+     * expectation. So the same walk is asked for something it must find: the reading of a
+     * declaration's clauses holds the purse it spends.
+     */
+    @Test
+    void andTheWalkSeesAHolderThatIsThere() {
+        assertTrue(holdingAnAllowance().contains("souther/compiler/check/AdmissibleReading"),
+                "the reading that spends an allowance holds it, so a walk that cannot find that is"
+                        + " finding nothing at all");
+    }
+
+    /** Every class with a field of that type, which is a record component as well. */
+    private static List<String> holdingAnAllowance() {
+        TreeSet<String> out = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                for (FieldModel field : classOf(each).fields()) {
+                    if (field.fieldType().stringValue().equals("L" + ALLOWANCE + ";")) {
+                        out.add(internalName(module, each));
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(out);
+    }
+
+    /**
+     * The methods of {@code owner} a caller can reach whose signature mentions an allowance, by
+     * name.
+     *
+     * <p>What a caller can reach, because the rule is about what may be asked of the value. A
+     * private helper of one of these is part of how that operation is written and reaches no purse
+     * a caller did not hand over.
+     */
+    private static List<String> namingAnAllowance(String owner) {
+        TreeSet<String> out = new TreeSet<>();
+        for (Path module : REPOSITORY.modules()) {
+            for (Path each : classesUnder(module)) {
+                if (!internalName(module, each).equals(owner)) {
+                    continue;
+                }
+                for (MethodModel method : classOf(each).methods()) {
+                    if (!method.flags().has(AccessFlag.PRIVATE)
+                            && method.methodType().stringValue().contains("L" + ALLOWANCE + ";")) {
+                        out.add(method.methodName().stringValue());
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(out);
+    }
+
+    private static ClassModel classOf(Path compiled) {
+        try {
+            return ClassFile.of().parse(Files.readAllBytes(compiled));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The class's own binary name, taken against the directory it was found under rather than off
+     *  the first {@code classes} in the path, which a checkout under one would be. */
+    private static String internalName(Path module, Path compiled) {
+        String name = classesOf(module).relativize(compiled).toString().replace('\\', '/');
+        return name.substring(0, name.length() - ".class".length());
+    }
+
+    private static Path classesOf(Path module) {
+        return module.resolve("target").resolve("classes");
+    }
+
+    private static List<Path> classesUnder(Path module) {
+        Path where = classesOf(module);
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(p -> p.toString().endsWith(".class")).toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -681,9 +681,15 @@ sealed interface Confinement<A> {
             return values.at(position);
         }
 
-        /** Both conjunctions holding at once, in both languages. */
-        Conjoined<A> meet(Conjoined<A> other) {
-            return new Conjoined<>(values.meet(other.values), ordered.meet(other.ordered),
+        /**
+         * Both conjunctions holding at once, in both languages.
+         *
+         * <p>{@code sets} is the answer this is being met into, which is the caller's. What the two
+         * readings come to where their vocabularies meet is a set neither of them holds, and it is
+         * built here.
+         */
+        Conjoined<A> meet(Conjoined<A> other, Allowance<A> sets) {
+            return new Conjoined<>(values.meet(other.values, sets), ordered.meet(other.ordered),
                     Confinement.both(carriers, other.carriers),
                     eitherShown(admission(), other.admission()));
         }
@@ -699,11 +705,6 @@ sealed interface Confinement<A> {
             Admission<B> said = shown == null ? null
                     : new Admission<>(shown.emptiness(), shown.by(), at, shown.how());
             return new Conjoined<>(values.renamed(naming), ordered.renamed(naming), out, said);
-        }
-
-        /** The same, with these values in place of what nothing read leaves. */
-        Conjoined<A> withValues(ConjoinedAdmissibleValues<A> read) {
-            return new Conjoined<>(read, ordered, carriers, shown);
         }
 
         /** The same, with {@code bounded} taken as holding of the positions it bounds, on the
@@ -746,7 +747,7 @@ sealed interface Confinement<A> {
             }
             return new Conjoined<>(
                     ConjoinedAdmissibleValues.of(
-                            AdmissibleValues.<A>top().meet(read.values(), sets), sets),
+                            AdmissibleValues.<A>top().meet(read.values(), sets)),
                     ordered.meet(read.ordered), Confinement.both(carriers, read.carriers()),
                     // What the reading was already shown empty by, which is a fact about the rules
                     // and travels with them. Left behind, a declaration refused because two of its

--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -684,9 +684,9 @@ sealed interface Confinement<A> {
         /**
          * Both conjunctions holding at once, in both languages.
          *
-         * <p>{@code sets} is the answer this is being met into, which is the caller's. What the two
-         * readings come to where their vocabularies meet is a set neither of them holds, and it is
-         * built here.
+         * <p>What the two readings come to where their vocabularies meet is a set neither of them
+         * holds, so it belongs to the answer being built out of the pair — and {@code sets} is what
+         * that answer may spend, handed over by whoever is building it.
          */
         Conjoined<A> meet(Conjoined<A> other, Allowance<A> sets) {
             return new Conjoined<>(values.meet(other.values, sets), ordered.meet(other.ordered),

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -6,6 +6,7 @@ import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.Allowance;
 import souther.compiler.values.ConjoinedAdmissibleValues;
 
 import java.lang.reflect.RecordComponent;
@@ -425,10 +426,17 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
      * <p>Both sides have to be said in one vocabulary already. Two readings of two values name their
      * positions the way each value declares them, and met without being renamed first they would
      * hold each other's rules — which is {@link #renamed} and not this.
+     *
+     * @param sets what the answer being built out of these two may spend on the sets it comes to.
+     *             The caller's, because that answer is the caller's: each of these was read under
+     *             the allowance of its own declaration and is bounded by it, and what they come to
+     *             where their vocabularies meet is a third set neither of them paid for. Taken from
+     *             one of the two instead, which of them paid would follow which side {@code .meet}
+     *             was written on, and with it how exactly the composition came out
      */
-    public ConstraintState<A> meet(ConstraintState<A> other) {
+    public ConstraintState<A> meet(ConstraintState<A> other, Allowance<A> sets) {
         return new ConstraintState<>(numbers.meet(other.numbers), facts.meet(other.facts),
-                confinement.meet(other.confinement), shown || other.shown);
+                confinement.meet(other.confinement, sets), shown || other.shown);
     }
 
     /**
@@ -488,22 +496,8 @@ public record ConstraintState<A>(NumericDomain<A> numbers, PredicateFacts<A> fac
      * conjunctions firing on a side that read nothing, and lifting it is about which rules went
      * unread rather than about how the alternatives are held.
      */
-    ConstraintState<A> takingRead(Confinement.Worked<A> read,
-                                  souther.compiler.values.Allowance<A> sets) {
+    ConstraintState<A> takingRead(Confinement.Worked<A> read, Allowance<A> sets) {
         return new ConstraintState<>(numbers, facts, confinement.taking(read, sets), shown);
-    }
-
-    /**
-     * The same state, its values spending what {@code sets} allows.
-     *
-     * <p>For a caller building one answer out of several. Two states read from two declarations
-     * were each put together under their own allowance, and what they come to met is a third
-     * admitted set that neither of them paid for — so the caller that is building it says where
-     * that is charged, and the states are taken under it before they are met.
-     */
-    public ConstraintState<A> under(souther.compiler.values.Allowance<A> sets) {
-        return new ConstraintState<>(numbers, facts,
-                confinement.withValues(confinement.values().under(sets)), shown);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -411,12 +411,12 @@ public final class FieldDomains {
             // is not made truer by a note about how the values were held.
             boolean separated = true;
             for (FactSubject name : named(seeded, field)) {
-                // Put together by what put the reading together, since that is the answer being
-                // built: the two subjects are two ways one name's rules were filed, and what they
-                // leave between them is the machine that name pays for. Where it could not be
+                // Charged to what the reading was read under, since this is the same answer still
+                // being built: the two subjects are two ways one name's rules were filed, and what
+                // they leave between them is the machine that name pays for. Where it could not be
                 // built, the set widens and says so in the same breath — which is the list below.
                 souther.compiler.values.Allowance.Composed made =
-                        values.sets().meet(values.blockOf(name), here, values.at(name));
+                        seeded.allowed().meet(values.blockOf(name), here, values.at(name));
                 here = made.set();
                 if (made.gaveUp()) {
                     why.add(UnreadReason.EXACT_VALUES_TOO_COSTLY);

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -9,7 +9,6 @@ import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Rel;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.AdmissibleSet;
-import souther.compiler.values.ConjoinedAdmissibleValues;
 import souther.compiler.values.UnreadReason;
 import souther.compiler.values.ValueSet;
 
@@ -379,68 +378,14 @@ public final class FieldDomains {
                 out.put(field, bounds);
             }
         });
-        // Which values may stand at each name, resolved onto names for the same reason the bounds
-        // are. Every one of them and not only the fields: what a name wraps is at no name of its
-        // own, and it is what a reader of a newtype asks about.
-        Map<RuleKey, ValueSet> admitted = new LinkedHashMap<>();
-        Map<RuleKey, List<UnreadReason>> unread = new LinkedHashMap<>();
-        Set<RuleKey> notSeparated = new LinkedHashSet<>();
-        // Every name that answers to either subject. A number is called one thing by the interval
-        // algebra and another by everything else, and the two are filed as they are found — so a
-        // reading keyed by one of the maps would leave a name held only by the other answering
-        // from a default, which is the widest thing there is to say and is said about a place a
-        // clause may well have narrowed.
-        Set<RuleKey> written = new LinkedHashSet<>(seeded.keys().keySet());
-        written.addAll(seeded.atoms().keySet());
-        written.forEach(field -> {
-            ConjoinedAdmissibleValues<FactSubject> values = seeded.constraints().values();
-            // Both subjects the name answers to, since a number has one of each and a clause
-            // reaching it is filed under whichever the reading recognised. Both are about the same
-            // values, so what holds of it is what both leave.
-            ValueSet here = ValueSet.ANY;
-            List<UnreadReason> why = new ArrayList<>();
-            // Asked of each subject the name answers to, as the values are. What the reading could
-            // not hold together is a fact about the subjects a choice reached across, and a name
-            // outside them is left where it was.
-            //
-            // Not asked at all where the reading admits nothing. What it holds there is not the
-            // relation's projections — those are empty wherever the relation is — but where the
-            // arithmetic had got to when it learned that no value of this type exists, so whether
-            // it is exact is a question about a projection nobody is being shown. And the answer
-            // owed about such a declaration is that it has no values, which is said elsewhere and
-            // is not made truer by a note about how the values were held.
-            boolean separated = true;
-            for (FactSubject name : named(seeded, field)) {
-                // Charged to what the reading was read under, since this is the same answer still
-                // being built: the two subjects are two ways one name's rules were filed, and what
-                // they leave between them is the machine that name pays for. Where it could not be
-                // built, the set widens and says so in the same breath — which is the list below.
-                souther.compiler.values.Allowance.Composed made =
-                        seeded.allowed().meet(values.blockOf(name), here, values.at(name));
-                here = made.set();
-                if (made.gaveUp()) {
-                    why.add(UnreadReason.EXACT_VALUES_TOO_COSTLY);
-                }
-                separated = separated && values.projectionExactAt(name);
-                // Every one of them. Two subjects of one name are two ways the same rules were
-                // filed, and a rule filed under one of them is not the rule filed under the other:
-                // an ordering the interval algebra knows the place by and a pattern the values
-                // reading knows it by stop this reading in two ways, and each is a rule of the
-                // author's to act on. Said once here — a limit met under both names is one limit.
-                values.whyUnread(name).forEach(each -> {
-                    if (!why.contains(each)) {
-                        why.add(each);
-                    }
-                });
-            }
-            admitted.put(field, here);
-            if (!why.isEmpty()) {
-                unread.put(field, List.copyOf(why));
-            }
-            if (!separated) {
-                notSeparated.add(field);
-            }
-        });
+        // Which values may stand at each name is read off the reading and not worked out here. What
+        // a name admits is the sets of the subjects it is filed under met, which takes a machine —
+        // and the purse that pays for it is the one the clauses were read under, which is the
+        // reading's and stays there.
+        //
+        // Every one of them and not only the fields: what a name wraps is at no name of its own,
+        // and it is what a reader of a newtype asks about.
+        //
         // Resolved here rather than handed over as atoms. An atom is a name the seeding gave a shape
         // and means nothing once the reading that named it is gone, so a caller holding one could
         // only ask the domain it came from — which is this one, while it is still here.
@@ -459,16 +404,12 @@ public final class FieldDomains {
         // Every subject a name answers to, filed under the name, in the order the value declares
         // them. A proof that names a place is settled by this order: read off a domain's own map,
         // the place named would be the one whose clause was read first.
-        //
-        // The order is the walk's, and the walk's is the declaration's. `written` is the keys
-        // followed by the atoms, and that is the keys: an atom is named from a body key, so a
-        // name with an atom has a key and the second pass adds nothing. A size has no key and
-        // is not one of these — it is a number taken of what stands at a name.
         SequencedMap<FactSubject, RuleKey> placeOf = new LinkedHashMap<>();
-        written.forEach(field ->
-                named(seeded, field).forEach(term -> placeOf.putIfAbsent(term, field)));
-        return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
-                Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().noLines(),
+        seeded.written().forEach(field ->
+                seeded.named(field).forEach(term -> placeOf.putIfAbsent(term, field)));
+        return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(seeded.admitted()),
+                Map.copyOf(seeded.unreadAt()), Set.copyOf(seeded.notSeparated()),
+                seeded.reading().directs(), seeded.reading().noLines(),
                 seeded.reading().withoutAnEnd(), seeded.reading().aboutOneCoordinate(),
                 seeded.reading().aboutTheStrings(),
                 reach.withoutParts(),
@@ -1665,21 +1606,6 @@ public final class FieldDomains {
             }
         }
         return true;
-    }
-
-    /** Both subjects the name {@code path} answers to. A number has one of each and everything
-     * else has the second, and a clause is filed under whichever the reading recognised. */
-    private static List<FactSubject> named(InvariantChecker.Seeded seeded, RuleKey path) {
-        List<FactSubject> names = new ArrayList<>();
-        FactSubject atom = seeded.atoms().get(path);
-        if (atom != null) {
-            names.add(atom);
-        }
-        FactSubject key = seeded.keys().get(path);
-        if (key != null) {
-            names.add(key);
-        }
-        return names;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.Allowance;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.PathEngine.Entered;
@@ -448,8 +449,16 @@ public final class InvariantChecker {
      * @param handedOn the positions this reading ended at with a declaration still to be read under
      *                 them, which is an obligation on whoever walks the positions rather than
      *                 anything wrong here — see {@link Gathering#handedOn}
+     * @param allowed what this reading spent to say what it says, and what a reader finishing it
+     *                spends. Here because this is one answer part-built and not a value that
+     *                answers: a name of the declaration is filed under more than one subject, and
+     *                what it admits is the sets of those met — which is a set of this answer, built
+     *                after the walk that started it has returned. Given a purse of its own, the
+     *                same position would be allowed its machine twice
      */
-    record Seeded(ConstraintState<FactSubject> constraints, Map<RuleKey, FactSubject> atoms,
+    record Seeded(ConstraintState<FactSubject> constraints,
+                  Allowance<FactSubject> allowed,
+                  Map<RuleKey, FactSubject> atoms,
                   Map<RuleKey, FactSubject> keys,
                   Map<RuleKey, FieldDomains.Counted> held, Reading reading, ReadingEvidence took,
                   boolean everyClauseRead, Map<RuleKey, Set<RulesMissed>> notGathered,
@@ -480,18 +489,6 @@ public final class InvariantChecker {
             // iterates in an order salted once per JVM run, and what is read off these is a list of
             // causes a report prints.
             readBy = Collections.unmodifiableMap(new LinkedHashMap<>(readBy));
-        }
-
-        /** What a walk that fell over comes to: no position named, no rule read, and saying so of
-         *  every position, since nothing here knows which of them the rules were about. */
-        static Seeded nothingRead() {
-            return new Seeded(ConstraintState.<FactSubject>top(), Map.of(), Map.of(), Map.of(),
-                    new Reading(List.of(), List.of(), List.of(), List.of(), List.of(), Map.of(),
-                            Map.of(), Map.of(), Map.of()),
-                    new ReadingEvidence(),
-                    false, Map.of(RuleKey.THE_VALUE,
-                            Set.of(new RulesMissed.ReadingFellOver())),
-                    Set.of(RuleKey.THE_VALUE), Set.of(), Map.of(), Map.of());
         }
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
@@ -760,7 +757,7 @@ public final class InvariantChecker {
         // another pay into the same machine. Made per position inside — a complicated rule at
         // one position may not spend what a plain one at another was going to need, or which of
         // the two went unanswered would turn on the order they were written in.
-        souther.compiler.values.Allowance<FactSubject> allowed =
+        Allowance<FactSubject> allowed =
                 policy.allowanceForAdmittedValues();
         Map<RuleRef, Map<Core, ReadByClauses.OfAPart>> adoptedBy = new LinkedHashMap<>();
         Map<RuleRef, ReadByClauses.OfARule> narrowedBy = new LinkedHashMap<>();
@@ -874,7 +871,7 @@ public final class InvariantChecker {
             }
             constraints = ConstraintState.settling(constraints, atom, each.getValue(), spaced);
         }
-        return new Seeded(constraints, atoms, keys, held, reading, took, read,
+        return new Seeded(constraints, allowed, atoms, keys, held, reading, took, read,
                 notGathered, unreadOfEveryValue, Set.copyOf(handedOn),
                 readBy, Map.copyOf(spacing));
     }
@@ -1043,7 +1040,7 @@ public final class InvariantChecker {
      * to a factor, and which factors there are is settled by the rules rather than before them, so
      * a list of the expected ones would leave out the one an equality made.
      */
-    private static int spentBy(souther.compiler.values.Allowance<FactSubject> allowed) {
+    private static int spentBy(Allowance<FactSubject> allowed) {
         return allowed.spentSoFar();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -3,6 +3,8 @@ package souther.compiler.check;
 import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.Allowance;
+import souther.compiler.values.ConjoinedAdmissibleValues;
+import souther.compiler.values.UnreadReason;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.PathEngine.Entered;
@@ -449,22 +451,29 @@ public final class InvariantChecker {
      * @param handedOn the positions this reading ended at with a declaration still to be read under
      *                 them, which is an obligation on whoever walks the positions rather than
      *                 anything wrong here — see {@link Gathering#handedOn}
-     * @param allowed what this reading spent to say what it says, and what a reader finishing it
-     *                spends. Here because this is one answer part-built and not a value that
-     *                answers: a name of the declaration is filed under more than one subject, and
-     *                what it admits is the sets of those met — which is a set of this answer, built
-     *                after the walk that started it has returned. Given a purse of its own, the
-     *                same position would be allowed its machine twice
+     * @param admitted which values may stand at each name the reading wrote. Answered here because
+     *                 a name is filed under more than one subject and what it admits is the sets of
+     *                 those met — which is a machine, and the purse that pays for it is the one this
+     *                 reading was read under. Left to a caller, the caller would need that purse to
+     *                 finish an answer this reading started, and every later holder of this reading
+     *                 would be holding one
+     * @param unreadAt everything that stopped the reading from speaking for each name, empty where
+     *                 nothing did. Beside {@link #admitted} and never after it: a name whose sets
+     *                 could not be met is one this widened, and the two arrive together or a reader
+     *                 is handed every value with nothing saying why
+     * @param notSeparated the names whose values this reading cannot show are the whole of what the
+     *                 rules leave
      */
-    record Seeded(ConstraintState<FactSubject> constraints,
-                  Allowance<FactSubject> allowed,
-                  Map<RuleKey, FactSubject> atoms,
+    record Seeded(ConstraintState<FactSubject> constraints, Map<RuleKey, FactSubject> atoms,
                   Map<RuleKey, FactSubject> keys,
                   Map<RuleKey, FieldDomains.Counted> held, Reading reading, ReadingEvidence took,
                   boolean everyClauseRead, Map<RuleKey, Set<RulesMissed>> notGathered,
                   Set<RuleKey> unreadOfEveryValue, Set<RuleKey> handedOn,
                   Map<RuleRef, Map<Core, PartRead>> readBy,
-                  Map<FactSubject, souther.compiler.numeric.Granularity> spacing) {
+                  Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
+                  Map<RuleKey, ValueSet> admitted,
+                  Map<RuleKey, List<UnreadReason>> unreadAt,
+                  Set<RuleKey> notSeparated) {
 
         /** The atom each count is recorded against, for a reader that wants the subject and not
          *  which operation it is a count of. Projected rather than kept beside {@link #held()}: two
@@ -473,6 +482,23 @@ public final class InvariantChecker {
             Map<RuleKey, FactSubject> out = new LinkedHashMap<>();
             held.forEach((path, counted) -> out.put(path, counted.atom()));
             return out;
+        }
+
+        /**
+         * Both subjects the name {@code path} answers to.
+         *
+         * <p>A number has one of each and everything else has the second, and a clause is filed
+         * under whichever the reading recognised. Answered here because which subjects a name is
+         * filed under is how this reading files them: read from outside, a caller would be walking
+         * two of these maps and would be answering for a filing it does not own.
+         */
+        List<FactSubject> named(RuleKey path) {
+            return InvariantChecker.named(atoms, keys, path);
+        }
+
+        /** Every name this reading wrote — see {@link InvariantChecker#written}. */
+        Set<RuleKey> written() {
+            return InvariantChecker.written(atoms, keys);
         }
 
         public Seeded {
@@ -489,6 +515,12 @@ public final class InvariantChecker {
             // iterates in an order salted once per JVM run, and what is read off these is a list of
             // causes a report prints.
             readBy = Collections.unmodifiableMap(new LinkedHashMap<>(readBy));
+            // In the order the declaration writes its names, for the reason above: what is read off
+            // these is what a report says about each place, and a walk over a salted order would
+            // list them by a rule of this JVM run's.
+            admitted = Collections.unmodifiableMap(new LinkedHashMap<>(admitted));
+            unreadAt = Collections.unmodifiableMap(new LinkedHashMap<>(unreadAt));
+            notSeparated = Collections.unmodifiableSet(new LinkedHashSet<>(notSeparated));
         }
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
@@ -871,9 +903,96 @@ public final class InvariantChecker {
             }
             constraints = ConstraintState.settling(constraints, atom, each.getValue(), spaced);
         }
-        return new Seeded(constraints, allowed, atoms, keys, held, reading, took, read,
+        // And what stands at each name the reading wrote, which is the last of this answer and is
+        // built here because here is where the purse is. A name is filed under a subject the
+        // interval algebra knows it by and a subject everything else knows it by, and what it
+        // admits is what both leave — a machine, out of the same allowance every rule that reached
+        // the name paid into. Handed over unfinished, whoever asked would need this purse to
+        // finish it, and a reading kept by a reader that only asks questions of it would be
+        // keeping an allowance.
+        Map<RuleKey, ValueSet> admitted = new LinkedHashMap<>();
+        Map<RuleKey, List<UnreadReason>> unreadAt = new LinkedHashMap<>();
+        Set<RuleKey> notSeparated = new LinkedHashSet<>();
+        ConjoinedAdmissibleValues<FactSubject> readAs = constraints.values();
+        for (RuleKey field : written(atoms, keys)) {
+            ValueSet here = ValueSet.ANY;
+            List<UnreadReason> why = new ArrayList<>();
+            // Not asked at all where the reading admits nothing. What it holds there is not the
+            // relation's projections — those are empty wherever the relation is — but where the
+            // arithmetic had got to when it learned that no value of this type exists, so whether
+            // it is exact is a question about a projection nobody is being shown. And the answer
+            // owed about such a declaration is that it has no values, which is said elsewhere and
+            // is not made truer by a note about how the values were held.
+            boolean separated = true;
+            for (FactSubject name : named(atoms, keys, field)) {
+                // Where it could not be built, the set widens and says so in the same breath —
+                // which is the list below.
+                Allowance.Composed made =
+                        allowed.meet(readAs.blockOf(name), here, readAs.at(name));
+                here = made.set();
+                if (made.gaveUp()) {
+                    why.add(UnreadReason.EXACT_VALUES_TOO_COSTLY);
+                }
+                separated = separated && readAs.projectionExactAt(name);
+                // Every one of them. Two subjects of one name are two ways the same rules were
+                // filed, and a rule filed under one of them is not the rule filed under the other:
+                // an ordering the interval algebra knows the place by and a pattern the values
+                // reading knows it by stop this reading in two ways, and each is a rule of the
+                // author's to act on. Said once here — a limit met under both names is one limit.
+                for (UnreadReason each : readAs.whyUnread(name)) {
+                    if (!why.contains(each)) {
+                        why.add(each);
+                    }
+                }
+            }
+            admitted.put(field, here);
+            if (!why.isEmpty()) {
+                unreadAt.put(field, List.copyOf(why));
+            }
+            if (!separated) {
+                notSeparated.add(field);
+            }
+        }
+        return new Seeded(constraints, atoms, keys, held, reading, took, read,
                 notGathered, unreadOfEveryValue, Set.copyOf(handedOn),
-                readBy, Map.copyOf(spacing));
+                readBy, Map.copyOf(spacing), admitted, unreadAt, notSeparated);
+    }
+
+    /**
+     * Every name a reading wrote, which is every name that answers to either subject.
+     *
+     * <p>A number is called one thing by the interval algebra and another by everything else, and
+     * the two are filed as they are found — so a walk over one of the maps would leave a name held
+     * only by the other answering from a default, which is the widest thing there is to say and is
+     * said about a place a clause may well have narrowed.
+     *
+     * <p>The keys and then the atoms, which is the keys: an atom is named from a body key, so a
+     * name with an atom has a key and the second pass adds nothing. A size has no key and is not
+     * one of these — it is a number taken of what stands at a name. So the order is the walk's, and
+     * the walk's is the declaration's.
+     */
+    private static Set<RuleKey> written(Map<RuleKey, FactSubject> atoms,
+                                        Map<RuleKey, FactSubject> keys) {
+        Set<RuleKey> out = new LinkedHashSet<>(keys.keySet());
+        out.addAll(atoms.keySet());
+        return out;
+    }
+
+    /** Both subjects the name {@code path} answers to — see {@link Seeded#named}. Over the two maps
+     *  rather than over a reading, so that the reading itself can be answered for before there is
+     *  one to ask. */
+    private static List<FactSubject> named(Map<RuleKey, FactSubject> atoms,
+                                           Map<RuleKey, FactSubject> keys, RuleKey path) {
+        List<FactSubject> names = new ArrayList<>();
+        FactSubject atom = atoms.get(path);
+        if (atom != null) {
+            names.add(atom);
+        }
+        FactSubject key = keys.get(path);
+        if (key != null) {
+            names.add(key);
+        }
+        return names;
     }
 
     /** The atom of a count that may not be there, which every lookup of one wants. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -365,10 +365,11 @@ final class ReadQuantities implements Quantities {
         // What the values of this space cost to work out. One for the space and not one per
         // parameter: what each parameter was read under is the allowance of its own declaration,
         // and the set a position finally admits here is met out of all of them — so this is the
-        // answer being built and this is where building it is charged.
+        // answer being built and this is where building it is charged. Handed to each meet, since
+        // that is where a set neither reading holds comes to be.
         souther.compiler.values.Allowance<InputAtom> sets = policy.allowanceForAdmittedValues();
         for (FieldDomains.Carried<InputAtom> each : conditioned(under).values()) {
-            made = made.meet(each.constraints().under(sets));
+            made = made.meet(each.constraints(), sets);
         }
         // And what the context itself says about the values, which is as much a part of what the
         // question is asked against as any clause. A row this question is about is one the

--- a/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
@@ -30,10 +30,24 @@ import java.util.Set;
  * was before any of this.
  *
  * <p><b>One answer, one allowance.</b> Turning a rule into the set it names and putting a position's
- * sets together are the same spending, and so is putting two readings' answers together afterwards —
- * what comes out of that is a third set nobody has paid for. An answer given a fresh allowance for
- * each of those may spend its whole budget several times over, and the bound would be on a phase
- * rather than on the answer.
+ * sets together are the same spending, and both are part of the one answer being built. An answer
+ * given a fresh allowance for each of those may spend its whole budget several times over, and the
+ * bound would be on a phase rather than on the answer.
+ *
+ * <p><b>And putting two answers together is a third answer.</b> A reading of one declaration is
+ * bounded by the purse it was read under; two of them met over one vocabulary come to a set neither
+ * of them holds, and that set belongs to whoever asked for it. So it is paid for out of that
+ * caller's own allowance, and the readings' purses are where they were — a composition charged to
+ * an operand's purse would spend what a declaration was allowed on an answer about somebody else's
+ * question.
+ *
+ * <p><b>Which is why this is held by whoever is building an answer and never by a value that
+ * answers.</b> A value carrying one is a value carrying a fact about no reading in it, and a
+ * composition of two such values has two purses to pick from — so which of them pays, and with it
+ * how exactly the composition comes out, would be settled by which side the call was written on.
+ * Every operation here that may build takes the allowance it spends
+ * ({@link AdmissibleValues#meet}, {@link ConjoinedAdmissibleValues#meet}), and the ones that build
+ * nothing take none.
  *
  * <p><b>And nothing composes outside it.</b> Everything that may build is asked for through
  * {@link AdmittedPlan} and worked out by a {@link Realizer}, which is what makes the order the work
@@ -383,30 +397,6 @@ public final class Allowance<A> {
             spent += budget.mostBuilt() - nowhereMeter.left();
         }
         return spent;
-    }
-
-    /**
-     * The same allowance, filed under what {@code naming} calls each position.
-     *
-     * <p>One answer and not two. A reading renamed into another vocabulary is the same answer being
-     * built under other names, so what a position has spent goes with it — given a fresh allowance,
-     * a position would be allowed its machine once on each side of the renaming and the product of
-     * the two would be bought by nobody. The meters and the worked-out answers themselves, and not
-     * copies of them, for that reason.
-     */
-    public <B> Allowance<B> renamed(java.util.function.Function<A, B> naming) {
-        // What was lent goes with the positions it was lent to, which are the realizers below: each
-        // of them holds the lending question already, asked under the name it was asked under. A
-        // position this hears of only after the renaming is one that was in no lending question,
-        // there being nothing under either name to lend — so what is left here lends nothing.
-        Allowance<B> out = new Allowance<>(budget, Known.nothing());
-        meters.forEach((block, meter) -> out.meters.put(block.renamed(naming), meter));
-        realizers.forEach((block, made) -> out.realizers.put(block.renamed(naming), made));
-        spent.forEach(block -> out.spent.add(block.renamed(naming)));
-        out.nowhere = nowhere;
-        out.nowhereMeter = nowhereMeter;
-        out.spentElsewhere = spentElsewhere;
-        return out;
     }
 
     /** Every value there is, and the fact that this is not what the rules leave. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
@@ -45,9 +45,10 @@ import java.util.Set;
  * answers.</b> A value carrying one is a value carrying a fact about no reading in it, and a
  * composition of two such values has two purses to pick from — so which of them pays, and with it
  * how exactly the composition comes out, would be settled by which side the call was written on.
- * Every operation here that may build takes the allowance it spends
- * ({@link AdmissibleValues#meet}, {@link ConjoinedAdmissibleValues#meet}), and the ones that build
- * nothing take none.
+ * So an operation that may build is told which allowance it spends, and one that builds nothing
+ * takes none. Who holds one is written down and counted off the compiled classes
+ * ({@code AnAllowanceIsHeldByWhoeverIsBuildingAnAnswerTest}), rather than listed here, where a
+ * holder added later would be one this sentence had not heard of.
  *
  * <p><b>And nothing composes outside it.</b> Everything that may build is asked for through
  * {@link AdmittedPlan} and worked out by a {@link Realizer}, which is what makes the order the work

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -49,6 +49,12 @@ import java.util.function.Function;
  * over one vocabulary is asking for their product. What is promised is that a conjunction pays the
  * product only where the positions actually meet.
  *
+ * <p><b>No allowance is held.</b> An {@link Allowance} is what one answer being built may spend, and
+ * this is a value rather than an answer under construction — so every operation of it that may put
+ * two sets together is told which answer pays ({@link #meet}), and the ones that build nothing take
+ * none. Held here, the purse would be the one thing about a conjunction that is not a fact about the
+ * readings in it, and a binary operation between two of them would have two to choose from.
+ *
  * <p>No join. A choice between alternatives happens while one declaration is read, which is below
  * this and inside {@link AdmissibleValues}. A disjunction of two factored conjunctions would have to
  * expand them to be said at all, and nothing asks for one.
@@ -69,23 +75,8 @@ public final class ConjoinedAdmissibleValues<A> {
      */
     private final Map<A, AdmissibleValues<A>> naming;
 
-    /**
-     * What put these readings together, and what will put them together with the next one.
-     *
-     * <p>Carried rather than passed in, because the allowance it holds belongs to the answer being
-     * built and not to whoever is asking for the next meet. A conjunction is the one place two
-     * readings of one declaration come together, so the composer that paid for the sets in it is
-     * the composer the next conjunction has to spend from — handed a fresh one, two patterns at a
-     * position would each be affordable and their product would be bought twice.
-     *
-     * <p>Null where nothing has been read, which is a conjunction with no factors and nothing to
-     * put together.
-     */
-    private final Allowance<A> sets;
-
-    private ConjoinedAdmissibleValues(List<AdmissibleValues<A>> factors, Allowance<A> sets) {
+    private ConjoinedAdmissibleValues(List<AdmissibleValues<A>> factors) {
         this.factors = List.copyOf(factors);
-        this.sets = sets;
         Map<A, AdmissibleValues<A>> named = new LinkedHashMap<>();
         for (AdmissibleValues<A> each : this.factors) {
             for (A subject : each.subjects()) {
@@ -98,39 +89,21 @@ public final class ConjoinedAdmissibleValues<A> {
         this.naming = Collections.unmodifiableMap(named);
     }
 
-    /**
-     * What put these sets together, for a reader that has to put one of them together with another.
-     *
-     * <p>Null where nothing was read. A reader holding that is holding every value at every
-     * position, which is what it would have composed its way to anyway.
-     */
-    public Allowance<A> sets() {
-        return sets;
-    }
-
-    /**
-     * The same readings, spending what {@code sets} allows.
-     *
-     * <p>What an answer built out of other answers does with them. The readings below were put
-     * together where each was read, each spending its own declaration's allowance; met into one
-     * they are a different admitted set, over positions this caller names, and it is that set the
-     * allowance has to be about. So the composer comes from whoever is building the answer, and the
-     * readings are taken under it rather than each bringing its own.
-     *
-     * <p>Nothing already read is undone. What is being said is where the next machine is charged.
-     */
-    public ConjoinedAdmissibleValues<A> under(Allowance<A> sets) {
-        return this.sets == sets ? this : new ConjoinedAdmissibleValues<>(factors, sets);
-    }
-
-    /** Nothing read, so every position holds every value — and nothing to put together. */
+    /** Nothing read, so every position holds every value. */
     public static <A> ConjoinedAdmissibleValues<A> top() {
-        return new ConjoinedAdmissibleValues<>(List.of(), null);
+        return new ConjoinedAdmissibleValues<>(List.of());
     }
 
-    /** One reading, which is a conjunction of one, beside what put its sets together. */
-    public static <A> ConjoinedAdmissibleValues<A> of(AdmissibleValues<A> read, Allowance<A> sets) {
-        return new ConjoinedAdmissibleValues<>(List.of(read), sets);
+    /**
+     * One reading, which is a conjunction of one.
+     *
+     * <p>No allowance, because holding a reading is not composing one. What the reading admits was
+     * built where the reading was read and out of what that answer was allowed; wrapping it here
+     * puts no two sets together and asks for no machine, so there is nothing to charge and nobody
+     * to charge it to.
+     */
+    public static <A> ConjoinedAdmissibleValues<A> of(AdmissibleValues<A> read) {
+        return new ConjoinedAdmissibleValues<>(List.of(read));
     }
 
     /**
@@ -278,23 +251,26 @@ public final class ConjoinedAdmissibleValues<A> {
      * is one factor over all three. Merged pairwise in one pass, the result would hold two factors
      * that share {@code c}, and every answer that rests on the vocabularies being disjoint would be
      * answering from a factor that is not the only one naming its subject.
+     *
+     * <p><b>{@code sets} is the caller's and not either side's.</b> Where the vocabularies meet, a
+     * factor of the result is a set neither reading holds, and the answer it is part of is the one
+     * being built here. Read off the receiver instead, which of two purses paid would be settled by
+     * which side {@code .meet} was written on: charged to a purse that never admitted these
+     * readings, a composition one of them could not afford gets built; charged to the smaller of
+     * the two, one that both could afford does not. Neither is a fact about the readings, so
+     * neither is a question a value of this can answer.
      */
-    public ConjoinedAdmissibleValues<A> meet(ConjoinedAdmissibleValues<A> other) {
+    public ConjoinedAdmissibleValues<A> meet(ConjoinedAdmissibleValues<A> other,
+                                             Allowance<A> sets) {
         if (other.factors.isEmpty()) {
             return this;
         }
         if (factors.isEmpty()) {
             return other;
         }
-        // One answer is being built, so one composer is spending for it. Two readings that were put
-        // together by different composers are two answers, and meeting them would charge a position
-        // of one against the allowance of the other. An assertion because it is a fact about how
-        // this compiler reads a declaration rather than about any model.
-        assert sets == other.sets
-                : "two readings put together by different composers are two answers";
         List<AdmissibleValues<A>> both = new ArrayList<>(factors);
         both.addAll(other.factors);
-        return new ConjoinedAdmissibleValues<>(byComponent(both, sets), sets);
+        return new ConjoinedAdmissibleValues<>(byComponent(both, sets));
     }
 
     /**
@@ -303,13 +279,14 @@ public final class ConjoinedAdmissibleValues<A> {
      * <p>Factor by factor, and the vocabularies stay disjoint because the naming names two subjects
      * two subjects — which is the caller's to hold to and is what
      * {@code souther.compiler.check.InjectiveRenaming} is.
+     *
+     * <p>Nothing is built, so nothing is charged. The sets are the ones already worked out, filed
+     * under other names.
      */
     public <B> ConjoinedAdmissibleValues<B> renamed(Function<A, B> naming) {
         List<AdmissibleValues<B>> out = new ArrayList<>(factors.size());
         factors.forEach(each -> out.add(each.renamed(naming)));
-        // The allowances go with the names. It is the same answer being built, so what a position
-        // has spent is what it has spent whichever vocabulary it is filed under.
-        return new ConjoinedAdmissibleValues<>(out, sets == null ? null : sets.renamed(naming));
+        return new ConjoinedAdmissibleValues<>(out);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -25,12 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReadingsConjoinedAreNotMultipliedTest {
 
     /**
-     * What puts the sets of these readings together.
+     * What the answer built in each of these is allowed to spend putting sets together.
      *
-     * <p>One for the file, and one for every conjunction in it: a conjunction is the one place two
-     * readings of a declaration come together, so the composer that paid for the sets in one is the
-     * composer the next meet spends from. Every set here is values written out, so nothing is built
-     * and no allowance is spent.
+     * <p>One for the file rather than one per test, which is what a file of readings over values
+     * written out can have: every set here is values, so nothing below builds a machine and nothing
+     * is spent. A test about what a composition costs makes its own — see
+     * {@code WhatAConjunctionCostsIsTheComposersToSayTest}.
      */
     private static final Allowance<String> SETS = AsACompilationAllows.forAdmittedValues();
 
@@ -38,8 +38,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
     @Test
     void readingsOverDisjointPositionsStayApart() {
         ConjoinedAdmissibleValues<String> both =
-                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"), SETS)
-                        .meet(ConjoinedAdmissibleValues.of(twoAlternatives("c", "d"), SETS));
+                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
+                        .meet(ConjoinedAdmissibleValues.of(twoAlternatives("c", "d")), SETS);
 
         assertEquals(2, both.factors().size(), "one factor per reading");
         both.factors().forEach(each -> assertEquals(2, alternativesOf(each),
@@ -50,8 +50,8 @@ class ReadingsConjoinedAreNotMultipliedTest {
     @Test
     void andEachPositionIsAnsweredAsItWas() {
         ConjoinedAdmissibleValues<String> both =
-                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"), SETS)
-                        .meet(ConjoinedAdmissibleValues.of(twoAlternatives("c", "d"), SETS));
+                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
+                        .meet(ConjoinedAdmissibleValues.of(twoAlternatives("c", "d")), SETS);
 
         assertEquals(twoAlternatives("a", "b").at("a"), both.at("a"));
         assertEquals(twoAlternatives("c", "d").at("d"), both.at("d"));
@@ -70,14 +70,14 @@ class ReadingsConjoinedAreNotMultipliedTest {
     @Test
     void factorsReachingEachOtherThroughAThirdAreOneFactor() {
         ConjoinedAdmissibleValues<String> apart =
-                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"), SETS)
+                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
                         .meet(ConjoinedAdmissibleValues.of(
-                                AdmissibleValues.at("c", just("x")), SETS));
+                                AdmissibleValues.at("c", just("x"))), SETS);
         assertEquals(2, apart.factors().size());
 
         ConjoinedAdmissibleValues<String> joined = apart.meet(ConjoinedAdmissibleValues.of(
                 AdmissibleValues.at("b", just("y"))
-                        .meet(AdmissibleValues.at("c", just("x")), SETS), SETS));
+                        .meet(AdmissibleValues.at("c", just("x")), SETS)), SETS);
 
         assertEquals(1, joined.factors().size(), "all three reach each other");
         assertEquals(Set.of("a", "b", "c"), joined.subjects());
@@ -89,10 +89,10 @@ class ReadingsConjoinedAreNotMultipliedTest {
     @Test
     void oneFactorHoldingNothingIsTheWholeHoldingNothing() {
         ConjoinedAdmissibleValues<String> both =
-                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"), SETS)
+                ConjoinedAdmissibleValues.of(twoAlternatives("a", "b"))
                         .meet(ConjoinedAdmissibleValues.of(
                                 AdmissibleValues.at("c", just("x"))
-                                        .meet(AdmissibleValues.at("c", just("y")), SETS), SETS));
+                                        .meet(AdmissibleValues.at("c", just("y")), SETS)), SETS);
 
         assertEquals(Emptiness.EMPTY, both.anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY));
     }
@@ -122,12 +122,12 @@ class ReadingsConjoinedAreNotMultipliedTest {
         AdmissibleValues<String> bridge =
                 AdmissibleValues.unreadable(Set.of("b", "x"), UnreadReason.RELATES_TWO_POSITIONS);
 
-        ConjoinedAdmissibleValues<String> apart = ConjoinedAdmissibleValues.of(named, SETS)
-                .meet(ConjoinedAdmissibleValues.of(arrivedSecond, SETS));
+        ConjoinedAdmissibleValues<String> apart = ConjoinedAdmissibleValues.of(named)
+                .meet(ConjoinedAdmissibleValues.of(arrivedSecond), SETS);
         assertEquals(2, apart.factors().size(), "these two share nothing");
 
         ConjoinedAdmissibleValues<String> joined =
-                apart.meet(ConjoinedAdmissibleValues.of(bridge, SETS));
+                apart.meet(ConjoinedAdmissibleValues.of(bridge), SETS);
 
         assertEquals(1, joined.factors().size(), "and the third reaches both of them");
         assertEquals(List.of(UnreadReason.FORM_NOT_READ, UnreadReason.RELATES_TWO_POSITIONS),
@@ -152,7 +152,7 @@ class ReadingsConjoinedAreNotMultipliedTest {
         assertTrue(read.projectionExactAt("elsewhere"));
         assertEquals(List.of(), read.whyUnread("elsewhere"));
 
-        assertTrue(ConjoinedAdmissibleValues.of(read, SETS).at("elsewhere").isAny());
+        assertTrue(ConjoinedAdmissibleValues.of(read).at("elsewhere").isAny());
         assertTrue(ConjoinedAdmissibleValues.<String>top().at("elsewhere").isAny(),
                 "and a conjunction of no readings names nothing at all");
     }
@@ -172,9 +172,9 @@ class ReadingsConjoinedAreNotMultipliedTest {
         assertFalse(nothing.hasReadings());
 
         ConjoinedAdmissibleValues<String> overOneVocabulary =
-                ConjoinedAdmissibleValues.of(AdmissibleValues.at("x", just("A")), SETS)
+                ConjoinedAdmissibleValues.of(AdmissibleValues.at("x", just("A")))
                         .meet(ConjoinedAdmissibleValues.of(
-                                AdmissibleValues.at("x", just("B")), SETS));
+                                AdmissibleValues.at("x", just("B"))), SETS);
 
         assertEquals(1, overOneVocabulary.factors().size(),
                 "two readings of one position are one factor");
@@ -201,7 +201,7 @@ class ReadingsConjoinedAreNotMultipliedTest {
                 "the reading holds `x` nowhere but among the positions a choice opened, and it is"
                         + " a position the reading is about all the same");
         assertEquals(opened.whyUnread("x"),
-                ConjoinedAdmissibleValues.of(opened, SETS).whyUnread("x"),
+                ConjoinedAdmissibleValues.of(opened).whyUnread("x"),
                 "so a conjunction of it answers about `x` out of the factor that names it");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
@@ -100,6 +100,10 @@ class WhatAConjunctionCostsIsTheComposersToSayTest {
                         + " not told about, an answer nobody budgeted for would come back exact");
         assertEquals(PLENTY - forward.left(HERE), PLENTY - backward.left(HERE),
                 "and the same is spent building it");
+        assertEquals(forward.spentSoFar(), backward.spentSoFar(),
+                "over every purse the answer opened and not the one this test can name: which"
+                        + " blocks a reading has is settled by its equalities, so a composition"
+                        + " that opened another would spend where nothing was watching");
     }
 
     /**
@@ -128,6 +132,8 @@ class WhatAConjunctionCostsIsTheComposersToSayTest {
         assertEquals(one.whyUnread("here"), other.whyUnread("here"));
         assertEquals(Set.of(HERE), forward.spent());
         assertEquals(forward.spent(), backward.spent());
+        assertEquals(forward.spentSoFar(), backward.spentSoFar(),
+                "and the same is spent finding out, over every purse the answer opened");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAConjunctionCostsIsTheComposersToSayTest.java
@@ -1,0 +1,152 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.regex.Language;
+import souther.compiler.regex.PatternParser;
+import souther.compiler.regex.PatternPlan;
+import souther.compiler.regex.PatternRead;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What two conjoined readings come to is settled by the purse the caller names, and not by which of
+ * them the call was written on.
+ *
+ * <p>Where two readings name the same position, the factor they merge into holds a set neither of
+ * them holds — and building it takes a machine somebody pays for. That answer is the caller's, so
+ * the purse is the caller's ({@link ConjoinedAdmissibleValues#meet}). Read off one of the operands
+ * instead, the pair would have two purses to be composed under and which one paid would be settled
+ * by which side {@code .meet} was typed on: a composition the smaller purse refused gets built under
+ * the roomier one, and the same two readings the other way round are refused again.
+ *
+ * <p>So the two orders are asked of purses that are equal and separate. Equal, because the same
+ * question has to be put to both; separate, because an allowance is what one answer has spent so far
+ * — asked twice of one of them, the second order would be measuring a purse the first order had
+ * already emptied.
+ */
+class WhatAConjunctionCostsIsTheComposersToSayTest {
+
+    private static final Sameness.Block<String> HERE = Sameness.Block.of("here");
+
+    /** More than anything here asks for, so that a measurement is of the work and not of a limit. */
+    private static final int PLENTY = 10_000_000;
+
+    /**
+     * Two readings of one position, each admitting the strings whose length divides a number.
+     *
+     * <p>Chosen because their meet is a machine as large as the two numbers multiply to and is never
+     * empty: what is wanted is a composition big enough to be refused by a purse that has room for
+     * each reading on its own. Values written out would be met by set arithmetic and cost nothing,
+     * and there would be no purse to tell apart.
+     */
+    private static ConjoinedAdmissibleValues<String> everyMultipleOf(int every) {
+        return ConjoinedAdmissibleValues.of(AdmissibleValues.at("here",
+                ValueSet.matching(language("(?:[0-9]{" + every + "})+"))));
+    }
+
+    private static Language language(String regex) {
+        PatternRead read = PatternParser.read(regex);
+        Language made = PatternPlan.of(assertInstanceOf(PatternRead.Read.class, read, regex)
+                .syntax()).compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter());
+        assertNotNull(made, regex);
+        return made;
+    }
+
+    /** An allowance of {@code inAll} states in all, no one machine being larger than the lot. */
+    private static Allowance<String> allowing(int inAll) {
+        return Allowance.of(new PatternPlan.Budget(inAll, inAll));
+    }
+
+    /** What building this composition takes at the position, measured rather than reckoned. */
+    private static int costOfConjoining() {
+        Allowance<String> measuring = allowing(PLENTY);
+        everyMultipleOf(3).meet(everyMultipleOf(4), measuring);
+        return PLENTY - measuring.left(HERE);
+    }
+
+    /**
+     * A purse with room builds the same set whichever reading the call was written on.
+     *
+     * <p>And the same amount of it is spent, which is the half a set alone would not show: an answer
+     * that came out equal while one order had paid for a machine the other borrowed would be two
+     * answers that agree today.
+     */
+    @Test
+    void aRoomyPurseAnswersTheSameEitherWayRound() {
+        Allowance<String> forward = allowing(PLENTY);
+        Allowance<String> backward = allowing(PLENTY);
+
+        ConjoinedAdmissibleValues<String> one = everyMultipleOf(3).meet(everyMultipleOf(4), forward);
+        ConjoinedAdmissibleValues<String> other =
+                everyMultipleOf(4).meet(everyMultipleOf(3), backward);
+
+        assertFalse(one.at("here").isAny(),
+                "the composition was built, or the two orders agree about nothing");
+        assertEquals(one.at("here"), other.at("here"));
+        assertTrue(one.projectionExactAt("here"));
+        assertEquals(one.projectionExactAt("here"), other.projectionExactAt("here"));
+        assertEquals(List.of(), one.whyUnread("here"));
+        assertEquals(one.whyUnread("here"), other.whyUnread("here"));
+        assertTrue(forward.left(HERE) < PLENTY,
+                "the purse the caller named is the one that paid — built out of one this call was"
+                        + " not told about, an answer nobody budgeted for would come back exact");
+        assertEquals(PLENTY - forward.left(HERE), PLENTY - backward.left(HERE),
+                "and the same is spent building it");
+    }
+
+    /**
+     * And a purse that is short gives up the same way round.
+     *
+     * <p>Room for either reading and one state short of room for what they come to, so the only
+     * thing that can refuse this is the composition itself. What comes back is every value, and the
+     * shortfall arrives beside it.
+     */
+    @Test
+    void aShortPurseGivesUpTheSameEitherWayRound() {
+        int oneStateShort = costOfConjoining() - 1;
+        Allowance<String> forward = allowing(oneStateShort);
+        Allowance<String> backward = allowing(oneStateShort);
+
+        ConjoinedAdmissibleValues<String> one = everyMultipleOf(3).meet(everyMultipleOf(4), forward);
+        ConjoinedAdmissibleValues<String> other =
+                everyMultipleOf(4).meet(everyMultipleOf(3), backward);
+
+        assertTrue(one.at("here").isAny(), "the composition was refused, which is what is being"
+                + " asked about — a purse this test did not make short says nothing");
+        assertEquals(one.at("here"), other.at("here"));
+        assertFalse(one.projectionExactAt("here"));
+        assertEquals(one.projectionExactAt("here"), other.projectionExactAt("here"));
+        assertEquals(List.of(UnreadReason.EXACT_VALUES_TOO_COSTLY), one.whyUnread("here"));
+        assertEquals(one.whyUnread("here"), other.whyUnread("here"));
+        assertEquals(Set.of(HERE), forward.spent());
+        assertEquals(forward.spent(), backward.spent());
+    }
+
+    /**
+     * The purse that was named is what the answer follows.
+     *
+     * <p>The control the two tests above rest on: they say the orders agree, and that says something
+     * only where the purses do not. The same pair of readings comes to two different answers under
+     * two purses, and the difference is which purse the caller named — a reading holds none, so
+     * there is no other place the choice could have come from.
+     */
+    @Test
+    void andTheTwoPursesAnswerDifferently() {
+        Allowance<String> roomy = allowing(PLENTY);
+        Allowance<String> oneStateShort = allowing(costOfConjoining() - 1);
+
+        ValueSet built = everyMultipleOf(3).meet(everyMultipleOf(4), roomy).at("here");
+        ValueSet refused = everyMultipleOf(3).meet(everyMultipleOf(4), oneStateShort).at("here");
+
+        assertFalse(built.isAny());
+        assertTrue(refused.isAny());
+    }
+}


### PR DESCRIPTION
Closes #1392.

## What was wrong

`ConjoinedAdmissibleValues` held an `Allowance` and spent it in `meet`. That
made the purse a fact about the value rather than about the answer being
built, and between two values there were two purses to choose from. The
receiver's won, so which purse paid — and with it whether the composition
came out exact or widened to every value — was settled by which side the call
was written on.

The assertion beside it said the two purses had to be the same object, which
is not something either reading knows, and `under` let any caller replace the
one in hand. The one production composer does exactly that on every operand
before meeting, so the invariant the assertion named was one nothing kept.

## What it is now

The value holds no allowance. `meet` is told which answer pays, as
`AdmissibleValues.meet` already was, and the operations that build nothing
take none: `of` wraps a reading, `renamed` files the same sets under other
names. `ConstraintState.meet` takes it the same way and `under` goes, its one
caller now naming its purse where it composes.

What this buys is not that a crossing cannot be written — a caller can still
hand over a purse that admitted neither reading. It is that the choice cannot
be made silently out of an operand: the composition is charged to the answer
being built, and whoever is building it has to say which that is.

`Allowance.renamed` goes with it. Its only caller was a purse riding inside a
value, and what it moved was thrown away by the next `under`.

One reader was finishing an answer the reading had started: a name is filed
under a subject the interval algebra knows it by and a subject everything else
knows it by, and what it admits is what both leave, which takes a machine. That
is the reading's own filing, so it is the reading's own answer. It is worked out
where the purse still is and handed over as sets, and the list of names and the
subjects each answers to go with it, being reads of the same two maps.

Which is not where this first went. The purse was put on the seeded reading for
that one reader to spend — and that reading is kept: two readers hold one to
seed once and ask many times, so an allowance was reachable from an object that
only answers questions. The same defect this change is about, one field further
out.

## Two things removed along the way

`Seeded.nothingRead()` had no caller. What a walk that fell over comes to is not
a reading part-built, and nothing was asking for it.

`InvariantChecker` spelled `Allowance` out in full at three places, and the new
code is a fourth. A file spelling one name two ways is worse than either, so the
file takes the import.

## How it is closed

A conjunction of two readings over one vocabulary, under purses that are equal
and separate, comes to the same set and spends the same either way round — and
the purse the caller named is the one that paid. Where the purse is a state
short of what the composition takes, both orders give up alike and say so at
the same position. Both rest on a control that the two purses answer
differently, or agreement between the orders would be agreement about nothing.

An architecture test writes down everywhere an allowance can be reached from,
read off the compiled classes. Every row is a reading that has not finished
answering or something holding one, and none of them is an answer a reading
published — so a purse taken back into one of those is a finding rather than an
edit. A conjunction names an allowance only in the operation that composes,
counted the same way and over its nested types too.

Reached from and not held in, because what a reader can spend is what it can
reach: through what it holds, however many fields away, and inside a collection
whose element type the erasure drops. Both are asked for by name, since a walk
that reads a field's erasure one level deep is the walk that let the mistake
above through.

## Left out

A composition takes a purse of its own and does not read what the readings'
own purses already built, so a machine one of them made may be made again.
That is `Allowance.besides`'s question and a different invariant — what work
may be reused across two answers, rather than which answer pays — and it is
not what #1392 reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

