### PR TITLE
A Decimal operation pays only for what it answers

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Generated.java
+++ b/souther-bench/src/main/java/souther/bench/Generated.java
@@ -9,6 +9,8 @@ import souther.runtime.Behavior;
 import souther.runtime.PersistentVector;
 
 import java.lang.reflect.Constructor;
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +57,7 @@ final class Generated {
         Behavior<Object, Object> keyed = behavior(loader, "Keyed");
         Behavior<Object, Object> modded = behavior(loader, "Modded");
         Behavior<Object, Object> parted = behavior(loader, "Parted");
+        Behavior<Object, Object> priced = behavior(loader, "Priced");
         Behavior<Object, Object> amountOf = behavior(loader, "AmountOf");
 
         for (int elements : SIZES) {
@@ -68,6 +71,7 @@ final class Generated {
             perElement(report, "keyed", elements, keyed, input);
             perElement(report, "modded", elements, modded, input);
             perElement(report, "parted", elements, parted, input);
+            perElement(report, "priced", elements, priced, decimals(elements));
         }
         perElement(report, "amountOf", 1, amountOf, 42L);
     }
@@ -96,6 +100,16 @@ final class Generated {
         PersistentVector<Long> input = PersistentVector.empty();
         for (long i = 0; i < elements; i++) {
             input = input.append(i);
+        }
+        return input;
+    }
+
+    /** The same numbers as Decimals, for a behavior taking {@code List<Decimal>}: built outside
+     *  the timing so that no conversion is in the loop being measured. */
+    private static PersistentVector<BigDecimal> decimals(int elements) {
+        PersistentVector<BigDecimal> input = PersistentVector.empty();
+        for (long i = 0; i < elements; i++) {
+            input = input.append(BigDecimal.valueOf(i));
         }
         return input;
     }
@@ -164,6 +178,27 @@ final class Generated {
         });
         report.line("RUN   %-14s %7.2f ns/element   (the same counting, on a java.util.HashMap)",
                 "merge", counting.medianMillis() * scale);
+
+        // What `priced` is doing, written by hand against BigDecimal: the same product and sum per
+        // element, the rate held once. What the figure above is to be read against — the distance
+        // between the two is what the run time puts around a Decimal operation, since the
+        // arithmetic underneath is the same.
+        List<BigDecimal> decimals = new ArrayList<>();
+        for (long i = 0; i < elements; i++) {
+            decimals.add(BigDecimal.valueOf(i));
+        }
+        BigDecimal rate = new BigDecimal("1.1");
+        Timing pricing = Timing.of(4, 7, () -> {
+            for (int r = 0; r < repetitions; r++) {
+                BigDecimal acc = BigDecimal.ZERO;
+                for (BigDecimal x : decimals) {
+                    acc = acc.add(x.multiply(rate));
+                }
+                sink = acc;
+            }
+        });
+        report.line("RUN   %-14s %7.2f ns/element   (the same pricing, on java.math.BigDecimal)",
+                "pricing", pricing.medianMillis() * scale);
     }
 
 }

--- a/souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou
+++ b/souther-bench/src/main/resources/souther/bench/corpus/runtime/runtime.sou
@@ -1,7 +1,7 @@
 // What the generated code costs to run, rather than to produce. Every behavior here is driven
 // directly through `Behavior.apply` from the benchmark, so each measures one shape of work:
 // accumulating over a list, building a list, and constructing a value that carries an invariant.
-module bench.runtime exposing ( sumAll, evensDoubled, tally, flipped, kept, held, keyed, modded, amountOf )
+module bench.runtime exposing ( sumAll, evensDoubled, tally, flipped, kept, held, keyed, modded, priced, amountOf )
 
 data Amount = Int
     invariant value >= 0
@@ -61,6 +61,14 @@ let keyed (xs) = Map.size(keying(xs))
 behavior modded : (xs: List<Int>) -> Int
 let modded (xs) = List.fold((acc, x) -> acc + Int.floorMod(x, 16), 0, xs)
 
