### PR TITLE
A relation between positions is decided by looking for an assignment, not only by counting

### DIFF
--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -13,14 +13,16 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeDynamicInstruction;
 import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -218,16 +220,53 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
     }
 
     /**
-     * And the walk sees classes at all.
+     * And it reads a saying that is written as a reference to one.
      *
-     * <p>Matched against a name nothing has, every list above would be empty and equal to an empty
-     * expectation. So the same walk is asked for something it must find.
+     * <p>{@code Emptiness::isEmpty} puts no call to the word in the code that wrote it: what it
+     * names is a handle among a bootstrap's arguments. A walk over calls alone would read a nest
+     * observing a settled answer as one saying nothing, and nothing in production is written that
+     * way today — so what holds the walk to it is a body beside this test that is.
      */
     @Test
-    void andTheWalkSeesTheReadingThatOwnsThePair() {
+    void andItReadsASayingWrittenAsAReference() {
+        assertFalse(Referring.OBSERVES.test(Emptiness.NONEMPTY), "the fixture observes by handle");
+        assertTrue(saidHere().stream().anyMatch(use -> use.said().equals("isEmpty")),
+                "the fixture beside this test observes a settled answer through a reference, so a"
+                        + " walk that cannot find it there is one that would let one past");
+    }
+
+    /**
+     * And the walk sees classes at all, in every module the repository has.
+     *
+     * <p>Matched against a name nothing has, every list above would be empty and equal to an empty
+     * expectation. And a module whose classes are not there is one the walk reads nothing of while
+     * the lists still match — so what is asserted is that every module the reactor names was read,
+     * and not only that something was.
+     */
+    @Test
+    void andEveryModuleTheRepositoryHoldsWasRead() {
+        List<String> unbuilt = new ArrayList<>();
+        int read = 0;
+        for (Path module : REPOSITORY.modules()) {
+            Path where = classesOf(module);
+            if (!classesUnder(where).isEmpty()) {
+                read++;
+            } else if (Files.isDirectory(module.resolve("src").resolve("main").resolve("java"))) {
+                // A module holding only tests or only a pom leaves no classes and is not one this
+                // walk is missing.
+                unbuilt.add(module.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), unbuilt,
+                "a module whose classes are not built is one this walk passes over, and a walk that"
+                        + " passes over a module answers about the rest while saying it answers"
+                        + " about all of them");
+        assertTrue(read > 1, "the classes this reads are in more than the one module that declares"
+                + " the word");
         assertTrue(nestsSaying(saidInProduction(), _ -> true)
                         .contains("souther/compiler/check/Confinement"),
-                "the pair's own reading says the word, so a walk that cannot find it there is"
+                "and the pair's own reading says the word, so a walk that cannot find it there is"
                         + " finding nothing at all");
     }
 
@@ -249,6 +288,20 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         }
     }
 
+    /**
+     * A body that observes a settled answer through a reference to the observation, for the same
+     * reason.
+     *
+     * <p>Nothing in production is written this way today, so a walk that could not read it would go
+     * on reporting the same owner sets — and the day something is, it would pass the rules without
+     * being one of the nests they name.
+     */
+    private enum Referring {
+        ;
+
+        static final Predicate<Emptiness> OBSERVES = Emptiness::isEmpty;
+    }
+
     /** The nests of the sayings {@code which} keeps, each once and in one order. */
     private static List<String> nestsSaying(List<Use> said, Predicate<Use> which) {
         Set<String> out = new TreeSet<>();
@@ -256,11 +309,15 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return new ArrayList<>(out);
     }
 
+    private static Path classesOf(Path module) {
+        return module.resolve("target").resolve("classes");
+    }
+
     /** Every saying of the word in the reactor's own compiled classes. */
     private static List<Use> saidInProduction() {
         List<Path> where = new ArrayList<>();
         for (Path module : REPOSITORY.modules()) {
-            where.add(module.resolve("target").resolve("classes"));
+            where.add(classesOf(module));
         }
         List<Use> found = saidUnder(where);
         assertFalse(found.isEmpty(), "no saying of the word was read at all");
@@ -310,7 +367,9 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
                     }
                     String where = method.methodName().stringValue();
                     for (CodeElement element : code) {
-                        saidBy(element).ifPresent(what -> found.add(new Use(nest, where, what)));
+                        for (String what : saidBy(element)) {
+                            found.add(new Use(nest, where, what));
+                        }
                     }
                 }
             }
@@ -318,21 +377,46 @@ class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
         return found;
     }
 
