### PR TITLE
A condition's shape is recognised once, and a reading is handed the answer

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -125,7 +125,7 @@ final class AdmissibleReading {
      * <p>And a position of two values is read as itself. Naming one is stating it, which is the
      * one value it then holds, and the polarity above says which — the reading of the clause has
      * already turned {@code p == false} and {@code p /= true} into this leaf denied
-     * ({@link Conditions#restated}), so nothing here asks how the author spelled it.
+     * ({@link ClauseExpr}), so nothing here asks how the author spelled it.
      */
     PlannedValues<FactSubject> leaf(Core e, boolean positive, Denotations at) {
         if (e instanceof Core.Binary b

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -79,10 +79,13 @@ sealed interface ClauseExpr {
     /**
      * What a reading is handed: a part of no connective, or a connective it takes whole.
      *
-     * <p>A binding is not one of these. Where the environment changes is the fold's to find and
-     * {@link ClauseScope}'s to answer, so a reading is never handed one — which is a fact about the
-     * types here and not a rule anybody has to keep. A second account of what a binder means cannot
-     * be written, because there is nowhere for it to be written.
+     * <p>A binding standing in the clause is not one of these. Where the environment changes is the
+     * fold's to find and {@link ClauseScope}'s to answer, so a reading is never handed one as a
+     * part — which is a fact about the types here and not a rule anybody has to keep.
+     *
+     * <p>What is inside a part is another matter. A binding nested there is still part of that
+     * leaf, and each question the part language asks about its own inside crosses it by asking the
+     * environment (ADR-0106) — which is the one answer again and not a second account of it.
      */
     sealed interface Part extends ClauseExpr permits Leaf, Joined {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseExpr.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.core.Core;
 import souther.compiler.semantics.ConditionJoin;
+import souther.compiler.types.BinOp;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,15 +63,44 @@ sealed interface ClauseExpr {
      */
     boolean positive();
 
+    /**
+     * The subtree of the tree this shape was written as, which is the outermost of what it is
+     * spelled as.
+     *
+     * <p>What an author wrote at this position, denials included. A reading that names a part it
+     * declined to descend into names it by this: {@link Leaf#of} and {@link Joined#of} have the
+     * denials taken off, which is what a reading of the part wants and not what a report about
+     * where it was written does.
+     */
+    default Core written() {
+        return spelled().get(0);
+    }
+
+    /**
+     * What a reading is handed: a part of no connective, or a connective it takes whole.
+     *
+     * <p>A binding is not one of these. Where the environment changes is the fold's to find and
+     * {@link ClauseScope}'s to answer, so a reading is never handed one — which is a fact about the
+     * types here and not a rule anybody has to keep. A second account of what a binder means cannot
+     * be written, because there is nowhere for it to be written.
+     */
+    sealed interface Part extends ClauseExpr permits Leaf, Joined {
+
+        /** The part itself, with the denials above it taken off, which is the innermost of what it
+         *  is spelled as. */
+        Core of();
+    }
+
     /** One part of no connective, stated where {@code positive} and denied where it is not. */
-    record Leaf(List<Core> spelled, boolean positive) implements ClauseExpr {
+    record Leaf(List<Core> spelled, boolean positive) implements Part {
 
         public Leaf {
             spelled = named(spelled);
         }
 
         /** The part itself, which is the innermost of what it is spelled as. */
-        Core of() {
+        @Override
+        public Core of() {
             return spelled.get(spelled.size() - 1);
         }
     }
@@ -85,7 +115,7 @@ sealed interface ClauseExpr {
      *            {@code BOTH} beside {@code positive} being false is a choice and not a conjunction
      */
     record Joined(List<Core> spelled, boolean positive, ConditionJoin how, ClauseExpr left,
-                  ClauseExpr right) implements ClauseExpr {
+                  ClauseExpr right) implements Part {
 
         public Joined {
             spelled = named(spelled);
@@ -99,8 +129,24 @@ sealed interface ClauseExpr {
          * happens to begin at. A denial carried down leaves the operator the author typed here and
          * the {@code not} above it, and the operator is the innermost of the two.
          */
-        Core of() {
+        @Override
+        public Core of() {
             return spelled.get(spelled.size() - 1);
+        }
+
+        /**
+         * The two subtrees this composes, as the author wrote them.
+         *
+         * <p>For a reading that takes the connective whole and still has something to say about
+         * what stands under it — that the author named these two values, say. Read back off the
+         * operator instead, such a reading would be recovering a structure it has already been
+         * given, which is the shape being worked out twice.
+         *
+         * <p>Two halves and no further. What is under each of them is that half's own shape, and
+         * this hands over the halves rather than the leaves below them.
+         */
+        List<Core> writtenHalves() {
+            return List.of(left.written(), right.written());
         }
     }
 
@@ -149,9 +195,9 @@ sealed interface ClauseExpr {
         if (clause instanceof Core.LetIn let) {
             return new Scoped(spelled, positive, let, of(let.body(), positive, List.of()));
         }
-        Conditions.Restated under = Conditions.restated(clause);
-        if (under != null) {
-            return of(under.condition(), under.denied() != positive, spelled);
+        ClauseExpr restated = restating(clause, positive, spelled);
+        if (restated != null) {
+            return restated;
         }
         if (clause instanceof Core.Binary bin) {
             // Stated, a conjunction gives both sides; denied, it gives the choice between their
@@ -165,5 +211,67 @@ sealed interface ClauseExpr {
             }
         }
         return new Leaf(spelled, positive);
+    }
+
+    /**
+     * The shape of what {@code clause} is written in terms of, or null where it is written in terms
+     * of nothing.
+     *
+     * <p>A restatement moves the polarity and nothing else, so what comes back is the shape of what
+     * is written under it, spelled as both nodes. Held here because it is the same question the
+     * connectives are — which part of the tree this clause is, and how it stands — and answering it
+     * anywhere else is a second reading of the shape. Private, so that there is nowhere else for
+     * one to be.
+     *
+     * <p>Read in the analysis representation and in no other. {@code Bool.not} is an ordinary
+     * helper, which that representation keeps as a call; the settled representation an imported
+     * clause is read in has expanded it into a body, and a rule about the operation has nothing to
+     * be about there. Reading the expansion too would be this deciding what a clause means from the
+     * shape a lowering happened to leave, for one helper out of every one the settling expands —
+     * the fragment an imported clause falls outside of is the whole of them (spec
+     * §invariant-discharge-representation).
+     *
+     * <p>So: the call, the {@code if} an author wrote themselves, and a comparison against a
+     * written {@code true} or {@code false} — {@code p == false} and {@code p /= true} deny what
+     * {@code p} states, and the other two state it.
+     *
+     * <p>The equivalence class and not the spellings. What a reading is given is a part and a
+     * polarity, so {@code not (p == false)} and {@code p} arrive as the same pair — and a reader
+     * that learned one spelling at a time would answer for the ones somebody had got to.
+     */
+    private static ClauseExpr restating(Core clause, boolean positive, List<Core> spelled) {
+        if (clause instanceof Core.PreservedCall call && call.operation().equals(DischargeRules.NOT)
+                && call.args().size() == 1) {
+            return of(call.args().get(0), !positive, spelled);
+        }
+        if (clause instanceof Core.If iff
+                && iff.then() instanceof Core.Bool t && !t.value()
+                && iff.els() instanceof Core.Bool f && f.value()) {
+            return of(iff.cond(), !positive, spelled);
+        }
+        return againstATruthValue(clause, positive, spelled);
+    }
+
+    /**
+     * The same of a comparison one side of which is a written {@code true} or {@code false}.
+     *
+     * <p>Whether it denies is whether the two disagree: an equality against {@code true} and a
+     * disequality against {@code false} state what the other side states, and the other pair deny
+     * it. Read off the operator and the literal rather than written out as four cases, so a fifth
+     * way to write the same thing arrives here as one of the two answers and not as a case nobody
+     * added.
+     */
+    private static ClauseExpr againstATruthValue(Core clause, boolean positive,
+                                                 List<Core> spelled) {
+        if (!(clause instanceof Core.Binary bin)
+                || (bin.op() != BinOp.EQ && bin.op() != BinOp.NE)) {
+            return null;
+        }
+        boolean holds = bin.op() == BinOp.EQ;
+        if (bin.right() instanceof Core.Bool truth) {
+            return of(bin.left(), (truth.value() != holds) != positive, spelled);
+        }
+        return bin.left() instanceof Core.Bool truth
+                ? of(bin.right(), (truth.value() != holds) != positive, spelled) : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseReading.java
@@ -41,13 +41,19 @@ import souther.compiler.core.Core;
 interface ClauseReading<S, E> {
 
     /**
-     * What one part of the clause says, stated where {@code positive} and denied where it is not,
-     * read at the environment {@code at} it stands in.
+     * What one part of the clause says, read at the environment {@code at} it stands in.
      *
-     * <p>A part of no connective, or a connective this reading takes whole — the two are one case.
-     * What is inside a part is the part language's to ask, and a binding standing there is crossed
-     * by each question it asks about its own inside (ADR-0106); a connective taken whole is a part
-     * on exactly those terms.
+     * <p>A part of no connective, or a connective this reading takes whole — the two are one case,
+     * and {@link ClauseExpr.Part} is that case. What is inside a part is the part language's to
+     * ask, and a binding standing there is crossed by each question it asks about its own inside
+     * (ADR-0106); a connective taken whole is a part on exactly those terms.
+     *
+     * <p>Handed the shape and not the node. What the part is ({@link ClauseExpr.Part#of}), how it
+     * stands ({@link ClauseExpr#positive}), what the author wrote it as ({@link ClauseExpr#written})
+     * and, for a connective taken whole, which two halves it composes
+     * ({@link ClauseExpr.Joined#writtenHalves}) are all answers the shape already holds. A reading
+     * given the node alone works whichever of them it needs out of the tree again, which is the
+     * shape being read twice.
      *
      * <p>Reached with the denials already counted, so a reading of a comparison is a reading of the
      * comparison it states rather than of the one that was written. And reached with the bindings
@@ -55,7 +61,7 @@ interface ClauseReading<S, E> {
      * reading that answered from the environment the whole clause began in would be reading one
      * value's rule at another value's names.
      */
-    S whole(Core e, boolean positive, E at);
+    S whole(ClauseExpr.Part part, E at);
 
     /**
      * How far this reading goes into {@code join}, and what holding both of its parts comes to.
@@ -110,12 +116,12 @@ interface ClauseReading<S, E> {
     private S over(ClauseExpr shape, E at, ClauseScope<E> scope,
                    java.util.function.BiConsumer<Core, S> per) {
         S out = switch (shape) {
-            case ClauseExpr.Leaf it -> whole(it.of(), it.positive(), at);
+            case ClauseExpr.Leaf it -> whole(it, at);
             // How far this reading goes is its own answer, and taking the connective whole is
             // reading the node an author wrote it at as a part. A reading told to descend and
             // unable to compose what it found had nowhere to say so.
             case ClauseExpr.Joined it -> switch (at(it)) {
-                case Descent.Whole<S> _ -> whole(it.of(), it.positive(), at);
+                case Descent.Whole<S> _ -> whole(it, at);
                 case Descent.Into<S> into -> into.compose().apply(
                         over(it.left(), at, scope, per), over(it.right(), at, scope, per));
             };

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -160,10 +160,12 @@ final class Conditions {
          * so nothing above this had a shape to recognise differently for it.
          */
         @Override
-        public List<NumericConstraint> whole(Core e, boolean positive, Denotations at) {
+        public List<NumericConstraint> whole(ClauseExpr.Part part, Denotations at) {
+            boolean positive = part.positive();
             List<NumericConstraint> out = new ArrayList<>();
             for (StatedComparison stated
-                    : comparisonsStatedBy(terms, asSizeComparison(e), at).inReadingOrder()) {
+                    : comparisonsStatedBy(terms, asSizeComparison(part.of()), at)
+                            .inReadingOrder()) {
                 LinearForm<FactSubject> left = terms.affineOf(stated.left(), at);
                 LinearForm<FactSubject> right = terms.affineOf(stated.right(), at);
                 if (left != null && right != null) {
@@ -422,74 +424,6 @@ final class Conditions {
         public Polar denied(Polar statement) {
             return new Polar(statement.expr(), !statement.positive());
         }
-    }
-
-    /**
-     * One condition written in terms of another, and whether it states it or denies it.
-     *
-     * <p>What every walk over a clause carries is a pair — the part being read and whether the
-     * denials above it came out even — and this is the step that pair is moved by. Written as
-     * "what a negation is applied to", the step could only ever flip, so the ways of stating a
-     * condition without flipping were not steps at all and a walk stopped at them.
-     *
-     * @param condition what is written under, which the walk goes on with
-     * @param denied    whether holding this one is denying that one
-     */
-    record Restated(Core condition, boolean denied) {}
-
-    /**
-     * What {@code e} is written in terms of, or {@code null} where it is written in terms of
-     * nothing.
-     *
-     * <p>Read in the analysis representation and in no other. {@code Bool.not} is an ordinary
-     * helper, which that representation keeps as a call; the settled representation an imported
-     * clause is read in has expanded it into a body, and a rule about the operation has nothing to
-     * be about there. Reading the expansion too would be this deciding what a clause means from the
-     * shape a lowering happened to leave, for one helper out of every one the settling expands —
-     * the fragment an imported clause falls outside of is the whole of them (spec
-     * §invariant-discharge-representation).
-     *
-     * <p>So: the call, the {@code if} an author wrote themselves, and a comparison against a
-     * written {@code true} or {@code false} — {@code p == false} and {@code p /= true} deny what
-     * {@code p} states, and the other two state it.
-     *
-     * <p>The equivalence class and not the spellings. What a reader below is given is an atom and a
-     * polarity, so {@code not (p == false)} and {@code p} arrive as the same pair — and a reader
-     * that learned one spelling at a time would answer for the ones somebody had got to.
-     */
-    static Restated restated(Core e) {
-        if (e instanceof Core.PreservedCall call && call.operation().equals(DischargeRules.NOT)
-                && call.args().size() == 1) {
-            return new Restated(call.args().get(0), true);
-        }
-        if (e instanceof Core.If iff
-                && iff.then() instanceof Core.Bool t && !t.value()
-                && iff.els() instanceof Core.Bool f && f.value()) {
-            return new Restated(iff.cond(), true);
-        }
-        return againstATruthValue(e);
-    }
-
-    /**
-     * The same of a comparison one side of which is a written {@code true} or {@code false}.
-     *
-     * <p>Whether it denies is whether the two disagree: an equality against {@code true} and a
-     * disequality against {@code false} state what the other side states, and the other pair deny
-     * it. Read off the operator and the literal rather than written out as four cases, so a fifth
-     * way to write the same thing arrives here as one of the two answers and not as a case nobody
-     * added.
-     */
-    private static Restated againstATruthValue(Core e) {
-        if (!(e instanceof Core.Binary bin)
-                || (bin.op() != BinOp.EQ && bin.op() != BinOp.NE)) {
-            return null;
-        }
-        boolean holds = bin.op() == BinOp.EQ;
-        if (bin.right() instanceof Core.Bool truth) {
-            return new Restated(bin.left(), truth.value() != holds);
-        }
-        return bin.left() instanceof Core.Bool truth
-                ? new Restated(bin.right(), truth.value() != holds) : null;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExpansionCost.java
@@ -77,7 +77,7 @@ final class ExpansionCost implements ClauseReading<Long, Void> {
      * parts come out costing nothing and be admitted under any budget.
      */
     @Override
-    public Long whole(Core e, boolean positive, Void at) {
+    public Long whole(ClauseExpr.Part part, Void at) {
         return 1L;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.semantics.ConditionJoin;
 import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.DischargeRules.Carrying;
 import souther.compiler.check.DischargeRules.Projection;
@@ -125,8 +124,9 @@ final class Predicates {
         }
 
         @Override
-        public List<Quantified> whole(Core e, boolean positive, Denotations at) {
-            return of.quantifierStatedBy(Conditions.asSizeComparison(e), positive, at);
+        public List<Quantified> whole(ClauseExpr.Part part, Denotations at) {
+            return of.quantifierStatedBy(Conditions.asSizeComparison(part.of()), part.positive(),
+                    at);
         }
 
         private static List<Quantified> together(List<Quantified> left, List<Quantified> right) {
@@ -722,9 +722,9 @@ final class Predicates {
         }
 
         @Override
-        public Owed whole(Core e, boolean positive, Denotations at) {
-            return of.owing(Conditions.asSizeComparison(e), at, unnamed, positive, decidesFalse,
-                    discharge);
+        public Owed whole(ClauseExpr.Part part, Denotations at) {
+            return of.owing(Conditions.asSizeComparison(part.of()), at, unnamed, part.positive(),
+                    decidesFalse, discharge);
         }
     }
 
@@ -945,38 +945,92 @@ final class Predicates {
      * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
      * outside the affine fragment, leave {@code k} unchanged (sound). */
     Assumed assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
-        Core cond = Conditions.asSizeComparison(rawCond);
-        if (cond instanceof Core.Binary b) {
-            // Recognised once, and both of what a connective can compose read off the answer. A
-            // connective composing both halves under the polarity in force gives each of them under
-            // that polarity; one composing either of them gives neither, and what is left of it is
-            // that the author named the two.
-            ConditionJoin join =
-                    ConditionJoin.of(b.op()).map(each -> each.under(positive)).orElse(null);
-            if (join == ConditionJoin.BOTH) {
-                Assumed left = assumeCond(b.left(), k, at, positive);
-                // Either side taken in is the condition taken in. A conjunction one half of which
-                // reads is not one nothing was read of, and calling it that would name this
-                // compiler's limit where the limit was reached on one operand only.
-                return assumeCond(b.right(), left.known(), at, positive)
-                        .alsoRead(left.taken(), left.shapeRead());
-            }
-            if (join == ConditionJoin.EITHER) {
-                return taking(cond, List.of(b.left(), b.right()), k, at, positive);
-            }
+        return new Assuming(this).read(rawCond, positive, at, terms::inside).from(k);
+    }
+
+    /**
+     * What taking a clause as holding does to what is known, before it is given a state to do it to.
+     *
+     * <p>Threading a state through the parts is this reading's own algebra and not the shape's: the
+     * right half of a conjunction is taken under what the left half left, so the two are read in
+     * order. Held as a state the fold carried downward, every reading over a clause would be one
+     * that runs left to right, which is true of this one and of none of the others.
+     */
+    @FunctionalInterface
+    private interface Assumption {
+
+        /** What this comes to, taken under {@code known}. */
+        Assumed from(Known known);
+    }
+
+    /**
+     * What a condition taken in makes known, read over the shape it was written in.
+     *
+     * <p>Over the shape ({@link ClauseExpr}) and not over the tree, so that what a connective
+     * composes, where a denial goes and where a binding stands are recognised once and this reading
+     * agrees with every other by having been given the answer. Read as a tree of its own, this had
+     * words for a connective and a denial and none for a binding — so a rule an author stated by
+     * naming it made nothing known, while the same rule written out made the comparison known, and
+     * the one reader with no tree-rebuilding above it named a dead branch on one spelling only.
+     */
+    private record Assuming(Predicates of) implements ClauseReading<Assumption, Denotations> {
+
+        /**
+         * A conjunction is taken in a half at a time, and a choice whole.
+         *
+         * <p>One of a choice's parts holds and this cannot say which, so taking either of them in
+         * would rule out values the condition admits. What is left of it is that the author named
+         * the two, which the part it is read as says.
+         */
+        @Override
+        public Descent<Assumption> at(ClauseExpr.Joined join) {
+            return switch (join.how()) {
+                case BOTH -> new Descent.Into<>(Assuming::both);
+                case EITHER -> new Descent.Whole<>();
+            };
         }
-        Conditions.Restated under = Conditions.restated(cond);
-        if (under != null) {
-            return assumeCond(under.condition(), k, at, under.denied() != positive);
+
+        @Override
+        public Assumption whole(ClauseExpr.Part part, Denotations at) {
+            return known -> of.taking(part, known, at);
         }
+
+        /**
+         * The right half under what the left half left.
+         *
+         * <p>Either side taken in is the condition taken in. A conjunction one half of which reads
+         * is not one nothing was read of, and calling it that would name this compiler's limit
+         * where the limit was reached on one operand only.
+         */
+        private static Assumption both(Assumption left, Assumption right) {
+            return known -> {
+                Assumed one = left.from(known);
+                return right.from(one.known()).alsoRead(one.taken(), one.shapeRead());
+            };
+        }
+    }
+
+    /**
+     * What taking one part of a condition as holding comes to.
+     *
+     * <p>Every reading of the comparison it states, because each of them holds of the same values:
+     * the order a call decides, and the bound on the sign that decides it. Which one a clause is
+     * read against is settled where the clause is read, so a guard states each of them rather than
+     * choosing here.
+     */
+    private Assumed taking(ClauseExpr.Part part, Known k, Denotations at) {
+        boolean positive = part.positive();
+        Core cond = Conditions.asSizeComparison(part.of());
         List<StatedComparison> readings =
                 Conditions.comparisonsStatedBy(terms, cond, at).inReadingOrder();
         if (readings.isEmpty()) {
-            return taking(cond, List.of(), k, at, positive);
+            // What a choice names is its two halves, taken from the shape that composed them: this
+            // reading states neither of them, and without saying they were named a value one of
+            // them computes is one nothing has ever spoken of.
+            return taking(cond,
+                    part instanceof ClauseExpr.Joined join ? join.writtenHalves() : List.of(),
+                    k, at, positive);
         }
-        // Every reading, because each of them holds of the same values: the order a call decides,
-        // and the bound on the sign that decides it. Which one a clause is read against is settled
-        // where the clause is read, so a guard states each of them rather than choosing here.
         Assumed so = new Assumed(k, false, false);
         for (StatedComparison stated : readings) {
             Assumed one = taking(stated, so.known(), at, positive);

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -1021,15 +1021,16 @@ final class Predicates {
     private Assumed taking(ClauseExpr.Part part, Known k, Denotations at) {
         boolean positive = part.positive();
         Core cond = Conditions.asSizeComparison(part.of());
+        // A connective taken whole states no comparison — that is what taking it whole means — so
+        // it is not asked for one. What it names is the two halves the shape composed, and without
+        // saying they were named a value one of them computes is one nothing has ever spoken of.
+        if (part instanceof ClauseExpr.Joined join) {
+            return taking(cond, join.writtenHalves(), k, at, positive);
+        }
         List<StatedComparison> readings =
                 Conditions.comparisonsStatedBy(terms, cond, at).inReadingOrder();
         if (readings.isEmpty()) {
-            // What a choice names is its two halves, taken from the shape that composed them: this
-            // reading states neither of them, and without saying they were named a value one of
-            // them computes is one nothing has ever spoken of.
-            return taking(cond,
-                    part instanceof ClauseExpr.Joined join ? join.writtenHalves() : List.of(),
-                    k, at, positive);
+            return taking(cond, List.of(), k, at, positive);
         }
         Assumed so = new Assumed(k, false, false);
         for (StatedComparison stated : readings) {

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -488,7 +488,9 @@ sealed interface StatedByClauses {
          * than one.
          */
         @Override
-        public StatedByClauses whole(Core e, boolean positive, Denotations at) {
+        public StatedByClauses whole(ClauseExpr.Part part, Denotations at) {
+            Core e = part.of();
+            boolean positive = part.positive();
             PlannedValues<FactSubject> said = values.leaf(e, positive, at);
             OrderedIntervals<FactSubject> range = ordered.leaf(e, positive, at);
             Set<FactSubject> mentions = mentioned(e, at);

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
@@ -12,8 +12,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -123,13 +125,21 @@ class AClauseUnderABindingIsReadInsideItTest {
      * and the parts are the leaf and the connective it takes whole; a binding is a shape of its own
      * and goes to {@link ClauseScope}. So a second account of what a binder means is not something
      * anybody has to be stopped from writing — it does not compile.
+     *
+     * <p>As a set, because that is what a sealed type's members are: {@code
+     * getPermittedSubclasses} answers in no order it specifies, so reading its array as a sequence
+     * takes an order from something that has none.
+     *
+     * <p>And as two answers, because they fail for different reasons: one says the parts are still
+     * these two, the other that a binding is still not one of them.
      */
     @Test
     void aBindingIsNotAPartAReadingCanBeHanded() {
-        assertEquals(List.of(List.of(ClauseExpr.Leaf.class, ClauseExpr.Joined.class), false),
-                List.of(List.of(ClauseExpr.Part.class.getPermittedSubclasses()),
-                        ClauseExpr.Part.class.isAssignableFrom(ClauseExpr.Scoped.class)),
-                "what a reading may be handed, and whether a binding is among it");
+        assertEquals(Set.of(ClauseExpr.Leaf.class, ClauseExpr.Joined.class),
+                Set.of(ClauseExpr.Part.class.getPermittedSubclasses()),
+                "what a reading may be handed");
+        assertFalse(ClauseExpr.Part.class.isAssignableFrom(ClauseExpr.Scoped.class),
+                "a binding is not something a reading can be handed as a part");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AClauseUnderABindingIsReadInsideItTest.java
@@ -51,8 +51,8 @@ class AClauseUnderABindingIsReadInsideItTest {
         private final List<AtALeaf> leaves = new ArrayList<>();
 
         @Override
-        public List<AtALeaf> whole(Core e, boolean positive, String at) {
-            leaves.add(new AtALeaf(e, positive, at));
+        public List<AtALeaf> whole(ClauseExpr.Part part, String at) {
+            leaves.add(new AtALeaf(part.of(), part.positive(), at));
             return List.of(leaves.get(leaves.size() - 1));
         }
 
@@ -114,6 +114,22 @@ class AClauseUnderABindingIsReadInsideItTest {
         assertEquals(List.of(), reading(clause).stream()
                         .filter(one -> one.part() instanceof Core.LetIn).toList(),
                 "what a binder means is the environment's answer and no evaluator's");
+    }
+
+    /**
+     * And there is nowhere for one to be handed.
+     *
+     * <p>The same thing said of the types rather than of a walk. What a reading is given is a part,
+     * and the parts are the leaf and the connective it takes whole; a binding is a shape of its own
+     * and goes to {@link ClauseScope}. So a second account of what a binder means is not something
+     * anybody has to be stopped from writing — it does not compile.
+     */
+    @Test
+    void aBindingIsNotAPartAReadingCanBeHanded() {
+        assertEquals(List.of(List.of(ClauseExpr.Leaf.class, ClauseExpr.Joined.class), false),
+                List.of(List.of(ClauseExpr.Part.class.getPermittedSubclasses()),
+                        ClauseExpr.Part.class.isAssignableFrom(ClauseExpr.Scoped.class)),
+                "what a reading may be handed, and whether a binding is among it");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OnlyAFoldOverAWholeClauseTreeIsOneTest.java
@@ -42,7 +42,10 @@ class OnlyAFoldOverAWholeClauseTreeIsOneTest {
      * leaving them owed. {@code Predicates.Owing} says what a clause owes and {@code
      * Predicates.Quantifiers} says which quantifiers it states: two answers about one clause, each
      * reading it to the depth its own answer composes to, and both meeting the connectives the
-     * shape already recognised rather than either recognising them again.
+     * shape already recognised rather than either recognising them again. {@code
+     * Predicates.Assuming} says what taking a condition in makes known, which is the third answer
+     * over that same shape; it composes a conjunction by taking its right half under what the left
+     * half left, so what it reads a clause into is a state and not a value.
      *
      * <p>A row for a reading of one language — the values, the ranges, or whatever is written next
      * — is the edge this exists to refuse. Those interpret leaves, and the fold that composes them
@@ -51,6 +54,7 @@ class OnlyAFoldOverAWholeClauseTreeIsOneTest {
     private static final Set<String> FOLDS = Set.of(
             "souther.compiler.check.Conditions$Stating",
             "souther.compiler.check.ExpansionCost",
+            "souther.compiler.check.Predicates$Assuming",
             "souther.compiler.check.Predicates$Owing",
             "souther.compiler.check.Predicates$Quantifiers",
             "souther.compiler.check.StatedByClauses$Reading");

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnOperatorMayStillBeHeldIsWrittenDownTest.java
@@ -258,9 +258,6 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " else about them is read off the shape it leaves"),
             new Held("souther.compiler.check.FieldDomains.lambda$projection$2",
                     "walks into both halves for the clause that bounds a field"),
-            new Held("souther.compiler.check.Predicates.assumeCond",
-                    "walks into both halves under the polarity in force, for what a condition"
-                            + " taken in makes known"),
             new Held("souther.compiler.partition.Condition.of",
                     "the composition, which the shape it makes carries"),
             new Held("souther.compiler.partition.ClauseStatements.walk",
@@ -342,7 +339,7 @@ class WhereAnOperatorMayStillBeHeldIsWrittenDownTest {
                             + " until somebody says what it means here"),
             new Held("souther.compiler.check.Conditions.asSizeComparison",
                     "writes the equality an emptiness check means: a size stood against nought"),
-            new Held("souther.compiler.check.Conditions.againstATruthValue",
+            new Held("souther.compiler.check.ClauseExpr.againstATruthValue",
                     "asks whether the operator is the equality or the disequality, for a comparison"
                             + " one side of which is a written truth value: which of the two it is"
                             + " and which value was written are together what says whether such a"

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
@@ -25,27 +25,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * Which readers of a condition cross a binding, which stop at one, and what makes up for it.
+ * Which readers of a condition cross a binding, which stop at one, and why the two are not the same
+ * kind of reader.
  *
  * <p>A rule an author names is expanded where it stands, so a condition written as a call is a
- * binding holding the argument with the rule written against it. What decides whether such a node
- * is read is the walk to the comparison and never the language that reads one: what is under the
- * binding is the rule, and each of the readers below states it once the environment has been
- * entered.
+ * binding holding the argument with the rule written against it. There are two kinds of reader of
+ * such a condition, and what separates them is what they are handed.
  *
- * <p>So the reading that says what a condition states crosses it — it is read over the clause's
- * shape, which is where a binding is a place the environment changes rather than a form nobody has
- * a word for. The readers that walk to a comparison for themselves stop: they recognise a
- * restatement and a connective and then ask for the comparison, and a binding is none of the three.
+ * <p><b>A reader of a flat condition does not read a binder node.</b> {@link
+ * Conditions#comparisonsStatedBy} is handed one expression and asks which comparisons it states; a
+ * binding is not a comparison, and it is not that reader's business to say what one means. Handed
+ * what is under the binding it states the rule, and handed the binding itself in that same
+ * environment it states nothing — so what stops it is the node and never the environment.
  *
- * <p>They are not handed one on the way to a construction. The walk that threads knowledge enters a
- * binding standing inside a value and goes on over the rebuilt tree ({@link InvariantChecker}), so
- * by the time an arm is opened the condition is the comparison the source would have written. What
- * an author sees of a construction is therefore the same either way, and the difference between the
- * two spellings is held here rather than there.
+ * <p><b>A reader of a whole clause crosses one.</b> A binding is a shape the clause has
+ * ({@link ClauseExpr.Scoped}), the fold finds it and {@link ClauseScope} answers for it, and every
+ * reading over that shape meets the leaves under it holding what their names mean. A reading is
+ * never handed the binding itself: {@link ClauseExpr.Part} is what it is handed, and a binding is
+ * not one.
  *
- * <p>One report does differ, and it is not the construction: a branch no value reaches is named
- * where the condition was written out and not where it was named.
+ * <p><b>What a condition taken in makes known is the second kind.</b> It reads three answers off one
+ * shape beside what a clause states and which quantifiers it names, so a rule stated through a
+ * helper makes known what the same rule written out makes known — in what is entailed, in whether
+ * anything was taken in, and in whether the shape was read. It was the first kind until it was
+ * written as a reading: it recognised a connective and a denial for itself, had no word for a
+ * binding, and a rule an author named made nothing known.
+ *
+ * <p><b>And the hoist inside the invariant checker is a different job.</b> That one enters a binding
+ * standing inside a value — under a field read, under one side of a comparison — so that the value
+ * built after it is read under the names the call handed over. It is about what a walk sees next and
+ * not about what environment a clause is read in, and it stays where it is.
  */
 class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
 
@@ -67,17 +76,26 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
         return new Core.Read("n", VALUE, Type.INT, POS);
     }
 
+    private static Core.Binary binary(BinOp op, Core left, Core right) {
+        return new Core.Binary(op, left, right, SourceConstructOrigin.unwritten(), Type.BOOL, POS);
+    }
+
     /** `<subject> >= 0`, the rule itself. */
     private static Core.Binary rule(Core subject) {
-        return new Core.Binary(BinOp.GE, subject, new Core.Int(0, Type.INT, POS),
-                SourceConstructOrigin.unwritten(), Type.BOOL, POS);
+        return binary(BinOp.GE, subject, new Core.Int(0, Type.INT, POS));
+    }
+
+    /** `let $n = n in <written against $n>`, which is what naming a rule expands to. */
+    private static Core.LetIn naming(java.util.function.Function<Core, Core> body) {
+        BindingId bound = new BindingId(OWNER, 1);
+        Core written = body.apply(new Core.Read("$n", bound, Type.INT, POS));
+        return new Core.LetIn(new Core.Binder("$n", bound), subject(), written, written.type(),
+                POS);
     }
 
     /** `let $n = n in $n >= 0`, which is what naming the rule expands to. */
     private static Core.LetIn named() {
-        BindingId bound = new BindingId(OWNER, 1);
-        Core.Binary body = rule(new Core.Read("$n", bound, Type.INT, POS));
-        return new Core.LetIn(new Core.Binder("$n", bound), subject(), body, body.type(), POS);
+        return naming(WhoCrossesABindingInAConditionAndWhoDoesNotTest::rule);
     }
 
     private static List<NumericConstraint> stated(Terms terms, Core cond, Denotations at) {
@@ -86,7 +104,8 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
         return out;
     }
 
-    /** What a condition states on its own: the rule written out, and nothing where it was named. */
+    /** What a condition states on its own, which is read over the clause's shape and crosses a
+     *  binding. */
     @Test
     void theReadingOfWhatAConditionStatesCrossesABinding() {
         Terms terms = terms();
@@ -97,9 +116,17 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
                 "how many relations each spelling states");
     }
 
-    /** And so does the reader of comparisons under it, which is what that walk asks. */
+    /**
+     * And the reader of a flat condition does not, which is the boundary and not a defect.
+     *
+     * <p>What it is asked is which comparisons one expression states. A binding is not a comparison
+     * and what a binder means is not this reader's answer, so it says none — and the reading above
+     * gets the rule by having crossed the binding before it asks this at all. A reader of a flat
+     * condition that learned to enter a binding would be the second account of a binder this whole
+     * arrangement exists to stop.
+     */
     @Test
-    void theReaderOfComparisonsStopsAtOneToo() {
+    void theFlatReaderOfComparisonsDoesNotReadABinderNode() {
         Terms terms = terms();
 
         assertEquals(List.of(1, 0), List.of(
@@ -110,29 +137,12 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
                 "how many comparisons each spelling states");
     }
 
-    /** And so does the walk that threads knowledge along a path. */
-    @Test
-    void theWalkThatThreadsKnowledgeStopsAtOneAsWell() {
-        Terms terms = terms();
-        Predicates predicates = new Predicates(terms);
-        Denotations at = rootAt();
-        LinearForm<FactSubject> about = terms.affineOf(subject(), at);
-        assertNotNull(about, "the value the rule is about is a form this reads");
-
-        assertEquals(List.of(true, false), List.of(
-                        predicates.assumeCond(rule(subject()), Known.top(), at, true)
-                                .known().numbers().entails(about, Rel.GE),
-                        predicates.assumeCond(named(), Known.top(), at, true)
-                                .known().numbers().entails(about, Rel.GE)),
-                "whether what is known entails the rule, written out and named");
-    }
-
     /**
      * What stops such a reader is the node and not the environment it would read one in.
      *
      * <p>Handed what is under the binding, the reader of comparisons states the rule; handed the
      * binding itself in that same environment, it states nothing. So an entered environment is not
-     * what it is missing — the binding is a form its own walk has no word for, and a reading that
+     * what it is missing — the binding is a form its own reading has no word for, and a reading that
      * goes over the clause's shape crosses it without ever being handed one (ADR-0106).
      */
     @Test
@@ -147,6 +157,132 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
                         Conditions.comparisonsStatedBy(terms, named, inside)
                                 .inReadingOrder().size()),
                 "what is under the binding, and the binding handed whole to the same reader");
+    }
+
+    /** And so does the walk that threads knowledge along a path, which is a reading of the shape. */
+    @Test
+    void theWalkThatThreadsKnowledgeCrossesABindingAsWell() {
+        Terms terms = terms();
+        Predicates predicates = new Predicates(terms);
+        Denotations at = rootAt();
+        LinearForm<FactSubject> about = terms.affineOf(subject(), at);
+        assertNotNull(about, "the value the rule is about is a form this reads");
+
+        assertEquals(List.of(true, true), List.of(
+                        predicates.assumeCond(rule(subject()), Known.top(), at, true)
+                                .known().numbers().entails(about, Rel.GE),
+                        predicates.assumeCond(named(), Known.top(), at, true)
+                                .known().numbers().entails(about, Rel.GE)),
+                "whether what is known entails the rule, written out and named");
+    }
+
+    /**
+     * And the whole of what it answers agrees, not the state alone.
+     *
+     * <p>Three answers and not one. What is entailed says what a proof may rest on; whether anything
+     * was taken in and whether the shape was read say what an unsettled arm may be explained by, and
+     * a spelling that agreed on the first and not on the other two would report this compiler's
+     * limit at a rule it had in fact read to the end.
+     */
+    @Test
+    void takingARuleInAnswersTheSameWhicheverWayItWasWritten() {
+        Terms terms = terms();
+        Predicates predicates = new Predicates(terms);
+        Denotations at = rootAt();
+        LinearForm<FactSubject> about = terms.affineOf(subject(), at);
+
+        assertEquals(answering(predicates.assumeCond(rule(subject()), Known.top(), at, true), about),
+                answering(predicates.assumeCond(named(), Known.top(), at, true), about),
+                "what taking the rule in came to, written out and named");
+    }
+
+    /** What one of these came to, as the three answers it is. */
+    private static List<Object> answering(Predicates.Assumed assumed,
+                                          LinearForm<FactSubject> about) {
+        return List.of(assumed.known().numbers().entails(about, Rel.GE), assumed.taken(),
+                assumed.shapeRead());
+    }
+
+    /**
+     * A conjunction is taken a half at a time, the right under what the left left.
+     *
+     * <p>Which is this reading's own algebra and not the shape's: the shape says these two are
+     * composed, and taking them in order is what taking a conjunction in means here. Read with each
+     * half given the state the conjunction began in, the left half's rule would be gone from what
+     * comes out, and a pair of halves nothing can satisfy at once would come out satisfiable — which
+     * is exactly the answer a branch nothing reaches is decided by.
+     */
+    @Test
+    void aConjunctionTakesItsRightHalfUnderWhatItsLeftHalfLeft() {
+        Terms terms = terms();
+        Predicates predicates = new Predicates(terms);
+        Denotations at = rootAt();
+        Core.LetIn both = naming(bound -> binary(BinOp.AND,
+                binary(BinOp.GE, bound, new Core.Int(1, Type.INT, POS)),
+                binary(BinOp.LE, bound, new Core.Int(0, Type.INT, POS))));
+
+        assertEquals(true,
+                predicates.assumeCond(both, Known.top(), at, true).known().reachesNothing(),
+                "no value is at once above nought and below it, which only the half that was read"
+                        + " second can find out");
+    }
+
+    /**
+     * A choice names the two halves it composes, and nothing under them.
+     *
+     * <p>One of a choice's parts holds and this cannot say which, so neither is taken in. What is
+     * left of it is that the author named the two, which is read off the shape that composed them —
+     * the halves as they were written, denials and all. Walked instead, every comparison under the
+     * choice would be named, which widens what a clause may be owed for and what a report may point
+     * at.
+     */
+    @Test
+    void aChoiceNamesItsTwoHalvesAndNoFurther() {
+        Terms terms = terms();
+        Predicates predicates = new Predicates(terms);
+        Denotations at = rootAt();
+        Core deeper = binary(BinOp.GE, subject(), new Core.Int(1, Type.INT, POS));
+        Core half = binary(BinOp.OR, deeper,
+                binary(BinOp.LE, subject(), new Core.Int(9, Type.INT, POS)));
+        Core beside = binary(BinOp.EQ, subject(), new Core.Int(5, Type.INT, POS));
+        Known known = predicates.assumeCond(binary(BinOp.OR, half, beside), Known.top(), at, true)
+                .known();
+
+        assertEquals(List.of(true, true, false), List.of(
+                        known.speaksOf(terms.subjectOf(half, at)),
+                        known.speaksOf(terms.subjectOf(beside, at)),
+                        known.speaksOf(terms.subjectOf(deeper, at))),
+                "the two halves of the choice, and a comparison one of them is written out of");
+    }
+
+    /**
+     * And a denial above a binding reaches the connective under it.
+     *
+     * <p>The three shapes at once. A denial is carried to the leaves as the shape is read, so
+     * denying a named rule turns over the connective inside the helper's body — a conjunction denied
+     * is the choice between the denials, and denying that again is the conjunction back. Read as
+     * three recognitions in three readers, the one that had no word for the binding stopped before
+     * the other two ever ran.
+     */
+    @Test
+    void aDenialAboveANamedRuleReachesTheConnectiveUnderIt() {
+        Terms terms = terms();
+        Predicates predicates = new Predicates(terms);
+        Denotations at = rootAt();
+        LinearForm<FactSubject> about = terms.affineOf(subject(), at);
+        Core.LetIn both = naming(bound -> binary(BinOp.AND,
+                binary(BinOp.GE, bound, new Core.Int(0, Type.INT, POS)),
+                binary(BinOp.LE, bound, new Core.Int(0, Type.INT, POS))));
+        // `named(n) == false`, taken as failing, which is the conjunction stated.
+        Known known = predicates.assumeCond(
+                binary(BinOp.EQ, both, new Core.Bool(false, Type.BOOL, POS)),
+                Known.top(), at, false).known();
+
+        assertEquals(List.of(true, true), List.of(
+                        known.numbers().entails(about, Rel.GE),
+                        known.numbers().entails(about, Rel.LE)),
+                "each way nought is stood against, from the two halves of the denied conjunction"
+                        + " under the binding");
     }
 
     private static final String YEN = """
@@ -164,7 +300,7 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
     }
 
     /** The condition the analysis is given, where the rule was named: the binding the expansion
-     *  wrote, which is the shape the readers above stop at. */
+     *  wrote, which is the shape a reading crosses and a flat reader stops at. */
     @Test
     void theConditionTheAnalysisReadsIsTheBindingTheExpansionWrote() {
         Compilation compilation = Compilation.ofSource(YEN + """
@@ -191,8 +327,7 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
         Core.forEachChild(e, child -> forks(child, out));
     }
 
-    /** And what a construction the arms are given comes to, which is the same either way: the walk
-     *  enters the binding and goes on over the rebuilt tree before any arm is opened. */
+    /** And what a construction the arms are given comes to, which is the same either way. */
     @Test
     void aConstructionGivenTheArmsIsAnsweredWhicheverWayTheConditionWasWritten() {
         assertEquals(List.of(List.of(), List.of()), List.of(
@@ -257,17 +392,19 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
     }
 
     /**
-     * The one report that does differ, and it is not the construction.
+     * And the report an author sees of a branch no value reaches, which is the same either way.
      *
-     * <p>A condition stating nothing about what the arm is leaves the construction owed both ways.
-     * The branch no value reaches is named where the rule was written out and not where it was
-     * named, which is a reader the rebuilt tree does not reach.
+     * <p>A condition stating nothing about what the arm is leaves the construction owed both ways,
+     * and the branch nothing reaches is named both ways. This is the reader with no tree-rebuilding
+     * above it: what it asks is which branches a value can be in, over the tree the analysis holds,
+     * and the binding it meets there is crossed because what it asks the condition is a reading of
+     * the clause's shape.
      */
     @Test
-    void aBranchNoValueReachesIsNamedOnlyWhereTheConditionWasWrittenOut() {
-        assertEquals(List.of(
-                        List.of("E2011 check.invariant.title", "E1327 check.dead.branch.title"),
-                        List.of("E2011 check.invariant.title")), List.of(
+    void aBranchNoValueReachesIsNamedWhicheverWayTheConditionWasWritten() {
+        List<String> both = List.of("E2011 check.invariant.title", "E1327 check.dead.branch.title");
+
+        assertEquals(List.of(both, both), List.of(
                         reported(YEN + """
                                 behavior f : (n: Int) -> Yen constructs Yen
                                 let f (n) = Yen(if n == n then n else 0)

--- a/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhoCrossesABindingInAConditionAndWhoDoesNotTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -86,7 +87,7 @@ class WhoCrossesABindingInAConditionAndWhoDoesNotTest {
     }
 
     /** `let $n = n in <written against $n>`, which is what naming a rule expands to. */
-    private static Core.LetIn naming(java.util.function.Function<Core, Core> body) {
+    private static Core.LetIn naming(Function<Core, Core> body) {
         BindingId bound = new BindingId(OWNER, 1);
         Core written = body.apply(new Core.Read("$n", bound, Type.INT, POS));
         return new Core.LetIn(new Core.Binder("$n", bound), subject(), written, written.type(),

--- a/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/AnOperatorIsAskedWhatItComposesInOnePlaceTest.java
@@ -56,9 +56,6 @@ class AnOperatorIsAskedWhatItComposesInOnePlaceTest {
                     "the same for a clause, with the denial the tree is read under applied as the"
                             + " shape is made"),
 
-            new Licence("souther.compiler.check.Predicates.assumeCond", 1,
-                    "the same, for what a condition taken in makes known"),
-
             new Licence("souther.compiler.check.ClauseHelpers.shaped", 1,
                     "the shape an author wrote a clause in, which is walking into what composes"
                             + " both halves. The one place an authored part is recognised: which"


### PR DESCRIPTION
Closes #1412.

A branch nothing reaches was named where a rule was written out and not
where the same rule was named, and nothing about the two spellings is
meant to differ.

## The cause

The shape a condition is written out of — a conjunction, a choice, a
denial, a binding — was read out of the tree in two places.
`ClauseExpr.of` is one, and it has a word for each of them. What taking
a condition in makes known was the other: it recognised a connective and
a denial for itself, had no word for a binding, and a rule an author
stated by naming it therefore made nothing known.

The reports an author sees agreed anyway, because the invariant
checker's walk hoists a binding standing inside a value out of the way
before it asks. The reader with no such hoist above it is the walk that
says which branches a value can be in, and that is where the difference
showed. Giving that walk a hoist of its own would be the same rule
written a third time.

## The change

A reading is handed `ClauseExpr.Part` — a leaf, or a connective it takes
whole. A binding is not one, so a second account of what a binder means
cannot be written. Beside what a part is, the shape hands over how it
stands, what the author wrote it as, and which two halves a connective
taken whole composes, so a reading has no reason to go back to the tree.

Recognising a restatement moves into the shape as a private detail,
which is where the connectives and the bindings are already recognised.
Nothing else can reach it.

What a condition makes known is then a reading over that shape, beside
what a clause states and which quantifiers it names. What it reads a
clause into is a state rather than a value: a conjunction is taken a
half at a time, the right half under what the left half left. That
ordering is this reading's own algebra and stays inside it, so no other
reading over a clause is made to run left to right.

The invariant checker's hoist stays. It answers what a walk sees next,
which is not what environment a clause is read in.

## What is fixed, and how

A binding is not a part a reading can be handed: said of the permitted
subtypes rather than of anybody's code. Asking an operator what it
composes was already licensed call site by call site, and the licence
this reading held is given back. Recognising a restatement is closed by
visibility.

Beside the reports, the answers underneath are pinned: what is entailed
together with whether anything was taken in and whether the shape was
read, the right half of a conjunction taken under what the left half
left, the two halves a choice names and nothing under them, and a denial
above a binding reaching the connective inside it.

The reader of a flat condition still states nothing of a binder node.
That is the boundary between a reader of one expression and a reading of
a whole clause, and the test says so rather than treating it as a defect.

## What moved

Nothing an author sees changed anywhere but at the branch this is about.
The population's diagnostics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