+// The same accumulation as `sumAll`, over Decimals: a product and a sum per element, and a literal
+// in the step. What it measures is what a Decimal operation costs over what the number underneath
+// it costs, so the input is already Decimal and no conversion is in the loop. Against `sumAll`,
+// the distance is the two operations and the literal; against the same loop over BigDecimal in
+// Java, it is what the run time puts around them.
+behavior priced : (xs: List<Decimal>) -> Decimal
+let priced (xs) = List.fold((acc, x) -> acc + x * 1.1m, 0.0m, xs)
+
 // Accumulating into a tuple: `partition` carries a pair of lists and writes one of them per element,
 // which is the shape `take`, `drop`, `indexedMap` and `distinct` all fold. A tuple is a value, so
 // one is built per element, and this is where that costs what it costs. It answers a size for the
@@ -93,6 +101,8 @@ example keyed
     | ([1, 2, 17, 33]) -> 2
 example modded
     | ([1, 2, 17, 33]) -> 5
+example priced
+    | ([1.0m, 2.0m, 3.0m]) -> 6.6m
 example parted
     | ([1, 2, 3, 4]) -> 2
 example amountOf

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -30,6 +30,8 @@ import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.Label;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -670,13 +672,15 @@ final class BodyGen {
                 // emits from keeps none, and one arriving means it was handed another tree.
                 case Core.PreservedCall p -> throw p.unexpectedIn("the emitter");
                 case Core.Int x -> code.loadConstant(x.value());
-                case Core.Decimal x -> {
-                    code.new_(CD_BigDecimal);
-                    code.dup();
-                    code.loadConstant(x.value().toString());
-                    code.invokespecial(CD_BigDecimal, "<init>",
-                            MethodTypeDesc.of(ConstantDescs.CD_void, CD_String));
-                }
+                // A literal is a constant of the class it is written in, and is loaded as one: a
+                // dynamic constant the JVM resolves once, by running the BigDecimal constructor
+                // on the spelling, and answers from the constant pool thereafter. Constructing it
+                // where it stands would parse the spelling on every evaluation, and a literal in
+                // the step of a fold is evaluated once per element.
+                case Core.Decimal x -> code.ldc(DynamicConstantDesc.ofNamed(
+                        ConstantDescs.BSM_INVOKE, "decimal", CD_BigDecimal,
+                        MethodHandleDesc.ofConstructor(CD_BigDecimal, CD_String),
+                        x.value().toString()));
                 case Core.Str x -> code.loadConstant(x.value());
                 case Core.Bool x -> {
                     if (x.value()) code.iconst_1(); else code.iconst_0();

--- a/souther-compiler/src/test/java/souther/compiler/codegen/ADecimalLiteralIsAConstantOfTheClassItIsWrittenInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/ADecimalLiteralIsAConstantOfTheClassItIsWrittenInTest.java
@@ -1,0 +1,171 @@
+package souther.compiler.codegen;
+
+import souther.compiler.Compiler;
+import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.jvm.ClassFileImage;
+import souther.compiler.jvm.GeneratedClass;
+import souther.compiler.jvm.GeneratedClasses;
+import souther.runtime.Behavior;
+import souther.runtime.PersistentVector;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.constantpool.ConstantDynamicEntry;
+import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.instruction.ConstantInstruction.LoadConstantInstruction;
+import java.lang.classfile.instruction.NewObjectInstruction;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.reflect.Constructor;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A Decimal literal is emitted once per class it is written in, and loaded where it stands.
+ *
+ * <p>What is held is that constructing the value does not happen once per evaluation. A literal in
+ * the step of a fold is evaluated once per element, and a {@code new BigDecimal("1.1")} there
+ * parses the spelling that many times. The literal is loaded as a dynamic constant: the class file
+ * names the {@code BigDecimal} constructor and the spelling as the constant's bootstrap, the JVM
+ * runs that once at resolution, and every later load answers from the constant pool.
+ *
+ * <p>Read off the class file rather than off the objects. That two loads answer the same
+ * {@code BigDecimal} instance is true, and is not a property of a Souther {@code Decimal} — two
+ * Decimals are equal by value and nothing in the language observes their identity. What the
+ * language does observe is what an evaluation costs, and the class file says that: one
+ * {@code ldc} of a dynamic constant per literal, and one pool entry per spelling per class.
+ */
+class ADecimalLiteralIsAConstantOfTheClassItIsWrittenInTest {
+
+    private static final String MODULE = """
+            module demo
+
+            // The literal is in the step of a fold, which is evaluated once per element.
+            behavior priced : (xs: List<Decimal>) -> Decimal
+            let priced (xs) = List.fold((acc, x) -> acc + x * 1.1m, 0.0m, xs)
+
+            // The same spelling twice in one body: one pool entry, loaded twice.
+            behavior twice : (d: Decimal) -> Decimal
+            let twice (d) = d * 1.1m + 1.1m
+            """;
+
+    /** A spelling and how it reached the code of one class: loaded as a constant, or built. */
+    private record Reached(List<String> loadedSpellings, int built, int poolEntries) {}
+
+    private static Map<String, Reached> reached() {
+        Map<String, Reached> byClass = new TreeMap<>();
+        for (Map.Entry<String, ClassFileImage> emitted : Compiler.compile(MODULE).entrySet()) {
+            ClassModel model = ClassFile.of().parse(emitted.getValue().bytes());
+            List<String> loaded = new ArrayList<>();
+            int built = 0;
+            for (MethodModel method : model.methods()) {
+                if (!(method.code().orElse(null) instanceof CodeModel body)) {
+                    continue;
+                }
+                for (CodeElement element : body) {
+                    switch (element) {
+                        case NewObjectInstruction made
+                                when "java/math/BigDecimal".equals(made.className().asInternalName())
+                                -> built++;
+                        case LoadConstantInstruction load
+                                when load.constantValue() instanceof DynamicConstantDesc<?> constant
+                                -> loaded.add(spellingOf(constant));
+                        default -> { }
+                    }
+                }
+            }
+            int entries = 0;
+            for (PoolEntry entry : model.constantPool()) {
+                if (entry instanceof ConstantDynamicEntry dynamic
+                        && "decimal".equals(dynamic.name().stringValue())) {
+                    entries++;
+                }
+            }
+            if (!loaded.isEmpty() || built > 0 || entries > 0) {
+                byClass.put(emitted.getKey(), new Reached(loaded, built, entries));
+            }
+        }
+        return byClass;
+    }
+
+    /**
+     * The spelling a literal's constant carries, having checked that it is the literal's constant:
+     * resolved by running the {@code BigDecimal(String)} constructor on that spelling, and nothing
+     * else.
+     */
+    private static String spellingOf(DynamicConstantDesc<?> constant) {
+        assertEquals(ConstantDescs.BSM_INVOKE, constant.bootstrapMethod(),
+                "a Decimal literal is resolved by ConstantBootstraps.invoke");
+        assertEquals(2, constant.bootstrapArgs().length, "a constructor and its one argument");
+        assertTrue(constant.bootstrapArgs()[0] instanceof DirectMethodHandleDesc handle
+                        && handle.kind() == DirectMethodHandleDesc.Kind.CONSTRUCTOR
+                        && "Ljava/math/BigDecimal;".equals(handle.owner().descriptorString()),
+                "the constant runs the BigDecimal constructor: " + constant);
+        return (String) constant.bootstrapArgs()[1];
+    }
+
+    @Test
+    void everyLiteralIsLoadedAsAConstantAndNoneIsConstructedWhereItStands() {
+        Map<String, Reached> byClass = reached();
+        List<String> spellings = new ArrayList<>();
+        for (Map.Entry<String, Reached> each : byClass.entrySet()) {
+            assertEquals(0, each.getValue().built(),
+                    each.getKey() + " constructs a BigDecimal where a literal stands");
+            spellings.addAll(each.getValue().loadedSpellings());
+        }
+        // Every literal the module writes, and each as many times as it is written: `0.0m` once,
+        // `1.1m` three times. A walk that stopped seeing loads would pass the assertion above on
+        // its own.
+        assertEquals(List.of("0.0", "1.1", "1.1", "1.1"), spellings.stream().sorted().toList());
+    }
+
+    @Test
+    void oneSpellingIsOnePoolEntryHoweverOftenItIsLoaded() {
+        Map<String, Reached> byClass = reached();
+        boolean loadedTwiceSomewhere = false;
+        for (Map.Entry<String, Reached> each : byClass.entrySet()) {
+            Reached reached = each.getValue();
+            long distinct = reached.loadedSpellings().stream().distinct().count();
+            assertEquals(distinct, reached.poolEntries(),
+                    each.getKey() + " holds a pool entry per load rather than per spelling: "
+                            + reached.loadedSpellings());
+            loadedTwiceSomewhere |= reached.loadedSpellings().size() > distinct;
+        }
+        assertTrue(loadedTwiceSomewhere,
+                "no class loads one spelling twice, so the entry count says nothing: " + byClass);
+    }
+
+    @Test
+    void theFoldAnswersWithTheLiteralInItsStep() throws Exception {
+        ClassLoader loader = new MemoryClassLoader(Compiler.compile(MODULE),
+                getClass().getClassLoader());
+        Behavior<Object, Object> priced = behavior(loader, "priced");
+        Behavior<Object, Object> twice = behavior(loader, "twice");
+
+        PersistentVector<BigDecimal> xs = PersistentVector.from(
+                List.of(new BigDecimal("1"), new BigDecimal("2"), new BigDecimal("3")));
+        assertEquals(0, new BigDecimal("6.6").compareTo((BigDecimal) priced.apply(xs)));
+        assertEquals(0, new BigDecimal("2.2").compareTo((BigDecimal) twice.apply(new BigDecimal("1"))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Behavior<Object, Object> behavior(ClassLoader loader, String name)
+            throws ReflectiveOperationException {
+        Class<?> emitted = GeneratedClasses.load(loader, new GeneratedClass.BehaviorImpl("demo", name));
+        Constructor<?> ctor = emitted.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        return (Behavior<Object, Object>) ctor.newInstance();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
@@ -11,7 +11,11 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.ConstantInstruction.LoadConstantInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -56,7 +60,7 @@ class DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest {
      * language has, and those are {@code DecimalMath}'s.
      */
     private static final Set<String> REPRESENTATION = Set.of(
-            "<init>",       // a literal
+            "<init>",       // a literal, named as the bootstrap of the constant that loads it
             "signum",       // the zero test the `/` operator branches on
             "compareTo",    // the comparison operators, and a Map/Set key
             "equals", "hashCode", "toString");
@@ -99,24 +103,65 @@ class DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest {
                     | DivisionByZero -> Out { value = i.a, m = 0 }
             """;
 
+    /**
+     * Two ways a method reaches a {@code BigDecimal} method, read into one vocabulary. An
+     * invocation stands in the code. A literal is loaded as a dynamic constant whose bootstrap
+     * arguments name the constructor as a method handle, and the JVM runs it at resolution — which
+     * is a way to run any {@code BigDecimal} method without an invoke instruction to read. Both go
+     * through the same allowlist, so that there is one policy and not one per way.
+     */
+    private static List<String> reaches(CodeElement element) {
+        return switch (element) {
+            case InvokeInstruction call ->
+                    List.of(call.owner().asInternalName() + "." + call.name().stringValue());
+            case LoadConstantInstruction loaded
+                    when loaded.constantValue() instanceof DynamicConstantDesc<?> constant -> {
+                List<String> handles = new ArrayList<>();
+                for (ConstantDesc argument : constant.bootstrapArgs()) {
+                    if (argument instanceof DirectMethodHandleDesc handle) {
+                        handles.add(handle.owner().descriptorString()
+                                .replaceAll("^L|;$", "") + "." + handle.methodName());
+                    }
+                }
+                yield handles;
+            }
+            default -> List.of();
+        };
+    }
+
     @Test
     void noEmittedCodeRunsADecimalOperationOnBigDecimalItself() {
         Set<String> byTheBackend = new TreeSet<>();
+        Set<String> onBigDecimal = new TreeSet<>();
         for (Map.Entry<String, ClassFileImage> emitted : Compiler.compile(MODULE).entrySet()) {
             for (MethodModel method : ClassFile.of().parse(emitted.getValue().bytes()).methods()) {
                 if (!(method.code().orElse(null) instanceof CodeModel body)) {
                     continue;
                 }
                 for (CodeElement element : body) {
-                    if (element instanceof InvokeInstruction call
-                            && "java/math/BigDecimal".equals(call.owner().asInternalName())
-                            && !REPRESENTATION.contains(call.name().stringValue())) {
-                        byTheBackend.add(emitted.getKey() + "." + method.methodName().stringValue()
-                                + " calls BigDecimal." + call.name().stringValue());
+                    for (String target : reaches(element)) {
+                        if (!target.startsWith("java/math/BigDecimal.")) {
+                            continue;
+                        }
+                        String name = target.substring(target.lastIndexOf('.') + 1);
+                        onBigDecimal.add(name);
+                        if (!REPRESENTATION.contains(name)) {
+                            byTheBackend.add(emitted.getKey() + "."
+                                    + method.methodName().stringValue()
+                                    + " calls BigDecimal." + name);
+                        }
                     }
                 }
             }
         }
+
+        // The literal in `lit` reaches the constructor through a dynamic constant and through no
+        // invoke instruction. If the walk stops seeing it, the allowlist above is being applied to
+        // half of what reaches BigDecimal, and this test is green over an emitter that hides an
+        // operation the same way.
+        assertEquals(true, onBigDecimal.contains("<init>"),
+                "no literal's constructor was read out of a dynamic constant; what reached"
+                        + " BigDecimal was " + onBigDecimal);
 
         assertEquals(Set.of(), byTheBackend,
                 "the backend invokes something on BigDecimal that is not building a value or asking"

--- a/souther-runtime/src/main/java/souther/runtime/DecimalMath.java
+++ b/souther-runtime/src/main/java/souther/runtime/DecimalMath.java
@@ -2,7 +2,6 @@ package souther.runtime;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.function.Supplier;
 
 /**
  * Every Decimal operation the language has (spec §stdlib-decimal), and the one place
@@ -19,8 +18,8 @@ import java.util.function.Supplier;
  * {@code int}: the narrowing is {@link #scale}, and it is exact or it aborts, so no division runs at
  * a scale other than the one written. And every one of these operations is partial — a sum, a
  * difference, a product or a quotient whose scale leaves what a {@code BigDecimal} holds raises
- * {@code ArithmeticException} — so each runs through {@link #aborting}, which reports it the way an
- * {@code Int} overflow is reported (spec §jvm-abort). Neither is a business result.
+ * {@code ArithmeticException} — so each catches that and reports it as {@link #outOfRange}, the way
+ * an {@code Int} overflow is reported (spec §jvm-abort). Neither is a business result.
  */
 public final class DecimalMath {
 
@@ -30,7 +29,7 @@ public final class DecimalMath {
     private static final MathContext DIVIDE = new MathContext(29, java.math.RoundingMode.HALF_UP);
 
     /**
-     * Runs a {@code BigDecimal} operation and reports the way it refuses as the abort it is.
+     * The abort a {@code BigDecimal} operation's refusal is reported as.
      *
      * <p>{@code BigDecimal} answers on a range and not on every pair: a result whose scale leaves
      * the 32 bits a scale is kept in raises {@code ArithmeticException} — "Overflow", "Underflow",
@@ -38,13 +37,15 @@ public final class DecimalMath {
      * the product included. Left alone it arrives at a boundary as a {@code java.math} exception
      * from a program that has no such type. It is the same kind of thing an {@code Int} overflow is
      * ({@link IntMath}): a model bug rather than a business result, so it aborts.
+     *
+     * <p>Each operation catches the exception itself and builds {@code what} in the {@code catch}.
+     * The message names both operands through {@link #describe}, which walks their digits, and an
+     * operation that answers — which is every one in a loop that runs — must not pay for the
+     * message of the one that does not. So the operation is written where it stands, as a call and
+     * a return, and only this is shared.
      */
-    private static <T> T aborting(Supplier<T> operation, String what) {
-        try {
-            return operation.get();
-        } catch (ArithmeticException _) {
-            throw new ConstraintViolation(what + " is outside the range a Decimal holds");
-        }
+    private static ConstraintViolation outOfRange(String what) {
+        return new ConstraintViolation(what + " is outside the range a Decimal holds");
     }
 
     /**
@@ -70,7 +71,7 @@ public final class DecimalMath {
      * or it is nothing.
      *
      * <p>This answers whether the number can be handed over unchanged, and nothing else. Whether the
-     * operation asked for at that scale has an answer is {@link #aborting}'s question: a scale of
+     * operation asked for at that scale has an answer is {@link #outOfRange}'s question: a scale of
      * {@code 2147483647} passes here — an {@code int} holds it exactly — and a division at it still
      * has no result a {@code BigDecimal} can hold. The two are separate because they fail for
      * separate reasons, and a message calling the second one a scale out of range would be wrong
@@ -104,20 +105,30 @@ public final class DecimalMath {
 
     /** {@code Decimal.add(a, b)}, and the {@code +} operator. */
     public static BigDecimal add(BigDecimal a, BigDecimal b) {
-        return aborting(() -> a.add(b), "the sum of " + describe(a) + " and " + describe(b));
+        try {
+            return a.add(b);
+        } catch (ArithmeticException _) {
+            throw outOfRange("the sum of " + describe(a) + " and " + describe(b));
+        }
     }
 
     /** {@code Decimal.subtract(a, b)}, and the {@code -} operator. */
     public static BigDecimal subtract(BigDecimal a, BigDecimal b) {
-        return aborting(() -> a.subtract(b),
-                "the difference of " + describe(a) + " and " + describe(b));
+        try {
+            return a.subtract(b);
+        } catch (ArithmeticException _) {
+            throw outOfRange("the difference of " + describe(a) + " and " + describe(b));
+        }
     }
 
     /** {@code Decimal.multiply(a, b)}, and the {@code *} operator. A product's scale is the sum of
      *  its factors' scales, so this is the operation that reaches the end of the range first. */
     public static BigDecimal multiply(BigDecimal a, BigDecimal b) {
-        return aborting(() -> a.multiply(b),
-                "the product of " + describe(a) + " and " + describe(b));
+        try {
+            return a.multiply(b);
+        } catch (ArithmeticException _) {
+            throw outOfRange("the product of " + describe(a) + " and " + describe(b));
+        }
     }
 
     /**
@@ -135,7 +146,11 @@ public final class DecimalMath {
         if (b.signum() == 0) {
             throw new ConstraintViolation("division by zero: " + describe(a) + " / 0");
         }
-        return aborting(() -> a.divide(b, DIVIDE), "the quotient of " + describe(a) + " and " + describe(b));
+        try {
+            return a.divide(b, DIVIDE);
+        } catch (ArithmeticException _) {
+            throw outOfRange("the quotient of " + describe(a) + " and " + describe(b));
+        }
     }
 
     /**
@@ -160,9 +175,12 @@ public final class DecimalMath {
             return DivisionByZero.INSTANCE;
         }
         int places = scale(scale, "Decimal.divide");
-        return aborting(() -> dividend.divide(divisor, places, toJava(mode)),
-                "the quotient of " + describe(dividend) + " and " + describe(divisor)
-                        + " at scale " + scale);
+        try {
+            return dividend.divide(divisor, places, toJava(mode));
+        } catch (ArithmeticException _) {
+            throw outOfRange("the quotient of " + describe(dividend) + " and " + describe(divisor)
+                    + " at scale " + scale);
+        }
     }
 
     /**
@@ -206,8 +224,12 @@ public final class DecimalMath {
      * be taken of at all, which is a different failure of the same operation and says so.
      */
     public static long toInt(RoundingMode mode, BigDecimal d) {
-        BigDecimal whole = aborting(() -> d.setScale(0, toJava(mode)),
-                "the whole number " + describe(d) + " rounds to");
+        BigDecimal whole;
+        try {
+            whole = d.setScale(0, toJava(mode));
+        } catch (ArithmeticException _) {
+            throw outOfRange("the whole number " + describe(d) + " rounds to");
+        }
         try {
             return whole.longValueExact();
         } catch (ArithmeticException _) {
@@ -220,7 +242,10 @@ public final class DecimalMath {
      *  descriptor is derived from that declaration, so the two cannot drift apart. */
     public static BigDecimal round(long scale, RoundingMode mode, BigDecimal d) {
         int places = scale(scale, "Decimal.round");
-        return aborting(() -> d.setScale(places, toJava(mode)),
-                describe(d) + " rounded to scale " + scale);
+        try {
+            return d.setScale(places, toJava(mode));
+        } catch (ArithmeticException _) {
+            throw outOfRange(describe(d) + " rounded to scale " + scale);
+        }
     }
 }


### PR DESCRIPTION
Closes #1404.

A fold that adds a product of two Decimals per element cost a large multiple of the same loop over `BigDecimal` written by hand. The generated loop was the right loop; what was paid per element was in the two places a Decimal operation goes through, and neither was the arithmetic.

## What changed

`DecimalMath` no longer runs an operation through `aborting`. Every operator handed it a finished message naming both operands through `describe`, which walks their digits, so an operation that answered paid for the message of the one that did not. Each partial operator now runs its `BigDecimal` call as a call and a return and builds the message in the `catch`, through `outOfRange`, which is the one place a Decimal range failure is reported. The `Int` narrowing failure in `toInt` keeps its own message: it is not a Decimal range failure.

`BodyGen` emits a Decimal literal as an `ldc` of a dynamic constant rather than constructing it where it stands. `ConstantBootstraps.invoke` runs the `BigDecimal` constructor on the spelling once at resolution, and the constant pool answers thereafter, so a literal in the step of a fold is no longer parsed once per element. Nothing is added to the class: no field, no `<clinit>`, and the same spelling written twice in one class is one pool entry, which the `ClassFile` API guarantees.

`souther-bench run` gains a `priced` line: a fold over a `List<Decimal>` with a literal in its step, read against `sumAll` and `tally` the way the other shapes are, and against `pricing`, the same loop over `BigDecimal` written by hand in `structure`. Before this change the Souther fold cost a large multiple of the hand-written loop; after it the two are within a few percent of each other.

## What holds it

The check that the backend performs no Decimal operation on `BigDecimal` itself read only invoke instructions. A constructor named as the bootstrap of a dynamic constant is run by the JVM without one, which is a way to run any `BigDecimal` method the check would not see. The method handles in a constant's bootstrap arguments now go through the same allowlist as an invocation, and the literal's constructor is the control that the walk sees them.

A new test reads the class file for what an evaluation of a literal costs: every literal is an `ldc` of a dynamic constant resolved by the `BigDecimal(String)` constructor, none is constructed where it stands, and one spelling is one pool entry however often it is loaded. It holds the class-file shape and not the identity of the `BigDecimal` two loads answer, since no Souther Decimal observes that. The fold's answer is checked by running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)