### PR TITLE
A rule says how a reader finds it, and a handle says which rule it is

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
@@ -76,6 +76,33 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
     /** One way, which is the shape everything is held to. */
     record OneWayToOneRule(souther.compiler.check.RuleCitation cited) { }
 
+    /**
+     * The same pair, with the rule reached through a type variable.
+     *
+     * <p>What a variable is instantiated with is settled where the state is built, and this walk is
+     * not asking that. It is asking whether the state can hold a rule of its own, and a variable
+     * bounded by one says statically that it can — so a walk that passed over it would let the pair
+     * through under the one spelling nobody would think to look at.
+     */
+    record TwoWaysThroughAVariable<R extends souther.compiler.check.RuleRef>(
+            R rule, souther.compiler.check.RuleCitation cited) { }
+
+    /** A state that holds a rule, for the pair below to inherit. */
+    static class HoldsARule {
+        souther.compiler.check.RuleRef rule;
+    }
+
+    /**
+     * And the same pair, with one half inherited.
+     *
+     * <p>What a state carries is what an instance of it holds, which is its own fields and the ones
+     * above it. Read off the class's own declarations, a pair split over a hierarchy is two states
+     * with one way each and one instance with two.
+     */
+    static class TwoWaysThroughASuperclass extends HoldsARule {
+        souther.compiler.check.RuleCitation cited;
+    }
+
     @Test
     void nothingThisRepositoryPublishesHoldsARuleAndAHandleBesideIt() {
         Carried carried = Carried.ofWhatThisRepositoryPublishes();
@@ -104,8 +131,16 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
 
         assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysToOneRule")),
                 "a rule and a handle beside it are two ways to one rule");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAVariable")),
+                "a variable bounded by a rule is a way to one, whatever it is instantiated with");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughASuperclass")),
+                "and what a state carries is what an instance of it holds, the fields above it"
+                        + " among them");
         assertEquals(1, carried.waysToARuleFrom(fixture("OneWayToOneRule")),
                 "and a handle alone is one, since the rule it carries is not a second way");
