### PR TITLE
Take a choice where a choice is taken, and leave no way to take one after

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Confinement.java
@@ -648,6 +648,11 @@ sealed interface Confinement<A> {
      *
      * <p>The sets are in hand, so every alternative can be asked where its positions stop and the
      * answer is settled either way.
+     *
+     * <p>Nothing here composes two readings. Every connective a clause is read by is spent by the
+     * time one of these exists — the conjunction that outlives it is the one between declarations,
+     * and a caller relating two holds {@link Conjoined}. What is left to do to one of these is ask
+     * it, and tell it what a choice already settled left open.
      */
     final class Worked<A> implements Confinement<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1482,22 +1482,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     }
 
     /**
-     * Either reading holding.
-     *
-     * <p>Over the positions both spoke about, since a position one of them left open is one the two
-     * of them together leave open.
-     *
-     * <p>What an alternative nothing could read left open is not said here, and cannot be. Which
-     * positions those are turns on which branches anybody can be in, and that is settled over the
-     * whole declaration — after this join, out of what it and every other one came to. So it
-     * arrives afterwards ({@link #alsoOpenedAt}), from the one walk that knows both the alternatives
-     * an author wrote and what became of them.
-     */
-    public AdmissibleValues<A> join(AdmissibleValues<A> other, Allowance<A> sets) {
-        return joining(other, false, sets);
-    }
-
-    /**
      * The same reading, also unable to speak for {@code these} because a choice offered an
      * alternative nothing could read.
      *
@@ -1512,189 +1496,9 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
                         guaranteed, defaultGuaranteed, guaranteedTogether, tangled, widened);
     }
 
-    /**
-     * Either reading holding, with the alternatives of the two held apart.
-     *
-     * <p>The same choice, read without merging what it leaves back into one product. A choice
-     * between alternatives written at two positions is a union of two products and no product holds
-     * it, so merging is where the relation goes — and it goes unnoticed, because the projections
-     * survive a union and it is the next conjunction that spends what was lost.
-     *
-     * <p>Held apart, the conjunction meets the alternatives pairwise, the pairs nothing stands in
-     * drop out, and what is left is what the rules leave. Which is why nothing is owed here: the
-     * union of two products is what it is, and this states it rather than approximating it.
-     *
-     * <p>How many may be held is not this reading's to decide. What bounds them is settled from the
-     * clauses before any of them is read ({@code ExpansionCost}), so that precision cannot turn on
-     * how a fold was bracketed.
-     */
-    public AdmissibleValues<A> joinApart(AdmissibleValues<A> other, Allowance<A> sets) {
-        return joining(other, true, sets);
-    }
-
-    private AdmissibleValues<A> joining(AdmissibleValues<A> other, boolean apart,
-                                        Allowance<A> sets) {
-        Set<Sameness.Block<A>> gaveUp = new LinkedHashSet<>();
-        // An alternative nobody can take leaves the answer to the others. Both being that is a
-        // different case: no side speaks for the other, and meeting them would state a conjunction
-        // the alternatives never stood in. What the choice admits nothing at is what every
-        // alternative admits nothing at, and where there is no such position the choice still
-        // admits nothing.
-        if (isBottom() && other.isBottom()) {
-            // Emptied by what emptied both. A block one branch was left nothing at is one the
-            // other may stand at, so what the choice is left nothing at is what neither of them
-            // has a value for — the same rule the rest of a dead choice is put together by.
-            return new AdmissibleValues<>(
-                    new Held.Nothing<>(Refusal.shownByBoth(refusedBy(), other.refusedBy())),
-                    emptyInBoth(other),
-                    standing.and(other.standing),
-                    Map.of(), ValueSet.NONE, true,
-                    eachApart(both(tangled, other.tangled)),
-                    eachApart(both(widened, other.widened)));
-        }
-        if (isBottom()) {
-            return other;
-        }
-        if (other.isBottom()) {
-            return this;
-        }
-        // The alternatives of the choice, and with them the coordinates it answers in: what a
-        // position holds under a choice is settled by what every alternative holds it as, so the
-        // blocks are the ones both sides state and everything said of a coarser one comes apart
-        // into them.
-        Held<A> held = apart ? apart(other, sets, gaveUp) : merged(other, sets, gaveUp);
-        Sameness<A> heldAsOne = held instanceof Held.Alternatives<A> it
-                ? it.commonSameness() : Sameness.discrete();
-        // What the alternatives guarantee between them, which is what settles whether anything is
-        // left for an unread rule to have widened.
-        Map<Sameness.Block<A>, ValueSet> covered =
-                guaranteedBy(this, other, heldAsOne, sets::joinPromised);
-        ValueSet coveredElsewhere =
-                sets.joinPromised(null, defaultGuaranteed, other.defaultGuaranteed).set();
-        Standing<A> spoiled = standing.and(other.standing);
-        // What each rule left standing is kept whole. Whether a position is answerable for it is
-        // read off the two ends where the question is asked ({@link #speaksFor}) rather than
-        // settled here: what covers a position is an alternative, and a rule stated beside the
-        // choice may leave nothing of that alternative.
-        Set<Sameness.Block<A>> shapedBy = mapped(promisedAt(), heldAsOne);
-        shapedBy.addAll(mapped(other.promisedAt(), heldAsOne));
-        // A union of two products alike everywhere but at one place is the product with that place
-        // widened, so the promise survives as one about whole values where the alternatives are
-        // written at no more than one position between them. Anywhere else the union holds a value
-        // from one alternative at one position beside a value from the other at another, which is a
-        // combination neither of them stands for.
-        //
-        // Sufficient and not necessary, and deliberately so. A union is also a product where one
-        // alternative promises everything the other does, and where the two differ at only one
-        // position however many they are written at — and both of those compare the two boxes a
-        // bracketing happened to put together, so a choice of three alternatives answers one way
-        // written to the left and another to the right. Measured: both were tried and both broke
-        // `AChoiceIsOneConnectiveAndNotATree`. Coarse and the same either way is the trade, and
-        // what it costs is a promise this could have kept rather than one it could not.
-        return new AdmissibleValues<>(held,
-                widenedBy(perPosition, other.perPosition, sets, heldAsOne, gaveUp),
-                alsoStanding(spoiled, gaveUp),
-                covered, coveredElsewhere,
-                guaranteedTogether && other.guaranteedTogether && shapedBy.size() <= 1,
-                // Merging a union back into one product loses a relation among the blocks the
-                // alternatives are written at, and outside those the two of them agree on
-                // everything by saying nothing. Measured the same way the promise above is, and by
-                // the same sufficient condition, so a choice at one block keeps both.
-                apart || shapedBy.size() <= 1
-                        ? mapped(both(tangled, other.tangled), heldAsOne)
-                        : both(mapped(both(tangled, other.tangled), heldAsOne), shapedBy),
-                // The projections survive whatever the alternatives are written at: the projection
-                // of a union is the union of the projections.
-                both(both(widened, other.widened), gaveUp));
-    }
-
-    /**
-     * The one product holding both readings' alternatives, which is what a choice comes to while
-     * the alternatives are held one at a time.
-     *
-     * <p>The keys of both and not of either: a position one side says nothing about is one the
-     * choice says nothing about, since a value satisfying that side may hold anything there.
-     *
-     * <p>A product over what both sides hold as one value. An equality one branch states and the
-     * other does not is not the choice's, so the merged product is over the finer of the two
-     * relations — kept, the choice would hold positions as one value on the strength of a branch
-     * somebody may not be in.
-     */
-    private Held<A> merged(AdmissibleValues<A> other, Allowance<A> sets,
-                           Set<Sameness.Block<A>> gaveUp) {
-        Sameness<A> heldAsOne = sameness().common(other.sameness());
-        Map<Sameness.Block<A>, ValueSet> out = new LinkedHashMap<>();
-        Set<Sameness.Block<A>> named = new LinkedHashSet<>();
-        adopted().forEach(atom -> named.add(heldAsOne.blockOf(atom)));
-        for (Sameness.Block<A> block : named) {
-            A member = block.members().iterator().next();
-            ValueSet there = other.at(member);
-            if (there.isAny()) {
-                // Nothing to put together, and the block is kept where it is more than one
-                // position: what those positions being one value says stands whatever they admit.
-                if (!block.isOne()) {
-                    out.put(block, ValueSet.ANY);
-                }
-                continue;
-            }
-            Allowance.Composed made = sets.join(block, at(member), there);
-            if (made.gaveUp()) {
-                gaveUp.add(block);
-            }
-            out.put(block, made.set());
-        }
-        // Live by construction: a join of two sets is empty only where both are, and neither side
-        // is bottom here. What it states of two blocks is what every alternative of both states of
-        // them — a denial one branch reads is not the choice's, the same way an equality is not.
-        return one(new Alternative<>(new Box<>(out),
-                apartInEveryAlternative(heldAsOne)
-                        .commonWith(other.apartInEveryAlternative(heldAsOne), heldAsOne)));
-    }
-
-    /**
-     * What every alternative of this reading states to differ, said at {@code finer}.
-     *
-     * <p>Every one of them and not any: an alternative is one somebody may be in, so a denial one
-     * of them states is a rule a value satisfying another need not meet. Read at the blocks the
-     * caller answers in, because that is where the answer is filed — a denial stated where two
-     * positions were one value says as much of each of them where they are two.
-     */
-    private Apartness<A> apartInEveryAlternative(Sameness<A> finer) {
-        return Apartness.commonTo(alternatives().stream().map(Alternative::apart).toList(), finer);
-    }
-
-    /**
-     * The alternatives of both, which is what the choice leaves where they are held apart.
-     *
-     * <p>A set, so the same alternative offered twice is one. Neither side is bottom here, so every
-     * box of either stands in the choice — nothing is dropped and nothing is merged.
-     */
-    private Held<A> apart(AdmissibleValues<A> other, Allowance<A> sets,
-                          Set<Sameness.Block<A>> gaveUp) {
-        Set<Alternative<A>> boxes = new LinkedHashSet<>(alternatives());
-        boxes.addAll(other.alternatives());
-        Held.Alternatives.Made<A> made = Held.Alternatives.of(boxes, sets);
-        gaveUp.addAll(made.gaveUp());
-        return made.held();
-    }
-
-
     /** The alternatives this holds, which a reading that admits nothing has none of. */
     private Set<Alternative<A>> alternatives() {
         return held instanceof Held.Alternatives<A> it ? it.boxes() : Set.of();
-    }
-
-    /** What every alternative of both admits nothing at, which is what a choice between two
-     *  impossible ones leaves — and nothing else. Values an alternative nobody can take left a
-     *  position are under no obligation from the choice, so they leave with it. */
-    private Map<A, ValueSet> emptyInBoth(AdmissibleValues<A> other) {
-        Map<A, ValueSet> out = new LinkedHashMap<>();
-        adopted().forEach(atom -> {
-            if (at(atom).isEmpty() && other.at(atom).isEmpty()) {
-                out.put(atom, ValueSet.NONE);
-            }
-        });
-        return out;
     }
 
     /** The positions this holds an answer about, in the order they were read. */
@@ -1713,26 +1517,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
         return Held.Alternatives.of(box);
     }
 
