### PR TITLE
The edit measurement writes a comment, and a product with an unnamed type inside a list is left out rather than thrown

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Incremental.java
+++ b/souther-bench/src/main/java/souther/bench/Incremental.java
@@ -47,7 +47,7 @@ final class Incremental {
             compilation.diagnostics();
         });
         Timing comment = Timing.ofRounds(40, 40, round ->
-                apply(compilation, byId, imported, byId.get(imported) + "\n-- round " + round + "\n"));
+                apply(compilation, byId, imported, byId.get(imported) + "\n// round " + round + "\n"));
         Timing atImported = Timing.ofRounds(40, 40, round ->
                 apply(compilation, byId, imported, added(byId.get(imported), round)));
         Timing atLeaf = Timing.ofRounds(40, 40, round ->

--- a/souther-compiler/src/main/java/souther/compiler/derive/CodecShape.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/CodecShape.java
@@ -92,10 +92,28 @@ sealed interface CodecShape {
                     of(m.value(), d, field, pos, symbols));
             case Type.OptionOf o -> new OptionOf(present(o, d, field, pos, symbols));
             case Type.TupleOf _ -> throw aTuple(t, d, field, pos);
-            case Type.FnOf _, Type.Union _, Type.Erroneous _,
+            // Not a refusal: a type nobody could name was reported where the name is written, and
+            // a shape cannot be built over it. Met here and not before the walk, so that what stands
+            // outside it in the type — a tuple, a map's key — is refused in the order the walk
+            // refuses everything else, and only this leaf is left unsaid.
+            case Type.Erroneous _ -> throw new Unnamed();
+            case Type.FnOf _, Type.Union _,
                  Type.Var _, Type.MetaVar _, Type.Nothing _, Type.Never _ ->
                     throw noRepresentation(t, d, field, pos);
         };