+        assertEquals(1, carried.waysToARuleFrom(fixture("HoldsARule")),
+                "and the half that holds only the rule is one way, so the pair above is the"
+                        + " hierarchy's and not either half's");
     }
 
     /**
@@ -179,7 +214,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          */
         int waysToARuleFrom(String owner) {
             int ways = 0;
-            for (Signature each : carriedBy(modelOf(owner))) {
+            for (Carries each : carriedBy(modelOf(owner))) {
                 if (reachesARule(each, Through.ANYTHING)) {
                     ways++;
                 }
@@ -201,7 +236,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          * that keeps rules keeps a collection of them, and what is inside carries its own handle.
          */
         boolean isAboutOneRule(String owner) {
-            for (Signature each : carriedBy(modelOf(owner))) {
+            for (Carries each : carriedBy(modelOf(owner))) {
                 if (reachesARule(each, Through.ONE_VALUE_AT_A_TIME)) {
                     return true;
                 }
@@ -218,26 +253,53 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
             return model;
         }
 
-        /** What one class keeps: a record's components, or the instance fields of anything else. */
-        private static List<Signature> carriedBy(ClassModel model) {
-            Optional<RecordAttribute> record = model.findAttribute(Attributes.record());
-            List<Signature> out = new ArrayList<>();
-            if (record.isPresent()) {
-                for (RecordComponentInfo component : record.get().components()) {
-                    out.add(WhatASignatureReaches.componentSignature(component));
-                }
-                return out;
-            }
-            for (FieldModel field : model.fields()) {
-                if (field.flags().has(AccessFlag.STATIC)) {
+        /**
+         * What one class keeps: a record's components, or the instance fields of anything else,
+         * with the state it inherits among them.
+         *
+         * <p>What a state carries is what an instance of it holds. Read off the class's own
+         * declarations alone, a pair split over a hierarchy is two classes with one way each while
+         * every instance of the lower one has both.
+         *
+         * <p>Each carried thing keeps the class that declared it beside it, because a signature is
+         * read in the frame of whoever wrote it: a variable named in a superclass's field is that
+         * superclass's, and looked up in the wrong frame it is a name with no bound.
+         */
+        private List<Carries> carriedBy(ClassModel model) {
+            List<Carries> out = new ArrayList<>();
+            for (ClassModel each = model; each != null; each = superclassOf(each)) {
+                Optional<RecordAttribute> record = each.findAttribute(Attributes.record());
+                if (record.isPresent()) {
+                    for (RecordComponentInfo component : record.get().components()) {
+                        out.add(new Carries(WhatASignatureReaches.componentSignature(component),
+                                each));
+                    }
                     continue;
                 }
-                out.add(field.findAttribute(Attributes.signature())
-                        .map(SignatureAttribute::asTypeSignature)
-                        .orElseGet(() -> Signature.of(field.fieldTypeSymbol())));
+                for (FieldModel field : each.fields()) {
+                    if (field.flags().has(AccessFlag.STATIC)) {
+                        continue;
+                    }
+                    ClassModel owner = each;
+                    out.add(new Carries(field.findAttribute(Attributes.signature())
+                            .map(SignatureAttribute::asTypeSignature)
+                            .orElseGet(() -> Signature.of(field.fieldTypeSymbol())), owner));
+                }
             }
             return out;
         }
+
+        /** The class above this one, where this repository built it. A class whose parent it did
+         *  not build carries nothing this walk can read, which is where the walk stops. */
+        private ClassModel superclassOf(ClassModel model) {
+            return model.superclass()
+                    .map(each -> classes.get(each.name().stringValue()))
+                    .orElse(null);
+        }
+
+        /** One thing a state carries, and the class whose type parameters its signature is read
+         *  against. */
+        private record Carries(Signature type, ClassModel declaredBy) { }
 
         /** How much of what a state carries a walk is allowed through. */
         private enum Through {
@@ -251,8 +313,8 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
         }
 
         /** Whether one thing a class carries reaches the rule it is about. */
-        private boolean reachesARule(Signature type, Through through) {
-            for (String named : namesIn(type, through)) {
+        private boolean reachesARule(Carries carried, Through through) {
+            for (String named : namesIn(carried.type(), through, carried.declaredBy())) {
                 if (reachesARule(named, through)) {
                     return true;
                 }
@@ -276,7 +338,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
                 return false;
             }
             boolean found = false;
-            for (Signature each : carriedBy(model)) {
+            for (Carries each : carriedBy(model)) {
                 if (reachesARule(each, through)) {
                     found = true;
                     break;
@@ -332,26 +394,46 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
             }
         }
 
-        /** Every class a signature names, its type arguments among them: a set of handles reaches
-         *  what a handle does, except where the walk is asked for one value at a time. */
-        private static Set<String> namesIn(Signature type, Through through) {
+        /**
+         * Every class a signature names, its type arguments among them: a set of handles reaches
+         * what a handle does, except where the walk is asked for one value at a time.
+         *
+         * <p>{@code declaredBy} is the class whose type parameters a variable in the signature is
+         * looked up in, which is whoever wrote the field.
+         */
+        private static Set<String> namesIn(Signature type, Through through,
+                                           ClassModel declaredBy) {
             Set<String> out = new LinkedHashSet<>();
-            collect(type, through, out);
+            collect(type, through, declaredBy, out);
             return out;
         }
 
-        private static void collect(Signature type, Through through, Set<String> into) {
+        private static void collect(Signature type, Through through, ClassModel declaredBy,
+                                    Set<String> into) {
             switch (type) {
                 case Signature.BaseTypeSig _ -> { }
                 case Signature.ArrayTypeSig array -> {
                     if (through == Through.ANYTHING) {
-                        collect(array.componentSignature(), through, into);
+                        collect(array.componentSignature(), through, declaredBy, into);
                     }
                 }
-                // A variable's bound is not walked. What a state carries under one is settled where
-                // the state is built, and this is about what a class keeps rather than about what
-                // some instantiation of it could hold.
-                case Signature.TypeVarSig _ -> { }
+                // Through the bound its declaration gives it. What a variable is instantiated with
+                // is settled where the state is built and is not what is being asked: the question
+                // is whether the state can hold a rule of its own, and a variable bounded by one
+                // says so wherever it is instantiated.
+                case Signature.TypeVarSig variable -> {
+                    for (Signature.TypeParam declared
+                            : WhatASignatureReaches.typeParametersOf(declaredBy)) {
+                        if (!declared.identifier().equals(variable.identifier())) {
+                            continue;
+                        }
+                        declared.classBound()
+                                .ifPresent(each -> collect(each, through, declaredBy, into));
+                        for (Signature.RefTypeSig each : declared.interfaceBounds()) {
+                            collect(each, through, declaredBy, into);
+                        }
+                    }
+                }
                 case Signature.ClassTypeSig named -> {
                     String owner = named.classDesc().descriptorString().replaceAll("^L|;$", "");
                     into.add(owner);
@@ -360,7 +442,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
                     }
                     for (Signature.TypeArg argument : named.typeArgs()) {
                         if (argument instanceof Signature.TypeArg.Bounded bounded) {
-                            collect(bounded.boundType(), through, into);
+                            collect(bounded.boundType(), through, declaredBy, into);
                         }
                     }
                 }

--- a/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
@@ -10,6 +10,7 @@ import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.FieldModel;
+import java.lang.classfile.ClassSignature;
 import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.RecordAttribute;
 import java.lang.classfile.attribute.RecordComponentInfo;
@@ -19,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +105,28 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
         souther.compiler.check.RuleCitation cited;
     }
 
+    /** A state that holds whatever it is given, for the pair below to fill in. */
+    static class Holds<T> {
+        T held;
+    }
+
+    /**
+     * And the same pair again, with the rule given to a class above as a type argument.
+     *
+     * <p>The two above, together. A variable is read in the frame of whoever wrote the field, and
+     * what a subclass gave that frame is where the variable's answer is: read against the
+     * superclass's own declaration alone, {@code T} is bounded by nothing and the rule handed to it
+     * is gone.
+     */
+    static class TwoWaysThroughAParameterizedSuperclass
+            extends Holds<souther.compiler.check.RuleRef> {
+        souther.compiler.check.RuleCitation cited;
+    }
+
+    /** And the same pair with the rule in an array, which is the last shape a field's type has. */
+    record TwoWaysThroughAnArray(souther.compiler.check.RuleRef[] rules,
+                                 souther.compiler.check.RuleCitation cited) { }
+
     @Test
     void nothingThisRepositoryPublishesHoldsARuleAndAHandleBesideIt() {
         Carried carried = Carried.ofWhatThisRepositoryPublishes();
@@ -136,6 +160,8 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
         assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughASuperclass")),
                 "and what a state carries is what an instance of it holds, the fields above it"
                         + " among them");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAParameterizedSuperclass")),
+                "and a variable is answered by what the subclass gave the frame it is written in");
         assertEquals(1, carried.waysToARuleFrom(fixture("OneWayToOneRule")),
                 "and a handle alone is one, since the rule it carries is not a second way");
         assertEquals(1, carried.waysToARuleFrom(fixture("HoldsARule")),
@@ -162,6 +188,59 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
             assertEquals(1, carried.waysToARuleFrom(each),
                     () -> "and it reaches the rule it is about, by one way: " + each);
         }
+    }
+
+    /**
+     * Every shape a field's type has is one the walk goes through.
+     *
+     * <p>The population is the language's own, taken from the seal the class file API writes a
+     * signature with rather than from the shapes anybody thought of. Each hole found in this walk so
+     * far was a shape it passed over — a variable, then a variable answered by a subclass — and each
+     * was found by a reader rather than by the check, because what the walk covered was the states
+     * in front of it.
+     *
+     * <p>A base type names no class and can hold no rule, which is why it is the one shape with no
+     * fixture: the assertion is that every shape which <em>can</em> carry one is a shape a state
+     * built here is found through. A shape added to the seal arrives as a case with no fixture and
+     * fails, rather than as a way to hold a rule that nothing walks.
+     */
+    @Test
+    void everyShapeAFieldsTypeHasIsOneTheWalkGoesThrough() {
+        assertEquals(
+                Set.of(Signature.BaseTypeSig.class, Signature.ArrayTypeSig.class,
+                        Signature.ClassTypeSig.class, Signature.TypeVarSig.class),
+                shapesOf(Signature.class),
+                "the shapes the class file API writes a field's type with");
+
+        Carried carried = Carried.ofEverythingCompiledHere();
+        // One state per shape that can name a class, each holding a rule through that shape and a
+        // handle beside it. Found as two ways is the walk having gone through the shape.
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysToOneRule")),
+                "a class named outright");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAnArray")),
+                "an array of them");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAVariable")),
+                "a variable bounded by one");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAParameterizedSuperclass")),
+                "and a variable a class below answered");
+    }
+
+    /**
+     * The shapes a value of {@code sealed} has, as the API declares them.
+     *
+     * <p>Down to the last interface the class file API names and no further: what a seal permits
+     * below that is the one implementation the platform ships, which is not a shape of the language
+     * and would make this a list of somebody's classes.
+     */
+    private static Set<Class<?>> shapesOf(Class<?> sealed) {
+        Class<?>[] permits = sealed.getPermittedSubclasses();
+        Set<Class<?>> out = new LinkedHashSet<>();
+        for (Class<?> each : permits == null ? new Class<?>[0] : permits) {
+            if (each.isInterface() && each.getName().startsWith("java.lang.classfile.")) {
+                out.addAll(shapesOf(each));
+            }
+        }
+        return out.isEmpty() ? Set.of(sealed) : out;
     }
 
     /** The name the compiler gives a record declared in this test. */
@@ -267,23 +346,66 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          */
         private List<Carries> carriedBy(ClassModel model) {
             List<Carries> out = new ArrayList<>();
-            for (ClassModel each = model; each != null; each = superclassOf(each)) {
+            Map<String, Signature> given = Map.of();
+            for (ClassModel each = model; each != null; ) {
                 Optional<RecordAttribute> record = each.findAttribute(Attributes.record());
                 if (record.isPresent()) {
                     for (RecordComponentInfo component : record.get().components()) {
                         out.add(new Carries(WhatASignatureReaches.componentSignature(component),
-                                each));
+                                each, given));
                     }
-                    continue;
+                } else {
+                    for (FieldModel field : each.fields()) {
+                        if (field.flags().has(AccessFlag.STATIC)) {
+                            continue;
+                        }
+                        ClassModel owner = each;
+                        out.add(new Carries(field.findAttribute(Attributes.signature())
+                                .map(SignatureAttribute::asTypeSignature)
+                                .orElseGet(() -> Signature.of(field.fieldTypeSymbol())),
+                                owner, given));
+                    }
                 }
-                for (FieldModel field : each.fields()) {
-                    if (field.flags().has(AccessFlag.STATIC)) {
-                        continue;
+                ClassModel above = superclassOf(each);
+                given = above == null ? Map.of() : givenTo(above, each, given);
+                each = above;
+            }
+            return out;
+        }
+
+        /**
+         * What {@code below} gave the type parameters of {@code above}, resolved in the frame
+         * {@code below} was itself read in.
+         *
+         * <p>What makes a variable in an inherited field answerable. {@code class Two extends
+         * Holds<RuleRef>} says what {@code Holds}'s {@code T} is, and that is written in {@code
+         * Two}'s frame and nowhere in {@code Holds} — so a walk that went up carrying nothing would
+         * read {@code T} against a declaration that bounds it by nothing and lose the rule handed
+         * to it.
+         */
+        private static Map<String, Signature> givenTo(ClassModel above, ClassModel below,
+                                                      Map<String, Signature> givenToBelow) {
+            List<Signature.TypeParam> parameters = WhatASignatureReaches.typeParametersOf(above);
+            Signature.ClassTypeSig extended = below.findAttribute(Attributes.signature())
+                    .map(SignatureAttribute::asClassSignature)
+                    .map(ClassSignature::superclassSignature)
+                    .orElse(null);
+            if (parameters.isEmpty() || extended == null) {
+                return Map.of();
+            }
+            Map<String, Signature> out = new LinkedHashMap<>();
+            List<Signature.TypeArg> arguments = extended.typeArgs();
+            for (int i = 0; i < parameters.size() && i < arguments.size(); i++) {
+                if (arguments.get(i) instanceof Signature.TypeArg.Bounded bounded) {
+                    Signature argument = bounded.boundType();
+                    // Resolved as far as the frame below already knows: a subclass may pass on a
+                    // variable of its own, and what that one is was settled a step further down.
+                    if (argument instanceof Signature.TypeVarSig passed) {
+                        argument = givenToBelow.get(passed.identifier());
                     }
-                    ClassModel owner = each;
-                    out.add(new Carries(field.findAttribute(Attributes.signature())
-                            .map(SignatureAttribute::asTypeSignature)
-                            .orElseGet(() -> Signature.of(field.fieldTypeSymbol())), owner));
+                    if (argument != null) {
+                        out.put(parameters.get(i).identifier(), argument);
+                    }
                 }
             }
             return out;
@@ -297,9 +419,16 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
                     .orElse(null);
         }
 
-        /** One thing a state carries, and the class whose type parameters its signature is read
-         *  against. */
-        private record Carries(Signature type, ClassModel declaredBy) { }
+        /**
+         * One thing a state carries, the class whose type parameters its signature is read against,
+         * and what a class below gave those parameters.
+         *
+         * <p>The third is what tells an inherited field's variable from a name with no answer. A
+         * variable is looked up in what was given first and in its own declaration's bound after,
+         * because a bound says what may be handed in and an argument says what was.
+         */
+        private record Carries(Signature type, ClassModel declaredBy,
+                               Map<String, Signature> given) { }
 
         /** How much of what a state carries a walk is allowed through. */
         private enum Through {
@@ -314,7 +443,8 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
 
         /** Whether one thing a class carries reaches the rule it is about. */
         private boolean reachesARule(Carries carried, Through through) {
-            for (String named : namesIn(carried.type(), through, carried.declaredBy())) {
+            for (String named : namesIn(carried.type(), through, carried.declaredBy(),
+                    carried.given())) {
                 if (reachesARule(named, through)) {
                     return true;
                 }
@@ -401,36 +531,38 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          * <p>{@code declaredBy} is the class whose type parameters a variable in the signature is
          * looked up in, which is whoever wrote the field.
          */
-        private static Set<String> namesIn(Signature type, Through through,
-                                           ClassModel declaredBy) {
+        private static Set<String> namesIn(Signature type, Through through, ClassModel declaredBy,
+                                           Map<String, Signature> given) {
             Set<String> out = new LinkedHashSet<>();
-            collect(type, through, declaredBy, out);
+            collect(type, through, declaredBy, given, out);
             return out;
         }
 
         private static void collect(Signature type, Through through, ClassModel declaredBy,
-                                    Set<String> into) {
+                                    Map<String, Signature> given, Set<String> into) {
             switch (type) {
                 case Signature.BaseTypeSig _ -> { }
-                case Signature.ArrayTypeSig array -> {
-                    if (through == Through.ANYTHING) {
-                        collect(array.componentSignature(), through, declaredBy, into);
-                    }
-                }
-                // Through the bound its declaration gives it. What a variable is instantiated with
-                // is settled where the state is built and is not what is being asked: the question
-                // is whether the state can hold a rule of its own, and a variable bounded by one
-                // says so wherever it is instantiated.
+                case Signature.ArrayTypeSig array ->
+                        collect(array.componentSignature(), through, declaredBy, given, into);
+                // What was handed in first, and the bound its declaration gives it after. A bound
+                // says what may be handed to a variable and an argument says what was, and both
+                // answer the question this asks: whether the state can hold a rule of its own.
+                // Which of the two is present depends on where the field was written, so both are
+                // read and neither stands in for the other.
                 case Signature.TypeVarSig variable -> {
+                    Signature handedIn = given.get(variable.identifier());
+                    if (handedIn != null) {
+                        collect(handedIn, through, declaredBy, given, into);
+                    }
                     for (Signature.TypeParam declared
                             : WhatASignatureReaches.typeParametersOf(declaredBy)) {
                         if (!declared.identifier().equals(variable.identifier())) {
                             continue;
                         }
-                        declared.classBound()
-                                .ifPresent(each -> collect(each, through, declaredBy, into));
+                        declared.classBound().ifPresent(
+                                each -> collect(each, through, declaredBy, given, into));
                         for (Signature.RefTypeSig each : declared.interfaceBounds()) {
-                            collect(each, through, declaredBy, into);
+                            collect(each, through, declaredBy, given, into);
                         }
                     }
                 }
@@ -442,10 +574,14 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
                     }
                     for (Signature.TypeArg argument : named.typeArgs()) {
                         if (argument instanceof Signature.TypeArg.Bounded bounded) {
-                            collect(bounded.boundType(), through, declaredBy, into);
+                            collect(bounded.boundType(), through, declaredBy, given, into);
                         }
                     }
                 }
+                // Not something a field is written as. What a class keeps is a field's type, and
+                // the shapes below are the ones a field's type has ({@link
+                // #everyShapeAFieldsTypeHas}).
+                default -> { }
             }
         }
 

--- a/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -127,6 +128,25 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
     record TwoWaysThroughAnArray(souther.compiler.check.RuleRef[] rules,
                                  souther.compiler.check.RuleCitation cited) { }
 
+    /** A state keeping rules and no handle, which is a table of them and not a state about one. */
+    record HoldsManyRules(souther.compiler.check.RuleRef[] rules) { }
+
+    /** A state that passes what it is given on, wrapped, to the one above it. */
+    static class Passes<U> extends Holds<Optional<U>> { }
+
+    /**
+     * And the pair where the rule reaches the field through a variable inside another type.
+     *
+     * <p>What a class below gives a parameter is a type and not always a name: {@code Passes} hands
+     * {@code Holds} an {@code Optional<U>}, and {@code U} is answered a step further down. Read as a
+     * name to look up, the argument is kept whole and the answer under it is left in a frame that
+     * has none.
+     */
+    static class TwoWaysThroughAWrappedVariable
+            extends Passes<souther.compiler.check.RuleRef> {
+        souther.compiler.check.RuleCitation cited;
+    }
+
     @Test
     void nothingThisRepositoryPublishesHoldsARuleAndAHandleBesideIt() {
         Carried carried = Carried.ofWhatThisRepositoryPublishes();
@@ -162,11 +182,18 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
                         + " among them");
         assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAParameterizedSuperclass")),
                 "and a variable is answered by what the subclass gave the frame it is written in");
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysThroughAWrappedVariable")),
+                "wherever in what was given the variable stands");
         assertEquals(1, carried.waysToARuleFrom(fixture("OneWayToOneRule")),
                 "and a handle alone is one, since the rule it carries is not a second way");
         assertEquals(1, carried.waysToARuleFrom(fixture("HoldsARule")),
                 "and the half that holds only the rule is one way, so the pair above is the"
                         + " hierarchy's and not either half's");
+        assertFalse(carried.isAboutOneRule(fixture("HoldsManyRules")),
+                "an array of rules is many of them, as a collection of them is, so a state whose"
+                        + " only rules are in one is not a state about one rule");
+        assertTrue(carried.isAboutOneRule(fixture("HoldsARule")),
+                "and one that keeps a rule is, which is what the array is being told from");
     }
 
     /**
@@ -346,7 +373,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          */
         private List<Carries> carriedBy(ClassModel model) {
             List<Carries> out = new ArrayList<>();
-            Map<String, Signature> given = Map.of();
+            Map<String, Given> given = Map.of();
             for (ClassModel each = model; each != null; ) {
                 Optional<RecordAttribute> record = each.findAttribute(Attributes.record());
                 if (record.isPresent()) {
@@ -383,8 +410,8 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          * read {@code T} against a declaration that bounds it by nothing and lose the rule handed
          * to it.
          */
-        private static Map<String, Signature> givenTo(ClassModel above, ClassModel below,
-                                                      Map<String, Signature> givenToBelow) {
+        private static Map<String, Given> givenTo(ClassModel above, ClassModel below,
+                                                  Map<String, Given> givenToBelow) {
             List<Signature.TypeParam> parameters = WhatASignatureReaches.typeParametersOf(above);
             Signature.ClassTypeSig extended = below.findAttribute(Attributes.signature())
                     .map(SignatureAttribute::asClassSignature)
@@ -393,23 +420,30 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
             if (parameters.isEmpty() || extended == null) {
                 return Map.of();
             }
-            Map<String, Signature> out = new LinkedHashMap<>();
+            Map<String, Given> out = new LinkedHashMap<>();
             List<Signature.TypeArg> arguments = extended.typeArgs();
             for (int i = 0; i < parameters.size() && i < arguments.size(); i++) {
                 if (arguments.get(i) instanceof Signature.TypeArg.Bounded bounded) {
-                    Signature argument = bounded.boundType();
-                    // Resolved as far as the frame below already knows: a subclass may pass on a
-                    // variable of its own, and what that one is was settled a step further down.
-                    if (argument instanceof Signature.TypeVarSig passed) {
-                        argument = givenToBelow.get(passed.identifier());
-                    }
-                    if (argument != null) {
-                        out.put(parameters.get(i).identifier(), argument);
-                    }
+                    // Kept with the frame it was written in rather than rewritten into the frame
+                    // above. An argument is a type and not a name — {@code extends Holds<Optional<U>>}
+                    // hands one over with a variable inside it — so what makes it answerable is
+                    // reading it where it was written, at whatever depth its variables stand.
+                    out.put(parameters.get(i).identifier(),
+                            new Given(bounded.boundType(), below, givenToBelow));
                 }
             }
             return out;
         }
+
+        /**
+         * A type a class below handed to a parameter above, and the frame to read it in.
+         *
+         * <p>The frame is the whole of why this is not a signature on its own. What was handed over
+         * may name variables of the class that handed it, and those are answered a step further
+         * down — so an argument read in the frame above is a name with nothing to say, and one
+         * rewritten into that frame would have to be rebuilt shape by shape.
+         */
+        private record Given(Signature type, ClassModel frame, Map<String, Given> env) { }
 
         /** The class above this one, where this repository built it. A class whose parent it did
          *  not build carries nothing this walk can read, which is where the walk stops. */
@@ -428,7 +462,7 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          * because a bound says what may be handed in and an argument says what was.
          */
         private record Carries(Signature type, ClassModel declaredBy,
-                               Map<String, Signature> given) { }
+                               Map<String, Given> given) { }
 
         /** How much of what a state carries a walk is allowed through. */
         private enum Through {
@@ -532,27 +566,33 @@ class OneWayFromAStateToTheRuleItIsAboutTest {
          * looked up in, which is whoever wrote the field.
          */
         private static Set<String> namesIn(Signature type, Through through, ClassModel declaredBy,
-                                           Map<String, Signature> given) {
+                                           Map<String, Given> given) {
             Set<String> out = new LinkedHashSet<>();
             collect(type, through, declaredBy, given, out);
             return out;
         }
 
         private static void collect(Signature type, Through through, ClassModel declaredBy,
-                                    Map<String, Signature> given, Set<String> into) {
+                                    Map<String, Given> given, Set<String> into) {
             switch (type) {
                 case Signature.BaseTypeSig _ -> { }
-                case Signature.ArrayTypeSig array ->
+                // Many of what is inside it, as a collection is. A state keeping an array of rules
+                // keeps rules and not a rule, so the walk that tells one from many stops here for
+                // the reason it stops at a collection.
+                case Signature.ArrayTypeSig array -> {
+                    if (through == Through.ANYTHING) {
                         collect(array.componentSignature(), through, declaredBy, given, into);
+                    }
+                }
                 // What was handed in first, and the bound its declaration gives it after. A bound
                 // says what may be handed to a variable and an argument says what was, and both
                 // answer the question this asks: whether the state can hold a rule of its own.
                 // Which of the two is present depends on where the field was written, so both are
                 // read and neither stands in for the other.
                 case Signature.TypeVarSig variable -> {
-                    Signature handedIn = given.get(variable.identifier());
+                    Given handedIn = given.get(variable.identifier());
                     if (handedIn != null) {
-                        collect(handedIn, through, declaredBy, given, into);
+                        collect(handedIn.type(), through, handedIn.frame(), handedIn.env(), into);
                     }
                     for (Signature.TypeParam declared
                             : WhatASignatureReaches.typeParametersOf(declaredBy)) {

--- a/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest.java
@@ -1,0 +1,408 @@
+package souther.architecture;
+
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.Attributes;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.RecordAttribute;
+import java.lang.classfile.attribute.RecordComponentInfo;
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.reflect.AccessFlag;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Nothing this compiler holds has two ways to the rule it is about.
+ *
+ * <p>Which rule of the model a piece of evidence is about, and how a reader is sent to that rule,
+ * are two questions about one rule. Held as two things built apart, they can be built about two
+ * rules — and nothing is wrong with such a value until a document writes both, where the identity it
+ * files an entry under and the sentence it writes beside it name different rules. That is the shape
+ * a rule with no name being called {@code comparison} whatever kind of rule it was turned out to
+ * have, and the word was not the whole of it: the word was recoverable and the arrangement that lost
+ * it was not.
+ *
+ * <p>So a handle carries the rule it is a handle for, and this is the rule that says nothing carries
+ * a rule beside one. What a state may hold is the rule, or a handle, or a rule and the place a
+ * reader reached it at — never a rule and a handle that were not made from each other.
+ *
+ * <p><b>The whole component graph and not the fields spelled on one class.</b> A reading of a
+ * comparison held the rule beside a {@code Read} whose own field was the handle, which no rule about
+ * one class's own components would see. So the walk goes through everything a state carries, and a
+ * handle is one unit: reaching a rule <em>through</em> a handle is the one way there is, and the
+ * handle's own component is not a second one.
+ *
+ * <p>What this does not hold is that two such values cannot be made and passed as arguments. A
+ * method taking a rule and a handle beside it can still be written; what is closed is keeping them,
+ * which is where such a pair survives long enough for two readers to disagree about it.
+ */
+class OneWayFromAStateToTheRuleItIsAboutTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    private static final String RULE = "souther/compiler/check/RuleRef";
+
+    private static final String HANDLE = "souther/compiler/check/RuleCitation";
+
+    /**
+     * A state carrying a rule and a handle beside it, which is what this is about.
+     *
+     * <p>Written here so that the walk is read for what it finds and not only for what it fails to
+     * find. A rule over a population everything satisfies passes on the day the population is empty
+     * and on the day the walk stops working, and neither is the day the model changed.
+     */
+    record TwoWaysToOneRule(souther.compiler.check.RuleRef rule,
+                            souther.compiler.check.RuleCitation cited) { }
+
+    /** One way, which is the shape everything is held to. */
+    record OneWayToOneRule(souther.compiler.check.RuleCitation cited) { }
+
+    @Test
+    void nothingThisRepositoryPublishesHoldsARuleAndAHandleBesideIt() {
+        Carried carried = Carried.ofWhatThisRepositoryPublishes();
+        Set<String> holdingTwo = new TreeSet<>();
+        for (String each : carried.everyClass()) {
+            if (carried.isAboutOneRule(each) && carried.waysToARuleFrom(each) > 1) {
+                holdingTwo.add(each.replace('/', '.').replace('$', '.'));
+            }
+        }
+
+        assertEquals(Set.of(), holdingTwo,
+                "a state with two ways to the rule it is about can be built about two rules, and"
+                        + " what is written from it then files an entry under one and describes"
+                        + " the other");
+    }
+
+    /**
+     * And the walk finds one that is there.
+     *
+     * <p>Both halves, because a walk that counted nothing would satisfy the rule above: the pair
+     * this refuses is reported, and the one shape that is allowed is not.
+     */
+    @Test
+    void theWalkFindsAStateThatHoldsTwoAndPassesOneThatHoldsOne() {
+        Carried carried = Carried.ofEverythingCompiledHere();
+
+        assertEquals(2, carried.waysToARuleFrom(fixture("TwoWaysToOneRule")),
+                "a rule and a handle beside it are two ways to one rule");
+        assertEquals(1, carried.waysToARuleFrom(fixture("OneWayToOneRule")),
+                "and a handle alone is one, since the rule it carries is not a second way");
+    }
+
+    /**
+     * And the population is not empty: the states this is about are in it.
+     *
+     * <p>Named rather than counted, because what makes this rule worth running is that the readings
+     * of a rule are among what it walks. A count would be satisfied by any classes at all.
+     */
+    @Test
+    void theReadingsOfARuleAreAmongWhatWasWalked() {
+        Carried carried = Carried.ofWhatThisRepositoryPublishes();
+
+        for (String each : List.of("souther/compiler/partition/PredicateOrigin",
+                "souther/compiler/partition/LineOrigin$ComparisonOrigin",
+                "souther/compiler/inputs/RuleWithoutALine",
+                "souther/compiler/inputs/PlacementSeed")) {
+            assertTrue(carried.everyClass().contains(each),
+                    () -> "a reading of a rule this is about was not walked: " + each);
+            assertEquals(1, carried.waysToARuleFrom(each),
+                    () -> "and it reaches the rule it is about, by one way: " + each);
+        }
+    }
+
+    /** The name the compiler gives a record declared in this test. */
+    private static String fixture(String name) {
+        return "souther/architecture/OneWayFromAStateToTheRuleItIsAboutTest$" + name;
+    }
+
+    /**
+     * What each class this repository built carries, and what those reach.
+     *
+     * <p>Read off the class files rather than off the sources, because what a state holds is what
+     * was compiled: a record's components and the instance fields of everything else. What a class
+     * mentions in a method body is not among them — a pair made and handed on is not a pair anybody
+     * keeps.
+     */
+    private static final class Carried {
+
+        private final Map<String, ClassModel> classes;
+
+        /** What each class reaches, per how much of what it carries the walk was allowed
+         *  through. */
+        private final Map<String, Boolean> reaches = new HashMap<>();
+
+        /** The classes this walk is inside of, so that a type holding itself is finite. A class part
+         *  way through its own reading reaches nothing new by being asked again. */
+        private final Set<String> underway = new LinkedHashSet<>();
+
+        private Carried(Map<String, ClassModel> classes) {
+            this.classes = classes;
+        }
+
+        static Carried ofWhatThisRepositoryPublishes() {
+            return new Carried(read(List.of("classes")));
+        }
+
+        static Carried ofEverythingCompiledHere() {
+            return new Carried(read(List.of("classes", "test-classes")));
+        }
+
+        Set<String> everyClass() {
+            return classes.keySet();
+        }
+
+        /**
+         * How many of {@code owner}'s components reach the rule it is about.
+         *
+         * <p>Counted over the components and not over the paths below them, because a class holding
+         * two ways further down is a class this reports on its own. What is asked here is whether
+         * this one holds a second answer beside the one it already has.
+         */
+        int waysToARuleFrom(String owner) {
+            int ways = 0;
+            for (Signature each : carriedBy(modelOf(owner))) {
+                if (reachesARule(each, Through.ANYTHING)) {
+                    ways++;
+                }
+            }
+            return ways;
+        }
+
+        /**
+         * Whether {@code owner} is a state about one rule of the model.
+         *
+         * <p>Which is what makes the count above mean anything. A reading of a comparison is about
+         * the comparison it read; a table of what each of a declaration's clauses raised is about
+         * as many rules as the declaration has clauses, and two entries in it that name one rule
+         * are one rule twice by design. Held to the same count, every table of rules would be
+         * refused for being a table.
+         *
+         * <p>Told apart by whether the rule is reached without going through a collection, which is
+         * what "one" and "many" are spelled as here. A state that keeps a rule keeps it; a state
+         * that keeps rules keeps a collection of them, and what is inside carries its own handle.
+         */
+        boolean isAboutOneRule(String owner) {
+            for (Signature each : carriedBy(modelOf(owner))) {
+                if (reachesARule(each, Through.ONE_VALUE_AT_A_TIME)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private ClassModel modelOf(String owner) {
+            ClassModel model = classes.get(owner);
+            if (model == null) {
+                throw new AssertionError("this repository built no " + owner
+                        + ", so what it carries is a question this cannot answer");
+            }
+            return model;
+        }
+
+        /** What one class keeps: a record's components, or the instance fields of anything else. */
+        private static List<Signature> carriedBy(ClassModel model) {
+            Optional<RecordAttribute> record = model.findAttribute(Attributes.record());
+            List<Signature> out = new ArrayList<>();
+            if (record.isPresent()) {
+                for (RecordComponentInfo component : record.get().components()) {
+                    out.add(WhatASignatureReaches.componentSignature(component));
+                }
+                return out;
+            }
+            for (FieldModel field : model.fields()) {
+                if (field.flags().has(AccessFlag.STATIC)) {
+                    continue;
+                }
+                out.add(field.findAttribute(Attributes.signature())
+                        .map(SignatureAttribute::asTypeSignature)
+                        .orElseGet(() -> Signature.of(field.fieldTypeSymbol())));
+            }
+            return out;
+        }
+
+        /** How much of what a state carries a walk is allowed through. */
+        private enum Through {
+
+            /** Everything, which is what counting the ways to one rule asks. */
+            ANYTHING,
+
+            /** Everything but a collection, which is what tells a state about one rule from a table
+             *  of many. */
+            ONE_VALUE_AT_A_TIME
+        }
+
+        /** Whether one thing a class carries reaches the rule it is about. */
+        private boolean reachesARule(Signature type, Through through) {
+            for (String named : namesIn(type, through)) {
+                if (reachesARule(named, through)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean reachesARule(String named, Through through) {
+            // A handle is a rule and the way to it in one value, so reaching one is reaching the
+            // rule. Its own component is not a second way, which is why the walk stops here.
+            if (isA(named, HANDLE) || isA(named, RULE)) {
+                return true;
+            }
+            String key = named + "/" + through;
+            Boolean had = reaches.get(key);
+            if (had != null) {
+                return had;
+            }
+            ClassModel model = classes.get(named);
+            if (model == null || !underway.add(key)) {
+                return false;
+            }
+            boolean found = false;
+            for (Signature each : carriedBy(model)) {
+                if (reachesARule(each, through)) {
+                    found = true;
+                    break;
+                }
+            }
+            underway.remove(key);
+            reaches.put(key, found);
+            return found;
+        }
+
+        /** Whether {@code named} is {@code wanted} or is declared under it, which is how a seal's
+         *  arms answer for the seal. */
+        private boolean isA(String named, String wanted) {
+            if (named.equals(wanted)) {
+                return true;
+            }
+            ClassModel model = classes.get(named);
+            if (model == null) {
+                return false;
+            }
+            for (var each : model.interfaces()) {
+                if (isA(each.name().stringValue(), wanted)) {
+                    return true;
+                }
+            }
+            return model.superclass()
+                    .map(it -> isA(it.name().stringValue(), wanted))
+                    .orElse(false);
+        }
+
+        /**
+         * Whether what {@code owner} names holds many of what is inside it.
+         *
+         * <p>Asked of the platform rather than matched against a list of names written here. A list
+         * is a list of the collections somebody thought of, and the day a state keeps its rules in
+         * one that is not on it, this walk calls a table of many rules a state about one and refuses
+         * it for holding two.
+         *
+         * <p>{@code Optional} is not one of these, and the question answers that on its own: what is
+         * inside one is one value.
+         */
+        private static boolean holdsManyAtATime(String owner) {
+            if (!owner.startsWith("java/")) {
+                return false;
+            }
+            try {
+                Class<?> named = Class.forName(owner.replace('/', '.'));
+                return java.util.Collection.class.isAssignableFrom(named)
+                        || Map.class.isAssignableFrom(named)
+                        || Stream.class.isAssignableFrom(named);
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        }
+
+        /** Every class a signature names, its type arguments among them: a set of handles reaches
+         *  what a handle does, except where the walk is asked for one value at a time. */
+        private static Set<String> namesIn(Signature type, Through through) {
+            Set<String> out = new LinkedHashSet<>();
+            collect(type, through, out);
+            return out;
+        }
+
+        private static void collect(Signature type, Through through, Set<String> into) {
+            switch (type) {
+                case Signature.BaseTypeSig _ -> { }
+                case Signature.ArrayTypeSig array -> {
+                    if (through == Through.ANYTHING) {
+                        collect(array.componentSignature(), through, into);
+                    }
+                }
+                // A variable's bound is not walked. What a state carries under one is settled where
+                // the state is built, and this is about what a class keeps rather than about what
+                // some instantiation of it could hold.
+                case Signature.TypeVarSig _ -> { }
+                case Signature.ClassTypeSig named -> {
+                    String owner = named.classDesc().descriptorString().replaceAll("^L|;$", "");
+                    into.add(owner);
+                    if (through == Through.ONE_VALUE_AT_A_TIME && holdsManyAtATime(owner)) {
+                        return;
+                    }
+                    for (Signature.TypeArg argument : named.typeArgs()) {
+                        if (argument instanceof Signature.TypeArg.Bounded bounded) {
+                            collect(bounded.boundType(), through, into);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Map<String, ClassModel> read(List<String> outputs) {
+            Map<String, ClassModel> out = new HashMap<>();
+            ClassFile parser = ClassFile.of();
+            for (Path module : REPOSITORY.modules()) {
+                for (String output : outputs) {
+                    Path where = module.resolve("target").resolve(output);
+                    if (!Files.isDirectory(where)) {
+                        continue;
+                    }
+                    for (Path each : classFilesUnder(where)) {
+                        String name = where.relativize(each).toString()
+                                .replace(java.io.File.separatorChar, '/')
+                                .replaceAll("\\.class$", "");
+                        if (name.startsWith("souther/")) {
+                            out.putIfAbsent(name, parse(parser, each));
+                        }
+                    }
+                }
+            }
+            return out;
+        }
+
+        private static ClassModel parse(ClassFile parser, Path file) {
+            try {
+                return parser.parse(Files.readAllBytes(file));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static List<Path> classFilesUnder(Path where) {
+            try (Stream<Path> found = Files.walk(where)) {
+                return found.filter(each -> each.toString().endsWith(".class")).toList();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -115,14 +115,12 @@ final class AReportOfOneBorder {
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.rate", "weigh", 0),
-                        new souther.compiler.check.RuleCitation.WrittenAt<>(
-                                new RuleRef.Comparison("weigh",
-                                        new souther.compiler.types.SourceConstructOrigin(
-                                                new WrittenOwner.Body("example.rate", "weigh"),
-                                                2, 0,
-                                                souther.compiler.types.SourceConstruct.BINARY)),
-                                souther.compiler.diag.Citation.of(
-                                        new souther.compiler.diag.SourcePos(3, 5))),
+                        new RuleRef.Comparison("weigh",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("example.rate", "weigh"), 2, 0,
+                                        souther.compiler.types.SourceConstruct.BINARY)),
+                        souther.compiler.diag.Citation.of(
+                                new souther.compiler.diag.SourcePos(3, 5)),
                         WHERE),
                 new souther.compiler.partition.LineFacts(
                         new ComparisonClaim.Cut(souther.compiler.numeric.Towards.BELOW, true)));

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -112,13 +112,15 @@ final class AReportOfOneBorder {
      */
     static Border aBorderABodyDrew() {
         LineOrigin origin = new LineOrigin.ComparisonOrigin(
-                new RuleRef.Comparison("weigh", new souther.compiler.types.SourceConstructOrigin(
-                        new WrittenOwner.Body("example.rate", "weigh"), 2, 0,
-                        souther.compiler.types.SourceConstruct.BINARY)),
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.rate", "weigh", 0),
-                        new souther.compiler.check.RuleCitation.WrittenAt(
+                        new souther.compiler.check.RuleCitation.WrittenAt<>(
+                                new RuleRef.Comparison("weigh",
+                                        new souther.compiler.types.SourceConstructOrigin(
+                                                new WrittenOwner.Body("example.rate", "weigh"),
+                                                2, 0,
+                                                souther.compiler.types.SourceConstruct.BINARY)),
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5))),
                         WHERE),

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -111,7 +111,7 @@ public final class FieldDomains {
     private final Map<RuleRef.Invariant, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
      *  conjunct is about, and not what the conjunct written beside it raised. */
-    private final Map<RuleRef, Map<Core, Required>> raisedByPart;
+    private final Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart;
 
     /** What the reading answered for each boundary question it raised and left standing. */
     private final Map<BoundaryQuestion, BoundaryStanding> standing;
@@ -174,7 +174,7 @@ public final class FieldDomains {
     private final Map<RuleKey, Counted> countAt;
     /** What the reading that builds the bounds made of each part of each rule. Per part, because a
      *  rule is represented where every part of it is. */
-    private final Map<RuleRef, Map<Core, InvariantChecker.PartRead>> readBy;
+    private final Map<RuleRef.Invariant, Map<Core, InvariantChecker.PartRead>> readBy;
     /** How each atom's values are spaced, so that settling one afterwards states the same equality
      *  the reading would have stated for it. */
     private final Map<FactSubject, souther.compiler.numeric.Granularity> spacing;
@@ -189,7 +189,7 @@ public final class FieldDomains {
                          List<AboutOneCoordinate> aboutTheStrings,
                          PartsLeftOut withoutParts,
                          Map<RuleRef.Invariant, Required> raised,
-                         Map<RuleRef, Map<Core, Required>> raisedByPart,
+                         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                          Map<BoundaryQuestion, BoundaryStanding> standing, ReadingEvidence took,
                          Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                          Map<RuleKey, Set<RulesMissed>> notGathered, Set<RuleKey> handedOn,
@@ -199,7 +199,7 @@ public final class FieldDomains {
                          Map<NumberAt<RuleKey>, Count> settled,
                          Set<RuleKey> unreadOfEveryValue,
                          Map<RuleKey, FactSubject> atomAt, Map<RuleKey, Counted> countAt,
-                         Map<RuleRef, Map<Core, InvariantChecker.PartRead>> readBy,
+                         Map<RuleRef.Invariant, Map<Core, InvariantChecker.PartRead>> readBy,
                          Map<FactSubject, souther.compiler.numeric.Granularity> spacing) {
         this.byName = byName;
         this.heldByName = heldByName;
@@ -900,7 +900,7 @@ public final class FieldDomains {
      * here while the question was an obligation beside a subject and the pair admitted combinations
      * nothing raises.
      */
-    private RuleAccounting.Outcome answered(RuleRef rule, Owed owed) {
+    private RuleAccounting.Outcome answered(RuleRef.Invariant rule, Owed owed) {
         return switch (owed) {
             case Owed.AdmittedValues it -> admissionAnswered(rule, it.path());
             case Owed.Boundary it -> boundaryAnswered(rule, it.on());
@@ -928,7 +928,8 @@ public final class FieldDomains {
      * question's word depend on a table nobody had asked it of, and left every reader downstream
      * looking at a list where the model has one answer.
      */
-    private RuleAccounting.Outcome boundaryAnswered(RuleRef rule, NumberAt<RuleKey> where) {
+    private RuleAccounting.Outcome boundaryAnswered(RuleRef.Invariant rule,
+                                                    NumberAt<RuleKey> where) {
         BoundaryStanding said = rule instanceof RuleRef.Invariant invariant
                 ? standing.get(new BoundaryQuestion(invariant, where)) : null;
         return said == null
@@ -949,7 +950,7 @@ public final class FieldDomains {
      * clause beside it: {@code value >= 1} leaves the reading of values short at a name, and
      * {@code value == 7} written beside it was taken in whole.
      */
-    private RuleAccounting.Outcome admissionAnswered(RuleRef rule, RuleKey at) {
+    private RuleAccounting.Outcome admissionAnswered(RuleRef.Invariant rule, RuleKey at) {
         List<FactSubject> named = named(at);
         // A part of the rule nothing took in outranks everything else about it. An end placed by
         // one conjunct is not an account of the conjunct written beside it.
@@ -996,7 +997,8 @@ public final class FieldDomains {
      * <p>Both empty is the accounting coming apart. The rule was met by the walk that asks and by
      * nothing that reads, and neither the rule nor the position has a word for it.
      */
-    private RuleAccounting.Why stoppedBy(RuleRef rule, RuleKey at, List<FactSubject> named) {
+    private RuleAccounting.Why stoppedBy(RuleRef.Invariant rule, RuleKey at,
+                                         List<FactSubject> named) {
         // What a rule is answerable for, as the facts it is answerable for. Asked for the reasons
         // alone here, the written places they were decided at would be gone one call before the
         // account that names the rule, and two facts about two clauses would arrive as one.

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -108,7 +108,7 @@ public final class FieldDomains {
      *  {@link #movedEnds}. */
     private volatile List<Placed> moved;
     /** What each clause reaching this value raises, keyed on the rule it is. */
-    private final Map<RuleRef, Required> raised;
+    private final Map<RuleRef.Invariant, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
      *  conjunct is about, and not what the conjunct written beside it raised. */
     private final Map<RuleRef, Map<Core, Required>> raisedByPart;
@@ -118,7 +118,7 @@ public final class FieldDomains {
     /** Which readings took each clause in, as each of them said so. */
     private final ReadingEvidence took;
     /** The accounting, worked out once. Every name of a value asks the same question of it. */
-    private volatile Map<RuleRef, RuleAccounting> accounting;
+    private volatile Map<RuleRef.Invariant, RuleAccounting> accounting;
     /** Which declarations relate each coordinate to something else, and so could have moved where it
      * stops — see {@link #narrowedBy}. */
     private final Map<RuleKey, List<TypeSymbol.AtModule>> narrowers;
@@ -188,7 +188,7 @@ public final class FieldDomains {
                          List<WithoutAnEnd> withoutAnEnd, List<AboutOneCoordinate> aboutOneCoordinate,
                          List<AboutOneCoordinate> aboutTheStrings,
                          PartsLeftOut withoutParts,
-                         Map<RuleRef, Required> raised,
+                         Map<RuleRef.Invariant, Required> raised,
                          Map<RuleRef, Map<Core, Required>> raisedByPart,
                          Map<BoundaryQuestion, BoundaryStanding> standing, ReadingEvidence took,
                          Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
@@ -846,7 +846,7 @@ public final class FieldDomains {
      * managed — the second is what a completeness written per reader amounts to, and it says the
      * model was read in full for exactly as long as nobody adds a reader.
      */
-    public Map<RuleRef, Required> required() {
+    public Map<RuleRef.Invariant, Required> required() {
         return raised;
     }
 
@@ -876,12 +876,12 @@ public final class FieldDomains {
      * first case and by the reading of values in the second — so a completeness read off either
      * reading alone reports a model that was read in full as one this compiler could not read.
      */
-    public Map<RuleRef, RuleAccounting> accounting() {
-        Map<RuleRef, RuleAccounting> had = accounting;
+    public Map<RuleRef.Invariant, RuleAccounting> accounting() {
+        Map<RuleRef.Invariant, RuleAccounting> had = accounting;
         if (had != null) {
             return had;
         }
-        Map<RuleRef, RuleAccounting> out = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, RuleAccounting> out = new LinkedHashMap<>();
         raised.forEach((rule, required) ->
                 out.put(rule,
                         RuleAccounting.of(rule, required, owed -> answered(rule, owed))));
@@ -1647,14 +1647,28 @@ public final class FieldDomains {
                 : "the algebra proved no rule of its own and this reading names none";
     }
 
+    /**
+     * A rule as a sort key, which is the author's word for it or what it is where they wrote none.
+     *
+     * <p>Spelled here because what it is for is here. Nobody is shown this: what a reader is sent to
+     * a rule by is a citation, which carries a place for the rules that have no name, and an order
+     * has no place to put one.
+     */
+    private static String orderOf(RuleRef rule) {
+        return switch (rule) {
+            case RuleRef.Named it -> it.citedName();
+            case RuleRef.Written it -> "the " + it.whatItIs();
+        };
+    }
+
     /** What a cause is filed under, so that two runs print them the same way round. */
     private static String orderOf(ProjectionEvidence.Cause cause) {
         return switch (cause) {
             case ProjectionEvidence.Cause.Unavailable it -> "1 " + it.path();
             case ProjectionEvidence.Cause.Unrepresented it ->
-                    "2 " + it.rule().named() + " " + it.path();
+                    "2 " + orderOf(it.rule()) + " " + it.path();
             case ProjectionEvidence.Cause.Lossy it ->
-                    "3 " + it.rule().named() + " " + it.atom() + " " + it.unstated();
+                    "3 " + orderOf(it.rule()) + " " + it.atom() + " " + it.unstated();
             case ProjectionEvidence.Cause.Rounded it -> "4 " + it.atom();
             case ProjectionEvidence.Cause.NothingIsLeft _ -> "5";
             case ProjectionEvidence.Cause.PositionsSpacedDifferently _ -> "6";

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -469,7 +469,7 @@ public final class InvariantChecker {
                   Map<RuleKey, FieldDomains.Counted> held, Reading reading, ReadingEvidence took,
                   boolean everyClauseRead, Map<RuleKey, Set<RulesMissed>> notGathered,
                   Set<RuleKey> unreadOfEveryValue, Set<RuleKey> handedOn,
-                  Map<RuleRef, Map<Core, PartRead>> readBy,
+                  Map<RuleRef.Invariant, Map<Core, PartRead>> readBy,
                   Map<FactSubject, souther.compiler.numeric.Granularity> spacing,
                   Map<RuleKey, ValueSet> admitted,
                   Map<RuleKey, List<UnreadReason>> unreadAt,
@@ -654,7 +654,7 @@ public final class InvariantChecker {
         // Per part, because a rule is represented where every part of it is: a conjunct the bounds
         // hold nothing of leaves the range wider than the rule however well the conjunct beside it
         // went, and a set unioned over the whole clause says the opposite.
-        Map<RuleRef, Map<Core, PartRead>> readBy = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Map<Core, PartRead>> readBy = new LinkedHashMap<>();
 
         Gathering gathering = new Gathering() {
 
@@ -791,8 +791,8 @@ public final class InvariantChecker {
         // the two went unanswered would turn on the order they were written in.
         Allowance<FactSubject> allowed =
                 policy.allowanceForAdmittedValues();
-        Map<RuleRef, Map<Core, ReadByClauses.OfAPart>> adoptedBy = new LinkedHashMap<>();
-        Map<RuleRef, ReadByClauses.OfARule> narrowedBy = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Map<Core, ReadByClauses.OfAPart>> adoptedBy = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, ReadByClauses.OfARule> narrowedBy = new LinkedHashMap<>();
         // One reader for this value's positions, used over however many clauses reach it, and
         // the one that decides the choices in what they came to.
         StatedByClauses.Reading reader = StatedByClauses
@@ -1286,9 +1286,9 @@ public final class InvariantChecker {
      *                reaching the position, so a reader taking it for one rule's would lend a rule
      *                that narrows nothing whatever its neighbours narrowed
      */
-    record PartsRead(Map<RuleRef, Map<Core, PartRead>> read,
-                     Map<RuleRef, Map<Core, ReadByClauses.OfAPart>> account,
-                     Map<RuleRef, ReadByClauses.OfARule> byRule) {
+    record PartsRead(Map<RuleRef.Invariant, Map<Core, PartRead>> read,
+                     Map<RuleRef.Invariant, Map<Core, ReadByClauses.OfAPart>> account,
+                     Map<RuleRef.Invariant, ReadByClauses.OfARule> byRule) {
 
         /** What the reading that builds the bounds made of {@code part} of {@code rule}, or null
          *  where it read no such part — which is not the same as having read it and made nothing of
@@ -1432,7 +1432,7 @@ public final class InvariantChecker {
                    List<FieldDomains.AboutOneCoordinate> aboutTheStrings,
                    Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
                    Map<RuleRef.Invariant, Required> raised,
-                   Map<RuleRef, Map<Core, Required>> raisedByPart,
+                   Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                    Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
     private Reading directsIn(List<Written> stated, Denotations at,
@@ -1469,7 +1469,7 @@ public final class InvariantChecker {
         List<FieldDomains.AboutOneCoordinate> aboutTheStrings = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
         Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
-        Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
         stated.forEach(each ->
@@ -1506,7 +1506,7 @@ public final class InvariantChecker {
                         Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
                         PartsRead parts,
-                        Map<RuleRef, Map<Core, Required>> raisedByPart) {
+                        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart) {
         raises(raised, rule, states);
         // And what this part of it raises, kept apart from what the rule raises. A reader that found
         // one conjunct wanting reaches for this: the questions of the conjunct written beside it are
@@ -1584,7 +1584,7 @@ public final class InvariantChecker {
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         PartsRead parts,
-                        Map<RuleRef, Map<Core, Required>> raisedByPart,
+                        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing,
                         PartsLeftOut withoutParts) {
@@ -1642,7 +1642,7 @@ public final class InvariantChecker {
                         Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         PartsRead parts,
-                        Map<RuleRef, Map<Core, Required>> raisedByPart,
+                        Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
                                 FieldDomains.BoundaryStanding> standing,
                         PartsLeftOut withoutParts) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1431,7 +1431,7 @@ public final class InvariantChecker {
                    List<FieldDomains.AboutOneCoordinate> aboutOneCoordinate,
                    List<FieldDomains.AboutOneCoordinate> aboutTheStrings,
                    Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
-                   Map<RuleRef, Required> raised,
+                   Map<RuleRef.Invariant, Required> raised,
                    Map<RuleRef, Map<Core, Required>> raisedByPart,
                    Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing) {}
 
@@ -1468,7 +1468,7 @@ public final class InvariantChecker {
         // put among them it would set every other conjunct about the number to be read again.
         List<FieldDomains.AboutOneCoordinate> aboutTheStrings = new ArrayList<>();
         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers = new LinkedHashMap<>();
-        Map<RuleRef, Required> raised = new LinkedHashMap<>();
+        Map<RuleRef.Invariant, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
@@ -1487,7 +1487,7 @@ public final class InvariantChecker {
     }
 
     /** What {@code clause} raises, taken together with whatever its other conjuncts raised. */
-    private static void raises(Map<RuleRef, Required> into, RuleRef.Invariant rule,
+    private static void raises(Map<RuleRef.Invariant, Required> into, RuleRef.Invariant rule,
                                ClauseStates states) {
         into.merge(rule, Required.ofInvariant(states), Required::and);
     }
@@ -1503,7 +1503,7 @@ public final class InvariantChecker {
      */
     private void settle(Core part, RuleRef.Invariant rule, ClauseStates states,
                         InvariantBound.Read placed,
-                        Map<FactSubject, Coordinate> byName, Map<RuleRef, Required> raised,
+                        Map<FactSubject, Coordinate> byName, Map<RuleRef.Invariant, Required> raised,
                         ReadingEvidence took,
                         PartsRead parts,
                         Map<RuleRef, Map<Core, Required>> raisedByPart) {
@@ -1581,7 +1581,7 @@ public final class InvariantChecker {
                         List<FieldDomains.AboutOneCoordinate> naming,
                         List<FieldDomains.AboutOneCoordinate> namingTheStrings,
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
-                        Map<RuleRef, Required> raised, ReadingEvidence took,
+                        Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         PartsRead parts,
                         Map<RuleRef, Map<Core, Required>> raisedByPart,
@@ -1639,7 +1639,7 @@ public final class InvariantChecker {
                         List<FieldDomains.AboutOneCoordinate> naming,
                         List<FieldDomains.AboutOneCoordinate> namingTheStrings,
                         Map<RuleKey, List<TypeSymbol.AtModule>> narrowers,
-                        Map<RuleRef, Required> raised, ReadingEvidence took,
+                        Map<RuleRef.Invariant, Required> raised, ReadingEvidence took,
                         Map<RuleKey, Type> typeAt,
                         PartsRead parts,
                         Map<RuleRef, Map<Core, Required>> raisedByPart,

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
@@ -47,10 +47,10 @@ import java.util.Set;
 final class ReadingEvidence {
 
     /** Where each reading took a clause in. */
-    private final Map<RuleRef, Set<FactSubject>> spokenFor = new LinkedHashMap<>();
+    private final Map<RuleRef.Invariant, Set<FactSubject>> spokenFor = new LinkedHashMap<>();
 
     /** Where a part of a clause was taken in by nothing, which no other part makes up for. */
-    private final Map<RuleRef, Set<FactSubject>> left = new LinkedHashMap<>();
+    private final Map<RuleRef.Invariant, Set<FactSubject>> left = new LinkedHashMap<>();
 
     /**
      * What stopped the reading of values at each position of each rule.
@@ -74,10 +74,10 @@ final class ReadingEvidence {
      * <p>A set, because nothing here is in an order anybody may read. Which of two an author wrote
      * first is the source's to say and is asked where a document is written.
      */
-    private final Map<RuleRef, Set<RuleShortfall>> stopped = new LinkedHashMap<>();
+    private final Map<RuleRef.Invariant, Set<RuleShortfall>> stopped = new LinkedHashMap<>();
 
     /** A reading took {@code rule} in at {@code position}. */
-    void record(RuleRef rule, FactSubject position) {
+    void record(RuleRef.Invariant rule,FactSubject position) {
         spokenFor.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).add(position);
     }
 
@@ -88,13 +88,13 @@ final class ReadingEvidence {
      * nothing read, however well the other half went — so an end placed by one conjunct does not
      * answer for the conjunct beside it.
      */
-    boolean anyLeftStanding(RuleRef rule, Collection<FactSubject> positions) {
+    boolean anyLeftStanding(RuleRef.Invariant rule,Collection<FactSubject> positions) {
         Set<FactSubject> standing = left.get(rule);
         return standing != null && positions.stream().anyMatch(standing::contains);
     }
 
     /** A part of {@code rule} was taken in by nothing, of the positions it named. */
-    void leftStanding(RuleRef rule, Set<FactSubject> positions) {
+    void leftStanding(RuleRef.Invariant rule,Set<FactSubject> positions) {
         left.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(positions);
     }
 
@@ -122,7 +122,7 @@ final class ReadingEvidence {
      * Nothing is asked here because nothing of the wrong kind can be made: what arrives is refused
      * where it would be built, which is one fact away from where a caller could have written it.
      */
-    void stoppedBy(RuleRef rule, Set<RuleShortfall> read) {
+    void stoppedBy(RuleRef.Invariant rule,Set<RuleShortfall> read) {
         stopped.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(read);
     }
 
@@ -133,7 +133,7 @@ final class ReadingEvidence {
      * under whichever the reading recognised. Empty where this reading recorded nothing of the
      * rule there, which a caller has to answer for rather than fill in from the position.
      */
-    Set<RuleShortfall> stoppedBy(RuleRef rule, Collection<FactSubject> positions) {
+    Set<RuleShortfall> stoppedBy(RuleRef.Invariant rule,Collection<FactSubject> positions) {
         Set<RuleShortfall> here = stopped.get(rule);
         if (here == null) {
             return Set.of();
@@ -154,7 +154,7 @@ final class ReadingEvidence {
      * algebra and another by everything else, and a clause reaching it is filed under whichever the
      * reading recognised.
      */
-    boolean tookIn(RuleRef rule, Collection<FactSubject> positions) {
+    boolean tookIn(RuleRef.Invariant rule,Collection<FactSubject> positions) {
         if (anyLeftStanding(rule, positions)) {
             return false;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ReadingEvidence.java
@@ -77,7 +77,7 @@ final class ReadingEvidence {
     private final Map<RuleRef.Invariant, Set<RuleShortfall>> stopped = new LinkedHashMap<>();
 
     /** A reading took {@code rule} in at {@code position}. */
-    void record(RuleRef.Invariant rule,FactSubject position) {
+    void record(RuleRef.Invariant rule, FactSubject position) {
         spokenFor.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).add(position);
     }
 
@@ -88,13 +88,13 @@ final class ReadingEvidence {
      * nothing read, however well the other half went — so an end placed by one conjunct does not
      * answer for the conjunct beside it.
      */
-    boolean anyLeftStanding(RuleRef.Invariant rule,Collection<FactSubject> positions) {
+    boolean anyLeftStanding(RuleRef.Invariant rule, Collection<FactSubject> positions) {
         Set<FactSubject> standing = left.get(rule);
         return standing != null && positions.stream().anyMatch(standing::contains);
     }
 
     /** A part of {@code rule} was taken in by nothing, of the positions it named. */
-    void leftStanding(RuleRef.Invariant rule,Set<FactSubject> positions) {
+    void leftStanding(RuleRef.Invariant rule, Set<FactSubject> positions) {
         left.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(positions);
     }
 
@@ -122,7 +122,7 @@ final class ReadingEvidence {
      * Nothing is asked here because nothing of the wrong kind can be made: what arrives is refused
      * where it would be built, which is one fact away from where a caller could have written it.
      */
-    void stoppedBy(RuleRef.Invariant rule,Set<RuleShortfall> read) {
+    void stoppedBy(RuleRef.Invariant rule, Set<RuleShortfall> read) {
         stopped.computeIfAbsent(rule, _ -> new LinkedHashSet<>()).addAll(read);
     }
 
@@ -133,7 +133,7 @@ final class ReadingEvidence {
      * under whichever the reading recognised. Empty where this reading recorded nothing of the
      * rule there, which a caller has to answer for rather than fill in from the position.
      */
-    Set<RuleShortfall> stoppedBy(RuleRef.Invariant rule,Collection<FactSubject> positions) {
+    Set<RuleShortfall> stoppedBy(RuleRef.Invariant rule, Collection<FactSubject> positions) {
         Set<RuleShortfall> here = stopped.get(rule);
         if (here == null) {
             return Set.of();
@@ -154,7 +154,7 @@ final class ReadingEvidence {
      * algebra and another by everything else, and a clause reaching it is filed under whichever the
      * reading recognised.
      */
-    boolean tookIn(RuleRef.Invariant rule,Collection<FactSubject> positions) {
+    boolean tookIn(RuleRef.Invariant rule, Collection<FactSubject> positions) {
         if (anyLeftStanding(rule, positions)) {
             return false;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -169,11 +169,6 @@ public final class RuleAccounting {
                         + " stands for a reason");
             }
         }
-
-        /** Which rule raised it, which the handle for it carries. */
-        public RuleRef.Named rule() {
-            return cited.rule();
-        }
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -38,14 +38,12 @@ import java.util.function.Function;
  */
 public final class RuleAccounting {
 
-    private final RuleRef rule;
-    private final RuleCitation cited;
+    private final RuleCitation.Named cited;
     private final Required required;
     private final Map<Owed, Outcome> answers;
 
-    private RuleAccounting(RuleRef rule, RuleCitation cited, Required required,
+    private RuleAccounting(RuleCitation.Named cited, Required required,
                            Map<Owed, Outcome> answers) {
-        this.rule = rule;
         this.cited = cited;
         this.required = required;
         this.answers = Collections.unmodifiableMap(answers);
@@ -61,9 +59,9 @@ public final class RuleAccounting {
      * caller hold a genuine {@link Required} beside answers it wrote itself. A reader outside wants
      * a finished accounting, never a way to make one.
      */
-    static RuleAccounting of(RuleRef rule, Required required,
+    static RuleAccounting of(RuleRef.Named rule, Required required,
                              Function<Owed, Outcome> answered) {
-        return new RuleAccounting(rule, citedAsAClause(rule), required,
+        return new RuleAccounting(new RuleCitation.Named(rule), required,
                 answers(rule, required, answered));
     }
 
@@ -89,32 +87,19 @@ public final class RuleAccounting {
     }
 
     /**
-     * How a reader finds a rule this way in can be about.
+     * Which rule of the model, as everything that names a rule names it.
      *
-     * <p>A clause, either kind, and never a comparison. What comes this way is a rule an author
-     * wrote a name beside, and a comparison raises nothing this is made of.
+     * <p>Asked of the handle, which is what holds it. A clause, either kind, and never a rule
+     * written rather than named: what those raise is answered by the reading that raised it, so
+     * there is no accounting of one for anybody to build, and {@link #of} is where the language
+     * refuses it.
      */
-    private static RuleCitation citedAsAClause(RuleRef rule) {
-        return switch (rule) {
-            case RuleRef.Invariant it -> RuleCitation.named(it);
-            case RuleRef.Ensures it -> RuleCitation.named(it);
-            // A comparison and a predicate are written rather than named, and neither comes this
-            // way at all: what they raise is answered by the reading that raised it, so there is no
-            // accounting of one for anybody to build. What such a rule leaves is a finding about
-            // the position.
-            case RuleRef.Comparison _, RuleRef.Predicate _ -> throw new IllegalArgumentException(
-                    "a rule written rather than named raises nothing an accounting is made of: "
-                            + rule);
-        };
-    }
-
-    /** Which rule of the model, as everything that names a rule names it. */
-    public RuleRef rule() {
-        return rule;
+    public RuleRef.Named rule() {
+        return cited.rule();
     }
 
     /** How a reader finds it, which is not what tells it from another rule. */
-    public RuleCitation cited() {
+    public RuleCitation.Named cited() {
         return cited;
     }
 
@@ -158,7 +143,7 @@ public final class RuleAccounting {
     public List<Unanswered> unansweredQuestions() {
         return answers.entrySet().stream()
                 .filter(e -> e.getValue() instanceof Outcome.Unaccounted)
-                .map(e -> new Unanswered(rule, cited, e.getKey(),
+                .map(e -> new Unanswered(cited, e.getKey(),
                         ((Outcome.Unaccounted) e.getValue()).why()))
                 .toList();
     }
@@ -176,18 +161,24 @@ public final class RuleAccounting {
      * last moment — right while only invariants raise a question, and a decision about what a rule
      * is taken by whoever consumed one.
      */
-    public record Unanswered(RuleRef rule, RuleCitation cited, Owed owed, Why why) {
+    public record Unanswered(RuleCitation.Named cited, Owed owed, Why why) {
 
         public Unanswered {
-            if (why == null) {
-                throw new IllegalArgumentException("a question nothing answered stands for a reason");
+            if (cited == null || why == null) {
+                throw new IllegalArgumentException("a question nothing answered is of some rule and"
+                        + " stands for a reason");
             }
+        }
+
+        /** Which rule raised it, which the handle for it carries. */
+        public RuleRef.Named rule() {
+            return cited.rule();
         }
     }
 
     @Override
     public String toString() {
-        return rule + " " + answers;
+        return rule() + " " + answers;
     }
 
     /** What became of one question. */

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
@@ -5,6 +5,7 @@ import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.source.SourceId;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * How a reader finds the rule a question is about.
@@ -129,7 +130,7 @@ public sealed interface RuleCitation {
             case RuleRef.Named it -> Set.of(new Named(it));
             case RuleRef.Written it -> reachedAt.stream()
                     .map(each -> (RuleCitation) new WrittenAt(it, each))
-                    .collect(java.util.stream.Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toUnmodifiableSet());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
@@ -4,6 +4,8 @@ import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.source.SourceId;
 
+import java.util.Set;
+
 /**
  * How a reader finds the rule a question is about.
  *
@@ -12,10 +14,21 @@ import souther.compiler.source.SourceId;
  * on, which is not the same thing and must not become a key — a rule written once and read twice is
  * one rule, and a rule and the handle for it are not in step wherever a name is absent.
  *
- * <p>Two answers, because rules are found two ways. An author names a clause of an invariant and
- * looks it up by that name; a comparison in a body has no name and is found where it is written. A
- * single string over both would have to spell a place as a name, and {@link RuleRef#named} says why
- * that is wrong for the one that has none: a comparison is written rather than named.
+ * <p><b>A projection that holds what it is a projection of.</b> {@link #rule} is the rule this is
+ * the handle for, and it is here rather than beside this in whoever is holding both. A state
+ * carrying a rule and a handle built apart from it can be built with the two disagreeing, and
+ * nothing about such a state is wrong until a document writes both — where the rule says one thing
+ * and the sentence beside it says another. So there is one path from a piece of evidence to the rule
+ * it is about, and it runs through here.
+ *
+ * <p>Holding the rule does not make this an identity. What a reader is shown is
+ * {@link souther.compiler.publish.PublishedRuleHandle}, which is what an order over handles is taken
+ * over, and two of these that a document writes alike come to one value there.
+ *
+ * <p>Two answers, because rules are found two ways, and which of the two a rule is found by is the
+ * rule's own answer rather than a choice a caller makes ({@link RuleRef.Named},
+ * {@link RuleRef.Written}). An author names a clause of an invariant and looks it up by that name; a
+ * comparison in a body has no name and is found where it is written.
  *
  * <p><b>Not {@link souther.compiler.partition.LineOrigin}.</b> That says where a rule was read, and
  * one rule read in two calls of a helper has two of them — so putting it here would make a document
@@ -25,30 +38,19 @@ import souther.compiler.source.SourceId;
 public sealed interface RuleCitation {
 
     /**
-     * How a reader finds a rule the author wrote a name beside.
+     * Which rule of the model this is the handle for.
      *
-     * <p>Two overloads and no {@code RuleRef} one, which is the point. {@link RuleRef#named} answers
-     * for a comparison too — with what it is rather than what it is called — and a total factory
-     * over {@code RuleRef} would hand that back as a name, sending an author to look for a clause
-     * called {@code the comparison}. Nothing in {@link Named} would refuse it: the string is not
-     * empty. A comparison is found by {@link WrittenAt}, from where it is written, which is a place
-     * this could not invent.
+     * <p>The one way from a handle to the rule. A reader holding a piece of evidence asks it for the
+     * citation and the citation for the rule, so the two cannot be about different rules.
      */
-    static Named named(RuleRef.Invariant rule) {
-        return new Named(rule.named());
-    }
+    RuleRef rule();
 
-    /** The same, of a clause of an {@code ensures}. */
-    static Named named(RuleRef.Ensures rule) {
-        return new Named(rule.named());
-    }
-
-    /** The name the author gave it, as a report writes the rule. */
-    record Named(String name) implements RuleCitation {
+    /** How a reader finds a rule the author wrote a name beside. */
+    record Named(RuleRef.Named rule) implements RuleCitation {
 
         public Named {
-            if (name == null || name.isEmpty()) {
-                throw new IllegalArgumentException("a rule called nothing is cited by where it is");
+            if (rule == null) {
+                throw new IllegalArgumentException("a citation is of some rule");
             }
         }
     }
@@ -59,12 +61,21 @@ public sealed interface RuleCitation {
      * <p>{@link Citation} and not a bare position, because where a rule is written and where a
      * reader is standing are not always the same file: a comparison inside a helper is written
      * there and reached from the call, and the same type says both.
+     *
+     * <p>Which kind of written rule, kept in the type. A reading that draws a line is a comparison's
+     * and a reading that tells a set of values from the rest is a predicate's, and a holder of one
+     * says which it is ({@link souther.compiler.partition.RuleEvidenceOrigin}). Erased to
+     * {@link RuleRef.Written} here, a holder wanting the kind back would either narrow it at a cast
+     * or keep the rule a second time, and the second is what this type exists to have removed.
+     *
+     * @param <R> which kind of written rule this is the handle for
      */
-    record WrittenAt(Citation at) implements RuleCitation {
+    record WrittenAt<R extends RuleRef.Written>(R rule, Citation at) implements RuleCitation {
 
         public WrittenAt {
-            if (at == null) {
-                throw new IllegalArgumentException("a rule with no name is found by where it is");
+            if (rule == null || at == null) {
+                throw new IllegalArgumentException(
+                        "a rule with no name is found by where it is: " + rule + " at " + at);
             }
         }
     }
@@ -77,15 +88,64 @@ public sealed interface RuleCitation {
      * What is not shared is an identity: where a rule was read is
      * {@link souther.compiler.partition.LineOrigin}'s and one rule has as many of those as it has
      * readings.
+     *
+     * <p>Every word here is read off {@link #rule}. What goes in front of a place is what that rule
+     * is, so a kind of rule added to the seal is one this sentence has words for or one that stops
+     * the compile.
      */
     default String said(SourceNameResolver names, SourceId sectionSource) {
         return switch (this) {
-            case Named named -> named.name();
+            case Named it -> it.rule().citedName();
             // Written here, and reached from somewhere else: a comparison inside a helper is one
             // rule and a reader is sent to two places, which the citation already tells apart.
-            case WrittenAt written -> WHAT_IT_IS
-                    + joining(written.at()) + written.at().said(names, sectionSource);
+            case WrittenAt<?> it -> it.rule().whatItIs()
+                    + joining(it.at()) + it.at().said(names, sectionSource);
         };
+    }
+
+    /**
+     * Where a handle reaches its rule, which is nothing for a rule the author named.
+     *
+     * <p>The one place a handle is taken apart. What a fold over these keeps is the rule once and
+     * the places beside it, so that no state holds a second answer to which rule it is about, and
+     * this is how a reader's handle becomes a place to keep.
+     */
+    static Set<Citation> placeOf(RuleCitation cited) {
+        return switch (cited) {
+            case Named _ -> Set.of();
+            case WrittenAt<?> it -> Set.of(it.at());
+        };
+    }
+
+    /**
+     * Every handle for {@code rule} that the places in {@code reachedAt} offer.
+     *
+     * <p>The inverse of {@link #placeOf}, and the one place a handle is put back together. A rule
+     * the author named is found by that name from anywhere, so it has one handle however many
+     * readers offered it; one written rather than named has a handle per place it was reached at.
+     */
+    static Set<RuleCitation> handlesFor(RuleRef rule, Set<Citation> reachedAt) {
+        requireReached(rule, reachedAt);
+        return switch (rule) {
+            case RuleRef.Named it -> Set.of(new Named(it));
+            case RuleRef.Written it -> reachedAt.stream()
+                    .map(each -> (RuleCitation) new WrittenAt<>(it, each))
+                    .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        };
+    }
+
+    /**
+     * That {@code rule} was reached in the way rules of its kind are reached.
+     *
+     * <p>A rule with no name is found by where it is, so one of those with no place is something
+     * nobody can be sent to look at; and a place beside a rule the author named is a second way to
+     * say one thing, which two readers could spell two ways.
+     */
+    static void requireReached(RuleRef rule, Set<Citation> reachedAt) {
+        if (rule instanceof RuleRef.Written == reachedAt.isEmpty()) {
+            throw new IllegalArgumentException("a rule with no name is reached at a place and a rule"
+                    + " with one is reached by it: " + rule + " at " + reachedAt);
+        }
     }
 
     /**
@@ -97,17 +157,4 @@ public sealed interface RuleCitation {
     static String joining(Citation at) {
         return at instanceof Citation.Elsewhere ? " in " : "@";
     }
-
-    /**
-     * What a report calls a rule that has no name, which is one word.
-     *
-     * <p>One word because there is one thing to say. This was the construct the comparison stood
-     * in, which is not the rule: a condition holds as many rules as it holds comparisons, so
-     * {@code guard} was one word for all of them — and a comparison given a name a line above the
-     * fork that tests it is the same rule with no fork over it to take a word from.
-     *
-     * <p>English, like every other word a report writes from a rule. What a diagnostic says instead
-     * is chosen in the reader's language, from the same fact.
-     */
-    String WHAT_IT_IS = "comparison";
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
@@ -62,15 +62,14 @@ public sealed interface RuleCitation {
      * reader is standing are not always the same file: a comparison inside a helper is written
      * there and reached from the call, and the same type says both.
      *
-     * <p>Which kind of written rule, kept in the type. A reading that draws a line is a comparison's
-     * and a reading that tells a set of values from the rest is a predicate's, and a holder of one
-     * says which it is ({@link souther.compiler.partition.RuleEvidenceOrigin}). Erased to
-     * {@link RuleRef.Written} here, a holder wanting the kind back would either narrow it at a cast
-     * or keep the rule a second time, and the second is what this type exists to have removed.
-     *
-     * @param <R> which kind of written rule this is the handle for
+     * <p>{@link RuleRef.Written} and not a kind of one. A holder that answers for a comparison and
+     * for nothing else keeps the comparison and the place, and makes the handle
+     * ({@link souther.compiler.partition.LineOrigin.ComparisonOrigin}) — which is the shape a fold
+     * over these already has. Carried as a type variable here instead, the variable is unbound
+     * wherever a handle is reached through this interface, and a document's own answers are then
+     * types nothing settles.
      */
-    record WrittenAt<R extends RuleRef.Written>(R rule, Citation at) implements RuleCitation {
+    record WrittenAt(RuleRef.Written rule, Citation at) implements RuleCitation {
 
         public WrittenAt {
             if (rule == null || at == null) {
@@ -98,7 +97,7 @@ public sealed interface RuleCitation {
             case Named it -> it.rule().citedName();
             // Written here, and reached from somewhere else: a comparison inside a helper is one
             // rule and a reader is sent to two places, which the citation already tells apart.
-            case WrittenAt<?> it -> it.rule().whatItIs()
+            case WrittenAt it -> it.rule().whatItIs()
                     + joining(it.at()) + it.at().said(names, sectionSource);
         };
     }
@@ -113,7 +112,7 @@ public sealed interface RuleCitation {
     static Set<Citation> placeOf(RuleCitation cited) {
         return switch (cited) {
             case Named _ -> Set.of();
-            case WrittenAt<?> it -> Set.of(it.at());
+            case WrittenAt it -> Set.of(it.at());
         };
     }
 
@@ -129,7 +128,7 @@ public sealed interface RuleCitation {
         return switch (rule) {
             case RuleRef.Named it -> Set.of(new Named(it));
             case RuleRef.Written it -> reachedAt.stream()
-                    .map(each -> (RuleCitation) new WrittenAt<>(it, each))
+                    .map(each -> (RuleCitation) new WrittenAt(it, each))
                     .collect(java.util.stream.Collectors.toUnmodifiableSet());
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleRef.java
@@ -30,7 +30,89 @@ import souther.compiler.types.WrittenOwner;
  * those are answers about a boundary, they are the same rule's whichever way they come out, and a
  * key holding them files one rule under several.
  */
-public sealed interface RuleRef {
+public sealed interface RuleRef permits RuleRef.Named, RuleRef.Written {
+
+    /**
+     * A rule the author wrote a name beside, which is how a reader finds it.
+     *
+     * <p>Which of the two ways a rule is found is a property of the kind of rule it is, and this is
+     * that property made a type. A clause of an invariant and a clause of an {@code ensures} always
+     * have something the author called them; a comparison and a predicate never do. Left implicit,
+     * the division was a thing every caller had to know and none could be held to — a citation was
+     * free to be built the wrong way round for the rule it was of, and what refused it was a
+     * {@code switch} throwing at whichever build first wrote such a rule.
+     */
+    sealed interface Named extends RuleRef permits Invariant, Ensures {
+
+        /**
+         * What a report calls this rule, which is the name the author gave it.
+         *
+         * <p>A name and not a place. A diagnostic is built where no reader is — nothing there knows
+         * what to call a source — so a place written into its text would be a line and a column with
+         * no file. A rule with no name is not here at all: it is found by where it is written, which
+         * is {@link Written}'s side of the seal.
+         *
+         * <p>The words of both kinds together, so a reader holding one can be held to them without
+         * reading whoever writes the sentence. No {@code default} arm: a kind added to this seal and
+         * left without words stops the compile.
+         *
+         * <p>English, like every other word this writes. What a diagnostic says instead is chosen in
+         * the reader's language, from the same rule.
+         */
+        default String citedName() {
+            return switch (this) {
+                // What the author called it, and where they called it nothing, which of the
+                // declaration's clauses it is — counted from one, as somebody reading the
+                // declaration counts them. Two unnamed clauses of one declaration are two rules,
+                // and rendered by the declaration alone they are one word twice.
+                case Invariant i -> "invariant " + i.clause().id().declaredOn().name()
+                        + i.clause().name().map(n -> " (" + n + ")")
+                                .orElse(" #" + (i.clause().id().ordinal() + 1));
+                // The behavior, and the words that tell one of its rules from another. A clause
+                // belongs to a behavior, so there is always something to call it; only a clause
+                // stating one rule over every answer has neither a name nor a case, and the
+                // behavior's own name is then the whole of it.
+                case Ensures e -> "ensures " + e.rule().behavior().name()
+                        + (e.clause().isEmpty() ? "" : " (" + e.clause() + ")");
+            };
+        }
+    }
+
+    /**
+     * A rule the author wrote rather than named, which is found by where it is written.
+     *
+     * <p>The other half of the seal, and what tells the two halves apart is what a reader is given
+     * to act on. Nothing here has a name to be looked up by, so a report writes what the rule is
+     * and where it stands, and the place is one no reader can invent.
+     */
+    sealed interface Written extends RuleRef permits Comparison, Predicate {
+
+        /**
+         * What a report calls a rule that has no name, which is one word per kind of them.
+         *
+         * <p>A word about the rule and not about the construct it stands in. A comparison may stand
+         * in the condition of an {@code if} or a {@code guard}, be given a name a line above the
+         * fork that tests it, or be what the behavior answers with, and it is one rule in all of
+         * those — so a word for the thing around it is a word the rule can lose.
+         *
+         * <p>One word per kind and not one word over the seal, because the kind is what a reader
+         * acts on. Sent to a comparison they are sent to a line on the order the values are counted
+         * on and owed a row either side of it; sent to a predicate they are sent to a set told from
+         * the rest, where there is no line and no side. That division is the one
+         * {@link souther.compiler.partition.RuleEvidenceOrigin} is split along.
+         *
+         * <p>The words of both kinds together, and no {@code default} arm, for the reason
+         * {@link Named#citedName} gives.
+         *
+         * <p>English, like every other word this writes.
+         */
+        default String whatItIs() {
+            return switch (this) {
+                case Comparison _ -> "comparison";
+                case Predicate _ -> "predicate";
+            };
+        }
+    }
 
     /**
      * A clause of a {@code data}'s invariant.
@@ -38,7 +120,7 @@ public sealed interface RuleRef {
      * <p>The clause and not the declaration it is on. Two clauses of one declaration are two rules,
      * and a report owes a line to each ({@link Clause}).
      */
-    record Invariant(Clause.Ref clause) implements RuleRef {
+    record Invariant(Clause.Ref clause) implements Named {
 
         public Invariant {
             if (clause == null) {
@@ -68,7 +150,7 @@ public sealed interface RuleRef {
      *                 comparison from another wherever it is met
      */
     record Comparison(String behavior, SourceConstructOrigin origin)
-            implements RuleRef {
+            implements Written {
 
         public Comparison {
             if (behavior == null || origin == null) {
@@ -112,7 +194,7 @@ public sealed interface RuleRef {
      *                 from another wherever it is met
      */
     record Predicate(String behavior, SourceConstructOrigin origin)
-            implements RuleRef {
+            implements Written {
 
         public Predicate {
             if (behavior == null || origin == null) {
@@ -167,11 +249,14 @@ public sealed interface RuleRef {
      *
      * @param rule   which rule of which clause, which is what tells one from another. Two arms of
      *               one clause may name the same case, so the author's words for it are not enough
-     * @param clause what a report calls it: the name the author gave the clause, or the case the arm
+     * @param clause the author's words for it: the name they gave the clause, or the case the arm
      *               names where they gave none, or empty where the clause states one rule over every
-     *               answer
+     *               answer. Part of the identity as well as the source of
+     *               {@link Named#citedName}'s words for this rule — two of these agreeing on
+     *               {@code rule} and differing here are two values and not one, so this is not
+     *               presentation a reader may drop from the equality
      */
-    record Ensures(BehaviorContract.RuleId rule, String clause) implements RuleRef {
+    record Ensures(BehaviorContract.RuleId rule, String clause) implements Named {
 
         public Ensures {
             if (rule == null) {
@@ -185,41 +270,5 @@ public sealed interface RuleRef {
                         "a clause the author named nothing is named by nothing, not by null");
             }
         }
-    }
-
-    /**
-     * What a report calls this rule.
-     *
-     * <p>A name and not a place. A diagnostic is built where no reader is — nothing there knows what
-     * to call a source — so a place written into its text would be a line and a column with no file.
-     * Where the rule is a comparison, the place is pointed at instead, by whoever holds the reading
-     * it was met in.
-     *
-     * <p>English, like every other word this writes. What a diagnostic says instead is chosen in the
-     * reader's language, from the same rule.
-     */
-    default String named() {
-        return switch (this) {
-            // What the author called it, and where they called it nothing, which of the
-            // declaration's clauses it is — counted from one, as somebody reading the declaration
-            // counts them. Two unnamed clauses of one declaration are two rules, and rendered by the
-            // declaration alone they are one word twice.
-            case Invariant i -> "invariant " + i.clause().id().declaredOn().name()
-                    + i.clause().name().map(n -> " (" + n + ")")
-                            .orElse(" #" + (i.clause().id().ordinal() + 1));
-            // The behavior, and the words that tell one of its rules from another. A clause belongs
-            // to a behavior, so there is always something to call it; only a clause stating one rule
-            // over every answer has neither a name nor a case, and the behavior's own name is then
-            // the whole of it.
-            case Ensures e -> "ensures " + e.rule().behavior().name()
-                    + (e.clause().isEmpty() ? "" : " (" + e.clause() + ")");
-            // A comparison is written rather than named, so this is what it is and not what the
-            // author called it. Never rendered to a reader on its own: a rule with no name gets a
-            // sentence of its own, and the catalog holds those words in every language. What reaches
-            // this is a caller that wanted something to call the rule anyway.
-            case Comparison _ -> "the comparison";
-            // A predicate is applied rather than named, so this is what it is, for the reason above.
-            case Predicate _ -> "the predicate";
-        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -1552,13 +1552,13 @@ public final class InputDomain {
             // one rule — each rule chose a number for itself, and this reading answers for the
             // position.
             FilingCoordinate at = filedAt(path, each.at(), type, source);
-            RuleCitation cited = RuleCitation.named(each.from());
+            RuleCitation cited = new RuleCitation.Named(each.from());
             switch (measured) {
                 // No number answers for the position, so none of these ends has anywhere to go —
                 // the ones the choice was between and the ones that arrived at a position already
                 // undecided alike. Which values may stand there is what the rules say, and nothing
                 // about the choice of number touches it.
-                case MeasuredCoordinate.Undetermined _ -> out.boundaryUndetermined(each.from(),
+                case MeasuredCoordinate.Undetermined _ -> out.boundaryUndetermined(
                         cited, at, new BlockReason.CompetingCoordinates());
                 case MeasuredCoordinate.At it -> {
                     if (it.coordinate().equals(each.at().of())) {
@@ -1567,8 +1567,7 @@ public final class InputDomain {
                         // Read to the end, at a number this position is not measured at. Nothing is
                         // undecided about it and no question stands: the rule says where a number
                         // of this place stops, and the position is divided along another.
-                        out.add(each.from(), cited, at,
-                                new BlockReason.RuleAboutAnotherCoordinate());
+                        out.add(cited, at, new BlockReason.RuleAboutAnotherCoordinate());
                     }
                 }
             }
@@ -1682,11 +1681,11 @@ public final class InputDomain {
             // time is stopped by whatever stopped each branch — so they are asked as the several
             // questions they are rather than one of them standing for the rest.
             each.at().why().forEach(why ->
-                    found.asked(StandingQuestion.BoundaryUndetermined.of(each.rule(), each.cited(),
+                    found.asked(StandingQuestion.BoundaryUndetermined.of(each.cited(),
                             FilingCoordinate.at(path), why)));
         }
         for (souther.compiler.check.RuleAccounting.Unanswered each : placed.unanswered(path)) {
-            out.add(StandingQuestion.Exact.of(each.rule(), each.cited(),
+            out.add(StandingQuestion.Exact.of(each.cited(),
                     switch (each.owed()) {
                         case souther.compiler.check.Owed.AdmittedValues _ ->
                                 new InputQuestion.AboutAPosition(path);
@@ -1735,8 +1734,7 @@ public final class InputDomain {
             // At the number that rule is about, which the rule itself says. Nothing is missing here
             // for the position to stand in for: a clause was read far enough to be about one number
             // or the other, and it is only the line that nothing came of.
-            out.add(each.from(),
-                    RuleCitation.named(each.from()),
+            out.add(new RuleCitation.Named(each.from()),
                     filedAt(path, each.at(), type, source),
                     each.why());
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -148,9 +148,9 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
         // Rule by rule, and every question each of them raised. What a reading holds afterwards is
         // what the rules came to together — a field two clauses narrow is one narrowed field — so an
         // account taken from there is one either clause can go missing from with nothing to see.
-        bounds().accounting().forEach((rule, accounting) ->
+        bounds().accounting().values().forEach(accounting ->
                 accounting.answers().keySet().forEach(owed ->
-                        out.add(PlacementSeed.of(root, owed, rule, accounting.cited()))));
+                        out.add(PlacementSeed.of(root, owed, accounting.cited()))));
         return List.copyOf(out);
     }
 
@@ -326,11 +326,11 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
             return List.of();
         }
         List<RuleUnclassifiedAt> out = new ArrayList<>();
-        bounds().accounting().forEach((rule, accounting) ->
+        bounds().accounting().values().forEach(accounting ->
                 accounting.undetermined().stream()
                         .filter(each -> each.at().equals(where))
-                        .forEach(each -> out.add(new RuleUnclassifiedAt(rule, accounting.cited(),
-                                each))));
+                        .forEach(each ->
+                                out.add(new RuleUnclassifiedAt(accounting.cited(), each))));
         TermPath above = alsoAt(path);
         if (above != null) {
             out.addAll(alsoReaching.outer().unclassified(above));
@@ -338,9 +338,15 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
         return List.copyOf(out);
     }
 
-    /** One rule, how a reader finds it, and one place its classification did not come out. */
-    record RuleUnclassifiedAt(RuleRef rule, RuleCitation cited,
-                              Requirement.BoundaryUndetermined at) {}
+    /** How a reader finds the rule, which says which rule it is, and one place its classification
+     *  did not come out. */
+    record RuleUnclassifiedAt(RuleCitation cited, Requirement.BoundaryUndetermined at) {
+
+        /** Which rule of the model, which the handle for it carries. */
+        RuleRef rule() {
+            return cited.rule();
+        }
+    }
 
     /**
      * How much of what the rules say the bounds at {@code path} are able to state.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -10,7 +10,6 @@ import souther.compiler.check.Owed;
 import souther.compiler.check.Requirement;
 import souther.compiler.check.RuleAccounting;
 import souther.compiler.check.RuleCitation;
-import souther.compiler.check.RuleRef;
 import souther.compiler.check.ProjectionEvidence;
 import souther.compiler.check.Rules;
 import souther.compiler.check.Shape;
@@ -340,13 +339,7 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules, Reaching alsoRe
 
     /** How a reader finds the rule, which says which rule it is, and one place its classification
      *  did not come out. */
-    record RuleUnclassifiedAt(RuleCitation cited, Requirement.BoundaryUndetermined at) {
-
-        /** Which rule of the model, which the handle for it carries. */
-        RuleRef rule() {
-            return cited.rule();
-        }
-    }
+    record RuleUnclassifiedAt(RuleCitation cited, Requirement.BoundaryUndetermined at) {}
 
     /**
      * How much of what the rules say the bounds at {@code path} are able to state.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacementSeed.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacementSeed.java
@@ -25,16 +25,21 @@ import souther.compiler.check.RuleRef;
  * its cases, so one of these becomes a filing at each of them. Nothing here says where, and nothing
  * here says a name reached nowhere.
  */
-public record PlacementSeed(RuleAddress address, Placed placed, RuleRef by, RuleCitation cited) {
+public record PlacementSeed(RuleAddress address, Placed placed, RuleCitation cited) {
 
     public PlacementSeed {
         if (address == null || placed == null) {
             throw new IllegalArgumentException("a rule placed something somewhere");
         }
-        if (by == null || cited == null) {
+        if (cited == null) {
             throw new IllegalArgumentException(
                     "and it was some rule that placed it, which a reader can be sent to look at");
         }
+    }
+
+    /** Which rule placed it, which the handle for it carries. */
+    public RuleRef by() {
+        return cited.rule();
     }
 
     /**
@@ -76,7 +81,7 @@ public record PlacementSeed(RuleAddress address, Placed placed, RuleRef by, Rule
      * <p>Exhaustive over {@link NumericTerm}, with no {@code default}: a term of a third kind is a
      * name this would have to read, and stopping the compile is what says so.
      */
-    public static PlacementSeed of(RuleAddress address, NumericTerm term, RuleRef by,
+    public static PlacementSeed of(RuleAddress address, NumericTerm term,
                                    RuleCitation cited) {
         return new PlacementSeed(address, new Placed.ANumberOfIt(switch (term) {
             case NumericTerm.ValueOf _ -> new NumberAt.OfWhatNumber.OfItsOwnValue();
@@ -88,7 +93,7 @@ public record PlacementSeed(RuleAddress address, Placed placed, RuleRef by, Rule
             // written about what its elements come to.
             case NumericTerm.TakenOver over ->
                     new NumberAt.OfWhatNumber.OfWhatAnOperationAnswers(over.operation());
-        }), by, cited);
+        }), cited);
     }
 
     /**
@@ -102,14 +107,14 @@ public record PlacementSeed(RuleAddress address, Placed placed, RuleRef by, Rule
      * other standing, so an account keyed on the field is one a rule can go missing from without
      * anything to see. What tells them apart is the rule, so the rule is carried.
      */
-    public static PlacementSeed of(TermPath root, Owed owed, RuleRef by, RuleCitation cited) {
+    public static PlacementSeed of(TermPath root, Owed owed, RuleCitation cited) {
         return switch (owed) {
             case Owed.AdmittedValues values ->
                     new PlacementSeed(new RuleAddress(root, values.path()),
-                            new Placed.TheValuesThere(), by, cited);
+                            new Placed.TheValuesThere(), cited);
             case Owed.Boundary boundary ->
                     new PlacementSeed(new RuleAddress(root, boundary.on().position()),
-                            new Placed.ANumberOfIt(boundary.on().of()), by, cited);
+                            new Placed.ANumberOfIt(boundary.on().of()), cited);
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleWithoutALine.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleWithoutALine.java
@@ -2,6 +2,7 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -24,10 +25,10 @@ import java.util.Set;
  * then came back as one the model divides no way, which is the opposite of what the declaration
  * says.
  *
- * <p>Two values and not one, and for two reasons. {@code rule} tells one rule from another and is
- * what a reader groups by; {@code cited} is the handle an author acts on, and the two are not in
- * step wherever a rule has no name. Neither stands in for the other, and only the
- * first is part of what makes two of these one finding.
+ * <p>The rule once, and the places it was reached at beside it. What a reader groups by is the rule
+ * ({@link Fact}); what an author acts on is a handle, which is that rule together with a place, and
+ * {@link #cited} makes them rather than keeping them. Kept, a handle would be a second answer to
+ * which rule this is about, free to be of another one.
  *
  * <p><b>Named for what is true of everything in it.</b> Two opposite things bring a rule here — one
  * this compiler got partway through, and one it read from end to end that draws no line — and what
@@ -40,31 +41,29 @@ import java.util.Set;
  * became of a rule here. Counted as the first, a rule this compiler read completely is one nobody
  * could read.
  *
- * @param fact  which rule, at which position, and why there is no line — the whole of what makes
- *              two of these one finding ({@link Fact})
- * @param cited how a reader finds it — a name where the author gave one, a place where they did
- *              not. Every one that was offered, because a rule found by two readers is one finding
- *              and each of them says how to reach it; which of them a document writes is that
- *              document's to decide
+ * @param fact      which rule, at which position, and why there is no line — the whole of what makes
+ *                  two of these one finding ({@link Fact})
+ * @param reachedAt every place a reader was offered for the rule, because a rule found by two
+ *                  readers is one finding and each of them says where it reached it; which of them a
+ *                  document writes is that document's to decide. Empty exactly where the author
+ *                  named the rule, which is found by that name from anywhere
  */
-public record RuleWithoutALine(Fact fact, Set<RuleCitation> cited) {
+public record RuleWithoutALine(Fact fact, Set<Citation> reachedAt) {
 
     public RuleWithoutALine {
         if (fact == null) {
             throw new IllegalArgumentException("a rule is without a line somewhere, and for a"
                     + " reason");
         }
-        cited = cited == null ? Set.of() : Set.copyOf(cited);
-        if (cited.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "a rule with no line here is one a reader can be sent to look at");
-        }
+        reachedAt = reachedAt == null ? Set.of() : Set.copyOf(reachedAt);
+        RuleCitation.requireReached(fact.rule(), reachedAt);
     }
 
     /** One reader's finding, as that reader produced it. */
-    public static RuleWithoutALine of(RuleRef rule, RuleCitation cited, FilingCoordinate at,
+    public static RuleWithoutALine of(RuleCitation cited, FilingCoordinate at,
                                       BlockReason.RuleWithoutLineReason why) {
-        return new RuleWithoutALine(new Fact(rule, at, why), Set.of(cited));
+        return new RuleWithoutALine(new Fact(cited.rule(), at, why),
+                RuleCitation.placeOf(cited));
     }
 
     /**
@@ -101,10 +100,21 @@ public record RuleWithoutALine(Fact fact, Set<RuleCitation> cited) {
     }
 
     /**
-     * Both readers' findings, as one: the rule, with every handle either of them offered.
+     * How a reader finds it — a name where the author gave one, a place where they did not.
+     *
+     * <p>Made from the rule and the places rather than kept beside them. A handle is the rule
+     * together with where it was reached, so made here it is of this finding's rule and can be of no
+     * other ({@link RuleCitation}).
+     */
+    public Set<RuleCitation> cited() {
+        return RuleCitation.handlesFor(fact.rule(), reachedAt);
+    }
+
+    /**
+     * Both readers' findings, as one: the rule, with every place either of them reached it at.
      *
      * <p>Of one rule, and it says so rather than taking the caller's word. What comes out carries
-     * this one's fact, so two that are not one fact would come out as one of them cited where the
+     * this one's fact, so two that are not one fact would come out as one of them reached where the
      * other was.
      */
     public RuleWithoutALine mergedWith(RuleWithoutALine other) {
@@ -112,8 +122,8 @@ public record RuleWithoutALine(Fact fact, Set<RuleCitation> cited) {
             throw new IllegalArgumentException("two findings put together are one rule with no"
                     + " line: " + fact + " and " + other.fact);
         }
-        Set<RuleCitation> both = new HashSet<>(cited);
-        both.addAll(other.cited);
+        Set<Citation> both = new HashSet<>(reachedAt);
+        both.addAll(other.reachedAt);
         return new RuleWithoutALine(fact, both);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RulesWithNoLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RulesWithNoLine.java
@@ -1,7 +1,6 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.RuleCitation;
-import souther.compiler.check.RuleRef;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -135,9 +134,9 @@ public record RulesWithNoLine(List<RuleWithoutALine> reported,
         private final Map<Object, StandingQuestion.Unclassified> unclassified = new LinkedHashMap<>();
 
         /** One more finding, which is what a report says about the rule at that place. */
-        public void add(RuleRef rule, RuleCitation cited, FilingCoordinate at,
+        public void add(RuleCitation cited, FilingCoordinate at,
                         BlockReason.RuleWithoutLineReason why) {
-            add(RuleWithoutALine.of(rule, cited, at, why));
+            add(RuleWithoutALine.of(cited, at, why));
         }
 
         /**
@@ -149,9 +148,9 @@ public record RulesWithNoLine(List<RuleWithoutALine> reported,
          * {@code ensures} come this way — there is no reading that says what either raises, so
          * where the reading of one stopped there is nothing to have been determined.
          */
-        public void unclassified(RuleRef rule, RuleCitation cited, FilingCoordinate at,
+        public void unclassified(RuleCitation cited, FilingCoordinate at,
                                  BlockReason.RuleReadingStopped why) {
-            asked(StandingQuestion.NothingClassifiesIt.of(rule, cited, at, why));
+            asked(StandingQuestion.NothingClassifiesIt.of(cited, at, why));
         }
 
         /**
@@ -163,10 +162,10 @@ public record RulesWithNoLine(List<RuleWithoutALine> reported,
          * is what holds the border measure open, and the classes are settled beside it rather than
          * held open with it.
          */
-        public void boundaryUndetermined(RuleRef rule, RuleCitation cited, FilingCoordinate at,
+        public void boundaryUndetermined(RuleCitation cited, FilingCoordinate at,
                                          BlockReason.RuleReadingStopped why) {
-            add(RuleWithoutALine.of(rule, cited, at, why));
-            asked(StandingQuestion.BoundaryUndetermined.of(rule, cited, at, why));
+            add(RuleWithoutALine.of(cited, at, why));
+            asked(StandingQuestion.BoundaryUndetermined.of(cited, at, why));
         }
 
         /** One a reader already made, which is how the findings of two readings meet. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
@@ -3,6 +3,7 @@ package souther.compiler.inputs;
 import souther.compiler.check.CoverageObligation;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -144,7 +145,7 @@ public sealed interface StandingQuestion {
      *                position's answer was short of stands beside them under no order at all
      *                ({@link WhatAQuestionStandsOn})
      */
-    record Exact(Fact fact, Set<RuleCitation> cited,
+    record Exact(Fact fact, Set<Citation> reachedAt,
                  WhatAQuestionStandsOn stopped) implements StandingQuestion {
 
         public Exact {
@@ -152,11 +153,8 @@ public sealed interface StandingQuestion {
                 throw new IllegalArgumentException("a standing question names a rule and what it"
                         + " asks");
             }
-            cited = cited == null ? Set.of() : Set.copyOf(cited);
-            if (cited.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "a question names a rule a reader can be sent to");
-            }
+            reachedAt = reachedAt == null ? Set.of() : Set.copyOf(reachedAt);
+            RuleCitation.requireReached(fact.rule(), reachedAt);
             if (stopped == null) {
                 throw new IllegalArgumentException(
                         "a question stands because something was short of it");
@@ -164,14 +162,19 @@ public sealed interface StandingQuestion {
         }
 
         /** One reader's account of it, as that reader produced it. */
-        public static Exact of(RuleRef rule, RuleCitation cited, InputQuestion asks,
+        public static Exact of(RuleCitation cited, InputQuestion asks,
                                WhatAQuestionStandsOn stopped) {
-            return new Exact(new Fact(rule, asks), Set.of(cited), stopped);
+            return new Exact(new Fact(cited.rule(), asks), RuleCitation.placeOf(cited), stopped);
         }
 
         @Override
         public RuleRef rule() {
             return fact.rule();
+        }
+
+        @Override
+        public Set<RuleCitation> cited() {
+            return RuleCitation.handlesFor(fact.rule(), reachedAt);
         }
 
         /** What it asks and what it asks it about. */
@@ -223,8 +226,8 @@ public sealed interface StandingQuestion {
             }
             Optional<BlockReason.AnswerRealizationStopped> answer =
                     mine.isPresent() ? mine : theirs;
-            Set<RuleCitation> both = new HashSet<>(cited);
-            both.addAll(it.cited);
+            Set<Citation> both = new HashSet<>(reachedAt);
+            both.addAll(it.reachedAt);
             return new Exact(fact, both,
                     new WhatAQuestionStandsOn(stopped.itsRuleLeft(), answer));
         }
@@ -299,31 +302,33 @@ public sealed interface StandingQuestion {
      * only the measure answering it.
      */
     record NothingClassifiesIt(NothingClassifiesIt.Filed filed,
-                                  Set<RuleCitation> cited) implements Unclassified {
+                                  Set<Citation> reachedAt) implements Unclassified {
 
         public NothingClassifiesIt {
             if (filed == null) {
                 throw new IllegalArgumentException(
                         "a rule nothing classified is one rule, filed somewhere, for a reason");
             }
-            cited = cited == null ? Set.of() : Set.copyOf(cited);
-            if (cited.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "a rule left open is one a reader can be sent to look at");
-            }
+            reachedAt = reachedAt == null ? Set.of() : Set.copyOf(reachedAt);
+            RuleCitation.requireReached(filed.rule(), reachedAt);
         }
 
         /** One reader's account of it, as that reader produced it. */
-        public static NothingClassifiesIt of(RuleRef rule, RuleCitation cited,
-                                                    FilingCoordinate at,
-                                                    BlockReason.RuleReadingStopped why) {
-            return new NothingClassifiesIt(new NothingClassifiesIt.Filed(rule, at, why),
-                    Set.of(cited));
+        public static NothingClassifiesIt of(RuleCitation cited, FilingCoordinate at,
+                                             BlockReason.RuleReadingStopped why) {
+            return new NothingClassifiesIt(
+                    new NothingClassifiesIt.Filed(cited.rule(), at, why),
+                    RuleCitation.placeOf(cited));
         }
 
         @Override
         public RuleRef rule() {
             return filed.rule();
+        }
+
+        @Override
+        public Set<RuleCitation> cited() {
+            return RuleCitation.handlesFor(filed.rule(), reachedAt);
         }
 
         /** Where a reader is sent to look, which is not what the rule is about. */
@@ -359,8 +364,8 @@ public sealed interface StandingQuestion {
                 throw new IllegalArgumentException("two accounts put together are of one rule: "
                         + filed + " and " + it.filed);
             }
-            Set<RuleCitation> both = new HashSet<>(cited);
-            both.addAll(it.cited);
+            Set<Citation> both = new HashSet<>(reachedAt);
+            both.addAll(it.reachedAt);
             return new NothingClassifiesIt(filed, both);
         }
 
@@ -407,31 +412,33 @@ public sealed interface StandingQuestion {
      * @param cited how a reader finds the rule
      */
     record BoundaryUndetermined(BoundaryUndetermined.Filed filed,
-                                Set<RuleCitation> cited) implements Unclassified {
+                                Set<Citation> reachedAt) implements Unclassified {
 
         public BoundaryUndetermined {
             if (filed == null) {
                 throw new IllegalArgumentException("a question nothing worked out is one question,"
                         + " of one rule, filed somewhere");
             }
-            cited = cited == null ? Set.of() : Set.copyOf(cited);
-            if (cited.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "a rule left open is one a reader can be sent to look at");
-            }
+            reachedAt = reachedAt == null ? Set.of() : Set.copyOf(reachedAt);
+            RuleCitation.requireReached(filed.rule(), reachedAt);
         }
 
         /** One reader's account of it, as that reader produced it. */
-        public static BoundaryUndetermined of(RuleRef rule, RuleCitation cited,
-                                              FilingCoordinate at,
+        public static BoundaryUndetermined of(RuleCitation cited, FilingCoordinate at,
                                               BlockReason.RuleReadingStopped why) {
-            return new BoundaryUndetermined(new BoundaryUndetermined.Filed(rule, at, why),
-                    Set.of(cited));
+            return new BoundaryUndetermined(
+                    new BoundaryUndetermined.Filed(cited.rule(), at, why),
+                    RuleCitation.placeOf(cited));
         }
 
         @Override
         public RuleRef rule() {
             return filed.rule();
+        }
+
+        @Override
+        public Set<RuleCitation> cited() {
+            return RuleCitation.handlesFor(filed.rule(), reachedAt);
         }
 
         @Override
@@ -464,8 +471,8 @@ public sealed interface StandingQuestion {
                 throw new IllegalArgumentException("two accounts put together are of one question: "
                         + filed + " and " + it.filed);
             }
-            Set<RuleCitation> both = new HashSet<>(cited);
-            both.addAll(it.cited);
+            Set<Citation> both = new HashSet<>(reachedAt);
+            both.addAll(it.reachedAt);
             return new BoundaryUndetermined(filed, both);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
@@ -137,7 +137,8 @@ public sealed interface StandingQuestion {
      *
      * @param fact    which rule raised it and what it asks, which is what tells one question from
      *                another ({@link Fact})
-     * @param cited   how a reader finds that rule
+     * @param reachedAt every place a reader was offered for that rule, empty exactly where the
+     *                author named it and it is found by that name from anywhere
      * @param stopped every reason it stands. A question is answered when every part that asked it
      *                has been read, so a part standing behind another is a second thing to lift.
      *                What the parts of the rule left keeps the order the author wrote them in and
@@ -409,7 +410,8 @@ public sealed interface StandingQuestion {
      * and everything that reads one of these has to say what it does about it.
      *
      * @param filed which rule, where it was filed and what stopped the reading
-     * @param cited how a reader finds the rule
+     * @param reachedAt every place a reader was offered for that rule, empty exactly where the
+     *                  author named it
      */
     record BoundaryUndetermined(BoundaryUndetermined.Filed filed,
                                 Set<Citation> reachedAt) implements Unclassified {

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -94,9 +94,10 @@ public record AuthoredLine(RuleRef rule, int conjunct, LineFacts facts,
      * reached first. Where a reading of it is being said rather than the line, the place is there to
      * point at and {@link LineOrigin#describe} says it.
      *
-     * <p>The two halves of the seal, spelled here because this is the sentence being written. A rule
-     * with no name has no name to be given one at the type that holds it, and a word for it that
-     * lived there would answer {@code named()} for something nobody named.
+     * <p>The two halves of the seal, spelled here because this is the sentence being written. Which
+     * of the two a rule is found by is the rule's own answer and it says nothing about what a
+     * sentence with no place in it should read; a fold over both that lived on the rule would be one
+     * word for a question only a caller writing a sentence has.
      */
     public String saidWithoutAPlace() {
         return said(switch (rule) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -83,18 +83,26 @@ public record AuthoredLine(RuleRef rule, int conjunct, LineFacts facts,
     }
 
     /**
-     * What a report calls this line.
+     * What a report calls this line where it has no place to point at.
      *
-     * <p>The rule's own name, and the declarations that took it in beside it. A narrowing is not
-     * part of the rule, so the rule does not say it and this does.
+     * <p>The author's word for the rule where they wrote one and what the rule is where they did
+     * not, with the declarations that took it in beside it. A narrowing is not part of the rule, so
+     * the rule does not say it and this does.
      *
-     * <p>A name and not a place, because a debt is not at one: a line an {@code invariant} drew is
-     * met wherever the type is carried, so any place to print would be the position of whichever
-     * behavior a walk reached first. Where a reading of it is being named rather than the line, the
-     * place is said by {@link LineOrigin#describe}.
+     * <p>Not a place, because a debt is not at one: a line an {@code invariant} drew is met wherever
+     * the type is carried, so any place to print would be the position of whichever behavior a walk
+     * reached first. Where a reading of it is being said rather than the line, the place is there to
+     * point at and {@link LineOrigin#describe} says it.
+     *
+     * <p>The two halves of the seal, spelled here because this is the sentence being written. A rule
+     * with no name has no name to be given one at the type that holds it, and a word for it that
+     * lived there would answer {@code named()} for something nobody named.
      */
-    public String named() {
-        return said(rule.named());
+    public String saidWithoutAPlace() {
+        return said(switch (rule) {
+            case RuleRef.Named it -> it.citedName();
+            case RuleRef.Written it -> "the " + it.whatItIs();
+        });
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorSetStatements.java
@@ -160,7 +160,7 @@ public final class BehaviorSetStatements {
                 case Outcome.NotGot(var at, var why) ->
                         blocked.add(new ClassingBlocker(at, each.origin(), why));
                 case Outcome.SayingNothing(var at, var why) -> saying.add(
-                        RuleWithoutALine.of(each.origin().rule(), each.origin().cited(), at, why));
+                        RuleWithoutALine.of(each.origin().cited(), at, why));
                 // Nothing places it, so there is nobody to say it to. Which is the answer the
                 // reading of a comparison gives the same shape, and not this walk being quiet.
                 case Outcome.Nowhere _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -995,7 +995,8 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
         Level leaves = Seam.of(space, cut, valueBelongs(origin)).leaving(kept);
         if (end == null || !end.at().sameAs(placeOf(leaves))) {
             throw new IllegalStateException(
-                    "a bound whose line is not where what it leaves stops: " + origin.saidWithoutAPlace());
+                    "a bound whose line is not where what it leaves stops: "
+                            + origin.saidWithoutAPlace());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -995,7 +995,7 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
         Level leaves = Seam.of(space, cut, valueBelongs(origin)).leaving(kept);
         if (end == null || !end.at().sameAs(placeOf(leaves))) {
             throw new IllegalStateException(
-                    "a bound whose line is not where what it leaves stops: " + origin.named());
+                    "a bound whose line is not where what it leaves stops: " + origin.saidWithoutAPlace());
         }
     }
 
@@ -1043,7 +1043,7 @@ public record Border(BoundaryTarget cut, LineOrigin origin, Map<DomainPoint, Poi
             return order;
         }
         throw new IllegalStateException("which way a rule is satisfied from its line, asked of one"
-                + " that names a value and orders nothing: " + origin.named());
+                + " that names a value and orders nothing: " + origin.saidWithoutAPlace());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -76,10 +76,10 @@ public record BorderObligationId(AuthoredLine line, Level at) {
         return line.rule();
     }
 
-    /** What a report calls this line, which is the rule's own name and never a place a body reached
-     *  it at. */
-    public String named() {
-        return line.named();
+    /** What a report calls this line — the author's word for the rule where they wrote one and what
+     *  the rule is where they did not, and never a place a body reached it at. */
+    public String saidWithoutAPlace() {
+        return line.saidWithoutAPlace();
     }
 
     /** The declaration this line is owed to, where a declaration's clause drew it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClassingBlocker.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClassingBlocker.java
@@ -52,7 +52,6 @@ public record ClassingBlocker(NumericTerm.FromOnePosition at, PredicateOrigin by
 
     /** What a person is shown, which is the other thing this is. */
     public RuleWithoutALine reported() {
-        return RuleWithoutALine.of(by.rule(), by.cited(),
-                FilingCoordinate.at(at.position()), why);
+        return RuleWithoutALine.of(by.cited(), FilingCoordinate.at(at.position()), why);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -323,16 +323,16 @@ public final class EnsuresThresholds {
             return;
         }
         souther.compiler.check.RuleCitation cited =
-                souther.compiler.check.RuleCitation.named(rule);
+                new souther.compiler.check.RuleCitation.Named(rule);
         // And what each place is left with, which for a clause of an `ensures` turns on whether its
         // reading finished. Nothing works out what such a clause raises about an input — what it
         // states is a relation the behavior is held to — so where the reading stopped there is
         // nothing that was determined.
         left.forEach((named, why) -> {
             if (why instanceof BlockReason.RuleReadingStopped stopped) {
-                withoutALine.unclassified(rule, cited, named, stopped);
+                withoutALine.unclassified(cited, named, stopped);
             } else {
-                withoutALine.add(rule, cited, named, why);
+                withoutALine.add(cited, named, why);
             }
         });
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -509,10 +509,10 @@ public final class GuardThresholds {
         // Whose body it is, from the name the catalog issued. Taken from a caller beside it, the
         // rule this reports and the comparison it is read off would be free to be of two behaviors,
         // and the occurrence being one this plan holds would not refuse it.
-        RuleRef.Comparison rule =
-                new RuleRef.Comparison(comparison.which().behavior(), comparison.origin());
         souther.compiler.check.RuleCitation cited =
-                new souther.compiler.check.RuleCitation.WrittenAt(comparison.at());
+                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                        new RuleRef.Comparison(comparison.which().behavior(), comparison.origin()),
+                        comparison.at());
         // What each place is left with, and which places there are, are the assessment's one
         // answer. A rule that was read is filed at its quantity's coordinates and says one thing
         // there, because the quantity is one subject; a reading that stopped has none, and each
@@ -523,9 +523,9 @@ public final class GuardThresholds {
         // reading stopped there is nothing that was determined and nothing that could have been.
         read.whatEachPlaceIsLeftWith().forEach((at, why) -> {
             if (why instanceof BlockReason.RuleReadingStopped stopped) {
-                out.unclassified(rule, cited, at, stopped);
+                out.unclassified(cited, at, stopped);
             } else {
-                out.add(rule, cited, at, why);
+                out.add(cited, at, why);
             }
         });
     }
@@ -539,9 +539,10 @@ public final class GuardThresholds {
         // and it is required rather than looked up leniently because only an admitted reading
         // reaches here and the policy admits nothing the plan does not number.
         return new LineOrigin.ComparisonOrigin(
-                new RuleRef.Comparison(each.which().behavior(), each.origin()),
                 new LineOrigin.ComparisonOrigin.Read(each.which(),
-                        new souther.compiler.check.RuleCitation.WrittenAt(each.at()),
+                        new souther.compiler.check.RuleCitation.WrittenAt<>(
+                                new RuleRef.Comparison(each.which().behavior(), each.origin()),
+                                each.at()),
                         plan.requireEmissionSiteOf(each.which())),
                 new LineFacts(cutting.claim()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -510,7 +510,7 @@ public final class GuardThresholds {
         // rule this reports and the comparison it is read off would be free to be of two behaviors,
         // and the occurrence being one this plan holds would not refuse it.
         souther.compiler.check.RuleCitation cited =
-                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                new souther.compiler.check.RuleCitation.WrittenAt(
                         new RuleRef.Comparison(comparison.which().behavior(), comparison.origin()),
                         comparison.at());
         // What each place is left with, and which places there are, are the assessment's one
@@ -540,9 +540,8 @@ public final class GuardThresholds {
         // reaches here and the policy admits nothing the plan does not number.
         return new LineOrigin.ComparisonOrigin(
                 new LineOrigin.ComparisonOrigin.Read(each.which(),
-                        new souther.compiler.check.RuleCitation.WrittenAt<>(
-                                new RuleRef.Comparison(each.which().behavior(), each.origin()),
-                                each.at()),
+                        new RuleRef.Comparison(each.which().behavior(), each.origin()),
+                        each.at(),
                         plan.requireEmissionSiteOf(each.which())),
                 new LineFacts(cutting.claim()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -135,7 +135,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          * ({@link souther.compiler.check.RuleCitation}).
          */
         public RuleRef.Comparison rule() {
-            return read.written().rule();
+            return read.rule();
         }
 
         /**
@@ -158,10 +158,12 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          *              {@code B} false and rows that never reached {@code B}. The comparison and not
          *              the number it is instrumented under — two readers agreeing that they mean one
          *              place should not come down to their having been handed the same int
-         * @param written which comparison of the model this is, and how a reader finds it, which is
-         *              where it is written. The comparison's own place and not the fork's — a
-         *              condition holding three comparisons is three rules, and a reader sent to the
-         *              {@code if} is given one handle for all of them
+         * @param rule which comparison of the model this is, which is the same value however many
+         *              times the comparison is read
+         * @param writtenAt where a reader finds it, which is where it is written. The comparison's
+         *              own place and not the fork's — a condition holding three comparisons is
+         *              three rules, and a reader sent to the {@code if} is given one handle for all
+         *              of them
          * @param recordedAt where a run through that comparison is written down. Beside the
          *              comparison and not instead of it: which comparison this reads is what
          *              everything about the rule is said of, and this is only how a run is asked
@@ -169,15 +171,28 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          *              that numbered it, so the two cannot come from different builds
          */
         public record Read(souther.compiler.coverage.ComparisonOccurrence comparison,
-                           souther.compiler.check.RuleCitation.WrittenAt<RuleRef.Comparison> written,
+                           RuleRef.Comparison rule, Citation writtenAt,
                            souther.compiler.coverage.ComparisonEmissionSite recordedAt) {
 
             public Read {
-                if (comparison == null || written == null || recordedAt == null) {
+                if (comparison == null || rule == null || writtenAt == null
+                        || recordedAt == null) {
                     throw new IllegalArgumentException(
                             "a rule read off a comparison names one, cites it and says where a run"
                                     + " through it is recorded");
                 }
+            }
+
+            /**
+             * How a reader finds the rule, which is where it is written.
+             *
+             * <p>Made here rather than kept, so that the handle is of {@link #rule} and can be of no
+             * other. Kept beside the rule, the two could be built about different comparisons — and
+             * a document writing both would file an entry under one rule with a sentence about
+             * another.
+             */
+            public souther.compiler.check.RuleCitation.WrittenAt written() {
+                return new souther.compiler.check.RuleCitation.WrittenAt(rule, writtenAt);
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -91,7 +91,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
             }
             if (keeps == null) {
                 throw new IllegalArgumentException(
-                        "a bound places one of a range's two ends: " + rule.named());
+                        "a bound places one of a range's two ends: " + rule.citedName());
             }
             if (conjunct < 0) {
                 throw new IllegalArgumentException(
@@ -118,22 +118,33 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      *              ComparisonClaim}), which decides which neighbour is the other class's edge:
      *              {@code <= 3000} leaves 3001 over there, {@code < 3000} leaves 2999
      */
-    record ComparisonOrigin(RuleRef.Comparison rule, Read read, LineFacts facts)
-            implements LineOrigin {
+    record ComparisonOrigin(Read read, LineFacts facts) implements LineOrigin {
 
         public ComparisonOrigin {
-            if (facts == null) {
+            if (read == null || facts == null) {
                 throw new IllegalArgumentException("a line is what some comparison placed");
             }
         }
 
         /**
-         * Which reading of the comparison this is, and where that reading was.
+         * Which comparison of the model this reads.
          *
-         * <p>None of it tells one rule from another. A comparison inside a non-recursive helper is
-         * read once per call of that helper, so one comparison the author wrote arrives as several
-         * of these — each a real occurrence, each measured on its own, and all of them the same
-         * rule.
+         * <p>Through the handle the reading holds and not beside it. A rule and how a reader is sent
+         * to it are one answer, and kept as two they could be built about two comparisons — which
+         * would put an identity and a sentence about different rules in one entry of a document
+         * ({@link souther.compiler.check.RuleCitation}).
+         */
+        public RuleRef.Comparison rule() {
+            return read.written().rule();
+        }
+
+        /**
+         * Which comparison this reads, which reading of it this is, and where that reading was.
+         *
+         * <p>Only the handle tells one rule from another. A comparison inside a non-recursive helper
+         * is read once per call of that helper, so one comparison the author wrote arrives as
+         * several of these — each a real occurrence, each measured on its own, and all of them the
+         * same rule, which is the one {@code written} names.
          *
          * <p>No fork. What a row met the line by is getting the comparison to answer, and the
          * comparison is where that is recorded — so the arms of the {@code if} standing round it
@@ -147,10 +158,10 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          *              {@code B} false and rows that never reached {@code B}. The comparison and not
          *              the number it is instrumented under — two readers agreeing that they mean one
          *              place should not come down to their having been handed the same int
-         * @param written how a reader finds the rule, which is where it is written. The
-         *              comparison's own place and not the fork's — a condition holding three
-         *              comparisons is three rules, and a reader sent to the {@code if} is given one
-         *              handle for all of them
+         * @param written which comparison of the model this is, and how a reader finds it, which is
+         *              where it is written. The comparison's own place and not the fork's — a
+         *              condition holding three comparisons is three rules, and a reader sent to the
+         *              {@code if} is given one handle for all of them
          * @param recordedAt where a run through that comparison is written down. Beside the
          *              comparison and not instead of it: which comparison this reads is what
          *              everything about the rule is said of, and this is only how a run is asked
@@ -158,7 +169,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          *              that numbered it, so the two cannot come from different builds
          */
         public record Read(souther.compiler.coverage.ComparisonOccurrence comparison,
-                           souther.compiler.check.RuleCitation.WrittenAt written,
+                           souther.compiler.check.RuleCitation.WrittenAt<RuleRef.Comparison> written,
                            souther.compiler.coverage.ComparisonEmissionSite recordedAt) {
 
             public Read {
@@ -356,9 +367,9 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
     @Override
     default souther.compiler.check.RuleCitation cited() {
         return switch (this) {
-            case InvariantOrigin i -> souther.compiler.check.RuleCitation.named(i.rule());
+            case InvariantOrigin i -> new souther.compiler.check.RuleCitation.Named(i.rule());
             case ComparisonOrigin g -> g.read().written();
-            case EnsuresOrigin e -> souther.compiler.check.RuleCitation.named(e.rule());
+            case EnsuresOrigin e -> new souther.compiler.check.RuleCitation.Named(e.rule());
             case NarrowedOrigin n -> n.bound().cited();
         };
     }
@@ -383,8 +394,8 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      */
     default String describe(SourceNameResolver names, SourceId sectionSource) {
         return switch (this) {
-            case InvariantOrigin i -> i.rule().named();
-            case EnsuresOrigin e -> e.rule().named();
+            case InvariantOrigin i -> i.rule().citedName();
+            case EnsuresOrigin e -> e.rule().citedName();
             // The same word and the same join a question about this rule is written with. A rule
             // and a line it drew are found the same way, and two spellings of one place read as two
             // places.
@@ -451,15 +462,15 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
     }
 
     /**
-     * The same rule, named without a place.
+     * The same rule, said without a place.
      *
      * <p>What a diagnostic's own sentence says. A diagnostic is built where no reader is — nothing
      * there knows what to call a source — so a place written into its text would be a line and a
      * column with no file, read against whichever file the report happens to be about. Where the rule
-     * is a guard, the place is pointed at instead, by {@link #citation}.
+     * has no name, the place is pointed at instead, by {@link #citation}.
      */
-    default String named() {
-        return authoredLine().named();
+    default String saidWithoutAPlace() {
+        return authoredLine().saidWithoutAPlace();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineOrigin.java
@@ -112,8 +112,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      * comparison is not modelled, because no measure asks it: a row meets the line by lighting the
      * comparison's own probe.
      *
-     * @param rule  which comparison, which is the rule and the whole of it
-     * @param read  which reading of that rule this is, and where it was met
+     * @param read  which comparison this is, which reading of it, and where it was met
      * @param facts what the rule placed on the values ({@link souther.compiler.check.ComparisonClaim
      *              ComparisonClaim}), which decides which neighbour is the other class's edge:
      *              {@code <= 3000} leaves 3001 over there, {@code < 3000} leaves 2999
@@ -134,6 +133,7 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
          * would put an identity and a sentence about different rules in one entry of a document
          * ({@link souther.compiler.check.RuleCitation}).
          */
+        @Override
         public RuleRef.Comparison rule() {
             return read.rule();
         }
@@ -499,22 +499,28 @@ public sealed interface LineOrigin extends RuleEvidenceOrigin {
      *
      * <p>Asked rather than matched on the text: what a rule is called is a rendering, and two of
      * them read the same word.
+     *
+     * <p>And asked of the rule, which is what says so ({@link RuleRef.Named},
+     * {@link RuleRef.Written}). Read off which reading this is, the answer would be a second one
+     * beside the rule's own — agreeing while the arms line up, and coming apart the day a reading
+     * is added for a rule with no name, where this would answer {@code false} about a rule
+     * {@link #cited} sends a reader to by its place.
      */
     default boolean isWrittenRatherThanNamed() {
-        return switch (this) {
-            case ComparisonOrigin _ -> true;
-            case NarrowedOrigin n -> n.bound().isWrittenRatherThanNamed();
-            case InvariantOrigin _, EnsuresOrigin _ -> false;
-        };
+        return rule() instanceof RuleRef.Written;
     }
 
-    /** Where the rule is written, where it is a rule that has a place rather than a name. */
+    /**
+     * Where the rule is written, where it is a rule that has a place rather than a name.
+     *
+     * <p>Taken out of the handle, for the reason above: the handle is what carries the place, and a
+     * reading that answered from its own arm would be a second answer to what the handle already
+     * says.
+     */
     default java.util.Optional<Citation> citation() {
-        return switch (this) {
-            case ComparisonOrigin g -> java.util.Optional.of(g.read().written().at());
-            case NarrowedOrigin n -> n.bound().citation();
-            case InvariantOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
-        };
+        return cited() instanceof souther.compiler.check.RuleCitation.WrittenAt written
+                ? java.util.Optional.of(written.at())
+                : java.util.Optional.empty();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
@@ -137,7 +137,7 @@ public final class LinesRead {
 
     private static String said(List<Line> lines) {
         return lines.stream()
-                .map(each -> each.at().label() + " (" + each.by().named() + ")")
+                .map(each -> each.at().label() + " (" + each.by().saidWithoutAPlace() + ")")
                 .collect(java.util.stream.Collectors.joining(", "));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesWhereTheyFall.java
@@ -197,7 +197,7 @@ public final class LinesWhereTheyFall {
             // nobody meant. What an author is owed is the pairing, and it is said here.
             // The line is what has nowhere to go: the rule was read, an end came out of it, and
             // which of the positions it runs between is what nothing worked out.
-            notPlaced.boundaryUndetermined(line.by().rule(), line.by().cited(),
+            notPlaced.boundaryUndetermined(line.by().cited(),
                     new FilingCoordinate.OfTerm(filed.getFirst().name()),
                     new BlockReason.CasePairingNotDetermined());
             return;
@@ -264,7 +264,7 @@ public final class LinesWhereTheyFall {
             return new WhereTheNameStands.AsWritten(term);
         }
         PlacementFiling filing = inputs.file(
-                PlacementSeed.of(address, term, origin.rule(), origin.cited()));
+                PlacementSeed.of(address, term, origin.cited()));
         List<NumericTerm> filed = new ArrayList<>();
         for (souther.compiler.inputs.PlacementOutcome outcome : filing.outcomes()) {
             switch (outcome) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -613,8 +613,7 @@ public final class Partitions {
                 // Read, and tells none of the position's values from the others. Reported, and the
                 // rules beside it divide the position exactly as they would have without it.
                 case TOLD_NOTHING_APART -> {
-                    found.add(RuleWithoutALine.of(each.what().by().rule(),
-                            each.what().by().cited(),
+                    found.add(RuleWithoutALine.of(each.what().by().cited(),
                             new FilingCoordinate.AtPosition(term.position()), each.why()));
                     account.disposedOf(each.what(),
                             new EvidenceAccount.Disposition.TheRuleDividedNothing(term));
@@ -670,8 +669,7 @@ public final class Partitions {
         // finding kept here would be one nobody reads.
         if (made.why() != null && blocked.isEmpty()) {
             RuleEvidence.statementsIn(answered.notComposed())
-                    .forEach(each -> found.add(RuleWithoutALine.of(each.origin().rule(),
-                            each.origin().cited(),
+                    .forEach(each -> found.add(RuleWithoutALine.of(each.origin().cited(),
                             new FilingCoordinate.AtPosition(term.position()), made.why())));
         }
         // Said here because this is where they were asked. A blocker carried in and never reached

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
@@ -13,30 +13,40 @@ import souther.compiler.check.RuleRef;
  * which values it tells from the rest, and that is a fact about the sets it admits, said by whoever
  * worked them out and not carried here.
  *
- * <p><b>Three things and three layers, none of them standing for another.</b> {@link #rule} is which
- * rule of the model this is, minted where the source was read and the same at every call of a helper
- * holding it. {@link #occurrence} is which of this body's readings of that rule this one is, issued
- * by the walk that met them. And this value is what a piece of evidence carries: the identity of one
- * reading, which is what an account of what became of each rule is filed under.
+ * <p><b>Three things and three layers, none of them standing for another.</b> Which rule of the
+ * model this is, minted where the source was read and the same at every call of a helper holding it.
+ * {@link #occurrence} is which of this body's readings of that rule this one is, issued by the walk
+ * that met them. And this value is what a piece of evidence carries: the identity of one reading,
+ * which is what an account of what became of each rule is filed under.
  *
- * @param rule       which predicate, which is the rule and the whole of it
+ * <p>The rule through the handle and not beside it. Which predicate this reads and how a reader is
+ * sent to it are one answer, and held as two components they could be built about two rules — where
+ * the identity a document files this under and the sentence it writes beside it are of different
+ * rules ({@link RuleCitation}).
+ *
  * @param occurrence which reading of that rule this is. What tells two readings of one rule apart,
  *                   and the only thing here that does — {@code helper("JP", code)} and
  *                   {@code helper("US", code)} read one rule twice and divide one position two ways
- * @param written    how a reader finds the rule, which is where it is written. The application's own
- *                   place: a condition holding two predicates is two rules, and a reader sent to the
- *                   condition is given one handle for both
+ * @param written    which predicate, and how a reader finds it, which is where it is written. The
+ *                   application's own place: a condition holding two predicates is two rules, and a
+ *                   reader sent to the condition is given one handle for both
  */
-public record PredicateOrigin(RuleRef.Predicate rule, PredicateOccurrence occurrence,
-                              RuleCitation.WrittenAt written)
+public record PredicateOrigin(PredicateOccurrence occurrence,
+                              RuleCitation.WrittenAt<RuleRef.Predicate> written)
         implements RuleEvidenceOrigin {
 
     public PredicateOrigin {
-        if (rule == null || occurrence == null || written == null) {
+        if (occurrence == null || written == null) {
             throw new IllegalArgumentException(
                     "a reading of a predicate is a reading of some rule, told from the others, and"
                             + " written somewhere");
         }
+    }
+
+    /** Which predicate, which is the rule and the whole of it. */
+    @Override
+    public RuleRef.Predicate rule() {
+        return written.rule();
     }
 
     /** Where it is written, which is how a rule with no name is found. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateOrigin.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
 
 /**
  * One reading of a predicate applied in a behavior's body.
@@ -27,31 +28,32 @@ import souther.compiler.check.RuleRef;
  * @param occurrence which reading of that rule this is. What tells two readings of one rule apart,
  *                   and the only thing here that does — {@code helper("JP", code)} and
  *                   {@code helper("US", code)} read one rule twice and divide one position two ways
- * @param written    which predicate, and how a reader finds it, which is where it is written. The
+ * @param rule       which predicate, which is the rule and the whole of it
+ * @param writtenAt  where it is written, which is how a reader finds a rule with no name. The
  *                   application's own place: a condition holding two predicates is two rules, and a
  *                   reader sent to the condition is given one handle for both
  */
-public record PredicateOrigin(PredicateOccurrence occurrence,
-                              RuleCitation.WrittenAt<RuleRef.Predicate> written)
+public record PredicateOrigin(PredicateOccurrence occurrence, RuleRef.Predicate rule,
+                              Citation writtenAt)
         implements RuleEvidenceOrigin {
 
     public PredicateOrigin {
-        if (occurrence == null || written == null) {
+        if (occurrence == null || rule == null || writtenAt == null) {
             throw new IllegalArgumentException(
                     "a reading of a predicate is a reading of some rule, told from the others, and"
                             + " written somewhere");
         }
     }
 
-    /** Which predicate, which is the rule and the whole of it. */
-    @Override
-    public RuleRef.Predicate rule() {
-        return written.rule();
-    }
-
-    /** Where it is written, which is how a rule with no name is found. */
+    /**
+     * How a reader finds it, which is where it is written.
+     *
+     * <p>Made here rather than kept, so that the handle is of {@link #rule} and can be of no other.
+     * Kept beside the rule, the two could be built about different predicates — and a document
+     * writing both would file an entry under one rule with a sentence about another.
+     */
     @Override
     public RuleCitation cited() {
-        return written;
+        return new RuleCitation.WrittenAt(rule, writtenAt);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
@@ -3,7 +3,6 @@ package souther.compiler.partition;
 import souther.compiler.check.AnalysisBody;
 import souther.compiler.check.ElementBindings;
 import souther.compiler.check.PredicateStatement;
-import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
 import souther.compiler.check.StatedContract;
 import souther.compiler.check.StringPredicates;
@@ -181,9 +180,8 @@ record PredicateReadings(List<Reading> predicates) {
                              StringPredicates.Stated states, InputReads reads, List<Reading> out) {
         out.add(new Reading(
                 new PredicateOrigin(new PredicateOccurrence(out.size()),
-                        new RuleCitation.WrittenAt<>(
-                                new RuleRef.Predicate(behavior, call.origin()),
-                                Citation.of(call.pos()))),
+                        new RuleRef.Predicate(behavior, call.origin()),
+                        Citation.of(call.pos())),
                 states, reads));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PredicateReadings.java
@@ -180,9 +180,10 @@ record PredicateReadings(List<Reading> predicates) {
     private static void read(Core.PreservedCall call, String behavior,
                              StringPredicates.Stated states, InputReads reads, List<Reading> out) {
         out.add(new Reading(
-                new PredicateOrigin(new RuleRef.Predicate(behavior, call.origin()),
-                        new PredicateOccurrence(out.size()),
-                        new RuleCitation.WrittenAt(Citation.of(call.pos()))),
+                new PredicateOrigin(new PredicateOccurrence(out.size()),
+                        new RuleCitation.WrittenAt<>(
+                                new RuleRef.Predicate(behavior, call.origin()),
+                                Citation.of(call.pos()))),
                 states, reads));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
@@ -126,7 +126,7 @@ public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHand
     static PublishedRuleHandle of(RuleCitation cited) {
         return switch (cited) {
             case RuleCitation.Named it -> new Named(it.rule().citedName());
-            case RuleCitation.WrittenAt<?> it -> it.at() instanceof Citation.Elsewhere out
+            case RuleCitation.WrittenAt it -> it.at() instanceof Citation.Elsewhere out
                     ? new Reached(it.rule().whatItIs(), placeOf(it.at()),
                             out.provenance().reachedBy())
                     : new Written(it.rule().whatItIs(), placeOf(it.at()));

--- a/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
+++ b/souther-compiler/src/main/java/souther/compiler/publish/PublishedRuleHandle.java
@@ -9,24 +9,65 @@ import java.util.Optional;
 /**
  * How a document sends a reader to a rule, as the things a document's words for it are made of.
  *
- * <p>The projection of a {@link RuleCitation} onto what varies in the sentence a report writes:
- * the name where the author gave one, and otherwise whether the code is here or reached from here,
- * where it is, and what it is reached by. Everything else a citation carries is how this compiler
- * came to be holding it.
+ * <p>The projection of a {@link RuleCitation} onto what varies in the sentence a report writes: the
+ * name where the author gave one, and otherwise what the rule is, whether the code is here or
+ * reached from here, where it is, and what it is reached by. Everything else a citation carries is
+ * how this compiler came to be holding it.
  *
  * <p><b>Made so that two handles a document writes alike are one value.</b> Choosing one of several
  * takes a comparison, and a comparison over what a citation is rather than over what is written of
  * it can come out equal for two handles a reader can tell apart — and then which is written is
- * whichever the set of them happened to iterate first, which is the thing this whole change exists
- * to have removed.
+ * whichever the set of them happened to iterate first, which is the thing this whole type exists to
+ * have removed.
  *
- * <p>So this and never {@link RuleCitation} is what the order is over. Two citations that project
- * here alike are two a reader cannot tell apart, and which of those a document writes is not a
- * question about the document.
+ * <p>So this and never {@link RuleCitation} is what the order is over, and what it must keep is one
+ * property: two of these that are equal are two a document writes the same sentence for. A rule's
+ * kind is in the sentence, so it is here — left out, a comparison and a predicate written at one
+ * place would come to one value and be printed two ways.
+ *
+ * <p>Three and not one with a field that is sometimes absent, because they are three kinds of
+ * evidence. A name is what the author called the rule; a place is where this document's own source
+ * has it; and a reach is a place in code out of sight together with what reaches it, which is what
+ * makes the place mean something. Read back out of an absent field, the third would be the second
+ * with something extra, and every consumer would rebuild the distinction from the absence.
  */
-public record PublishedRuleHandle(Optional<String> name, Where where, Place at,
-                                  Optional<String> reachedBy)
-        implements Comparable<PublishedRuleHandle> {
+public sealed interface PublishedRuleHandle extends Comparable<PublishedRuleHandle> {
+
+    /** The author gave it a name, and that is what a reader is told. */
+    record Named(String name) implements PublishedRuleHandle {
+
+        public Named {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("a rule called nothing is reached by where it is");
+            }
+        }
+    }
+
+    /** It has no name and is written where a reader can be sent, so what is said is what it is and
+     *  where. */
+    record Written(String kind, Place at) implements PublishedRuleHandle {
+
+        public Written {
+            if (kind == null || kind.isEmpty() || at == null) {
+                throw new IllegalArgumentException("a rule with no name is said as what it is and"
+                        + " where: " + kind + " at " + at);
+            }
+        }
+    }
+
+    /** It has no name and the code is out of sight, so what is said is what it is, where it came
+     *  from, and what reaches it. */
+    record Reached(String kind, Place at, String reachedBy) implements PublishedRuleHandle {
+
+        public Reached {
+            if (kind == null || kind.isEmpty() || at == null
+                    || reachedBy == null || reachedBy.isEmpty()) {
+                throw new IllegalArgumentException("code out of sight is said as what it is, where"
+                        + " it came from and what reaches it: " + kind + " at " + at + " by "
+                        + reachedBy);
+            }
+        }
+    }
 
     /**
      * Where a report says the rule is, as it says it.
@@ -40,7 +81,7 @@ public record PublishedRuleHandle(Optional<String> name, Where where, Place at,
      * at different lines of an unnamed text came out as one value — and the choice between them
      * fell back to whichever the set of them iterated first.
      */
-    public sealed interface Place extends Comparable<Place> {
+    sealed interface Place extends Comparable<Place> {
 
         /** In a file this compile holds, so a reader can be sent to it. */
         record InSource(PublishedAt at) implements Place {}
@@ -81,38 +122,14 @@ public record PublishedRuleHandle(Optional<String> name, Where where, Place at,
         }
     }
 
-    /** Which of the three kinds of sentence a report writes for a rule. */
-    public enum Where {
-
-        /** The author gave it a name, and that is what a reader is told. */
-        NAMED,
-
-        /** It has no name and is written where a reader can be sent. */
-        WRITTEN,
-
-        /** It has no name and the code is out of sight, so what is said is where it came from. */
-        ELSEWHERE
-    }
-
-    public PublishedRuleHandle {
-        if (where == null || at == null) {
-            throw new IllegalArgumentException("a rule is reached one of three ways");
-        }
-        name = name == null ? Optional.empty() : name;
-        reachedBy = reachedBy == null ? Optional.empty() : reachedBy;
-    }
-
     /** How a document would write {@code cited}. */
-    public static PublishedRuleHandle of(RuleCitation cited) {
+    static PublishedRuleHandle of(RuleCitation cited) {
         return switch (cited) {
-            case RuleCitation.Named it ->
-                    new PublishedRuleHandle(Optional.of(it.name()), Where.NAMED,
-                            new Place.Nowhere(), Optional.empty());
-            case RuleCitation.WrittenAt it -> new PublishedRuleHandle(Optional.empty(),
-                    it.at() instanceof Citation.Elsewhere ? Where.ELSEWHERE : Where.WRITTEN,
-                    placeOf(it.at()),
-                    it.at() instanceof Citation.Elsewhere out
-                            ? Optional.of(out.provenance().reachedBy()) : Optional.empty());
+            case RuleCitation.Named it -> new Named(it.rule().citedName());
+            case RuleCitation.WrittenAt<?> it -> it.at() instanceof Citation.Elsewhere out
+                    ? new Reached(it.rule().whatItIs(), placeOf(it.at()),
+                            out.provenance().reachedBy())
+                    : new Written(it.rule().whatItIs(), placeOf(it.at()));
         };
     }
 
@@ -145,36 +162,49 @@ public record PublishedRuleHandle(Optional<String> name, Where where, Place at,
 
     /**
      * Which of two a document writes first: a name the author gave before a place they did not,
-     * a place before code out of sight, and two of one kind by where they are and what they say.
+     * a place before code out of sight, and two of one kind by what they say and where they are.
      *
      * <p>A rank and not a ranking: what it is for is that a run choosing between the same two
      * chooses the same way, and a reader given a name has the word the model uses where a reader
      * given a place has what there is instead.
+     *
+     * <p>Over every part of each kind, so that this is zero for exactly the pairs {@code equals} is
+     * true of. Two that a document writes alike are one value and either may be written; two it
+     * writes apart are ordered, and which comes first does not depend on the order a set of them
+     * came out in.
      */
     @Override
-    public int compareTo(PublishedRuleHandle other) {
-        int kind = Integer.compare(rank(where), rank(other.where));
+    default int compareTo(PublishedRuleHandle other) {
+        int kind = Integer.compare(rank(this), rank(other));
         if (kind != 0) {
             return kind;
         }
-        int named = name.orElse("").compareTo(other.name.orElse(""));
-        if (named != 0) {
-            return named;
-        }
-        int reached = reachedBy.orElse("").compareTo(other.reachedBy.orElse(""));
-        if (reached != 0) {
-            return reached;
-        }
-        return at.compareTo(other.at);
+        return switch (this) {
+            case Named it -> it.name().compareTo(((Named) other).name());
+            case Written it -> {
+                Written also = (Written) other;
+                int word = it.kind().compareTo(also.kind());
+                yield word != 0 ? word : it.at().compareTo(also.at());
+            }
+            case Reached it -> {
+                Reached also = (Reached) other;
+                int word = it.kind().compareTo(also.kind());
+                if (word != 0) {
+                    yield word;
+                }
+                int by = it.reachedBy().compareTo(also.reachedBy());
+                yield by != 0 ? by : it.at().compareTo(also.at());
+            }
+        };
     }
 
     /** Which of the three kinds of sentence comes first, written out rather than read off how the
-     *  constants happen to be declared. */
-    private static int rank(Where where) {
-        return switch (where) {
-            case NAMED -> 0;
-            case WRITTEN -> 1;
-            case ELSEWHERE -> 2;
+     *  arms happen to be declared. */
+    private static int rank(PublishedRuleHandle handle) {
+        return switch (handle) {
+            case Named _ -> 0;
+            case Written _ -> 1;
+            case Reached _ -> 2;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4727,10 +4727,10 @@ public final class Adequacy {
                                                 owed.against(), owed.debt().id().saidWithoutAPlace());
                         // A body's line, owed once wherever it is read, so the sentence names no
                         // quantity: which of the four points, and which rule — by name where the
-                        // author gave it one, and as the construct where it is a comparison found
-                        // by where it is written. Writing where the point is takes a quantity and
-                        // a quantity is a reading's, so that is said under this, by the reading
-                        // whose word it is.
+                        // author gave it one, and as what the rule is where they gave none and it
+                        // is found by where it is written. Writing where the point is takes a
+                        // quantity and a quantity is a reading's, so that is said under this, by
+                        // the reading whose word it is.
                         case About.APointOfABorder(var point) -> switch (point.cited()) {
                             case souther.compiler.check.RuleCitation.Named named ->
                                     point.role().againstTheLine()
@@ -4892,6 +4892,12 @@ public final class Adequacy {
          * and the catalog holds them in every language. No {@code default}, so a kind of written
          * rule added to the seal arrives here as a case with no phrase rather than as one quietly
          * answered with its neighbour's.
+         *
+         * <p>What reaches this is a rule that drew a line, which today is a comparison: the sentence
+         * is about a line and a predicate draws none, so a border's rule is a comparison's
+         * ({@link souther.compiler.partition.LineOrigin}). The predicate phrase is here because the
+         * seal is total and not because a document writes one, and what holds the two words together
+         * for a document that does is asked where such a document is written.
          */
         private static souther.compiler.diag.Localizable whatItIs(
                 souther.compiler.check.RuleRef.Written rule) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4181,7 +4181,7 @@ public final class Adequacy {
                 .nameOf(id.declaredLine().orElseThrow());
         // A clause whose end this could not read from the declaration has no form to print, and
         // the rule's own name is the whole of what there is to call the line.
-        return named == null ? id.named() : named;
+        return named == null ? id.saidWithoutAPlace() : named;
     }
 
     /** The declaration's own reading of its own rules, kept: it draws as many lines as its
@@ -4720,11 +4720,11 @@ public final class Adequacy {
                                 owed.debt().role().againstTheLine()
                                         ? new ExampleMessage.NoRowIsAtThePointOfTheBorderARuleDrew(
                                                 owed.debt().role().name(), owed.axis(),
-                                                owed.against(), owed.debt().id().named())
+                                                owed.against(), owed.debt().id().saidWithoutAPlace())
                                         : new ExampleMessage
                                                 .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
                                                 owed.debt().role().name(), owed.axis(),
-                                                owed.against(), owed.debt().id().named());
+                                                owed.against(), owed.debt().id().saidWithoutAPlace());
                         // A body's line, owed once wherever it is read, so the sentence names no
                         // quantity: which of the four points, and which rule — by name where the
                         // author gave it one, and as the construct where it is a comparison found
@@ -4735,18 +4735,22 @@ public final class Adequacy {
                             case souther.compiler.check.RuleCitation.Named named ->
                                     point.role().againstTheLine()
                                             ? new ExampleMessage.NoRowIsAtThePointOfTheLineARuleDrew(
-                                                    point.role().name(), named.name())
+                                                    point.role().name(),
+                                                    named.rule().citedName())
                                             : new ExampleMessage
                                                     .NoRowIsAtThePointAwayFromTheLineARuleDrew(
-                                                    point.role().name(), named.name());
-                            case souther.compiler.check.RuleCitation.WrittenAt _ ->
+                                                    point.role().name(),
+                                                    named.rule().citedName());
+                            case souther.compiler.check.RuleCitation.WrittenAt<?> written ->
                                     point.role().againstTheLine()
                                             ? new ExampleMessage
                                                     .NoRowIsAtThePointOfTheLineAConstructDrew(
-                                                    point.role().name(), theComparison())
+                                                    point.role().name(),
+                                                    whatItIs(written.rule()))
                                             : new ExampleMessage
                                                     .NoRowIsAtThePointAwayFromTheLineAConstructDrew(
-                                                    point.role().name(), theComparison());
+                                                    point.role().name(),
+                                                    whatItIs(written.rule()));
                         };
                         case About.AnArmNoRowGoesThrough(var arm) ->
                                 new ExampleMessage.NoRowGoesThroughThatArm(
@@ -4807,16 +4811,16 @@ public final class Adequacy {
                     // the file the diagnostic is in; a label no longer takes its file from where it
                     // is shown, so what was left unsaid can be said.
                     if (point.cited()
-                            instanceof souther.compiler.check.RuleCitation.WrittenAt(var cited)) {
-                        switch (cited) {
+                            instanceof souther.compiler.check.RuleCitation.WrittenAt<?> written) {
+                        switch (written.at()) {
                             case souther.compiler.diag.Citation.Written w ->
                                     built.secondary(souther.compiler.diag.Region.point(w.at()),
                                             new ExampleMessage.TheConstructThatDrawsTheLine(
-                                                    theComparison()));
+                                                    whatItIs(written.rule())));
                             case souther.compiler.diag.Citation.Reached r ->
                                     built.secondary(souther.compiler.diag.Region.point(r.at()),
                                             new ExampleMessage.TheConstructThatDrawsTheLine(
-                                                    theComparison()));
+                                                    whatItIs(written.rule())));
                             // Nowhere this compilation can put a marker. Where the guard is written
                             // out of sight the label says so instead; where it is in a text the
                             // caller handed over there is no declaration to name and nothing to say,
@@ -4825,7 +4829,7 @@ public final class Adequacy {
                             case souther.compiler.diag.Citation.Elsewhere e ->
                                     built.secondaryOutOfSight(e.provenance(),
                                             new ExampleMessage.TheConstructThatDrawsTheLine(
-                                                    theComparison()));
+                                                    whatItIs(written.rule())));
                             case souther.compiler.diag.Citation.Unplaced _ -> { }
                         }
                     }
@@ -4875,11 +4879,28 @@ public final class Adequacy {
             };
         }
 
-        /** What a sentence calls a rule that has no name, as a phrase the reader's language
-         *  supplies. One phrase, because a rule found by where it is written is a comparison —
-         *  which construct stands around it is a fact about the body and not about the rule. */
-        private static souther.compiler.diag.Localizable theComparison() {
-            return souther.compiler.diag.Localizable.of("construct.comparison");
+        /**
+         * What a sentence calls a rule that has no name, as a phrase the reader's language supplies.
+         *
+         * <p>One phrase per kind of such rule and not one over them, because a reader acts on the
+         * kind: sent to a comparison they are sent to a line and owed a row either side of it, and
+         * sent to a predicate they are sent to a set of values told from the rest. Which construct
+         * stands around either is a fact about the body and not about the rule, so no phrase here is
+         * a keyword.
+         *
+         * <p>Written out rather than built from the rule's own word, because these are catalog keys
+         * and the catalog holds them in every language. No {@code default}, so a kind of written
+         * rule added to the seal arrives here as a case with no phrase rather than as one quietly
+         * answered with its neighbour's.
+         */
+        private static souther.compiler.diag.Localizable whatItIs(
+                souther.compiler.check.RuleRef.Written rule) {
+            return switch (rule) {
+                case souther.compiler.check.RuleRef.Comparison _ ->
+                        souther.compiler.diag.Localizable.of("construct.comparison");
+                case souther.compiler.check.RuleRef.Predicate _ ->
+                        souther.compiler.diag.Localizable.of("construct.predicate");
+            };
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4741,7 +4741,7 @@ public final class Adequacy {
                                                     .NoRowIsAtThePointAwayFromTheLineARuleDrew(
                                                     point.role().name(),
                                                     named.rule().citedName());
-                            case souther.compiler.check.RuleCitation.WrittenAt<?> written ->
+                            case souther.compiler.check.RuleCitation.WrittenAt written ->
                                     point.role().againstTheLine()
                                             ? new ExampleMessage
                                                     .NoRowIsAtThePointOfTheLineAConstructDrew(
@@ -4811,7 +4811,7 @@ public final class Adequacy {
                     // the file the diagnostic is in; a label no longer takes its file from where it
                     // is shown, so what was left unsaid can be said.
                     if (point.cited()
-                            instanceof souther.compiler.check.RuleCitation.WrittenAt<?> written) {
+                            instanceof souther.compiler.check.RuleCitation.WrittenAt written) {
                         switch (written.at()) {
                             case souther.compiler.diag.Citation.Written w ->
                                     built.secondary(souther.compiler.diag.Region.point(w.at()),

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -2741,9 +2741,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * How schema 3 spells which kind of rule an identity is of.
      *
      * <p>A wire value and not a word for the rule, which is what the name used to say. What a rule
-     * is called is {@link RuleCitation}'s answer, and the two say one thing
-     * again as of version 4 — they are still separate values, because what a document groups by is a
-     * contract a version pins and what a reader is shown is not.
+     * with no name is called is {@link RuleRef.Written#whatItIs}'s answer, and what one with a name
+     * is called is the author's; the two surfaces say one thing and are still separate values,
+     * because what a document groups by is a contract a version pins and what a reader is shown is
+     * not. That they agree today is held over every kind of rule the seal has rather than by their
+     * being one string.
      *
      * <p>Here rather than at the one place it is written, for the reason the others are. No
      * {@code default}, so a rule shape added and not given a spelling stops the compile rather than

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -597,7 +597,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     // and a point beside it names a run, and a sentence that wrote `=` for both said
                     // a run was one value.
                     out.append(String.format("      %s no row is at the %s%n",
-                            mark(f), pointOf(owed, owed.debt().id().named())));
+                            mark(f), pointOf(owed, owed.debt().id().saidWithoutAPlace())));
                 }
             }
         });

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -615,6 +615,7 @@ construct.if=the `if`
 construct.guard=the `guard`
 construct.comprehension=the comprehension
 construct.comparison=the comparison
+construct.predicate=the predicate
 arm.then=the `then` arm
 arm.else=the `else` arm
 arm.continued=the body past the guard

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -608,6 +608,7 @@ construct.if=`if`
 construct.guard=`guard`
 construct.comprehension=内包表記
 construct.comparison=比較
+construct.predicate=述語
 arm.then=`then` の腕
 arm.else=`else` の腕
 arm.continued=guard を通過した先の本体

--- a/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
@@ -84,9 +84,9 @@ class AGuardsQuestionIsCitedByWhereItIsWrittenTest {
     void itIsCitedByThePlaceAndNamedByNothing() {
         PartitionEvidence.NotRead.AnUnclassifiedRule one = writtenComparisons().getFirst();
 
-        RuleCitation.WrittenAt written = one.cited().stream()
+        RuleCitation.WrittenAt<?> written = one.cited().stream()
                 .filter(RuleCitation.WrittenAt.class::isInstance)
-                .map(RuleCitation.WrittenAt.class::cast).findFirst()
+                .map(each -> (RuleCitation.WrittenAt<?>) each).findFirst()
                 .orElseThrow(() -> new AssertionError("a comparison has no name, so it is cited by"
                         + " where it is written: " + one.cited()));
         assertTrue(written.said(SourceNameResolver.identity(), null).startsWith("comparison@"),
@@ -119,6 +119,6 @@ class AGuardsQuestionIsCitedByWhereItIsWrittenTest {
                 .map(RuleCitation.Named.class::cast).findFirst()
                 .orElseThrow(() -> new AssertionError("an invariant is cited by the name the"
                         + " author gave it: " + evidence.unanswered().get(0).cited()));
-        assertEquals("invariant Length (square)", named.name());
+        assertEquals("invariant Length (square)", named.rule().citedName());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGuardsQuestionIsCitedByWhereItIsWrittenTest.java
@@ -84,9 +84,9 @@ class AGuardsQuestionIsCitedByWhereItIsWrittenTest {
     void itIsCitedByThePlaceAndNamedByNothing() {
         PartitionEvidence.NotRead.AnUnclassifiedRule one = writtenComparisons().getFirst();
 
-        RuleCitation.WrittenAt<?> written = one.cited().stream()
+        RuleCitation.WrittenAt written = one.cited().stream()
                 .filter(RuleCitation.WrittenAt.class::isInstance)
-                .map(each -> (RuleCitation.WrittenAt<?>) each).findFirst()
+                .map(each -> (RuleCitation.WrittenAt) each).findFirst()
                 .orElseThrow(() -> new AssertionError("a comparison has no name, so it is cited by"
                         + " where it is written: " + one.cited()));
         assertTrue(written.said(SourceNameResolver.identity(), null).startsWith("comparison@"),

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -438,7 +438,7 @@ class AMeasureWithNoNumberSaysWhyTest {
         assertFalse(lines.isEmpty(), "the invariant draws two");
         for (BorderAssessment.Point line : lines) {
             assertEquals(ItemAssessment.Coverage.NotAsked.NO_ROWS, line.item().weakeningSource().why(),
-                    line.border().origin().named() + " at " + line.asked());
+                    line.border().origin().saidWithoutAPlace() + " at " + line.asked());
         }
     }
 
@@ -535,9 +535,9 @@ class AMeasureWithNoNumberSaysWhyTest {
                 continue;   // nothing was measured there and nothing was waiting on a row
             }
             assertNotEquals(ItemAssessment.Coverage.NotAsked.NO_ROWS, line.item().weakeningSource().why(),
-                    line.border().origin().named() + " at " + line.asked());
+                    line.border().origin().saidWithoutAPlace() + " at " + line.asked());
             assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(line.item().weakeningSource()),
-                    line.border().origin().named() + " at " + line.asked());
+                    line.border().origin().saidWithoutAPlace() + " at " + line.asked());
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -118,8 +118,8 @@ class CompileExampleBoundaryTest {
         BorderAssessment.Point zero = at(away, "0").get(0);
         assertFalse(zero.owed().hasRowWitness());
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(zero.item().weakeningSource()));
-        assertTrue(zero.border().origin().named().startsWith("invariant"),
-                zero.border().origin().named());
+        assertTrue(zero.border().origin().saidWithoutAPlace().startsWith("invariant"),
+                zero.border().origin().saidWithoutAPlace());
 
         List<BorderAssessment> edge = lines(MODEL + """
 
@@ -144,7 +144,7 @@ class CompileExampleBoundaryTest {
         assertTrue(hundred.owed().hasRowWitness(),
                 "the row wrote 100 and the guard compared it");
         assertTrue(hundred.border().origin().isWrittenRatherThanNamed(),
-                hundred.border().origin().named());
+                hundred.border().origin().saidWithoutAPlace());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -827,10 +827,11 @@ class EverySchemaWordIsAccountedForTest {
     /** A rule read far enough to say it restricts the values, and no further. */
     private static souther.compiler.inputs.StandingQuestion boundaryUndetermined() {
         return souther.compiler.inputs.StandingQuestion.BoundaryUndetermined.of(
-                new souther.compiler.check.RuleRef.Comparison("f",
-                        new souther.compiler.types.SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 0, 0,
-                                souther.compiler.types.SourceConstruct.IF)),
-                new souther.compiler.check.RuleCitation.WrittenAt(
+                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                        new souther.compiler.check.RuleRef.Comparison("f",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("m", "b"), 0, 0,
+                                        souther.compiler.types.SourceConstruct.IF)),
                         souther.compiler.diag.Citation.of(
                                 new souther.compiler.diag.SourcePos(1, 1))),
                 souther.compiler.inputs.FilingCoordinate.at(
@@ -841,10 +842,11 @@ class EverySchemaWordIsAccountedForTest {
     /** A rule this compiler did not read far enough to classify. */
     private static souther.compiler.inputs.StandingQuestion unclassified() {
         return souther.compiler.inputs.StandingQuestion.NothingClassifiesIt.of(
-                new souther.compiler.check.RuleRef.Comparison("f",
-                        new souther.compiler.types.SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 0, 0,
-                                souther.compiler.types.SourceConstruct.IF)),
-                new souther.compiler.check.RuleCitation.WrittenAt(
+                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                        new souther.compiler.check.RuleRef.Comparison("f",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("m", "b"), 0, 0,
+                                        souther.compiler.types.SourceConstruct.IF)),
                         souther.compiler.diag.Citation.of(
                                 new souther.compiler.diag.SourcePos(1, 1))),
                 souther.compiler.inputs.FilingCoordinate.at(
@@ -856,10 +858,11 @@ class EverySchemaWordIsAccountedForTest {
     private static souther.compiler.inputs.StandingQuestion asking(
             souther.compiler.inputs.InputQuestion about) {
         return souther.compiler.inputs.StandingQuestion.Exact.of(
-                new souther.compiler.check.RuleRef.Comparison("f",
-                        new souther.compiler.types.SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 0, 0,
-                                souther.compiler.types.SourceConstruct.IF)),
-                new souther.compiler.check.RuleCitation.WrittenAt(
+                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                        new souther.compiler.check.RuleRef.Comparison("f",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("m", "b"), 0, 0,
+                                        souther.compiler.types.SourceConstruct.IF)),
                         souther.compiler.diag.Citation.of(
                                 new souther.compiler.diag.SourcePos(1, 1))),
                 about,

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -827,7 +827,7 @@ class EverySchemaWordIsAccountedForTest {
     /** A rule read far enough to say it restricts the values, and no further. */
     private static souther.compiler.inputs.StandingQuestion boundaryUndetermined() {
         return souther.compiler.inputs.StandingQuestion.BoundaryUndetermined.of(
-                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                new souther.compiler.check.RuleCitation.WrittenAt(
                         new souther.compiler.check.RuleRef.Comparison("f",
                                 new souther.compiler.types.SourceConstructOrigin(
                                         new WrittenOwner.Body("m", "b"), 0, 0,
@@ -842,7 +842,7 @@ class EverySchemaWordIsAccountedForTest {
     /** A rule this compiler did not read far enough to classify. */
     private static souther.compiler.inputs.StandingQuestion unclassified() {
         return souther.compiler.inputs.StandingQuestion.NothingClassifiesIt.of(
-                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                new souther.compiler.check.RuleCitation.WrittenAt(
                         new souther.compiler.check.RuleRef.Comparison("f",
                                 new souther.compiler.types.SourceConstructOrigin(
                                         new WrittenOwner.Body("m", "b"), 0, 0,
@@ -858,7 +858,7 @@ class EverySchemaWordIsAccountedForTest {
     private static souther.compiler.inputs.StandingQuestion asking(
             souther.compiler.inputs.InputQuestion about) {
         return souther.compiler.inputs.StandingQuestion.Exact.of(
-                new souther.compiler.check.RuleCitation.WrittenAt<>(
+                new souther.compiler.check.RuleCitation.WrittenAt(
                         new souther.compiler.check.RuleRef.Comparison("f",
                                 new souther.compiler.types.SourceConstructOrigin(
                                         new WrittenOwner.Body("m", "b"), 0, 0,

--- a/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest.java
@@ -366,7 +366,7 @@ class AChoiceIsDecidedByEveryClauseAndAnsweredByItsOwnTest {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted
                             && unaccounted.why()
                                     instanceof RuleAccounting.Why.TheValueReadingSays says) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 says.why());
                     }
                 }));

--- a/souther-compiler/src/test/java/souther/compiler/check/ALimitIsAnsweredForByWhatAskedForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALimitIsAnsweredForByWhatAskedForItTest.java
@@ -191,7 +191,7 @@ class ALimitIsAnsweredForByWhatAskedForItTest {
 
     /** The name the author gave the rule, which is how this test says which one it means. */
     private static String named(RuleAccounting accounting) {
-        String printed = ((RuleCitation.Named) accounting.cited()).name();
+        String printed = accounting.cited().rule().citedName();
         return printed.substring(printed.indexOf('(') + 1, printed.indexOf(')'));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
@@ -44,7 +44,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
                 """.formatted(clause);
     }
 
-    private static Map<RuleRef, RuleAccounting> accountingOf(String source, String type) {
+    private static Map<RuleRef.Invariant, RuleAccounting> accountingOf(String source, String type) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
@@ -62,7 +62,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
                 ? invariant.clause().name().map(ClauseName::value) : java.util.Optional.empty();
     }
 
-    private static RuleAccounting rule(Map<RuleRef, RuleAccounting> accounting, String clause) {
+    private static RuleAccounting rule(Map<RuleRef.Invariant, RuleAccounting> accounting, String clause) {
         return accounting.entrySet().stream()
                 .filter(e -> nameOf(e.getKey()).filter(clause::equals).isPresent())
                 .map(Map.Entry::getValue).findFirst()
@@ -147,7 +147,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
      */
     @Test
     void aFailureAtAPositionIsNotTheAccountOfTheClausesBesideIt() {
-        Map<RuleRef, RuleAccounting> accounting = accountingOf("""
+        Map<RuleRef.Invariant, RuleAccounting> accounting = accountingOf("""
                 module example.rooms
 
                 data Length = Int

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleNoAlternativeNeededIsStillOneNobodyReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleNoAlternativeNeededIsStillOneNobodyReadTest.java
@@ -109,7 +109,7 @@ class ARuleNoAlternativeNeededIsStillOneNobodyReadTest {
     @Test
     void theAccountingIsNotReadOffTheCompleteness() {
         FieldDomains read = read(LEFT_ASSOCIATED);
-        Map<RuleRef, RuleAccounting> accounting = read.accounting();
+        Map<RuleRef.Invariant, RuleAccounting> accounting = read.accounting();
 
         assertEquals(1, accounting.size(), "one clause, so one rule to account for");
         assertEquals(AdmissibleSet.READ_IN_FULL, read.admits(RuleKey.of("n")).completeness());

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryPartAReadingStoppedOnSaysWhyTest.java
@@ -115,7 +115,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
         read.accounting().values().forEach(accounting ->
                 accounting.answers().forEach((owed, outcome) -> {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 unaccounted.why().getClass().getSimpleName());
                     }
                 }));
@@ -148,7 +148,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted
                             && unaccounted.why()
                                     instanceof RuleAccounting.Why.TheEndReadingSays says) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 List.of(says.why().getClass().getSimpleName()));
                     }
                 }));
@@ -222,7 +222,7 @@ class EveryPartAReadingStoppedOnSaysWhyTest {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted
                             && unaccounted.why()
                                     instanceof RuleAccounting.Why.TheValueReadingSays says) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 says.why());
                     }
                 }));

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class WhatARuleRaisesIsAskedOfTheRuleTest {
 
-    private static Map<RuleRef, Required> raisedBy(String source, String type) {
+    private static Map<RuleRef.Invariant, Required> raisedBy(String source, String type) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
@@ -57,7 +57,7 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
                 ? invariant.clause().name().map(ClauseName::value) : java.util.Optional.empty();
     }
 
-    private static Required only(Map<RuleRef, Required> raised, String clause) {
+    private static Required only(Map<RuleRef.Invariant, Required> raised, String clause) {
         return raised.entrySet().stream()
                 .filter(e -> nameOf(e.getKey()).filter(clause::equals).isPresent())
                 .map(Map.Entry::getValue).findFirst()
@@ -74,7 +74,7 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
      */
     @Test
     void anOrderingBoundRaisesTheValuesAndTheLine() {
-        Map<RuleRef, Required> raised = raisedBy("""
+        Map<RuleRef.Invariant, Required> raised = raisedBy("""
                 module example.rooms
 
                 data Length = Int
@@ -183,7 +183,7 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
      */
     @Test
     void aRelationBetweenTwoPositionsRaisesNothing() {
-        Map<RuleRef, Required> raised = raisedBy("""
+        Map<RuleRef.Invariant, Required> raised = raisedBy("""
                 module example.booking
 
                 data Span = { startsAt: Int, endsAt: Int }
@@ -235,7 +235,7 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
      */
     @Test
     void aConjunctionRaisesWhatItsPartsRaiseTogether() {
-        Map<RuleRef, Required> raised = raisedBy("""
+        Map<RuleRef.Invariant, Required> raised = raisedBy("""
                 module example.booking
 
                 data Span = { startsAt: Int, endsAt: Int }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAStandingQuestionIsAccountedForByTest.java
@@ -252,7 +252,7 @@ class WhatAStandingQuestionIsAccountedForByTest {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted
                             && unaccounted.why()
                             instanceof RuleAccounting.Why.TheValueReadingSays says) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 new StandsOn(says.why(), says.aboutTheAnswer().reasons()));
                     }
                 }));
@@ -305,7 +305,7 @@ class WhatAStandingQuestionIsAccountedForByTest {
         read(source).accounting().values().forEach(accounting ->
                 accounting.answers().forEach((owed, outcome) -> {
                     if (outcome instanceof RuleAccounting.Outcome.Unaccounted unaccounted) {
-                        out.put(((RuleCitation.Named) accounting.cited()).name() + " at " + owed,
+                        out.put(accounting.cited().rule().citedName() + " at " + owed,
                                 unaccounted.why().getClass().getSimpleName());
                     }
                 }));

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest.java
@@ -328,7 +328,8 @@ class WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest {
             FieldDomains domains = read(only(written));
             assertEquals(List.of("invariant Length (nonfive)"),
                     domains.projection().causes().stream()
-                            .map(cause -> ((ProjectionEvidence.Cause.Lossy) cause).rule().named())
+                            .map(cause -> ((RuleRef.Named)
+                                    ((ProjectionEvidence.Cause.Lossy) cause).rule()).citedName())
                             .distinct().toList(),
                     "written as `" + written.replace('\n', ';') + "`");
         }
@@ -399,7 +400,7 @@ class WhatMakesARangeExactIsNotWhatAnswersACoverageQuestionTest {
                 .filter(rule -> rule instanceof RuleRef.Invariant invariant
                         && invariant.clause().name().map(ClauseName::value)
                                 .filter(name::equals).isPresent())
-                .map(rule -> ((RuleRef.Invariant) rule).clause())
+                .map(RuleRef.Invariant::clause)
                 .findFirst().orElseThrow(() -> new AssertionError("no clause called `" + name + "`"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANameIsReadOnceHoweverTheRuleSpelledItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANameIsReadOnceHoweverTheRuleSpelledItTest.java
@@ -95,10 +95,9 @@ class ANameIsReadOnceHoweverTheRuleSpelledItTest {
         TermPath root = TermPath.of("h");
         souther.compiler.check.RuleRef.Invariant rule = someRule(measuredIn(TWO_WAYS));
         PlacementSeed values = PlacementSeed.of(root,
-                new Owed.AdmittedValues(RuleKey.of("name")), rule, someCitation(rule));
+                new Owed.AdmittedValues(RuleKey.of("name")), someCitation(rule));
         PlacementSeed line = PlacementSeed.of(root,
-                new Owed.Boundary(NumberAt.valueOf(RuleKey.of("name"))), rule,
-                someCitation(rule));
+                new Owed.Boundary(NumberAt.valueOf(RuleKey.of("name"))), someCitation(rule));
 
         assertEquals(values.address(), line.address());
         assertEquals(new PlacementSeed.Placed.TheValuesThere(), values.placed());
@@ -210,14 +209,14 @@ class ANameIsReadOnceHoweverTheRuleSpelledItTest {
      *  it at. */
     private static PlacementSeed seedOf(TermPath root, NumericTerm term,
                                         souther.compiler.check.RuleRef.Invariant rule) {
-        return PlacementSeed.of(RuleAddress.of(root, term.subjectPath()), term, rule,
+        return PlacementSeed.of(RuleAddress.of(root, term.subjectPath()), term,
                 someCitation(rule));
     }
 
     /** How a report would send a reader to it. */
     private static souther.compiler.check.RuleCitation someCitation(
             souther.compiler.check.RuleRef.Invariant rule) {
-        return souther.compiler.check.RuleCitation.named(rule);
+        return new souther.compiler.check.RuleCitation.Named(rule);
     }
 
     private static InputDomain reading(String source, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.RuleReadingSource;
+import souther.compiler.check.RuleRef;
 import souther.compiler.check.RuleReadings;
 import souther.compiler.check.CoverageObligation;
 import souther.compiler.check.Prepared;
@@ -111,7 +112,7 @@ class APositionSaysWhichOfItsRulesWentUnansweredTest {
         List<StandingQuestion> open = positionOf(ONE_RULE_UNANSWERED).unansweredQuestions();
 
         assertEquals(List.of("invariant Length (even)", "invariant Length (even)"),
-                open.stream().map(each -> each.rule().named()).toList(),
+                open.stream().map(each -> ((RuleRef.Named) each.rule()).citedName()).toList(),
                 "the clause the author wrote, as a report names it — and not the position it "
                         + "is about");
         StandingQuestion.Exact asked = open.stream()

--- a/souther-compiler/src/test/java/souther/compiler/inputs/EveryPlacementEndsSomewhereSaidOutLoudTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/EveryPlacementEndsSomewhereSaidOutLoudTest.java
@@ -75,7 +75,7 @@ class EveryPlacementEndsSomewhereSaidOutLoudTest {
                 new RuleAddress(TermPath.of("q"), RuleKey.of("limit")),
                 new PlacementSeed.Placed.ANumberOfIt(
                         new NumberAt.OfWhatNumber.OfItsOwnValue()),
-                aRule(read), someCitation(aRule(read))));
+                someCitation(aRule(read))));
 
         assertEquals(List.of("q@A.limit", "q@B.limit"),
                 filedAt(filing));
@@ -94,7 +94,7 @@ class EveryPlacementEndsSomewhereSaidOutLoudTest {
         InputDomain read = reading(SHARED, "read");
         PlacementFiling filing = read.file(new PlacementSeed(
                 new RuleAddress(TermPath.of("h"), new RuleKey(List.of("q", "limit"))),
-                new PlacementSeed.Placed.TheValuesThere(), aRule(read), someCitation(aRule(read))));
+                new PlacementSeed.Placed.TheValuesThere(), someCitation(aRule(read))));
 
         assertEquals(List.of("h.q@A.limit", "h.q@B.limit"),
                 filedAt(filing));
@@ -113,7 +113,7 @@ class EveryPlacementEndsSomewhereSaidOutLoudTest {
         // returns to `Chain`, so the name gets that far and no further.
         PlacementFiling filing = read.file(new PlacementSeed(
                 new RuleAddress(pathOf(read, "c@Cons"), new RuleKey(List.of("tail", "head"))),
-                new PlacementSeed.Placed.TheValuesThere(), aRule(read), someCitation(aRule(read))));
+                new PlacementSeed.Placed.TheValuesThere(), someCitation(aRule(read))));
 
         assertEquals(List.of(), filedAt(filing));
         assertTrue(filing.anythingUnresolved(), "and nothing else stands in its place");
@@ -259,7 +259,7 @@ class EveryPlacementEndsSomewhereSaidOutLoudTest {
     /** How a report would send a reader to it. */
     private static souther.compiler.check.RuleCitation someCitation(
             souther.compiler.check.RuleRef.Invariant rule) {
-        return souther.compiler.check.RuleCitation.named(rule);
+        return new souther.compiler.check.RuleCitation.Named(rule);
     }
 
     private static InputDomain reading(String source, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/NoRuleIsPlacedWhereNothingAccountsForItTest.java
@@ -114,7 +114,8 @@ class NoRuleIsPlacedWhereNothingAccountsForItTest {
     @Test
     void everyRuleThatPlacedAnEndIsInTheAccount() throws Exception {
         for (PlacedRules rules : everyValueRead()) {
-            java.util.Set<souther.compiler.check.RuleRef> counted = rules.bounds().accounting().keySet();
+            java.util.Set<souther.compiler.check.RuleRef.Invariant> counted =
+                    rules.bounds().accounting().keySet();
             for (souther.compiler.check.FieldDomains.Placed each : rules.bounds().placed()) {
                 assertTrue(counted.contains(each.from()),
                         () -> "`" + each.from() + "` placed an end at " + each.path()

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneIdentityIsFoldedOnceAndKeepsEveryHandleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneIdentityIsFoldedOnceAndKeepsEveryHandleTest.java
@@ -47,9 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
 
     private static final RuleCitation HERE =
-            new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(3, 3)));
+            new RuleCitation.WrittenAt(comparison(),Citation.of(new SourcePos(3, 3)));
     private static final RuleCitation REACHED_FROM_A_CALL =
-            new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(9, 1)));
+            new RuleCitation.WrittenAt(comparison(),Citation.of(new SourcePos(9, 1)));
 
     @Test
     void oneRuleFoundTwiceIsOneFindingCitedBothWays() {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneIdentityIsFoldedOnceAndKeepsEveryHandleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneIdentityIsFoldedOnceAndKeepsEveryHandleTest.java
@@ -2,6 +2,8 @@ package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.types.WrittenOwner;
 import souther.compiler.check.RuleRef;
@@ -10,6 +12,8 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.source.SourceId;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * reader wrote for itself would keep whichever handle it met first, and a fold further down could
  * only accumulate what those let through.
  *
+ * <p>Two handles of one rule are two places and never a name and a place. Which of the two ways a
+ * rule is found is the rule's own answer, so a rule the author named has one handle however many
+ * readers offered it, and one written rather than named has a handle per place it was reached at —
+ * a helper's comparison read from two calls.
+ *
  * <p>And two lists there, folded apart. What a report says about a rule that came to no line and
  * what holds a measure open until somebody reads further are different things about one rule, so
  * neither is an account of the other and each is folded on its own.
@@ -37,20 +46,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
 
-    private static final RuleCitation NAMED = new RuleCitation.Named("n");
-    private static final RuleCitation PLACED =
-            new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3)));
+    private static final RuleCitation HERE =
+            new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(3, 3)));
+    private static final RuleCitation REACHED_FROM_A_CALL =
+            new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(9, 1)));
 
     @Test
     void oneRuleFoundTwiceIsOneFindingCitedBothWays() {
         RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-        gathered.add(found(NAMED, "x"));
-        gathered.add(found(PLACED, "x"));
+        gathered.add(found(HERE, "x"));
+        gathered.add(found(REACHED_FROM_A_CALL, "x"));
 
         assertEquals(1, gathered.found().reported().size(),
                 () -> "one rule at one position for one reason is one finding: "
                         + gathered.found().reported());
-        assertEquals(Set.of(NAMED, PLACED), gathered.found().reported().get(0).cited(),
+        assertEquals(Set.of(HERE, REACHED_FROM_A_CALL), gathered.found().reported().get(0).cited(),
                 "and a reader can be sent to it either way either reader offered");
     }
 
@@ -58,11 +68,11 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     @Test
     void whichReaderFoundItFirstDecidesNothing() {
         RulesWithNoLine.Gathered one = new RulesWithNoLine.Gathered();
-        one.add(found(NAMED, "x"));
-        one.add(found(PLACED, "x"));
+        one.add(found(HERE, "x"));
+        one.add(found(REACHED_FROM_A_CALL, "x"));
         RulesWithNoLine.Gathered theOtherWayRound = new RulesWithNoLine.Gathered();
-        theOtherWayRound.add(found(PLACED, "x"));
-        theOtherWayRound.add(found(NAMED, "x"));
+        theOtherWayRound.add(found(REACHED_FROM_A_CALL, "x"));
+        theOtherWayRound.add(found(HERE, "x"));
 
         assertEquals(one.found(), theOtherWayRound.found(),
                 "and what each hands on is one value, which compares by what is in it");
@@ -72,8 +82,8 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     @Test
     void twoRulesAreTwoFindings() {
         RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-        gathered.add(found(NAMED, "x"));
-        gathered.add(found(NAMED, "y"));
+        gathered.add(found(HERE, "x"));
+        gathered.add(found(HERE, "y"));
 
         assertEquals(2, gathered.found().reported().size(), () -> gathered.found().reported().toString());
     }
@@ -81,10 +91,33 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     /** And nothing puts together two findings that are not one rule. */
     @Test
     void twoFindingsThatAreNotOneRuleAreNotPutTogether() {
-        RuleWithoutALine here = found(NAMED, "x");
-        RuleWithoutALine elsewhere = found(NAMED, "y");
+        RuleWithoutALine here = found(HERE, "x");
+        RuleWithoutALine elsewhere = found(HERE, "y");
 
         assertThrows(IllegalArgumentException.class, () -> here.mergedWith(elsewhere));
+    }
+
+    /**
+     * A rule is reached the way rules of its kind are reached, and a finding says so.
+     *
+     * <p>What the fold keeps is the rule once and the places beside it, so a handle it hands back
+     * is of that rule and can be of no other. A rule the author named has no place to keep, and one
+     * written rather than named has nowhere for a reader to be sent without one.
+     */
+    @Test
+    void aRuleIsReachedTheWayItsKindIsReached() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new RuleWithoutALine(
+                        new RuleWithoutALine.Fact(comparison(), at("x"),
+                                new BlockReason.ComparisonBetweenPositions()),
+                        Set.of()),
+                "a comparison with no place is one nobody can be sent to look at");
+        assertThrows(IllegalArgumentException.class,
+                () -> new RuleWithoutALine(
+                        new RuleWithoutALine.Fact(invariant(), at("x"),
+                                new BlockReason.ComparisonBetweenPositions()),
+                        Set.of(Citation.of(new SourcePos(3, 3)))),
+                "and a place beside a rule the author named is a second way to say one thing");
     }
 
     /**
@@ -97,14 +130,15 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     @Test
     void aQuestionAboutAnUnclassifiedRuleIsFoldedBesideTheFindings() {
         RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-        gathered.unclassified(comparison(), NAMED, at("x"), new BlockReason.UnreadComparisonForm());
-        gathered.unclassified(comparison(), PLACED, at("x"),
+        gathered.unclassified(HERE, at("x"), new BlockReason.UnreadComparisonForm());
+        gathered.unclassified(REACHED_FROM_A_CALL, at("x"),
                 new BlockReason.UnreadComparisonForm());
-        gathered.add(comparison(), NAMED, at("x"), new BlockReason.ComparisonBetweenPositions());
+        gathered.add(HERE, at("x"), new BlockReason.ComparisonBetweenPositions());
 
         assertEquals(1, gathered.found().unclassified().size(),
                 () -> "one rule, one place, one limit: " + gathered.found().unclassified());
-        assertEquals(Set.of(NAMED, PLACED), gathered.found().unclassified().get(0).cited(),
+        assertEquals(Set.of(HERE, REACHED_FROM_A_CALL),
+                gathered.found().unclassified().get(0).cited(),
                 "and both handles are kept, as they are for a finding");
         assertEquals(1, gathered.found().reported().size(),
                 () -> "the rule read to the end is beside it and not folded into it: "
@@ -115,9 +149,10 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
      *  wrote it short of is untouched. */
     @Test
     void oneQuestionCitedTwoWaysKeepsBothHandlesAndTheAuthorsOrder() {
-        StandingQuestion both = asked(NAMED, standingOn()).mergedWith(asked(PLACED, standingOn()));
+        StandingQuestion both = asked(HERE, standingOn())
+                .mergedWith(asked(REACHED_FROM_A_CALL, standingOn()));
 
-        assertEquals(Set.of(NAMED, PLACED), both.cited());
+        assertEquals(Set.of(HERE, REACHED_FROM_A_CALL), both.cited());
         assertEquals(standingOn(), both.stopped());
     }
 
@@ -126,8 +161,9 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     void twoAccountsOfOneQuestionCannotDisagreeAboutWhatTheAuthorWrote() {
         BlockReason.RuleReadingStopped form = new BlockReason.UnreadComparisonForm();
         BlockReason.RuleReadingStopped domain = new BlockReason.UnreadComparisonDomain();
-        StandingQuestion one = asked(NAMED, standingOn(form, domain));
-        StandingQuestion theOtherWayRound = asked(PLACED, standingOn(domain, form));
+        StandingQuestion one = asked(HERE, standingOn(form, domain));
+        StandingQuestion theOtherWayRound =
+                asked(REACHED_FROM_A_CALL, standingOn(domain, form));
 
         assertThrows(TwoAccountsOfOneQuestion.class, () -> one.mergedWith(theOtherWayRound));
     }
@@ -144,10 +180,10 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
      */
     @Test
     void anAccountThatMetTheAnswersLimitIsNotDisagreeingWithOneThatDidNot() {
-        StandingQuestion both = asked(NAMED, standingOn())
-                .mergedWith(asked(PLACED, itsRuleAlone()));
+        StandingQuestion both = asked(HERE, standingOn())
+                .mergedWith(asked(REACHED_FROM_A_CALL, itsRuleAlone()));
 
-        assertEquals(Set.of(NAMED, PLACED), both.cited());
+        assertEquals(Set.of(HERE, REACHED_FROM_A_CALL), both.cited());
         assertEquals(Optional.of(new BlockReason.ExactValuesTooCostly()),
                 both.stopped().itsPositionWasShortOf(),
                 "the question stands on it, and it was met once");
@@ -156,8 +192,8 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     /** And two that met different limits are disagreeing about the position. */
     @Test
     void andTwoThatMetDifferentLimitsAreRefused() {
-        StandingQuestion one = asked(NAMED, standingOn());
-        StandingQuestion other = asked(PLACED, new WhatAQuestionStandsOn(
+        StandingQuestion one = asked(HERE, standingOn());
+        StandingQuestion other = asked(REACHED_FROM_A_CALL, new WhatAQuestionStandsOn(
                 RuleReasons.one(new BlockReason.UnreadComparisonForm()),
                 Optional.of(new BlockReason.RulesNotHandedOnAsSets())));
 
@@ -173,9 +209,9 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     /** And a question that asks something is not an account of one that asks nothing. */
     @Test
     void theTwoKindsOfStandingQuestionAreNotTwoAccountsOfOneThing() {
-        StandingQuestion asks = asked(NAMED, standingOn());
+        StandingQuestion asks = asked(HERE, standingOn());
         StandingQuestion unclassified = StandingQuestion.NothingClassifiesIt.of(
-                comparison(), NAMED, at("x"), new BlockReason.UnreadComparisonForm());
+                HERE, at("x"), new BlockReason.UnreadComparisonForm());
 
         assertThrows(IllegalArgumentException.class, () -> asks.mergedWith(unclassified));
         assertThrows(IllegalArgumentException.class, () -> unclassified.mergedWith(asks));
@@ -194,9 +230,9 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     void whatStoppedAReadingIsAskedOfTheFindingsAndOfTheQuestions() {
         BlockReason.RuleReadingStopped form = new BlockReason.UnreadComparisonForm();
         RulesWithNoLine.Gathered asFinding = new RulesWithNoLine.Gathered();
-        asFinding.add(comparison(), NAMED, at("x"), form);
+        asFinding.add(HERE, at("x"), form);
         RulesWithNoLine.Gathered asQuestion = new RulesWithNoLine.Gathered();
-        asQuestion.unclassified(comparison(), NAMED, at("x"), form);
+        asQuestion.unclassified(HERE, at("x"), form);
 
         assertEquals(null, RulesWithNoLine.NONE.aReadingThatStopped(),
                 "nothing found, so nothing stopped");
@@ -210,14 +246,14 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     @Test
     void aRuleReadFromEndToEndStoppedNothing() {
         RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-        gathered.add(found(NAMED, "x"));
+        gathered.add(found(HERE, "x"));
 
         assertEquals(null, gathered.found().aReadingThatStopped(),
                 () -> "the reading got through it: " + gathered.found().reported());
     }
 
     private static RuleWithoutALine found(RuleCitation cited, String at) {
-        return RuleWithoutALine.of(comparison(), cited, at(at),
+        return RuleWithoutALine.of(cited, at(at),
                 new BlockReason.ComparisonBetweenPositions());
     }
 
@@ -226,7 +262,7 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
     }
 
     private static StandingQuestion asked(RuleCitation cited, WhatAQuestionStandsOn stopped) {
-        return StandingQuestion.Exact.of(comparison(), cited,
+        return StandingQuestion.Exact.of(cited,
                 new InputQuestion.AboutAPosition(TermPath.of("x")), stopped);
     }
 
@@ -247,8 +283,15 @@ class OneIdentityIsFoldedOnceAndKeepsEveryHandleTest {
         return new WhatAQuestionStandsOn(RuleReasons.from(written), Optional.empty());
     }
 
-    private static RuleRef comparison() {
+    private static RuleRef.Comparison comparison() {
         return new RuleRef.Comparison("b", new SourceConstructOrigin(
                 new WrittenOwner.Body("m", "b"), 1, 1, SourceConstruct.IF));
+    }
+
+    /** A rule the author named, for the half of the pairing that has no place. */
+    private static RuleRef.Invariant invariant() {
+        return new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 0),
+                Optional.of(new ClauseName("cap"))));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
@@ -8,6 +8,7 @@ import tools.jackson.databind.json.JsonMapper;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.types.WrittenOwner;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.observe.RunSensitivity;
 import souther.compiler.partition.ReportedReason;
@@ -314,10 +315,11 @@ class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
     void aReasonSaysWhatBecameOfTheReadingAndNotWhatAMeasureIsShortOf() {
         for (BlockReason.RuleWithoutLineReason each : everyRuleWithoutALine()) {
             RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-            gathered.add(new RuleRef.Comparison("b",
-                            new SourceConstructOrigin(new WrittenOwner.Body("m", "b"),
-                                    1, 1, SourceConstruct.IF)),
-                    new RuleCitation.Named("n"),
+            gathered.add(new RuleCitation.WrittenAt<>(
+                            new RuleRef.Comparison("b",
+                                    new SourceConstructOrigin(new WrittenOwner.Body("m", "b"),
+                                            1, 1, SourceConstruct.IF)),
+                            Citation.of(new SourcePos(1, 1))),
                     new FilingCoordinate.AtPosition(TermPath.of("x")), each);
             RulesWithNoLine filed = gathered.found();
 

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
@@ -315,7 +315,7 @@ class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
     void aReasonSaysWhatBecameOfTheReadingAndNotWhatAMeasureIsShortOf() {
         for (BlockReason.RuleWithoutLineReason each : everyRuleWithoutALine()) {
             RulesWithNoLine.Gathered gathered = new RulesWithNoLine.Gathered();
-            gathered.add(new RuleCitation.WrittenAt<>(
+            gathered.add(new RuleCitation.WrittenAt(
                             new RuleRef.Comparison("b",
                                     new SourceConstructOrigin(new WrittenOwner.Body("m", "b"),
                                             1, 1, SourceConstruct.IF)),

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsHandedOnIsNotWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsHandedOnIsNotWhatIsReportedTest.java
@@ -147,7 +147,7 @@ class WhatIsHandedOnIsNotWhatIsReportedTest {
 
     /** What the clause is called, taken out of the name a report prints it under. */
     private static String named(souther.compiler.check.RuleRef.Invariant rule) {
-        String written = rule.named();
+        String written = rule.citedName();
         return written.substring(written.indexOf('(') + 1, written.indexOf(')'));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -230,11 +230,11 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                         new souther.compiler.types.SourceConstructOrigin(
                                 new WrittenOwner.Body("example.banding", "twice"), 2, 0,
                                 souther.compiler.types.SourceConstruct.BINARY));
-        return new LineOrigin.ComparisonOrigin(rule,
+        return new LineOrigin.ComparisonOrigin(
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.banding", "twice", occurrence),
-                        new souther.compiler.check.RuleCitation.WrittenAt(
+                        new souther.compiler.check.RuleCitation.WrittenAt<>(rule,
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(15, 16))),
                         WHERE.comparison(occurrence)),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -234,9 +234,9 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.banding", "twice", occurrence),
-                        new souther.compiler.check.RuleCitation.WrittenAt<>(rule,
-                                souther.compiler.diag.Citation.of(
-                                        new souther.compiler.diag.SourcePos(15, 16))),
+                        rule,
+                        souther.compiler.diag.Citation.of(
+                                new souther.compiler.diag.SourcePos(15, 16)),
                         WHERE.comparison(occurrence)),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(
                         souther.compiler.numeric.Towards.BELOW, true)));

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -196,14 +196,12 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.weigh", "weigh", 0),
-                        new souther.compiler.check.RuleCitation.WrittenAt<>(
-                                new RuleRef.Comparison("weigh",
-                                        new souther.compiler.types.SourceConstructOrigin(
-                                                new WrittenOwner.Body("example.weigh", "weigh"),
-                                                2, 0,
-                                                souther.compiler.types.SourceConstruct.BINARY)),
-                                souther.compiler.diag.Citation.of(
-                                        new souther.compiler.diag.SourcePos(3, 5))),
+                        new RuleRef.Comparison("weigh",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("example.weigh", "weigh"), 2, 0,
+                                        souther.compiler.types.SourceConstruct.BINARY)),
+                        souther.compiler.diag.Citation.of(
+                                new souther.compiler.diag.SourcePos(3, 5)),
                         WHERE),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseOfATypeDoesNotPartItsValuesTest.java
@@ -192,14 +192,16 @@ class AClauseOfATypeDoesNotPartItsValuesTest {
     private static final ComparisonEmissionSite WHERE = Numberings.comparison(1, 0);
 
     private static LineOrigin aComparison() {
-        return new LineOrigin.ComparisonOrigin(new RuleRef.Comparison("weigh",
-                new souther.compiler.types.SourceConstructOrigin(
-                        new WrittenOwner.Body("example.weigh", "weigh"), 2, 0,
-                        souther.compiler.types.SourceConstruct.BINARY)),
+        return new LineOrigin.ComparisonOrigin(
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence(
                                 "example.weigh", "weigh", 0),
-                        new souther.compiler.check.RuleCitation.WrittenAt(
+                        new souther.compiler.check.RuleCitation.WrittenAt<>(
+                                new RuleRef.Comparison("weigh",
+                                        new souther.compiler.types.SourceConstructOrigin(
+                                                new WrittenOwner.Body("example.weigh", "weigh"),
+                                                2, 0,
+                                                souther.compiler.types.SourceConstruct.BINARY)),
                                 souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(3, 5))),
                         WHERE),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -260,9 +260,9 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aWrappersRuleReachesAPositionInsideARecord() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant Wrapped #1", lines.get("onHeld/v.w.n = 1").origin().named());
+        assertEquals("invariant Wrapped #1", lines.get("onHeld/v.w.n = 1").origin().saidWithoutAPlace());
         assertEquals("invariant NonEmptyBag #1",
-                lines.get("onHeldBag/List.length(v.b.xs) = 1").origin().named());
+                lines.get("onHeldBag/List.length(v.b.xs) = 1").origin().saidWithoutAPlace());
     }
 
     /** And through as many names as are worn, since a name wrapped round a value is not a step. */
@@ -270,7 +270,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aWrappersRuleReachesThroughAStackOfNames() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant W2 #1", lines.get("onStacked/v.w.n = 2").origin().named());
+        assertEquals("invariant W2 #1", lines.get("onStacked/v.w.n = 2").origin().saidWithoutAPlace());
     }
 
     /**
@@ -289,9 +289,9 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aNameWrappedRoundARecordReachesItsPositions() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant Wrapped #1", lines.get("onWrapped/v.n = 1").origin().named());
+        assertEquals("invariant Wrapped #1", lines.get("onWrapped/v.n = 1").origin().saidWithoutAPlace());
         assertEquals("invariant NonEmptyBag #1",
-                lines.get("onNonEmpty/List.length(v.xs) = 1").origin().named());
+                lines.get("onNonEmpty/List.length(v.xs) = 1").origin().saidWithoutAPlace());
     }
 
     /**
@@ -664,7 +664,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         assertTrue(lines.containsKey("onWrapped/v.a = 9"),
                 "and one step lower under the wrapper's clause: " + lines.keySet());
         assertEquals("invariant A #1 within Wrapped",
-                lines.get("onWrapped/v.a = 9").origin().named(),
+                lines.get("onWrapped/v.a = 9").origin().saidWithoutAPlace(),
                 "the wrapper moved the edge `A` drew and did not draw one");
     }
 
@@ -682,7 +682,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         Map<String, BorderAssessment> lines = linesOf(WRAPPED_RELATION, "wrappedrelation");
 
         assertEquals("invariant A #1 within Wrapped",
-                lines.get("onHeld/v.w.a = 9").origin().named(),
+                lines.get("onHeld/v.w.a = 9").origin().saidWithoutAPlace(),
                 "the clause is `Wrapped`'s wherever a `Wrapped` is held: " + lines.keySet());
     }
 
@@ -745,7 +745,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRelationThatMovedNoEndDoesNotNameOne() {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
-        assertEquals("invariant A #1 within Inner", lines.get("onOuter/v.a = 7").origin().named(),
+        assertEquals("invariant A #1 within Inner", lines.get("onOuter/v.a = 7").origin().saidWithoutAPlace(),
                 "`Outer`'s clause reaches nothing `a` had not already passed");
     }
 
@@ -765,7 +765,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
         assertEquals("invariant A #1 within Again or Twice",
-                lines.get("onIdle/v.a = 7").origin().named(),
+                lines.get("onIdle/v.a = 7").origin().saidWithoutAPlace(),
                 "`Idle`'s clause moves this end nowhere");
     }
 
@@ -774,8 +774,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void eachEndIsHeldByWhicheverDeclarationHoldsIt() {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
-        assertEquals("invariant N #1 within Both", lines.get("onBoth/v.n = 3").origin().named());
-        assertEquals("invariant N #2 within Upper", lines.get("onBoth/v.n = 7").origin().named());
+        assertEquals("invariant N #1 within Both", lines.get("onBoth/v.n = 3").origin().saidWithoutAPlace());
+        assertEquals("invariant N #2 within Upper", lines.get("onBoth/v.n = 7").origin().saidWithoutAPlace());
     }
 
     /** A length floor over an element type nothing inhabits. Its own module, since a declaration that

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -199,9 +199,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
                 read("p: Pair", "Int.multiply(p.x, p.x) < 10").noLine().unclassified().getFirst();
 
         assertInstanceOf(RuleRef.Comparison.class, said.rule());
-        RuleCitation.WrittenAt cited = said.cited().stream()
+        RuleCitation.WrittenAt<?> cited = said.cited().stream()
                 .filter(RuleCitation.WrittenAt.class::isInstance)
-                .map(RuleCitation.WrittenAt.class::cast).findFirst()
+                .map(each -> (RuleCitation.WrittenAt<?>) each).findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "a rule with no name is found by where it is: " + said.cited()));
         souther.compiler.diag.Citation.Written where = assertInstanceOf(

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -199,9 +199,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
                 read("p: Pair", "Int.multiply(p.x, p.x) < 10").noLine().unclassified().getFirst();
 
         assertInstanceOf(RuleRef.Comparison.class, said.rule());
-        RuleCitation.WrittenAt<?> cited = said.cited().stream()
+        RuleCitation.WrittenAt cited = said.cited().stream()
                 .filter(RuleCitation.WrittenAt.class::isInstance)
-                .map(each -> (RuleCitation.WrittenAt<?>) each).findFirst()
+                .map(each -> (RuleCitation.WrittenAt) each).findFirst()
                 .orElseThrow(() -> new AssertionError(
                         "a rule with no name is found by where it is: " + said.cited()));
         souther.compiler.diag.Citation.Written where = assertInstanceOf(

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineIsNamedByTheClauseThatDrewItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineIsNamedByTheClauseThatDrewItTest.java
@@ -98,7 +98,7 @@ class ALineIsNamedByTheClauseThatDrewItTest {
         Cut at1 = cutAt(length, 1L);
 
         assertEquals(List.of("invariant Length (floorA)", "invariant Length (floorB)"),
-                at1.origins().stream().map(LineOrigin::named).toList(),
+                at1.origins().stream().map(LineOrigin::saidWithoutAPlace).toList(),
                 "one cut, two rules that drew it");
 
         // Under the declaration that drew them, and named in the terms it wrote: the line is owed

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionMeasuredTwoWaysNamesBothRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionMeasuredTwoWaysNamesBothRulesTest.java
@@ -117,7 +117,10 @@ class APositionMeasuredTwoWaysNamesBothRulesTest {
 
     private static Set<String> named(Set<RuleRef> rules) {
         Set<String> out = new LinkedHashSet<>();
-        rules.forEach(each -> out.add(each.named()));
+        rules.forEach(each -> out.add(switch (each) {
+            case RuleRef.Named it -> it.citedName();
+            case RuleRef.Written it -> "the " + it.whatItIs();
+        }));
         return out;
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -107,10 +107,9 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     /** A question of a rule of this position that nothing answered. */
     private static StandingQuestion standing() {
         return StandingQuestion.Exact.of(
-                new RuleRef.Invariant(new Clause.Ref(
+                new RuleCitation.Named(new RuleRef.Invariant(new Clause.Ref(
                         new Clause.Id(TypeSymbols.declared(new TypeKey("probe", "N")), 0),
-                        java.util.Optional.empty())),
-                new RuleCitation.Named("invariant N"),
+                        java.util.Optional.empty()))),
                 new InputQuestion.AboutAPosition(AT),
                 new WhatAQuestionStandsOn(RuleReasons.one(new BlockReason.UnreadValueRule()),
                         Optional.empty()));

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -7,7 +7,6 @@ import souther.compiler.coverage.Numberings;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Carrier;
-import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.inputs.NumericTerm;
@@ -106,12 +105,11 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
         return new LineOrigin.ComparisonOrigin(
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence("example.one", "f", 0),
-                        new RuleCitation.WrittenAt<>(
-                                new RuleRef.Comparison("f",
-                                        new souther.compiler.types.SourceConstructOrigin(
-                                                new WrittenOwner.Body("example.one", "f"), 2, 0,
-                                                souther.compiler.types.SourceConstruct.BINARY)),
-                                Citation.of(new souther.compiler.diag.SourcePos(1, 1))),
+                        new RuleRef.Comparison("f",
+                                new souther.compiler.types.SourceConstructOrigin(
+                                        new WrittenOwner.Body("example.one", "f"), 2, 0,
+                                        souther.compiler.types.SourceConstruct.BINARY)),
+                        Citation.of(new souther.compiler.diag.SourcePos(1, 1)),
                         WHERE),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAccountEstablishesItsDenominatorBeforeItCountsTest.java
@@ -104,13 +104,14 @@ class AnAccountEstablishesItsDenominatorBeforeItCountsTest {
      *  values, which is what the account may not be asked to do by name alone. */
     private static LineOrigin origin() {
         return new LineOrigin.ComparisonOrigin(
-                new RuleRef.Comparison("f", new souther.compiler.types.SourceConstructOrigin(
-                        new WrittenOwner.Body("example.one", "f"), 2, 0,
-                        souther.compiler.types.SourceConstruct.BINARY)),
                 new LineOrigin.ComparisonOrigin.Read(
                         new souther.compiler.coverage.ComparisonOccurrence("example.one", "f", 0),
-                        new RuleCitation.WrittenAt(Citation.of(
-                                new souther.compiler.diag.SourcePos(1, 1))),
+                        new RuleCitation.WrittenAt<>(
+                                new RuleRef.Comparison("f",
+                                        new souther.compiler.types.SourceConstructOrigin(
+                                                new WrittenOwner.Body("example.one", "f"), 2, 0,
+                                                souther.compiler.types.SourceConstruct.BINARY)),
+                                Citation.of(new souther.compiler.diag.SourcePos(1, 1))),
                         WHERE),
                 new LineFacts(new souther.compiler.check.ComparisonClaim.Cut(Towards.BELOW, true)));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -151,7 +151,7 @@ class PartitionsTest {
                 axis(span, "span.to").cuts().stream().map(Cut::at).toList());
         assertEquals(List.of("invariant Minute (withinDay)", "invariant Minute (withinDay) within Span"),
                 axis(span, "span.from").cuts().stream()
-                        .map(c -> c.origins().get(0).named()).toList(),
+                        .map(c -> c.origins().get(0).saidWithoutAPlace()).toList(),
                 "the rule that drew each end is the one that wrote it, not the outermost name");
     }
 
@@ -187,10 +187,10 @@ class PartitionsTest {
         assertEquals(List.of(Count.of(0L), Count.of(10L)),
                 o.cuts().stream().map(Cut::at).toList());
         assertEquals(List.of("invariant Outer (outerMin)", "invariant Inner (innerMin)"),
-                o.cuts().get(0).origins().stream().map(LineOrigin::named).toList(),
+                o.cuts().get(0).origins().stream().map(LineOrigin::saidWithoutAPlace).toList(),
                 "one value, two rules, and a row is owed to each");
         assertEquals(List.of("invariant Outer (outerMax)"),
-                o.cuts().get(1).origins().stream().map(LineOrigin::named).toList());
+                o.cuts().get(1).origins().stream().map(LineOrigin::saidWithoutAPlace).toList());
     }
 
     /** A `Decimal` under two names reads the same way. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -99,7 +99,7 @@ class WhatAClauseDrawsALineOnTest {
                     ensures asked = NotFound -> id.value > 0
                 """, "findTodo");
 
-        assertEquals("ensures findTodo (asked)", clauses.thresholds().get(0).origin().named());
+        assertEquals("ensures findTodo (asked)", clauses.thresholds().get(0).origin().saidWithoutAPlace());
     }
 
     /** Where the author named no clause, the case the arm is about is what is left to say. */
@@ -116,7 +116,7 @@ class WhatAClauseDrawsALineOnTest {
                     ensures NotFound -> id.value > 0
                 """, "findTodo");
 
-        assertEquals("ensures findTodo (NotFound)", clauses.thresholds().get(0).origin().named());
+        assertEquals("ensures findTodo (NotFound)", clauses.thresholds().get(0).origin().saidWithoutAPlace());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/publish/OnePlaceIsComparedOneWayWhereverItIsComparedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/OnePlaceIsComparedOneWayWhereverItIsComparedTest.java
@@ -49,7 +49,7 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
             Optional.empty()));
 
     private static RuleCitation writtenAt(Citation at) {
-        return new RuleCitation.WrittenAt<>(WRITTEN_RATHER_THAN_NAMED, at);
+        return new RuleCitation.WrittenAt(WRITTEN_RATHER_THAN_NAMED, at);
     }
 
     @Test
@@ -81,7 +81,7 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
                 PublicationOrders.handleFor(List.of(
                                 writtenAt(EARLIER),
                                 writtenAt(LATER)))
-                        .map(each -> ((RuleCitation.WrittenAt<?>) each).at())
+                        .map(each -> ((RuleCitation.WrittenAt) each).at())
                         .flatMap(PublishedAt::of),
                 "one order over places, asked twice");
     }

--- a/souther-compiler/src/test/java/souther/compiler/publish/OnePlaceIsComparedOneWayWhereverItIsComparedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/OnePlaceIsComparedOneWayWhereverItIsComparedTest.java
@@ -2,10 +2,17 @@ package souther.compiler.publish;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.Clause;
 import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.source.SourceId;
+import souther.compiler.types.SourceConstruct;
+import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.WrittenOwner;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,15 +37,30 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
     private static final Citation EARLIER = Citation.of(pos(9, 1));
     private static final Citation LATER = Citation.of(pos(10, 1));
 
+    /** One rule with no name, so that what tells two handles of it apart is where each was
+     *  reached. */
+    private static final RuleRef.Comparison WRITTEN_RATHER_THAN_NAMED =
+            new RuleRef.Comparison("b", new SourceConstructOrigin(
+                    new WrittenOwner.Body("m", "b"), 0, 0, SourceConstruct.BINARY));
+
+    /** And one the author named, which is reached by that name from anywhere. */
+    private static final RuleRef.Invariant NAMED = new RuleRef.Invariant(new Clause.Ref(
+            new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 0),
+            Optional.empty()));
+
+    private static RuleCitation writtenAt(Citation at) {
+        return new RuleCitation.WrittenAt<>(WRITTEN_RATHER_THAN_NAMED, at);
+    }
+
     @Test
     void theHandleAndThePlaceAgreeAboutWhichOfTwoLinesComesFirst() {
         Optional<PublishedAt> place = PublicationOrders.placeFor(List.of(LATER, EARLIER));
         Optional<RuleCitation> handle = PublicationOrders.handleFor(List.of(
-                new RuleCitation.WrittenAt(LATER), new RuleCitation.WrittenAt(EARLIER)));
+                writtenAt(LATER), writtenAt(EARLIER)));
 
         assertEquals(Optional.of(9), place.map(PublishedAt::line),
                 "the place nearest the top of the file is the one a fact is written at");
-        assertEquals(Optional.of(new RuleCitation.WrittenAt(EARLIER)), handle,
+        assertEquals(Optional.of(writtenAt(EARLIER)), handle,
                 "and the handle at that same place is the one a rule is reached by");
     }
 
@@ -57,9 +79,9 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
     void aHandleIsComparedByTheOrderOverPlaces() {
         assertEquals(PublicationOrders.placeFor(List.of(EARLIER, LATER)),
                 PublicationOrders.handleFor(List.of(
-                                new RuleCitation.WrittenAt(EARLIER),
-                                new RuleCitation.WrittenAt(LATER)))
-                        .map(each -> ((RuleCitation.WrittenAt) each).at())
+                                writtenAt(EARLIER),
+                                writtenAt(LATER)))
+                        .map(each -> ((RuleCitation.WrittenAt<?>) each).at())
                         .flatMap(PublishedAt::of),
                 "one order over places, asked twice");
     }
@@ -74,8 +96,8 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
      */
     @Test
     void twoRulesInATextThisCannotNameAreToldApartByWhereTheyAre() {
-        RuleCitation earlier = new RuleCitation.WrittenAt(Citation.of(new SourcePos(1, 1)));
-        RuleCitation later = new RuleCitation.WrittenAt(Citation.of(new SourcePos(2, 2)));
+        RuleCitation earlier = writtenAt(Citation.of(new SourcePos(1, 1)));
+        RuleCitation later = writtenAt(Citation.of(new SourcePos(2, 2)));
 
         assertEquals(PublicationOrders.handleFor(List.of(earlier, later)),
                 PublicationOrders.handleFor(List.of(later, earlier)),
@@ -87,8 +109,8 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
     /** And a place a reader can be sent to comes before one nobody can. */
     @Test
     void aPlaceAReaderCanBeSentToComesBeforeOneNobodyCan() {
-        RuleCitation held = new RuleCitation.WrittenAt(EARLIER);
-        RuleCitation unnamed = new RuleCitation.WrittenAt(Citation.of(new SourcePos(1, 1)));
+        RuleCitation held = writtenAt(EARLIER);
+        RuleCitation unnamed = writtenAt(Citation.of(new SourcePos(1, 1)));
 
         assertEquals(Optional.of(held), PublicationOrders.handleFor(List.of(unnamed, held)),
                 "a reader sent to a file is better served than one sent to two numbers");
@@ -97,9 +119,9 @@ class OnePlaceIsComparedOneWayWhereverItIsComparedTest {
     /** A name the author gave comes before a place they did not. */
     @Test
     void aNameComesBeforeAPlace() {
-        assertEquals(Optional.of(new RuleCitation.Named("n")),
+        assertEquals(Optional.of(new RuleCitation.Named(NAMED)),
                 PublicationOrders.handleFor(List.of(
-                        new RuleCitation.WrittenAt(EARLIER), new RuleCitation.Named("n"))));
+                        writtenAt(EARLIER), new RuleCitation.Named(NAMED))));
     }
 
     private static SourcePos pos(int line, int column) {

--- a/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
@@ -159,6 +159,114 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
     }
 
     /**
+     * That the population varies each part of a sentence about code reached from here.
+     *
+     * <p>Said out loud because the sentence has three parts and only one of them varies by being
+     * put there: a handle is made of a citation and a rule, so the kind varies by pairing the same
+     * citation with both, and the place and what reaches it vary only if the compilation happened to
+     * offer two that differ. Left to happen, a comparison of that part could be dropped and this
+     * would stay green on whatever the fixture came back with.
+     */
+    @Test
+    void thePopulationVariesEachPartOfASentenceAboutCodeReachedFromHere() {
+        List<PublishedRuleHandle.Reached> reached = everyShapeOfSentence().stream()
+                .map(PublishedRuleHandle::of)
+                .filter(PublishedRuleHandle.Reached.class::isInstance)
+                .map(PublishedRuleHandle.Reached.class::cast).toList();
+
+        assertTrue(variedAlone(reached, Part.WHAT_THE_RULE_IS),
+                () -> "two that differ in what the rule is and in nothing else: " + reached);
+        assertTrue(reached.stream().map(Part.WHAT_REACHES_IT::of).distinct().count() > 1,
+                () -> "and two reached by different code: " + reached);
+    }
+
+    /**
+     * And each part of such a sentence on its own tells two handles apart.
+     *
+     * <p>Built here rather than taken from a compilation. Where the code is and what reaches it move
+     * together in what a compile offers — a second declaration is a second place — so a pair varying
+     * one of them alone is not something a model can be written to produce, and a property left to
+     * what a fixture happens to emit is a property about the fixture.
+     *
+     * <p>Which is the whole of what this adds: the parts a document writes are the parts the order
+     * is over, so dropping any one of them from the comparison makes two sentences a reader can tell
+     * apart into one value.
+     */
+    @Test
+    void eachPartOfSuchASentenceTellsTwoHandlesApart() {
+        PublishedRuleHandle.Place here =
+                new PublishedRuleHandle.Place.Unplaced(1, 1);
+        PublishedRuleHandle.Place there =
+                new PublishedRuleHandle.Place.Unplaced(2, 1);
+        PublishedRuleHandle.Reached said =
+                new PublishedRuleHandle.Reached("comparison", here, "Int.clamp");
+
+        assertNotEquals(0, Integer.signum(said.compareTo(
+                        new PublishedRuleHandle.Reached("predicate", here, "Int.clamp"))),
+                "what the rule is");
+        assertNotEquals(0, Integer.signum(said.compareTo(
+                        new PublishedRuleHandle.Reached("comparison", there, "Int.clamp"))),
+                "where the code is");
+        assertNotEquals(0, Integer.signum(said.compareTo(
+                        new PublishedRuleHandle.Reached("comparison", here, "Int.abs"))),
+                "and what reaches it");
+        assertEquals(0, said.compareTo(
+                        new PublishedRuleHandle.Reached("comparison", here, "Int.clamp")),
+                "and two alike in every part are one value");
+    }
+
+    /**
+     * The parts of a sentence about code reached from here.
+     *
+     * <p>Named rather than passed as functions, so that "the rest" is the rest: two lambdas reading
+     * one part are two objects, and a walk that told them apart by identity would be asking whether
+     * every part differs.
+     */
+    private enum Part {
+
+        WHAT_THE_RULE_IS,
+
+        WHERE_THE_CODE_IS,
+
+        WHAT_REACHES_IT;
+
+        String of(PublishedRuleHandle.Reached said) {
+            return switch (this) {
+                case WHAT_THE_RULE_IS -> said.kind();
+                case WHERE_THE_CODE_IS -> said.at().toString();
+                case WHAT_REACHES_IT -> said.reachedBy();
+            };
+        }
+    }
+
+    /**
+     * Whether {@code these} hold two that differ in {@code part} and agree on the rest.
+     *
+     * <p>Agreeing on the rest is what makes the pair say something about that part. Two that differ
+     * everywhere are told apart by whichever part is compared first, so a projection that had
+     * dropped one of them would tell them apart all the same.
+     */
+    private static boolean variedAlone(List<PublishedRuleHandle.Reached> these, Part part) {
+        for (PublishedRuleHandle.Reached one : these) {
+            for (PublishedRuleHandle.Reached other : these) {
+                if (part.of(one).equals(part.of(other))) {
+                    continue;
+                }
+                boolean restAgrees = true;
+                for (Part each : Part.values()) {
+                    if (each != part && !each.of(one).equals(each.of(other))) {
+                        restAgrees = false;
+                    }
+                }
+                if (restAgrees) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * The citations of code this compile reaches rather than holds, taken from a compilation.
      *
      * <p>Made where a source is placed, and only there. So this reads a model whose rules are in a
@@ -178,6 +286,7 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
 
                 let classify (n) = {
                     guard Int.clamp(0, 100, n) > 70 else Low
+                    guard Int.abs(n) > 3 else Low
                     Accepted { at = n }
                 }
                 """;

--- a/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
@@ -9,6 +9,11 @@ import souther.compiler.check.RuleRef;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BehaviorEvidence;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
 import souther.compiler.source.SourceId;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
@@ -16,8 +21,10 @@ import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.WrittenOwner;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -122,10 +129,11 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
      * these that a document writes alike are the pair either of which may be chosen, and every
      * other pair is one it has to tell apart.
      *
-     * <p>Code out of sight is not among them, and it is not being passed over: a citation of it is
-     * made where a source is placed and there is no way to write one from out here. What such a
-     * handle says is held over a compilation instead, where one arises
-     * ({@code ARuleWithoutALineIsNamedByTheRule}).
+     * <p>Code reached from here is among them, taken from a compilation rather than written. A
+     * citation of it is made where a source is placed and that is the one way there is, on purpose —
+     * so what this needs is one of the real ones, and a handle is then made of it and each kind of
+     * rule. Left out because it could not be written, the arm this type has for it would be the one
+     * arm whose reason for existing nothing checks.
      */
     private static List<RuleCitation> everyShapeOfSentence() {
         RuleRef.Named named = new RuleRef.Invariant(new Clause.Ref(
@@ -134,7 +142,7 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
         RuleRef.Named alsoNamed = new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 1),
                 Optional.of(new ClauseName("floor"))));
-        return List.of(
+        List<RuleCitation> out = new ArrayList<>(List.of(
                 new RuleCitation.Named(named),
                 new RuleCitation.Named(alsoNamed),
                 new RuleCitation.WrittenAt(COMPARISON, AT),
@@ -142,21 +150,83 @@ class TwoHandlesADocumentWritesApartAreTwoValuesTest {
                 new RuleCitation.WrittenAt(COMPARISON,
                         Citation.of(new SourcePos(10, 1, WHERE))),
                 new RuleCitation.WrittenAt(COMPARISON,
-                        Citation.of(new SourcePos(9, 1))));
+                        Citation.of(new SourcePos(9, 1)))));
+        for (Citation each : reachedFromHere()) {
+            out.add(new RuleCitation.WrittenAt(COMPARISON, each));
+            out.add(new RuleCitation.WrittenAt(PREDICATE, each));
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The citations of code this compile reaches rather than holds, taken from a compilation.
+     *
+     * <p>Made where a source is placed, and only there. So this reads a model whose rules are in a
+     * library the compile did not open, and keeps what the readings offered — which is the one way
+     * to have such a citation out here, and is what makes the arm this type has for one something
+     * the property below is asked over.
+     */
+    private static List<Citation> reachedFromHere() {
+        String model = """
+                module m
+
+                data Low
+                data Accepted = { at: Int }
+
+                behavior classify : (n: Int) -> Accepted | Low
+                    constructs Accepted
+
+                let classify (n) = {
+                    guard Int.clamp(0, 100, n) > 70 else Low
+                    Accepted { at = n }
+                }
+                """;
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        BehaviorEvidence behavior =
+                AdequacyReport.of(compilation).modules().get(0).behaviors().get(0).evidence();
+        List<Citation> out = new ArrayList<>();
+        for (BorderAssessment each
+                : behavior.boundaryReadings().made().orElse(List.of())) {
+            Citation where = each.border().origin().citation().orElse(null);
+            if (where instanceof Citation.Elsewhere && !out.contains(where)) {
+                out.add(where);
+            }
+        }
+        return out;
     }
 
     private static String said(RuleCitation cited) {
         return cited.said(SourceNameResolver.identity(), null);
     }
 
-    /** That the population above is one a document writes more than one sentence for, so the pairs
-     *  it is asked about are pairs. */
+    /**
+     * That the population above is one a document writes more than one sentence for, and that every
+     * kind of sentence it has is in it.
+     *
+     * <p>Both, because the property is over pairs and a population of one shape is a population of
+     * one pair. An arm missing here is an arm whose reason for existing nothing asks about, which is
+     * how the third one came to be left out the first time.
+     */
     @Test
-    void thePopulationHoldsSentencesADocumentWritesApart() {
+    void thePopulationHoldsEveryKindOfSentenceADocumentWrites() {
+        List<PublishedRuleHandle> handles = everyShapeOfSentence().stream()
+                .map(PublishedRuleHandle::of).toList();
+
         assertTrue(everyShapeOfSentence().stream().map(
                         TwoHandlesADocumentWritesApartAreTwoValuesTest::said)
                 .distinct().count() > 1,
                 "a population a document writes one sentence for says nothing about telling two"
                         + " apart");
+        assertEquals(
+                Set.of(PublishedRuleHandle.Named.class, PublishedRuleHandle.Written.class,
+                        PublishedRuleHandle.Reached.class),
+                Set.of(PublishedRuleHandle.class.getPermittedSubclasses()),
+                "the three kinds of sentence this type has");
+        for (Class<?> each : PublishedRuleHandle.class.getPermittedSubclasses()) {
+            assertTrue(handles.stream().anyMatch(each::isInstance),
+                    () -> "and each of them is in what the property above is asked over: " + each);
+        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/publish/TwoHandlesADocumentWritesApartAreTwoValuesTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.publish;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.source.SourceId;
+import souther.compiler.types.SourceConstruct;
+import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.WrittenOwner;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two handles a document writes apart are two values, and two it writes alike are one.
+ *
+ * <p>What this type is for. Choosing one of several takes a comparison, and a comparison that comes
+ * out equal for two handles a reader can tell apart leaves the choice to whichever the set of them
+ * iterated first — a document whose sentence turns on the order a walk happened to take.
+ *
+ * <p>So the property is the one the projection has to keep, in both directions. Two handles that are
+ * one value are written the same way, which is what lets either be chosen; two that are written
+ * differently are not one value, which is what stops the choice from being arbitrary. A rule's kind
+ * is in the sentence, so it is in the projection — left out, a comparison and a rule about the
+ * strings at a position written in one place came to one value and were printed two ways.
+ *
+ * <p>And the order agrees with the equality, because both are asked of the same value. A comparison
+ * answering zero where {@code equals} answers false is a pair the sort calls interchangeable and the
+ * reader does not.
+ */
+class TwoHandlesADocumentWritesApartAreTwoValuesTest {
+
+    private static final SourceId WHERE = new SourceId("0");
+
+    private static final Citation AT = Citation.of(new SourcePos(9, 1, WHERE));
+
+    /**
+     * Two rules with no name, written at one place, of the two kinds there are.
+     *
+     * <p>One place, because what is being asked is whether the kind survives the projection. Told
+     * apart by where they are, this pair would say nothing about the word.
+     */
+    private static final RuleRef.Comparison COMPARISON = new RuleRef.Comparison("b",
+            new SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 0, 0,
+                    SourceConstruct.BINARY));
+
+    private static final RuleRef.Predicate PREDICATE = new RuleRef.Predicate("b",
+            new SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 1, 0,
+                    SourceConstruct.CALL));
+
+    @Test
+    void aComparisonAndAPredicateAtOnePlaceAreTwoHandles() {
+        PublishedRuleHandle comparison =
+                PublishedRuleHandle.of(new RuleCitation.WrittenAt(COMPARISON, AT));
+        PublishedRuleHandle predicate =
+                PublishedRuleHandle.of(new RuleCitation.WrittenAt(PREDICATE, AT));
+
+        assertNotEquals(comparison, predicate,
+                "a reader sent to a line and a reader sent to a set are told two things");
+        assertNotEquals(0, Integer.signum(comparison.compareTo(predicate)),
+                "so the order tells them apart rather than calling either the one to write");
+    }
+
+    /**
+     * And which of the two a caller had first decides nothing.
+     *
+     * <p>The failure this is about, said as what a run does: the same pair, offered the other way
+     * round, comes back with the same answer.
+     */
+    @Test
+    void whichOfThemACallerHadFirstDecidesNothing() {
+        RuleCitation comparison = new RuleCitation.WrittenAt(COMPARISON, AT);
+        RuleCitation predicate = new RuleCitation.WrittenAt(PREDICATE, AT);
+
+        assertEquals(PublicationOrders.handleFor(List.of(comparison, predicate)),
+                PublicationOrders.handleFor(List.of(predicate, comparison)),
+                "the handle a document writes is not the one a set of them iterated first");
+    }
+
+    /**
+     * Two handles that are equal are written the same way, and two that are not are not.
+     *
+     * <p>The property in full, over a population that varies each part of each kind of sentence in
+     * turn. A part left out of the projection shows up as two of these being one value while the
+     * two sentences differ.
+     */
+    @Test
+    void twoHandlesAreOneValueExactlyWhereADocumentWritesThemAlike() {
+        List<RuleCitation> population = everyShapeOfSentence();
+        for (RuleCitation one : population) {
+            for (RuleCitation other : population) {
+                PublishedRuleHandle here = PublishedRuleHandle.of(one);
+                PublishedRuleHandle there = PublishedRuleHandle.of(other);
+                boolean written = said(one).equals(said(other));
+
+                assertEquals(written, here.equals(there),
+                        () -> "one value exactly where a document writes them alike: "
+                                + said(one) + " and " + said(other));
+                assertEquals(written, here.compareTo(there) == 0,
+                        () -> "and the order agrees with the equality: "
+                                + said(one) + " and " + said(other));
+            }
+        }
+    }
+
+    /**
+     * One handle of every shape of sentence a document writes.
+     *
+     * <p>Varied one part at a time: the kind of rule, whose rule it is, and where it is. Two of
+     * these that a document writes alike are the pair either of which may be chosen, and every
+     * other pair is one it has to tell apart.
+     *
+     * <p>Code out of sight is not among them, and it is not being passed over: a citation of it is
+     * made where a source is placed and there is no way to write one from out here. What such a
+     * handle says is held over a compilation instead, where one arises
+     * ({@code ARuleWithoutALineIsNamedByTheRule}).
+     */
+    private static List<RuleCitation> everyShapeOfSentence() {
+        RuleRef.Named named = new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 0),
+                Optional.of(new ClauseName("cap"))));
+        RuleRef.Named alsoNamed = new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 1),
+                Optional.of(new ClauseName("floor"))));
+        return List.of(
+                new RuleCitation.Named(named),
+                new RuleCitation.Named(alsoNamed),
+                new RuleCitation.WrittenAt(COMPARISON, AT),
+                new RuleCitation.WrittenAt(PREDICATE, AT),
+                new RuleCitation.WrittenAt(COMPARISON,
+                        Citation.of(new SourcePos(10, 1, WHERE))),
+                new RuleCitation.WrittenAt(COMPARISON,
+                        Citation.of(new SourcePos(9, 1))));
+    }
+
+    private static String said(RuleCitation cited) {
+        return cited.said(SourceNameResolver.identity(), null);
+    }
+
+    /** That the population above is one a document writes more than one sentence for, so the pairs
+     *  it is asked about are pairs. */
+    @Test
+    void thePopulationHoldsSentencesADocumentWritesApart() {
+        assertTrue(everyShapeOfSentence().stream().map(
+                        TwoHandlesADocumentWritesApartAreTwoValuesTest::said)
+                .distinct().count() > 1,
+                "a population a document writes one sentence for says nothing about telling two"
+                        + " apart");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/OneFactIsOneWeakeningHoweverItWasEvidencedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneFactIsOneWeakeningHoweverItWasEvidencedTest.java
@@ -252,7 +252,7 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
      * rule's own answer, so a comparison is reached where it was read and never by a name.
      */
     private static RuleCitation reachedAt(int line) {
-        return new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(line, 1)));
+        return new RuleCitation.WrittenAt(comparison(),Citation.of(new SourcePos(line, 1)));
     }
 
     private static WeakeningSet of(Weakening one) {

--- a/souther-compiler/src/test/java/souther/compiler/query/OneFactIsOneWeakeningHoweverItWasEvidencedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneFactIsOneWeakeningHoweverItWasEvidencedTest.java
@@ -87,34 +87,30 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
 
     @Test
     void aRuleCitedTwoWaysIsOneFact() {
-        WeakeningSet named = ruleWithoutALine(new RuleCitation.Named("n"));
-        WeakeningSet placed = ruleWithoutALine(
-                new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3))));
+        WeakeningSet here = ruleWithoutALine(reachedAt(9));
+        WeakeningSet fromACall = ruleWithoutALine(reachedAt(3));
 
-        assertEquals(1, named.union(placed).causes().size(),
+        assertEquals(1, here.union(fromACall).causes().size(),
                 "a rule and the handle for it are two questions, and the union folds on the rule");
-        assertEquals(named.union(placed), placed.union(named),
+        assertEquals(here.union(fromACall), fromACall.union(here),
                 "which reader cited it first is no part of what the union comes to");
-        assertEquals(Set.of(new RuleCitation.Named("n"),
-                        new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3)))),
-                questionIn(named.union(placed)).question().cited(),
+        assertEquals(Set.of(reachedAt(9), reachedAt(3)),
+                questionIn(here.union(fromACall)).question().cited(),
                 "and the one rule keeps every handle a reader was offered");
     }
 
     @Test
     void aQuestionCitedTwoWaysIsOneFact() {
-        WeakeningSet named = standingQuestion(new RuleCitation.Named("n"),
+        WeakeningSet here = standingQuestion(reachedAt(9),
                 new BlockReason.UnreadComparisonForm());
-        WeakeningSet placed = standingQuestion(
-                new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3))),
+        WeakeningSet fromACall = standingQuestion(reachedAt(3),
                 new BlockReason.UnreadComparisonForm());
 
-        assertEquals(1, named.union(placed).causes().size(),
+        assertEquals(1, here.union(fromACall).causes().size(),
                 "which rule it is and what it asks are what tell one standing question from"
                         + " another");
-        assertEquals(Set.of(new RuleCitation.Named("n"),
-                        new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3)))),
-                questionIn(named.union(placed)).question().cited(),
+        assertEquals(Set.of(reachedAt(9), reachedAt(3)),
+                questionIn(here.union(fromACall)).question().cited(),
                 "and the one question keeps every handle a reader was offered");
     }
 
@@ -131,15 +127,15 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
     void aQuestionCitedTwoWaysKeepsTheAuthorsOneAccountOfWhatStoppedIt() {
         BlockReason.RuleReadingStopped form = new BlockReason.UnreadComparisonForm();
         BlockReason.AnswerRealizationStopped answer = new BlockReason.ExactValuesTooCostly();
-        RuleCitation named = new RuleCitation.Named("n");
-        RuleCitation placed = new RuleCitation.WrittenAt(Citation.of(new SourcePos(3, 3)));
-        WeakeningSet met = standingQuestion(named, form, answer);
-        WeakeningSet metElsewhere = standingQuestion(placed, form, answer);
+        RuleCitation here = reachedAt(9);
+        RuleCitation fromACall = reachedAt(3);
+        WeakeningSet met = standingQuestion(here, form, answer);
+        WeakeningSet metElsewhere = standingQuestion(fromACall, form, answer);
 
         assertEquals(1, met.union(metElsewhere).causes().size(),
                 "which rule it is and what it asks are what tell one standing question from"
                         + " another");
-        assertEquals(Set.of(named, placed),
+        assertEquals(Set.of(here, fromACall),
                 questionIn(met.union(metElsewhere)).question().cited(),
                 "and both handles came with it");
         assertEquals(new WhatAQuestionStandsOn(RuleReasons.one(form), Optional.of(answer)),
@@ -164,9 +160,9 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
     void twoAccountsOfOneQuestionCannotDisagreeOnTheAuthorsOrder() {
         BlockReason.RuleReadingStopped form = new BlockReason.UnreadComparisonForm();
         BlockReason.RuleReadingStopped domain = new BlockReason.UnreadComparisonDomain();
-        WeakeningSet met = standingQuestion(new RuleCitation.Named("n"), form, domain);
+        WeakeningSet met = standingQuestion(reachedAt(9), form, domain);
         WeakeningSet theOtherWayRound =
-                standingQuestion(new RuleCitation.Named("m"), domain, form);
+                standingQuestion(reachedAt(12), domain, form);
 
         assertThrows(TwoAccountsOfOneQuestion.class, () -> met.union(theOtherWayRound),
                 "two readings of one question that disagree about what the author wrote are not"
@@ -215,7 +211,7 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
 
     private static WeakeningSet ruleWithoutALine(RuleCitation cited) {
         return of(new Weakening.ModelReadingIncomplete(ClosureGap.QuestionUnanswered.of(
-                StandingQuestion.NothingClassifiesIt.of(comparison(), cited,
+                StandingQuestion.NothingClassifiesIt.of(cited,
                         new FilingCoordinate.AtPosition(TermPath.of("x")),
                         new BlockReason.UnreadComparisonForm()))));
     }
@@ -228,7 +224,7 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
                     new SourcePos(1, i + 1, new SourceId("one")), stopped[i]));
         }
         return of(new Weakening.ModelReadingIncomplete(ClosureGap.QuestionUnanswered.of(
-                StandingQuestion.Exact.of(comparison(), cited,
+                StandingQuestion.Exact.of(cited,
                         new InputQuestion.AboutAPosition(TermPath.of("x")),
                         new WhatAQuestionStandsOn(RuleReasons.from(written), Optional.empty())))));
     }
@@ -238,15 +234,25 @@ class OneFactIsOneWeakeningHoweverItWasEvidencedTest {
                                                  BlockReason.RuleReadingStopped stopped,
                                                  BlockReason.AnswerRealizationStopped answer) {
         return of(new Weakening.ModelReadingIncomplete(ClosureGap.QuestionUnanswered.of(
-                StandingQuestion.Exact.of(comparison(), cited,
+                StandingQuestion.Exact.of(cited,
                         new InputQuestion.AboutAPosition(TermPath.of("x")),
                         new WhatAQuestionStandsOn(RuleReasons.one(stopped),
                                 Optional.of(answer))))));
     }
 
-    private static RuleRef comparison() {
+    private static RuleRef.Comparison comparison() {
         return new RuleRef.Comparison("b", new SourceConstructOrigin(
                 new WrittenOwner.Body("m", "b"), 1, 1, SourceConstruct.IF));
+    }
+
+    /**
+     * One handle for that rule, reached at {@code line}.
+     *
+     * <p>Two handles of one rule are two places. Which of the two ways a rule is found is the
+     * rule's own answer, so a comparison is reached where it was read and never by a name.
+     */
+    private static RuleCitation reachedAt(int line) {
+        return new RuleCitation.WrittenAt<>(comparison(), Citation.of(new SourcePos(line, 1)));
     }
 
     private static WeakeningSet of(Weakening one) {

--- a/souther-compiler/src/test/java/souther/compiler/report/ADocumentSendsAReaderToAPredicateAsAPredicateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/ADocumentSendsAReaderToAPredicateAsAPredicateTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A document that names a rule about the strings at a position calls it a predicate on both
+ * surfaces.
+ *
+ * <p>The end of what {@link OneRuleIsCalledOneThingOnBothSurfacesTest} holds of the two words, over
+ * a model rather than over a rule built by hand. What is asked there is that the words agree; what
+ * is asked here is that a document written from a real compilation is one where they do — which
+ * takes the handle a reader is given and the identity beside it having come from the same rule all
+ * the way through.
+ *
+ * <p>Written because nothing in the fixtures produced such an entry. A word that is wrong for a kind
+ * of rule no checked-in document holds is wrong where nobody is looking, and the first reader to
+ * meet it is the one this exists instead of.
+ */
+class ADocumentSendsAReaderToAPredicateAsAPredicateTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * A behavior stating a rule about the strings at one of its positions.
+     *
+     * <p>The rule is a call and not a comparison, which is the whole point: a reader following the
+     * handle is sent to the application, and what they find there is not a line on an order.
+     */
+    private static final String A_PREDICATE_IN_A_BODY = """
+            module m
+
+            data Yes
+            data No
+
+            behavior f : (prefix: String, code: String) -> Yes | No
+            let f (prefix, code) = if String.startsWith(prefix, code) then Yes else No
+            """;
+
+    @Test
+    void aPredicateIsCalledAPredicateWhereverTheDocumentNamesIt() {
+        List<JsonNode> named = entriesNamingARule(A_PREDICATE_IN_A_BODY);
+
+        assertFalse(named.isEmpty(),
+                () -> "no entry of this document names a rule, so what it calls one is a question"
+                        + " this cannot answer: " + json(A_PREDICATE_IN_A_BODY));
+        List<String> predicates = new ArrayList<>();
+        for (JsonNode each : named) {
+            if ("predicate".equals(each.get("ruleId").get("kind").asString())) {
+                predicates.add(each.get("rule").asString());
+            }
+        }
+
+        assertFalse(predicates.isEmpty(),
+                () -> "this model states a rule about the strings at a position and no entry is of"
+                        + " one, so the word for such a rule is not being written anywhere: "
+                        + json(A_PREDICATE_IN_A_BODY));
+        for (String said : predicates) {
+            assertTrue(said.startsWith("predicate@") || said.startsWith("predicate in "),
+                    () -> "a reader following the handle is sent to a predicate and told what it"
+                            + " is: " + said);
+        }
+    }
+
+    /**
+     * And the same rule is not called a comparison anywhere in the document.
+     *
+     * <p>The negative half, over the words rather than over the entries. An entry keyed
+     * {@code predicate} whose sentence said {@code comparison} is the pair this is about, and a
+     * check that only read the entries of one kind would pass while the other surface still said
+     * the wrong word.
+     */
+    @Test
+    void andNoEntryOfThisModelIsSentToAComparison() {
+        for (JsonNode each : entriesNamingARule(A_PREDICATE_IN_A_BODY)) {
+            String kind = each.get("ruleId").get("kind").asString();
+            String said = each.get("rule").asString();
+
+            assertEquals(kind, said.replaceAll("[@ ].*$", ""),
+                    () -> "the word a reader is shown and the word a consumer groups by are of one"
+                            + " rule: " + each);
+        }
+    }
+
+    /** Every entry of the document that names a rule both ways, wherever a measure writes one. */
+    private static List<JsonNode> entriesNamingARule(String model) {
+        List<JsonNode> out = new ArrayList<>();
+        collect(JSON.readTree(json(model)), out);
+        return out;
+    }
+
+    private static void collect(JsonNode node, List<JsonNode> into) {
+        if (node.isObject() && node.has("rule") && node.get("rule").isString()
+                && node.has("ruleId")) {
+            into.add(node);
+        }
+        node.values().forEach(each -> collect(each, into));
+    }
+
+    private static String json(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).json(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/EveryKindOfRuleADocumentCanNameHasAnIdentityAndAWordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/EveryKindOfRuleADocumentCanNameHasAnIdentityAndAWordTest.java
@@ -78,11 +78,30 @@ class EveryKindOfRuleADocumentCanNameHasAnIdentityAndAWordTest {
     @Test
     void thePopulationIsEveryKindTheSealHas() {
         assertEquals(
-                Set.copyOf(RuleRef.class.getPermittedSubclasses() == null ? List.of()
-                        : List.of(RuleRef.class.getPermittedSubclasses())),
+                kindsOf(RuleRef.class),
                 everyKind().stream().map(each -> (Class<?>) each.getClass())
                         .collect(Collectors.toSet()),
                 "one of each kind of rule the seal has, and no other");
+    }
+
+    /**
+     * Every kind of rule the seal names, which are its leaves.
+     *
+     * <p>Walked to the leaves rather than read off what {@code RuleRef} permits directly. The seal
+     * divides first by how a reader finds a rule and then by which kind of rule it is, so its own
+     * permits are the two halves and none of them is a kind a document names. Read one level deep,
+     * this population would be two things nobody can build and no kind at all.
+     */
+    private static Set<Class<?>> kindsOf(Class<?> sealed) {
+        Class<?>[] permits = sealed.getPermittedSubclasses();
+        if (permits == null || permits.length == 0) {
+            return Set.of(sealed);
+        }
+        Set<Class<?>> out = new java.util.LinkedHashSet<>();
+        for (Class<?> each : permits) {
+            out.addAll(kindsOf(each));
+        }
+        return out;
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
@@ -1,38 +1,134 @@
 package souther.compiler.report;
 
-import souther.compiler.report.AdequacyReport;
-import souther.compiler.types.WrittenOwner;
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.check.BehaviorContract;
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.SourceConstruct;
 import souther.compiler.types.SourceConstructOrigin;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
+import souther.compiler.types.WrittenOwner;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A rule with no name is called the same thing by a reader and by a document.
  *
- * <p>Two surfaces and one rule. A reader is sent to a comparison by where it is written and sees
- * {@code comparison@…}; a document groups the same rule under a word of its own. While every
- * comparison a rule was read off stood in the condition of a {@code guard} or an {@code if}, calling
- * it {@code guard} was not yet wrong — the word named the construct and every construct was one of
- * those. A comparison a behavior answers with stands in neither, so the word became a statement
- * about the rule that is false of it, and a document grouping by it puts rules of a body under a
- * construct they are not written in.
+ * <p>Two surfaces and one rule. A reader is sent to a rule with no name by where it is written and
+ * sees {@code comparison@…}; a document groups the same rule under a word of its own. While every
+ * rule found that way was a comparison, calling all of them {@code comparison} was not yet wrong —
+ * the word named the one kind there was. A behavior's rule about the strings at a position is found
+ * the same way and is not a comparison, so the word became a statement about the rule that is false
+ * of it, and a reader following the handle was sent to a call and told it was a comparison.
+ *
+ * <p>Over every kind of rule the seal has, and not over one somebody built here. The word that was
+ * wrong was wrong for a kind nobody had written a case for, so a check of one kind is a check that
+ * passes for exactly the kinds it was written after.
  *
  * <p>Held to the reader's word rather than to a spelling written down here. Both surfaces naming
  * {@code guard} would satisfy a pair of literals as readily as both naming the rule.
+ *
+ * <p>What is checked is the agreement and not a shared spelling. The wire word is a contract a
+ * schema version pins and what a reader is shown is not, so the two stay separate values that a
+ * version may take apart deliberately — and that this is where such a version would be refused is
+ * the point of asking here rather than folding them into one string.
  */
 class OneRuleIsCalledOneThingOnBothSurfacesTest {
 
-    @Test
-    void aDocumentCallsAComparisonWhatAReaderIsShown() {
-        RuleRef.Comparison rule = new RuleRef.Comparison("f",
-                new SourceConstructOrigin(new WrittenOwner.Body("m", "b"), 0, 0,
-                        SourceConstruct.IF));
+    /**
+     * One of each kind, built by hand.
+     *
+     * <p>From the seal and not from a compilation: what is being asked is whether every kind agrees
+     * with itself across the two surfaces, and a model that happens to write three kinds of rule
+     * would make the population what that model states.
+     */
+    private static List<RuleRef> everyKind() {
+        WrittenOwner.Body body = new WrittenOwner.Body("m", "b");
+        return List.of(
+                new RuleRef.Invariant(new Clause.Ref(
+                        new Clause.Id(TypeSymbols.declared(new TypeKey("m", "Amount")), 0),
+                        Optional.of(new ClauseName("cap")))),
+                new RuleRef.Ensures(
+                        new BehaviorContract.RuleId(new ValueName.Behavior("m", "b"), 0, 0, null),
+                        "c"),
+                new RuleRef.Comparison("b",
+                        new SourceConstructOrigin(body, 1, 0, SourceConstruct.BINARY)),
+                new RuleRef.Predicate("b",
+                        new SourceConstructOrigin(body, 2, 0, SourceConstruct.CALL)));
+    }
 
-        assertEquals(RuleCitation.WHAT_IT_IS, AdequacyReport.schemaRuleKind(rule));
+    /** That the list above is the seal and not a list somebody kept up by hand. */
+    @Test
+    void thePopulationIsEveryKindTheSealHas() {
+        assertEquals(
+                Set.of(RuleRef.Invariant.class, RuleRef.Ensures.class,
+                        RuleRef.Comparison.class, RuleRef.Predicate.class),
+                everyKind().stream().map(each -> (Class<?>) each.getClass())
+                        .collect(Collectors.toSet()),
+                "one of each kind of rule the seal has, and no other");
+        assertEquals(
+                Set.of(RuleRef.Named.class, RuleRef.Written.class),
+                Set.of(RuleRef.class.getPermittedSubclasses()),
+                "and the seal divides them by how a reader finds them, which is what the two"
+                        + " surfaces are two ways of saying");
+    }
+
+    /**
+     * Every kind of rule found by where it is written is called the same thing on both surfaces.
+     *
+     * <p>The handle's own sentence and not a word this test knows: what a reader sees is the front
+     * of the sentence, cut at the join, so a word that stopped agreeing with the document's would
+     * fail here whichever of the two moved.
+     */
+    @Test
+    void aDocumentCallsARuleWithNoNameWhatAReaderIsShown() {
+        for (RuleRef each : everyKind()) {
+            if (!(each instanceof RuleRef.Written written)) {
+                continue;
+            }
+            RuleCitation cited = new RuleCitation.WrittenAt<>(written,
+                    Citation.of(new SourcePos(1, 1)));
+            String said = cited.said(SourceNameResolver.identity(), null);
+
+            assertEquals(AdequacyReport.schemaRuleKind(each),
+                    said.substring(0, said.indexOf('@')),
+                    () -> "the word a reader is shown and the word a document groups by, for "
+                            + each);
+        }
+    }
+
+    /**
+     * And a rule the author named is shown that name, which is nobody's word but theirs.
+     *
+     * <p>The other half of the seal, so that the check above is not passing because every kind of
+     * rule reached this test as one with no name.
+     */
+    @Test
+    void aRuleTheAuthorNamedIsShownTheirName() {
+        for (RuleRef each : everyKind()) {
+            if (!(each instanceof RuleRef.Named named)) {
+                continue;
+            }
+            RuleCitation cited = new RuleCitation.Named(named);
+
+            assertEquals(named.citedName(), cited.said(SourceNameResolver.identity(), null),
+                    () -> "a rule with a name is cited by it: " + each);
+            assertTrue(!named.citedName().isBlank(),
+                    () -> "and there is a name to cite it by: " + each);
+        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/OneRuleIsCalledOneThingOnBothSurfacesTest.java
@@ -17,6 +17,7 @@ import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.ValueName;
 import souther.compiler.types.WrittenOwner;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -75,16 +76,29 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
     @Test
     void thePopulationIsEveryKindTheSealHas() {
         assertEquals(
-                Set.of(RuleRef.Invariant.class, RuleRef.Ensures.class,
-                        RuleRef.Comparison.class, RuleRef.Predicate.class),
+                kindsOf(RuleRef.class),
                 everyKind().stream().map(each -> (Class<?>) each.getClass())
                         .collect(Collectors.toSet()),
                 "one of each kind of rule the seal has, and no other");
         assertEquals(
                 Set.of(RuleRef.Named.class, RuleRef.Written.class),
                 Set.of(RuleRef.class.getPermittedSubclasses()),
-                "and the seal divides them by how a reader finds them, which is what the two"
+                "and the seal divides them first by how a reader finds them, which is what the two"
                         + " surfaces are two ways of saying");
+    }
+
+    /** Every kind of rule the seal names, which are its leaves — the halves it divides into first
+     *  are not kinds a document names. */
+    private static Set<Class<?>> kindsOf(Class<?> sealed) {
+        Class<?>[] permits = sealed.getPermittedSubclasses();
+        if (permits == null || permits.length == 0) {
+            return Set.of(sealed);
+        }
+        Set<Class<?>> out = new LinkedHashSet<>();
+        for (Class<?> each : permits) {
+            out.addAll(kindsOf(each));
+        }
+        return out;
     }
 
     /**
@@ -100,7 +114,7 @@ class OneRuleIsCalledOneThingOnBothSurfacesTest {
             if (!(each instanceof RuleRef.Written written)) {
                 continue;
             }
-            RuleCitation cited = new RuleCitation.WrittenAt<>(written,
+            RuleCitation cited = new RuleCitation.WrittenAt(written,
                     Citation.of(new SourcePos(1, 1)));
             String said = cited.said(SourceNameResolver.identity(), null);
 

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatKeepsAnUndeterminedVerdictOpenIsSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatKeepsAnUndeterminedVerdictOpenIsSaidTest.java
@@ -8,7 +8,9 @@ import tools.jackson.databind.json.JsonMapper;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.types.WrittenOwner;
 import souther.compiler.check.RuleRef;
+import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.FilingCoordinate;
 import souther.compiler.inputs.StandingQuestion;
@@ -371,11 +373,12 @@ class WhatKeepsAnUndeterminedVerdictOpenIsSaidTest {
     private static Weakening ruleUnread(BlockReason.RuleReadingStopped why, String term) {
         return new Weakening.ModelReadingIncomplete(ClosureGap.QuestionUnanswered.of(
                 StandingQuestion.NothingClassifiesIt.of(
-                        new RuleRef.Comparison("go",
-                                new SourceConstructOrigin(
-                                        new WrittenOwner.Body("m", "b"), 0, 0,
-                                        SourceConstruct.IF)),
-                        new RuleCitation.Named(term),
+                        new RuleCitation.WrittenAt<>(
+                                new RuleRef.Comparison("go",
+                                        new SourceConstructOrigin(
+                                                new WrittenOwner.Body("m", "b"), 0, 0,
+                                                SourceConstruct.IF)),
+                                Citation.of(new SourcePos(1, 1))),
                         new FilingCoordinate.AtPosition(TermPath.of(term)), why)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatKeepsAnUndeterminedVerdictOpenIsSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatKeepsAnUndeterminedVerdictOpenIsSaidTest.java
@@ -373,7 +373,7 @@ class WhatKeepsAnUndeterminedVerdictOpenIsSaidTest {
     private static Weakening ruleUnread(BlockReason.RuleReadingStopped why, String term) {
         return new Weakening.ModelReadingIncomplete(ClosureGap.QuestionUnanswered.of(
                 StandingQuestion.NothingClassifiesIt.of(
-                        new RuleCitation.WrittenAt<>(
+                        new RuleCitation.WrittenAt(
                                 new RuleRef.Comparison("go",
                                         new SourceConstructOrigin(
                                                 new WrittenOwner.Body("m", "b"), 0, 0,


### PR DESCRIPTION
Closes #1389.

`RuleCitation.said` wrote `comparison` in front of the place for every rule the author did not name. The word was true while a comparison was the only rule found that way; a behavior's rule about the strings at a position is found the same way and is not one, so a document named it `comparison` beside a `ruleId` whose `kind` said `predicate` — an identity and a citation of one entry disagreeing about the rule.

The word was not missing. Every place that built such a citation built the rule on the same expression and dropped it, and the constant in front of the place was that rule's kind, reinvented as something true of one member of a set that had grown.

## What closes it

Which of the two ways a rule is found is a property of the kind of rule, so `RuleRef` divides into `Named` and `Written`. It was already true — `named()` returned the author's word for two kinds and what the rule is for the other two — and it was enforced by a switch that threw at whichever build first wrote such a rule.

A citation carries the rule it is a handle for, and every word comes off it: the author's name where they wrote one, what the rule is where they did not. The root `named()` is gone, so a caller that wants a word for a rule with no name says which word where it writes the sentence, rather than asking a rule with no name what it is called.

With the rule inside the handle, nothing holds a rule and a handle built apart from it. `RuleAccounting`, `ComparisonOrigin`, `PredicateOrigin`, `PlacementSeed`, `RuleUnclassifiedAt`, `RuleWithoutALine` and the three `StandingQuestion` arms each had both. They now have one path to the rule, and the folds keep the rule once with the places it was reached at beside it — two handles of one rule are two places, never a name and a place, which is a state that was reachable and could not be true.

`PublishedRuleHandle` becomes a sum. The kind is in the sentence, so it is in the projection: kept out, a comparison and a predicate written at one place came to one value and were printed two ways, and which a document wrote fell to whichever a set iterated first. The three arms are three kinds of evidence rather than one with a field that is sometimes absent.

The reader's-language phrase had the same shape — one phrase for every rule with no name — and is fixed with it.

## What holds it closed

An architecture test refuses a state with two ways to the rule it is about, walked over the whole component graph, since the pair this is about had the handle a step inside a neighbour.

A witness compiles a model stating a rule about the strings at a position and reads the document it produces. Nothing in the fixtures held such an entry, so the word was wrong where nobody was looking. Spelling the predicate's word back to `comparison` reproduces the issue's own entry and turns it red.

The agreement between the two surfaces is asked over every kind of rule the seal has, where it was asked over one. The two stay separate values — what a schema version pins and what a reader is shown are different contracts — and this is where a version that takes them apart is refused rather than found later.

## Left alone

`RuleRef.Ensures.clause` is the author's words for a clause and part of the identity. Whether `BehaviorContract.RuleId` already tells every `ensures` rule apart, which would make it presentation duplicated inside an identity, is a different question from this one and is not answered here; the doc says which two roles it plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)