-
-    /** Either side holding at each position, which is what both spoke about: a position one of
-     *  them says nothing about is one a value satisfying that side may hold anything at. */
-    private static <A> Map<A, ValueSet> widenedBy(Map<A, ValueSet> these, Map<A, ValueSet> those,
-                                                  Allowance<A> sets, Sameness<A> heldAsOne,
-                                                  Set<Sameness.Block<A>> gaveUp) {
-        Map<A, ValueSet> out = new LinkedHashMap<>();
-        these.forEach((atom, set) -> {
-            ValueSet there = those.get(atom);
-            if (there != null) {
-                Sameness.Block<A> block = heldAsOne.blockOf(atom);
-                Allowance.Composed made = sets.join(block, set, there);
-                if (made.gaveUp()) {
-                    gaveUp.add(block);
-                }
-                out.put(atom, made.set());
-            }
-        });
-        return out;
-    }
 
     /** Every position of either, in the order they were recorded. */
     private static <A> Set<A> both(Set<A> these, Set<A> those) {
@@ -1779,25 +1563,6 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
     private ValueSet promisedFor(Sameness.Block<A> block) {
         return guaranteed.getOrDefault(blockOf(block.members().iterator().next()),
                 defaultGuaranteed);
-    }
-
-    /**
-     * The positions an alternative beside this one may have widened.
-     *
-     * <p>Every position this reading's promise is written at, which is every position a rule of it
-     * reached — narrowed there or not. Not the positions it narrows: a branch that read two rules
-     * and came out admitting every value at a position narrows nothing there and had rules about it
-     * all the same, and which of the two a branch looks like turns on where the brackets of the
-     * choice fell. Asked of what a reading is about rather than of what it managed, the answer is
-     * the same either way.
-     *
-     * <p>These are candidates and not the answer. What is recorded against them is that an
-     * alternative went unread beside them; whether that is anything the position is answerable for
-     * is settled by {@link #speaksFor}, which reads it off the two ends where the question is asked.
-     * A position the alternatives cover between them carries a reason nobody is ever shown.
-     */
-    private Set<Sameness.Block<A>> promisedAt() {
-        return guaranteed.keySet();
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -14,9 +14,17 @@ import java.util.Set;
  * Which values each position may hold, over all the rules a reading took in.
  *
  * <p>A state and not a set. A rule is written about a whole value and may name several of its
- * positions, and the connectives join whole readings rather than the answer at one position — so
- * what a conjunction and a disjunction are applied to is this, and the arithmetic at one position
- * is {@link ValueSet}.
+ * positions, and a connective composes whole readings rather than the answer at one position — so
+ * what a conjunction is applied to is this, and the arithmetic at one position is {@link ValueSet}.
+ *
+ * <p><b>A choice is taken while a reading is a description.</b> Which alternatives anybody can be
+ * in is a question about the whole of what was read of a clause — the values and the order together
+ * — so it is settled a layer out, over {@link PlannedValues}, and what is worked out afterwards is
+ * worked out from a description a choice has already been taken in. This holds what that choice
+ * left, and is asked about it, and is conjoined with the readings of other declarations
+ * ({@link ConjoinedAdmissibleValues}); there is no operation here that composes two of these into
+ * another choice, and a reader looking for one is looking on the wrong side of {@link
+ * PlannedValues#resolve}.
  *
  * <h2>What is held</h2>
  *
@@ -39,18 +47,20 @@ import java.util.Set;
  * position read on its own, by the same connectives — and that is what a reading admitting nothing
  * answers from.
  *
- * <p><b>A position no box holds is at {@link ValueSet#ANY}.</b> That is what makes the two
- * connectives what they are below, and it is the one thing to hold on to while reading them.
+ * <p><b>A position no box holds is at {@link ValueSet#ANY}.</b> That is what makes a connective what
+ * it is, and it is the one thing to hold on to while reading {@link #meet} here or a choice over on
+ * the description side.
  *
  * <pre>
  *     meet             the keys of both, each side missing one standing at ANY
- *     join             the keys of both, each side missing one standing at ANY
+ *     a choice         the keys of both, each side missing one standing at ANY
  * </pre>
  *
- * <p>Which reads the same and is not: joining at a key one side does not hold is joining with ANY,
- * and that is ANY — so a join keeps only what both sides spoke about, and a meet keeps everything
- * either did. {@code value == "A" || something-this-cannot-read} has to come out saying nothing
- * about {@code value}, and a join written as a merge of the two maps says {@code "A"}.
+ * <p>Which reads the same and is not: composing a choice at a key one side does not hold is
+ * composing with ANY, and that is ANY — so a choice keeps only what both sides spoke about, and a
+ * meet keeps everything either did. {@code value == "A" || something-this-cannot-read} has to come
+ * out saying nothing about {@code value}, and a choice written as a merge of the two maps says
+ * {@code "A"}.
  *
  * <h2>What the reading knows about itself</h2>
  *

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -677,9 +677,9 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      *                left open
      * @param guaranteed which values each position is guaranteed to admit — read through
      *                {@link #guaranteedAt} rather than off this map, which holds a position whose
-     *                guarantee is the default as well. Held that way on purpose: the keys are
-     *                {@link #promisedAt}, the positions a rule of this reading reached, and
-     *                dropping the ones that came to the default would make that set turn on which
+     *                guarantee is the default as well. Held that way on purpose: the keys are the
+     *                positions a rule of this reading reached, and dropping the ones that came to
+     *                the default would make that set turn on which
      *                rules happened to leave a position where it started. A choice reads it twice
      *                over, and both readings would follow the brackets
      * @param defaultGuaranteed what a position this holds no guarantee for is guaranteed to admit.
@@ -1436,8 +1436,8 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * <p>Where a side admits nothing the conjunction does, and what it is left holding is the pairs
      * it worked out all the same: a rule stated beside an impossible one is still a rule that was
      * stated, so the values it left a position are values the reading read and are answered with.
-     * That is what parts a conjunction from a choice here — see {@link #join}, where nothing an
-     * alternative said survives the alternative being one nobody can take.
+     * That is what parts a conjunction from a choice — see {@link PlannedValues#bothDead}, where
+     * nothing an alternative said survives the alternative being one nobody can take.
      */
     private Held<A> met(AdmissibleValues<A> other, Allowance<A> sets,
                         Set<Sameness.Block<A>> gaveUp) {
@@ -1551,8 +1551,7 @@ public record AdmissibleValues<A>(Held<A> held, Map<A, ValueSet> perPosition,
      * however the side that made it was holding those positions.
      *
      * <p>The keys are the footprint as well as the values — the blocks a rule of these readings
-     * reached ({@link #promisedAt}) — so a block either side named is a key here whatever the
-     * promise came to. Dropped for coming to the default, which blocks a rule reached would turn
+     * reached — so a block either side named is a key here whatever the promise came to. Dropped for coming to the default, which blocks a rule reached would turn
      * on which rules happened to leave one where it started.
      */
     private static <A> Map<Sameness.Block<A>, ValueSet> guaranteedBy(

--- a/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
@@ -195,11 +195,6 @@ public final class Allowance<A> {
         return put(block, AdmittedPlan.meeting(both(one, other)));
     }
 
-    /** The values either admits — what a rule stated as one of two alternatives leaves. */
-    public Composed join(Sameness.Block<A> block, ValueSet one, ValueSet other) {
-        return put(block, AdmittedPlan.joining(both(one, other)));
-    }
-
     /**
      * The values any of them admits, said as one plan over all of them.
      *
@@ -238,11 +233,6 @@ public final class Allowance<A> {
      */
     public Composed meetPromised(Sameness.Block<A> block, ValueSet one, ValueSet other) {
         return promised(meet(block, one, other));
-    }
-
-    /** The same for a choice, on the same terms. */
-    public Composed joinPromised(Sameness.Block<A> block, ValueSet one, ValueSet other) {
-        return promised(join(block, one, other));
     }
 
     private static Composed promised(Composed made) {

--- a/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Allowance.java
@@ -222,11 +222,11 @@ public final class Allowance<A> {
     }
 
     /**
-     * The same two, where what comes out is a promise rather than a bound.
+     * The same two sets, where what comes out is a promise rather than a bound.
      *
      * <p>Giving up leaves nothing and not everything, which is the other direction. What
-     * {@link #meet} and {@link #join} answer is which values a position may hold, so an answer this
-     * did not build widens to every value and stays true. A promise says which values it certainly
+     * {@link #meet} answers is which values a position may hold, so an answer this did not build
+     * widens to every value and stays true. A promise says which values it certainly
      * may hold, and every value is the strongest thing that can be said rather than the weakest —
      * so an unbuilt one promises nothing, and a reader is short of a guarantee instead of holding
      * one nobody proved.

--- a/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ConjoinedAdmissibleValues.java
@@ -55,9 +55,10 @@ import java.util.function.Function;
  * none. Held here, the purse would be the one thing about a conjunction that is not a fact about the
  * readings in it, and a binary operation between two of them would have two to choose from.
  *
- * <p>No join. A choice between alternatives happens while one declaration is read, which is below
- * this and inside {@link AdmissibleValues}. A disjunction of two factored conjunctions would have to
- * expand them to be said at all, and nothing asks for one.
+ * <p>No join. A choice between alternatives is taken while one declaration is read and while its
+ * values are still descriptions, which is below this and before {@link AdmissibleValues} exists at
+ * all. A disjunction of two factored conjunctions would have to expand them to be said, and nothing
+ * asks for one.
  */
 public final class ConjoinedAdmissibleValues<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -559,10 +559,11 @@ public sealed interface PlannedValues<A> {
     /**
      * Either reading holding, with the alternatives of the two held apart.
      *
-     * <p>The same choice, read without merging what it leaves back into one product. Held apart,
-     * the conjunction meets the alternatives pairwise, the pairs nothing stands in drop out, and
-     * what is left is what the rules leave. Which is why nothing is owed here: the union of two
-     * products is what it is, and this states it rather than approximating it.
+     * <p>The same choice, read without merging what it leaves back into one product. Held apart, a
+     * conjunction after it distributes over the alternatives pairwise ({@link #meet}), the pairs
+     * nothing stands in drop out where the values are worked out ({@link #resolve}), and what is
+     * left is what the rules leave. Which is why nothing is owed here: the union of two products is
+     * what it is, and this states it rather than approximating it.
      *
      * <p>How many may be held is not this reading's to decide. What bounds them is settled from the
      * clauses before any of them is read ({@code ExpansionCost}), so that precision cannot turn on
@@ -632,9 +633,9 @@ public sealed interface PlannedValues<A> {
         // alternative promises everything the other does, and where the two differ at only one
         // position however many they are written at — and both of those compare the two boxes a
         // bracketing happened to put together, so a choice of three alternatives answers one way
-        // written to the left and another to the right. Measured: both were tried and both broke
-        // `AChoiceIsOneConnectiveAndNotATree`. Coarse and the same either way is the trade, and
-        // what it costs is a promise this could have kept rather than one it could not.
+        // written to the left and another to the right. Both were tried, and both broke that a
+        // choice is one connective and not a tree. Coarse and the same either way is the trade,
+        // and what it costs is a promise this could have kept rather than one it could not.
         Set<Sameness.Block<A>> shapedBy = mapped(promisedAt(here), heldAsOne);
         shapedBy.addAll(mapped(promisedAt(there), heldAsOne));
         return new Settled<>(held,

--- a/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/PlannedValues.java
@@ -527,22 +527,49 @@ public sealed interface PlannedValues<A> {
     }
 
     /**
-     * Either reading holding, both branches being ones somebody can take.
+     * Either reading holding, the alternatives merged back into one product.
      *
-     * <p>Which branches those are is not decided here. What a choice leaves turns on whether either
-     * branch admits anything, and that is a question about the whole of what was read of the clause
-     * — the values and the order together — so it is asked a layer out and this is called with the
-     * answer already in hand ({@code StatedByClauses}). Asked here as well, the two would be two
-     * answers to one question, and the one made of values alone would drop a branch the order
-     * refused and keep one the values did.
+     * <p>Over the positions both spoke about, since a position one of them left open is one the two
+     * of them together leave open.
+     *
+     * <p>A choice between alternatives written at two positions is a union of two products, and no
+     * product holds it — so merging is where the relation goes. It goes unnoticed: the projections
+     * survive a union, because the projection of a union is the union of the projections, and it is
+     * the next conjunction that spends what was lost. Two such readings are met one position at a
+     * time, and a pair the two of them refuse between them is a pair neither intersection excludes.
+     *
+     * <p>What an alternative nothing could read left open is not said here, and cannot be. Which
+     * positions those are turns on which branches anybody can be in, and that is settled over the
+     * whole declaration — after this choice, out of what it and every other one came to. So it
+     * arrives afterwards ({@link AdmissibleValues#alsoOpenedAt}), from the one walk that knows both
+     * the alternatives an author wrote and what became of them.
+     *
+     * <p><b>Both branches are ones somebody can take.</b> Which branches those are is not decided
+     * here. What a choice leaves turns on whether either branch admits anything, and that is a
+     * question about the whole of what was read of the clause — the values and the order together —
+     * so it is asked a layer out and this is called with the answer already in hand
+     * ({@code StatedByClauses}). Asked here as well, the two would be two answers to one question,
+     * and the one made of values alone would drop a branch the order refused and keep one the
+     * values did.
      */
     default PlannedValues<A> joinLive(PlannedValues<A> other) {
         return joinedLive(other, false);
     }
 
-    /** Either reading holding, with the alternatives of the two held apart — see
-     *  {@link AdmissibleValues#joinApart}. Both branches are ones somebody can take, by the rule
-     *  {@link #joinLive} states. */
+    /**
+     * Either reading holding, with the alternatives of the two held apart.
+     *
+     * <p>The same choice, read without merging what it leaves back into one product. Held apart,
+     * the conjunction meets the alternatives pairwise, the pairs nothing stands in drop out, and
+     * what is left is what the rules leave. Which is why nothing is owed here: the union of two
+     * products is what it is, and this states it rather than approximating it.
+     *
+     * <p>How many may be held is not this reading's to decide. What bounds them is settled from the
+     * clauses before any of them is read ({@code ExpansionCost}), so that precision cannot turn on
+     * how a fold was bracketed.
+     *
+     * <p>Both branches are ones somebody can take, by the rule {@link #joinLive} states.
+     */
     default PlannedValues<A> joinLiveApart(PlannedValues<A> other) {
         return joinedLive(other, true);
     }
@@ -551,9 +578,13 @@ public sealed interface PlannedValues<A> {
      * A choice neither branch of which anybody can take.
      *
      * <p>No branch speaks for the other, so answering with either would settle the proof by the
-     * order the operands were written in. What is left is the positions both of them leave nothing
-     * at, which is an answer about the whole value — see {@link AdmissibleValues#joinApart}, whose
-     * reasoning this is.
+     * order the operands were written in. Nor may they be met: a meet is a conjunction and the
+     * alternatives were never stated together.
+     *
+     * <p>What is left is the positions both of them leave nothing at, which is an answer about the
+     * whole value. A block one branch was left nothing at is one the other may stand at, so what
+     * the choice is left nothing at is what neither of them has a value for; where there is no such
+     * position the choice still admits nothing, and says so of no position in particular.
      */
     default PlannedValues<A> bothDead(PlannedValues<A> other) {
         Settled<A> here = settled();
@@ -575,8 +606,8 @@ public sealed interface PlannedValues<A> {
     /**
      * A choice both branches of which stand, as one description.
      *
-     * <p>The rules are {@link AdmissibleValues#joinApart}'s and the reasoning is written there.
-     * What is here is the same arithmetic over descriptions rather than sets, which is why it costs
+     * <p>What {@link #joinLive} and {@link #joinLiveApart} come to, which is where the rules of
+     * each are written. Arithmetic over descriptions and not over sets, which is why it costs
      * nothing and can be done before anything is built.
      */
     private PlannedValues<A> joinedLive(PlannedValues<A> other, boolean apart) {
@@ -589,14 +620,31 @@ public sealed interface PlannedValues<A> {
         AdmittedPlan coveredElsewhere = AdmittedPlan.joining(
                 List.of(here.defaultGuaranteed(), there.defaultGuaranteed()));
         // What an alternative nothing could read left open is not said here — see
-        // {@link AdmissibleValues#join}, whose reasoning this is.
+        // {@link #joinLive}, which says where it arrives instead.
         Standing<A> spoiled = here.standing().and(there.standing());
+        // A union of two products alike everywhere but at one place is the product with that place
+        // widened, so the promise survives as one about whole values where the alternatives are
+        // written at no more than one position between them. Anywhere else the union holds a value
+        // from one alternative at one position beside a value from the other at another, which is a
+        // combination neither of them stands for.
+        //
+        // Sufficient and not necessary, and deliberately so. A union is also a product where one
+        // alternative promises everything the other does, and where the two differ at only one
+        // position however many they are written at — and both of those compare the two boxes a
+        // bracketing happened to put together, so a choice of three alternatives answers one way
+        // written to the left and another to the right. Measured: both were tried and both broke
+        // `AChoiceIsOneConnectiveAndNotATree`. Coarse and the same either way is the trade, and
+        // what it costs is a promise this could have kept rather than one it could not.
         Set<Sameness.Block<A>> shapedBy = mapped(promisedAt(here), heldAsOne);
         shapedBy.addAll(mapped(promisedAt(there), heldAsOne));
         return new Settled<>(held,
                 widenedBy(here.perPosition(), there.perPosition()), spoiled,
                 covered, coveredElsewhere,
                 here.guaranteedTogether() && there.guaranteedTogether() && shapedBy.size() <= 1,
+                // Merging a union back into one product loses a relation among the blocks the
+                // alternatives are written at, and outside those the two of them agree on
+                // everything by saying nothing. Read by the same sufficient condition as the
+                // promise above, so a choice at one block keeps both.
                 apart || shapedBy.size() <= 1
                         ? mapped(both(here.tangled(), there.tangled()), heldAsOne)
                         : both(mapped(both(here.tangled(), there.tangled()), heldAsOne), shapedBy),

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -1,0 +1,152 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
+import souther.compiler.values.Allowance;
+import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.Emptiness;
+import souther.compiler.values.PlannedValues;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a choice with a branch nobody can be in leaves does not follow the brackets.
+ *
+ * <p>A choice between two branches that stand is composed by the values, and that it is one
+ * connective rather than a tree is held of that operation
+ * ({@code AChoiceIsOneConnectiveAndNotATreeTest}). A branch nobody can be in is not composed at
+ * all: which branches those are is a question about the values and the order together, so it is
+ * settled by the holder of both, and what the values are asked for is either the settlement of two
+ * dead branches or nothing at all.
+ *
+ * <p>So the property has two halves and this is the other one. Written the way the holder settles
+ * them — every branch dead is a settlement, one dead leaves the standing branch as it stands —
+ * three alternatives leave the same answer however they are bracketed and whatever order they were
+ * written in. Lost, a declaration refused for reasons nobody can be in would answer one way to the
+ * left of the brackets and another to the right.
+ *
+ * <p>The same property over what a report may say of such a choice is
+ * {@link AChoiceReadsTheRuleAndNotTheTreeItIsWrittenAsTest}.
+ */
+class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
+
+    private static final String X = "x";
+    private static final String Y = "y";
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    /** What every dead branch here was shown dead by, which is not what is under test. */
+    private static final Confinement.Admission<String> SHOWN =
+            Confinement.Admission.left(Emptiness.EMPTY);
+
+    private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
+
+    private static PlannedValues<String> says(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
+    private static Confinement.Planned<String> reading(PlannedValues<String> values) {
+        return new Confinement.Planned<>(values, OrderedIntervals.top(), Map.of());
+    }
+
+    /**
+     * One alternative and whether anybody can be in it, composed the way the holder of both
+     * languages composes them.
+     *
+     * <p>Whether a branch admits anything is settled over the values and the order together, so it
+     * is carried beside here rather than asked of either. What is under test is what the four cases
+     * leave, not which of them a clause falls into.
+     */
+    private record Branch(Confinement.Planned<String> reading, boolean dead) {
+
+        Branch or(Branch other) {
+            if (dead && other.dead) {
+                return new Branch(reading.bothDead(other.reading, SHOWN), true);
+            }
+            // Neither language is asked what a choice with one dead branch leaves: what it leaves
+            // is the standing branch, which the holder has in hand.
+            if (dead) {
+                return other;
+            }
+            if (other.dead) {
+                return this;
+            }
+            return new Branch(reading.either(other.reading, false), false);
+        }
+    }
+
+    /** A branch somebody can be in, and one nobody can. */
+    private Map<String, Branch> branches() {
+        Map<String, Branch> out = new LinkedHashMap<>();
+        out.put("x == A", new Branch(reading(says(X, A)), false));
+        out.put("y == B", new Branch(reading(says(Y, B)), false));
+        out.put("x == A && x == B", new Branch(
+                reading(says(X, A).meet(says(X, B)).leavingNothing()), true));
+        out.put("y == A && y == B", new Branch(
+                reading(says(Y, A).meet(says(Y, B)).leavingNothing()), true));
+        return out;
+    }
+
+    /** What a caller reads off the values a choice left, as one comparable value. */
+    private List<Object> answers(Branch branch) {
+        AdmissibleValues<String> values = branch.reading().resolve(sets).values();
+        List<Object> out = new ArrayList<>();
+        for (String position : List.of(X, Y)) {
+            out.add(values.at(position));
+            out.add(values.speaksFor(position));
+            out.add(values.guaranteedAt(position));
+        }
+        out.add(values.isBottom());
+        return out;
+    }
+
+    /** Three alternatives leave what they leave, however they are bracketed. */
+    @Test
+    void threeAlternativesLeaveTheSameHoweverTheyAreBracketed() {
+        Map<String, Branch> branches = branches();
+        branches.forEach((leftName, left) -> branches.forEach((middleName, middle) ->
+                branches.forEach((rightName, right) -> assertEquals(
+                        answers(left.or(middle).or(right)),
+                        answers(left.or(middle.or(right))),
+                        () -> "(" + leftName + " || " + middleName + ") || " + rightName
+                                + "   against   " + leftName + " || (" + middleName + " || "
+                                + rightName + ")"))));
+    }
+
+    /** And however they are ordered. */
+    @Test
+    void twoAlternativesLeaveTheSameHoweverTheyAreOrdered() {
+        Map<String, Branch> branches = branches();
+        branches.forEach((leftName, left) -> branches.forEach((rightName, right) ->
+                assertEquals(answers(left.or(right)), answers(right.or(left)),
+                        () -> leftName + " || " + rightName + "   against   "
+                                + rightName + " || " + leftName)));
+    }
+
+    /**
+     * And the control: the branches this is written about really are what they are said to be.
+     *
+     * <p>Every case above is reached only because some branch is dead and some is not. Were they
+     * all standing, the two tests would be the property held of live choices alone and would say
+     * nothing about a settlement.
+     */
+    @Test
+    void theBranchesAreTheOnesThePropertyNeeds() {
+        Map<String, Branch> branches = branches();
+        assertTrue(branches.values().stream().anyMatch(Branch::dead), "a branch nobody can be in");
+        assertTrue(branches.values().stream().anyMatch(each -> !each.dead()), "and one somebody can");
+        branches.forEach((name, branch) -> assertEquals(branch.dead(),
+                branch.reading().resolve(sets).values().isBottom(),
+                () -> name + " is not the branch it is filed as"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -1,6 +1,9 @@
 package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.OrderedIntervals;
 import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
@@ -42,6 +45,8 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
 
     private static final String X = "x";
     private static final String Y = "y";
+    /** The position every branch's ranges speak about, which no branch's values do. */
+    private static final String COUNTED = "counted";
     private static final Value A = Value.text("A");
     private static final Value B = Value.text("B");
 
@@ -55,8 +60,22 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
         return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
     }
 
-    private static Confinement.Planned<String> reading(PlannedValues<String> values) {
-        return new Confinement.Planned<>(values, OrderedIntervals.top(), Map.of());
+    /**
+     * A branch, whose ranges are ends somebody could be at whether or not its values leave
+     * anything.
+     *
+     * <p>The ranges are what a settlement has to be told about. A branch the values refused is one
+     * the order found nothing wrong with, so a choice that let the standing ends of a dead branch
+     * through would go on ruling things out on their strength — and with every branch at
+     * {@link OrderedIntervals#top} the two ways of composing two dead ones leave the same answer
+     * and nothing here would tell them apart.
+     */
+    private static Confinement.Planned<String> reading(PlannedValues<String> values,
+                                                       int low, int high) {
+        return new Confinement.Planned<>(values,
+                OrderedIntervals.at(COUNTED, new OrderedInterval(
+                        Endpoint.inclusive(Count.of(low)), Endpoint.inclusive(Count.of(high)))),
+                Map.of(COUNTED, Carrier.WHOLE));
     }
 
     /**
@@ -88,16 +107,33 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
     /** A branch somebody can be in, and one nobody can. */
     private Map<String, Branch> branches() {
         Map<String, Branch> out = new LinkedHashMap<>();
-        out.put("x == A", new Branch(reading(says(X, A)), false));
-        out.put("y == B", new Branch(reading(says(Y, B)), false));
+        out.put("x == A", new Branch(reading(says(X, A), 1, 2), false));
+        out.put("y == B", new Branch(reading(says(Y, B), 3, 4), false));
         out.put("x == A && x == B", new Branch(
-                reading(says(X, A).meet(says(X, B)).leavingNothing()), true));
+                reading(says(X, A).meet(says(X, B)).leavingNothing(), 100, 200), true));
         out.put("y == A && y == B", new Branch(
-                reading(says(Y, A).meet(says(Y, B)).leavingNothing()), true));
+                reading(says(Y, A).meet(says(Y, B)).leavingNothing(), 300, 400), true));
         return out;
     }
 
-    /** What a caller reads off the values a choice left, as one comparable value. */
+    /** A rule about the position the ranges above speak about, which the ends of a dead branch
+     *  would rule out and the ends of a standing one do. */
+    private Confinement.Planned<String> afterwards() {
+        return new Confinement.Planned<>(PlannedValues.top(),
+                OrderedIntervals.at(COUNTED, new OrderedInterval(
+                        Endpoint.inclusive(Count.of(1)), Endpoint.inclusive(Count.of(2)))),
+                Map.of(COUNTED, Carrier.WHOLE));
+    }
+
+    /**
+     * What a caller reads off what a choice left, as one comparable value.
+     *
+     * <p>The values, what already showed the reading empty, and what a rule met after the choice
+     * comes to. What is held of them is that the two sides of an equation agree, so what widening
+     * this buys is a bracketing or an ordering that tells them apart in any of the three — not a
+     * claim that one operation is being told from another, which no equation between two
+     * compositions can make.
+     */
     private List<Object> answers(Branch branch) {
         AdmissibleValues<String> values = branch.reading().resolve(sets).values();
         List<Object> out = new ArrayList<>();
@@ -107,6 +143,10 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
             out.add(values.guaranteedAt(position));
         }
         out.add(values.isBottom());
+        out.add(branch.reading().admission());
+        // And what the choice leaves a rule met after it, which is where ends left answering for a
+        // branch nobody can be in would rule something out on their own strength.
+        out.add(branch.reading().meet(afterwards()).resolve(sets).holdingNothing());
         return out;
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -9,7 +9,6 @@ import souther.compiler.values.AdmissibleValues;
 import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
-import souther.compiler.values.Emptiness;
 import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
@@ -52,7 +51,7 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
 
     /** What every dead branch here was shown dead by, which is not what is under test. */
     private static final Confinement.Admission<String> SHOWN =
-            Confinement.Admission.left(Emptiness.EMPTY);
+            Confinement.Admission.left(souther.compiler.values.Emptiness.EMPTY);
 
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -104,15 +104,22 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
         }
     }
 
-    /** A branch somebody can be in, and one nobody can. */
+    /**
+     * A branch somebody can be in, and one nobody can.
+     *
+     * <p>Dead two ways, because a branch is dead by whatever showed it so: two rules about one
+     * position leaving it no value, and an equality met with a denial of the same pair, which
+     * leaves every position a value and no assignment standing.
+     */
     private Map<String, Branch> branches() {
         Map<String, Branch> out = new LinkedHashMap<>();
         out.put("x == A", new Branch(reading(says(X, A), 1, 2), false));
         out.put("y == B", new Branch(reading(says(Y, B), 3, 4), false));
         out.put("x == A && x == B", new Branch(
                 reading(says(X, A).meet(says(X, B)).leavingNothing(), 100, 200), true));
-        out.put("y == A && y == B", new Branch(
-                reading(says(Y, A).meet(says(Y, B)).leavingNothing(), 300, 400), true));
+        out.put("x == y && x /= y", new Branch(
+                reading(PlannedValues.<String>holdingAsOne(X, Y)
+                        .meet(PlannedValues.heldApart(X, Y)).leavingNothing(), 300, 400), true));
         return out;
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest.java
@@ -93,7 +93,10 @@ class ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest {
                 return new Branch(reading.bothDead(other.reading, SHOWN), true);
             }
             // Neither language is asked what a choice with one dead branch leaves: what it leaves
-            // is the standing branch, which the holder has in hand.
+            // is the standing branch, which the holder has in hand. Composed instead, the choice
+            // would keep only what both sides spoke about — and a side nobody can be in spoke
+            // about positions the other did not, so the whole would come back saying nothing at
+            // all about them.
             if (dead) {
                 return other;
             }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest.java
@@ -12,9 +12,10 @@ import souther.compiler.query.ReadAs;
 import souther.compiler.query.Scopes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
-import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.AdmittedPlan;
 import souther.compiler.values.Allowance;
 import souther.compiler.values.AsACompilationAllows;
+import souther.compiler.values.PlannedValues;
 import souther.compiler.values.Value;
 import souther.compiler.values.ValueSet;
 
@@ -233,16 +234,15 @@ class WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest {
     @Test
     void alternativesAreAskedWholeAndNotThroughWhatTheyProjectOntoAPosition() {
         Allowance<FactSubject> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<FactSubject> here = AdmissibleValues.at(X, ValueSet.just(Value.text("A")))
-                .meet(AdmissibleValues.at(Y, ValueSet.just(Value.text("B"))), sets);
-        AdmissibleValues<FactSubject> there = AdmissibleValues.at(X, ValueSet.just(Value.text("C")))
-                .meet(AdmissibleValues.at(Y, ValueSet.just(Value.text("D"))), sets);
+        PlannedValues<FactSubject> here = pair("A", "B");
+        PlannedValues<FactSubject> there = pair("C", "D");
         OrderedIntervals<FactSubject> ends = OrderedIntervals
                 .at(X, new OrderedInterval(null, Endpoint.inclusive(Text.of("A"))))
                 .meet(OrderedIntervals.at(Y, new OrderedInterval(
                         Endpoint.inclusive(Text.of("D")), null)));
         ConstraintState<FactSubject> state = ConstraintState.<FactSubject>top()
-                .takingRead(Confinement.Worked.of(here.joinApart(there, sets), ends,
+                .takingRead(Confinement.Worked.of(
+                        here.joinLiveApart(there).resolve(sets).values(), ends,
                         Map.of(X, Carrier.TEXT, Y, Carrier.TEXT)), sets);
 
         assertEquals(ValueSet.oneOf(new LinkedHashSet<>(List.of(
@@ -263,6 +263,13 @@ class WhatARuleAdmitsAndWhereItStopsAreAskedTogetherTest {
 
     private static Emptiness atAField(String spelled, Emptiness under) {
         return new Emptiness.AtAField(new Emptiness.AtAField.Where.In(spelled), under);
+    }
+
+    /** One alternative of the choice below, while it is still a description — which is where a
+     *  choice is taken. */
+    private static PlannedValues<FactSubject> pair(String here, String there) {
+        return PlannedValues.<FactSubject>at(X, AdmittedPlan.of(ValueSet.just(Value.text(here))))
+                .meet(PlannedValues.at(Y, AdmittedPlan.of(ValueSet.just(Value.text(there)))));
     }
 
     /** How the one declaration of {@code source} was shown to have no value, or null where it has

--- a/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
@@ -7,9 +7,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -58,11 +60,27 @@ class AChoiceIsNotFormedOnAReadingThatIsBuiltTest {
             }
             for (Type parameter : method.getGenericParameterTypes()) {
                 if (mentionsAReading(parameter)) {
-                    out.add(reading.getSimpleName() + "#" + method.getName());
+                    out.add(named(reading, method));
                 }
             }
         }
         return out;
+    }
+
+    /**
+     * One operation, said so that another with the same name is another operation.
+     *
+     * <p>Whether it is taken on an instance or on the class, what it is given and what it hands
+     * back — which is the whole of what a caller reaches for. Written as the name alone, an
+     * overload beside one of these would be filed under the entry already here, and a second
+     * spelling would only have to borrow a name to pass.
+     */
+    private static String named(Class<?> reading, Method method) {
+        return reading.getSimpleName() + "#" + method.getName()
+                + Arrays.stream(method.getParameterTypes()).map(Class::getSimpleName)
+                        .collect(Collectors.joining(",", "(", ")"))
+                + " -> " + method.getReturnType().getSimpleName()
+                + (Modifier.isStatic(method.getModifiers()) ? " [static]" : "");
     }
 
     /** Whether {@code type} is a reading, or names one as an argument — a list of them is a
@@ -93,10 +111,11 @@ class AChoiceIsNotFormedOnAReadingThatIsBuiltTest {
      * was bracketed. {@code of} lifts one reading into a conjunction of one factor.
      */
     private static final Set<String> COMPOSING = Set.of(
-            "AdmissibleValues#meet",
-            "AdmissibleValues#metAll",
-            "ConjoinedAdmissibleValues#meet",
-            "ConjoinedAdmissibleValues#of");
+            "AdmissibleValues#meet(AdmissibleValues,Allowance) -> AdmissibleValues",
+            "AdmissibleValues#metAll(List,Allowance) -> AdmissibleValues [static]",
+            "ConjoinedAdmissibleValues#meet(ConjoinedAdmissibleValues,Allowance)"
+                    + " -> ConjoinedAdmissibleValues",
+            "ConjoinedAdmissibleValues#of(AdmissibleValues) -> ConjoinedAdmissibleValues [static]");
 
     @Test
     void nothingButAConjunctionTurnsTwoBuiltReadingsIntoOne() {

--- a/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A choice is taken while a reading is a description, and a built one has no way to form another.
@@ -106,18 +105,6 @@ class AChoiceIsNotFormedOnAReadingThatIsBuiltTest {
 
         assertEquals(new TreeSet<>(COMPOSING), new TreeSet<>(found),
                 "a built reading composes with another by a conjunction and by nothing else");
-    }
-
-    /**
-     * And the control: the walk finds the conjunction it is written about.
-     *
-     * <p>An empty answer above would pass whatever the readings hold, and a rule about which
-     * operations there are says nothing until it has found one.
-     */
-    @Test
-    void theWalkFindsTheConjunctionItIsWrittenAbout() {
-        assertTrue(composing(AdmissibleValues.class).contains("AdmissibleValues#meet"),
-                "the conjunction is what this walk has to be able to see");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsNotFormedOnAReadingThatIsBuiltTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.WhatWasCompiled;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A choice is taken while a reading is a description, and a built one has no way to form another.
+ *
+ * <p>Which alternatives anybody can be in is a question about the values and the order together, so
+ * it is settled over {@link PlannedValues} and what is built afterwards is built from a description
+ * a choice has already been taken in. A built reading keeps what that choice left, is asked about
+ * it, and is conjoined with the readings of other declarations. Given an operation that turns two
+ * of them into one that is not a conjunction, a caller could take a choice on this side of
+ * {@link PlannedValues#resolve} — where neither the order nor which branches stand is in hand — and
+ * the answer would be settled by whichever half of the question that caller happened to hold.
+ *
+ * <p><b>Said positively.</b> What is fixed is which operations may turn two readings into one, and
+ * not that no method is called {@code join}: a second spelling under another name would pass a rule
+ * written about the name. Every entry below is a conjunction or a lifting of one reading into a
+ * conjunction of one, and a new one is a decision somebody has to make rather than a line to add.
+ *
+ * <p>What is not fixed here is that a reading never reaches the arithmetic a choice is realized by.
+ * It does, legitimately: {@link AdmissibleValues.Held.Alternatives} asks the allowance what a block
+ * holds across the alternatives it already has, which is a fact derived from a choice already taken
+ * and not a choice being taken. The two are told apart by whether two readings go in, which is what
+ * is read below.
+ */
+class AChoiceIsNotFormedOnAReadingThatIsBuiltTest {
+
+    /** What a reading of worked-out values is, in either of the shapes one is held in. */
+    private static final Set<Class<?>> READINGS =
+            Set.of(AdmissibleValues.class, ConjoinedAdmissibleValues.class);
+
+    /**
+     * The operations a caller may turn readings into a reading by.
+     *
+     * <p>A method that hands one back and takes one — which, on an instance, is the two a caller
+     * holds, and on a static is however many it was given. Private methods are left out: what is
+     * fixed is the surface a caller can reach for, and a step inside one of these operations is
+     * that operation.
+     */
+    private static Set<String> composing(Class<?> reading) {
+        Set<String> out = new TreeSet<>();
+        for (Method method : reading.getDeclaredMethods()) {
+            if (method.isSynthetic() || Modifier.isPrivate(method.getModifiers())
+                    || !mentionsAReading(method.getGenericReturnType())) {
+                continue;
+            }
+            for (Type parameter : method.getGenericParameterTypes()) {
+                if (mentionsAReading(parameter)) {
+                    out.add(reading.getSimpleName() + "#" + method.getName());
+                }
+            }
+        }
+        return out;
+    }
+
+    /** Whether {@code type} is a reading, or names one as an argument — a list of them is a
+     *  caller's several answers however it was spelled. */
+    private static boolean mentionsAReading(Type type) {
+        if (type instanceof Class<?> it) {
+            return READINGS.stream().anyMatch(each -> each.isAssignableFrom(it));
+        }
+        if (type instanceof ParameterizedType it) {
+            if (mentionsAReading(it.getRawType())) {
+                return true;
+            }
+            for (Type argument : it.getActualTypeArguments()) {
+                if (mentionsAReading(argument)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The whole of what a built reading may be composed with another by.
+     *
+     * <p>{@code meet} is the conjunction, which is the one connective that outlives a description:
+     * a caller relating two declarations holds what each of them came to. {@code metAll} is that
+     * conjunction over several at once, so that what a block costs does not turn on how the fold
+     * was bracketed. {@code of} lifts one reading into a conjunction of one factor.
+     */
+    private static final Set<String> COMPOSING = Set.of(
+            "AdmissibleValues#meet",
+            "AdmissibleValues#metAll",
+            "ConjoinedAdmissibleValues#meet",
+            "ConjoinedAdmissibleValues#of");
+
+    @Test
+    void nothingButAConjunctionTurnsTwoBuiltReadingsIntoOne() {
+        Set<String> found = new LinkedHashSet<>(composing(AdmissibleValues.class));
+        found.addAll(composing(ConjoinedAdmissibleValues.class));
+
+        assertEquals(new TreeSet<>(COMPOSING), new TreeSet<>(found),
+                "a built reading composes with another by a conjunction and by nothing else");
+    }
+
+    /**
+     * And the control: the walk finds the conjunction it is written about.
+     *
+     * <p>An empty answer above would pass whatever the readings hold, and a rule about which
+     * operations there are says nothing until it has found one.
+     */
+    @Test
+    void theWalkFindsTheConjunctionItIsWrittenAbout() {
+        assertTrue(composing(AdmissibleValues.class).contains("AdmissibleValues#meet"),
+                "the conjunction is what this walk has to be able to see");
+    }
+
+    /**
+     * The one thing that realizes a choice of value sets.
+     *
+     * <p>A choice of two sets is a machine where either side is a language, and what a machine
+     * costs is charged to the position it is built for. Realized anywhere else, a compilation would
+     * pay for one twice or build one under an allowance nobody granted — so the arithmetic has one
+     * caller, and every way of asking for it goes through the position's own realizer.
+     *
+     * <p>{@link Sets} is the table itself: what it reaches is the free half of it, under a meter
+     * that pays for nothing, and a language handed to it is refused where it is asked for.
+     */
+    @Test
+    void aChoiceOfValueSetsIsRealizedInOnePlace() {
+        assertEquals(Set.of("souther.compiler.values.Realizer", "souther.compiler.values.Sets"),
+                new TreeSet<>(WhatWasCompiled.callersOf(Sets.class, "joinedUnder")),
+                "the join of two sets is built where a position's allowance pays for it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsOneConnectiveAndNotATreeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AChoiceIsOneConnectiveAndNotATreeTest.java
@@ -49,27 +49,42 @@ class AChoiceIsOneConnectiveAndNotATreeTest {
 
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
-    private Map<String, AdmissibleValues<String>> readings() {
-        Map<String, AdmissibleValues<String>> out = new LinkedHashMap<>();
-        out.put("top", AdmissibleValues.top());
-        out.put("value == A", AdmissibleValues.at("value", ValueSet.just(A)));
-        out.put("value == B", AdmissibleValues.at("value", ValueSet.just(B)));
-        out.put("value /= A", AdmissibleValues.at("value", ValueSet.allBut(A)));
-        out.put("other == A", AdmissibleValues.at("other", ValueSet.just(A)));
-        out.put("value == A && other == A", AdmissibleValues.at("value", ValueSet.just(A))
-                .meet(AdmissibleValues.at("other", ValueSet.just(A)), sets));
-        out.put("value == B && other == B", AdmissibleValues.at("value", ValueSet.just(B))
-                .meet(AdmissibleValues.at("other", ValueSet.just(B)), sets));
+    private static PlannedValues<String> at(String atom, ValueSet set) {
+        return PlannedValues.at(atom, AdmittedPlan.of(set));
+    }
+
+    /** A description worked out and told what its unread alternatives left open, which is what a
+     *  reader is handed. Said once, where the whole of what the clauses came to is in hand. */
+    private AdmissibleValues<String> opened(PlannedValues<String> planned) {
+        return planned.resolve(sets).values().alsoOpenedAt(OPENED);
+    }
+
+    /**
+     * The alternatives every triple below is drawn from, each one a branch somebody can be in.
+     *
+     * <p>Every one of them stands, because that is what a choice between two of them is a choice
+     * between. Where a branch is one nobody can be in, what the choice leaves is settled over the
+     * values and the order together and the alternatives are never composed — so a bracketing of
+     * those is a rule about the caller that settles them, and it is held where that caller is
+     * ({@code ADeadBranchIsSettledTheSameHoweverTheChoiceWasBracketedTest}).
+     */
+    private Map<String, PlannedValues<String>> readings() {
+        Map<String, PlannedValues<String>> out = new LinkedHashMap<>();
+        out.put("top", PlannedValues.top());
+        out.put("value == A", at("value", ValueSet.just(A)));
+        out.put("value == B", at("value", ValueSet.just(B)));
+        out.put("value /= A", at("value", ValueSet.allBut(A)));
+        out.put("other == A", at("other", ValueSet.just(A)));
+        out.put("value == A && other == A",
+                at("value", ValueSet.just(A)).meet(at("other", ValueSet.just(A))));
+        out.put("value == B && other == B",
+                at("value", ValueSet.just(B)).meet(at("other", ValueSet.just(B))));
         out.put("unread about value",
-                AdmissibleValues.unreadable(Set.of("value"), UnreadReason.FORM_NOT_READ));
+                PlannedValues.unreadable(Set.of("value"), UnreadReason.FORM_NOT_READ));
         out.put("unread about nothing",
-                AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ));
-        out.put("unread about both", AdmissibleValues.unreadable(Set.of("value", "other"),
+                PlannedValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ));
+        out.put("unread about both", PlannedValues.unreadable(Set.of("value", "other"),
                 UnreadReason.RELATES_TWO_POSITIONS));
-        out.put("two rules leaving nothing", AdmissibleValues.at("value", ValueSet.just(A))
-                .meet(AdmissibleValues.at("value", ValueSet.just(B)), sets));
-        out.put("shown impossible from outside",
-                AdmissibleValues.at("value", ValueSet.just(A)).leavingNothing());
         return out;
     }
 
@@ -106,11 +121,11 @@ class AChoiceIsOneConnectiveAndNotATreeTest {
     /** Three alternatives leave what they leave, however they are bracketed. */
     @Test
     void threeAlternativesLeaveTheSameHoweverTheyAreBracketed() {
-        Map<String, AdmissibleValues<String>> readings = readings();
+        Map<String, PlannedValues<String>> readings = readings();
         readings.forEach((leftName, left) -> readings.forEach((middleName, middle) ->
                 readings.forEach((rightName, right) -> assertEquals(
-                        answers(left.join(middle, sets).alsoOpenedAt(OPENED).join(right, sets).alsoOpenedAt(OPENED)),
-                        answers(left.join(middle.join(right, sets).alsoOpenedAt(OPENED), sets).alsoOpenedAt(OPENED)),
+                        answers(opened(left.joinLive(middle).joinLive(right))),
+                        answers(opened(left.joinLive(middle.joinLive(right)))),
                         () -> "(" + leftName + " || " + middleName + ") || " + rightName
                                 + "   against   " + leftName + " || (" + middleName + " || "
                                 + rightName + ")"))));
@@ -119,10 +134,10 @@ class AChoiceIsOneConnectiveAndNotATreeTest {
     /** And however they are ordered. */
     @Test
     void twoAlternativesLeaveTheSameHoweverTheyAreOrdered() {
-        Map<String, AdmissibleValues<String>> readings = readings();
+        Map<String, PlannedValues<String>> readings = readings();
         readings.forEach((leftName, left) -> readings.forEach((rightName, right) ->
-                assertEquals(answers(left.join(right, sets).alsoOpenedAt(OPENED)),
-                        answers(right.join(left, sets).alsoOpenedAt(OPENED)),
+                assertEquals(answers(opened(left.joinLive(right))),
+                        answers(opened(right.joinLive(left))),
                         () -> leftName + " || " + rightName + "   against   "
                                 + rightName + " || " + leftName)));
     }
@@ -130,14 +145,12 @@ class AChoiceIsOneConnectiveAndNotATreeTest {
     /** And a conjunction beside them reads the same, wherever the brackets of the choice fell. */
     @Test
     void aConjunctionBesideThemReadsTheSameEitherWay() {
-        Map<String, AdmissibleValues<String>> readings = readings();
-        AdmissibleValues<String> beside = AdmissibleValues.at("other", ValueSet.allBut(B));
+        Map<String, PlannedValues<String>> readings = readings();
+        PlannedValues<String> beside = at("other", ValueSet.allBut(B));
         readings.forEach((leftName, left) -> readings.forEach((middleName, middle) ->
                 readings.forEach((rightName, right) -> assertEquals(
-                        answers(left.join(middle, sets).alsoOpenedAt(OPENED).join(right, sets).alsoOpenedAt(OPENED)
-                                .meet(beside, sets)),
-                        answers(left.join(middle.join(right, sets).alsoOpenedAt(OPENED), sets).alsoOpenedAt(OPENED)
-                                .meet(beside, sets)),
+                        answers(opened(left.joinLive(middle).joinLive(right).meet(beside))),
+                        answers(opened(left.joinLive(middle.joinLive(right)).meet(beside))),
                         () -> "(" + leftName + " || " + middleName + ") || " + rightName
                                 + "   met with other /= B, against the other bracketing"))));
     }
@@ -152,16 +165,16 @@ class AChoiceIsOneConnectiveAndNotATreeTest {
      */
     @Test
     void andAFurtherAlternativeAfterThatConjunctionReadsTheSame() {
-        Map<String, AdmissibleValues<String>> readings = readings();
-        AdmissibleValues<String> beside = AdmissibleValues.at("other", ValueSet.allBut(B));
-        AdmissibleValues<String> after =
-                AdmissibleValues.unreadable(Set.of("value"), UnreadReason.FORM_NOT_READ);
+        Map<String, PlannedValues<String>> readings = readings();
+        PlannedValues<String> beside = at("other", ValueSet.allBut(B));
+        PlannedValues<String> after =
+                PlannedValues.unreadable(Set.of("value"), UnreadReason.FORM_NOT_READ);
         readings.forEach((leftName, left) -> readings.forEach((middleName, middle) ->
                 readings.forEach((rightName, right) -> assertEquals(
-                        answers(left.join(middle, sets).alsoOpenedAt(OPENED).join(right, sets).alsoOpenedAt(OPENED)
-                                .meet(beside, sets).join(after, sets).alsoOpenedAt(OPENED)),
-                        answers(left.join(middle.join(right, sets).alsoOpenedAt(OPENED), sets).alsoOpenedAt(OPENED)
-                                .meet(beside, sets).join(after, sets).alsoOpenedAt(OPENED)),
+                        answers(opened(left.joinLive(middle).joinLive(right)
+                                .meet(beside).joinLive(after))),
+                        answers(opened(left.joinLive(middle.joinLive(right))
+                                .meet(beside).joinLive(after))),
                         () -> "(" + leftName + " || " + middleName + ") || " + rightName
                                 + "   met with other /= B and joined with an unread rule about"
                                 + " value, against the other bracketing"))));

--- a/souther-compiler/src/test/java/souther/compiler/values/AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest.java
@@ -34,19 +34,25 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
      *  built and no allowance is spent. */
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
-    /** {@code value == 5}. */
-    private static AdmissibleValues<String> is5() {
-        return AdmissibleValues.at(VALUE, ValueSet.just(FIVE));
+    /** {@code value == 5}, while it is still a description — which is where a choice is taken. */
+    private static PlannedValues<String> is5() {
+        return PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.just(FIVE)));
     }
 
     /** {@code value /= 5}. */
-    private static AdmissibleValues<String> not5() {
-        return AdmissibleValues.at(VALUE, ValueSet.allBut(FIVE));
+    private static PlannedValues<String> not5() {
+        return PlannedValues.at(VALUE, AdmittedPlan.of(ValueSet.allBut(FIVE)));
     }
 
     /** A rule about the position that this reading has no word for. */
-    private static AdmissibleValues<String> unread() {
-        return AdmissibleValues.unreadable(Set.of(VALUE), UnreadReason.FORM_NOT_READ);
+    private static PlannedValues<String> unread() {
+        return PlannedValues.unreadable(Set.of(VALUE), UnreadReason.FORM_NOT_READ);
+    }
+
+    /** A description worked out and told what its unread alternatives left open, which is what a
+     *  reader is handed. Said once, where the whole of what the clauses came to is in hand. */
+    private AdmissibleValues<String> opened(PlannedValues<String> planned, Set<String> these) {
+        return planned.resolve(sets).values().alsoOpenedAt(these);
     }
 
     /** What a choice beside {@link #unread()} left open, which is what the alternative beside it
@@ -58,7 +64,7 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
     @Test
     void twoAlternativesCoveringThePositionLeaveNothingForAnUnreadOneToWiden() {
         AdmissibleValues<String> either =
-                is5().join(not5(), sets).join(unread(), sets).alsoOpenedAt(OPENED_AT_VALUE);
+                opened(is5().joinLive(not5()).joinLive(unread()), OPENED_AT_VALUE);
 
         assertEquals(ValueSet.ANY, either.at(VALUE));
         assertTrue(either.speaksFor(VALUE),
@@ -69,8 +75,7 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
     @Test
     void theSameHoweverTheAlternativesAreBracketed() {
         AdmissibleValues<String> either =
-                is5().join(not5().join(unread(), sets).alsoOpenedAt(OPENED_AT_VALUE), sets)
-                        .alsoOpenedAt(OPENED_AT_VALUE);
+                opened(is5().joinLive(not5().joinLive(unread())), OPENED_AT_VALUE);
 
         assertEquals(ValueSet.ANY, either.at(VALUE));
         assertTrue(either.speaksFor(VALUE),
@@ -88,8 +93,8 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
      */
     @Test
     void aConjunctionKeepsItsOwnAccountOfWhatWentUnread() {
-        AdmissibleValues<String> both = is5().meet(
-                AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), sets);
+        AdmissibleValues<String> both = opened(is5().meet(
+                PlannedValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ)), Set.of());
 
         assertEquals(ValueSet.NONE, both.guaranteedAt(VALUE),
                 "an unread conjunct may exclude anything, so nothing is guaranteed under it");
@@ -110,11 +115,12 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
      */
     @Test
     void anAlternativeThatMayAdmitNothingSettlesNothing() {
-        AdmissibleValues<String> either = is5()
-                .meet(AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), sets)
+        AdmissibleValues<String> either = opened(is5()
+                .meet(PlannedValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ))
                 // The alternative beside the unread one holds a clause nothing read as well, so it
                 // promised nothing for the other to take back and the choice opened nowhere.
-                .join(AdmissibleValues.unreadable(Set.of(OTHER), UnreadReason.FORM_NOT_READ), sets);
+                .joinLive(PlannedValues.unreadable(Set.of(OTHER), UnreadReason.FORM_NOT_READ)),
+                Set.of());
 
         assertEquals(List.of(UnreadReason.FORM_NOT_READ), either.whyUnread(OTHER),
                 "the alternative beside the unread one may admit nothing, so it vouches for nothing");
@@ -131,16 +137,17 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
      */
     @Test
     void aPositionTheChoiceHasSettledStaysSettledUnderAFurtherAlternative() {
-        AdmissibleValues<String> covered =
-                is5().join(not5(), sets).join(unread(), sets).alsoOpenedAt(OPENED_AT_VALUE);
-        AdmissibleValues<String> beside = AdmissibleValues.at(OTHER, ValueSet.just(Value.text("A")));
+        PlannedValues<String> covered = is5().joinLive(not5()).joinLive(unread());
+        PlannedValues<String> beside =
+                PlannedValues.at(OTHER, AdmittedPlan.of(ValueSet.just(Value.text("A"))));
+        Set<String> openedAtBoth = Set.of(VALUE, OTHER);
 
-        assertFalse(covered.standing().isEmpty(),
+        assertFalse(opened(covered, OPENED_AT_VALUE).standing().isEmpty(),
                 "a rule of it did go unread, and that is not taken back");
-        assertTrue(covered.join(beside, sets).alsoOpenedAt(Set.of(OTHER)).speaksFor(VALUE));
-        assertTrue(beside.join(covered, sets).alsoOpenedAt(Set.of(OTHER)).speaksFor(VALUE),
+        assertTrue(opened(covered.joinLive(beside), openedAtBoth).speaksFor(VALUE));
+        assertTrue(opened(beside.joinLive(covered), openedAtBoth).speaksFor(VALUE),
                 "and either way round");
-        assertTrue(covered.join(beside, sets).alsoOpenedAt(Set.of(OTHER)).speaksFor(OTHER),
+        assertTrue(opened(covered.joinLive(beside), openedAtBoth).speaksFor(OTHER),
                 "and the position the further alternative names is covered by the settled one");
     }
 
@@ -148,8 +155,7 @@ class AChoiceThatAlreadyAdmitsEverythingIsNotWidenedTest {
      *  the choice is still short of. */
     @Test
     void anAlternativeNothingCouldReadCoversNothing() {
-        AdmissibleValues<String> either =
-                is5().join(unread(), sets).alsoOpenedAt(OPENED_AT_VALUE);
+        AdmissibleValues<String> either = opened(is5().joinLive(unread()), OPENED_AT_VALUE);
 
         assertEquals(ValueSet.ANY, either.at(VALUE));
         assertEquals(List.of(UnreadReason.FORM_NOT_READ), either.whyUnread(VALUE),

--- a/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest.java
@@ -120,24 +120,23 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
      * equality read beside the choice can be refused against, so a declaration nothing satisfies
      * comes back admitted.
      *
-     * <p>Asked of the reading whose values are still descriptions as well as of the one whose
-     * values are sets. Both merge, both have to carry it, and which of the two a compilation takes
-     * is settled by how large the choice is rather than by anything a model says.
+     * <p>Merging is one of the two ways a choice is held, and which of them a compilation takes is
+     * settled by how large the choice is rather than by anything a model says. Held apart the
+     * alternatives keep their own denials and there is nothing to carry, so this is asked of the
+     * merged one.
      */
     @Test
     void aChoiceMergedIntoOneProductKeepsWhatEveryAlternativeStates() {
         Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
-        AdmissibleValues<String> merged = AdmissibleValues.<String>heldApart("p", "r")
-                .join(AdmissibleValues.heldApart("p", "r"), sets);
-        assertTrue(merged.meet(AdmissibleValues.holdingAsOne("p", "r"), sets).isBottom(),
-                "the choice states it, so an equality read beside it refuses");
-
         PlannedValues<String> planned = PlannedValues.<String>heldApart("p", "r")
                 .joinLive(PlannedValues.heldApart("p", "r"));
         assertTrue(planned.meet(PlannedValues.holdingAsOne("p", "r"))
                         .anyAlternativeAdmits((_, _) -> Emptiness.NONEMPTY) == Emptiness.EMPTY,
-                "and the same of a reading whose values are still descriptions");
+                "the choice states it, so an equality read beside it refuses");
+        assertTrue(planned.resolve(sets).values()
+                        .meet(AdmissibleValues.holdingAsOne("p", "r"), sets).isBottom(),
+                "and it is still stated once the values are worked out");
     }
 
     /** And a denial only one alternative states is not the choice's. */
@@ -273,26 +272,6 @@ class ADenialIsARelationOverTheBlocksAnAlternativeIsOverTest {
         }
         assertInstanceOf(RelationalWitness.ABlockApartFromItself.class, together.why());
         assertEquals(Set.of(Sameness.of("p", "r").blockOf("p")), together.blocks());
-    }
-
-    /**
-     * And a choice between it and an alternative somebody can take is that alternative.
-     *
-     * <p>A union with an empty member is the union of the rest, so what the choice leaves at
-     * {@code p} is what the branch anybody can take leaves it. Kept as a member, the dead branch
-     * says nothing about {@code p} — nothing narrowed it there — and the choice would come back
-     * admitting every value.
-     */
-    @Test
-    void andAChoiceBetweenItAndSomethingStandingIsThatSomething() {
-        Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
-        AdmissibleValues<String> dead = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.heldApart("p", "r"), sets);
-
-        assertEquals(ValueSet.just(A),
-                dead.joinApart(AdmissibleValues.at("p", ValueSet.just(A)), sets).at("p"));
-        assertEquals(ValueSet.just(A),
-                AdmissibleValues.at("p", ValueSet.just(A)).joinApart(dead, sets).at("p"));
     }
 
     /** What a reduction that refused was refused by. */

--- a/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
@@ -43,9 +43,20 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
         return AdmissibleValues.at(atom, ValueSet.just(value));
     }
 
+    /** One rule while it is still a description, which is where a choice between two of them is
+     *  taken. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
     /** Both positions of one alternative, which is a product and is held as one. */
-    private AdmissibleValues<String> pair(Value a, Value b) {
-        return says(A, a).meet(says(B, b), sets);
+    private static PlannedValues<String> pair(Value a, Value b) {
+        return plans(A, a).meet(plans(B, b));
+    }
+
+    /** A description worked out, which is the only way a reading holding alternatives is made. */
+    private AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(sets).values();
     }
 
     /**
@@ -58,8 +69,8 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
      */
     @Test
     void twoChoicesAcrossTwoPositionsLeaveTheOnePairThatStands() {
-        AdmissibleValues<String> one = pair(FIVE, ZERO).joinApart(pair(SIX, ONE), sets);
-        AdmissibleValues<String> two = pair(FIVE, ZERO).joinApart(pair(SIX, ZERO), sets);
+        AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ONE)));
+        AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ZERO)));
 
         AdmissibleValues<String> both = one.meet(two, sets);
 
@@ -79,30 +90,29 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
      */
     @Test
     void theAlternativesAreASetAndNotASequence() {
-        AdmissibleValues<String> a = pair(FIVE, ZERO);
-        AdmissibleValues<String> b = pair(SIX, ONE);
-        AdmissibleValues<String> c = pair(SIX, ZERO);
+        PlannedValues<String> a = pair(FIVE, ZERO);
+        PlannedValues<String> b = pair(SIX, ONE);
+        PlannedValues<String> c = pair(SIX, ZERO);
 
-        assertEquals(a.joinApart(b, sets).held(),
-                b.joinApart(a, sets).held(),
+        assertEquals(built(a.joinLiveApart(b)).held(),
+                built(b.joinLiveApart(a)).held(),
                 "either order, one union");
-        assertEquals(a.held(), a.joinApart(a, sets).held(),
+        assertEquals(built(a).held(), built(a.joinLiveApart(a)).held(),
                 "and the same alternative twice is one");
-        assertEquals(a.joinApart(b, sets)
-                        .joinApart(c, sets).held(),
-                a.joinApart(b.joinApart(c, sets), sets).held(),
+        assertEquals(built(a.joinLiveApart(b).joinLiveApart(c)).held(),
+                built(a.joinLiveApart(b.joinLiveApart(c))).held(),
                 "and three of them are the same three, bracketed either way");
     }
 
     /** Held apart, three alternatives are three, which is what a merged one cannot say. */
     @Test
     void whatIsHeldIsTheAlternativesAndNotTheirHull() {
-        AdmissibleValues<String> three = pair(FIVE, ZERO).joinApart(pair(SIX, ONE), sets)
-                .joinApart(pair(SIX, ZERO), sets);
+        AdmissibleValues<String> three = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ONE))
+                .joinLiveApart(pair(SIX, ZERO)));
 
         assertEquals(3, ((AdmissibleValues.Held.Alternatives<String>) three.held()).boxes().size());
-        assertNotEquals(three.held(), pair(FIVE, ZERO).join(pair(SIX, ONE), sets)
-                .join(pair(SIX, ZERO), sets).held());
+        assertNotEquals(three.held(), built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE))
+                .joinLive(pair(SIX, ZERO))).held());
         assertEquals(ValueSet.oneOf(Set.of(FIVE, SIX)), three.at(A), "and the projection is theirs");
     }
 
@@ -115,8 +125,8 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
      */
     @Test
     void aPositionBesideThemKeepsItsOwnAnswer() {
-        AdmissibleValues<String> one = pair(FIVE, ZERO).joinApart(pair(SIX, ONE), sets);
-        AdmissibleValues<String> two = pair(FIVE, ZERO).joinApart(pair(SIX, ZERO), sets);
+        AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ONE)));
+        AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLiveApart(pair(SIX, ZERO)));
         AdmissibleValues<String> apart = AdmissibleValues.at(C, ValueSet.just(ZERO));
 
         AdmissibleValues<String> all = one.meet(two, sets).meet(apart, sets);
@@ -135,10 +145,13 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
      */
     @Test
     void aChoiceBetweenTwoImpossibleAlternativesNamesNoPosition() {
-        AdmissibleValues<String> here = says(A, FIVE).meet(says(A, SIX), sets);
-        AdmissibleValues<String> there = says(B, ZERO).meet(says(B, ONE), sets);
+        PlannedValues<String> here = plans(A, FIVE).meet(plans(A, SIX));
+        PlannedValues<String> there = plans(B, ZERO).meet(plans(B, ONE));
 
-        AdmissibleValues<String> either = here.joinApart(there, sets);
+        // Neither branch is one anybody can be in, which is the settlement a caller reaches for
+        // once both are known dead rather than a choice between two that stand.
+        AdmissibleValues<String> either =
+                built(here.leavingNothing().bothDead(there.leavingNothing()));
 
         assertTrue(either.isBottom(), "neither alternative can be taken");
         assertEquals(ValueSet.ANY, either.at(A), "and neither position is one the choice empties");
@@ -149,15 +162,13 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
      *  is about which rules went unread, and holding a union reads none of them. */
     @Test
     void holdingThemApartPromisesWhatMergingThemDid() {
-        for (List<AdmissibleValues<String>> each : List.of(
-                List.of(says(A, FIVE), says(A, SIX)),
+        for (List<PlannedValues<String>> each : List.of(
+                List.of(plans(A, FIVE), plans(A, SIX)),
                 List.of(pair(FIVE, ZERO), pair(SIX, ONE)),
-                List.of(says(A, FIVE), AdmissibleValues.<String>unreadable(Set.of(B),
+                List.of(plans(A, FIVE), PlannedValues.<String>unreadable(Set.of(B),
                         UnreadReason.FORM_NOT_READ)))) {
-            AdmissibleValues<String> merged =
-                    each.get(0).join(each.get(1), sets);
-            AdmissibleValues<String> apart =
-                    each.get(0).joinApart(each.get(1), sets);
+            AdmissibleValues<String> merged = built(each.get(0).joinLive(each.get(1)));
+            AdmissibleValues<String> apart = built(each.get(0).joinLiveApart(each.get(1)));
 
             assertEquals(merged.guaranteedAt(A), apart.guaranteedAt(A), each + " at a");
             assertEquals(merged.guaranteedAt(B), apart.guaranteedAt(B), each + " at b");

--- a/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AlternativesHeldApartAnswerThePositionExactlyTest.java
@@ -39,10 +39,6 @@ class AlternativesHeldApartAnswerThePositionExactlyTest {
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
 
-    private static AdmissibleValues<String> says(String atom, Value value) {
-        return AdmissibleValues.at(atom, ValueSet.just(value));
-    }
-
     /** One rule while it is still a description, which is where a choice between two of them is
      *  taken. */
     private static PlannedValues<String> plans(String atom, Value value) {

--- a/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
@@ -37,6 +37,22 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
         return AdmissibleValues.at(atom, ValueSet.just(value));
     }
 
+    /** The same rule while it is still a description, which is where a choice between two of them
+     *  is taken. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
+    private static PlannedValues<String> unread(Set<String> named) {
+        return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
+    }
+
+    /** A description worked out and told what its unread alternatives left open, which is what a
+     *  reader is handed. Said once, where the whole of what the clauses came to is in hand. */
+    private AdmissibleValues<String> opened(PlannedValues<String> planned, Set<String> these) {
+        return planned.resolve(sets).values().alsoOpenedAt(these);
+    }
+
     /** A rule read and nothing else is what it says, and this can speak for the position. */
     @Test
     void aRuleReadIsWhatItSays() {
@@ -55,7 +71,8 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
     /** Stated as alternatives the same two leave both values, and refuse nothing. */
     @Test
     void theSameTwoAsAlternativesLeaveBoth() {
-        AdmissibleValues<String> either = says(VALUE, A).join(says(VALUE, B), sets);
+        AdmissibleValues<String> either = opened(plans(VALUE, A).joinLive(plans(VALUE, B)),
+                Set.of());
         assertEquals(ValueSet.oneOf(Set.of(A, B)), either.at(VALUE));
         assertFalse(either.isBottom());
         assertTrue(either.speaksFor(VALUE));
@@ -100,9 +117,7 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
     @Test
     void anUnreadAlternativeTakesBackWhatTheOtherSaid() {
         AdmissibleValues<String> either =
-                says(VALUE, A).join(
-                        AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), sets)
-                        .alsoOpenedAt(Set.of(VALUE));
+                opened(plans(VALUE, A).joinLive(unread(Set.of())), Set.of(VALUE));
         assertEquals(ValueSet.ANY, either.at(VALUE));
         assertFalse(either.isBottom());
     }
@@ -115,19 +130,18 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      */
     @Test
     void aPositionLeftOpenByAnUnreadAlternativeIsNotOneNothingWasSaidAbout() {
-        assertFalse(says(VALUE, A)
-                .join(AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), sets)
-                .alsoOpenedAt(Set.of(VALUE))
+        assertFalse(opened(plans(VALUE, A).joinLive(unread(Set.of())), Set.of(VALUE))
                 .speaksFor(VALUE));
-        assertFalse(AdmissibleValues.<String>unreadable(Set.of(), UnreadReason.FORM_NOT_READ)
-                .join(says(VALUE, A), sets).alsoOpenedAt(Set.of(VALUE)).speaksFor(VALUE));
+        assertFalse(opened(unread(Set.of()).joinLive(plans(VALUE, A)), Set.of(VALUE))
+                .speaksFor(VALUE));
     }
 
     /** A position neither alternative spoke about is open because neither said anything, which this
      * can speak for. */
     @Test
     void aPositionNeitherAlternativeSpokeAboutIsOpenAndSpokenFor() {
-        AdmissibleValues<String> either = says(VALUE, A).join(says(VALUE, B), sets);
+        AdmissibleValues<String> either = opened(plans(VALUE, A).joinLive(plans(VALUE, B)),
+                Set.of());
         assertEquals(ValueSet.ANY, either.at(OTHER));
         assertTrue(either.speaksFor(OTHER));
     }
@@ -140,7 +154,8 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      */
     @Test
     void aPositionOneAlternativeLeftOpenIsOpenBecauseTheModelLeavesItSo() {
-        AdmissibleValues<String> either = says(VALUE, A).join(AdmissibleValues.top(), sets);
+        AdmissibleValues<String> either =
+                opened(plans(VALUE, A).joinLive(PlannedValues.top()), Set.of());
         assertEquals(ValueSet.ANY, either.at(VALUE));
         assertTrue(either.speaksFor(VALUE));
     }
@@ -187,10 +202,9 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      */
     @Test
     void aPositionTakenBackByAnAlternativeSaysAnAlternativeTookItBack() {
-        AdmissibleValues<String> either = says(VALUE, A)
-                .join(AdmissibleValues.unreadable(Set.of(OTHER),
-                        UnreadReason.RELATES_TWO_POSITIONS), sets)
-                .alsoOpenedAt(Set.of(VALUE));
+        AdmissibleValues<String> either = opened(plans(VALUE, A).joinLive(
+                PlannedValues.unreadable(Set.of(OTHER), UnreadReason.RELATES_TWO_POSITIONS)),
+                Set.of(VALUE));
 
         assertEquals(List.of(UnreadReason.ALTERNATIVE_NOT_READ), either.whyUnread(VALUE));
         assertTrue(either.speaksFor(OTHER),
@@ -201,55 +215,16 @@ class AnUnreadRuleWidensAndSaysThatItDidTest {
      *  position is nearer than a branch that widened it from outside. */
     @Test
     void aRuleThatNamedThePositionOutranksTheBranchThatWidenedIt() {
-        AdmissibleValues<String> either =
-                AdmissibleValues.<String>unreadable(Set.of(VALUE),
+        AdmissibleValues<String> either = opened(
+                PlannedValues.<String>unreadable(Set.of(VALUE),
                                 UnreadReason.RELATES_TWO_POSITIONS)
-                        .meet(says(OTHER, A), sets)
+                        .meet(plans(OTHER, A))
                         // The alternative beside the unread one holds a clause nothing read as
                         // well, so it promised nothing for the other to take back and the choice
                         // opened nowhere.
-                        .join(AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ),
-                                sets);
+                        .joinLive(unread(Set.of())), Set.of());
 
         assertEquals(List.of(UnreadReason.RELATES_TWO_POSITIONS), either.whyUnread(VALUE));
-    }
-
-    /**
-     * An alternative that admits no value is one nobody can take, so the choice is the other one.
-     *
-     * <p>Written without this, a choice keeps only what both sides spoke about — and a side that
-     * admits nothing spoke about a position the other one did not, so the whole came out saying
-     * nothing at all. What a value satisfying the possible alternative is under is what that
-     * alternative says.
-     */
-    @Test
-    void anAlternativeAdmittingNothingLeavesTheChoiceToTheOther() {
-        AdmissibleValues<String> impossible = says(VALUE, A).meet(says(VALUE, B), sets);
-        AdmissibleValues<String> possible = says(OTHER, A);
-
-        assertTrue(impossible.isBottom(), "the first alternative admits nothing");
-        assertEquals(ValueSet.just(A), impossible.join(possible, sets).at(OTHER));
-        assertEquals(ValueSet.just(A), possible.join(impossible, sets).at(OTHER),
-                "and either way round");
-    }
-
-    /**
-     * A choice neither alternative of which can be taken admits nothing, and names what both name.
-     *
-     * <p>No side speaks for the other, so answering with either would settle which position is
-     * named by the order the two were written in. Nor may they be met: a meet is a conjunction and
-     * the alternatives were never stated together.
-     */
-    @Test
-    void aChoiceNeitherAlternativeOfWhichCanBeTakenAdmitsNothing() {
-        AdmissibleValues<String> here = says(VALUE, A).meet(says(VALUE, B), sets);
-        AdmissibleValues<String> there = says(OTHER, A).meet(says(OTHER, B), sets);
-
-        assertTrue(here.join(there, sets).isBottom());
-        assertTrue(there.join(here, sets).isBottom(), "and either way round");
-        assertTrue(here.join(there, sets).at(VALUE).isEmpty()
-                        == there.join(here, sets).at(VALUE).isEmpty(),
-                "and says the same about each position either way round");
     }
 
     /** And a reading shown impossible from outside admits nothing and names no position. */

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest.java
@@ -37,6 +37,18 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
         return AsACompilationAllows.forAdmittedValues();
     }
 
+    /** A rule while it is still a description, which is where a choice between two of them is
+     *  taken. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
+    /** A description worked out, which is the only way a reading holding alternatives is made. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned,
+                                                  Allowance<String> by) {
+        return planned.resolve(by).values();
+    }
+
     /** Every coordinate this reading files an answer under. */
     private static Set<Sameness.Block<String>> filedUnder(AdmissibleValues<String> reading) {
         Set<Sameness.Block<String>> out = new LinkedHashSet<>(reading.guaranteed().keySet());
@@ -117,10 +129,10 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
      *  apart into it. */
     @Test
     void aChoiceCarriesEachBranchesAnswersIntoTheFinerRelation() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.at("p", ValueSet.just(A)), allowing())
-                .join(AdmissibleValues.<String>holdingAsOne("p", "s")
-                        .meet(AdmissibleValues.at("p", ValueSet.just(B)), allowing()), allowing());
+        AdmissibleValues<String> reading = built(
+                PlannedValues.<String>holdingAsOne("p", "r").meet(plans("p", A))
+                        .joinLive(PlannedValues.<String>holdingAsOne("p", "s")
+                                .meet(plans("p", B))), allowing());
 
         assertTrue(reading.sameness().isDiscrete(),
                 "neither equality is stated by both branches");
@@ -130,10 +142,10 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     /** And held apart, each alternative keeps the equality it states. */
     @Test
     void alternativesHeldApartKeepTheirOwnEqualities() {
-        AdmissibleValues<String> reading = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .meet(AdmissibleValues.at("p", ValueSet.just(A)), allowing())
-                .joinApart(AdmissibleValues.<String>holdingAsOne("p", "s")
-                        .meet(AdmissibleValues.at("p", ValueSet.just(B)), allowing()), allowing());
+        AdmissibleValues<String> reading = built(
+                PlannedValues.<String>holdingAsOne("p", "r").meet(plans("p", A))
+                        .joinLiveApart(PlannedValues.<String>holdingAsOne("p", "s")
+                                .meet(plans("p", B))), allowing());
 
         assertTrue(reading.sameness().isDiscrete(),
                 "what the union can say of a position is what both alternatives say");
@@ -156,8 +168,8 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
      */
     @Test
     void aChoiceBetweenTwoEqualitiesLosesARelationAndSaysSo() {
-        AdmissibleValues<String> merged = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .join(AdmissibleValues.holdingAsOne("p", "s"), allowing());
+        AdmissibleValues<String> merged = built(PlannedValues.<String>holdingAsOne("p", "r")
+                .joinLive(PlannedValues.holdingAsOne("p", "s")), allowing());
 
         assertFalse(merged.relationExact(), "neither pair survives the merge");
         assertTrue(merged.projectionExactAt("p"), "and what each position holds is still exact");
@@ -168,8 +180,8 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     /** And held apart, nothing is lost: the alternatives keep the relation between them. */
     @Test
     void andHeldApartTheRelationSurvives() {
-        AdmissibleValues<String> apart = AdmissibleValues.<String>holdingAsOne("p", "r")
-                .joinApart(AdmissibleValues.holdingAsOne("p", "s"), allowing());
+        AdmissibleValues<String> apart = built(PlannedValues.<String>holdingAsOne("p", "r")
+                .joinLiveApart(PlannedValues.holdingAsOne("p", "s")), allowing());
 
         assertTrue(apart.relationExact(), "the union of two products is what it is");
     }
@@ -203,9 +215,8 @@ class EveryAnswerOfAReadingIsFiledUnderItsOwnBlocksTest {
     @Test
     void aReadingNoEqualityReachedIsAProductOverItsPositions() {
         Allowance<String> sets = allowing();
-        AdmissibleValues<String> reading = AdmissibleValues.at("p", ValueSet.just(A))
-                .meet(AdmissibleValues.at("r", ValueSet.just(B)), sets)
-                .joinApart(AdmissibleValues.at("p", ValueSet.just(B)), sets);
+        AdmissibleValues<String> reading = built(
+                plans("p", A).meet(plans("r", B)).joinLiveApart(plans("p", B)), sets);
 
         assertTrue(reading.sameness().isDiscrete());
         filedUnder(reading).forEach(block ->

--- a/souther-compiler/src/test/java/souther/compiler/values/EveryPairOfShapesIsOneSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/EveryPairOfShapesIsOneSetTest.java
@@ -83,9 +83,10 @@ class EveryPairOfShapesIsOneSetTest {
         return made.set();
     }
 
-    /** And what either holds, on the same terms. */
+    /** And what either holds, on the same terms — said as one plan over the alternatives, which is
+     *  how a block holds what its alternatives leave it. */
     private ValueSet joined(ValueSet one, ValueSet two) {
-        Allowance.Composed made = sets.join(POSITION, one, two);
+        Allowance.Composed made = sets.joining(POSITION, List.of(one, two));
         assertFalse(made.gaveUp(), () -> one + " join " + two + " is within what one answer holds");
         return made.set();
     }

--- a/souther-compiler/src/test/java/souther/compiler/values/HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest.java
@@ -34,11 +34,11 @@ class HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest {
                 .compile(PatternPlan.Budget.OF_ADMITTED_VALUES.meter()));
     }
 
-    /** One alternative: {@code left} holds one language and {@code right} holds the other. */
-    private static AdmissibleValues<String> pair(ValueSet left, ValueSet right,
-                                                 Allowance<String> by) {
-        return AdmissibleValues.at("left", left)
-                .meet(AdmissibleValues.at("right", right), by);
+    /** One alternative: {@code left} holds one language and {@code right} holds the other, while
+     *  it is still a description. */
+    private static PlannedValues<String> pair(ValueSet left, ValueSet right) {
+        return PlannedValues.at("left", AdmittedPlan.of(left))
+                .meet(PlannedValues.at("right", AdmittedPlan.of(right)));
     }
 
     /** Two alternatives held apart, which is a reading whose positions are related by its boxes. */
@@ -47,10 +47,11 @@ class HowAlternativesRelateTwoPositionsIsPartOfWhatAReadingCostsTest {
         ValueSet b = matching("x|b{300}");
         ValueSet c = matching("x|c{300}");
         ValueSet d = matching("x|d{300}");
-        return crossed
+        return (crossed
                 // Every alternative here was read whole, so the choice left nothing open.
-                ? pair(a, d, by).joinApart(pair(c, b, by), by)
-                : pair(a, b, by).joinApart(pair(c, d, by), by);
+                ? pair(a, d).joinLiveApart(pair(c, b))
+                : pair(a, b).joinLiveApart(pair(c, d)))
+                .resolve(by).values();
     }
 
     /** The same positions, the same sets, and the pairs the other way round. */

--- a/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/ReadingsConjoinedAreNotMultipliedTest.java
@@ -194,8 +194,9 @@ class ReadingsConjoinedAreNotMultipliedTest {
      */
     @Test
     void aPositionAChoiceOpenedIsOneTheReadingIsAbout() {
-        AdmissibleValues<String> opened = AdmissibleValues.at("x", just("A"))
-                .join(AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ), SETS)
+        AdmissibleValues<String> opened = PlannedValues.at("x", AdmittedPlan.of(just("A")))
+                .joinLive(PlannedValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ))
+                .resolve(SETS).values()
                 .alsoOpenedAt(Set.of("x"))
                 .leavingNothing();
 
@@ -251,10 +252,14 @@ class ReadingsConjoinedAreNotMultipliedTest {
     /** A reading of two positions leaving two alternatives, which is what a choice written across
      *  two positions comes to. */
     private static AdmissibleValues<String> twoAlternatives(String one, String other) {
-        return AdmissibleValues.at(one, just("x"))
-                .meet(AdmissibleValues.at(other, just("y")), SETS)
-                .joinApart(AdmissibleValues.at(one, just("p"))
-                        .meet(AdmissibleValues.at(other, just("q")), SETS), SETS);
+        return pair(one, "x", other, "y").joinLiveApart(pair(one, "p", other, "q"))
+                .resolve(SETS).values();
+    }
+
+    /** One alternative of that reading, while it is still a description. */
+    private static PlannedValues<String> pair(String one, String here, String other, String there) {
+        return PlannedValues.at(one, AdmittedPlan.of(just(here)))
+                .meet(PlannedValues.at(other, AdmittedPlan.of(just(there))));
     }
 
     private static ValueSet just(String text) {

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest.java
@@ -44,29 +44,60 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
     }
 
     /** What a clause of no connective is read into, whichever of them it is. */
-    private static List<AdmissibleValues<String>> leaves() {
+    private static List<PlannedValues<String>> leaves() {
         return List.of(
-                AdmissibleValues.top(),
-                AdmissibleValues.at(A, ValueSet.just(FIVE)),
-                AdmissibleValues.at(A, ValueSet.allBut(FIVE)),
-                AdmissibleValues.at(B, ValueSet.just(ZERO)),
-                AdmissibleValues.at(A, ValueSet.NONE),
-                AdmissibleValues.unreadable(Set.of(A), UnreadReason.FORM_NOT_READ),
-                AdmissibleValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ));
+                PlannedValues.top(),
+                PlannedValues.at(A, AdmittedPlan.of(ValueSet.just(FIVE))),
+                PlannedValues.at(A, AdmittedPlan.of(ValueSet.allBut(FIVE))),
+                PlannedValues.at(B, AdmittedPlan.of(ValueSet.just(ZERO))),
+                PlannedValues.at(A, AdmittedPlan.NONE),
+                PlannedValues.unreadable(Set.of(A), UnreadReason.FORM_NOT_READ),
+                PlannedValues.unreadable(Set.of(), UnreadReason.FORM_NOT_READ));
     }
 
     /** What puts the sets of one reading together. Every set here is written out, so nothing is
      *  built and no allowance is spent. */
     private final Allowance<String> sets = AsACompilationAllows.forAdmittedValues();
 
+    /** A description worked out, which is where the alternatives are counted. */
+    private AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(sets).values();
+    }
+
+    /**
+     * Either reading holding, as the holder of both languages settles it.
+     *
+     * <p>A branch nobody can be in is not composed — what the choice leaves is the branch that
+     * stands — and where neither can be there is nothing to compose and the settlement says so.
+     * The induction is over what the fold does, so it is over these four cases and not over an
+     * operation the fold never reaches for.
+     */
+    private PlannedValues<String> either(PlannedValues<String> one, PlannedValues<String> other,
+                                         boolean apart) {
+        if (dead(one) && dead(other)) {
+            return one.leavingNothing().bothDead(other.leavingNothing());
+        }
+        if (dead(one)) {
+            return other;
+        }
+        if (dead(other)) {
+            return one;
+        }
+        return apart ? one.joinLiveApart(other) : one.joinLive(other);
+    }
+
+    private boolean dead(PlannedValues<String> planned) {
+        return planned.holdsNothingAsBuilt(sets);
+    }
+
     /** The same, and everything one connective reaches from them. */
-    private List<AdmissibleValues<String>> readings() {
-        List<AdmissibleValues<String>> out = new ArrayList<>(leaves());
-        for (AdmissibleValues<String> one : leaves()) {
-            for (AdmissibleValues<String> other : leaves()) {
-                out.add(one.meet(other, sets));
-                out.add(one.joinApart(other, sets));
-                out.add(one.join(other, sets));
+    private List<PlannedValues<String>> readings() {
+        List<PlannedValues<String>> out = new ArrayList<>(leaves());
+        for (PlannedValues<String> one : leaves()) {
+            for (PlannedValues<String> other : leaves()) {
+                out.add(one.meet(other));
+                out.add(either(one, other, true));
+                out.add(either(one, other, false));
             }
         }
         return out;
@@ -76,21 +107,22 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
      *  what a rule with no word for it leaves is every value, which is a product like any other. */
     @Test
     void aLeafIsOneAlternative() {
-        for (AdmissibleValues<String> each : leaves()) {
-            assertTrue(held(each) <= 1, each + " is more than one alternative");
+        for (PlannedValues<String> each : leaves()) {
+            assertTrue(held(built(each)) <= 1, each + " is more than one alternative");
         }
-        assertEquals(1, held(AdmissibleValues.at(A, ValueSet.just(FIVE))));
-        assertEquals(1, held(AdmissibleValues.unreadable(Set.of(A), UnreadReason.FORM_NOT_READ)));
+        assertEquals(1, held(built(PlannedValues.at(A, AdmittedPlan.of(ValueSet.just(FIVE))))));
+        assertEquals(1, held(built(
+                PlannedValues.unreadable(Set.of(A), UnreadReason.FORM_NOT_READ))));
     }
 
     /** A choice holds at most the sum, which is what the count adds for one. */
     @Test
     void aChoiceHoldsAtMostTheSum() {
-        for (AdmissibleValues<String> one : readings()) {
-            for (AdmissibleValues<String> other : readings()) {
-                assertTrue(held(one.joinApart(other, sets)) <= held(one) + held(other),
-                        one + " || " + other);
-                assertTrue(held(one.join(other, sets)) <= held(one) + held(other),
+        for (PlannedValues<String> one : readings()) {
+            for (PlannedValues<String> other : readings()) {
+                int apart = held(built(one)) + held(built(other));
+                assertTrue(held(built(either(one, other, true))) <= apart, one + " || " + other);
+                assertTrue(held(built(either(one, other, false))) <= apart,
                         "and merged it holds no more than that: " + one + " || " + other);
             }
         }
@@ -99,9 +131,9 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
     /** And a conjunction at most the product, which is what the count multiplies for one. */
     @Test
     void aConjunctionHoldsAtMostTheProduct() {
-        for (AdmissibleValues<String> one : readings()) {
-            for (AdmissibleValues<String> other : readings()) {
-                assertTrue(held(one.meet(other, sets)) <= held(one) * held(other),
+        for (PlannedValues<String> one : readings()) {
+            for (PlannedValues<String> other : readings()) {
+                assertTrue(held(built(one.meet(other))) <= held(built(one)) * held(built(other)),
                         one + " && " + other);
             }
         }
@@ -114,13 +146,13 @@ class WhatACountTakenBeforeReadingPromisesAboutWhatIsBuiltTest {
      */
     @Test
     void andBothBoundsAreReached() {
-        AdmissibleValues<String> here = AdmissibleValues.at(A, ValueSet.just(FIVE))
-                .joinApart(AdmissibleValues.at(A, ValueSet.just(SIX)), sets);
-        AdmissibleValues<String> there = AdmissibleValues.at(B, ValueSet.just(ZERO))
-                .joinApart(AdmissibleValues.at(B, ValueSet.just(ONE)), sets);
+        PlannedValues<String> here = PlannedValues.at(A, AdmittedPlan.of(ValueSet.just(FIVE)))
+                .joinLiveApart(PlannedValues.at(A, AdmittedPlan.of(ValueSet.just(SIX))));
+        PlannedValues<String> there = PlannedValues.at(B, AdmittedPlan.of(ValueSet.just(ZERO)))
+                .joinLiveApart(PlannedValues.at(B, AdmittedPlan.of(ValueSet.just(ONE))));
 
-        assertEquals(2, held(here), "a choice of two, and the sum of one and one is two");
-        assertEquals(4, held(here.meet(there, sets)),
+        assertEquals(2, held(built(here)), "a choice of two, and the sum of one and one is two");
+        assertEquals(4, held(built(here.meet(there))),
                 "and a conjunction of two by two, none of whose pairs is empty, is four");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingCanPromiseAboutItsProjectionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatAReadingCanPromiseAboutItsProjectionsTest.java
@@ -47,9 +47,20 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
      *  nothing is built and no allowance is spent. */
     private static final Allowance<String> SETS = AsACompilationAllows.forAdmittedValues();
 
+    /** One rule while it is still a description, which is where a choice between two of them is
+     *  taken. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
     /** Both positions of one alternative, which is a product and is held as one. */
-    private static AdmissibleValues<String> pair(Value a, Value b) {
-        return says(A, a).meet(says(B, b), SETS);
+    private static PlannedValues<String> pair(Value a, Value b) {
+        return plans(A, a).meet(plans(B, b));
+    }
+
+    /** A description worked out, which is the only way a reading holding alternatives is made. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(SETS).values();
     }
 
     /** A reading with nothing read is exact about everything it says, which is nothing. */
@@ -65,7 +76,7 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
      *  union of two of them is one and nothing is lost. */
     @Test
     void aChoiceAtOnePositionPromisesItsRelation() {
-        AdmissibleValues<String> either = says(A, FIVE).join(says(A, SIX), SETS);
+        AdmissibleValues<String> either = built(plans(A, FIVE).joinLive(plans(A, SIX)));
 
         assertEquals(ValueSet.oneOf(Set.of(FIVE, SIX)), either.at(A));
         assertTrue(either.relationExact(), "two values of one position are a product");
@@ -81,7 +92,7 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
      */
     @Test
     void aChoiceAcrossTwoPositionsKeepsItsProjectionsAndLosesItsRelation() {
-        AdmissibleValues<String> one = pair(FIVE, ZERO).join(pair(SIX, ONE), SETS);
+        AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE)));
 
         assertEquals(ValueSet.oneOf(Set.of(FIVE, SIX)), one.at(A));
         assertEquals(ValueSet.oneOf(Set.of(ZERO, ONE)), one.at(B));
@@ -99,8 +110,8 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
      */
     @Test
     void twoChoicesAcrossTwoPositionsMetTogetherPromiseNeither() {
-        AdmissibleValues<String> one = pair(FIVE, ZERO).join(pair(SIX, ONE), SETS);
-        AdmissibleValues<String> two = pair(FIVE, ZERO).join(pair(SIX, ZERO), SETS);
+        AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE)));
+        AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLive(pair(SIX, ZERO)));
 
         AdmissibleValues<String> both = one.meet(two, SETS);
 
@@ -112,7 +123,7 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
     /** A conjunction of readings that are each a product is a product, and says so. */
     @Test
     void aConjunctionOfProductsPromisesBoth() {
-        AdmissibleValues<String> both = pair(FIVE, ZERO).meet(says(A, FIVE), SETS);
+        AdmissibleValues<String> both = built(pair(FIVE, ZERO).meet(plans(A, FIVE)));
 
         assertTrue(both.relationExact(), "the intersection of two products is a product");
         assertTrue(both.projectionExactAt(A));
@@ -132,8 +143,8 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
      */
     @Test
     void aPositionNoLostCorrelationReachesKeepsItsPromise() {
-        AdmissibleValues<String> one = pair(FIVE, ZERO).join(pair(SIX, ONE), SETS);
-        AdmissibleValues<String> two = pair(FIVE, ZERO).join(pair(SIX, ZERO), SETS);
+        AdmissibleValues<String> one = built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE)));
+        AdmissibleValues<String> two = built(pair(FIVE, ZERO).joinLive(pair(SIX, ZERO)));
         AdmissibleValues<String> apart = AdmissibleValues.at(C, ValueSet.just(ZERO));
 
         AdmissibleValues<String> all = one.meet(two, SETS).meet(apart, SETS);
@@ -150,10 +161,10 @@ class WhatAReadingCanPromiseAboutItsProjectionsTest {
         for (AdmissibleValues<String> each : java.util.List.<AdmissibleValues<String>>of(
                 AdmissibleValues.top(),
                 says(A, FIVE),
-                says(A, FIVE).join(says(A, SIX), SETS),
-                pair(FIVE, ZERO).join(pair(SIX, ONE), SETS),
-                pair(FIVE, ZERO).join(pair(SIX, ONE), SETS)
-                        .meet(pair(FIVE, ZERO).join(pair(SIX, ZERO), SETS), SETS))) {
+                built(plans(A, FIVE).joinLive(plans(A, SIX))),
+                built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE))),
+                built(pair(FIVE, ZERO).joinLive(pair(SIX, ONE))
+                        .meet(pair(FIVE, ZERO).joinLive(pair(SIX, ZERO)))))) {
             assertTrue(!each.relationExact() || each.projectionExactAt(A),
                     each + " promises its relation and not its projections");
         }

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest.java
@@ -54,6 +54,21 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
         return Arguments.of(Named.of(how, state));
     }
 
+    /** The same rule while it is still a description, which is where a choice between two of them
+     *  is taken. */
+    private static PlannedValues<String> plans(String atom, Value value) {
+        return PlannedValues.at(atom, AdmittedPlan.of(ValueSet.just(value)));
+    }
+
+    private static PlannedValues<String> plansUnreadable(Set<String> named) {
+        return PlannedValues.unreadable(named, UnreadReason.FORM_NOT_READ);
+    }
+
+    /** A description worked out, which is the only way a reading holding alternatives is made. */
+    private static AdmissibleValues<String> built(PlannedValues<String> planned) {
+        return planned.resolve(SETS).values();
+    }
+
     static Stream<Arguments> states() {
         return Stream.of(
                 made("top", AdmissibleValues.top()),
@@ -64,34 +79,39 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
                 made("meet of two read", says(VALUE, A).meet(says(OTHER, B), SETS)),
                 made("meet with an unread", says(VALUE, A).meet(unreadable(Set.of(OTHER)), SETS)),
                 made("meet leaving nothing", says(VALUE, A).meet(says(VALUE, B), SETS)),
-                made("join of two read", says(VALUE, A).join(says(VALUE, B), SETS)),
-                made("join with an unread", says(VALUE, A).join(unreadable(Set.of(VALUE)), SETS)
-                        .alsoOpenedAt(Set.of(VALUE))),
+                made("join of two read", built(plans(VALUE, A).joinLive(plans(VALUE, B)))),
+                made("join with an unread",
+                        built(plans(VALUE, A).joinLive(plansUnreadable(Set.of(VALUE))))
+                                .alsoOpenedAt(Set.of(VALUE))),
                 made("join covering the position",
-                        AdmissibleValues.at(VALUE, ValueSet.just(A))
-                                .join(AdmissibleValues.at(VALUE, ValueSet.allBut(A)), SETS)),
-                made("join of two that leave nothing",
-                        says(VALUE, A).meet(says(VALUE, B), SETS)
-                                .join(says(OTHER, A).meet(says(OTHER, B), SETS), SETS)),
+                        built(plans(VALUE, A).joinLive(PlannedValues.at(VALUE,
+                                AdmittedPlan.of(ValueSet.allBut(A)))))),
+                // Neither alternative of this one is a branch anybody can be in, which is a
+                // settlement and not a join — the operation is the one a caller reaches for once
+                // both branches are known dead.
+                made("a choice neither branch of which stands",
+                        built(plans(VALUE, A).meet(plans(VALUE, B)).leavingNothing()
+                                .bothDead(plans(OTHER, A).meet(plans(OTHER, B))
+                                        .leavingNothing()))),
                 made("join of a meet and an unread",
-                        says(VALUE, A).meet(unreadable(Set.of()), SETS)
-                                .join(says(VALUE, B), SETS).alsoOpenedAt(Set.of(VALUE))),
+                        built(plans(VALUE, A).meet(plansUnreadable(Set.of()))
+                                .joinLive(plans(VALUE, B))).alsoOpenedAt(Set.of(VALUE))),
                 made("choice over two positions",
-                        says(VALUE, A).meet(says(OTHER, A), SETS)
-                                .join(says(VALUE, B).meet(says(OTHER, B), SETS), SETS)),
+                        built(plans(VALUE, A).meet(plans(OTHER, A))
+                                .joinLive(plans(VALUE, B).meet(plans(OTHER, B))))),
                 made("choice over two positions, met",
-                        says(VALUE, A).meet(says(OTHER, A), SETS)
-                                .join(says(VALUE, B).meet(says(OTHER, B), SETS), SETS)
+                        built(plans(VALUE, A).meet(plans(OTHER, A))
+                                .joinLive(plans(VALUE, B).meet(plans(OTHER, B))))
                                 .meet(says(VALUE, A), SETS)),
                 made("heldApart", AdmissibleValues.heldApart(VALUE, OTHER)),
                 made("meet with heldApart",
                         says(VALUE, A).meet(AdmissibleValues.heldApart(VALUE, OTHER), SETS)),
                 made("join with heldApart",
-                        says(VALUE, A).join(AdmissibleValues.heldApart(VALUE, OTHER), SETS)),
+                        built(plans(VALUE, A).joinLive(PlannedValues.heldApart(VALUE, OTHER)))),
                 made("join nested under a join",
-                        says(VALUE, A).join(says(VALUE, B)
-                                .join(unreadable(Set.of(VALUE)), SETS).alsoOpenedAt(Set.of(VALUE)),
-                                SETS).alsoOpenedAt(Set.of(VALUE))));
+                        built(plans(VALUE, A).joinLive(plans(VALUE, B)
+                                .joinLive(plansUnreadable(Set.of(VALUE)))))
+                                .alsoOpenedAt(Set.of(VALUE))));
     }
 
     /**
@@ -138,7 +158,8 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
                 says(VALUE, A).meet(apart, SETS).guaranteedAt(VALUE),
                 "a conjunction the rule reaches guarantees nothing there");
         assertEquals(ValueSet.just(A),
-                says(VALUE, A).join(apart, SETS).guaranteedAt(VALUE),
+                built(plans(VALUE, A).joinLive(PlannedValues.heldApart(VALUE, OTHER)))
+                        .guaranteedAt(VALUE),
                 "and a branch beside it keeps what it guarantees on its own");
     }
 
@@ -150,8 +171,9 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
                 made("a meet under a wider one",
                         says(OTHER, A).meet(says(VALUE, A), SETS).meet(says(VALUE, B), SETS)),
                 made("two alternatives neither of which can be taken",
-                        says(VALUE, A).meet(says(VALUE, B), SETS)
-                                .join(says(OTHER, A).meet(says(OTHER, B), SETS), SETS)));
+                        built(plans(VALUE, A).meet(plans(VALUE, B)).leavingNothing()
+                                .bothDead(plans(OTHER, A).meet(plans(OTHER, B))
+                                        .leavingNothing()))));
     }
 
     /**
@@ -170,12 +192,12 @@ class WhatIsGuaranteedIsNeverMoreThanWhatIsAdmittedTest {
      */
     @Test
     void aChoiceOverTwoPositionsLeavesNoGuaranteeForAConjunctionToRestOn() {
-        AdmissibleValues<String> together = says(VALUE, A).meet(says(OTHER, A), SETS);
-        AdmissibleValues<String> apart = says(VALUE, B).meet(says(OTHER, B), SETS);
-        AdmissibleValues<String> otherB = says(VALUE, B).meet(says(OTHER, A), SETS);
+        PlannedValues<String> together = plans(VALUE, A).meet(plans(OTHER, A));
+        PlannedValues<String> apart = plans(VALUE, B).meet(plans(OTHER, B));
+        PlannedValues<String> otherB = plans(VALUE, B).meet(plans(OTHER, A));
 
-        AdmissibleValues<String> one = together.join(apart, SETS);
-        AdmissibleValues<String> two = together.join(otherB, SETS);
+        AdmissibleValues<String> one = built(together.joinLive(apart));
+        AdmissibleValues<String> two = built(together.joinLive(otherB));
         AdmissibleValues<String> both = one.meet(two, SETS);
 
         assertEquals(ValueSet.oneOf(Set.of(A, B)), both.at(VALUE),

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -195,27 +195,66 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
         about.addAll(right.readAbout());
         boolean overOne = left.choicesOverOnePosition() && right.choicesOverOnePosition()
                 && (by.equals("&&") || about.size() <= 1);
-        // What a choice between these two leaves open, said where the two of them are what was
-        // written: the positions the alternative beside an unread one reached. A conjunction leaves
-        // nothing open, since both of its clauses hold.
         Set<String> opened = new LinkedHashSet<>();
-        if (by.equals("||")) {
-            if (left.holdsSomethingUnread()) {
-                opened.addAll(promisedBy(right));
-            }
-            if (right.holdsSomethingUnread()) {
-                opened.addAll(promisedBy(left));
-            }
+        PlannedValues<String> planned;
+        if (by.equals("&&")) {
+            planned = left.planned().meet(right.planned());
+            // A conjunction leaves nothing open, since both of its clauses hold. What either side
+            // already had opened travels up with it: the positions are told to the answer once,
+            // where the whole of what the clauses came to is in hand.
+            opened.addAll(left.opened());
+            opened.addAll(right.opened());
+        } else {
+            planned = settled(left, right, opened);
         }
-        // What either side already had opened travels up with it: the positions are told to the
-        // answer once, where the whole of what the clauses came to is in hand.
+        return new Rule("(" + left.wrote() + " " + by + " " + right.wrote() + ")",
+                planned, opened, List.copyOf(could), about, overOne,
+                left.holdsSomethingUnread() || right.holdsSomethingUnread());
+    }
+
+    /**
+     * What a choice comes to, settled the way the holder of both languages settles one.
+     *
+     * <p>Four cases and not one. A branch nobody can be in is not composed: where one is, the
+     * choice is the branch that stands, and where neither is, the settlement says so of the two of
+     * them. Composed instead, this would be asking the description algebra a question its contract
+     * says it is not asked — and then what is compared against the models below would be this
+     * compiler's arithmetic reached a way no compile reaches it.
+     *
+     * <p>Which branches those are is asked of this compiler's own reading and never of the models:
+     * taken from the sets a rule was written down as leaving, the answer would be the expected side
+     * deciding what the compiler does, and the two would agree because one of them was made out of
+     * the other.
+     *
+     * <p>What a choice left open follows the same four cases. A position is open in a branch, so a
+     * branch nobody can be in takes what it opened with it — kept, the values would be settled and
+     * the account beside them would still be the one a choice that stands leaves.
+     */
+    private static PlannedValues<String> settled(Rule left, Rule right, Set<String> opened) {
+        boolean leftStands = !left.planned().holdsNothingAsBuilt(SETS);
+        boolean rightStands = !right.planned().holdsNothingAsBuilt(SETS);
+        if (!leftStands && !rightStands) {
+            return left.planned().leavingNothing().bothDead(right.planned().leavingNothing());
+        }
+        if (!leftStands) {
+            opened.addAll(right.opened());
+            return right.planned();
+        }
+        if (!rightStands) {
+            opened.addAll(left.opened());
+            return left.planned();
+        }
         opened.addAll(left.opened());
         opened.addAll(right.opened());
-        return new Rule("(" + left.wrote() + " " + by + " " + right.wrote() + ")",
-                by.equals("&&") ? left.planned().meet(right.planned())
-                        : left.planned().joinLive(right.planned()),
-                opened, List.copyOf(could), about, overOne,
-                left.holdsSomethingUnread() || right.holdsSomethingUnread());
+        // The positions the alternative beside an unread one reached, said where the two of them
+        // are what was written.
+        if (left.holdsSomethingUnread()) {
+            opened.addAll(promisedBy(right));
+        }
+        if (right.holdsSomethingUnread()) {
+            opened.addAll(promisedBy(left));
+        }
+        return left.planned().joinLive(right.planned());
     }
 
     /**
@@ -274,7 +313,29 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
             heldAgainstItsModels(both(either(left, middle), right));
             heldAgainstItsModels(both(left, either(middle, right)));
             heldAgainstItsModels(either(both(left, middle), right));
+            // A conjunction of two rules is where a branch nobody can be in comes from, and the
+            // enumeration above only ever puts one on the left of a choice. Without this, what a
+            // choice with a dead branch leaves would be held one way round out of two.
+            heldAgainstItsModels(either(left, both(middle, right)));
             heldAgainstItsModels(both(both(left, middle), right));
         })));
+    }
+
+    /**
+     * And a choice neither branch of which anybody can be in.
+     *
+     * <p>The fourth of the four cases a choice is settled by, which the enumerations above do not
+     * reach: they compose one dead branch at a time, and this one needs two. Written out of rules
+     * that were read, so that what makes each branch impossible is something this compiler worked
+     * out rather than something a model was told.
+     */
+    @Test
+    void andAChoiceNeitherBranchOfWhichAnybodyCanBeIn() {
+        Rule isA = rules().get(0);
+        Rule isB = rules().get(1);
+        Rule notA = rules().get(3);
+
+        heldAgainstItsModels(either(both(isA, isB), both(isA, notA)));
+        heldAgainstItsModels(either(both(isA, notA), both(isA, isB)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -63,6 +63,14 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
     /**
      * A reading of some rules, beside every set of records those rules could leave.
      *
+     * <p>The two are worked out apart. What the models say is put together out of the sets of
+     * records above by {@code &} and {@code |}; what this compiler says is put together by the
+     * connectives it composes descriptions with. A reading taken from either side to make the
+     * other would leave this asking whether the compiler agrees with itself.
+     *
+     * @param planned what this compiler read the rules into, before any of it is worked out
+     * @param opened what the alternatives nothing could read left open, gathered up the clause and
+     *                  told to the answer once
      * @param readAbout the positions the rules this could read are about
      * @param choicesOverOnePosition whether every choice in it is between alternatives the reading
      *                  took in about no more than one position between them. Where it is not, what
@@ -74,9 +82,16 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      *                  fact about the clause as it is written here, so it is decided here and
      *                  handed to the join rather than worked out from what the readings hold
      */
-    private record Rule(String wrote, AdmissibleValues<String> read, List<Integer> leaves,
-                        Set<String> readAbout, boolean choicesOverOnePosition,
-                        boolean holdsSomethingUnread) {}
+    private record Rule(String wrote, PlannedValues<String> planned, Set<String> opened,
+                        List<Integer> leaves, Set<String> readAbout,
+                        boolean choicesOverOnePosition, boolean holdsSomethingUnread) {
+
+        /** What a reader is handed: the description worked out, and told what the alternatives
+         *  nothing could read left open. Said once, over the whole of what the clauses came to. */
+        AdmissibleValues<String> answer() {
+            return planned.resolve(SETS).values().alsoOpenedAt(opened);
+        }
+    }
 
     /** Which values stand at {@code atom} in {@code records}, as a pair of bits. */
     private static int standingAt(String atom, int records) {
@@ -106,9 +121,9 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
     }
 
     /** A rule read in full: one set of records and no doubt about it. */
-    private static Rule read(String wrote, AdmissibleValues<String> read, String about,
-                             int records) {
-        return new Rule(wrote, read, List.of(records), Set.of(about), true, false);
+    private static Rule read(String wrote, ValueSet leaves, String about, int records) {
+        return new Rule(wrote, PlannedValues.at(about, AdmittedPlan.of(leaves)), Set.of(),
+                List.of(records), Set.of(about), true, false);
     }
 
     /**
@@ -122,7 +137,8 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
                 could.add(records);
             }
         }
-        return new Rule(wrote, AdmissibleValues.unreadable(names, why), could, Set.of(), true, true);
+        return new Rule(wrote, PlannedValues.unreadable(names, why), Set.of(), could, Set.of(),
+                true, true);
     }
 
     /** Whether {@code records} is settled by the named positions alone. */
@@ -142,10 +158,10 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
 
     private static List<Rule> rules() {
         return List.of(
-                read("value == A", AdmissibleValues.at(VALUE, ValueSet.just(A)), VALUE, 0b0011),
-                read("value == B", AdmissibleValues.at(VALUE, ValueSet.just(B)), VALUE, 0b1100),
-                read("other == A", AdmissibleValues.at(OTHER, ValueSet.just(A)), OTHER, 0b0101),
-                read("value /= A", AdmissibleValues.at(VALUE, ValueSet.allBut(A)), VALUE, 0b1100),
+                read("value == A", ValueSet.just(A), VALUE, 0b0011),
+                read("value == B", ValueSet.just(B), VALUE, 0b1100),
+                read("other == A", ValueSet.just(A), OTHER, 0b0101),
+                read("value /= A", ValueSet.allBut(A), VALUE, 0b1100),
                 unread("f(value)", Set.of(VALUE), UnreadReason.FORM_NOT_READ),
                 unread("f(other)", Set.of(OTHER), UnreadReason.FORM_NOT_READ),
                 unread("value /= other", Set.of(VALUE, OTHER), UnreadReason.RELATES_TWO_POSITIONS),
@@ -191,10 +207,14 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
                 opened.addAll(promisedBy(left));
             }
         }
+        // What either side already had opened travels up with it: the positions are told to the
+        // answer once, where the whole of what the clauses came to is in hand.
+        opened.addAll(left.opened());
+        opened.addAll(right.opened());
         return new Rule("(" + left.wrote() + " " + by + " " + right.wrote() + ")",
-                by.equals("&&") ? left.read().meet(right.read(), SETS)
-                        : left.read().join(right.read(), SETS).alsoOpenedAt(opened),
-                List.copyOf(could), about, overOne,
+                by.equals("&&") ? left.planned().meet(right.planned())
+                        : left.planned().joinLive(right.planned()),
+                opened, List.copyOf(could), about, overOne,
                 left.holdsSomethingUnread() || right.holdsSomethingUnread());
     }
 
@@ -219,15 +239,15 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
             }
             for (String atom : List.of(VALUE, OTHER)) {
                 int stands = standingAt(atom, records);
-                int holds = read(rule.read().at(atom));
-                int promised = read(rule.read().guaranteedAt(atom));
+                int holds = read(rule.answer().at(atom));
+                int promised = read(rule.answer().guaranteedAt(atom));
                 assertTrue((stands & ~holds) == 0, () -> rule.wrote()
                         + ": at " + atom + " the model leaves " + stands + " and the reading holds "
                         + holds + ", which is short of it");
                 assertTrue((promised & ~stands) == 0, () -> rule.wrote()
                         + ": at " + atom + " the reading promises " + promised
                         + " and the model leaves " + stands + ", which is less than promised");
-                assertTrue(!rule.choicesOverOnePosition() || !rule.read().speaksFor(atom)
+                assertTrue(!rule.choicesOverOnePosition() || !rule.answer().speaksFor(atom)
                                 || holds == stands,
                         () -> rule.wrote() + ": at " + atom + " the reading speaks for " + holds
                                 + " and the model leaves " + stands);

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatIsReadIsHeldAgainstTheModelsItCouldBeTest.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -187,28 +188,45 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
         return compose(left, right, "||");
     }
 
+    /**
+     * The half of a rule that is this compiler's answer, as one value.
+     *
+     * <p>Held together because a choice settles all of it or none of it. What an alternative
+     * promised and whether it holds a clause nothing read are what the next choice out reads to
+     * decide what it opened, so a settlement that took the branch that stands for the values and
+     * left these as the two branches together would answer the outer choice out of a branch nobody
+     * can be in. Built nowhere but in the two below, so a part of it added later has to be settled
+     * rather than composed beside them.
+     */
+    private record Answer(PlannedValues<String> planned, Set<String> opened, Set<String> readAbout,
+                          boolean choicesOverOnePosition, boolean holdsSomethingUnread) {}
+
     private static Rule compose(Rule left, Rule right, String by) {
         Set<Integer> could = new LinkedHashSet<>();
         left.leaves().forEach(here -> right.leaves().forEach(there ->
                 could.add(by.equals("&&") ? here & there : here | there)));
+        Answer answer = by.equals("&&") ? conjoined(left, right) : settled(left, right);
+        return new Rule("(" + left.wrote() + " " + by + " " + right.wrote() + ")",
+                answer.planned(), answer.opened(), List.copyOf(could), answer.readAbout(),
+                answer.choicesOverOnePosition(), answer.holdsSomethingUnread());
+    }
+
+    /**
+     * Both readings holding at once.
+     *
+     * <p>Every clause of both is one somebody satisfying the whole is under, so all of what either
+     * side is answerable for is what the conjunction is answerable for. Nothing is opened: a
+     * conjunction has no alternative for a position to be open in, and what either side already had
+     * opened travels up with it, to be told to the answer once where the whole of what the clauses
+     * came to is in hand.
+     */
+    private static Answer conjoined(Rule left, Rule right) {
         Set<String> about = new LinkedHashSet<>(left.readAbout());
         about.addAll(right.readAbout());
-        boolean overOne = left.choicesOverOnePosition() && right.choicesOverOnePosition()
-                && (by.equals("&&") || about.size() <= 1);
-        Set<String> opened = new LinkedHashSet<>();
-        PlannedValues<String> planned;
-        if (by.equals("&&")) {
-            planned = left.planned().meet(right.planned());
-            // A conjunction leaves nothing open, since both of its clauses hold. What either side
-            // already had opened travels up with it: the positions are told to the answer once,
-            // where the whole of what the clauses came to is in hand.
-            opened.addAll(left.opened());
-            opened.addAll(right.opened());
-        } else {
-            planned = settled(left, right, opened);
-        }
-        return new Rule("(" + left.wrote() + " " + by + " " + right.wrote() + ")",
-                planned, opened, List.copyOf(could), about, overOne,
+        Set<String> opened = new LinkedHashSet<>(left.opened());
+        opened.addAll(right.opened());
+        return new Answer(left.planned().meet(right.planned()), opened, about,
+                left.choicesOverOnePosition() && right.choicesOverOnePosition(),
                 left.holdsSomethingUnread() || right.holdsSomethingUnread());
     }
 
@@ -226,25 +244,34 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
      * deciding what the compiler does, and the two would agree because one of them was made out of
      * the other.
      *
-     * <p>What a choice left open follows the same four cases. A position is open in a branch, so a
-     * branch nobody can be in takes what it opened with it — kept, the values would be settled and
-     * the account beside them would still be the one a choice that stands leaves.
+     * <p><b>The whole of the answer follows the four cases and not the values alone.</b> Where one
+     * branch stands the choice is that branch, so what it promised, whether it holds a clause
+     * nothing read, and what its own choices reached are the standing branch's — these are what the
+     * next choice out reads to decide what it opened, and taken from the two branches together it
+     * would be answering out of a branch nobody can be in.
+     *
+     * <p>A choice neither branch of which stands is neither of them. It promises nothing and its
+     * alternatives lost nothing, and what showed it empty is what showed both — which is why that
+     * one keeps what either branch could not read.
      */
-    private static PlannedValues<String> settled(Rule left, Rule right, Set<String> opened) {
+    private static Answer settled(Rule left, Rule right) {
         boolean leftStands = !left.planned().holdsNothingAsBuilt(SETS);
         boolean rightStands = !right.planned().holdsNothingAsBuilt(SETS);
         if (!leftStands && !rightStands) {
-            return left.planned().leavingNothing().bothDead(right.planned().leavingNothing());
+            return new Answer(
+                    left.planned().leavingNothing().bothDead(right.planned().leavingNothing()),
+                    Set.of(), Set.of(), true,
+                    left.holdsSomethingUnread() || right.holdsSomethingUnread());
         }
         if (!leftStands) {
-            opened.addAll(right.opened());
-            return right.planned();
+            return standing(right);
         }
         if (!rightStands) {
-            opened.addAll(left.opened());
-            return left.planned();
+            return standing(left);
         }
-        opened.addAll(left.opened());
+        Set<String> about = new LinkedHashSet<>(left.readAbout());
+        about.addAll(right.readAbout());
+        Set<String> opened = new LinkedHashSet<>(left.opened());
         opened.addAll(right.opened());
         // The positions the alternative beside an unread one reached, said where the two of them
         // are what was written.
@@ -254,7 +281,17 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
         if (right.holdsSomethingUnread()) {
             opened.addAll(promisedBy(left));
         }
-        return left.planned().joinLive(right.planned());
+        return new Answer(left.planned().joinLive(right.planned()), opened, about,
+                left.choicesOverOnePosition() && right.choicesOverOnePosition()
+                        && about.size() <= 1,
+                left.holdsSomethingUnread() || right.holdsSomethingUnread());
+    }
+
+    /** What a choice one branch of which nobody can be in comes to, which is that branch — all of
+     *  it, and not its values with the two branches' account beside them. */
+    private static Answer standing(Rule branch) {
+        return new Answer(branch.planned(), branch.opened(), branch.readAbout(),
+                branch.choicesOverOnePosition(), branch.holdsSomethingUnread());
     }
 
     /**
@@ -337,5 +374,35 @@ class WhatIsReadIsHeldAgainstTheModelsItCouldBeTest {
 
         heldAgainstItsModels(either(both(isA, isB), both(isA, notA)));
         heldAgainstItsModels(either(both(isA, notA), both(isA, isB)));
+    }
+
+    /**
+     * And a choice whose dead branch is the only one holding a clause nothing read.
+     *
+     * <p>What the choice comes to is the branch that stands, which read everything it was given.
+     * Answered with the two branches' accounts put together, it would say a clause of it went
+     * unread — and the next choice out reads that to decide what an alternative beside an unread
+     * one promised, so the reading would take back a position on the strength of a branch nobody
+     * can be in.
+     *
+     * <p>Three rules deep on one side, which is what it takes: a conjunction of two is dead only
+     * where both were read, so the clause nothing read is the third.
+     */
+    @Test
+    void andAChoiceWhoseDeadBranchIsTheOnlyOneThatMissedARule() {
+        Rule isA = rules().get(0);
+        Rule isB = rules().get(1);
+        Rule otherIsA = rules().get(2);
+        Rule unreadAboutValue = rules().get(4);
+        Rule dead = both(both(unreadAboutValue, isA), isB);
+
+        assertTrue(dead.holdsSomethingUnread(), "the dead branch is the one that missed a rule");
+        assertFalse(otherIsA.holdsSomethingUnread(), "and the standing one read what it was given");
+
+        heldAgainstItsModels(either(dead, otherIsA));
+        heldAgainstItsModels(either(otherIsA, dead));
+        // And with one more choice around it, which is what reads the account the settlement left.
+        heldAgainstItsModels(either(either(dead, otherIsA), isB));
+        heldAgainstItsModels(either(isB, either(otherIsA, dead)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatTwoRulesAboutOnePositionLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatTwoRulesAboutOnePositionLeaveItTest.java
@@ -3,6 +3,7 @@ package souther.compiler.values;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,9 +35,10 @@ class WhatTwoRulesAboutOnePositionLeaveItTest {
         return sets.meet(POSITION, one, other).set();
     }
 
-    /** And what either leaves. */
+    /** And what either leaves, said as one plan over the alternatives — which is how a block holds
+     *  what its alternatives leave it. */
     private ValueSet joined(ValueSet one, ValueSet other) {
-        return sets.join(POSITION, one, other).set();
+        return sets.joining(POSITION, List.of(one, other)).set();
     }
 
     /** Two equalities naming different values leave nothing, which is the whole of the refusal. */

--- a/souther-compiler/src/test/java/souther/compiler/values/WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest.java
@@ -51,11 +51,19 @@ class WhichPositionIsLeftNothingDoesNotFollowTheBracketsTest {
         return at(A, a).meet(at(B, b), sets);
     }
 
+    /** The same pair while it is still a description, which is where a choice between two of them
+     *  is taken. */
+    private static PlannedValues<String> planned(Value a, Value b) {
+        return PlannedValues.at(A, AdmittedPlan.of(ValueSet.just(a)))
+                .meet(PlannedValues.at(B, AdmittedPlan.of(ValueSet.just(b))));
+    }
+
     /** The three above, in the orders a conjunction of them can be written in. */
     private List<AdmissibleValues<String>> everyOrder() {
         AdmissibleValues<String> x = pair(ZERO, ZERO);
         AdmissibleValues<String> y = at(A, ZERO);
-        AdmissibleValues<String> z = pair(ONE, ZERO).joinApart(pair(ZERO, ONE), sets);
+        AdmissibleValues<String> z = planned(ONE, ZERO).joinLiveApart(planned(ZERO, ONE))
+                .resolve(sets).values();
         List<AdmissibleValues<String>> out = new ArrayList<>();
         out.add(x.meet(y, sets).meet(z, sets));
         out.add(x.meet(z, sets).meet(y, sets));


### PR DESCRIPTION
Closes #1381.

`AdmissibleValues.join` and `joinApart` were reached by nothing a compile
runs, while the operations a compile does run — over descriptions, before
anything is built — cited them as the place their rules were written. The
mechanism and its account had come apart.

Read off the class files rather than the source, with `meet`'s caller as the
control that says the walk works. What dies with the two entries is
transitive and reaches the composition front the allowance offers, which
grep does not show.

## What is fixed

Choice is formed only while a reading is planned. Resolution may keep facts
a choice produced, but the resolved reading exposes no operation that can
form another; the only production authority that realizes a choice of value
sets is the realizer, so the cost of that realization has one payment point.

Two architecture tests hold it. One fixes which operations may turn readings
into a reading — said as the whole of what a caller may compose two built
readings by, rather than as the absence of a name, so a second spelling
under another name does not pass. The other fixes where a choice of value
sets is realized.

## What moved

Every test that stated a law of a choice now states it of the operation a
compile runs: the description is composed, then worked out under the
allowance the rest of the reading is worked out under. The semantic oracle
keeps its own arithmetic — what the models say is still put together out of
the record sets by themselves, so it stays a check of this compiler against
something written down apart from it, rather than a check of the compiler
against itself.

A choice neither branch of which anybody can be in is not a choice between
two that stand. Where a test wrote one, the operation is now the settlement
a caller reaches for once both are known dead; where a test wrote a choice
between a dead branch and a standing one, what it leaves is the standing
branch and no operation composes it, so that claim is held with the rest of
the settlement rather than by calling an operation outside its contract.

The reasoning moved with the mechanism, and split where it was two things:
what a choice means sits on the operation's contract, and the sufficient
condition this compiler reads a promise by sits beside the branch that
applies it.

## Left alone

The bracketing and ordering of a settlement is held over the four cases a
caller settles by. That property is an equation between two compositions, so
a change applied evenly to those cases cannot break it; telling the
settlement from a live choice is a different claim, and the test that makes
it already exists.

A choice both branches of which are dead is reached by the corpus, and
settling it by taking one side leaves the same refusal. The difference is in
how the parts under the branches are accounted for, and nothing reads that
for such a choice. Named here, not closed: it is about attribution and
predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)