+    }
+
+    /**
+     * The walk met a type nobody could name. Carries nothing and no stack: it is how the absence of
+     * a shape leaves the walk, and {@link Deriver#derive} is where it lands and becomes the absence
+     * of a representation.
+     */
+    final class Unnamed extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        Unnamed() {
+            super(null, null, false, false);
+        }
     }
 
     /** What an optional holds, which is not another optional. */

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -45,15 +45,20 @@ public final class Deriver {
     }
 
     /**
-     * The boundary representation of {@code d}, or null where its fields do not all name a type.
+     * The boundary representation of {@code d}, or null where a field of it carries, anywhere in
+     * its type, a type nobody could name.
      *
      * <p>Null and not a report. A field whose type nobody could name was reported where the name is
      * written, and saying it again here would say the same thing twice; what a caller does with the
      * absence is answer nothing about the declaration, which is what a module holding one is worth.
+     * Anywhere in the type, because the walk below reaches every position of it and would report
+     * the unnamed part as a type with no representation — which it is not; it is a type with no
+     * name, already said.
      */
     public static Codecs derive(Hir.Data d, Symbols symbols) {
         Map<String, Type> fields = TypeOps.fieldTypes(d, symbols);
-        if (fields.values().stream().anyMatch(t -> t instanceof Type.Erroneous)) {
+        if (fields.values().stream()
+                .anyMatch(t -> Type.mentions(t, inside -> inside instanceof Type.Erroneous))) {
             return null;
         }
         // One walk decides what each field carries, and the decoder and the encoder are both lowered

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -51,24 +51,27 @@ public final class Deriver {
      * <p>Null and not a report. A field whose type nobody could name was reported where the name is
      * written, and saying it again here would say the same thing twice; what a caller does with the
      * absence is answer nothing about the declaration, which is what a module holding one is worth.
-     * Anywhere in the type, because the walk below reaches every position of it and would report
-     * the unnamed part as a type with no representation — which it is not; it is a type with no
-     * name, already said.
+     *
+     * <p>Only that leaf is left unsaid. The walk meets the unnamed type where it sits, so what
+     * stands outside it — a tuple around it, a map keyed by something no map that crosses may be
+     * keyed by — is refused first, in the order the walk refuses everything else: {@code (T, Int)}
+     * with {@code T} unnamed is refused as a tuple, and {@code Map<Int, T>} for its key. What is
+     * absorbed is the one report there would be about {@code T} itself, which was already made.
      */
     public static Codecs derive(Hir.Data d, Symbols symbols) {
         Map<String, Type> fields = TypeOps.fieldTypes(d, symbols);
-        if (fields.values().stream()
-                .anyMatch(t -> Type.mentions(t, inside -> inside instanceof Type.Erroneous))) {
-            return null;
-        }
         // One walk decides what each field carries, and the decoder and the encoder are both lowered
         // from it. Asked separately they would agree only by coincidence: a builder with an arm the
         // other lacks reports the shape it did not implement as one the language refuses, which is
         // how an unimplemented case comes to look like a rule (see CodecShape).
         Map<String, CodecShape> shapes = new LinkedHashMap<>();
-        for (Map.Entry<String, Type> f : fields.entrySet()) {
-            shapes.put(f.getKey(), CodecShape.of(f.getValue(), d, f.getKey(),
-                    fieldPos(d, f.getKey()), symbols));
+        try {
+            for (Map.Entry<String, Type> f : fields.entrySet()) {
+                shapes.put(f.getKey(), CodecShape.of(f.getValue(), d, f.getKey(),
+                        fieldPos(d, f.getKey()), symbols));
+            }
+        } catch (CodecShape.Unnamed _) {
+            return null;
         }
         // the decoder and the encoder each read the value under a name of their own, so each owns
         // the bindings it writes rather than sharing the declaration's

--- a/souther-compiler/src/test/java/souther/compiler/derive/AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/derive/AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest.java
@@ -1,32 +1,46 @@
 package souther.compiler.derive;
 
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
+import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A product a field of which carries a type nobody could name is left out of the derived module,
- * wherever in the field's type the unnamed part sits.
+ * wherever in the field's type the unnamed part sits — and only that leaf is left unsaid.
  *
- * <p>The name was reported where it is written, so deriving says nothing more; what it does is
- * answer nothing about the declaration. That was true of a field whose whole type is the unnamed
- * one and not of {@code List<T>} with {@code T} unnamed: the walk that builds the representation
- * met the {@code ?} inside the list and raised the report for a type with no boundary
- * representation as an exception, through the store, out of the compilation. An author who breaks
- * the module a product imports from — a line that is not yet a comment — has the compiler throw
- * where it should report, and the store keeps nothing of the question that threw.
+ * <p>The name was reported where it is written, so deriving says nothing more about it; what it
+ * does is answer nothing about the declaration. That was true of a field whose whole type is the
+ * unnamed one and not of {@code List<T>} with {@code T} unnamed: the walk that builds the
+ * representation met the {@code ?} inside the list and raised the report for a type with no
+ * boundary representation, through the store, out of the compilation. An author who breaks the
+ * module a product imports from — a line that is not yet a comment — had the compiler throw where
+ * it should report.
+ *
+ * <p>What is absorbed is the one report there would be about the unnamed type itself. What stands
+ * outside it in the type is refused as it is refused for any other type: the walk meets the
+ * unnamed leaf where it sits, so a tuple around it is refused as a tuple and a map keyed by an
+ * {@code Int} for its key, before the leaf is reached. A scan for the unnamed type ahead of the
+ * walk would have silenced those too, and they are not the same thing said twice.
  */
 class AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest {
+
+    private static final SourceId UPSTREAM = new SourceId("upstream.sou");
+    private static final SourceId DOWNSTREAM = new SourceId("downstream.sou");
 
     private static final String IMPORTED = """
             module upstream exposing ( Reason )
@@ -40,30 +54,71 @@ class AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest {
             """;
 
     /** Compiles both, with {@code upstream} as written or with a line that does not parse
-     *  appended, and answers every code reported. */
-    private static List<String> codes(String upstream) {
+     *  appended, and answers what each document was told. */
+    private static Map<SourceId, List<Located>> diagnostics(String upstream) {
         Map<String, String> byId = new LinkedHashMap<>();
-        byId.put("upstream.sou", upstream);
-        byId.put("downstream.sou", IMPORTING);
-        Compilation compilation = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        compilation.diagnostics();
-        List<String> codes = new ArrayList<>();
-        compilation.db().allReports()
-                .forEach(found -> codes.add(found.report().diagnostic().code().toString()));
-        return codes;
+        byId.put(UPSTREAM.toString(), upstream);
+        byId.put(DOWNSTREAM.toString(), IMPORTING);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).diagnostics();
     }
 
+    /**
+     * The document that does not parse is told so. The one importing it is told that its import
+     * reaches no module — which is about the line it wrote — and nothing else: not the product,
+     * whose field came to carry the unnamed type through that import.
+     */
     @Test
-    void aBrokenImportIsReportedWhereItIsWrittenAndNowhereElse() {
-        List<String> codes = codes(IMPORTED + "\n-- not a comment\n");
-        assertFalse(codes.isEmpty(), "the line that does not parse is reported");
-        assertFalse(codes.contains("E1311"),
-                "the product whose field carries the unnamed type says nothing of its own: " + codes);
+    void aBrokenImportIsReportedWhereItIsWrittenAndTheProductSaysNothing() {
+        Map<SourceId, List<Located>> told = diagnostics(IMPORTED + "\n-- not a comment\n");
+        assertFalse(told.get(UPSTREAM).isEmpty(), "the line that does not parse is reported");
+        assertEquals(List.of("E1504"), codes(told.get(DOWNSTREAM)),
+                "the importing document is told of its import and of nothing else");
     }
 
-    /** The negative control: as written, the pair compiles and reports nothing. */
+    private static List<String> codes(List<Located> told) {
+        return told.stream().map(each -> each.diagnostic().code().toString()).toList();
+    }
+
+    /** The negative control: as written, the pair compiles and neither document is told anything. */
     @Test
     void asWrittenNothingIsReported() {
-        assertTrue(codes(IMPORTED).isEmpty(), codes(IMPORTED).toString());
+        Map<SourceId, List<Located>> told = diagnostics(IMPORTED);
+        assertEquals(List.of(), told.get(UPSTREAM));
+        assertEquals(List.of(), told.get(DOWNSTREAM));
+    }
+
+    /**
+     * Wherever the unnamed part sits under a position the boundary admits, the product says nothing
+     * of its own: the unnamed name is reported once, where it is written, and that is all.
+     */
+    @Test
+    void underAnAdmittedPositionOnlyTheNameIsReported() {
+        for (String type : List.of("Missing", "List<Missing>", "Set<Missing>", "Option<Missing>",
+                "Map<String, Missing>", "List<Option<Missing>>")) {
+            Map<String, String> byId = new LinkedHashMap<>();
+            byId.put("demo.sou", "module demo\ndata X = { f: " + type + " }\n");
+            List<String> codes = codes(Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY)
+                    .diagnostics().get(new SourceId("demo.sou")));
+            assertEquals(List.of("E1023"), codes, type + " is told " + codes);
+        }
+    }
+
+    /**
+     * What stands outside the unnamed part is refused as it would be for any type there: the walk
+     * reaches the tuple and the map's key before the leaf. These are the reports the pre-walk scan
+     * would have lost, and each is about something other than the name.
+     */
+    @Test
+    void whatStandsOutsideTheUnnamedPartIsStillRefused() {
+        assertTrue(refused("(Missing, Int)").contains("E1311"),
+                "a tuple around the unnamed type is refused as a tuple");
+        assertTrue(refused("Map<Int, Missing>").contains("E1314"),
+                "a map keyed by an Int around the unnamed type is refused for its key");
+    }
+
+    private static String refused(String type) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(
+                "module demo\ndata X = { f: " + type + " }\n"));
+        return e.getMessage();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/derive/AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/derive/AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest.java
@@ -1,0 +1,69 @@
+package souther.compiler.derive;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A product a field of which carries a type nobody could name is left out of the derived module,
+ * wherever in the field's type the unnamed part sits.
+ *
+ * <p>The name was reported where it is written, so deriving says nothing more; what it does is
+ * answer nothing about the declaration. That was true of a field whose whole type is the unnamed
+ * one and not of {@code List<T>} with {@code T} unnamed: the walk that builds the representation
+ * met the {@code ?} inside the list and raised the report for a type with no boundary
+ * representation as an exception, through the store, out of the compilation. An author who breaks
+ * the module a product imports from — a line that is not yet a comment — has the compiler throw
+ * where it should report, and the store keeps nothing of the question that threw.
+ */
+class AFieldWhoseTypeIsNowhereNamedIsLeftOutWhereverTheNameSitsTest {
+
+    private static final String IMPORTED = """
+            module upstream exposing ( Reason )
+            data Reason = { text: String }
+            """;
+
+    private static final String IMPORTING = """
+            module downstream
+            import upstream ( Reason )
+            data Refused = { reasons: List<Reason> }
+            """;
+
+    /** Compiles both, with {@code upstream} as written or with a line that does not parse
+     *  appended, and answers every code reported. */
+    private static List<String> codes(String upstream) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("upstream.sou", upstream);
+        byId.put("downstream.sou", IMPORTING);
+        Compilation compilation = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        compilation.diagnostics();
+        List<String> codes = new ArrayList<>();
+        compilation.db().allReports()
+                .forEach(found -> codes.add(found.report().diagnostic().code().toString()));
+        return codes;
+    }
+
+    @Test
+    void aBrokenImportIsReportedWhereItIsWrittenAndNowhereElse() {
+        List<String> codes = codes(IMPORTED + "\n-- not a comment\n");
+        assertFalse(codes.isEmpty(), "the line that does not parse is reported");
+        assertFalse(codes.contains("E1311"),
+                "the product whose field carries the unnamed type says nothing of its own: " + codes);
+    }
+
+    /** The negative control: as written, the pair compiles and reports nothing. */
+    @Test
+    void asWrittenNothingIsReported() {
+        assertTrue(codes(IMPORTED).isEmpty(), codes(IMPORTED).toString());
+    }
+}


### PR DESCRIPTION
Closes #1406. Closes #1407.

The `edit` line of `souther-bench` had never been printed. `Incremental` appended `-- round N` to the first source of the corpus, the one the others import, as the trailing comment it measures the cost of. A comment in Souther is `//`, so the line did not parse, the imported module lost its declarations, and a product downstream came to carry a `?` inside a `List`. The compilation then threw E1311 for that product, about a name that had already been reported where it is written.

That report is a defect of the compiler and not of the measurement. `Deriver.derive` leaves a product out of the derived module when a field of it carries a type nobody could name, since the name was reported where it is written; it read each field's type with `instanceof Type.Erroneous`, so a `?` nested inside a list, a map, an option or a set passed the check, and the walk that builds the representation met it there and reported it as a type with no boundary representation. The walk now meets the unnamed leaf where it sits and leaves through a sentinel that `Deriver` turns into the absence of a representation. Only that leaf is left unsaid: what stands outside it in the type is refused in the order the walk refuses everything else, so `(T, Int)` with `T` unnamed is refused as a tuple and `Map<Int, T>` for its key. A scan for the unnamed type ahead of the walk would have silenced those too, and they are not the same thing said twice.

A test pins each document's reports by source: the document that does not parse is told so, the importing one is told of its import and nothing else. Under an admitted position only the name is reported; around the unnamed part a tuple and a map's key are refused as they would be for any type. The last of those was red with the scan ahead of the walk.

The measurement writes `// round N`, so the edit reaches the parse and stops there as its doc says, and `souther-bench edit` prints a line for each corpus.

The two are one pull request because each alone leaves the other meaningless: the measurement fixed on its own would never again reach the defect, and the defect fixed on its own would leave the measurement writing a line that is not the edit it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)