-    /** What one instruction says of the word, where it says anything. */
-    private static Optional<String> saidBy(CodeElement element) {
+    /**
+     * What one instruction says of the word, where it says anything.
+     *
+     * <p>A reference is the call it stands for. {@code Emptiness::isEmpty} puts no call to the word
+     * in the code that wrote it — what it names is a handle among a bootstrap's arguments — so a
+     * walk over calls alone reads a nest that observes a settled answer as one that says nothing.
+     */
+    private static List<String> saidBy(CodeElement element) {
         if (element instanceof FieldInstruction field) {
             String named = field.name().stringValue();
             if (named.equals(TAKEN_APART)) {
-                return Optional.of(TAKEN_APART);
+                return List.of(TAKEN_APART);
             }
             return field.owner().asInternalName().equals(EMPTINESS)
-                    ? Optional.of(named) : Optional.empty();
+                    ? List.of(named) : List.of();
         }
-        if (element instanceof InvokeInstruction call
-                && call.owner().asInternalName().equals(EMPTINESS)) {
-            return Optional.of(call.name().stringValue());
+        if (element instanceof InvokeInstruction call) {
+            return call.owner().asInternalName().equals(EMPTINESS)
+                    ? List.of(call.name().stringValue()) : List.of();
         }
-        return Optional.empty();
+        if (element instanceof InvokeDynamicInstruction lambda) {
+            List<String> out = new ArrayList<>();
+            for (var argument : lambda.bootstrapArgs()) {
+                if (argument instanceof DirectMethodHandleDesc handle
+                        && named(handle.owner()).equals(EMPTINESS)) {
+                    // Whichever kind of handle it is, what it names is what the code would have
+                    // said had it been written out: a field for a constant, a method for the rest.
+                    out.add(handle.methodName());
+                }
+            }
+            return out;
+        }
+        return List.of();
+    }
+
+    /** What a descriptor names, as a class is named in a class file. */
+    private static String named(ClassDesc owner) {
+        String descriptor = owner.descriptorString();
+        return descriptor.startsWith("L") && descriptor.endsWith(";")
+                ? descriptor.substring(1, descriptor.length() - 1) : descriptor;
     }
 
     /** Whether the bytes name the word anywhere at all. */

--- a/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
+++ b/souther-architecture-test/src/test/java/souther/architecture/WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.java
@@ -1,0 +1,378 @@
+package souther.architecture;
+
+import souther.compiler.values.Emptiness;
+import souther.test.RepositoryLayout;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Who may say that a position admits something, and who may only say that one admits nothing.
+ *
+ * <p>{@link Emptiness} answers three ways and the two settled answers are not one another's mirror.
+ * Either half of a pair holding nothing leaves the pair nothing, so {@code EMPTY} is sound from
+ * whichever reading reached it. {@code NONEMPTY} is a claim about the whole of what was asked, and
+ * {@code Confinement} says in its own words what that whole is: which values a position may take
+ * and where its order stops, and nothing else. The components beside it stay outside, so a reader
+ * taking one of these answers for "a value of this declaration exists" would be holding a claim no
+ * reduction here carries.
+ *
+ * <p>So everywhere the word is said is written down. What the lists hold is readings that work an
+ * admission out and hand it on; what they must not grow is a reader that acts on the settled
+ * positive answer as though it were about more than the reading that gave it.
+ *
+ * <p><b>Three rules and not one, because they are three claims.</b> The widest names every nest
+ * that touches a settled answer at all — said as a constant, or asked of one through the operations
+ * that observe and compose settledness, since {@code a.joined(b)} carries a positive answer onwards
+ * without spelling one. Inside it is who may make the positive answer. Inside that is the one the
+ * contract is about: which nests outside the readings themselves say it.
+ *
+ * <p><b>What these rules do not say.</b> They fix who may name a settled answer, and not who may
+ * act on one: a nest already on a list can grow a second reader of an answer it was already making,
+ * and no owner set changes. Nor is {@code x != EMPTY} caught, which is a weaker reading than
+ * {@code NONEMPTY} and says less. What is claimed is what a walk over the compiled classes holds.
+ *
+ * <p>Read off those classes, because a call is what the compiler made of it: a lambda body, a
+ * method reference and a switch are three spellings a scan of source text would have to know about
+ * one at a time. Every module's classes, because this module is built last and a check living in
+ * the module it is about passes over everything built after it.
+ */
+class WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest {
+
+    private static final String EMPTINESS = "souther/compiler/values/Emptiness";
+
+    /** The two answers that settle something, which is what these rules are about.
+     *  {@code UNDECIDED} settles nothing and is named freely. */
+    private static final Set<String> SETTLED = Set.of("EMPTY", "NONEMPTY");
+
+    /** The operations that read whether an answer is settled or carry one onwards. A caller of
+     *  these holds a settled answer without naming one, which is why calling them counts as saying
+     *  it. */
+    private static final Set<String> OBSERVES_OR_COMPOSES = Set.of("isEmpty", "met", "joined");
+
+    /** What javac writes for a switch over this word: a synthetic table of its constants, read by
+     *  whoever switched. Taking the answer apart by which of the three it is, under a spelling that
+     *  names no constant in the code that does it. */
+    private static final String TAKEN_APART = "$SwitchMap$souther$compiler$values$Emptiness";
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /**
+     * Every nest that says a position is settled one way or the other.
+     *
+     * <p>The readings that work an admission out, and nothing else. {@code Carrier} and
+     * {@code TextExtents} answer what a set of values and a range come to between them, which is
+     * the bottom of the pair; {@code Confinement} owns the pair and the walk over the alternatives
+     * that both halves are asked along. {@code AdmissibleValues},
+     * {@code ConjoinedAdmissibleValues} and {@code PlannedValues} are that walk over what a reading
+     * holds, and {@code Apartness} is what the denials between two blocks come to.
+     * {@code Realized} says whether everything asked for was built. {@code StatedByClauses} and
+     * {@code Settlement} put the answers of a choice's branches together.
+     *
+     * <p>What is not here is the list's point. Nothing else in {@code check}, nothing downstream of
+     * the compiler, and nothing that reports: a settled answer reaching one of those would be a
+     * claim travelling further than the reading that made it.
+     */
+    private static final List<String> SAYS_A_POSITION_IS_SETTLED = List.of(
+            "souther/compiler/check/Carrier",
+            "souther/compiler/check/Confinement",
+            "souther/compiler/check/Settlement",
+            "souther/compiler/check/StatedByClauses",
+            "souther/compiler/values/AdmissibleValues",
+            "souther/compiler/values/Apartness",
+            "souther/compiler/values/ConjoinedAdmissibleValues",
+            "souther/compiler/values/PlannedValues",
+            "souther/compiler/values/Realized",
+            "souther/compiler/values/TextExtents");
+
+    /**
+     * And who may make the settled positive answer.
+     *
+     * <p>{@code Settlement} is the one nest that says a position is settled without ever saying it
+     * admits something: it joins two branches' answers and reads whether the join came out empty. A
+     * nest arriving here is one that has begun to claim something exists, which is what these rules
+     * are about.
+     */
+    private static final List<String> SAYS_SOMETHING_IS_ADMITTED = List.of(
+            "souther/compiler/check/Carrier",
+            "souther/compiler/check/Confinement",
+            "souther/compiler/check/StatedByClauses",
+            "souther/compiler/values/AdmissibleValues",
+            "souther/compiler/values/Apartness",
+            "souther/compiler/values/ConjoinedAdmissibleValues",
+            "souther/compiler/values/PlannedValues",
+            "souther/compiler/values/Realized",
+            "souther/compiler/values/TextExtents");
+
+    /**
+     * And which of them are outside the readings that hold the values.
+     *
+     * <p>{@code values} is where an admission is worked out, so a nest there saying something is
+     * admitted is a reading answering about itself. These three are in {@code check}:
+     * {@code Carrier} makes the answer at the bottom of the pair, {@code Confinement} owns the
+     * pair, and {@code StatedByClauses} is where an answer that came out positive decides something
+     * else — a choice whose two branches both stand is held open rather than merged.
+     */
+    private static final List<String> SAYS_IT_OUTSIDE_THE_READINGS = List.of(
+            "souther/compiler/check/Carrier",
+            "souther/compiler/check/Confinement",
+            "souther/compiler/check/StatedByClauses");
+
+    /** One saying of the word, and whose code holds it. */
+    private record Use(String nest, String method, String said) {}
+
+    @Test
+    void everyNestThatSaysAPositionIsSettledIsWrittenDown() {
+        assertEquals(SAYS_A_POSITION_IS_SETTLED, nestsSaying(saidInProduction(),
+                        use -> SETTLED.contains(use.said())
+                                || OBSERVES_OR_COMPOSES.contains(use.said())),
+                "a settled answer is about the reading that reached it, so where it is said is"
+                        + " written down: said somewhere new, a claim about which values a position"
+                        + " may take and where its order stops is being read as one about more");
+    }
+
+    @Test
+    void andOnlyTheseSayThatSomethingIsAdmitted() {
+        assertEquals(SAYS_SOMETHING_IS_ADMITTED,
+                nestsSaying(saidInProduction(), use -> use.said().equals("NONEMPTY")),
+                "nothing is admitted where either half of the pair holds nothing, and something is"
+                        + " admitted only where both were asked: the second is a claim about the"
+                        + " pair, and a nest that has begun making it is a nest to read");
+    }
+
+    @Test
+    void andOutsideTheReadingsThreeSayIt() {
+        assertEquals(SAYS_IT_OUTSIDE_THE_READINGS, nestsSaying(saidInProduction(),
+                        use -> use.said().equals("NONEMPTY")
+                                && !use.nest().startsWith("souther/compiler/values/")),
+                "an admission is worked out in the readings; outside them it is made at the bottom"
+                        + " of the pair, by the pair itself, and read once where two branches that"
+                        + " both stand are held open");
+    }
+
+    /**
+     * And the walk reads a body the source does not name.
+     *
+     * <p>Two of the sayings are inside lambdas — the stand-in answering that the values refuse
+     * nothing, so that what the ranges alone refuse can be asked. A walk that read declared methods
+     * and not the synthetic ones javac writes for these would miss both and go on reporting the
+     * same owner sets, since those two nests say the word elsewhere as well.
+     */
+    @Test
+    void andTheWalkReadsALambdaBody() {
+        assertEquals(List.of("souther/compiler/check/Confinement",
+                        "souther/compiler/values/PlannedValues"),
+                nestsSaying(saidInProduction(), use -> use.said().equals("NONEMPTY")
+                        && use.method().startsWith("lambda$")),
+                "these say it in a lambda body, and a walk that cannot see one is reading less than"
+                        + " it reports");
+    }
+
+    /**
+     * And nothing takes the answer apart by which of the three it is.
+     *
+     * <p>A switch over this word says something the three rules above do not watch for: it reads
+     * the answer as a choice between arms rather than asking whether it settles anything. It is
+     * also the one shape whose constants are named in a synthetic class rather than in the code
+     * that switched, so what is asserted is that there is none.
+     *
+     * <p>Shown with the same detector run over a body that does switch ({@link Taking}), because an
+     * expectation of none passes just as well when the detector has stopped working — which is what
+     * the day javac writes a switch some other way would look like.
+     */
+    @Test
+    void andNothingTakesTheAnswerApartByWhichOfTheThreeItIs() {
+        assertEquals(1, Taking.by(Emptiness.NONEMPTY), "the fixture answers by switching");
+        assertTrue(saidHere().stream().anyMatch(use -> use.said().equals(TAKEN_APART)),
+                "the fixture beside this test switches over the word, so a detector that cannot"
+                        + " find it there is one that would report none anywhere");
+
+        assertEquals(List.of(),
+                nestsSaying(saidInProduction(), use -> use.said().equals(TAKEN_APART)),
+                "this takes the answer apart by which of the three it is, which the rules above do"
+                        + " not watch: what they read is who names one");
+    }
+
+    /**
+     * And the walk sees classes at all.
+     *
+     * <p>Matched against a name nothing has, every list above would be empty and equal to an empty
+     * expectation. So the same walk is asked for something it must find.
+     */
+    @Test
+    void andTheWalkSeesTheReadingThatOwnsThePair() {
+        assertTrue(nestsSaying(saidInProduction(), _ -> true)
+                        .contains("souther/compiler/check/Confinement"),
+                "the pair's own reading says the word, so a walk that cannot find it there is"
+                        + " finding nothing at all");
+    }
+
+    /**
+     * A body that switches over the word, for the detector to be held to.
+     *
+     * <p>Compiled beside this test and never among the classes the rules read, which are the
+     * modules' own. What it is for is that a rule expecting none has something to be shown finding.
+     */
+    private enum Taking {
+        ;
+
+        static int by(Emptiness said) {
+            return switch (said) {
+                case EMPTY -> 0;
+                case NONEMPTY -> 1;
+                case UNDECIDED -> 2;
+            };
+        }
+    }
+
+    /** The nests of the sayings {@code which} keeps, each once and in one order. */
+    private static List<String> nestsSaying(List<Use> said, Predicate<Use> which) {
+        Set<String> out = new TreeSet<>();
+        said.stream().filter(which).forEach(use -> out.add(use.nest()));
+        return new ArrayList<>(out);
+    }
+
+    /** Every saying of the word in the reactor's own compiled classes. */
+    private static List<Use> saidInProduction() {
+        List<Path> where = new ArrayList<>();
+        for (Path module : REPOSITORY.modules()) {
+            where.add(module.resolve("target").resolve("classes"));
+        }
+        List<Use> found = saidUnder(where);
+        assertFalse(found.isEmpty(), "no saying of the word was read at all");
+        return found;
+    }
+
+    /** Every saying in the classes compiled beside this test, which is the fixture above. */
+    private static List<Use> saidHere() {
+        try {
+            return saidUnder(List.of(Path.of(
+                    WhoMaySayThatAPositionAdmitsSomethingIsWrittenDownTest.class
+                            .getProtectionDomain().getCodeSource().getLocation().toURI())));
+        } catch (URISyntaxException notAPath) {
+            throw new IllegalStateException("this test's own classes are somewhere unreadable",
+                    notAPath);
+        }
+    }
+
+    /**
+     * Every saying of the word under {@code roots}.
+     *
+     * <p>The word's own class is passed over: what an enum's constants do among themselves is how
+     * one is written, and read as sayings they would put the word on every list as a namer of
+     * itself.
+     */
+    private static List<Use> saidUnder(List<Path> roots) {
+        List<Use> found = new ArrayList<>();
+        for (Path root : roots) {
+            for (Path each : classesUnder(root)) {
+                byte[] bytes = bytesOf(each);
+                // Cheap first, so the code of a class with nothing to do with this is never walked.
+                // The filter admits more than these rules are about — another type in `check` is
+                // called the same — and refuses nothing that could match, which is the direction it
+                // has to err in.
+                if (!holdsTheWord(bytes)) {
+                    continue;
+                }
+                ClassModel model = ClassFile.of().parse(bytes);
+                String nest = nestOf(model.thisClass().asInternalName());
+                if (nest.equals(EMPTINESS)) {
+                    continue;
+                }
+                for (MethodModel method : model.methods()) {
+                    CodeModel code = method.code().orElse(null);
+                    if (code == null) {
+                        continue;
+                    }
+                    String where = method.methodName().stringValue();
+                    for (CodeElement element : code) {
+                        saidBy(element).ifPresent(what -> found.add(new Use(nest, where, what)));
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /** What one instruction says of the word, where it says anything. */
+    private static Optional<String> saidBy(CodeElement element) {
+        if (element instanceof FieldInstruction field) {
+            String named = field.name().stringValue();
+            if (named.equals(TAKEN_APART)) {
+                return Optional.of(TAKEN_APART);
+            }
+            return field.owner().asInternalName().equals(EMPTINESS)
+                    ? Optional.of(named) : Optional.empty();
+        }
+        if (element instanceof InvokeInstruction call
+                && call.owner().asInternalName().equals(EMPTINESS)) {
+            return Optional.of(call.name().stringValue());
+        }
+        return Optional.empty();
+    }
+
+    /** Whether the bytes name the word anywhere at all. */
+    private static boolean holdsTheWord(byte[] bytes) {
+        byte[] word = "Emptiness".getBytes(StandardCharsets.US_ASCII);
+        for (int start = 0; start + word.length <= bytes.length; start++) {
+            int at = 0;
+            while (at < word.length && bytes[start + at] == word[at]) {
+                at++;
+            }
+            if (at == word.length) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** What a class is written inside: a helper, a lambda's synthetic method and a switch's
+     *  synthetic table are all part of the type they were written in. */
+    private static String nestOf(String internalName) {
+        int nested = internalName.indexOf('$');
+        return nested < 0 ? internalName : internalName.substring(0, nested);
+    }
+
+    private static byte[] bytesOf(Path compiled) {
+        try {
+            return Files.readAllBytes(compiled);
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+    }
+
+    private static List<Path> classesUnder(Path where) {
+        if (!Files.isDirectory(where)) {
+            return List.of();
+        }
+        try (Stream<Path> found = Files.walk(where)) {
+            return found.filter(each -> each.toString().endsWith(".class")).toList();
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -85,6 +85,17 @@ public final class Apartness<A> {
      * of many blocks each holding a handful of values is a large search and one of two blocks
      * holding many values is not, and how many blocks there are tells the two apart the wrong way
      * round.
+     *
+     * <p>What it comes to. The search stands on at most about twice this many assignments, each
+     * checked against the blocks given a value before it, which holds one relation to a fraction of
+     * a second whatever shape it is. Measured on the shapes that are actually hard — a relation
+     * with no three blocks all stated to differ that three values are still not enough for — it is
+     * a few milliseconds, so what this figure is doing is bounding the case nobody has built rather
+     * than the ones there are.
+     *
+     * <p>Read the other way it is what a declaration may ask for: ten positions over a sum of four
+     * cases, or twenty over two. A position count and a carrier past that is a relation this says
+     * nothing about.
      */
     private static final long MOST_ASSIGNMENTS = 1L << 20;
 

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -35,20 +35,42 @@ import java.util.function.Function;
 public final class Apartness<A> {
 
     /**
-     * How many sets of blocks this will look at before it stops.
+     * How many blocks a relation may have for the sets of them all stated to differ to be looked
+     * for.
      *
-     * <p>Looked at and not found. How many sets a relation has does not say how much work finding
-     * them is: a relation whose blocks are all stated to differ has one such set and as many ways
-     * of reaching it as anyone likes, so a bound on the answers is no bound on the walk. What is
-     * counted is every set the walk stands on, whether or not it turns out to be one nothing can be
-     * added to.
+     * <p>A bound on the shape and never on a walk part-way through one. How far a walk gets by some
+     * number of steps depends on which block it started from, and two writings of one relation are
+     * one relation ({@link #equals}) that would then be decided one way written this way round and
+     * another written the other. Read off the shape before anything is walked, the answer is a fact
+     * about the relation.
      *
-     * <p>A stated limit and not a figure anything derives. How much work a relation is worth is not
-     * bounded by how many rules were written, and a reduction that walked all of it would make what
-     * a declaration costs turn on a shape nothing else here charges for. Reaching it is this saying
-     * nothing, which is what it says of every relation it has no argument for.
+     * <p>Which is what gives this figure something to be derived from. {@link #grow} takes as its
+     * pivot the block stated to differ from most of what may still be added, and the exponential
+     * part of a maximal-clique walk that pivots this way is {@code 3^(n/3)} in the number of blocks
+     * — the same figure as the most sets of pairwise-apart blocks that {@code n} blocks can have.
+     * What is left to measure is how much a step of this walk costs, and on the shape that reaches
+     * that bound thirty blocks is a tenth of a second, with every three blocks after it three times
+     * as much.
+     *
+     * <p><b>So the pivot is part of this bound and not a way of going faster.</b> Taking the first
+     * block still in play instead leaves the walk reaching one set once for every order its blocks
+     * come in, and this figure would be a bound on nothing.
      */
-    private static final int SETS_LOOKED_AT = 4096;
+    private static final int MOST_BLOCKS_WALKED = 30;
+
+    /**
+     * And how large a relation may be for its shape to be looked at at all.
+     *
+     * <p>What the relation itself comes to as an adjacency and what each level of the walk costs,
+     * which the bound above does not reach: a relation whose blocks are all stated to differ is
+     * walked in one path however many blocks it has, so it is admitted past that bound and would
+     * otherwise be admitted with no bound at all.
+     *
+     * <p>Measured: a relation of this many pairs whose blocks are all stated to differ is walked in
+     * about a fiftieth of a second. A relation the general bound admits has at most a few hundred
+     * pairs, so this is the one that reaches such a relation's shape.
+     */
+    private static final int MOST_EDGES_HELD = 5000;
 
     /** In the order they were stated, so that what is written out of a reading comes out the same
      *  on two compiles of one model. */
@@ -105,6 +127,51 @@ public final class Apartness<A> {
     /** Whether some pair states a block differs from itself, which nothing satisfies. */
     public boolean holdsABlockApartFromItself() {
         return edges.stream().anyMatch(Edge::isOfOneBlock);
+    }
+
+    /** How much walking this relation is, before any of it is walked. */
+    public Extent extent() {
+        return new Extent(blocks().size(), edges.size());
+    }
+
+    /**
+     * How large a relation is, as the numbers a reduction over it can be admitted by.
+     *
+     * <p>Read off the relation and not off a walk of it, which is what lets an admission be a fact
+     * about the relation: a walk stopped part-way through has got as far as the order its pairs
+     * were stated in took it, and one relation written two ways round would be decided one way and
+     * not the other. So how much walking a shape is, is settled before there is a walk to stop.
+     *
+     * @param blocks how many blocks some pair names
+     * @param edges how many pairs are stated
+     */
+    public record Extent(int blocks, int edges) {
+
+        /**
+         * Whether every block is stated to differ from every other.
+         *
+         * <p>Its own case because the walk is a different walk on it. {@link #grow} pivots on the
+         * block stated to differ from most of what may still be added, and where that is every
+         * other block, each level has one way in and the whole relation is one path — so a relation
+         * of this shape is walked in as many steps as it has blocks, however many that is, and the
+         * bound the general case needs is a bound it does not.
+         */
+        public boolean isComplete() {
+            return edges == (long) blocks * (blocks - 1) / 2;
+        }
+
+        /**
+         * Whether every set of blocks all stated to differ can be found.
+         *
+         * <p>Two bounds and not one, because they are about two different things. How many blocks
+         * there are bounds the walk, and how many pairs there are bounds the relation itself — what
+         * it comes to as an adjacency and what one level of the walk costs. The second is what
+         * reaches a relation admitted past the first.
+         */
+        boolean admitsCounting() {
+            return edges <= MOST_EDGES_HELD
+                    && (isComplete() || blocks <= MOST_BLOCKS_WALKED);
+        }
     }
 
     /**
@@ -253,12 +320,13 @@ public final class Apartness<A> {
      * apiece for every part of it. So the parts are covered by the whole and emitting them as well
      * is the same question asked again — once per subset, which is as many as there are subsets.
      *
-     * <p>Bounded by {@code most}, and by refusing rather than by answering with less: how many of
-     * these there are is not something the rules bound, and a reading that stopped partway would
-     * decide a declaration by how far it happened to get. A relation too large to walk is one this
-     * says nothing about, which is what it says about every relation it has no reduction for.
+     * <p>Walked to the end or not walked at all. Whoever asks decides whether the shape is one
+     * worth walking ({@link Extent#admitsCounting}), which is read off the relation before there is
+     * a walk; stopped part-way instead, this would answer with the sets one order of the pairs
+     * happened to reach first, and a relation written the other way round would be answered
+     * differently.
      */
-    public List<Set<Sameness.Block<A>>> everyPairwiseApartSet(int most) {
+    public List<Set<Sameness.Block<A>>> everyPairwiseApartSet() {
         Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
         for (Edge<A> edge : edges) {
             if (edge.isOfOneBlock()) {
@@ -267,53 +335,11 @@ public final class Apartness<A> {
             apart.computeIfAbsent(edge.one(), _ -> new LinkedHashSet<>()).add(edge.other());
             apart.computeIfAbsent(edge.other(), _ -> new LinkedHashSet<>()).add(edge.one());
         }
-        Walk<A> walk = new Walk<>(most);
+        List<Set<Sameness.Block<A>>> found = new ArrayList<>();
         grow(new LinkedHashSet<>(), new LinkedHashSet<>(apart.keySet()), new LinkedHashSet<>(),
-                apart, walk);
-        if (walk.spent()) {
-            return List.of();
-        }
-        walk.found().sort(
-                Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
-        return walk.found();
-    }
-
-    /**
-     * What a walk over the sets has found and what it has spent finding it.
-     *
-     * <p>Both, because the second is what the bound is on. How many sets there are does not say how
-     * much work finding them is — a relation whose blocks are all stated to differ has one set and
-     * a search that looks at every way to reach it — so a bound on the answers is no bound at all,
-     * and the walk that ran into it would be the walk nobody was counting.
-     */
-    private static final class Walk<A> {
-
-        private final List<Set<Sameness.Block<A>>> found = new ArrayList<>();
-        private final int most;
-        private int steps;
-
-        private Walk(int most) {
-            this.most = most;
-        }
-
-        List<Set<Sameness.Block<A>>> found() {
-            return found;
-        }
-
-        /** Whether this has looked at as much as it is allowed to. */
-        boolean spent() {
-            return steps > most || found.size() > most;
-        }
-
-        /** One more set looked at, whether or not it turned out to be one nothing can be added
-         *  to. */
-        void looked() {
-            steps++;
-        }
-
-        void add(Set<Sameness.Block<A>> these) {
-            found.add(Collections.unmodifiableSet(new LinkedHashSet<>(these)));
-        }
+                apart, found);
+        found.sort(Comparator.comparingInt((Set<Sameness.Block<A>> each) -> each.size()).reversed());
+        return found;
     }
 
     /**
@@ -332,14 +358,11 @@ public final class Apartness<A> {
      */
     private void grow(Set<Sameness.Block<A>> sofar, Set<Sameness.Block<A>> may,
                       Set<Sameness.Block<A>> taken,
-                      Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart, Walk<A> walk) {
-        walk.looked();
-        if (walk.spent()) {
-            return;
-        }
+                      Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart,
+                      List<Set<Sameness.Block<A>>> found) {
         if (may.isEmpty()) {
             if (taken.isEmpty() && sofar.size() > 1) {
-                walk.add(sofar);
+                found.add(Collections.unmodifiableSet(new LinkedHashSet<>(sofar)));
             }
             return;
         }
@@ -364,10 +387,7 @@ public final class Apartness<A> {
             still.retainAll(apartFromNext);
             Set<Sameness.Block<A>> covered = new LinkedHashSet<>(aside);
             covered.retainAll(apartFromNext);
-            grow(grown, still, covered, apart, walk);
-            if (walk.spent()) {
-                return;
-            }
+            grow(grown, still, covered, apart, found);
             left.remove(next);
             aside.add(next);
         }
@@ -517,9 +537,16 @@ public final class Apartness<A> {
      * values than a caller counted never runs out, and a block this cannot say the values of is one
      * nothing is known about — dropped from the set either way, which leaves a smaller set, and a
      * shortage shown of fewer blocks is a shortage.
+     *
+     * <p>And asked only of a relation whose shape says the sets can all be found. A relation past
+     * that is one this argument says nothing about, which is what it says of every relation whose
+     * sets hold enough values.
      */
     private RelationalWitness<A> counting(Map<Sameness.Block<A>, Admits> left) {
-        for (Set<Sameness.Block<A>> apart : everyPairwiseApartSet(SETS_LOOKED_AT)) {
+        if (!extent().admitsCounting()) {
+            return null;
+        }
+        for (Set<Sameness.Block<A>> apart : everyPairwiseApartSet()) {
             Map<Sameness.Block<A>, Set<Value>> counted = new LinkedHashMap<>();
             apart.forEach(block -> {
                 if (left.get(block) instanceof Admits.These it) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -87,42 +87,6 @@ public final class Apartness<A> {
      */
     private static final int MOST_EDGES_HELD = 5000;
 
-    /**
-     * And how many assignments a relation may have for one of them to be looked for.
-     *
-     * <p>Every block's values against every other's, which is what a search for an assignment
-     * reaches at most one of per branch it takes to the end. Read off the values before any of them
-     * are tried, so that whether a relation is answered is a fact about the relation and not about
-     * where the search happened to start — the same reason the two figures above are about the
-     * shape rather than about a walk.
-     *
-     * <p>Bounding the assignments and not the blocks, because that is what the work is. A relation
-     * of many blocks each holding a handful of values is a large search and one of two blocks
-     * holding many values is not, and how many blocks there are tells the two apart the wrong way
-     * round.
-     *
-     * <p>What it comes to. Every branch the search takes is one assignment, and it stands on a
-     * block of that assignment at each step — so what it does is this many assignments times how
-     * many blocks there are, and not twice this many: a block left one value is a step the search
-     * takes all the same, so the branches are not all two ways. That holds one relation to a
-     * fraction of a second whatever shape it is. Measured on the shapes that are actually hard — a
-     * relation with no three blocks all stated to differ that three values are still not enough for
-     * — it is a few milliseconds, so what this figure bounds is the case nobody has built rather
-     * than the ones there are.
-     *
-     * <p>Read off what the rules leave and not off what they started from. Taking away the values
-     * one-valued blocks hold makes the search smaller, so a relation that would be past this figure
-     * as written may be inside it once that has run — and what a reading may still be asked is a
-     * question about what it holds now. Which does not put the answer back on the order the rules
-     * were written in: taking values away runs to a fixpoint, and where it stops is the same
-     * whichever block it started at.
-     *
-     * <p>Read the other way it is what a declaration may ask for: ten positions over a sum of four
-     * cases, or twenty over two. A position count and a carrier past that is a relation this says
-     * nothing about.
-     */
-    private static final long MOST_ASSIGNMENTS = 1L << 20;
-
     /** In the order they were stated, so that what is written out of a reading comes out the same
      *  on two compiles of one model. */
     private final Set<Edge<A>> edges;
@@ -579,9 +543,12 @@ public final class Apartness<A> {
             return new Reduction.NotKnown<>();
         }
         TellingApart<A> over = TellingApart.over(mayHold, this::apartFrom);
+        // The blocks the search was over, asked of the search. Read off what was handed to it
+        // instead, this would be the same set worked out twice, and the day the two differ is the
+        // day a lack names blocks nothing was looked for over.
         return over.isSatisfiable() ? found
                 : new Reduction.Nothing<>(
-                        new RelationalWitness.NoAssignmentTellsThemApart<>(mayHold.keySet()));
+                        new RelationalWitness.NoAssignmentTellsThemApart<>(over.blocks()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -86,12 +86,21 @@ public final class Apartness<A> {
      * holding many values is not, and how many blocks there are tells the two apart the wrong way
      * round.
      *
-     * <p>What it comes to. The search stands on at most about twice this many assignments, each
-     * checked against the blocks given a value before it, which holds one relation to a fraction of
-     * a second whatever shape it is. Measured on the shapes that are actually hard — a relation
-     * with no three blocks all stated to differ that three values are still not enough for — it is
-     * a few milliseconds, so what this figure is doing is bounding the case nobody has built rather
+     * <p>What it comes to. Every branch the search takes is one assignment, and it stands on a
+     * block of that assignment at each step — so what it does is this many assignments times how
+     * many blocks there are, and not twice this many: a block left one value is a step the search
+     * takes all the same, so the branches are not all two ways. That holds one relation to a
+     * fraction of a second whatever shape it is. Measured on the shapes that are actually hard — a
+     * relation with no three blocks all stated to differ that three values are still not enough for
+     * — it is a few milliseconds, so what this figure bounds is the case nobody has built rather
      * than the ones there are.
+     *
+     * <p>Read off what the rules leave and not off what they started from. Taking away the values
+     * one-valued blocks hold makes the search smaller, so a relation that would be past this figure
+     * as written may be inside it once that has run — and what a reading may still be asked is a
+     * question about what it holds now. Which does not put the answer back on the order the rules
+     * were written in: taking values away runs to a fixpoint, and where it stops is the same
+     * whichever block it started at.
      *
      * <p>Read the other way it is what a declaration may ask for: ten positions over a sum of four
      * cases, or twenty over two. A position count and a carrier past that is a relation this says
@@ -461,12 +470,24 @@ public final class Apartness<A> {
      * nothing stands. And what none of those reaches is looked for: whether some way of giving the
      * blocks values tells every stated pair apart.
      *
-     * <p><b>Why the first three stay, once the fourth decides.</b> Refusing by reading the rule and
-     * by taking values away is what says which blocks the lack is about — one pair, or a chain of
-     * four — where looking for an assignment can only name the blocks it looked over. The first is
-     * also what the fourth rests on: a block holding more values than the relation has blocks is
-     * left out of the search because it can be given one after every other block has, and a block
-     * stated to differ from itself is a block no such argument holds for.
+     * <p><b>Why the first three stay, once the fourth decides.</b> Not one reason but three.
+     *
+     * <p>Refusing by reading the rule and by taking values away is what says which blocks the lack
+     * is about — one pair, or a chain of four — where looking for an assignment can only name the
+     * blocks it looked over. Reading the rule is also what the fourth rests on: a block holding
+     * more values than the relation has blocks is left out of the search because it can be given
+     * one after every other block has, and a block stated to differ from itself is a block no such
+     * argument holds for.
+     *
+     * <p>Counting decides where the fourth is not admitted to look, which is most of what a large
+     * relation is. Blocks all stated to differ are refused however many of them there are, and a
+     * search over that many blocks is past what it looks through several times over.
+     *
+     * <p>And taking values away makes the search smaller as well as refusing: a relation whose
+     * blocks lose the values their one-valued neighbours hold may be inside what the fourth looks
+     * through where it was not before. So the three are what decides outside the fourth's reach and
+     * what says the lack better inside it, and neither of those is being kept for the sake of the
+     * other.
      *
      * <p><b>What it still cannot.</b> A relation whose shape is past what either search is admitted
      * by, and a relation naming a block whose values nothing wrote down. Both are
@@ -600,10 +621,17 @@ public final class Apartness<A> {
      * denials were stated and writes what it finds as it goes, so a chain running that way is
      * followed to its end within one sweep — and a refusal by taking values away is a chain from a
      * block left one value, which is the only shape this argument refuses. What a second round can
-     * still do is tighten a set the count below then reads. It is here for that and because a
-     * single sweep would make the answer turn on the order the denials happen to be stated in;
-     * measured, removing it leaves the whole suite green, so nothing yet holds it to what it is
-     * for.
+     * still do is tighten what the two arguments below then read: a set the count is taken of, and
+     * how much of a search there is left to make. It is here for that and because a single sweep
+     * would make the answer turn on the order the denials happen to be stated in; measured,
+     * removing it leaves the whole suite green, so nothing yet holds it to what it is for.
+     *
+     * <p><b>What this leaves is what the search is asked over.</b> Taking values away is not only a
+     * way of refusing sooner and of saying the lack more nearly than a search can. A relation past
+     * what the search looks through as it was written may be inside it once this has run, and then
+     * this is what made an answer possible rather than what explained one. Which does not put the
+     * answer back on how the rules were written: this runs to a fixpoint, and where it stops does
+     * not depend on which block it started at.
      */
     private RelationalWitness<A> takingWhatOneValueBlocksHold(Map<Sameness.Block<A>, Admits> left) {
         // The blocks and not the entries, because taking a value away writes back into the map this

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -63,13 +63,15 @@ public final class Apartness<A> {
      *
      * <p>The other way a walk over the sets is cheap, and it is not the bound above with a
      * different figure. Each pair a relation leaves out can double how many sets of blocks all
-     * stated to differ it has — a relation leaving none has one — so what this bounds is the sets
-     * rather than the blocks, and a relation of many blocks leaving few pairs out has as few sets
-     * as a small one.
+     * stated to differ it has — a relation leaving none has one — so a relation of many blocks
+     * leaving few pairs out has as few of them to find as a small relation.
      *
-     * <p>Measured on the shape that reaches that doubling, a relation leaving this many pairs out
-     * is walked in about a fiftieth of a second, and every four more of them is sixteen times as
-     * much.
+     * <p><b>Which is what the figure is derived from, and not what it is.</b> How many sets there
+     * are is not how much walking finding them is: this walk is not one whose steps a count of its
+     * answers bounds, and a bound read off the first alone would be a bound on nothing. What the
+     * left-out pairs give is the axis the work runs along; where on that axis to stop is measured,
+     * on the shape that reaches the doubling — a relation leaving this many pairs out is walked in
+     * about a fiftieth of a second, and every four more of them is sixteen times as much.
      */
     private static final int MOST_PAIRS_LEFT_OUT = 12;
 
@@ -169,9 +171,9 @@ public final class Apartness<A> {
          * count of blocks does not. {@link #grow} pivots on the block stated to differ from most of
          * what may still be added, so where a block is stated to differ from every other, each
          * level has one way in and the whole relation is one path however many blocks it has. Each
-         * pair left out can double how many sets there are, and the walk with them: measured, a
-         * relation of this many pairs left out is walked in a fiftieth of a second and every four
-         * more of them is sixteen times as much.
+         * pair left out is a level with a way in beside that one, and can double how many sets
+         * there are to find. How much walking that comes to is measured rather than read off the
+         * doubling — how many answers a walk has is not how many steps it takes.
          *
          * <p>The property and not the shape that has none of them. A relation all of whose pairs
          * are stated is this at nothing, and one pair short of it is a relation the walk is as

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -198,8 +199,21 @@ public final class Apartness<A> {
          * are, and a relation of few pairs left out has as many pairs as blocks allow.
          */
         boolean admitsCounting() {
-            return edges <= MOST_EDGES_HELD
+            return isSmallEnoughToRead()
                     && (blocks <= MOST_BLOCKS_WALKED || pairsLeftOut() <= MOST_PAIRS_LEFT_OUT);
+        }
+
+        /**
+         * Whether the relation itself is small enough for anything here to read its shape.
+         *
+         * <p>Asked by both of the things that read it and not by one of them. Every pair is
+         * something a walk over the sets holds in an adjacency, and every pair is something the
+         * making of a search question reads however few blocks that question is over — so a
+         * relation past this is one neither may be handed, and a reader that asked only its own
+         * figures would be reading a relation of any size at all.
+         */
+        boolean isSmallEnoughToRead() {
+            return edges <= MOST_EDGES_HELD;
         }
     }
 
@@ -350,16 +364,22 @@ public final class Apartness<A> {
      * is the same question asked again — once per subset, which is as many as there are subsets.
      *
      * <p>Walked to the end or not walked at all. Whether the shape is one worth walking is read off
-     * the relation before there is a walk ({@link Extent#admitsCounting}); stopped part-way
-     * instead, this would answer with the sets one order of the pairs happened to reach first, and
-     * a relation written the other way round would be answered differently.
+     * the relation before there is a walk ({@link Extent#admitsCounting}).
      *
-     * <p>Which is why this is not something a reader outside can call. What it costs is bounded by
-     * the shape and by nothing it does itself, so a caller that had not asked the shape would be
-     * walking a relation nobody had agreed to spend that much on — and the agreement is
-     * {@link #counting}, which asks before it walks.
+     * <p>Which is why nothing reaches the walk itself. What it costs is bounded by the shape and by
+     * nothing it does itself, so an entry that left the asking to whoever called it would be a
+     * bound held by whatever the caller remembered — which is what this was while the asking was
+     * the caller's, written in the walk's own words for the caller to honour.
+     *
+     * <p>Nothing where the shape is past it, and never a shorter list. A walk that answered with
+     * the sets it happened to reach would decide a declaration by how far it got, and the same
+     * relation written the other way round would be answered differently.
      */
-    List<Set<Sameness.Block<A>>> everyPairwiseApartSet() {
+    Optional<List<Set<Sameness.Block<A>>>> everySetWorthWalkingFor() {
+        return extent().admitsCounting() ? Optional.of(everyPairwiseApartSet()) : Optional.empty();
+    }
+
+    private List<Set<Sameness.Block<A>>> everyPairwiseApartSet() {
         Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
         for (Edge<A> edge : edges) {
             if (edge.isOfOneBlock()) {
@@ -536,15 +556,12 @@ public final class Apartness<A> {
      * shape the search is not admitted for is neither.
      */
     private Reduction<A> lookedFor(Map<Sameness.Block<A>, Set<Value>> mayHold, Reduction<A> found) {
-        // Before the question is made and not after. Both figures the search is bounded by are
-        // read off the values — how many blocks there are and what their values come to between
-        // them — and making the question out of them costs the square of the blocks, so an
-        // admission asked of the made question would be a bound on the looking and none at all on
-        // the making.
-        if (!TellingApart.isWorthLookingThrough(mayHold)) {
+        Optional<TellingApart<A>> asked =
+                TellingApart.lookingThrough(extent(), mayHold, this::apartFrom);
+        if (asked.isEmpty()) {
             return new Reduction.NotKnown<>();
         }
-        TellingApart<A> over = TellingApart.over(mayHold, this::apartFrom);
+        TellingApart<A> over = asked.get();
         // The blocks the search was over, asked of the search. Read off what was handed to it
         // instead, this would be the same set worked out twice, and the day the two differ is the
         // day a lack names blocks nothing was looked for over.
@@ -688,10 +705,11 @@ public final class Apartness<A> {
      * sets hold enough values.
      */
     private RelationalWitness<A> counting(Map<Sameness.Block<A>, Admits> left) {
-        if (!extent().admitsCounting()) {
+        Optional<List<Set<Sameness.Block<A>>>> walked = everySetWorthWalkingFor();
+        if (walked.isEmpty()) {
             return null;
         }
-        for (Set<Sameness.Block<A>> apart : everyPairwiseApartSet()) {
+        for (Set<Sameness.Block<A>> apart : walked.get()) {
             Map<Sameness.Block<A>, Set<Value>> counted = new LinkedHashMap<>();
             apart.forEach(block -> {
                 if (left.get(block) instanceof Admits.These it) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -72,6 +72,22 @@ public final class Apartness<A> {
      */
     private static final int MOST_EDGES_HELD = 5000;
 
+    /**
+     * And how many assignments a relation may have for one of them to be looked for.
+     *
+     * <p>Every block's values against every other's, which is what a search for an assignment
+     * reaches at most one of per branch it takes to the end. Read off the values before any of them
+     * are tried, so that whether a relation is answered is a fact about the relation and not about
+     * where the search happened to start — the same reason the two figures above are about the
+     * shape rather than about a walk.
+     *
+     * <p>Bounding the assignments and not the blocks, because that is what the work is. A relation
+     * of many blocks each holding a handful of values is a large search and one of two blocks
+     * holding many values is not, and how many blocks there are tells the two apart the wrong way
+     * round.
+     */
+    private static final long MOST_ASSIGNMENTS = 1L << 20;
+
     /** In the order they were stated, so that what is written out of a reading comes out the same
      *  on two compiles of one model. */
     private final Set<Edge<A>> edges;
@@ -426,18 +442,25 @@ public final class Apartness<A> {
      * {@link Reduction.NotKnown}, which says that this reduction did not settle it and never that
      * something stands.
      *
-     * <p><b>What it can refuse, in the order it tries.</b> A block stated to differ from itself is
+     * <p><b>Four arguments, in the order it tries them.</b> A block stated to differ from itself is
      * read off the rule. A block whose neighbours each hold one value loses those values, and where
      * that leaves it none, nothing stands — run to a fixpoint, because a block cut down to one
-     * value cuts down its own neighbours. And a set of blocks each stated to differ from every
-     * other needs a value apiece, so where there are fewer values between them than there are
-     * blocks, nothing stands.
+     * value cuts down its own neighbours. A set of blocks each stated to differ from every other
+     * needs a value apiece, so where there are fewer values between them than there are blocks,
+     * nothing stands. And what none of those reaches is looked for: whether some way of giving the
+     * blocks values tells every stated pair apart.
      *
-     * <p><b>What it cannot.</b> Which values a general relation leaves is a colouring, and this is
-     * not one: {@code a /= b && b /= c && c /= d && d /= e && e /= a} over two values is refused by
-     * no pair and by no set of blocks that are all apart, and this says nothing about it. That is a
-     * widening like every other here — the relation is carried whole, and what a later reduction
-     * shows is shown of what is already held.
+     * <p><b>Why the first three stay, once the fourth decides.</b> Refusing by reading the rule and
+     * by taking values away is what says which blocks the lack is about — one pair, or a chain of
+     * four — where looking for an assignment can only name the blocks it looked over. The first is
+     * also what the fourth rests on: a block holding more values than the relation has blocks is
+     * left out of the search because it can be given one after every other block has, and a block
+     * stated to differ from itself is a block no such argument holds for.
+     *
+     * <p><b>What it still cannot.</b> A relation whose shape is past what either search is admitted
+     * by, and a relation naming a block whose values nothing wrote down. Both are
+     * {@link Reduction.NotKnown}, which says that this did not settle it and never that something
+     * stands.
      *
      * @param admitting what each block is left, which is a question about a block and a range and
      *                  belongs to whoever holds both
@@ -466,7 +489,92 @@ public final class Apartness<A> {
         if (why != null) {
             return new Reduction.Nothing<>(why);
         }
-        return assignable(left, atMost) ? new Reduction.Standing<>() : new Reduction.NotKnown<>();
+        return switch (projection(left)) {
+            case Projection.TheWholeOfIt<A> it -> lookedFor(it.over(), new Reduction.Standing<>());
+            case Projection.APartOfIt<A> it -> lookedFor(it.over(), new Reduction.NotKnown<>());
+        };
+    }
+
+    /**
+     * What looking for an assignment over {@code over} comes to, where finding one leaves
+     * {@code found}.
+     *
+     * <p>Two answers from the search and three from here. Running out says nothing satisfies the
+     * denials, which is true of the relation whichever part of it was searched; finding one says
+     * what the caller passed in, which is what the two arms of a {@link Projection} differ about. A
+     * shape the search is not admitted for is neither.
+     */
+    private Reduction<A> lookedFor(TellingApart<A> over, Reduction<A> found) {
+        if (over.isNothingToAsk()) {
+            return found;
+        }
+        if (over.assignments(MOST_ASSIGNMENTS) > MOST_ASSIGNMENTS) {
+            return new Reduction.NotKnown<>();
+        }
+        return over.isSatisfiable() ? found
+                : new Reduction.Nothing<>(
+                        new RelationalWitness.NoAssignmentTellsThemApart<>(over.blocks()));
+    }
+
+    /**
+     * The blocks an assignment is looked for over, and whether finding one answers for the whole
+     * relation.
+     *
+     * <p>Two blocks are left out, for reasons that are not each other's. A block holding more
+     * values than the relation has blocks can be given one after every other block has — it has
+     * more values than it has neighbours, so one of them is always free — which makes leaving it
+     * out cost nothing in either direction. A block whose values nothing wrote down is left out
+     * because there is nothing to search; and that is sound one way only, since such a block may
+     * hold no value at all.
+     *
+     * <p>So the two are told apart by being two arms rather than by a condition somebody has to
+     * remember to ask. Refusing carries from a part of the relation to the whole of it in both,
+     * because an assignment to all the blocks is an assignment to some of them; standing carries
+     * only from {@link Projection.TheWholeOfIt}.
+     *
+     * <p>The first of them is the argument {@link #reduce} refuses a block stated to differ from
+     * itself before reaching: such a block has no free value however many it holds, and reading it
+     * as one that can be given a value last is what leaving it out would be.
+     */
+    private Projection<A> projection(Map<Sameness.Block<A>, Admits> left) {
+        Map<Sameness.Block<A>, Set<Value>> mayHold = new LinkedHashMap<>();
+        boolean whole = true;
+        for (Map.Entry<Sameness.Block<A>, Admits> each : left.entrySet()) {
+            switch (each.getValue()) {
+                case Admits.These it -> mayHold.put(each.getKey(), it.values());
+                case Admits.MoreThanCounted _ -> { }
+                case Admits.NotKnown _ -> whole = false;
+            }
+        }
+        Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
+        mayHold.keySet().forEach(block -> {
+            Set<Sameness.Block<A>> theirs = new LinkedHashSet<>(apartFrom(block));
+            theirs.retainAll(mayHold.keySet());
+            apart.put(block, theirs);
+        });
+        TellingApart<A> over = TellingApart.over(mayHold, apart);
+        return whole ? new Projection.TheWholeOfIt<>(over) : new Projection.APartOfIt<>(over);
+    }
+
+    /**
+     * What of a relation an assignment is looked for over, and what finding one there shows.
+     *
+     * <p>Held as two arms and not as a set with a flag beside it, so that a reader is made to say
+     * which of the two it has before it can read the blocks. Written as one, the condition that
+     * tells them apart would be asked once for refusing and once for standing, and the two are not
+     * the same condition.
+     *
+     * @param <A> what a position is called
+     */
+    private sealed interface Projection<A> {
+
+        /** The whole relation: what is left out was going to be given a value whatever the rest
+         *  held, so an assignment found here is an assignment to all of it. */
+        record TheWholeOfIt<A>(TellingApart<A> over) implements Projection<A> {}
+
+        /** A part of it: some block's values are not written down, so an assignment found here is
+         *  one for the blocks it covers and says nothing about the block left out. */
+        record APartOfIt<A>(TellingApart<A> over) implements Projection<A> {}
     }
 
     /**
@@ -601,31 +709,6 @@ public final class Apartness<A> {
             }
         }
         return false;
-    }
-
-    /**
-     * Whether every block can be given a value no block it is stated to differ from takes, shown by
-     * an argument that does not depend on which block is taken first.
-     *
-     * <p><b>And by no other.</b> An assignment found by taking the blocks in some order is an
-     * assignment, but which orders find one is not a fact about the relation: two writings of one
-     * rule are one relation, and a reading that stood on the order they were stated in would answer
-     * a model one way written this way round and another written the other. So what is claimed here
-     * is the one thing every order shows.
-     *
-     * <p>What that leaves is a relation whose blocks each hold more values than the relation has
-     * blocks. Anything else is {@link Reduction.NotKnown}, which is what this says of every relation
-     * it has no argument for — a satisfiable one included.
-     */
-    private boolean assignable(Map<Sameness.Block<A>, Admits> left, int atMost) {
-        // Every block holding more values than there are blocks, so each of them can be given one
-        // no other took whatever order they are taken in. Which is the whole of what is claimed
-        // here: taking them in an order and giving each the first value its neighbours have not
-        // taken finds an assignment for some relations and not for others, and which it is turns on
-        // the order the denials were stated in — so a relation would stand written one way and be
-        // undecided written the other, and the two are one relation.
-        return atMost >= left.size()
-                && left.values().stream().allMatch(each -> each instanceof Admits.MoreThanCounted);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Apartness.java
@@ -59,16 +59,31 @@ public final class Apartness<A> {
     private static final int MOST_BLOCKS_WALKED = 30;
 
     /**
+     * How many pairs a relation may leave out for its blocks to be walked however many there are.
+     *
+     * <p>The other way a walk over the sets is cheap, and it is not the bound above with a
+     * different figure. Each pair a relation leaves out can double how many sets of blocks all
+     * stated to differ it has — a relation leaving none has one — so what this bounds is the sets
+     * rather than the blocks, and a relation of many blocks leaving few pairs out has as few sets
+     * as a small one.
+     *
+     * <p>Measured on the shape that reaches that doubling, a relation leaving this many pairs out
+     * is walked in about a fiftieth of a second, and every four more of them is sixteen times as
+     * much.
+     */
+    private static final int MOST_PAIRS_LEFT_OUT = 12;
+
+    /**
      * And how large a relation may be for its shape to be looked at at all.
      *
      * <p>What the relation itself comes to as an adjacency and what each level of the walk costs,
-     * which the bound above does not reach: a relation whose blocks are all stated to differ is
-     * walked in one path however many blocks it has, so it is admitted past that bound and would
-     * otherwise be admitted with no bound at all.
+     * which neither bound above reaches: a relation leaving few pairs out is walked in nearly one
+     * path however many blocks it has, so it is admitted past the first and would otherwise be
+     * admitted with no bound at all.
      *
-     * <p>Measured: a relation of this many pairs whose blocks are all stated to differ is walked in
-     * about a fiftieth of a second. A relation the general bound admits has at most a few hundred
-     * pairs, so this is the one that reaches such a relation's shape.
+     * <p>Measured: a relation of this many pairs all of which are stated is walked in about a
+     * fiftieth of a second. A relation the block bound admits has at most a few hundred pairs, so
+     * this is the one that reaches a relation admitted the other way.
      */
     private static final int MOST_EDGES_HELD = 5000;
 
@@ -166,7 +181,7 @@ public final class Apartness<A> {
     }
 
     /** How much walking this relation is, before any of it is walked. */
-    public Extent extent() {
+    Extent extent() {
         return new Extent(blocks().size(), edges.size());
     }
 
@@ -181,32 +196,44 @@ public final class Apartness<A> {
      * @param blocks how many blocks some pair names
      * @param edges how many pairs are stated
      */
-    public record Extent(int blocks, int edges) {
+    record Extent(int blocks, int edges) {
 
         /**
-         * Whether every block is stated to differ from every other.
+         * How many pairs of blocks are not stated to differ.
          *
-         * <p>Its own case because the walk is a different walk on it. {@link #grow} pivots on the
-         * block stated to differ from most of what may still be added, and where that is every
-         * other block, each level has one way in and the whole relation is one path — so a relation
-         * of this shape is walked in as many steps as it has blocks, however many that is, and the
-         * bound the general case needs is a bound it does not.
+         * <p>What decides the walk on a relation nearly all of whose pairs are stated, which the
+         * count of blocks does not. {@link #grow} pivots on the block stated to differ from most of
+         * what may still be added, so where a block is stated to differ from every other, each
+         * level has one way in and the whole relation is one path however many blocks it has. Each
+         * pair left out can double how many sets there are, and the walk with them: measured, a
+         * relation of this many pairs left out is walked in a fiftieth of a second and every four
+         * more of them is sixteen times as much.
+         *
+         * <p>The property and not the shape that has none of them. A relation all of whose pairs
+         * are stated is this at nothing, and one pair short of it is a relation the walk is as
+         * cheap on — so an admission that named the first would be about an example rather than
+         * about what makes it cheap, and would say nothing of the relation beside it.
          */
-        public boolean isComplete() {
-            return edges == (long) blocks * (blocks - 1) / 2;
+        long pairsLeftOut() {
+            return (long) blocks * (blocks - 1) / 2 - edges;
         }
 
         /**
          * Whether every set of blocks all stated to differ can be found.
          *
-         * <p>Two bounds and not one, because they are about two different things. How many blocks
-         * there are bounds the walk, and how many pairs there are bounds the relation itself — what
-         * it comes to as an adjacency and what one level of the walk costs. The second is what
-         * reaches a relation admitted past the first.
+         * <p>Two ways in, because two different things make this walk cheap and neither covers the
+         * other. A relation of few blocks is cheap because there are few sets to find at all; a
+         * relation of few pairs left out is cheap however many blocks it has, because the pivot
+         * leaves almost no way in at each level. A relation of many blocks nearly all of whose
+         * pairs are stated is the second and not the first.
+         *
+         * <p>And a bound on the relation itself beside them, which neither reaches: what it comes
+         * to as an adjacency and what one level of the walk costs are set by how many pairs there
+         * are, and a relation of few pairs left out has as many pairs as blocks allow.
          */
         boolean admitsCounting() {
             return edges <= MOST_EDGES_HELD
-                    && (isComplete() || blocks <= MOST_BLOCKS_WALKED);
+                    && (blocks <= MOST_BLOCKS_WALKED || pairsLeftOut() <= MOST_PAIRS_LEFT_OUT);
         }
     }
 
@@ -356,13 +383,17 @@ public final class Apartness<A> {
      * apiece for every part of it. So the parts are covered by the whole and emitting them as well
      * is the same question asked again — once per subset, which is as many as there are subsets.
      *
-     * <p>Walked to the end or not walked at all. Whoever asks decides whether the shape is one
-     * worth walking ({@link Extent#admitsCounting}), which is read off the relation before there is
-     * a walk; stopped part-way instead, this would answer with the sets one order of the pairs
-     * happened to reach first, and a relation written the other way round would be answered
-     * differently.
+     * <p>Walked to the end or not walked at all. Whether the shape is one worth walking is read off
+     * the relation before there is a walk ({@link Extent#admitsCounting}); stopped part-way
+     * instead, this would answer with the sets one order of the pairs happened to reach first, and
+     * a relation written the other way round would be answered differently.
+     *
+     * <p>Which is why this is not something a reader outside can call. What it costs is bounded by
+     * the shape and by nothing it does itself, so a caller that had not asked the shape would be
+     * walking a relation nobody had agreed to spend that much on — and the agreement is
+     * {@link #counting}, which asks before it walks.
      */
-    public List<Set<Sameness.Block<A>>> everyPairwiseApartSet() {
+    List<Set<Sameness.Block<A>>> everyPairwiseApartSet() {
         Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
         for (Edge<A> edge : edges) {
             if (edge.isOfOneBlock()) {
@@ -522,8 +553,10 @@ public final class Apartness<A> {
             return new Reduction.Nothing<>(why);
         }
         return switch (projection(left)) {
-            case Projection.TheWholeOfIt<A> it -> lookedFor(it.over(), new Reduction.Standing<>());
-            case Projection.APartOfIt<A> it -> lookedFor(it.over(), new Reduction.NotKnown<>());
+            case Projection.TheWholeOfIt<A> it ->
+                    lookedFor(it.mayHold(), new Reduction.Standing<>());
+            case Projection.APartOfIt<A> it ->
+                    lookedFor(it.mayHold(), new Reduction.NotKnown<>());
         };
     }
 
@@ -536,16 +569,19 @@ public final class Apartness<A> {
      * what the caller passed in, which is what the two arms of a {@link Projection} differ about. A
      * shape the search is not admitted for is neither.
      */
-    private Reduction<A> lookedFor(TellingApart<A> over, Reduction<A> found) {
-        if (over.isNothingToAsk()) {
-            return found;
-        }
-        if (over.assignments(MOST_ASSIGNMENTS) > MOST_ASSIGNMENTS) {
+    private Reduction<A> lookedFor(Map<Sameness.Block<A>, Set<Value>> mayHold, Reduction<A> found) {
+        // Before the question is made and not after. Both figures the search is bounded by are
+        // read off the values — how many blocks there are and what their values come to between
+        // them — and making the question out of them costs the square of the blocks, so an
+        // admission asked of the made question would be a bound on the looking and none at all on
+        // the making.
+        if (!TellingApart.isWorthLookingThrough(mayHold)) {
             return new Reduction.NotKnown<>();
         }
+        TellingApart<A> over = TellingApart.over(mayHold, this::apartFrom);
         return over.isSatisfiable() ? found
                 : new Reduction.Nothing<>(
-                        new RelationalWitness.NoAssignmentTellsThemApart<>(over.blocks()));
+                        new RelationalWitness.NoAssignmentTellsThemApart<>(mayHold.keySet()));
     }
 
     /**
@@ -578,14 +614,7 @@ public final class Apartness<A> {
                 case Admits.NotKnown _ -> whole = false;
             }
         }
-        Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
-        mayHold.keySet().forEach(block -> {
-            Set<Sameness.Block<A>> theirs = new LinkedHashSet<>(apartFrom(block));
-            theirs.retainAll(mayHold.keySet());
-            apart.put(block, theirs);
-        });
-        TellingApart<A> over = TellingApart.over(mayHold, apart);
-        return whole ? new Projection.TheWholeOfIt<>(over) : new Projection.APartOfIt<>(over);
+        return whole ? new Projection.TheWholeOfIt<>(mayHold) : new Projection.APartOfIt<>(mayHold);
     }
 
     /**
@@ -602,11 +631,11 @@ public final class Apartness<A> {
 
         /** The whole relation: what is left out was going to be given a value whatever the rest
          *  held, so an assignment found here is an assignment to all of it. */
-        record TheWholeOfIt<A>(TellingApart<A> over) implements Projection<A> {}
+        record TheWholeOfIt<A>(Map<Sameness.Block<A>, Set<Value>> mayHold) implements Projection<A> {}
 
         /** A part of it: some block's values are not written down, so an assignment found here is
          *  one for the blocks it covers and says nothing about the block left out. */
-        record APartOfIt<A>(TellingApart<A> over) implements Projection<A> {}
+        record APartOfIt<A>(Map<Sameness.Block<A>, Set<Value>> mayHold) implements Projection<A> {}
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
@@ -14,10 +14,11 @@ import java.util.Set;
  *
  * <p><b>Not one shape, because it is not one argument.</b> A block stated to differ from itself is
  * refused by reading the rule; a block left no value by its neighbours is refused by taking values
- * away; a set of blocks with fewer values between them than there are blocks is refused by counting.
- * Held as the counting one alone, the first two would be reported as a shortage of values that no
- * count was taken of — and a reduction learned later is a case added here rather than a sentence
- * somebody has to rewrite.
+ * away; a set of blocks with fewer values between them than there are blocks is refused by counting;
+ * and blocks no assignment of what they hold tells apart are refused by looking for one. Held as the
+ * counting one alone, the others would be reported as a shortage of values that no count was taken
+ * of — and a reduction learned later is a case added here rather than a sentence somebody has to
+ * rewrite.
  *
  * @param <A> what a position is called
  */
@@ -40,6 +41,11 @@ public sealed interface RelationalWitness<A> {
                 Set<Sameness.Block<B>> blocks = new LinkedHashSet<>();
                 it.blocks().forEach(block -> blocks.add(block.renamed(naming)));
                 yield new TooFewValuesBetweenThem<>(blocks, it.available());
+            }
+            case NoAssignmentTellsThemApart<A> it -> {
+                Set<Sameness.Block<B>> blocks = new LinkedHashSet<>();
+                it.blocks().forEach(block -> blocks.add(block.renamed(naming)));
+                yield new NoAssignmentTellsThemApart<>(blocks);
             }
         };
     }
@@ -116,6 +122,39 @@ public sealed interface RelationalWitness<A> {
                 throw new IllegalArgumentException("blocks stated to differ are refused by there"
                         + " being fewer values than blocks, and " + blocks + " have " + available);
             }
+        }
+    }
+
+    /**
+     * Blocks no way of giving them values tells apart.
+     *
+     * <p>Shown by looking for one and running out, which is what a shortage cannot show and is not
+     * a stronger version of it: {@code a /= b && b /= c && c /= d && d /= e && e /= a} over two
+     * values has no set of three blocks all stated to differ and needs three values all the same.
+     * So this is beside {@link TooFewValuesBetweenThem} and never a way of writing one — which
+     * that one refuses to be written as, since it is given the values it counted and there are not
+     * fewer of them here.
+     *
+     * <p><b>The blocks and no values beside them.</b> What has nothing is an assignment to all of
+     * them, and which assignments there were is not something a count can stand for: the same
+     * blocks holding the same values are refused in a cycle and satisfied in a chain. Named as a
+     * shortage, the sentence would send an author looking for more values, and there is no number
+     * of them that would do — which is the same distinction {@code PositionsHeldAsOneAreHeldApart}
+     * is told from {@code NoDistinctValuesForPositionsHeldApart} by.
+     *
+     * <p>Several of them wherever the block each is left something on its own, which is what a
+     * relation is asked about: a lack at one block is that block's own answer and is reached before
+     * anything asks what the denials between blocks come to.
+     *
+     * @param blocks the blocks an assignment was looked for over, which are those whose values are
+     *               written down: a block holding more of them than the relation has blocks was
+     *               never going to run out and is not part of what has nothing
+     */
+    record NoAssignmentTellsThemApart<A>(
+            Set<Sameness.Block<A>> blocks) implements RelationalWitness<A> {
+
+        public NoAssignmentTellsThemApart {
+            blocks = Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/RelationalWitness.java
@@ -136,11 +136,16 @@ public sealed interface RelationalWitness<A> {
      * fewer of them here.
      *
      * <p><b>The blocks and no values beside them.</b> What has nothing is an assignment to all of
-     * them, and which assignments there were is not something a count can stand for: the same
-     * blocks holding the same values are refused in a cycle and satisfied in a chain. Named as a
-     * shortage, the sentence would send an author looking for more values, and there is no number
-     * of them that would do — which is the same distinction {@code PositionsHeldAsOneAreHeldApart}
-     * is told from {@code NoDistinctValuesForPositionsHeldApart} by.
+     * them, and no set of values stands for which assignments there were: the same blocks holding
+     * the same values are refused in a ring of odd length and satisfied in a ring of even length,
+     * so a reader handed the values could not tell the two apart. {@link TooFewValuesBetweenThem}
+     * carries them because a shortage is a fact about how many there are; this is not, and carrying
+     * them would be carrying what a count was not taken of.
+     *
+     * <p><b>Read as the same sentence as a shortage, and rightly.</b> What a report says of either
+     * is that these positions are left no way of differing, and an author is sent to the same
+     * rules. The two are told apart here because a proof is not a sentence — a reduction learned
+     * later reads which argument refused — and not because the words would have to differ.
      *
      * <p>Several of them wherever the block each is left something on its own, which is what a
      * relation is asked about: a lack at one block is that block's own answer and is reached before

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -1,0 +1,145 @@
+package souther.compiler.values;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Whether some way of giving these blocks values tells every stated pair of them apart.
+ *
+ * <p>A question with two answers and no third. Whether an assignment exists is a fact about the
+ * blocks and the values, so a reading that ran out of what it allowed itself to do would be
+ * answering about its own budget — and which way it went would turn on where the walk started,
+ * which is a fact about how the rules were written. So how much work this is, is decided before it
+ * begins ({@link #assignments}), and inside that it is walked to the end.
+ *
+ * <p><b>Every block's values are written down.</b> A block whose values nobody counted, or whose
+ * values are more than a caller was counting, is not one of these — which of those it was, and what
+ * follows from leaving it out, belongs to whoever builds the question rather than here.
+ *
+ * @param <A> what a position is called
+ */
+final class TellingApart<A> {
+
+    /** The blocks, in the order the relation stated them, so that two runs over one relation take
+     *  them the same way round. */
+    private final List<Sameness.Block<A>> blocks;
+
+    /** What each of them may hold, indexed as the blocks are. */
+    private final List<List<Value>> mayHold;
+
+    /** Which earlier blocks each is stated to differ from, indexed as the blocks are. Earlier
+     *  only, because a pair is checked once and the walk gives values out in this order. */
+    private final List<int[]> apartFromEarlier;
+
+    private TellingApart(List<Sameness.Block<A>> blocks, List<List<Value>> mayHold,
+                         List<int[]> apartFromEarlier) {
+        this.blocks = blocks;
+        this.mayHold = mayHold;
+        this.apartFromEarlier = apartFromEarlier;
+    }
+
+    /**
+     * The question over {@code mayHold}, where {@code apart} says which blocks a block is stated to
+     * differ from.
+     *
+     * <p>The blocks are put in the order a value is easiest to run out of: fewest values first, and
+     * among those the one stated to differ from most of the others. Which order they are taken in
+     * does not change the answer — the walk runs to the end either way — and it changes how much of
+     * the walk is reached before a branch is refused.
+     */
+    static <A> TellingApart<A> over(Map<Sameness.Block<A>, Set<Value>> mayHold,
+                                    Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart) {
+        List<Sameness.Block<A>> order = new ArrayList<>(mayHold.keySet());
+        order.sort((one, other) -> {
+            int fewest = Integer.compare(mayHold.get(one).size(), mayHold.get(other).size());
+            return fewest != 0 ? fewest
+                    : Integer.compare(apart.getOrDefault(other, Set.of()).size(),
+                            apart.getOrDefault(one, Set.of()).size());
+        });
+        List<List<Value>> values = new ArrayList<>();
+        List<int[]> earlier = new ArrayList<>();
+        for (int at = 0; at < order.size(); at++) {
+            values.add(List.copyOf(mayHold.get(order.get(at))));
+            Set<Sameness.Block<A>> theirs = apart.getOrDefault(order.get(at), Set.of());
+            List<Integer> before = new ArrayList<>();
+            for (int other = 0; other < at; other++) {
+                if (theirs.contains(order.get(other))) {
+                    before.add(other);
+                }
+            }
+            int[] indices = new int[before.size()];
+            for (int each = 0; each < indices.length; each++) {
+                indices[each] = before.get(each);
+            }
+            earlier.add(indices);
+        }
+        return new TellingApart<>(order, values, earlier);
+    }
+
+    /** The blocks an assignment is being looked for over. */
+    Set<Sameness.Block<A>> blocks() {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
+    }
+
+    /** Whether there is nothing to look for, which is what no block at all leaves. */
+    boolean isNothingToAsk() {
+        return blocks.isEmpty();
+    }
+
+    /**
+     * How many assignments there are, which is how much walking this can be.
+     *
+     * <p>Every block's values against every other's, which the walk reaches at most one of per
+     * branch it takes to the end. Counted up to {@code most} and no further: past there the answer
+     * is that it is more than that, and the product of enough sets of values is a number no
+     * {@code long} holds.
+     */
+    long assignments(long most) {
+        long many = 1;
+        for (List<Value> these : mayHold) {
+            if (these.size() > most / Math.max(many, 1)) {
+                return most + 1;
+            }
+            many *= these.size();
+        }
+        return many;
+    }
+
+    /** Whether some assignment gives every block a value no block it is stated to differ from
+     *  takes. */
+    boolean isSatisfiable() {
+        return given(0, new Value[blocks.size()]);
+    }
+
+    /** Whether the blocks from {@code at} on can be given values, where the ones before it have
+     *  them. */
+    private boolean given(int at, Value[] taken) {
+        if (at == blocks.size()) {
+            return true;
+        }
+        for (Value value : mayHold.get(at)) {
+            if (free(at, value, taken)) {
+                taken[at] = value;
+                if (given(at + 1, taken)) {
+                    return true;
+                }
+            }
+        }
+        taken[at] = null;
+        return false;
+    }
+
+    /** Whether no block before {@code at} that it is stated to differ from holds {@code value}. */
+    private boolean free(int at, Value value, Value[] taken) {
+        for (int other : apartFromEarlier.get(at)) {
+            if (value.equals(taken[other])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -2,10 +2,12 @@ package souther.compiler.values;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Whether some way of giving these blocks values tells every stated pair of them apart.
@@ -43,28 +45,40 @@ final class TellingApart<A> {
     }
 
     /**
-     * The question over {@code mayHold}, where {@code apart} says which blocks a block is stated to
-     * differ from.
+     * The question over {@code mayHold}, where {@code apartFrom} says which blocks of the whole
+     * relation a block is stated to differ from.
+     *
+     * <p><b>The whole relation's neighbours, cut down here.</b> Which of them are part of this
+     * question is settled by which blocks it is over, and that is one fact — handed a relation
+     * already cut down to match, it would be two, and a caller that cut it somewhere else would be
+     * asking a question with a pair missing. A missing pair is not a question that fails: it is one
+     * that finds an assignment nothing stated forbids, which is the wrong answer in the direction
+     * nothing else here would catch.
      *
      * <p>The blocks are put in the order a value is easiest to run out of: fewest values first, and
      * among those the one stated to differ from most of the others. Which order they are taken in
-     * does not change the answer — the walk runs to the end either way — and it changes how much of
-     * the walk is reached before a branch is refused.
+     * does not change the answer — the search runs to the end either way — and it changes how much
+     * of it is reached before a branch is refused.
      */
     static <A> TellingApart<A> over(Map<Sameness.Block<A>, Set<Value>> mayHold,
-                                    Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart) {
+                                    Function<Sameness.Block<A>, Set<Sameness.Block<A>>> apartFrom) {
+        Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
+        for (Sameness.Block<A> block : mayHold.keySet()) {
+            Set<Sameness.Block<A>> theirs = new LinkedHashSet<>(apartFrom.apply(block));
+            theirs.retainAll(mayHold.keySet());
+            apart.put(block, theirs);
+        }
         List<Sameness.Block<A>> order = new ArrayList<>(mayHold.keySet());
         order.sort((one, other) -> {
             int fewest = Integer.compare(mayHold.get(one).size(), mayHold.get(other).size());
             return fewest != 0 ? fewest
-                    : Integer.compare(apart.getOrDefault(other, Set.of()).size(),
-                            apart.getOrDefault(one, Set.of()).size());
+                    : Integer.compare(apart.get(other).size(), apart.get(one).size());
         });
         List<List<Value>> values = new ArrayList<>();
         List<int[]> earlier = new ArrayList<>();
         for (int at = 0; at < order.size(); at++) {
             values.add(List.copyOf(mayHold.get(order.get(at))));
-            Set<Sameness.Block<A>> theirs = apart.getOrDefault(order.get(at), Set.of());
+            Set<Sameness.Block<A>> theirs = apart.get(order.get(at));
             List<Integer> before = new ArrayList<>();
             for (int other = 0; other < at; other++) {
                 if (theirs.contains(order.get(other))) {
@@ -85,28 +99,61 @@ final class TellingApart<A> {
         return Collections.unmodifiableSet(new LinkedHashSet<>(blocks));
     }
 
-    /** Whether there is nothing to look for, which is what no block at all leaves. */
-    boolean isNothingToAsk() {
-        return blocks.isEmpty();
-    }
+    /**
+     * How many assignments there may be for one of them to be looked for.
+     *
+     * <p>Every block's values against every other's, which the search reaches at most one of per
+     * branch it takes to the end.
+     */
+    private static final long MOST_ASSIGNMENTS = 1L << 20;
 
     /**
-     * How many assignments there are, which is how much walking this can be.
+     * And how many blocks a question may be over.
      *
-     * <p>Every block's values against every other's, which the walk reaches at most one of per
-     * branch it takes to the end. Counted up to {@code most} and no further: past there the answer
-     * is that it is more than that, and the product of enough sets of values is a number no
-     * {@code long} holds.
+     * <p>Beside the assignments and not instead of them, because the two bound different halves of
+     * what this does. A block is a step on every branch the search takes and a pair between two
+     * blocks is a thing checked at that step, so how many blocks there are decides what a branch
+     * costs where the assignments decide how many branches there are. Bounded by the assignments
+     * alone, a run of blocks each holding one value is a question of a single assignment and of as
+     * many blocks as anybody cares to write — which is a search that costs whatever the model
+     * costs, and the making of the question costs the square of it.
+     *
+     * <p>Which is the shape that showed the two were two. Nothing else here would have: a block
+     * holding one value is what the argument above this one leaves behind, and it multiplies the
+     * assignments by one.
      */
-    long assignments(long most) {
+    private static final int MOST_BLOCKS = 64;
+
+    /**
+     * Whether a question over {@code mayHold} is one worth looking through.
+     *
+     * <p>Asked of the values alone and before anything is built, which is what makes it a bound.
+     * Both figures are read off {@code mayHold} — how many blocks it has and what their values come
+     * to between them — so nothing has to be assembled to find out whether assembling it was
+     * allowed. Asked of a question already made, this would be a bound on the search and none at
+     * all on the making of it, and the making is the square of the blocks.
+     *
+     * <p>Counted and compared in one place, so the figures are named once. Answered as numbers for
+     * a caller to hold against its own bounds, each would be written twice — once to count up to
+     * and once to compare with — and two spellings of one figure that drift apart make a question
+     * looked through further than anything allowed.
+     *
+     * <p>A question over no blocks is within both, and is one an empty assignment answers.
+     */
+    static <A> boolean isWorthLookingThrough(Map<Sameness.Block<A>, Set<Value>> mayHold) {
+        if (mayHold.size() > MOST_BLOCKS) {
+            return false;
+        }
         long many = 1;
-        for (List<Value> these : mayHold) {
-            if (these.size() > most / Math.max(many, 1)) {
-                return most + 1;
+        for (Set<Value> these : mayHold.values()) {
+            // Counted no further than the bound, because the product of enough sets of values is a
+            // number no `long` holds and past the bound the answer is already settled.
+            if (these.size() > MOST_ASSIGNMENTS / Math.max(many, 1)) {
+                return false;
             }
             many *= these.size();
         }
-        return many;
+        return true;
     }
 
     /** Whether some assignment gives every block a value no block it is stated to differ from

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -27,8 +27,8 @@ import java.util.function.Function;
  */
 final class TellingApart<A> {
 
-    /** The blocks, in the order the relation stated them, so that two runs over one relation take
-     *  them the same way round. */
+    /** The blocks, in the order the search gives values out in, which {@link #over} settles from
+     *  what each of them holds and not from the order the relation stated them. */
     private final List<Sameness.Block<A>> blocks;
 
     /** What each of them may hold, indexed as the blocks are. */

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -103,7 +103,19 @@ final class TellingApart<A> {
      * How many assignments there may be for one of them to be looked for.
      *
      * <p>Every block's values against every other's, which the search reaches at most one of per
-     * branch it takes to the end.
+     * branch it takes to the end. Every branch stands on a block of that assignment at each step,
+     * so what the search does is this many assignments times how many blocks there are — and not
+     * twice this many, since a block left one value is a step it takes all the same and its
+     * branches are not all two ways. Which is why the figure below is beside this one.
+     *
+     * <p>That holds one relation to a fraction of a second whatever shape it is. Measured on the
+     * shapes that are actually hard — a relation with no three blocks all stated to differ that
+     * three values are still not enough for — it is a few milliseconds, so what this bounds is the
+     * case nobody has built rather than the ones there are.
+     *
+     * <p>Read the other way it is what a declaration may ask for: ten positions over a sum of four
+     * cases, or twenty over two. A relation of more positions over a larger carrier is one this
+     * says nothing about.
      */
     private static final long MOST_ASSIGNMENTS = 1L << 20;
 

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -15,8 +15,9 @@ import java.util.function.Function;
  * <p>A question with two answers and no third. Whether an assignment exists is a fact about the
  * blocks and the values, so a reading that ran out of what it allowed itself to do would be
  * answering about its own budget — and which way it went would turn on where the walk started,
- * which is a fact about how the rules were written. So how much work this is, is decided before it
- * begins ({@link #assignments}), and inside that it is walked to the end.
+ * which is a fact about how the rules were written. So how much work this is, is decided before
+ * there is a question to ask it of ({@link #isWorthLookingThrough}), and inside that it is walked to
+ * the end.
  *
  * <p><b>Every block's values are written down.</b> A block whose values nobody counted, or whose
  * values are more than a caller was counting, is not one of these — which of those it was, and what

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -17,8 +17,8 @@ import java.util.function.Function;
  * blocks and the values, so a reading that ran out of what it allowed itself to do would be
  * answering about its own budget — and which way it went would turn on where the walk started,
  * which is a fact about how the rules were written. So how much work this is, is decided before
- * there is a question to ask it of ({@link #isWorthLookingThrough}), and inside that it is walked to
- * the end.
+ * there is a question to ask it of ({@link #lookingThrough}, which is the only way to hold one), and
+ * inside that it is walked to the end.
  *
  * <p><b>Every block's values are written down.</b> A block whose values nobody counted, or whose
  * values are more than a caller was counting, is not one of these — which of those it was, and what

--- a/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/TellingApart.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -61,8 +62,9 @@ final class TellingApart<A> {
      * does not change the answer — the search runs to the end either way — and it changes how much
      * of it is reached before a branch is refused.
      */
-    static <A> TellingApart<A> over(Map<Sameness.Block<A>, Set<Value>> mayHold,
-                                    Function<Sameness.Block<A>, Set<Sameness.Block<A>>> apartFrom) {
+    private static <A> TellingApart<A> over(
+            Map<Sameness.Block<A>, Set<Value>> mayHold,
+            Function<Sameness.Block<A>, Set<Sameness.Block<A>>> apartFrom) {
         Map<Sameness.Block<A>, Set<Sameness.Block<A>>> apart = new LinkedHashMap<>();
         for (Sameness.Block<A> block : mayHold.keySet()) {
             Set<Sameness.Block<A>> theirs = new LinkedHashSet<>(apartFrom.apply(block));
@@ -138,6 +140,30 @@ final class TellingApart<A> {
     private static final int MOST_BLOCKS = 64;
 
     /**
+     * The question over {@code mayHold} where it is one worth looking through, and nothing where
+     * it is not.
+     *
+     * <p><b>The only way to hold one of these.</b> Every figure the search is bounded by is asked
+     * here, before the question is made, and there is no way of making one that does not come
+     * through this — so a figure cannot be forgotten by a caller and the asking cannot be put after
+     * the making. Both of those had happened while this was two calls with the order written
+     * between them in a comment: a comment is not violated, it only stops being true.
+     *
+     * <p>Nothing where the shape is past what is looked through, which is the absence of a question
+     * and never an answer to one. What the search answers stays two-valued; a shape nobody may ask
+     * about is not a third thing it says.
+     *
+     * @param relation how large the relation this is a part of is, which the making of the question
+     *                 reads once however few blocks the question is over
+     */
+    static <A> Optional<TellingApart<A>> lookingThrough(
+            Apartness.Extent relation, Map<Sameness.Block<A>, Set<Value>> mayHold,
+            Function<Sameness.Block<A>, Set<Sameness.Block<A>>> apartFrom) {
+        return relation.isSmallEnoughToRead() && isWorthLookingThrough(mayHold)
+                ? Optional.of(over(mayHold, apartFrom)) : Optional.empty();
+    }
+
+    /**
      * Whether a question over {@code mayHold} is one worth looking through.
      *
      * <p>Asked of the values alone and before anything is built, which is what makes it a bound.
@@ -153,7 +179,7 @@ final class TellingApart<A> {
      *
      * <p>A question over no blocks is within both, and is one an empty assignment answers.
      */
-    static <A> boolean isWorthLookingThrough(Map<Sameness.Block<A>, Set<Value>> mayHold) {
+    private static <A> boolean isWorthLookingThrough(Map<Sameness.Block<A>, Set<Value>> mayHold) {
         if (mayHold.size() > MOST_BLOCKS) {
             return false;
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest.java
@@ -116,4 +116,34 @@ class WhatDenialsComeToDoesNotTurnOnHowTheyWereWrittenTest {
                     invariant ok = p == q && q /= r && p == Ready && r == Done
                 """);
     }
+
+    /**
+     * A ring of positions each stated to differ from the next needs a third value where it is of
+     * odd length.
+     *
+     * <p>No position here is pinned to a value, so no position takes one from its neighbours; and no
+     * three of them are all stated to differ, so counting them against what the type holds shows
+     * nothing. What refuses it is that there is no way of giving five positions two values with
+     * every neighbouring pair different, which is read off the rules by looking for one.
+     */
+    @Test
+    void aRingOfOddLengthOverTwoCasesHasNoValue() {
+        assertEquals(List.of("NoValuesTheseCanAllDifferIn"), saidOf(STAGE + """
+                data Five = { a: Stage, b: Stage, c: Stage, d: Stage, e: Stage }
+                    invariant no = a /= b && b /= c && c /= d && d /= e && e /= a
+                """), "a ring of five over two cases");
+    }
+
+    /** And a ring of even length has one, as does a run of them that does not close. */
+    @Test
+    void andARingOfEvenLengthHasOneAsDoesARunThatDoesNotClose() {
+        admits(STAGE + """
+                data Four = { a: Stage, b: Stage, c: Stage, d: Stage }
+                    invariant ok = a /= b && b /= c && c /= d && d /= a
+                """);
+        admits(STAGE + """
+                data Five = { a: Stage, b: Stage, c: Stage, d: Stage, e: Stage }
+                    invariant ok = a /= b && b /= c && c /= d && d /= e
+                """);
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -31,6 +31,10 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     private static final Sameness.Block<String> Q = Sameness.Block.of("q");
     private static final Sameness.Block<String> R = Sameness.Block.of("r");
 
+    /** The first block of a run or a ring these tests build, for giving one of them a value the
+     *  rest do not have. */
+    private static final Sameness.Block<String> P0 = Sameness.Block.of("p0");
+
     private static final Value A = Value.text("A");
     private static final Value B = Value.text("B");
     private static final Value C = Value.text("C");
@@ -657,10 +661,12 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      */
     @Test
     void andARelationOfOneAssignmentOverManyBlocksIsUnanswered() {
-        assertInstanceOf(Apartness.Reduction.NotKnown.class, runOf(100).reduce(this::alternating),
-                "one assignment, and more blocks than are stepped through");
-        assertInstanceOf(Apartness.Reduction.Standing.class, runOf(60).reduce(this::alternating),
-                "and the same run inside the bound is answered");
+        // One block between the two, and their assignments are the same number: each block holds
+        // one value, so what the answer turns on is how many blocks there are and nothing else.
+        assertInstanceOf(Apartness.Reduction.NotKnown.class, runOf(65).reduce(this::alternating),
+                "one assignment, and one block more than are stepped through");
+        assertInstanceOf(Apartness.Reduction.Standing.class, runOf(64).reduce(this::alternating),
+                "and one block fewer is answered");
     }
 
     /** A run of {@code many} blocks, each stated to differ from the next. */
@@ -694,51 +700,71 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      */
     @Test
     void andHowLargeTheRelationIsReachesTheSearchAsWellAsTheCount() {
-        assertFalse(new Apartness.Extent(101, 5050).isSmallEnoughToRead(),
-                "a relation of this many pairs is past what may be read at all");
-        assertTrue(new Apartness.Extent(100, 4950).isSmallEnoughToRead(),
-                "and one pair fewer is inside it");
-        assertFalse(new Apartness.Extent(101, 5050).admitsCounting(),
-                "so the count is not taken of it either, which is the reader it was written for");
+        // One pair between the two, and nothing else between them: the same blocks, so what the
+        // answer turns on is how many pairs there are and not how many blocks. Compared against a
+        // shape of another block count, this would pass just as well against a bound on the blocks,
+        // which is a different rule that happens to answer these two the same way.
+        Apartness.Extent within = new Apartness.Extent(101, 5000);
+        Apartness.Extent past = new Apartness.Extent(101, 5001);
 
-        // And the search is not made of it, asked at the seam the relation's size arrives through.
-        // Two blocks holding two values apiece is a question inside every figure of its own, so
-        // what is left to refuse it is how large the relation those blocks are part of is.
+        assertTrue(within.isSmallEnoughToRead(), "as many pairs as may be read");
+        assertFalse(past.isSmallEnoughToRead(), "and one more than that");
+
+        // And the search is not made of the second, asked at the seam the relation's size arrives
+        // through. Two blocks holding two values apiece is a question inside every figure of its
+        // own, so what is left to refuse it is how large the relation those blocks are part of is.
         java.util.Map<Sameness.Block<String>, Set<Value>> two =
                 java.util.Map.of(P, Set.of(A, B), Q, Set.of(A, B));
-        assertTrue(TellingApart.lookingThrough(new Apartness.Extent(101, 5050), two,
-                        _ -> Set.of()).isEmpty(),
-                "a search over two blocks is a small question, and the relation holding them is"
-                        + " read once to make it however small the question is");
-        assertTrue(TellingApart.lookingThrough(new Apartness.Extent(100, 4950), two,
-                        _ -> Set.of()).isPresent(),
-                "and one pair fewer leaves a question to ask");
+        assertTrue(TellingApart.lookingThrough(within, two, _ -> Set.of()).isPresent(),
+                "a search over two blocks is a small question and there is one to ask");
+        assertTrue(TellingApart.lookingThrough(past, two, _ -> Set.of()).isEmpty(),
+                "and one pair more in the relation holding them leaves none, because making the"
+                        + " question reads every pair however small the question is");
+    }
+
+    /**
+     * And what a relation all of whose pairs are stated may be, which is where that figure bites.
+     *
+     * <p>Not one pair apart, because there is no such pair to compare against: at this many blocks
+     * every relation leaving few enough pairs out to be counted for that reason has more pairs than
+     * may be read, and every relation with few enough pairs to be read leaves too many out. What
+     * the two figures come to together is a size of relation all of whose pairs are stated, and
+     * that is what is asserted rather than an isolation there is none of.
+     */
+    @Test
+    void andTheLargestRelationAllOfWhosePairsAreStatedThatIsCounted() {
+        assertTrue(new Apartness.Extent(100, 100 * 99 / 2).admitsCounting(),
+                "every block against every other, and few enough pairs to read");
+        assertFalse(new Apartness.Extent(101, 101 * 100 / 2).admitsCounting(),
+                "and one block more is more pairs than may be read");
     }
 
     /**
      * And a relation with more assignments than are looked through is one this says nothing about.
      *
-     * <p>A cycle of odd length again, so that what changes between the two halves is how many
-     * values its blocks hold and nothing else: the same relation is refused where its assignments
-     * can be looked through and unanswered where they cannot.
+     * <p>One relation and one value between the two halves. Every block holds two values, which is
+     * as many assignments as are looked through; then one block holds a third, which is more.
+     * Nothing else moves — the same blocks, the same pairs — so what the answer turns on is the
+     * assignments and not how many blocks there are or how large the relation is.
      *
-     * <p>Which is what makes the bound a bound and not an accident. Asserted only past it, the case
-     * would pass just as well if the search had stopped working — and asserted only inside it,
-     * nothing would say where the reading stops.
+     * <p>And they are one value apart, which is what holds the figure to what it is. A third value
+     * given to every block would be past the bound too, and so would a relation of twice the
+     * blocks; asserted that way, the case would pass for any figure between the two, and what it
+     * says is that there is one somewhere.
      */
     @Test
     void andARelationWithMoreAssignmentsThanAreLookedThroughIsUnanswered() {
-        Apartness<String> odd = cycleOf(everyOneOf(19));
+        Apartness<String> even = cycleOf(everyOneOf(20));
         Set<Value> two = Set.of(A, B);
         Set<Value> three = new LinkedHashSet<>(two);
-        three.add(Value.text("C"));
+        three.add(C);
 
-        assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
-                refusedBy(odd.reduce((_, _) -> new Admits.These(two))),
-                "two values apiece over these blocks is a search this is allowed to make");
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                even.reduce((_, _) -> new Admits.These(two)),
+                "two values apiece over these blocks is as many assignments as are looked through");
         assertInstanceOf(Apartness.Reduction.NotKnown.class,
-                odd.reduce((_, _) -> new Admits.These(three)),
-                "and three apiece is more assignments than it looks through");
+                even.reduce((block, _) -> new Admits.These(block.equals(P0) ? three : two)),
+                "and one value more at one block is one assignment too many");
     }
 
     /** A relation nothing stated is one nothing refuses. */

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -317,11 +317,11 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         Apartness<String> triangle = Apartness.of("p", "q")
                 .and(Apartness.of("q", "r")).and(Apartness.of("r", "p"));
 
-        assertEquals(List.of(Set.of(P, Q, R)), triangle.everyPairwiseApartSet(),
+        assertEquals(List.of(Set.of(P, Q, R)), triangle.everySetWorthWalkingFor().orElseThrow(),
                 "one set, and not every part of it nor every order its blocks come in");
 
         Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
-        assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everyPairwiseApartSet(),
+        assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everySetWorthWalkingFor().orElseThrow(),
                 "and a chain is two of them, neither of which the other holds");
     }
 
@@ -344,7 +344,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
             }
         }
 
-        assertEquals(1, all.everyPairwiseApartSet().size(),
+        assertEquals(1, all.everySetWorthWalkingFor().orElseThrow().size(),
                 "one set, and not every part of it nor every order its blocks come in");
         assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
                 refusedBy(all.reduce(holding(java.util.Map.of()))));
@@ -395,17 +395,26 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     @Test
     void andARelationPastBothOfThoseIsOneThisSaysNothingAbout() {
         List<String> named = everyOneOf(34);
+        Apartness<String> past = leavingOut(named, 13);
+        Apartness<String> within = leavingOut(named, 12);
 
         assertInstanceOf(Apartness.Reduction.NotKnown.class,
-                leavingOut(named, 20).reduce(holding(java.util.Map.of())),
+                past.reduce(holding(java.util.Map.of())),
                 "past what either question admits, and so unanswered");
         assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
-                refusedBy(leavingOut(named, 12).reduce(holding(java.util.Map.of()))),
-                "and inside the bound the same count refuses it");
+                refusedBy(within.reduce(holding(java.util.Map.of()))),
+                "and one pair fewer left out is inside it, and counted");
     }
 
-    /** Every pair of {@code named} stated to differ but for {@code many} of them, no two of which
-     *  share a block, which is the most sets that many left-out pairs can make. */
+    /**
+     * Every pair of {@code named} stated to differ but for {@code many} of them, no two of which
+     * share a block, which is the most sets that many left-out pairs can make.
+     *
+     * <p>How many were left out is asserted rather than assumed. Asked for more pairs than the
+     * blocks can supply without sharing an end, this leaves out as many as it can and says nothing
+     * — and a boundary asserted through it would then be about a shape it never built, passing
+     * whatever the figure it is meant to hold was moved to.
+     */
     private static Apartness<String> leavingOut(List<String> named, int many) {
         Apartness<String> all = Apartness.nothing();
         for (int first = 0; first < named.size(); first++) {
@@ -416,6 +425,8 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
                 all = all.and(Apartness.of(named.get(first), named.get(second)));
             }
         }
+        assertEquals(many, all.extent().pairsLeftOut(),
+                "the fixture leaves out what it was asked to and not as many as it could");
         return all;
     }
 
@@ -539,7 +550,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         Set<Value> three = new LinkedHashSet<>(Set.of(A, B));
         three.add(C);
 
-        assertEquals(2, made.everyPairwiseApartSet().getFirst().size(),
+        assertEquals(2, made.everySetWorthWalkingFor().orElseThrow().getFirst().size(),
                 "the largest set of blocks all stated to differ is a pair");
         assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
                 refusedBy(made.reduce((_, _) -> new Admits.These(three))),
@@ -667,6 +678,41 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         String named = block.members().iterator().next();
         return new Admits.These(Set.of(
                 Integer.parseInt(named.substring(1)) % 2 == 0 ? A : B));
+    }
+
+    /**
+     * And how large the relation is reaches the search as well as the count.
+     *
+     * <p>A search over two blocks is a small question however large the relation holding them, and
+     * making it reads every pair the relation has. So the figure bounding what may be read at all
+     * is asked of both readers — asked of the count alone, a relation of any size could be read
+     * through by leaving all but two of its blocks holding more values than were counted.
+     *
+     * <p>Asserted of the shape rather than of a relation that size. Building one costs the square
+     * of its pairs, which is minutes at the figure this is about, and what the assertion is of is
+     * the question the shape is asked.
+     */
+    @Test
+    void andHowLargeTheRelationIsReachesTheSearchAsWellAsTheCount() {
+        assertFalse(new Apartness.Extent(101, 5050).isSmallEnoughToRead(),
+                "a relation of this many pairs is past what may be read at all");
+        assertTrue(new Apartness.Extent(100, 4950).isSmallEnoughToRead(),
+                "and one pair fewer is inside it");
+        assertFalse(new Apartness.Extent(101, 5050).admitsCounting(),
+                "so the count is not taken of it either, which is the reader it was written for");
+
+        // And the search is not made of it, asked at the seam the relation's size arrives through.
+        // Two blocks holding two values apiece is a question inside every figure of its own, so
+        // what is left to refuse it is how large the relation those blocks are part of is.
+        java.util.Map<Sameness.Block<String>, Set<Value>> two =
+                java.util.Map.of(P, Set.of(A, B), Q, Set.of(A, B));
+        assertTrue(TellingApart.lookingThrough(new Apartness.Extent(101, 5050), two,
+                        _ -> Set.of()).isEmpty(),
+                "a search over two blocks is a small question, and the relation holding them is"
+                        + " read once to make it however small the question is");
+        assertTrue(TellingApart.lookingThrough(new Apartness.Extent(100, 4950), two,
+                        _ -> Set.of()).isPresent(),
+                "and one pair fewer leaves a question to ask");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -2,6 +2,7 @@ package souther.compiler.values;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -306,19 +307,20 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      *
      * <p>A set inside one of these is refused only where the whole is, so emitting the parts as
      * well is the same question asked once per subset — and a set reached by taking its blocks in
-     * another order is that same set again. Both show up as a count taken more often than there are
-     * answers, which is what the bound on how many sets this will look at then runs into.
+     * another order is that same set again. Both are a count taken more often than there are
+     * answers, and how much walking a relation is worth is settled by how many blocks it has rather
+     * than by how many roads to one set the walk chose to take.
      */
     @Test
     void theSetsCountedAreTheOnesNothingCanBeAddedTo() {
         Apartness<String> triangle = Apartness.of("p", "q")
                 .and(Apartness.of("q", "r")).and(Apartness.of("r", "p"));
 
-        assertEquals(List.of(Set.of(P, Q, R)), triangle.everyPairwiseApartSet(64),
+        assertEquals(List.of(Set.of(P, Q, R)), triangle.everyPairwiseApartSet(),
                 "one set, and not every part of it nor every order its blocks come in");
 
         Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
-        assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everyPairwiseApartSet(64),
+        assertEquals(List.of(Set.of(P, Q), Set.of(Q, R)), chain.everyPairwiseApartSet(),
                 "and a chain is two of them, neither of which the other holds");
     }
 
@@ -327,9 +329,9 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      *
      * <p>Beside the cycle below, and the two together are what part the incompleteness this reading
      * means from one it would have by accident. Seven blocks all apart is the same argument three
-     * of them are refused by and nothing harder; a reading that reached it by walking every part of
-     * the set, or the set once per order its blocks come in, would run out of what it allows itself
-     * to look at and say nothing — and the shape it went quiet on would be the easy one.
+     * of them are refused by and nothing harder, and it is the shape the walk is cheapest on: the
+     * pivot leaves one way in at every level, so the whole relation is one path however many blocks
+     * it has.
      */
     @Test
     void andSevenBlocksAllStatedToDifferOverTwoValuesAreRefusedLikeThree() {
@@ -341,10 +343,85 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
             }
         }
 
-        assertEquals(1, all.everyPairwiseApartSet(64).size(),
+        assertEquals(1, all.everyPairwiseApartSet().size(),
                 "one set, and not every part of it nor every order its blocks come in");
         assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
                 refusedBy(all.reduce(holding(java.util.Map.of()))));
+    }
+
+    /**
+     * And blocks all stated to differ are counted however many of them there are.
+     *
+     * <p>Past the bound a general relation is admitted by, and refused all the same. What that
+     * bound is about is a walk that may reach one set by many roads; here the pivot leaves one way
+     * in at every level, so the shape says the walk is a single path and the relation is admitted
+     * on that.
+     *
+     * <p>Which is the whole reason the shape is asked two questions rather than one. Admitted by
+     * how many blocks it has alone, this relation would be the easy one the reading went quiet on.
+     */
+    @Test
+    void andBlocksAllStatedToDifferAreCountedHoweverManyOfThemThereAre() {
+        Apartness<String> all = allApart(everyOneOf(34));
+
+        assertTrue(all.extent().isComplete(), "every block is stated to differ from every other");
+        assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
+                refusedBy(all.reduce(holding(java.util.Map.of()))));
+    }
+
+    /**
+     * And a relation neither of those admits is one this says nothing about.
+     *
+     * <p>All apart but for one pair, which is a shape the count refuses — thirty-three of its
+     * blocks are stated to differ from each other and two values are not enough for them. It is not
+     * every block against every other, so the shape it is admitted by is how many blocks it has,
+     * and it has more than that allows.
+     *
+     * <p>Written down as the boundary rather than as a gap. The same shape one block smaller is
+     * refused, so what is asserted here is where this stops and not that it cannot count: a bound
+     * nothing shows the far side of is a bound nobody can tell from an accident.
+     */
+    @Test
+    void andARelationPastBothOfThoseIsOneThisSaysNothingAbout() {
+        List<String> named = everyOneOf(31);
+        Apartness<String> past = allApartBut(named, named.get(0), named.get(1));
+        List<String> fewer = everyOneOf(30);
+        Apartness<String> within = allApartBut(fewer, fewer.get(0), fewer.get(1));
+
+        assertFalse(past.extent().isComplete(), "one pair is not stated to differ");
+        assertInstanceOf(Apartness.Reduction.NotKnown.class, past.reduce(holding(
+                java.util.Map.of())), "past what either question admits, and so unanswered");
+
+        assertFalse(within.extent().isComplete(), "the same shape, one block smaller");
+        assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
+                refusedBy(within.reduce(holding(java.util.Map.of()))),
+                "and inside the bound the same count refuses it");
+    }
+
+    private static List<String> everyOneOf(int many) {
+        List<String> named = new ArrayList<>();
+        for (int each = 0; each < many; each++) {
+            named.add("p" + each);
+        }
+        return named;
+    }
+
+    private static Apartness<String> allApart(List<String> named) {
+        return allApartBut(named, null, null);
+    }
+
+    /** Every pair of {@code named} stated to differ, less the one pair {@code but} names. */
+    private static Apartness<String> allApartBut(List<String> named, String one, String other) {
+        Apartness<String> all = Apartness.nothing();
+        for (int first = 0; first < named.size(); first++) {
+            for (int second = first + 1; second < named.size(); second++) {
+                if (named.get(first).equals(one) && named.get(second).equals(other)) {
+                    continue;
+                }
+                all = all.and(Apartness.of(named.get(first), named.get(second)));
+            }
+        }
+        return all;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -33,6 +33,7 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
 
     private static final Value A = Value.text("A");
     private static final Value B = Value.text("B");
+    private static final Value C = Value.text("C");
 
     /** What a block admits, for a reduction that has to be asked. */
     private static Apartness.WhatABlockAdmits<String> holding(
@@ -406,6 +407,35 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         return named;
     }
 
+    /**
+     * A relation over eleven blocks whose largest set of blocks all stated to differ is a pair, and
+     * which three values do not satisfy.
+     *
+     * <p>Built beside a ring of five: a shadow of each of its blocks, stated to differ from that
+     * block's neighbours rather than from the block itself, and one block above stated to differ
+     * from every shadow. A shadow and its own block are not stated to differ, so no set of three
+     * grows, and the value the block above takes is one no shadow may hold — which leaves the ring
+     * two values, and a ring of five needs three.
+     */
+    private static Apartness<String> noThreeApartAndNotThreeColourable() {
+        List<String> ring = everyOneOf(5);
+        Apartness<String> all = cycleOf(ring);
+        for (int each = 0; each < ring.size(); each++) {
+            String shadow = "s" + ring.get(each);
+            all = all.and(Apartness.of(shadow, ring.get((each + 1) % ring.size())))
+                    .and(Apartness.of(shadow, ring.get((each + ring.size() - 1) % ring.size())))
+                    .and(Apartness.of("above", shadow));
+        }
+        return all;
+    }
+
+    private static Set<Value> four() {
+        Set<Value> these = new LinkedHashSet<>(Set.of(A, B));
+        these.add(C);
+        these.add(Value.text("D"));
+        return these;
+    }
+
     /** Each of {@code named} stated to differ from the next, and the last from the first. */
     private static Apartness<String> cycleOf(List<String> named) {
         Apartness<String> all = Apartness.nothing();
@@ -456,6 +486,40 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
                 "nothing satisfies it, and what shows that is running out of assignments");
         assertInstanceOf(Apartness.Reduction.Standing.class, even.reduce(holding(
                 java.util.Map.of())), "and two values are enough for this one, and it is said to");
+    }
+
+    /**
+     * And a relation no two of whose blocks make a set of three is still not satisfied by three
+     * values.
+     *
+     * <p>A ring of five is refused over two values, and a reading could reach that by counting how
+     * many blocks a ring has rather than by looking for an assignment. This one cannot be reached
+     * that way. No three of its blocks are all stated to differ, so every set the counting argument
+     * is asked of is a pair and three values are more than enough for a pair; and three values are
+     * still not enough for the whole of it.
+     *
+     * <p>Which is what parts the argument that was added from a rule about rings. Written as one,
+     * this relation would be admitted and no value of it exists.
+     *
+     * <p>Four values do satisfy it, and this does not say so: eleven blocks over four values is
+     * more assignments than are looked through. The smallest relation of this shape is this one, so
+     * that is not a size the bound could be raised past — it is where a reading that decides by
+     * looking stops.
+     */
+    @Test
+    void andBlocksNoThreeOfWhichAreAllApartAreStillNotSatisfiedByThreeValues() {
+        Apartness<String> made = noThreeApartAndNotThreeColourable();
+        Set<Value> three = new LinkedHashSet<>(Set.of(A, B));
+        three.add(C);
+
+        assertEquals(2, made.everyPairwiseApartSet().getFirst().size(),
+                "the largest set of blocks all stated to differ is a pair");
+        assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
+                refusedBy(made.reduce((_, _) -> new Admits.These(three))),
+                "and three values are not enough for it");
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                made.reduce((_, _) -> new Admits.These(four())),
+                "and what four values leave is past what is looked through");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -429,6 +429,12 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         return all;
     }
 
+    private static Set<Value> five() {
+        Set<Value> these = four();
+        these.add(Value.text("E"));
+        return these;
+    }
+
     private static Set<Value> four() {
         Set<Value> these = new LinkedHashSet<>(Set.of(A, B));
         these.add(C);
@@ -571,6 +577,38 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     void andABlockHoldingMoreValuesThanThereAreBlocksNeverRunsOut() {
         assertInstanceOf(Apartness.Reduction.Standing.class,
                 Apartness.of("p", "r").reduce((_, _) -> new Admits.MoreThanCounted()));
+    }
+
+    /**
+     * And what may still be asked is read off what the rules leave, not off what they started from.
+     *
+     * <p>One block pinned to a value and ten stated to differ from it, each holding five. As
+     * written that is more assignments than are looked through; once the ten have lost the value
+     * the pinned one holds, it is not, and the relation is answered.
+     *
+     * <p>So taking values away is not only what says a lack more nearly than a search can. It makes
+     * the search smaller, and a reading that read the shape before it ran would go quiet on a
+     * relation it can answer.
+     */
+    @Test
+    void andWhatMayStillBeAskedIsReadOffWhatTheRulesLeave() {
+        List<String> around = everyOneOf(10);
+        Apartness<String> all = Apartness.nothing();
+        for (String each : around) {
+            all = all.and(Apartness.of("pinned", each));
+        }
+        Set<Value> five = five();
+
+        assertInstanceOf(Apartness.Reduction.Standing.class,
+                all.reduce((block, _) -> block.equals(Sameness.Block.of("pinned"))
+                        ? new Admits.These(Set.of(A)) : new Admits.These(five)),
+                "the ten are left four values apiece, which is a search this makes");
+
+        // The same relation with nothing pinned, so that what changed is the narrowing and not the
+        // blocks or the pairs.
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                all.reduce((_, _) -> new Admits.These(five)),
+                "and five apiece is more assignments than are looked through");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -3,6 +3,7 @@ package souther.compiler.values;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -169,10 +170,9 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertEquals(Set.of(P, Q, R), few.blocks());
         assertEquals(Set.of(A, B), few.available());
 
-        // And the chain is not refused. Whether it is said to stand is a different question: a
-        // value apiece exists for it and no argument here shows one, which is what
-        // {@link Apartness.Reduction.NotKnown} says.
-        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+        // And the chain is not refused, and is said to stand: two values are enough for it, and
+        // what shows that is an assignment found rather than a count that came out even.
+        assertInstanceOf(Apartness.Reduction.Standing.class,
                 chain.reduce(holding(java.util.Map.of())));
     }
 
@@ -406,6 +406,15 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         return named;
     }
 
+    /** Each of {@code named} stated to differ from the next, and the last from the first. */
+    private static Apartness<String> cycleOf(List<String> named) {
+        Apartness<String> all = Apartness.nothing();
+        for (int each = 0; each < named.size(); each++) {
+            all = all.and(Apartness.of(named.get(each), named.get((each + 1) % named.size())));
+        }
+        return all;
+    }
+
     private static Apartness<String> allApart(List<String> named) {
         return allApartBut(named, null, null);
     }
@@ -425,34 +434,72 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     }
 
     /**
-     * A cycle of five over two values is refused by no pair and by no set of blocks all stated to
-     * differ, and this says nothing about it.
+     * A cycle of odd length over two values is refused, and one of even length stands.
      *
-     * <p>Nothing satisfies it — a cycle of odd length needs three values — and no argument this
-     * reduction has reaches it: no block is left one value, so nothing is taken away; and every set
-     * of blocks all stated to differ here is a pair, which two values are enough for. Deciding it
-     * is colouring a graph, which is a different question from the one this answers.
+     * <p>Neither is refused by a pair or by a set of blocks all stated to differ: no block is left
+     * one value, so nothing is taken away, and every such set here is a pair, which two values are
+     * enough for. What parts them is that a cycle of odd length needs three values and one of even
+     * length does not, and the only thing that reads that off the relation is looking for an
+     * assignment.
      *
-     * <p>Written down as the boundary and not as a gap to be closed here. What this holds is the
-     * whole relation, so a reduction that can colour is one added beside these rather than a
-     * rewrite of what they leave — and a reading that answered {@link Apartness.Reduction.Standing}
-     * would be claiming an assignment it has not got.
+     * <p>Which is why the two are asserted together. Refused by counting how many blocks a cycle
+     * has, both would come out the same way — and the reading would be answering a shape rather
+     * than a relation.
      */
     @Test
-    void aCycleOfFiveOverTwoValuesIsPastWhatThisReductionShows() {
-        Apartness<String> cycle = Apartness.of("a", "b")
-                .and(Apartness.of("b", "c")).and(Apartness.of("c", "d"))
-                .and(Apartness.of("d", "e")).and(Apartness.of("e", "a"));
+    void aCycleOfOddLengthOverTwoValuesIsRefusedAndOneOfEvenLengthStands() {
+        Apartness<String> odd = cycleOf(everyOneOf(5));
+        Apartness<String> even = cycleOf(everyOneOf(6));
 
-        assertInstanceOf(Apartness.Reduction.NotKnown.class, cycle.reduce(holding(
-                java.util.Map.of())), "nothing satisfies it, and no argument here reaches it");
+        assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
+                refusedBy(odd.reduce(holding(java.util.Map.of()))),
+                "nothing satisfies it, and what shows that is running out of assignments");
+        assertInstanceOf(Apartness.Reduction.Standing.class, even.reduce(holding(
+                java.util.Map.of())), "and two values are enough for this one, and it is said to");
     }
 
-    /** A block this cannot say the values of is one the relation says nothing about. */
+    /**
+     * And a block stated to differ from itself is refused whatever it holds.
+     *
+     * <p>Beside the search rather than inside it. A block holding more values than the relation has
+     * blocks is left out of the search, because it can be given a value after every other block has
+     * — and that argument holds for a block whose neighbours are other blocks and for no block that
+     * is its own. Left out on the count of its values alone, this relation would be a search over
+     * nothing, and a search over nothing finds an assignment.
+     */
+    @Test
+    void andABlockStatedToDifferFromItselfIsRefusedHoweverManyValuesItHolds() {
+        assertInstanceOf(RelationalWitness.ABlockApartFromItself.class,
+                refusedBy(Apartness.of("p", "p").reduce((_, _) -> new Admits.MoreThanCounted())));
+    }
+
+    /**
+     * A block this cannot say the values of is one the relation says nothing about.
+     *
+     * <p>Both ways round, which is what parts leaving such a block out from leaving out one that
+     * holds more values than were counted. An assignment found over the rest is not an assignment
+     * over this block, since it may hold no value at all; nothing satisfying the rest is nothing
+     * satisfying the whole, since an assignment to every block is an assignment to some of them.
+     */
     @Test
     void aBlockWhoseValuesAreNotKnownIsOneTheRelationSaysNothingAbout() {
         assertInstanceOf(Apartness.Reduction.NotKnown.class,
                 Apartness.of("p", "r").reduce((_, _) -> new Admits.NotKnown()));
+
+        // A relation the rest of which is satisfiable, so that what is asserted is the block left
+        // out and not a refusal reached some other way.
+        Apartness<String> chain = Apartness.of("p", "q").and(Apartness.of("q", "r"));
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                chain.reduce((block, _) -> block.equals(R) ? new Admits.NotKnown()
+                        : new Admits.These(Set.of(A, B))),
+                "the rest of it stands, and the block nothing wrote down may hold nothing");
+
+        // And nothing satisfying the part that was searched is nothing satisfying the whole.
+        Apartness<String> odd = cycleOf(everyOneOf(5)).and(Apartness.of("p0", "z"));
+        assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
+                refusedBy(odd.reduce((block, _) -> block.equals(Sameness.Block.of("z"))
+                        ? new Admits.NotKnown() : new Admits.These(Set.of(A, B)))),
+                "and a cycle beside it is refused whatever the block left out holds");
     }
 
     /** And a block holding more values than the relation has blocks never runs out. */
@@ -460,6 +507,32 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     void andABlockHoldingMoreValuesThanThereAreBlocksNeverRunsOut() {
         assertInstanceOf(Apartness.Reduction.Standing.class,
                 Apartness.of("p", "r").reduce((_, _) -> new Admits.MoreThanCounted()));
+    }
+
+    /**
+     * And a relation with more assignments than are looked through is one this says nothing about.
+     *
+     * <p>A cycle of odd length again, so that what changes between the two halves is how many
+     * values its blocks hold and nothing else: the same relation is refused where its assignments
+     * can be looked through and unanswered where they cannot.
+     *
+     * <p>Which is what makes the bound a bound and not an accident. Asserted only past it, the case
+     * would pass just as well if the search had stopped working — and asserted only inside it,
+     * nothing would say where the reading stops.
+     */
+    @Test
+    void andARelationWithMoreAssignmentsThanAreLookedThroughIsUnanswered() {
+        Apartness<String> odd = cycleOf(everyOneOf(19));
+        Set<Value> two = Set.of(A, B);
+        Set<Value> three = new LinkedHashSet<>(two);
+        three.add(Value.text("C"));
+
+        assertInstanceOf(RelationalWitness.NoAssignmentTellsThemApart.class,
+                refusedBy(odd.reduce((_, _) -> new Admits.These(two))),
+                "two values apiece over these blocks is a search this is allowed to make");
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                odd.reduce((_, _) -> new Admits.These(three)),
+                "and three apiece is more assignments than it looks through");
     }
 
     /** A relation nothing stated is one nothing refuses. */

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -358,45 +358,65 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      * in at every level, so the shape says the walk is a single path and the relation is admitted
      * on that.
      *
-     * <p>Which is the whole reason the shape is asked two questions rather than one. Admitted by
-     * how many blocks it has alone, this relation would be the easy one the reading went quiet on.
+     * <p><b>Leaving one pair out as well as leaving none.</b> A relation all of whose pairs are
+     * stated is one point of what makes the walk cheap, and an admission written on that point
+     * would be about an example rather than about the property — a relation one pair short of it is
+     * as cheap and would go unanswered. So both are asserted, and the second is what a rule about
+     * complete relations would miss.
      */
     @Test
-    void andBlocksAllStatedToDifferAreCountedHoweverManyOfThemThereAre() {
-        Apartness<String> all = allApart(everyOneOf(34));
+    void andBlocksNearlyAllStatedToDifferAreCountedHoweverManyOfThemThereAre() {
+        List<String> named = everyOneOf(34);
+        Apartness<String> all = allApart(named);
+        Apartness<String> butOne = allApartBut(named, List.of(named.get(0), named.get(1)));
 
-        assertTrue(all.extent().isComplete(), "every block is stated to differ from every other");
+        assertEquals(0, all.extent().pairsLeftOut(), "every block against every other");
         assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
                 refusedBy(all.reduce(holding(java.util.Map.of()))));
+
+        assertEquals(1, butOne.extent().pairsLeftOut(), "and this one leaves a pair out");
+        assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
+                refusedBy(butOne.reduce(holding(java.util.Map.of()))),
+                "which the walk is as cheap on, so it is counted too");
     }
 
     /**
      * And a relation neither of those admits is one this says nothing about.
      *
-     * <p>All apart but for one pair, which is a shape the count refuses — thirty-three of its
-     * blocks are stated to differ from each other and two values are not enough for them. It is not
-     * every block against every other, so the shape it is admitted by is how many blocks it has,
-     * and it has more than that allows.
+     * <p>Enough blocks to be past what a general relation is admitted by, and enough pairs left out
+     * to be past what a nearly-complete one is. Each pair left out can double how many sets of
+     * blocks all stated to differ there are to find, so a relation leaving many of them is what
+     * both questions are asked to keep out.
      *
-     * <p>Written down as the boundary rather than as a gap. The same shape one block smaller is
-     * refused, so what is asserted here is where this stops and not that it cannot count: a bound
+     * <p>Written down as the boundary rather than as a gap. The same relation leaving fewer pairs
+     * out is counted, so what is asserted is where this stops and not that it cannot count: a bound
      * nothing shows the far side of is a bound nobody can tell from an accident.
      */
     @Test
     void andARelationPastBothOfThoseIsOneThisSaysNothingAbout() {
-        List<String> named = everyOneOf(31);
-        Apartness<String> past = allApartBut(named, named.get(0), named.get(1));
-        List<String> fewer = everyOneOf(30);
-        Apartness<String> within = allApartBut(fewer, fewer.get(0), fewer.get(1));
+        List<String> named = everyOneOf(34);
 
-        assertFalse(past.extent().isComplete(), "one pair is not stated to differ");
-        assertInstanceOf(Apartness.Reduction.NotKnown.class, past.reduce(holding(
-                java.util.Map.of())), "past what either question admits, and so unanswered");
-
-        assertFalse(within.extent().isComplete(), "the same shape, one block smaller");
+        assertInstanceOf(Apartness.Reduction.NotKnown.class,
+                leavingOut(named, 20).reduce(holding(java.util.Map.of())),
+                "past what either question admits, and so unanswered");
         assertInstanceOf(RelationalWitness.TooFewValuesBetweenThem.class,
-                refusedBy(within.reduce(holding(java.util.Map.of()))),
+                refusedBy(leavingOut(named, 12).reduce(holding(java.util.Map.of()))),
                 "and inside the bound the same count refuses it");
+    }
+
+    /** Every pair of {@code named} stated to differ but for {@code many} of them, no two of which
+     *  share a block, which is the most sets that many left-out pairs can make. */
+    private static Apartness<String> leavingOut(List<String> named, int many) {
+        Apartness<String> all = Apartness.nothing();
+        for (int first = 0; first < named.size(); first++) {
+            for (int second = first + 1; second < named.size(); second++) {
+                if (second == first + 1 && first % 2 == 0 && first / 2 < many) {
+                    continue;
+                }
+                all = all.and(Apartness.of(named.get(first), named.get(second)));
+            }
+        }
+        return all;
     }
 
     private static List<String> everyOneOf(int many) {
@@ -452,15 +472,16 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
     }
 
     private static Apartness<String> allApart(List<String> named) {
-        return allApartBut(named, null, null);
+        return allApartBut(named, List.of());
     }
 
-    /** Every pair of {@code named} stated to differ, less the one pair {@code but} names. */
-    private static Apartness<String> allApartBut(List<String> named, String one, String other) {
+    /** Every pair of {@code named} stated to differ, less {@code spared}, which is a pair or is
+     *  none. */
+    private static Apartness<String> allApartBut(List<String> named, List<String> spared) {
         Apartness<String> all = Apartness.nothing();
         for (int first = 0; first < named.size(); first++) {
             for (int second = first + 1; second < named.size(); second++) {
-                if (named.get(first).equals(one) && named.get(second).equals(other)) {
+                if (spared.equals(List.of(named.get(first), named.get(second)))) {
                     continue;
                 }
                 all = all.and(Apartness.of(named.get(first), named.get(second)));
@@ -609,6 +630,43 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         assertInstanceOf(Apartness.Reduction.NotKnown.class,
                 all.reduce((_, _) -> new Admits.These(five)),
                 "and five apiece is more assignments than are looked through");
+    }
+
+    /**
+     * And a relation of one assignment over many blocks is one this says nothing about.
+     *
+     * <p>A run of blocks each stated to differ from the next and each left one value, alternating,
+     * so that taking values away finds nothing to take. Its blocks' values come to a single
+     * assignment between them however long the run is, so how many assignments there are says
+     * nothing about what looking through them costs — the looking is a step per block and the
+     * making of the question is the square of them.
+     *
+     * <p>Which is why the search is bounded by two figures. Bounded by the assignments alone, this
+     * is a relation of one assignment and of as many blocks as anybody writes.
+     */
+    @Test
+    void andARelationOfOneAssignmentOverManyBlocksIsUnanswered() {
+        assertInstanceOf(Apartness.Reduction.NotKnown.class, runOf(100).reduce(this::alternating),
+                "one assignment, and more blocks than are stepped through");
+        assertInstanceOf(Apartness.Reduction.Standing.class, runOf(60).reduce(this::alternating),
+                "and the same run inside the bound is answered");
+    }
+
+    /** A run of {@code many} blocks, each stated to differ from the next. */
+    private static Apartness<String> runOf(int many) {
+        List<String> named = everyOneOf(many);
+        Apartness<String> all = Apartness.nothing();
+        for (int each = 0; each + 1 < many; each++) {
+            all = all.and(Apartness.of(named.get(each), named.get(each + 1)));
+        }
+        return all;
+    }
+
+    /** One value apiece, alternating along the run, which is what nothing can take a value from. */
+    private Admits alternating(Sameness.Block<String> block, int atMost) {
+        String named = block.members().iterator().next();
+        return new Admits.These(Set.of(
+                Integer.parseInt(named.substring(1)) % 2 == 0 ? A : B));
     }
 
     /**


### PR DESCRIPTION
Closes #1395.

## What was wrong

The reading that holds a denial between two positions decided one by counting arguments: a value stated to differ from itself, a block whose neighbours take everything it was left, and a set of blocks all stated to differ with fewer values between them than there are blocks. Between them they decide the relations a count settles, and a ring of positions each stated to differ from the next is not one of those. A ring of odd length over two cases is satisfied by nothing and refused by none of them; a ring of even length is satisfied and claimed by none of them either. So both fell out the same side, as unanswered, and the declaration in the issue was accepted although no value of it exists.

The root of it is not a missing counting rule. Which values a general relation leaves is a colouring, and no argument over the relation was one — so adding a rule about rings would leave the next shape admitted and would have bought a rule that fires on one shape.

## What is here

An argument beside the three, which looks for an assignment. Running out refuses; finding one is what makes standing a claim rather than a failure to refuse.

The counting arguments stay, and not as a courtesy. Reading the rule and taking values away say which blocks the lack is about, where a search can only name the blocks it looked over. Reading the rule is what the search rests on: a block is left out of the search because it holds more values than the relation has blocks and so can be given one after every other block has, which no block stated to differ from itself can. Counting decides where the search is not admitted to look, which is most of what a large relation is. And taking values away makes the search smaller, so a relation past what the search looks through as written may be inside it once that has run.

What the search is asked over is held as two arms rather than a set with a condition beside it. A block holding more values than were counted is left out and costs nothing either way; a block whose values nothing wrote down is left out and costs the positive answer, since it may hold no value at all. Refusing carries from a part of a relation to the whole of it and standing does not, so the two are not one question asked twice.

The rule that claimed standing from every block holding more values than the relation has blocks is gone. Such a relation is a search over nothing, and a search over nothing finds an assignment.

## What a reading like this owes

How much a compilation spends on one relation, and that reaching the boundary says nothing rather than answering with less.

Every figure is read off the shape before anything is walked, so that whether a relation is answered is a fact about the relation and not about where a walk happened to start — two writings of one relation are one relation.

How many pairs a relation has bounds the relation itself, which is what both readers hold and read; neither may be handed one larger. Beside that, the walk over the sets of blocks all stated to differ is admitted by how many blocks there are, whose exponential part is what a maximal-clique walk pivoting on the most-connected block has, or by how many pairs it leaves out, since a relation leaving few of them has few such sets however many blocks it has — which is the property that makes a relation all of whose pairs are stated cheap, rather than that relation itself. And the search is admitted by how many blocks it is over and by what their values come to between them, the second because it is how many branches there are and the first because a block is a step on every one of them.

The step budget the walk used to stop on is gone with them: nothing here now has a state in which it has given up part-way. And neither admission is a call beside the thing it admits — the walk and the search are each reachable only through the entry that asks, so a figure cannot be forgotten by a caller nor asked after the work it bounds.

## Beside it

A check over the compiled classes of every module writing down who may say that a position admits something. A settled answer about which values a position may take and where its order stops is a claim about that pair and about nothing else, and this makes the positive answer's reach a list rather than a sentence in a doc — the population moved once already while this branch was being written.