### PR TITLE
A clause's topology is recognised once, and each reading says how far it descends

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -3,7 +3,7 @@ package souther.compiler.check;
 import souther.compiler.core.Core;
 
 /**
- * A clause tree read into one state, the connectives being the same whatever the leaves are read as.
+ * A clause tree read into one state, the connectives being the same whatever the parts are read as.
  *
  * <p>What a clause is written out of — a conjunction, a choice, a denial — is the clause's own shape
  * and not a fact about the language it is read in. Written once per language, that shape is the same
@@ -18,20 +18,25 @@ import souther.compiler.core.Core;
  * having found nothing wrong with the branch the other one refused.
  *
  * <p><b>What a clause states is answered upward and what its names mean is handed downward.</b> A
- * reading composes its leaves into one answer, and that answer is a function of the leaves; the
- * environment a leaf is read in is a function of the bindings above it, which is the other
+ * reading composes its parts into one answer, and that answer is a function of the parts; the
+ * environment a part is read in is a function of the bindings above it, which is the other
  * direction. Carried only upward, there was nowhere for a binding to be, so a clause under one was
  * a shape every reading had no word for — and since almost every binding this check meets is one a
  * helper's expansion made, a rule stated through a helper was read less than the same rule written
  * out.
  *
- * <p>So {@code E} is handed down and {@code S} comes back up, and a leaf is read at the environment
+ * <p>So {@code E} is handed down and {@code S} comes back up, and a part is read at the environment
  * it stands in. What a binding does to that environment is not asked of a reading: the fold finds
  * the boundary and {@link ClauseScope} answers it, which is what keeps a binder's meaning the
  * environment's (ADR-0106) rather than something each of three readings works out again.
  *
+ * <p><b>A part is not the same thing for every reading.</b> Where a reading stops is its own answer
+ * ({@link Descent}), so the node an author wrote a connective at is a part to a reading that takes
+ * it whole and is none to a reading that descends. What every reading shares is the shape below it,
+ * not the depth it reads to.
+ *
  * @param <S> what a reading of a clause comes to
- * @param <E> what the reading carries into a binding — what its leaves are read at
+ * @param <E> what the reading carries into a binding — what its parts are read at
  */
 interface ClauseReading<S, E> {
 
@@ -67,10 +72,10 @@ interface ClauseReading<S, E> {
      * What {@code e} leaves, stated where {@code positive} and denied where it is not, read from
      * {@code at} with {@code scope} answering for the bindings inside it.
      *
-     * <p>A denial is carried to the leaves rather than applied to what a branch came to. What a
+     * <p>A denial is carried down to the parts rather than applied to what a branch came to. What a
      * state says is a fact per position, and the denial of that is not one — the values a
      * conjunction rules out are a choice between the positions it named, which no map of positions
-     * holds. Carried down, every denial meets a leaf, where it is one.
+     * holds. Carried down, every denial meets a part, where it is one.
      */
     default S read(Core e, boolean positive, E at, ClauseScope<E> scope) {
         return read(e, positive, at, scope, null);

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -35,12 +35,14 @@ import souther.compiler.core.Core;
  */
 interface ClauseReading<S, E> {
 
-    /** What a clause this reading has no word for leaves, which is everything it had. */
-    S nothingSaid();
-
     /**
-     * What one clause of no connective says, stated where {@code positive} and denied where it is
-     * not, read at the environment {@code at} it stands in.
+     * What one part of the clause says, stated where {@code positive} and denied where it is not,
+     * read at the environment {@code at} it stands in.
+     *
+     * <p>A part of no connective, or a connective this reading takes whole — the two are one case.
+     * What is inside a part is the part language's to ask, and a binding standing there is crossed
+     * by each question it asks about its own inside (ADR-0106); a connective taken whole is a part
+     * on exactly those terms.
      *
      * <p>Reached with the denials already counted, so a reading of a comparison is a reading of the
      * comparison it states rather than of the one that was written. And reached with the bindings
@@ -48,21 +50,18 @@ interface ClauseReading<S, E> {
      * reading that answered from the environment the whole clause began in would be reading one
      * value's rule at another value's names.
      */
-    S leaf(Core e, boolean positive, E at);
-
-    /** Both readings holding at once. */
-    S both(S one, S other);
+    S whole(Core e, boolean positive, E at);
 
     /**
-     * Either reading holding, at the connective an author wrote it with.
+     * How far this reading goes into {@code join}, and what holding both of its parts comes to.
      *
-     * <p>The node is here because a reading with something to say about the choice has nowhere else
-     * to learn where it stands. What the fold hands up is two readings and a flag; which choice they
-     * are the two branches of is known at this call and at no call after it, so a reading that wants
-     * it and is not given it here works it out from something else — and the something else is
+     * <p>Asked of the shape and not of the operator, so what a connective composes is settled in
+     * one place. The whole shape is handed over because a reading with something to say about the
+     * choice has nowhere else to learn where it stands: which choice two readings are the branches
+     * of is known here and at no call after it, so a reading not given it works it out from
      * whichever place a walk happened to reach, which is a fact about the walk.
      */
-    S either(Core writtenAt, S one, S other);
+    Descent<S> at(ClauseExpr.Joined join);
 
     /**
      * What {@code e} leaves, stated where {@code positive} and denied where it is not, read from
@@ -105,11 +104,14 @@ interface ClauseReading<S, E> {
     private S over(ClauseExpr shape, E at, ClauseScope<E> scope,
                    java.util.function.BiConsumer<Core, S> per) {
         S out = switch (shape) {
-            case ClauseExpr.Leaf it -> leaf(it.of(), it.positive(), at);
-            case ClauseExpr.Joined it -> switch (it.how()) {
-                case BOTH -> both(over(it.left(), at, scope, per), over(it.right(), at, scope, per));
-                case EITHER -> either(it.of(), over(it.left(), at, scope, per),
-                        over(it.right(), at, scope, per));
+            case ClauseExpr.Leaf it -> whole(it.of(), it.positive(), at);
+            // How far this reading goes is its own answer, and taking the connective whole is
+            // reading the node an author wrote it at as a part. A reading told to descend and
+            // unable to compose what it found had nowhere to say so.
+            case ClauseExpr.Joined it -> switch (at(it)) {
+                case Descent.Whole<S> _ -> whole(it.of(), it.positive(), at);
+                case Descent.Into<S> into -> into.compose().apply(
+                        over(it.left(), at, scope, per), over(it.right(), at, scope, per));
             };
             // The one place the environment changes, and it changes for what is under the binding
             // alone. What the binding means is not worked out here and not by the reading either.

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -86,11 +86,12 @@ interface ClauseReading<S, E> {
      */
     default S read(Core e, boolean positive, E at, ClauseScope<E> scope,
                    java.util.function.BiConsumer<Core, S> per) {
-        S out = from(e, over(ClauseExpr.of(e, positive), at, scope, per));
-        if (per != null) {
-            per.accept(e, out);
-        }
-        return out;
+        // The clause is named once more here, on the outside of everything its shape was written
+        // as, which is where a caller holding the clause and nothing under it looks. What it came
+        // to is not told to {@code per} a second time: the walk below has already said it of the
+        // very same node, and a reader counting what it was told would count the whole clause
+        // twice and every part of it once.
+        return from(e, over(ClauseExpr.of(e, positive), at, scope, per));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -5,7 +5,6 @@ import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.LinearForm;
 import souther.compiler.numeric.Rel;
-import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.semantics.ConstantArguments;
 import souther.compiler.semantics.ResultRange;
 import souther.compiler.types.BinOp;
@@ -137,27 +136,64 @@ final class Conditions {
      */
     static void stating(Terms terms, Core rawCond, Denotations at, boolean positive,
                         List<NumericConstraint> out) {
-        Core cond = asSizeComparison(rawCond);
-        Restated under = restated(cond);
-        if (under != null) {
-            stating(terms, under.condition(), at, under.denied() != positive, out);
-            return;
-        }
-        if (cond instanceof Core.Binary b
-                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
-                        == ConditionJoin.BOTH) {
-            stating(terms, b.left(), at, positive, out);
-            stating(terms, b.right(), at, positive, out);
-            return;
-        }
-        // Every reading, because each of them holds of the values and an arm read without one of
-        // them is an arm bounded by less than what choosing it settles.
-        for (StatedComparison stated : comparisonsStatedBy(terms, cond, at).inReadingOrder()) {
-            LinearForm<FactSubject> left = terms.affineOf(stated.left(), at);
-            LinearForm<FactSubject> right = terms.affineOf(stated.right(), at);
-            if (left != null && right != null) {
-                out.add(new NumericConstraint(left.minus(right), stated.relationUnder(positive)));
+        out.addAll(new Stating(terms).read(rawCond, positive, at, terms::inside));
+    }
+
+    /**
+     * What a condition states, read over the shape it was written in.
+     *
+     * <p>Over the shape and not over the tree, so that what a connective composes is recognised in
+     * one place ({@link ClauseExpr}) and this reading agrees with every other by having been given
+     * the answer. And a binding is crossed on the way in, so a rule stated through a helper states
+     * what the same rule written out states — read as a shape with no word for it, such a rule
+     * stated nothing at all.
+     */
+    private record Stating(Terms terms)
+            implements ClauseReading<List<NumericConstraint>, Denotations> {
+
+        /**
+         * Every reading of one part, because each of them holds of the values: an arm read without
+         * one of them is an arm bounded by less than what choosing it settles.
+         *
+         * <p>Read through the same normalisation a guard is, which is where it belongs: an
+         * emptiness check is the comparison it means, and what that comparison composes is nothing,
+         * so nothing above this had a shape to recognise differently for it.
+         */
+        @Override
+        public List<NumericConstraint> whole(Core e, boolean positive, Denotations at) {
+            List<NumericConstraint> out = new ArrayList<>();
+            for (StatedComparison stated
+                    : comparisonsStatedBy(terms, asSizeComparison(e), at).inReadingOrder()) {
+                LinearForm<FactSubject> left = terms.affineOf(stated.left(), at);
+                LinearForm<FactSubject> right = terms.affineOf(stated.right(), at);
+                if (left != null && right != null) {
+                    out.add(new NumericConstraint(left.minus(right),
+                            stated.relationUnder(positive)));
+                }
             }
+            return out;
+        }
+
+        /**
+         * A conjunction states both of what it composes, and a choice states neither.
+         *
+         * <p>One of a choice's parts holds and this cannot say which, so what is left of it is that
+         * the author named the two — which is nothing this reading has a constraint for. Descending
+         * would state each part of a choice as though the values had to satisfy it.
+         */
+        @Override
+        public Descent<List<NumericConstraint>> at(ClauseExpr.Joined join) {
+            return switch (join.how()) {
+                case BOTH -> new Descent.Into<>(Stating::and);
+                case EITHER -> new Descent.Whole<>();
+            };
+        }
+
+        private static List<NumericConstraint> and(List<NumericConstraint> one,
+                                                   List<NumericConstraint> other) {
+            List<NumericConstraint> both = new ArrayList<>(one);
+            both.addAll(other);
+            return both;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Descent.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Descent.java
@@ -1,0 +1,43 @@
+package souther.compiler.check;
+
+import java.util.function.BinaryOperator;
+
+/**
+ * How far a reading goes into a connective the clause was written with.
+ *
+ * <p>A clause's shape is read out of the tree once ({@link ClauseExpr}), and every reading over it
+ * meets the same connectives. What they do not share is how far down they go: a reading whose state
+ * composes a choice reads both alternatives and joins them, and one whose state does not reads the
+ * choice as one thing and hands it to whatever reads a part. Held as a flag beside the fold, that
+ * decision and the composition it licenses were two answers a reading gave apart — and a reading
+ * that said it descended and could not compose had nowhere to say so.
+ *
+ * <p>So the two are one answer. Descending means saying how the parts compose, and a reading with
+ * no way to compose them says it takes the connective whole. What it is then handed is the node an
+ * author wrote it at, read as a part like any other.
+ *
+ * @param <S> what a reading of a clause comes to
+ */
+sealed interface Descent<S> {
+
+    /** The connective is read as one thing, and what is under it is not read at all. */
+    record Whole<S>() implements Descent<S> {}
+
+    /**
+     * Both of what it composes are read, and this is what holding them together comes to.
+     *
+     * <p>The composition and not a name for it. Which connective this is and what a reading makes
+     * of it are the reading's own business — a choice may be a join in one state and a meet in
+     * another — and a reading with something to say about where the choice was written closes over
+     * the node it was asked about.
+     */
+    record Into<S>(BinaryOperator<S> compose) implements Descent<S> {
+
+        public Into {
+            if (compose == null) {
+                throw new IllegalArgumentException(
+                        "a reading that descends says what holding both comes to");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
@@ -65,30 +65,36 @@ final class ExpansionCost implements ClauseReading<Long, Void> {
     }
 
     /** Nothing read is one alternative — the empty product — and is the identity of the fold. */
-    @Override
-    public Long nothingSaid() {
+    private long nothingSaid() {
         return 1L;
     }
 
     /**
      * One, whatever a reading later makes of it.
      *
-     * <p>A leaf a reading has no word for is one alternative and not none: what it leaves is
+     * <p>A part a reading has no word for is one alternative and not none: what it leaves is
      * everything, which is a box like any other. Counting it as none would let a clause of unread
-     * leaves come out costing nothing and be admitted under any budget.
+     * parts come out costing nothing and be admitted under any budget.
      */
     @Override
-    public Long leaf(Core e, boolean positive, Void at) {
+    public Long whole(Core e, boolean positive, Void at) {
         return 1L;
     }
 
+    /**
+     * Both connectives are counted to the end, because what is being counted is what the shape
+     * composes: a conjunction multiplies the alternatives of its halves and a choice adds them.
+     */
     @Override
-    public Long both(Long one, Long other) {
-        return Math.min(ceiling, one * other);
+    public Descent<Long> at(ClauseExpr.Joined join) {
+        return switch (join.how()) {
+            case BOTH -> new Descent.Into<>(this::both);
+            case EITHER -> new Descent.Into<>(
+                    (one, other) -> Math.min(ceiling, one + other));
+        };
     }
 
-    @Override
-    public Long either(Core writtenAt, Long one, Long other) {
-        return Math.min(ceiling, one + other);
+    private Long both(Long one, Long other) {
+        return Math.min(ceiling, one * other);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -1363,7 +1363,7 @@ public final class FieldDomains {
     private FieldDomains without(Set<AboutOneCoordinate> removed) {
         return of(named, data, source, policy, settled,
                 InvariantChecker.Reach.withoutParts(removed.stream()
-                        .map(each -> new PartsLeftOut.AuthoredPart(each.part(), each.read()))
+                        .map(AboutOneCoordinate::part)
                         .collect(java.util.stream.Collectors.toSet())),
                 StringMachineLookup.NONE);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -528,14 +528,21 @@ public final class FieldDomains {
      * <p>What such a rule does to the number is not here and is not this reading's: it is read by
      * asking what the rules leave the coordinate without it, and comparing ({@link #movedEndsOf}).
      *
+     * <p><b>The part and not what inside it was read.</b> This is what a counterfactual reading is
+     * asked without, and what such a reading can be asked without is a part its author wrote: an
+     * author told a rule holds an end rewrites the conjunct they typed, and half of a rule named
+     * through a helper is not something they can take away. So a part stating two rules that both
+     * reach one number is one candidate here — carrying the subtree each was read from, it was two,
+     * and a reading asked without either of them was asked without the part they share, which named
+     * the same part twice as holding an end it holds once.
+     *
      * @param at   the number its quantity is over
      * @param part which part of which rule it is
-     * @param read the part itself, which is what a counterfactual reading is asked without
      */
-    public record AboutOneCoordinate(NumberAt<RuleKey> at, PartId part, Core read) {
+    public record AboutOneCoordinate(NumberAt<RuleKey> at, PartId part) {
 
         public AboutOneCoordinate {
-            if (at == null || part == null || read == null) {
+            if (at == null || part == null) {
                 throw new IllegalArgumentException("a quantity over one number is some rule's");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -579,7 +579,7 @@ public final class InvariantChecker {
          * {@link #withoutClausesOf}: a clause has as many conjuncts as the author wrote, and taking
          * the clause away answers for all of them at once.
          */
-        static Reach withoutParts(java.util.Set<PartsLeftOut.AuthoredPart> parts) {
+        static Reach withoutParts(java.util.Set<PartId> parts) {
             return new Reach(RulesLeftOut.NONE, PartsLeftOut.without(parts), _ -> false);
         }
 
@@ -743,14 +743,23 @@ public final class InvariantChecker {
             }
             // The clause as one reading, and the parts its author wrote as subtrees of it. Which
             // parts there are was settled where the clause was split; nothing here decides it.
-            written.add(new Written(stated, declared.shape().onto(stated, origin)));
-            Predicates.Owed owed = c.predicates.assumed(stated, at, false,
-                    (part, said) -> gathering.constrained(origin, part, partRead(said)),
-                    // Which conjuncts of this rule were asked for. Which nodes of the clause
-                    // its conjuncts are is the predicate reader's answer, so what is handed
-                    // over is the one that is not wanted rather than a clause rebuilt without
-                    // it.
-                    reach.withoutParts().of(origin));
+            Written wrote = new Written(stated, declared.shape().onto(stated, origin));
+            written.add(wrote);
+            // A part at a time, and the ones this reading was asked for. Which parts a clause has
+            // was settled where it was split, so a part left out is one left out of the list —
+            // never a node a walk was told to step over.
+            Predicates.Owed owed = null;
+            for (Clauses.StatedPart part : wrote.parts()) {
+                if (reach.withoutParts().excludes(part.id())) {
+                    continue;
+                }
+                Predicates.Owed said = c.predicates.assumed(part.expr(), at, false,
+                        (of, came) -> gathering.constrained(origin, of, partRead(came)));
+                owed = owed == null ? said : owed.and(said);
+            }
+            if (owed == null) {
+                owed = Predicates.Owed.unread();
+            }
             // And the reading that builds the numeric constraints, said by what it produced.
             // `value * 2 >= 4` is beyond the two readings below and is taken in here about the
             // position itself; `value * value >= 4` comes back about an atom standing for the
@@ -1528,10 +1537,15 @@ public final class InvariantChecker {
         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         Map<FieldDomains.BoundaryQuestion, FieldDomains.BoundaryStanding> standing =
                 new LinkedHashMap<>();
-        stated.forEach(each -> each.parts().forEach(part ->
-                direct(part.expr(), each.from(), part.id(), at, byName, out, noLines,
-                        withoutAnEnd, aboutOneCoordinate, aboutTheStrings, narrowers, raised,
-                        took, typeAt, parts, raisedByPart, standing, withoutParts)));
+        // A part this reading was not asked for is not read, which is the same list of parts the
+        // reader of predicates was given: a part one of them reached that the other never read is a
+        // value whose rules were not gathered ({@link APartNoReadingSaw}).
+        stated.forEach(each -> each.parts().stream()
+                .filter(part -> !withoutParts.excludes(part.id()))
+                .forEach(part ->
+                        direct(part.expr(), each.from(), part.id(), at, byName, out, noLines,
+                                withoutAnEnd, aboutOneCoordinate, aboutTheStrings, narrowers,
+                                raised, took, typeAt, parts, raisedByPart, standing)));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
         return new Reading(List.copyOf(out), List.copyOf(noLines), List.copyOf(withoutAnEnd),
@@ -1561,11 +1575,9 @@ public final class InvariantChecker {
                           PartsRead parts,
                           Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                           Map<FieldDomains.BoundaryQuestion,
-                                  FieldDomains.BoundaryStanding> standing,
-                          PartsLeftOut withoutParts) {
+                                  FieldDomains.BoundaryStanding> standing) {
         direct(stated.spelled().get(0), from, part, at, byName, out, noLines, withoutAnEnd, naming,
-                namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart, standing,
-                withoutParts);
+                namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart, standing);
     }
 
     /** What {@code clause} raises, taken together with whatever its other conjuncts raised. */
@@ -1677,20 +1689,11 @@ public final class InvariantChecker {
                         PartsRead parts,
                         Map<RuleRef.Invariant, Map<Core, Required>> raisedByPart,
                         Map<FieldDomains.BoundaryQuestion,
-                                FieldDomains.BoundaryStanding> standing,
-                        PartsLeftOut withoutParts) {
+                                FieldDomains.BoundaryStanding> standing) {
         if (clause instanceof Core.LetIn li) {
             direct(li.body(), from, part, terms.inside(li, at), byName, out, noLines,
                     withoutAnEnd, naming, namingTheStrings, narrowers, raised, took, typeAt, parts,
-                    raisedByPart, standing, withoutParts);
-            return;
-        }
-        // A part this reading was not asked for is walked no further.
-        //
-        // Here as well as in the reader of predicates, because the two walk the clause together: a
-        // part this one reached that the other never read is a value whose rules were not gathered
-        // ({@link APartNoReadingSaw}), and leaving it out of one walk alone is exactly that.
-        if (withoutParts.excludes(from, clause)) {
+                    raisedByPart, standing);
             return;
         }
         // What one part states may be more than one rule: a part that names a rule is that rule's
@@ -1710,10 +1713,10 @@ public final class InvariantChecker {
                 && joined.how() == ConditionJoin.BOTH && joined.positive()) {
             statedIn(joined.left(), from, part, at, byName, out, noLines, withoutAnEnd, naming,
                     namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart,
-                    standing, withoutParts);
+                    standing);
             statedIn(joined.right(), from, part, at, byName, out, noLines, withoutAnEnd, naming,
                     namingTheStrings, narrowers, raised, took, typeAt, parts, raisedByPart,
-                    standing, withoutParts);
+                    standing);
             return;
         }
         // What a rule about the strings at a position says about where they stop, which is a rule

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1763,7 +1763,7 @@ public final class InvariantChecker {
         // did to it. Every shape of rule alike: whether an end is read from it below decides which
         // reader states where the values stop, and decides nothing about which conjuncts account
         // for where they stop.
-        aboutOneCoordinate(read, part, bin, naming);
+        aboutOneCoordinate(read, part, naming);
         // The coordinate-bearing side read as the left one, as `0 <= value` says what `value >= 0`
         // says.
         //
@@ -2324,7 +2324,7 @@ public final class InvariantChecker {
             // position measured by a count of itself has one of those, and a rule about the strings
             // is about neither that count nor whichever of the two this map happens to hold.
             NumberAt<RuleKey> value = NumberAt.valueOf(found.path());
-            naming.add(new FieldDomains.AboutOneCoordinate(value, part, clause));
+            aboutOneCoordinate(value, part, naming);
             // And the strings only where the rule was read to them. What a rule this could not read
             // admits is not every string; it is not known, and a run read off what the reading left
             // would be a run of a set the rule does not have. Whether it states where the values
@@ -2525,13 +2525,24 @@ public final class InvariantChecker {
      * what the rules leave the coordinate without this conjunct
      * ({@link FieldDomains#movedEndsOf}).
      */
-    private static void aboutOneCoordinate(CanonicalForm read, PartId part, Core.Binary bin,
+    private static void aboutOneCoordinate(CanonicalForm read, PartId part,
                                           List<FieldDomains.AboutOneCoordinate> out) {
         if (!(read instanceof CanonicalForm.Over over) || over.numbers().size() != 1) {
             return;
         }
-        out.add(new FieldDomains.AboutOneCoordinate(over.numbers().iterator().next().at(), part,
-                bin));
+        aboutOneCoordinate(over.numbers().iterator().next().at(), part, out);
+    }
+
+    /**
+     * One candidate, kept once. A part reaching one number twice is one thing to ask a
+     * counterfactual about, because taking a part away takes away everything it stated.
+     */
+    private static void aboutOneCoordinate(NumberAt<RuleKey> at, PartId part,
+                                           List<FieldDomains.AboutOneCoordinate> out) {
+        FieldDomains.AboutOneCoordinate said = new FieldDomains.AboutOneCoordinate(at, part);
+        if (!out.contains(said)) {
+            out.add(said);
+        }
     }
 
     /** One finding, kept once. A coordinate reached twice is one place with one thing to say. */

--- a/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartsLeftOut.java
@@ -1,29 +1,30 @@
 package souther.compiler.check;
 
-import souther.compiler.core.Core;
-
 import java.util.Set;
 
 /**
  * Which authored part of which rule a reading was asked to leave out.
  *
  * <p>Beside {@link RulesLeftOut} and not a finer setting of it. That one leaves out every rule some
- * declaration wrote, and what it is asked with is a declaration; this leaves out one conjunct of one
- * rule, and what it is asked with is that rule together with the node the conjunct was written as.
- * The two are different questions about different things, and a reading told to leave out "a part"
- * with no rule beside it would leave out whatever else happened to be written the same way.
+ * declaration wrote, and what it is asked with is a declaration; this leaves out one part of one
+ * rule, and what it is asked with is the name that part was issued under. The two are different
+ * questions about different things, and a reading told to leave out "a part" with no rule beside it
+ * would leave out whatever else happened to be written the same way.
+ *
+ * <p><b>The name and not the tree.</b> A part is named where a clause is split ({@link PartId}), so
+ * a reading told to leave one out is told which one and has nothing to recognise. Named by its tree
+ * instead, every reading that had to skip it matched a node — and a reading asked without a part
+ * types the clause again, so what it walks is a node equal to the one named rather than the same
+ * one, which is a match that holds only while two identical parts of one clause never both come up.
  *
  * <p>What such a reading is for is not here. A reader comparing what a value's rules leave with and
- * without one conjunct is asking what that conjunct was holding; nothing about the comparison
- * belongs to the reading that answers it.
+ * without one part is asking what that part was holding; nothing about the comparison belongs to
+ * the reading that answers it.
  */
 sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
 
     /** Every part of every rule is read. */
     PartsLeftOut NONE = new Nothing();
-
-    /** What the parts a reading takes in come to for one rule. */
-    Predicates.PartsToRead of(RuleRef.Invariant rule);
 
     /** Whether anything at all is left out, which is what a reading standing in for a
      *  counterfactual is. Asked of the arms rather than of one of them, so that an arm added is a
@@ -31,45 +32,37 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
     boolean leavesAnythingOut();
 
     /**
-     * Whether this reading was asked to leave {@code part} of {@code rule} out.
+     * Whether this reading was asked to leave {@code part} out.
      *
-     * <p>Off {@link #of} and not beside it. Two walks over one clause skip the part together — a
-     * part one reached that the other never read is a value whose rules were not gathered — so
-     * asking in two ways is two answers that have to agree, and there is one.
+     * <p>Asked once, by everything that walks the clause. Two walks over one clause skip the part
+     * together — a part one reached that the other never read is a value whose rules were not
+     * gathered — so asking in two ways is two answers that have to agree, and there is one.
      */
-    default boolean excludes(RuleRef.Invariant rule, Core part) {
-        return !of(rule).includes(part);
-    }
+    boolean excludes(PartId part);
 
     /** Nothing is left out. */
     record Nothing() implements PartsLeftOut {
 
         @Override
-        public Predicates.PartsToRead of(RuleRef.Invariant rule) {
-            return Predicates.PartsToRead.ALL;
+        public boolean leavesAnythingOut() {
+            return false;
         }
 
         @Override
-        public boolean leavesAnythingOut() {
+        public boolean excludes(PartId part) {
             return false;
         }
     }
 
     /**
-     * Some conjuncts of some rules are left out.
+     * Some parts of some rules are left out.
      *
      * <p>A set, because that is what a counterfactual reading is asked. Which of the candidates
      * account for an end is three questions and two of them take more than one away at a time — one
      * candidate is missed on its own, and one holds the end with every other candidate gone — so a
      * scope that could only name one would answer the first and stop.
-     *
-     * <p>The node and not a number. Which conjunct of a clause a part is is counted by more than one
-     * reading, and they count alike only where a clause is read positively — so what is named here
-     * is the node itself, which is the identity a part already has everywhere it is recorded. Held
-     * as a value: a reading asked to leave a part out types the clause again, and what it walks is
-     * a node equal to the one named here rather than the same one.
      */
-    record Some(Set<AuthoredPart> parts) implements PartsLeftOut {
+    record Some(Set<PartId> parts) implements PartsLeftOut {
 
         public Some {
             parts = Set.copyOf(parts);
@@ -79,39 +72,18 @@ sealed interface PartsLeftOut permits PartsLeftOut.Nothing, PartsLeftOut.Some {
         }
 
         @Override
-        public Predicates.PartsToRead of(RuleRef.Invariant of) {
-            Set<Core> here = parts.stream().filter(each -> each.part().rule().equals(of))
-                    .map(AuthoredPart::read).collect(java.util.stream.Collectors.toSet());
-            return here.isEmpty() ? Predicates.PartsToRead.ALL
-                    : Predicates.PartsToRead.without(here);
-        }
-
-        @Override
         public boolean leavesAnythingOut() {
             return true;
         }
-    }
 
-    /**
-     * One part of one rule, which is what a counterfactual reading is asked without.
-     *
-     * <p>Named by what the split that wrote the parts down called it, and holding the tree the
-     * reading of predicates matches on. The tree is not the identity: it is how the reading that
-     * walks a clause recognises the part it was told to leave out, and a reading asked without a
-     * part types the clause again, so what it walks is a node equal to this one rather than the
-     * same one.
-     */
-    record AuthoredPart(PartId part, Core read) {
-
-        public AuthoredPart {
-            if (part == null || read == null) {
-                throw new IllegalArgumentException("a part left out is some rule's own");
-            }
+        @Override
+        public boolean excludes(PartId part) {
+            return parts.contains(part);
         }
     }
 
     /** Every part but these. */
-    static PartsLeftOut without(Set<AuthoredPart> parts) {
+    static PartsLeftOut without(Set<PartId> parts) {
         return parts.isEmpty() ? NONE : new Some(parts);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -96,22 +96,6 @@ final class Predicates {
      * quantifier is recorded — denying one says some element fails the predicate, and which one is
      * not something this check can name. */
     void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
-        quantifiedBy(raw, at, positive, out, PartsToRead.ALL);
-    }
-
-    /**
-     * The same, reading only the parts {@code parts} asks for.
-     *
-     * <p>The same selection the obligations of a clause are read under, because they are read out
-     * of one clause. A conjunct left out of the one and left in the other is a clause taken half
-     * away, and what would come back is a guarantee assembled from two clauses — the whole one and
-     * the one the caller asked about.
-     */
-    void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out,
-                      PartsToRead parts) {
-        if (!parts.includes(raw)) {
-            return;
-        }
         Core e = Conditions.asSizeComparison(raw);
         // A clause under a binding states what the clause states, read where its names mean
         // something — the same rule the obligations of this clause are read under, and applied here
@@ -119,19 +103,19 @@ final class Predicates {
         // stated through a helper was owed by the one reading and unknown to the other, which is a
         // guarantee assembled from a clause read to two depths.
         if (e instanceof Core.LetIn li) {
-            quantifiedBy(li.body(), terms.inside(li, at), positive, out, parts);
+            quantifiedBy(li.body(), terms.inside(li, at), positive, out);
             return;
         }
         if (e instanceof Core.Binary b
                 && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
                         == ConditionJoin.BOTH) {
-            quantifiedBy(b.left(), at, positive, out, parts);
-            quantifiedBy(b.right(), at, positive, out, parts);
+            quantifiedBy(b.left(), at, positive, out);
+            quantifiedBy(b.right(), at, positive, out);
             return;
         }
         Conditions.Restated under = Conditions.restated(e);
         if (under != null) {
-            quantifiedBy(under.condition(), at, under.denied() != positive, out, parts);
+            quantifiedBy(under.condition(), at, under.denied() != positive, out);
             return;
         }
         if (!positive || !(e instanceof Core.PreservedCall call)
@@ -571,8 +555,7 @@ final class Predicates {
      * happened to be holding decide what a declaration says. The parameter is gone rather than
      * ignored: what is not there cannot come to be read. */
     Owed assumed(Core inv, Denotations at, boolean decidesFalse) {
-        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, null,
-                PartsToRead.ALL);
+        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, null);
     }
 
     /**
@@ -584,56 +567,12 @@ final class Predicates {
      * changes one of them.
      */
     Owed assumed(Core inv, Denotations at, boolean decidesFalse, PerPart per) {
-        return assumed(inv, at, decidesFalse, per, PartsToRead.ALL);
-    }
-
-    /**
-     * The same, reading only the parts {@code parts} asks for.
-     *
-     * <p>What a clause comes to with one of its conjuncts left out, which is what a reader asking
-     * what that conjunct was holding compares against. Left out here rather than by handing over a
-     * clause with the conjunct cut out of it: which nodes of an expression are its conjuncts is this
-     * reader's answer, and a caller rebuilding the clause without one would be deciding it a second
-     * time.
-     */
-    Owed assumed(Core inv, Denotations at, boolean decidesFalse, PerPart per, PartsToRead parts) {
-        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, per,
-                parts);
+        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, per);
     }
 
     /** Told what one part of a clause owed, keyed by the part it was read from. */
     interface PerPart {
         void read(Core part, Owed owed);
-    }
-
-    /**
-     * Which parts of a clause this reading takes in.
-     *
-     * <p>A conjunction is read a conjunct at a time here, and this is where a caller says which of
-     * those conjuncts it asked for. Nothing about why: a reading that leaves a part out to find what
-     * that part was holding, and one that leaves it out for any other reason, are one reading here.
-     * What the answer is for belongs to whoever asked, and a reader of predicates that knew would be
-     * deciding a caller's business in the middle of a semantic walk.
-     *
-     * <p>Asked of the node the clause was written as, which is the identity a part already has
-     * ({@link PerPart}). As a value and not by reference: a counterfactual reading types the
-     * declaration's clauses again, so the nodes it walks are not the nodes the first reading
-     * handed out, and a part named by reference would match nothing at all. What keeps two
-     * conjuncts written alike apart is where they are written, which every node carries.
-     */
-    @FunctionalInterface
-    interface PartsToRead {
-
-        /** Every part the clause has. */
-        PartsToRead ALL = _ -> true;
-
-        /** Whether this reading takes {@code part} in. */
-        boolean includes(Core part);
-
-        /** Every part but {@code excluded}, which is what a counterfactual reading asks for. */
-        static PartsToRead without(java.util.Set<Core> excluded) {
-            return part -> !excluded.contains(part);
-        }
     }
 
     /**
@@ -703,7 +642,7 @@ final class Predicates {
         // What each handed-over value is, worked out once and where the site stands. Read again
         // further down, a value under a binding would be asked about at names the site never had.
         return obligations(inv, at, handedOver(unnamed, at), true, decidesFalse,
-                Discharge.spending(k), null, PartsToRead.ALL);
+                Discharge.spending(k), null);
     }
 
     /**
@@ -715,15 +654,9 @@ final class Predicates {
      */
     private Owed obligations(Core rawInv, Denotations at, Set<FactSubject> unnamed,
                              boolean positive, boolean decidesFalse, Discharge discharge,
-                             PerPart per, PartsToRead parts) {
-        // A clause of one conjunct is that conjunct, so a caller leaving it out leaves out the
-        // whole of what the clause states. The halves of a conjunction are answered where they are
-        // split, which is the one place that knows a clause has halves.
-        if (!parts.includes(rawInv)) {
-            return Owed.unread();
-        }
+                             PerPart per) {
         Owed out = read(Conditions.asSizeComparison(rawInv), at, unnamed, positive, decidesFalse,
-                discharge, per, parts);
+                discharge, per);
         if (per != null) {
             // Keyed by the part as it was handed in, which is the node a reader of this walk holds.
             // What it was rewritten to on the way is this reading's business.
@@ -736,7 +669,7 @@ final class Predicates {
      * which is where each of them is taken as the comparison it states. */
     private Owed read(Core inv, Denotations at, Set<FactSubject> unnamed,
                       boolean positive, boolean decidesFalse, Discharge discharge,
-                      PerPart per, PartsToRead parts) {
+                      PerPart per) {
         // A clause under a binding states what the clause states, read where its names mean
         // something. Almost every binding here is one a helper's expansion made, so a rule stated
         // through a helper is one of these — and read as it stands it is a shape stating no
@@ -745,7 +678,7 @@ final class Predicates {
         // environment's answer, and this asks for it (ADR-0106).
         if (inv instanceof Core.LetIn li) {
             return obligations(li.body(), terms.inside(li, at), unnamed, positive, decidesFalse,
-                    discharge, per, parts);
+                    discharge, per);
         }
         if (inv instanceof Core.Binary b
                 && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
@@ -754,27 +687,14 @@ final class Predicates {
             // cannot read leaves its own run-time check standing without costing the others theirs.
             // That it stands is carried rather than dropped — the other half being discharged is
             // not the invariant proven.
-            //
-            // A half a caller did not ask for is the other half alone, which is what a clause
-            // without one of its conjuncts states. Not an empty answer composed with the other:
-            // what a conjunction comes to is its conjuncts together, and there is nothing here for
-            // a conjunct nobody read to contribute.
-            if (!parts.includes(b.left())) {
-                return obligations(b.right(), at, unnamed, positive, decidesFalse, discharge, per,
-                        parts);
-            }
-            if (!parts.includes(b.right())) {
-                return obligations(b.left(), at, unnamed, positive, decidesFalse, discharge, per,
-                        parts);
-            }
-            return obligations(b.left(), at, unnamed, positive, decidesFalse, discharge, per, parts)
+            return obligations(b.left(), at, unnamed, positive, decidesFalse, discharge, per)
                     .and(obligations(b.right(), at, unnamed, positive, decidesFalse, discharge,
-                            per, parts));
+                            per));
         }
         Conditions.Restated under = Conditions.restated(inv);
         if (under != null) {
             return obligations(under.condition(), at, unnamed, under.denied() != positive,
-                    decidesFalse, discharge, per, parts);
+                    decidesFalse, discharge, per);
         }
         ComparisonReadings readings = Conditions.comparisonsStatedBy(terms, inv, at);
         if (readings.inReadingOrder().isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -90,51 +90,79 @@ final class Predicates {
         return assume(assumed(stated, at, false), k, Known.Held.ON_THE_PATH).and(nested);
     }
 
-    /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
-     * Mirrors {@link #obligations}: a connective that composes both halves under the polarity in
-     * force states each of them under it, and a negation turns the polarity over. Only a stated
-     * quantifier is recorded — denying one says some element fails the predicate, and which one is
-     * not something this check can name. */
+    /** What {@code raw}, asserted with polarity {@code positive}, says of every element of a
+     * container, added to {@code out}. Read over the clause's shape as {@link #obligations} is, so
+     * the two agree about which parts a clause has by having been given the same answer. */
     void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
-        Core e = Conditions.asSizeComparison(raw);
-        // A clause under a binding states what the clause states, read where its names mean
-        // something — the same rule the obligations of this clause are read under, and applied here
-        // because the two are read out of one clause. Stopping here alone, a quantifier an author
-        // stated through a helper was owed by the one reading and unknown to the other, which is a
-        // guarantee assembled from a clause read to two depths.
-        if (e instanceof Core.LetIn li) {
-            quantifiedBy(li.body(), terms.inside(li, at), positive, out);
-            return;
+        out.addAll(new Quantifiers(this).read(raw, positive, at, terms::inside));
+    }
+
+    /**
+     * The quantifiers a clause states, read over the shape it was written in.
+     *
+     * <p>Over the shape ({@link ClauseExpr}), so a clause under a binding is read where its names
+     * mean something and a helper's expansion states what the same rule written out states. Read
+     * as a tree of its own, a quantifier an author stated through a helper was owed by the reading
+     * of what the clause owes and unknown to this one, which is a guarantee assembled from a clause
+     * read to two depths.
+     */
+    private record Quantifiers(Predicates of)
+            implements ClauseReading<List<Quantified>, Denotations> {
+
+        /**
+         * A conjunction states what both of its conjuncts state, and a choice is read whole.
+         *
+         * <p>Only a stated quantifier is recorded, and what a choice states is neither of its
+         * sides — one of them holds and this cannot say which — so the whole of it is read as a
+         * part, where nothing names a quantifier.
+         */
+        @Override
+        public Descent<List<Quantified>> at(ClauseExpr.Joined join) {
+            return switch (join.how()) {
+                case BOTH -> new Descent.Into<>(Quantifiers::together);
+                case EITHER -> new Descent.Whole<>();
+            };
         }
-        if (e instanceof Core.Binary b
-                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
-                        == ConditionJoin.BOTH) {
-            quantifiedBy(b.left(), at, positive, out);
-            quantifiedBy(b.right(), at, positive, out);
-            return;
+
+        @Override
+        public List<Quantified> whole(Core e, boolean positive, Denotations at) {
+            return of.quantifierStatedBy(Conditions.asSizeComparison(e), positive, at);
         }
-        Conditions.Restated under = Conditions.restated(e);
-        if (under != null) {
-            quantifiedBy(under.condition(), at, under.denied() != positive, out);
-            return;
+
+        private static List<Quantified> together(List<Quantified> left, List<Quantified> right) {
+            if (left.isEmpty() || right.isEmpty()) {
+                return left.isEmpty() ? right : left;
+            }
+            List<Quantified> both = new ArrayList<>(left);
+            both.addAll(right);
+            return both;
         }
+    }
+
+    /**
+     * The quantifier {@code e} is, where it is one, stated over the element it quantifies.
+     *
+     * <p>Denying one says some element fails the predicate, and which one is not something this
+     * check can name, so a denied quantifier states nothing here.
+     */
+    private List<Quantified> quantifierStatedBy(Core e, boolean positive, Denotations at) {
         if (!positive || !(e instanceof Core.PreservedCall call)
                 || !DischargeRules.isQuantifier(call.operation())) {
-            return;
+            return List.of();
         }
         Handed over = Combinators.handedTo(call, at);
         Carrying carried = DischargeRules.carried(call);
         if (over == null || carried == null || over.step().params().size() != 1) {
-            return;
+            return List.of();
         }
         // The container is the carrying rule's, which is the one argument this predicate is about.
         // What the operation hands its closure answers the same question about the same argument, and
         // is asked here only for the closure.
         FactSubject container = terms.subjectOf(carried.container(), at);
         if (container == null) {
-            return;
+            return List.of();
         }
-        out.add(new Quantified(container, carried.through(), over.step()));
+        return List.of(new Quantified(container, carried.through(), over.step()));
     }
 
     /**
@@ -655,47 +683,54 @@ final class Predicates {
     private Owed obligations(Core rawInv, Denotations at, Set<FactSubject> unnamed,
                              boolean positive, boolean decidesFalse, Discharge discharge,
                              PerPart per) {
-        Owed out = read(Conditions.asSizeComparison(rawInv), at, unnamed, positive, decidesFalse,
-                discharge, per);
-        if (per != null) {
-            // Keyed by the part as it was handed in, which is the node a reader of this walk holds.
-            // What it was rewritten to on the way is this reading's business.
-            per.read(rawInv, out);
-        }
-        return out;
+        return new Owing(this, unnamed, decidesFalse, discharge)
+                .read(rawInv, positive, at, terms::inside,
+                        per == null ? null : (part, owed) -> per.read(part, owed));
     }
 
-    /** What {@code inv} owes, read as it stands. Its parts are read through {@link #obligations},
-     * which is where each of them is taken as the comparison it states. */
-    private Owed read(Core inv, Denotations at, Set<FactSubject> unnamed,
-                      boolean positive, boolean decidesFalse, Discharge discharge,
-                      PerPart per) {
-        // A clause under a binding states what the clause states, read where its names mean
-        // something. Almost every binding here is one a helper's expansion made, so a rule stated
-        // through a helper is one of these — and read as it stands it is a shape stating no
-        // comparison, which is why a construction the guards refute was only ever refuted where the
-        // author had written the rule out. What the binder means is not worked out here: it is the
-        // environment's answer, and this asks for it (ADR-0106).
-        if (inv instanceof Core.LetIn li) {
-            return obligations(li.body(), terms.inside(li, at), unnamed, positive, decidesFalse,
-                    discharge, per);
+    /**
+     * What a clause owes, read over the shape it was written in.
+     *
+     * <p>Over the shape ({@link ClauseExpr}), so that what a connective composes is recognised in
+     * one place and this reading agrees with every other by having been given the answer. A binding
+     * is where the environment changes, which is why a rule stated through a helper owes what the
+     * same rule written out owes — read as a shape with no word for it, such a rule owed nothing
+     * and a construction the guards refute went unreported.
+     *
+     * <p>What it carries beside the clause is what a caller settled before the reading began: the
+     * values the site hands over that no clause may be read against, whether a clause folding false
+     * decides the construction, and which relations this reading may take in. None of them turns on
+     * where in the clause the reading stands.
+     */
+    private record Owing(Predicates of, Set<FactSubject> unnamed, boolean decidesFalse,
+                         Discharge discharge) implements ClauseReading<Owed, Denotations> {
+
+        /**
+         * A conjunction owes what both of its conjuncts owe, and a choice is read whole.
+         *
+         * <p>Each half of a conjunction on its own: an invariant is a set of things that hold, and
+         * one the check cannot read leaves its own run-time check standing without costing the
+         * others theirs. A choice states neither of its parts — one of them holds and this cannot
+         * say which — so what is handed to the reader of comparisons is the whole of it.
+         */
+        @Override
+        public Descent<Owed> at(ClauseExpr.Joined join) {
+            return switch (join.how()) {
+                case BOTH -> new Descent.Into<>(Owed::and);
+                case EITHER -> new Descent.Whole<>();
+            };
         }
-        if (inv instanceof Core.Binary b
-                && ConditionJoin.of(b.op()).map(join -> join.under(positive)).orElse(null)
-                        == ConditionJoin.BOTH) {
-            // Each half on its own: an invariant is a set of things that hold, and one the check
-            // cannot read leaves its own run-time check standing without costing the others theirs.
-            // That it stands is carried rather than dropped — the other half being discharged is
-            // not the invariant proven.
-            return obligations(b.left(), at, unnamed, positive, decidesFalse, discharge, per)
-                    .and(obligations(b.right(), at, unnamed, positive, decidesFalse, discharge,
-                            per));
+
+        @Override
+        public Owed whole(Core e, boolean positive, Denotations at) {
+            return of.owing(Conditions.asSizeComparison(e), at, unnamed, positive, decidesFalse,
+                    discharge);
         }
-        Conditions.Restated under = Conditions.restated(inv);
-        if (under != null) {
-            return obligations(under.condition(), at, unnamed, under.denied() != positive,
-                    decidesFalse, discharge, per);
-        }
+    }
+
+    /** What one part of a clause owes, read as the comparison it states. */
+    private Owed owing(Core inv, Denotations at, Set<FactSubject> unnamed,
+                       boolean positive, boolean decidesFalse, Discharge discharge) {
         ComparisonReadings readings = Conditions.comparisonsStatedBy(terms, inv, at);
         if (readings.inReadingOrder().isEmpty()) {
             return owedBy(inv, at, unnamed, positive, decidesFalse);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -472,11 +472,6 @@ sealed interface StatedByClauses {
             return terms::inside;
         }
 
-        /** What a clause this reading has no word for leaves, which is everything it had. */
-        StatedByClauses nothingSaid() {
-            return top(ordered.carriers());
-        }
-
         /** Either reading holding, as each language says it and the whole is held. */
         private Confinement.Planned<FactSubject> either(Confinement.Planned<FactSubject> one,
                                                        Confinement.Planned<FactSubject> other) {
@@ -550,6 +545,17 @@ sealed interface StatedByClauses {
          * a choice would be a conjunct of each of its alternatives, and each question the choice
          * asks of an alternative — whether anything read it, what it left open — would be answered
          * from a clause written outside the brackets.
+         *
+         * <p><b>And a choice's id is minted here</b>, where the two alternatives are what stands
+         * between the brackets, at the {@code ||} an author wrote them with.
+         *
+         * <p>Given no identity, an alternative nothing could read would have nowhere to stand and
+         * an author would be sent to a branch that was read; given no place, nothing downstream
+         * could put it in the order it was written in.
+         *
+         * <p>Which of the branches anybody can be in is not decided here. It is a question about
+         * the values, settled where the values are worked out ({@link #together},
+         * {@link #settling}), and what comes back to this tree is the fate.
          */
         @Override
         public Descent<StatedByClauses> at(ClauseExpr.Joined join) {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -472,8 +472,8 @@ sealed interface StatedByClauses {
             return terms::inside;
         }
 
-        @Override
-        public StatedByClauses nothingSaid() {
+        /** What a clause this reading has no word for leaves, which is everything it had. */
+        StatedByClauses nothingSaid() {
             return top(ordered.carriers());
         }
 
@@ -493,7 +493,7 @@ sealed interface StatedByClauses {
          * than one.
          */
         @Override
-        public StatedByClauses leaf(Core e, boolean positive, Denotations at) {
+        public StatedByClauses whole(Core e, boolean positive, Denotations at) {
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);
@@ -552,7 +552,18 @@ sealed interface StatedByClauses {
          * from a clause written outside the brackets.
          */
         @Override
-        public StatedByClauses both(StatedByClauses one, StatedByClauses other) {
+        public Descent<StatedByClauses> at(ClauseExpr.Joined join) {
+            // Both connectives are read to the end, because this state composes either of them: a
+            // choice between two readings of the whole value is a reading of the whole value, and
+            // an alternative that cannot be taken is dropped by asking everything known about it.
+            return switch (join.how()) {
+                case BOTH -> new Descent.Into<>(Both::new);
+                case EITHER -> new Descent.Into<>(
+                        (one, other) -> new Either(new ChoiceId(), join.of(), one, other));
+            };
+        }
+
+        private StatedByClauses both(StatedByClauses one, StatedByClauses other) {
             return new Both(one, other);
         }
 
@@ -568,23 +579,6 @@ sealed interface StatedByClauses {
         @Override
         public StatedByClauses from(Core e, StatedByClauses out) {
             return new CameFrom(e, out);
-        }
-
-        /**
-         * Either alternative holding, at the {@code ||} an author wrote it with.
-         *
-         * <p>The id is minted here, where the two alternatives are what stands between the
-         * brackets. Given no identity, an alternative nothing could read would have nowhere to
-         * stand and an author would be sent to a branch that was read; given no place, nothing
-         * downstream could put it in the order it was written in.
-         *
-         * <p>Which of the branches anybody can be in is not decided here. It is a question about
-         * the values, settled where the values are worked out ({@link #together},
-         * {@link #settling}), and what comes back to this tree is the fate.
-         */
-        @Override
-        public StatedByClauses either(Core writtenAt, StatedByClauses one, StatedByClauses other) {
-            return new Either(new ChoiceId(), writtenAt, one, other);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -563,10 +563,6 @@ sealed interface StatedByClauses {
             };
         }
 
-        private StatedByClauses both(StatedByClauses one, StatedByClauses other) {
-            return new Both(one, other);
-        }
-
         /**
          * What was read, remembering that it is what {@code e} came to.
          *

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -165,17 +165,27 @@ final class TypeGuarantees {
                                PartsLeftOut withoutParts) {
         // Where this clause becomes a rule of the model something can be attributed to. Settled here
         // so that no reader of the reading has to decide which of the rules of the model it holds.
-        RuleRef.Invariant rule = new RuleRef.Invariant(one.clause().ref());
-        // Which of this clause's conjuncts the caller asked for, and the same answer for everything
-        // read out of it. A guarantee is what one clause states, so a reading that took a conjunct
-        // out of what it owes and left it in what it quantifies would be a clause half taken away.
-        Predicates.PartsToRead read = withoutParts.of(rule);
         List<TypeGuarantee.Part> parts = new ArrayList<>();
-        Predicates.Owed owed = predicates.assumed(one.expr(), denotations, false,
-                (part, said) -> parts.add(new TypeGuarantee.Part(part, said)), read);
         List<Quantified> quantified = new ArrayList<>();
-        predicates.quantifiedBy(one.expr(), denotations, true, quantified, read);
-        return new TypeGuarantee(one.expr(), one.parts(), owed, quantified, parts);
+        // A part at a time, and the ones the caller asked for. Which parts a clause has was settled
+        // where it was split, so leaving one out is leaving a part out of the list and never a node
+        // out of a walk — and the same list answers for what the clause owes and for what it
+        // quantifies, since a part left out of the one and left in the other is a clause taken half
+        // away.
+        Predicates.Owed owed = null;
+        for (Clauses.StatedPart part : one.parts()) {
+            if (withoutParts.excludes(part.id())) {
+                continue;
+            }
+            Predicates.Owed said = predicates.assumed(part.expr(), denotations, false,
+                    (of, came) -> parts.add(new TypeGuarantee.Part(of, came)));
+            owed = owed == null ? said : owed.and(said);
+            predicates.quantifiedBy(part.expr(), denotations, true, quantified);
+        }
+        // Nothing owed where every part was left out, which is a clause with all of it taken away
+        // and not a clause that holds.
+        return new TypeGuarantee(one.expr(), one.parts(),
+                owed == null ? Predicates.Owed.unread() : owed, quantified, parts);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
@@ -51,24 +51,15 @@ class AClauseUnderABindingIsReadInsideItTest {
         private final List<AtALeaf> leaves = new ArrayList<>();
 
         @Override
-        public List<AtALeaf> nothingSaid() {
-            return List.of();
-        }
-
-        @Override
-        public List<AtALeaf> leaf(Core e, boolean positive, String at) {
+        public List<AtALeaf> whole(Core e, boolean positive, String at) {
             leaves.add(new AtALeaf(e, positive, at));
             return List.of(leaves.get(leaves.size() - 1));
         }
 
+        /** Both connectives are walked into, since what is being recorded is what reached a part. */
         @Override
-        public List<AtALeaf> both(List<AtALeaf> one, List<AtALeaf> other) {
-            return joined(one, other);
-        }
-
-        @Override
-        public List<AtALeaf> either(Core writtenAt, List<AtALeaf> one, List<AtALeaf> other) {
-            return joined(one, other);
+        public Descent<List<AtALeaf>> at(ClauseExpr.Joined join) {
+            return new Descent.Into<>(Recording::joined);
         }
 
         private static List<AtALeaf> joined(List<AtALeaf> one, List<AtALeaf> other) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAuthoredPartThatStatesTwoRulesIsReadAsOnePartTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAuthoredPartThatStatesTwoRulesIsReadAsOnePartTest.java
@@ -153,16 +153,51 @@ class AnAuthoredPartThatStatesTwoRulesIsReadAsOnePartTest {
     /** What is left of the other readings of the same clause. */
     @Test
     void whatTheOtherReadingsOfTheClauseLeave() {
-        assertEquals(List.of(2, 2), List.of(
+        // Two parts written out and one part named, because what a counterfactual reading can be
+        // asked without is a part: the two rules of the named spelling are one thing to take away
+        // and the two conjuncts of the written-out one are two.
+        assertEquals(List.of(2, 1), List.of(
                         writtenOut().aboutOneCoordinate().size(),
                         named().aboutOneCoordinate().size()),
-                "how many rules are read as being about one number");
+                "how many parts are read as being about one number");
         assertEquals(List.of(0, 0), List.of(
                         writtenOut().noLines().size(), named().noLines().size()),
                 "how many parts left no line at a number they are about");
         assertEquals(List.of(0, 0), List.of(
                         writtenOut().movedEnds().size(), named().movedEnds().size()),
                 "how many ends a counterfactual reading found another part holding");
+    }
+
+    /**
+     * And a counterfactual reading names the part once, however many of its rules reach the number.
+     *
+     * <p>What such a reading is asked without is a part an author wrote: half of a rule named
+     * through a helper is not something they can take away, so a part whose rules both bear on one
+     * number is one candidate to ask about. Held as two — one per subtree a rule was read from —
+     * every question about either is a question asked without the part they share, and the part
+     * comes back holding an end it holds once as though it held it twice.
+     *
+     * <p>Two rules no end is read from, because that is the reading that attributes an end at all:
+     * where a part placed a line of its own, where the values stop and who put them there is the
+     * reading of ends' answer and this is not asked.
+     */
+    @Test
+    void aPartIsNamedOnceHoweverManyOfItsRulesReachTheNumber() {
+        String rules = "%s * 2 >= 4 && %s * 3 >= 3";
+
+        assertEquals(List.of("0 true Endpoint[at=2, inclusive=true]"),
+                ends(read("", rules.formatted("value", "value"))),
+                "which part holds the lower end where the two rules were written out");
+        assertEquals(List.of("0 true Endpoint[at=2, inclusive=true]"),
+                ends(read("let two (n: Int) = " + rules.formatted("n", "n"), "two(value)")),
+                "and the same one part, named once, where they were named as one");
+    }
+
+    /** Each end a counterfactual found another part holding: whose part, which side, and where. */
+    private static List<String> ends(FieldDomains of) {
+        return of.movedEnds().stream()
+                .map(each -> each.part().ordinal() + " " + each.lower() + " " + each.end())
+                .toList();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/HowFarTheReadingOfWhatAClauseOwesDescendsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowFarTheReadingOfWhatAClauseOwesDescendsTest.java
@@ -30,6 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ({@code PerPart}), rather than on what any of them came to. What a conjunct owes is the reader of
  * comparisons' answer and is held elsewhere; how far the walk went is this reading's own, and it is
  * the thing that moves when a clause's shape is recognised somewhere else.
+ *
+ * <p>What it is told is keyed by the node, and the order below is the order the shape is walked in:
+ * what a part came to before what the connective composing it came to, and a node a restatement was
+ * written as before the node under it. A caller reads what it was told by the node it holds, so the
+ * order is not what any of them takes from it.
  */
 class HowFarTheReadingOfWhatAClauseOwesDescendsTest {
 
@@ -95,8 +100,8 @@ class HowFarTheReadingOfWhatAClauseOwesDescendsTest {
         Core.Binary either = joined(BinOp.OR, atLeastOne(), atMostNine());
         Core.Binary neither = denied(either);
 
-        assertEquals(List.of(atLeastOne(), atMostNine(), either, neither), read(neither),
-                "each part denied, the choice they were written as, and the denial of it");
+        assertEquals(List.of(atLeastOne(), atMostNine(), neither, either), read(neither),
+                "each part denied, and the two nodes the choice and its denial were written as");
     }
 
     /**
@@ -121,8 +126,8 @@ class HowFarTheReadingOfWhatAClauseOwesDescendsTest {
         Core.Binary both = joined(BinOp.AND, atLeastOne(), atMostNine());
         Core.Binary neither = denied(both);
 
-        assertEquals(List.of(both, neither), read(neither),
-                "the conjunction as the choice its denial makes of it, and the denial");
+        assertEquals(List.of(neither, both), read(neither),
+                "the two nodes the conjunction and its denial were written as, and neither half");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/HowFarTheReadingOfWhatAClauseOwesDescendsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowFarTheReadingOfWhatAClauseOwesDescendsTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -76,13 +75,8 @@ class HowFarTheReadingOfWhatAClauseOwesDescendsTest {
 
     /** The parts the reading says it read, in the order it read them. */
     private static List<Core> read(Core clause) {
-        return read(clause, Predicates.PartsToRead.ALL);
-    }
-
-    private static List<Core> read(Core clause, Predicates.PartsToRead asked) {
         List<Core> parts = new ArrayList<>();
-        new Predicates(terms()).assumed(clause, rootAt(), false, (part, _) -> parts.add(part),
-                asked);
+        new Predicates(terms()).assumed(clause, rootAt(), false, (part, _) -> parts.add(part));
         return parts;
     }
 
@@ -132,20 +126,24 @@ class HowFarTheReadingOfWhatAClauseOwesDescendsTest {
     }
 
     /**
-     * A conjunct a caller did not ask for is the other conjunct alone.
+     * What a conjunction owes is what its conjuncts owe together.
      *
-     * <p>Not an empty answer composed with the other: what a conjunction comes to is its conjuncts
-     * together, and there is nothing for a conjunct nobody read to contribute.
+     * <p>Which is why a caller wanting a clause without one of its parts leaves the part out of
+     * the list rather than telling this reading to step over a node: the two come to the same
+     * thing, and the list is where which parts a clause has was settled.
      */
     @Test
-    void aConjunctLeftOutIsTheConjunctBesideItAlone() {
-        Core.Binary both = joined(BinOp.AND, atLeastOne(), atMostNine());
+    void whatAConjunctionOwesIsWhatItsConjunctsOweTogether() {
+        Predicates predicates = new Predicates(terms());
+        Predicates.Owed together = predicates.assumed(
+                joined(BinOp.AND, atLeastOne(), atMostNine()), rootAt(), false);
+        Predicates.Owed apart = predicates.assumed(atLeastOne(), rootAt(), false)
+                .and(predicates.assumed(atMostNine(), rootAt(), false));
 
-        assertEquals(List.of(atMostNine(), both),
-                read(both, Predicates.PartsToRead.without(Set.of(atLeastOne()))),
-                "the conjunct that was asked for, and the clause it is a conjunct of");
-        assertEquals(List.of(), read(both, Predicates.PartsToRead.without(Set.of(both))),
-                "and a clause of one conjunct left out is the whole of what the clause states");
+        assertEquals(together.parts(), apart.parts(),
+                "read as one clause and read a conjunct at a time");
+        assertEquals(together.folded(), apart.folded(),
+                "and the same of what it came to on its own");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
@@ -31,18 +31,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class OnlyAFoldOverAWholeClauseTreeIsOneTest {
 
     /**
-     * The two that read a whole clause tree, and what each of them is.
+     * The ones that read a whole clause tree, and what each of them is.
      *
      * <p>{@code StatedByClauses.Reading} is the reading of a declaration's clauses, which is where
      * both languages are held and where the choices of a rule are decided. {@code ExpansionCost}
      * counts what a clause would expand to, over the same connectives and by the same walk, which
-     * is why it is this and not a walk of its own.
+     * is why it is this and not a walk of its own. {@code Conditions.Stating} says what a condition
+     * states as relations: it composes a conjunction and takes a choice whole, since one part of a
+     * choice holds and it cannot say which — which is answering for the connectives rather than
+     * leaving them owed.
      *
      * <p>A row for a reading of one language — the values, the ranges, or whatever is written next
      * — is the edge this exists to refuse. Those interpret leaves, and the fold that composes them
      * is the one above.
      */
     private static final Set<String> FOLDS = Set.of(
+            "souther.compiler.check.Conditions$Stating",
             "souther.compiler.check.ExpansionCost",
             "souther.compiler.check.StatedByClauses$Reading");
 

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
@@ -39,7 +39,10 @@ class OnlyAFoldOverAWholeClauseTreeIsOneTest {
      * is why it is this and not a walk of its own. {@code Conditions.Stating} says what a condition
      * states as relations: it composes a conjunction and takes a choice whole, since one part of a
      * choice holds and it cannot say which — which is answering for the connectives rather than
-     * leaving them owed.
+     * leaving them owed. {@code Predicates.Owing} says what a clause owes and {@code
+     * Predicates.Quantifiers} says which quantifiers it states: two answers about one clause, each
+     * reading it to the depth its own answer composes to, and both meeting the connectives the
+     * shape already recognised rather than either recognising them again.
      *
      * <p>A row for a reading of one language — the values, the ranges, or whatever is written next
      * — is the edge this exists to refuse. Those interpret leaves, and the fold that composes them
@@ -48,10 +51,12 @@ class OnlyAFoldOverAWholeClauseTreeIsOneTest {
     private static final Set<String> FOLDS = Set.of(
             "souther.compiler.check.Conditions$Stating",
             "souther.compiler.check.ExpansionCost",
+            "souther.compiler.check.Predicates$Owing",
+            "souther.compiler.check.Predicates$Quantifiers",
             "souther.compiler.check.StatedByClauses$Reading");
 
     @Test
-    void theOnlyAlgebrasOverAClauseTreeAreTheTwoThatReadOne() {
+    void theOnlyAlgebrasOverAClauseTreeAreTheOnesThatReadOne() {
         assertEquals(FOLDS, WhatWasCompiled.implementing(ClauseReading.class));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -256,8 +256,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                     "the shape an author wrote a clause in, which is walking into what composes"
                             + " both halves. The one walk that says what the parts are; everything"
                             + " else about them is read off the shape it leaves"),
-            new Held("souther.compiler.check.Conditions.stating",
-                    "the same under a polarity, for what a condition states on its own"),
             new Held("souther.compiler.check.FieldDomains.lambda$projection$2",
                     "walks into both halves for the clause that bounds a field"),
             new Held("souther.compiler.check.Predicates.assumeCond",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -261,10 +261,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
             new Held("souther.compiler.check.Predicates.assumeCond",
                     "walks into both halves under the polarity in force, for what a condition"
                             + " taken in makes known"),
-            new Held("souther.compiler.check.Predicates.quantifiedBy",
-                    "the same, for what it quantifies over"),
-            new Held("souther.compiler.check.Predicates.read",
-                    "the same, for the clauses a rule owes"),
             new Held("souther.compiler.partition.Condition.of",
                     "the composition, which the shape it makes carries"),
             new Held("souther.compiler.partition.ClauseStatements.walk",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
@@ -28,11 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Which readers of a condition cross a binding, which stop at one, and what makes up for it.
  *
  * <p>A rule an author names is expanded where it stands, so a condition written as a call is a
- * binding holding the argument with the rule written against it. Handed such a node, the readers
- * below stop: they recognise a restatement and a connective and then ask for the comparison, and a
- * binding is none of the three. What is under it is the rule, and each of them states it once the
- * environment has been entered — so what stops is the walk to the comparison and not the language
- * that reads one.
+ * binding holding the argument with the rule written against it. What decides whether such a node
+ * is read is the walk to the comparison and never the language that reads one: what is under the
+ * binding is the rule, and each of the readers below states it once the environment has been
+ * entered.
+ *
+ * <p>So the reading that says what a condition states crosses it — it is read over the clause's
+ * shape, which is where a binding is a place the environment changes rather than a form nobody has
+ * a word for. The readers that walk to a comparison for themselves stop: they recognise a
+ * restatement and a connective and then ask for the comparison, and a binding is none of the three.
  *
  * <p>They are not handed one on the way to a construction. The walk that threads knowledge enters a
  * binding standing inside a value and goes on over the rebuilt tree ({@link InvariantChecker}), so
@@ -84,10 +88,10 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
 
     /** What a condition states on its own: the rule written out, and nothing where it was named. */
     @Test
-    void theReadingOfWhatAConditionStatesStopsAtABinding() {
+    void theReadingOfWhatAConditionStatesCrossesABinding() {
         Terms terms = terms();
 
-        assertEquals(List.of(1, 0), List.of(
+        assertEquals(List.of(1, 1), List.of(
                         stated(terms, rule(subject()), rootAt()).size(),
                         stated(terms, named(), rootAt()).size()),
                 "how many relations each spelling states");
@@ -124,18 +128,19 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
     }
 
     /**
-     * What stops is the walk to the comparison and not the language that reads one.
+     * What crosses it is the shape, and what a reader of one part is handed is what is under it.
      *
-     * <p>The body states the rule where the environment has been entered, and the binding itself
-     * states nothing even there: an entered environment is not what such a reader is missing.
+     * <p>The body states the rule where the environment has been entered, and the binding handed to
+     * the part language states nothing even there — it is the walk to the part that crosses one,
+     * and the reader of a part is never given a binding to make sense of (ADR-0106).
      */
     @Test
-    void whatIsUnderTheBindingStatesTheRuleAndTheBindingItselfStatesNothing() {
+    void whatIsUnderTheBindingStatesTheRuleAndThePartLanguageIsNeverGivenOne() {
         Terms terms = terms();
         Core.LetIn named = named();
         Denotations inside = terms.inside(named, rootAt());
 
-        assertEquals(List.of(1, 0), List.of(
+        assertEquals(List.of(1, 1), List.of(
                         stated(terms, named.body(), inside).size(),
                         stated(terms, named, inside).size()),
                 "what is under the binding, and the binding handed whole to the same reader");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
@@ -128,21 +128,24 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
     }
 
     /**
-     * What crosses it is the shape, and what a reader of one part is handed is what is under it.
+     * What stops such a reader is the node and not the environment it would read one in.
      *
-     * <p>The body states the rule where the environment has been entered, and the binding handed to
-     * the part language states nothing even there — it is the walk to the part that crosses one,
-     * and the reader of a part is never given a binding to make sense of (ADR-0106).
+     * <p>Handed what is under the binding, the reader of comparisons states the rule; handed the
+     * binding itself in that same environment, it states nothing. So an entered environment is not
+     * what it is missing — the binding is a form its own walk has no word for, and a reading that
+     * goes over the clause's shape crosses it without ever being handed one (ADR-0106).
      */
     @Test
-    void whatIsUnderTheBindingStatesTheRuleAndThePartLanguageIsNeverGivenOne() {
+    void whatStopsAReaderOfComparisonsIsTheNodeAndNotTheEnvironment() {
         Terms terms = terms();
         Core.LetIn named = named();
         Denotations inside = terms.inside(named, rootAt());
 
-        assertEquals(List.of(1, 1), List.of(
-                        stated(terms, named.body(), inside).size(),
-                        stated(terms, named, inside).size()),
+        assertEquals(List.of(1, 0), List.of(
+                        Conditions.comparisonsStatedBy(terms, named.body(), inside)
+                                .inReadingOrder().size(),
+                        Conditions.comparisonsStatedBy(terms, named, inside)
+                                .inReadingOrder().size()),
                 "what is under the binding, and the binding handed whole to the same reader");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -58,10 +58,6 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
 
             new Licence("souther.compiler.check.Predicates.assumeCond", 1,
                     "the same, for what a condition taken in makes known"),
-            new Licence("souther.compiler.check.Predicates.quantifiedBy", 1,
-                    "the same, for what a rule says of every element of a container"),
-            new Licence("souther.compiler.check.Predicates.read", 1,
-                    "the same, for the clauses a rule owes"),
 
             new Licence("souther.compiler.check.ClauseHelpers.shaped", 1,
                     "the shape an author wrote a clause in, which is walking into what composes"

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -56,9 +56,6 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
                     "the same for a clause, with the denial the tree is read under applied as the"
                             + " shape is made"),
 
-            new Licence("souther.compiler.check.Conditions.stating", 1,
-                    "what a condition states on its own, walked into where the composition under"
-                            + " the polarity in force gives both halves"),
             new Licence("souther.compiler.check.Predicates.assumeCond", 1,
                     "the same, for what a condition taken in makes known"),
             new Licence("souther.compiler.check.Predicates.quantifiedBy", 1,


### PR DESCRIPTION
Closes #1336.

`ClauseExpr` says of itself that it is the one mapping from a clause tree to a shape and that everything downstream is an evaluator over it. The readings that ask what a condition states, what a construction owes, and what a rule says of every element of a container were not those evaluators: each walked the same clause with its own recursion, recognising `&&` and a restated condition again. That is why a binding under a clause had to be taught to each of them separately when #1333 closed, and why a rule stated through a helper could be owed by one reading and unknown to the next.

## How far a reading goes is the reading's own answer

The obstacle named in the issue is real: these readings do not all descend where the fold descends. An asserted choice is handed whole to the reader of comparisons, because what a choice states is neither of its sides and this cannot say which one holds; a denied conjunction is the same shape. Held as a flag beside a fold, that decision and the composition it licenses are two answers a reading gives apart, and a reading that says it descends and cannot compose what it found has nowhere to say so.

So `Descent` makes them one answer. A reading is asked of the connective — not of the operator — what holding both of its parts comes to, and a reading with nothing to compose says it takes the connective whole and is handed the node the author wrote it at, read as a part like any other.

## What moved

- What a condition states as relations, what a clause owes, and which quantifiers it states are readings over the shape. None of them asks the operator any more, and the licence lists say so.
- A caller wanting a clause without one of its parts leaves the part out of the list rather than telling the reading to step over a node. Which parts a clause has was already settled where the list was built, and the two come to the same thing.
- The clause is named once at the outside of what its shape was spelled as, which is where a caller holding the clause and nothing under it looks. What it came to is told to a reader of parts where the walk says it and not a second time at the root.

## A counterfactual is asked about a part

Taking the node out of that exclusion turned up a reading that was still choosing between subtrees. The reading that asks where a coordinate stops without some rule is asked without an authored part, while the candidates it chose between were one per subtree a rule had been read from. Those are one population only while a part states one rule — and a part stating two of them that both reach one number was two candidates sharing a part, so every question about either was asked without the part they share. The part came back named as holding an end twice that it holds once.

A candidate is now the part at the number. Half of a rule named through a helper is not something an author can take away, so it is not something to ask a counterfactual about, and the subtree each was read from was already read by nobody.

## Boundary

`Predicates.assumeCond` stays where it is, as the issue asked. It threads what is known from one side of a conjunction into the other, which is knowledge moving along short-circuit order rather than an answer composed out of the leaves. Folding it here would be a different claim.

The one difference the measurement found and this does not close is filed as #1412: a branch no value reaches is named where a condition was written out and not where it was named, which is a reader of reachability rather than of what a clause states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)